### PR TITLE
[updates] remove apache commons io

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [android] Use more robust mechanism for determining empty multipart bodies. ([#33977](https://github.com/expo/expo/pull/33977) by [@wschurman](https://github.com/wschurman))
 - fix E2E tests in Detox debug build ([#32951](https://github.com/expo/expo/pull/32951) by [@matejkriz](https://github.com/matejkriz))
 - Fix issue where syncing codesigning config for bare projects would clobber existing Expo.plist config ([#34597](https://github.com/expo/expo/pull/34597) by [@brentvatne](https://github.com/brentvatne))
+- Removed Apache Commons IO dependency and fixed crash issue on Android 7. ([#34638](https://github.com/expo/expo/pull/34638) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -112,7 +112,6 @@ dependencies {
   implementation("com.squareup.okhttp3:okhttp:4.9.2")
   implementation("com.squareup.okhttp3:okhttp-urlconnection:4.9.2")
   implementation("com.squareup.okhttp3:okhttp-brotli:4.9.2")
-  implementation("commons-io:commons-io:2.16.1")
   implementation("org.bouncycastle:bcutil-jdk15to18:1.78.1")
 
   testImplementation 'junit:junit:4.13.2'

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
@@ -6,8 +6,6 @@ import android.net.Uri
 import android.util.Log
 import expo.modules.core.errors.InvalidArgumentException
 import expo.modules.updates.codesigning.CodeSigningConfiguration
-import org.apache.commons.io.IOUtils
-import java.nio.charset.StandardCharsets
 
 enum class UpdatesConfigurationValidationResult {
   VALID,
@@ -215,7 +213,7 @@ data class UpdatesConfiguration(
 
       if (context != null && runtimeVersion == UPDATES_CONFIGURATION_RUNTIME_VERSION_READ_FINGERPRINT_FILE_SENTINEL) {
         return context.assets.open(FINGERPRINT_FILE_NAME).use { stream ->
-          IOUtils.toString(stream, StandardCharsets.UTF_8)
+          stream.bufferedReader(Charsets.UTF_8).use { it.readText() }
         }
       }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -111,6 +111,7 @@ object UpdatesUtils {
       // write file atomically by writing it to a temporary path and then renaming
       // this protects us against partially written files if the process is interrupted
       val tmpFile = File(destination.absolutePath + ".tmp")
+      tmpFile.parentFile?.mkdirs()
       digestInputStream.use { input ->
         tmpFile.outputStream().use { output ->
           input.copyTo(output)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -8,7 +8,6 @@ import expo.modules.updates.UpdatesConfiguration.CheckAutomaticallyConfiguration
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
-import org.apache.commons.io.FileUtils
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.*
@@ -112,7 +111,11 @@ object UpdatesUtils {
       // write file atomically by writing it to a temporary path and then renaming
       // this protects us against partially written files if the process is interrupted
       val tmpFile = File(destination.absolutePath + ".tmp")
-      FileUtils.copyInputStreamToFile(digestInputStream, tmpFile)
+      digestInputStream.use { input ->
+        tmpFile.outputStream().use { output ->
+          input.copyTo(output)
+        }
+      }
 
       // this message digest must be read after the input stream has been consumed in order to get the hash correctly
       val md = digestInputStream.messageDigest

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.AsyncTask
 import expo.modules.updates.loader.EmbeddedLoader
 import expo.modules.updates.logging.UpdatesLogger
-import org.apache.commons.io.FileUtils
 import java.io.File
 
 /**
@@ -30,7 +29,7 @@ class NoDatabaseLauncher @JvmOverloads constructor(
     try {
       val errorLogFile = File(context.filesDir, ERROR_LOG_FILENAME)
       val exceptionString = fatalException.toString()
-      FileUtils.writeStringToFile(errorLogFile, exceptionString, "UTF-8", true)
+      errorLogFile.appendText(exceptionString, Charsets.UTF_8)
     } catch (e: Exception) {
       logger.error("Failed to write fatal error to log", e)
     }
@@ -47,7 +46,7 @@ class NoDatabaseLauncher @JvmOverloads constructor(
         if (!errorLogFile.exists()) {
           return null
         }
-        val logContents = FileUtils.readFileToString(errorLogFile, "UTF-8")
+        val logContents = errorLogFile.readText(Charsets.UTF_8)
         errorLogFile.delete()
         logContents
       } catch (e: Exception) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/EmbeddedManifestUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/EmbeddedManifestUtils.kt
@@ -3,9 +3,7 @@ package expo.modules.updates.manifest
 import android.content.Context
 import android.util.Log
 import expo.modules.updates.UpdatesConfiguration
-import org.apache.commons.io.IOUtils
 import org.json.JSONObject
-import java.nio.charset.StandardCharsets
 
 /**
  * Helper object for accessing and memoizing the manifest embedded in the application package.
@@ -24,7 +22,7 @@ object EmbeddedManifestUtils {
     if (sEmbeddedUpdate == null) {
       try {
         context.assets.open(MANIFEST_FILENAME).use { stream ->
-          val manifestString = IOUtils.toString(stream, StandardCharsets.UTF_8)
+          val manifestString = stream.bufferedReader(Charsets.UTF_8).use { it.readText() }
           val manifestJson = JSONObject(manifestString)
           // automatically verify embedded manifest since it was already codesigned
           manifestJson.put("isVerified", true)


### PR DESCRIPTION
# Why

fixes #34538

# How

the newer apache commons io uses `File.toPath()` which is available from android api 26. 
though the [d8 desugaring](https://developer.android.com/studio/write/java11-nio-support-table) can help backward compatibility, it requires enable the feature from app project and may increase build time.
because expo-updates doesn't heavily uses the apache commons io. this pr just tries to replace the code using apache commons io to kotlin supported methods.

# Test Plan

- ci passed
- test running expo-updates on android 7 emulator

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
