### PR TITLE
feat(babel-preset-expo): Add decorators option for @babel/plugin-proposal-decorators

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `decorators` option to configure the `@babel/plugin-proposal-decorators` plugin.
+- Add `decorators` option to configure the `@babel/plugin-proposal-decorators` plugin. ([#34647](https://github.com/expo/expo/pull/34647) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `babel-plugin-syntax-hermes-parser` to the server preset for native RSC. ([#34213](https://github.com/expo/expo/pull/34213) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `displayName` to DOM components for better debugging. ([#33369](https://github.com/expo/expo/pull/33369) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Add `decorators` option to configure the `@babel/plugin-proposal-decorators` plugin.
 - Add `babel-plugin-syntax-hermes-parser` to the server preset for native RSC. ([#34213](https://github.com/expo/expo/pull/34213) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `displayName` to DOM components for better debugging. ([#33369](https://github.com/expo/expo/pull/33369) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/babel-preset-expo/README.md
+++ b/packages/babel-preset-expo/README.md
@@ -179,7 +179,7 @@ Platform-specific options have higher priority over top-level options.
 
 ### Babel Loader
 
-The babel loading mechanism must include the following properties on its `caller`.
+The Babel loading mechanism must include the following properties on its `caller`.
 
 #### platform
 

--- a/packages/babel-preset-expo/README.md
+++ b/packages/babel-preset-expo/README.md
@@ -1,44 +1,15 @@
 # babel-preset-expo
 
-This preset extends the default React Native preset (`@react-native/babel-preset`) and adds support for decorators, tree-shaking web packages, and loading font icons with optional native dependencies if they're installed.
+This preset extends the default React Native preset (`@react-native/babel-preset`) and adds support for tree shaking, bundle splitting, React Server Components, Hermes compilation, advanced dead-code elimination, reanimated, Expo DOM components, server-side rendering, and more...
 
-You can use this preset in any React Native project as a drop-in replacement for `@react-native/babel-preset`. If your project isn't using native font loading or web support then this preset will only add support for decorators with `@babel/plugin-proposal-decorators` - this is mostly used for supporting legacy community libraries.
-
-If you start your **web** project with `@expo/webpack-config` or `npx expo start` and your project doesn't contain a `babel.config.js` or a `.babelrc` then it will default to using `babel-preset-expo` for loading.
+You can use this preset in any React Native project as a drop-in replacement for `@react-native/babel-preset`.
 
 If you have problems with the code in this repository, please file issues & bug reports
-at https://github.com/expo/expo. Thanks!
+at https://github.com/expo/expo.
 
 ## Expo Bundler Spec Compliance
 
 A bundler must follow these requirements if they are to be considered spec compliant for use with a **universal React** (Expo) project.
-
-### Babel Loader
-
-The babel loading mechanism must include the following properties on its `caller`.
-
-#### platform
-
-A `platform` property denoting the target platform. If the `platform` is not defined, it will default to using `web` when the `bundler` is `webpack` -- this is temporary and will throw an error in the future.
-
-| Value     | Description             |
-| --------- | ----------------------- |
-| `ios`     | Runs on iOS devices     |
-| `android` | Runs on Android devices |
-| `web`     | Runs in web browsers    |
-
-#### bundler
-
-A `bundler` property denoting the name of the bundler that is being used to create the JavaScript bundle.
-If the `bundler` is not defined, it will default to checking if a `babel-loader` is used, if so then `webpack` will be used, otherwise it will default to `metro`.
-
-| Value     | Description                      |
-| --------- | -------------------------------- |
-| `metro`   | Bundling with [Metro][metro]     |
-| `webpack` | Bundling with [Webpack][webpack] |
-
-[metro]: https://facebook.github.io/metro/
-[webpack]: https://webpack.js.org/
 
 ## Options
 
@@ -205,3 +176,30 @@ All options can be passed in the platform-specific objects `native` and `web` to
 ```
 
 Platform-specific options have higher priority over top-level options.
+
+### Babel Loader
+
+The babel loading mechanism must include the following properties on its `caller`.
+
+#### platform
+
+A `platform` property denoting the target platform. If the `platform` is not defined, it will default to using `web` when the `bundler` is `webpack` -- this is temporary and will throw an error in the future.
+
+| Value     | Description             |
+| --------- | ----------------------- |
+| `ios`     | Runs on iOS devices     |
+| `android` | Runs on Android devices |
+| `web`     | Runs in web browsers    |
+
+#### bundler
+
+A `bundler` property denoting the name of the bundler that is being used to create the JavaScript bundle.
+If the `bundler` is not defined, it will default to checking if a `babel-loader` is used, if so then `webpack` will be used, otherwise it will default to `metro`.
+
+| Value     | Description                      |
+| --------- | -------------------------------- |
+| `metro`   | Bundling with [Metro][metro]     |
+| `webpack` | Bundling with [Webpack][webpack] |
+
+[metro]: https://facebook.github.io/metro/
+[webpack]: https://webpack.js.org/

--- a/packages/babel-preset-expo/build/index.d.ts
+++ b/packages/babel-preset-expo/build/index.d.ts
@@ -1,5 +1,10 @@
 import { ConfigAPI, TransformOptions } from '@babel/core';
 type BabelPresetExpoPlatformOptions = {
+    /** Disable or configure the `@babel/plugin-proposal-decorators` plugin. */
+    decorators?: false | {
+        legacy?: boolean;
+        version?: number;
+    };
     /** Enable or disable adding the Reanimated plugin by default. @default `true` */
     reanimated?: boolean;
     /** @deprecated Set `jsxRuntime: 'classic'` to disable automatic JSX handling.  */

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -247,7 +247,10 @@ function babelPresetExpo(api, options = {}) {
         plugins: [
             ...extraPlugins,
             // TODO: Remove
-            [require('@babel/plugin-proposal-decorators'), { legacy: true }],
+            platformOptions.decorators !== false && [
+                require('@babel/plugin-proposal-decorators'),
+                platformOptions.decorators ?? { legacy: true },
+            ],
             require('@babel/plugin-transform-export-namespace-from'),
             // Automatically add `react-native-reanimated/plugin` when the package is installed.
             // TODO: Move to be a customTransformOption.

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -24,6 +24,8 @@ import { reactServerActionsPlugin } from './server-actions-plugin';
 import { expoUseDomDirectivePlugin } from './use-dom-directive-plugin';
 
 type BabelPresetExpoPlatformOptions = {
+  /** Disable or configure the `@babel/plugin-proposal-decorators` plugin. */
+  decorators?: false | { legacy?: boolean; version?: number };
   /** Enable or disable adding the Reanimated plugin by default. @default `true` */
   reanimated?: boolean;
   /** @deprecated Set `jsxRuntime: 'classic'` to disable automatic JSX handling.  */
@@ -393,7 +395,10 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     plugins: [
       ...extraPlugins,
       // TODO: Remove
-      [require('@babel/plugin-proposal-decorators'), { legacy: true }],
+      platformOptions.decorators !== false && [
+        require('@babel/plugin-proposal-decorators'),
+        platformOptions.decorators ?? { legacy: true },
+      ],
       require('@babel/plugin-transform-export-namespace-from'),
       // Automatically add `react-native-reanimated/plugin` when the package is installed.
       // TODO: Move to be a customTransformOption.


### PR DESCRIPTION
# Why

- Give users the ability to customize this plugin https://github.com/expo/expo/issues/6898#issuecomment-2631802241

```js
[
  'babel-preset-expo',
  {
    decorators: false,
  },
]
```
