### PR TITLE
[docs] Add `isNew` field to Fingerprint API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/fingerprint.mdx
+++ b/docs/pages/versions/unversioned/sdk/fingerprint.mdx
@@ -5,6 +5,7 @@ description: A library to generate a fingerprint from a React Native project.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/@expo/fingerprint'
 packageName: '@expo/fingerprint'
 platforms: ['node']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v52.0.0/sdk/fingerprint.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/fingerprint.mdx
@@ -5,6 +5,7 @@ description: A library to generate a fingerprint from a React Native project.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/%40expo/fingerprint'
 packageName: '@expo/fingerprint'
 platforms: ['node']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #34626

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add the `isNew` field so that the "New" label is indicated in the sidebar for the Expo Fingerprint API reference page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-02-04 at 12 17 17@2x](https://github.com/user-attachments/assets/54eeac1a-90d7-454b-af2c-1e0d36eba22e)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
