### PR TITLE
[ios][core] Support returning `SharedObjects` with a `Promise`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [Android] Added support for Jetpack Compose views. ([#33759](https://github.com/expo/expo/pull/33759) by [@aleqsio](https://github.com/aleqsio))
 - support react-native 0.77 ([#33946](https://github.com/expo/expo/pull/33946) by [@vonovak](https://github.com/vonovak))
 - Implemented dispatching events by SwiftUI views. ([#33860](https://github.com/expo/expo/pull/33860) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Support returning `SharedObject`s from a `Promise`.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,7 +9,7 @@
 - [Android] Added support for Jetpack Compose views. ([#33759](https://github.com/expo/expo/pull/33759) by [@aleqsio](https://github.com/aleqsio))
 - support react-native 0.77 ([#33946](https://github.com/expo/expo/pull/33946) by [@vonovak](https://github.com/vonovak))
 - Implemented dispatching events by SwiftUI views. ([#33860](https://github.com/expo/expo/pull/33860) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] Support returning `SharedObject`s from a `Promise`.
+- [iOS] Support returning `SharedObject`s from a `Promise`. ([#34655](https://github.com/expo/expo/pull/34655) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
@@ -63,7 +63,7 @@ public final class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyA
   var takesOwner: Bool = false
 
   func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> ()) {
-    let promise = Promise { value in
+    let promise = Promise(appContext: appContext) { value in
       callback(.success(Conversions.convertFunctionResult(value, appContext: appContext)))
     } rejecter: { exception in
       callback(.failure(exception))

--- a/packages/expo-modules-core/ios/Core/Promise.swift
+++ b/packages/expo-modules-core/ios/Core/Promise.swift
@@ -17,7 +17,16 @@ public struct Promise: AnyArgument {
     }
   }
 
-  public func resolve(_ value: Any? = nil) {
+  public func resolve(_ value: Any? = nil, appContext: AppContext? = nil) {
+    if let value = value as? AnySharedObject, let appContext {
+      let result = Conversions.convertFunctionResult(
+        value,
+        appContext: appContext,
+        dynamicType: type(of: value).getDynamicType()
+      )
+      resolver(result)
+      return
+    }
     resolver(value)
   }
 

--- a/packages/expo-modules-core/ios/Core/Promise.swift
+++ b/packages/expo-modules-core/ios/Core/Promise.swift
@@ -4,6 +4,7 @@ public struct Promise: AnyArgument {
   public typealias ResolveClosure = (Any?) -> Void
   public typealias RejectClosure = (Exception) -> Void
 
+  internal let appContext: AppContext
   public var resolver: ResolveClosure
   public var rejecter: RejectClosure
 
@@ -17,8 +18,8 @@ public struct Promise: AnyArgument {
     }
   }
 
-  public func resolve(_ value: Any? = nil, appContext: AppContext? = nil) {
-    if let value = value as? AnySharedObject, let appContext {
+  public func resolve(_ value: Any? = nil) {
+    if let value = value as? AnySharedObject {
       let result = Conversions.convertFunctionResult(
         value,
         appContext: appContext,

--- a/packages/expo-modules-core/ios/Core/Promise.swift
+++ b/packages/expo-modules-core/ios/Core/Promise.swift
@@ -4,7 +4,7 @@ public struct Promise: AnyArgument {
   public typealias ResolveClosure = (Any?) -> Void
   public typealias RejectClosure = (Exception) -> Void
 
-  internal let appContext: AppContext
+  internal weak var appContext: AppContext?
   public var resolver: ResolveClosure
   public var rejecter: RejectClosure
 

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -289,6 +289,20 @@ class FunctionSpec: ExpoSpec {
           Function("withOptionalRecord") { (f: TestRecord?) in
             return "\(f?.property ?? "no value")"
           }
+          
+          AsyncFunction("withSharedObject") {
+            return SharedString("Test")
+          }
+          
+          AsyncFunction("withSharedObjectPromise") { (p: Promise) in
+            p.resolve(SharedString("Test with Promise"))
+          }
+          
+          Class("Shared", SharedString.self) {
+            Property("value") { shared in
+              return shared.ref
+            }
+          }
         })
       }
 
@@ -338,6 +352,63 @@ class FunctionSpec: ExpoSpec {
       it("accepts optional record") {
         expect(try runtime.eval("expo.modules.TestModule.withOptionalRecord({property: \"123\"})").asString()) == "123"
       }
+      
+      it("returns a SharedObject (async)") {
+        try runtime
+          .eval(
+            "expo.modules.TestModule.withSharedObject().then((result) => { globalThis.result = result; })"
+          )
+
+        expect(safeBoolEval("globalThis.result != null")).toEventually(beTrue(), timeout: .milliseconds(500))
+        let object = try runtime.eval("object = globalThis.result")
+        
+        expect(object.kind) == .object
+        expect(object.getObject().hasProperty("value")) == true
+        
+        let result = try runtime.eval("object.value")
+        expect(result.kind) == .string
+        expect(result.getString()) == "Test"
+      }
+      
+      it("returns a SharedObject with Promise") {
+        try runtime
+          .eval(
+            "expo.modules.TestModule.withSharedObjectPromise().then((result) => { globalThis.result = result; })"
+          )
+
+        expect(safeBoolEval("globalThis.result != null")).toEventually(beTrue(), timeout: .milliseconds(500))
+        let object = try runtime.eval("object = globalThis.result")
+        
+        expect(object.kind) == .object
+        expect(object.getObject().hasProperty("value")) == true
+        
+        let result = try runtime.eval("object.value")
+        expect(result.kind) == .string
+        expect(result.getString()) == "Test with Promise"
+      }
+      
+      // For async tests, this is a safe way to repeatedly evaluate JS
+      // and catch both Swift and ObjC exceptions
+      func safeBoolEval(_ js: String) -> Bool {
+        var result = false
+        do {
+          try EXUtilities.catchException {
+            guard let jsResult = try? runtime.eval(js) else {
+              return
+            }
+            result = jsResult.getBool()
+          }
+        } catch {
+          return false
+        }
+        return result
+      }
     }
+  }
+}
+
+private class SharedString: SharedRef<String> {
+  override var nativeRefType: String {
+    "string"
   }
 }


### PR DESCRIPTION
# Why
Currently on iOS, we can't return `SharedObject`s using a `Promise`. This is because `convertFunctionResult` is never called on this code path as it's up to the user to resolve the value. 

# How
When `resolve` is called, check if we are dealing with a `SharedObject` and convert the return value. ~~Ideally, we wouldn't need the `AppContext` but I didn't see another way. Open to suggestions.~~ 

# Test Plan
Bare expo. I'm adding support for returning the image directly from `expo-camera`. This now works with this change. All other uses of `promise.resolve` work as before.

