### PR TITLE
[docs] Tweak initial row count in `CollapsibleTalksGridWrapper`

### DIFF
--- a/docs/ui/components/CollapsibleTalksGridWrapper/index.tsx
+++ b/docs/ui/components/CollapsibleTalksGridWrapper/index.tsx
@@ -9,18 +9,21 @@ type CollapsibleGridProps = {
   initialCount?: number;
 };
 
-export function CollapsibleTalksGridWrapper({ items, initialCount = 9 }: CollapsibleGridProps) {
+export function CollapsibleTalksGridWrapper({ items }: CollapsibleGridProps) {
   const [showAll, setShowAll] = useState(false);
+  const initialRowCount = 3;
+  const itemsPerRow = 4;
+  const initialItems = initialRowCount * itemsPerRow;
 
   return (
     <>
       <TalkGridWrapper>
-        {items.slice(0, showAll ? items.length : initialCount).map(item => (
+        {items.slice(0, showAll ? items.length : initialItems).map(item => (
           <TalkGridCell key={item.videoId ?? item.event} {...item} />
         ))}
       </TalkGridWrapper>
 
-      {items.length > initialCount && (
+      {items.length > initialItems && (
         <div className="mt-6 flex justify-center">
           <Button
             theme="secondary"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on feedback from @Simek 

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update `CollapsibleTalksGridWrapper` to have an initial row count based on four items per row.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-02-04 at 16 46 45@2x](https://github.com/user-attachments/assets/65195f52-c397-46db-b3fc-6bdb9a8d6388)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
