### PR TITLE
[docs] Camera: add link to the `expo/examples` project

### DIFF
--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -7,9 +7,12 @@ iconUrl: '/static/images/packages/expo-camera.png'
 platforms: ['android*', 'ios*', 'web']
 ---
 
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import { BoxLink } from '~/ui/components/BoxLink';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -157,6 +160,15 @@ const styles = StyleSheet.create({
 ```
 
 </SnackInline>
+
+### Advanced usage
+
+<BoxLink
+  title="Camera app example"
+  description="A complete example that shows how to take a picture and display it. Written in TypeScript."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-camera"
+/>
 
 ## Web support
 

--- a/docs/pages/versions/v50.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/camera.mdx
@@ -6,10 +6,13 @@ packageName: 'expo-camera'
 iconUrl: '/static/images/packages/expo-camera.png'
 ---
 
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import { BoxLink } from '~/ui/components/BoxLink';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -157,6 +160,15 @@ const styles = StyleSheet.create({
 ```
 
 </SnackInline>
+
+### Advanced usage
+
+<BoxLink
+  title="Camera app example"
+  description="A complete example that shows how to take a picture and display it. Written in TypeScript."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-camera"
+/>
 
 ## Web support
 

--- a/docs/pages/versions/v51.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/camera.mdx
@@ -7,9 +7,12 @@ iconUrl: '/static/images/packages/expo-camera.png'
 platforms: ['android*', 'ios*', 'web']
 ---
 
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import { BoxLink } from '~/ui/components/BoxLink';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -157,6 +160,15 @@ const styles = StyleSheet.create({
 ```
 
 </SnackInline>
+
+### Advanced usage
+
+<BoxLink
+  title="Camera app example"
+  description="A complete example that shows how to take a picture and display it. Written in TypeScript."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-camera"
+/>
 
 ## Web support
 

--- a/docs/pages/versions/v52.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/camera.mdx
@@ -7,9 +7,12 @@ iconUrl: '/static/images/packages/expo-camera.png'
 platforms: ['android*', 'ios*', 'web']
 ---
 
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import { BoxLink } from '~/ui/components/BoxLink';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -157,6 +160,15 @@ const styles = StyleSheet.create({
 ```
 
 </SnackInline>
+
+### Advanced usage
+
+<BoxLink
+  title="Camera app example"
+  description="A complete example that shows how to take a picture and display it. Written in TypeScript."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-camera"
+/>
 
 ## Web support
 


### PR DESCRIPTION
# Why

Fixes ENG-12268

# How

Add link to the `expo/examples` camera app project on the `expo-camera` reference pages.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

![Screenshot 2025-02-04 at 14 41 03](https://github.com/user-attachments/assets/b0f7dc00-ba22-40cc-962b-b542007db5ca)

