### PR TITLE
[docs] Link to linking videos

### DIFF
--- a/docs/pages/linking/android-app-links.mdx
+++ b/docs/pages/linking/android-app-links.mdx
@@ -6,11 +6,18 @@ description: Learn how to configure Android App Links to open your Expo app from
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 To configure Android App Links for your app, you need to:
 
 - Add `intentFilters` and set `autoVerify` to true in your project's app config
 - Set up two-way association to verify your website and native app
+
+<VideoBoxLink
+  videoId="kNbEEYlFIPs"
+  time={399}
+  title="Watch: Set up Android App Links with Expo Router"
+/>
 
 ## Add `intentFilters` to the app config
 

--- a/docs/pages/linking/ios-universal-links.mdx
+++ b/docs/pages/linking/ios-universal-links.mdx
@@ -6,8 +6,15 @@ description: Learn how to configure iOS Universal Links to open your Expo app fr
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 To configure iOS Universal Links for your app, you need to set up the **two-way association** to verify your website and native app.
+
+<VideoBoxLink
+  videoId="kNbEEYlFIPs"
+  time={68}
+  title="Watch: Set up iOS Universal Links with Expo Router"
+/>
 
 ## Set up two-way association
 

--- a/docs/ui/components/VideoBoxLink/index.tsx
+++ b/docs/ui/components/VideoBoxLink/index.tsx
@@ -9,14 +9,15 @@ type VideoBoxLinkProps = {
   title: string;
   description: ReactNode;
   videoId: string;
+  time?: number;
   className?: string;
 };
 
-export function VideoBoxLink({ title, description, videoId, className }: VideoBoxLinkProps) {
+export function VideoBoxLink({ title, description, videoId, time, className }: VideoBoxLinkProps) {
   return (
     <A
       openInNewTab
-      href={`https://www.youtube.com/watch?v=${videoId}`}
+      href={`https://www.youtube.com/watch?v=${videoId}${time ? `&t=${time}` : ''}`}
       className={mergeClasses(
         'relative flex items-stretch overflow-hidden rounded-lg border border-default bg-default shadow-xs transition',
         'hocus:shadow-sm',


### PR DESCRIPTION
# Why

Link to the new universal and app links videos.

# How

Had to update the YouTube embed component to support linking to a specific timestamp.

# Test Plan

Tested locally on the app links and universal links pages.

<img width="731" alt="Screenshot 2025-02-04 at 22 57 02" src="https://github.com/user-attachments/assets/d6e775ec-eabd-415d-b1d6-393cab89bad0" />

<img width="746" alt="Screenshot 2025-02-04 at 22 57 09" src="https://github.com/user-attachments/assets/aaaf8dd0-f3f6-4f69-b820-e954e0b30197" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
