### PR TITLE
[maps][plugin] Add config-plugin for permissions

### DIFF
--- a/docs/pages/versions/unversioned/sdk/maps.mdx
+++ b/docs/pages/versions/unversioned/sdk/maps.mdx
@@ -160,7 +160,7 @@ import { AppleMaps, GoogleMaps } from 'expo-maps';
 
 ### Android
 
-To show the user's location on the map, the `expo-maps` module requires the following permissions:
+To show the user's location on the map, the `expo-maps` library requires the following permissions:
 
 - `ACCESS_COARSE_LOCATION`: for approximate device location
 - `ACCESS_FINE_LOCATION`: for precise device location

--- a/docs/pages/versions/unversioned/sdk/maps.mdx
+++ b/docs/pages/versions/unversioned/sdk/maps.mdx
@@ -88,6 +88,44 @@ Expo Maps provides access to the platform native map APIs on Android and iOS.
 
 </Collapsible>
 
+To display the user's location on the map, you need to declare and request location permission beforehand. You can configure this using the built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-maps",
+        {
+          "requestLocationPermission": "true",
+          "locationPermission": "Allow $(PRODUCT_NAME) to use your location"
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'requestLocationPermission',
+      description: 'A boolean to add permissions to **Info.plist** and AndroidManifest.xml.',
+      default: 'false',
+    },
+    {
+      name: 'locationPermission',
+      platform: 'ios',
+      description: 'A string to set the [`NSLocationWhenInUseUsageDescription`](#permission-nslocationwheninuseusagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to use your location"',
+    },
+  ]}
+/>
+
 ## Usage
 
 ```tsx

--- a/docs/pages/versions/unversioned/sdk/maps.mdx
+++ b/docs/pages/versions/unversioned/sdk/maps.mdx
@@ -10,7 +10,9 @@ isNew: true
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/ConfigSection';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
@@ -114,13 +116,14 @@ To display the user's location on the map, you need to declare and request locat
   properties={[
     {
       name: 'requestLocationPermission',
-      description: 'A boolean to add permissions to **Info.plist** and AndroidManifest.xml.',
+      description: 'A boolean to add permissions to **AndroidManifest.xml** and **Info.plist**.',
       default: 'false',
     },
     {
       name: 'locationPermission',
       platform: 'ios',
-      description: 'A string to set the [`NSLocationWhenInUseUsageDescription`](#permission-nslocationwheninuseusagedescription) permission message.',
+      description:
+        'A string to set the [`NSLocationWhenInUseUsageDescription`](#permission-nslocationwheninuseusagedescription) permission message.',
       default: '"Allow $(PRODUCT_NAME) to use your location"',
     },
   ]}
@@ -152,3 +155,28 @@ import { AppleMaps, GoogleMaps } from 'expo-maps';
 ```
 
 <APISection packageName="expo-maps" apiName="Maps" />
+
+## Permissions
+
+### Android
+
+To show the user's location on the map, the `expo-maps` module requires the following permissions:
+
+- `ACCESS_COARSE_LOCATION`: for approximate device location
+- `ACCESS_FINE_LOCATION`: for precise device location
+
+<AndroidPermissions
+  permissions={[
+    'ACCESS_COARSE_LOCATION',
+    'ACCESS_FINE_LOCATION',
+    'FOREGROUND_SERVICE',
+    'FOREGROUND_SERVICE_LOCATION',
+    'ACCESS_BACKGROUND_LOCATION',
+  ]}
+/>
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={['NSLocationWhenInUseUsageDescription']} />

--- a/docs/pages/versions/v52.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/maps.mdx
@@ -160,7 +160,7 @@ import { AppleMaps, GoogleMaps } from 'expo-maps';
 
 ### Android
 
-To show the user's location on the map, the `expo-maps` module requires the following permissions:
+To show the user's location on the map, the `expo-maps` library requires the following permissions:
 
 - `ACCESS_COARSE_LOCATION`: for approximate device location
 - `ACCESS_FINE_LOCATION`: for precise device location

--- a/docs/pages/versions/v52.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/maps.mdx
@@ -88,6 +88,44 @@ Expo Maps provides access to the platform native map APIs on Android and iOS.
 
 </Collapsible>
 
+To display the user's location on the map, you need to declare and request location permission beforehand. You can configure this using the built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-maps",
+        {
+          "requestLocationPermission": "true",
+          "locationPermission": "Allow $(PRODUCT_NAME) to use your location"
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'requestLocationPermission',
+      description: 'A boolean to add permissions to **Info.plist** and AndroidManifest.xml.',
+      default: 'false',
+    },
+    {
+      name: 'locationPermission',
+      platform: 'ios',
+      description: 'A string to set the [`NSLocationWhenInUseUsageDescription`](#permission-nslocationwheninuseusagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to use your location"',
+    },
+  ]}
+/>
+
 ## Usage
 
 ```tsx

--- a/docs/pages/versions/v52.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/maps.mdx
@@ -10,7 +10,9 @@ isNew: true
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/ConfigSection';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
@@ -114,13 +116,14 @@ To display the user's location on the map, you need to declare and request locat
   properties={[
     {
       name: 'requestLocationPermission',
-      description: 'A boolean to add permissions to **Info.plist** and AndroidManifest.xml.',
+      description: 'A boolean to add permissions to **AndroidManifest.xml** and **Info.plist**.',
       default: 'false',
     },
     {
       name: 'locationPermission',
       platform: 'ios',
-      description: 'A string to set the [`NSLocationWhenInUseUsageDescription`](#permission-nslocationwheninuseusagedescription) permission message.',
+      description:
+        'A string to set the [`NSLocationWhenInUseUsageDescription`](#permission-nslocationwheninuseusagedescription) permission message.',
       default: '"Allow $(PRODUCT_NAME) to use your location"',
     },
   ]}
@@ -152,3 +155,28 @@ import { AppleMaps, GoogleMaps } from 'expo-maps';
 ```
 
 <APISection packageName="expo-maps" apiName="Maps" />
+
+## Permissions
+
+### Android
+
+To show the user's location on the map, the `expo-maps` module requires the following permissions:
+
+- `ACCESS_COARSE_LOCATION`: for approximate device location
+- `ACCESS_FINE_LOCATION`: for precise device location
+
+<AndroidPermissions
+  permissions={[
+    'ACCESS_COARSE_LOCATION',
+    'ACCESS_FINE_LOCATION',
+    'FOREGROUND_SERVICE',
+    'FOREGROUND_SERVICE_LOCATION',
+    'ACCESS_BACKGROUND_LOCATION',
+  ]}
+/>
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={['NSLocationWhenInUseUsageDescription']} />

--- a/packages/expo-maps/plugin/build/withMapsLocation.d.ts
+++ b/packages/expo-maps/plugin/build/withMapsLocation.d.ts
@@ -1,0 +1,6 @@
+import { ConfigPlugin } from 'expo/config-plugins';
+declare const _default: ConfigPlugin<void | {
+    requestLocationPermission?: boolean | undefined;
+    locationPermission?: string | undefined;
+}>;
+export default _default;

--- a/packages/expo-maps/plugin/build/withMapsLocation.js
+++ b/packages/expo-maps/plugin/build/withMapsLocation.js
@@ -4,7 +4,7 @@ const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('expo-maps/package.json');
 const LOCATION_USAGE = 'Allow $(PRODUCT_NAME) to access your location';
 const withMapsLocation = (config, { requestLocationPermission, locationPermission } = {}) => {
-    // If addLocationPermission is not set explicity, don't add the permissions
+    // Don't add the permissions if requestLocationPermission is not set explicity
     if (!requestLocationPermission) {
         return config;
     }

--- a/packages/expo-maps/plugin/build/withMapsLocation.js
+++ b/packages/expo-maps/plugin/build/withMapsLocation.js
@@ -1,0 +1,21 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const config_plugins_1 = require("expo/config-plugins");
+const pkg = require('expo-maps/package.json');
+const LOCATION_USAGE = 'Allow $(PRODUCT_NAME) to access your location';
+const withMapsLocation = (config, { requestLocationPermission, locationPermission } = {}) => {
+    // If addLocationPermission is not set explicity, don't add the permissions
+    if (!requestLocationPermission) {
+        return config;
+    }
+    config_plugins_1.IOSConfig.Permissions.createPermissionsPlugin({
+        NSLocationWhenInUseUsageDescription: LOCATION_USAGE,
+    })(config, {
+        NSLocationWhenInUseUsageDescription: locationPermission,
+    });
+    return config_plugins_1.AndroidConfig.Permissions.withPermissions(config, [
+        'android.permission.ACCESS_COARSE_LOCATION',
+        'android.permission.ACCESS_FINE_LOCATION',
+    ]);
+};
+exports.default = (0, config_plugins_1.createRunOncePlugin)(withMapsLocation, pkg.name, pkg.version);

--- a/packages/expo-maps/plugin/src/withMapsLocation.ts
+++ b/packages/expo-maps/plugin/src/withMapsLocation.ts
@@ -1,0 +1,28 @@
+import { AndroidConfig, ConfigPlugin, IOSConfig, createRunOncePlugin } from 'expo/config-plugins';
+
+const pkg = require('expo-maps/package.json');
+const LOCATION_USAGE = 'Allow $(PRODUCT_NAME) to access your location';
+
+const withMapsLocation: ConfigPlugin<
+  {
+    requestLocationPermission?: boolean;
+    locationPermission?: string;
+  } | void
+> = (config, { requestLocationPermission, locationPermission } = {}) => {
+  // Don't add the permissions if requestLocationPermission is not set explicity
+  if (!requestLocationPermission) {
+    return config;
+  }
+  IOSConfig.Permissions.createPermissionsPlugin({
+    NSLocationWhenInUseUsageDescription: LOCATION_USAGE,
+  })(config, {
+    NSLocationWhenInUseUsageDescription: locationPermission,
+  });
+
+  return AndroidConfig.Permissions.withPermissions(config, [
+    'android.permission.ACCESS_COARSE_LOCATION',
+    'android.permission.ACCESS_FINE_LOCATION',
+  ]);
+};
+
+export default createRunOncePlugin(withMapsLocation, pkg.name, pkg.version);

--- a/packages/expo-maps/plugin/tsconfig.json
+++ b/packages/expo-maps/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}


### PR DESCRIPTION
# Why

To display the user location on the map, the app must first declare location permissions in **Info.plist** (for iOS) or **AndroidManifest.xml** (for Android) and then request them at runtime.

# How

Simplifies process by utilizing Expo Config Plugin.

Example app.json
```json
{
  "expo": {
    "plugins": [
      [
        "expo-maps",
        {
          "requestLocationPermission": "true",
          "locationPermission": "Allow $(PRODUCT_NAME) to use your location"
        }
      ]
    ]
  }
}
```

# Test Plan

Run expo prebuild and inspect the diff