### PR TITLE
[menu][Android] Fix `copyAssets` task output definition

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fixed performance monitor does not show on iOS. ([#33855](https://github.com/expo/expo/pull/33855) by [@kudo](https://github.com/kudo))
+- [Android] Fixed `task ':expo-dev-menu:generateDebugLintModel' uses this output of task ':expo-dev-menu:copyAssets' without declaring an explicit or implicit dependency`.
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fixed performance monitor does not show on iOS. ([#33855](https://github.com/expo/expo/pull/33855) by [@kudo](https://github.com/kudo))
-- [Android] Fixed `task ':expo-dev-menu:generateDebugLintModel' uses this output of task ':expo-dev-menu:copyAssets' without declaring an explicit or implicit dependency`.
+- [Android] Fixed `task ':expo-dev-menu:generateDebugLintModel' uses this output of task ':expo-dev-menu:copyAssets' without declaring an explicit or implicit dependency`. ([#34688](https://github.com/expo/expo/pull/34688) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -117,8 +117,7 @@ task copyAssets(type: Copy) {
 }
 
 project.afterEvaluate {
-  packageDebugAssets.dependsOn copyAssets
-  packageReleaseWithDevMenuAssets.dependsOn copyAssets
+  preBuild.dependsOn copyAssets
 }
 
 repositories {


### PR DESCRIPTION
# Why

Fixes:
```
* What went wrong:
A problem was found with the configuration of task ':expo-dev-menu:generateDebugLintModel' (type 'LintModelWriterTask').
  - Gradle detected a problem with the following location: '/Users/lukasz/work/test-app/node_modules/expo-dev-menu/android/src/debug/assets'.
    
    Reason: Task ':expo-dev-menu:generateDebugLintModel' uses this output of task ':expo-dev-menu:copyAssets' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':expo-dev-menu:copyAssets' as an input of ':expo-dev-menu:generateDebugLintModel'.
      2. Declare an explicit dependency on ':expo-dev-menu:copyAssets' from ':expo-dev-menu:generateDebugLintModel' using Task#dependsOn.
      3. Declare an explicit dependency on ':expo-dev-menu:copyAssets' from ':expo-dev-menu:generateDebugLintModel' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.10.2/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.
```

# How

Changed when `copyAssets` is invoked - now it's a part of the `preBuild` task, which seems to be what people generally do.

# Test Plan

- run `./gradlew lint` in a fresh project ✅ 