### PR TITLE
[docs] Add a page to list llms parsed files

### DIFF
--- a/docs/pages/llms.mdx
+++ b/docs/pages/llms.mdx
@@ -7,5 +7,5 @@ hideTOC: true
 At Expo, we support the [llms.txt](https://llmstxt.org/) initiative to provide documentation for large language models (LLMs) and apps that use them. Below is a list of documentation files available:
 
 - [/llms.txt](/llms.txt): A list of all available documentation files
-- [/llms-full.txt](/llms-full.txt): Complete documentation for Expo including tutorials and guides
+- [/llms-full.txt](/llms-full.txt): Complete documentation for Expo, including tutorials and guides
 - [/llms-eas.txt](/llms-eas.txt): Complete documentation for the Expo Application Services (EAS)

--- a/docs/pages/llms.mdx
+++ b/docs/pages/llms.mdx
@@ -1,0 +1,11 @@
+---
+title: Documentation for LLMs
+description: A list of Expo and EAS documentation files available for large language models (LLMs) and apps that use them.
+hideTOC: true
+---
+
+At Expo, we support the [llms.txt](https://llmstxt.org/) initiative to provide documentation for large language models (LLMs) and apps that use them. Below is a list of documentation files available:
+
+- [/llms.txt](/llms.txt): A list of all available documentation files
+- [/llms-full.txt](/llms-full.txt): Complete documentation for Expo including tutorials and guides
+- [/llms-eas.txt](/llms-eas.txt): Complete documentation for the Expo Application Services (EAS)

--- a/docs/pages/llms.mdx
+++ b/docs/pages/llms.mdx
@@ -7,5 +7,5 @@ hideTOC: true
 At Expo, we support the [llms.txt](https://llmstxt.org/) initiative to provide documentation for large language models (LLMs) and apps that use them. Below is a list of documentation files available:
 
 - [/llms.txt](/llms.txt): A list of all available documentation files
-- [/llms-full.txt](/llms-full.txt): Complete documentation for Expo, including tutorials and guides
+- [/llms-full.txt](/llms-full.txt): Complete documentation for Expo, including Expo Router, Expo Modules API, development process, and more
 - [/llms-eas.txt](/llms-eas.txt): Complete documentation for the Expo Application Services (EAS)


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on a discussion with @keith-kurak.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Create a page to list currently available parsed llms.txt files for Expo and EAS documentation.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-02-05 at 18 48 56@2x](https://github.com/user-attachments/assets/cd6ce4ef-beef-4ba5-8c0a-75b9d03516bc)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
