### PR TITLE
[video][android] Use `ExoPlayer.switchTargetView` for changing the `SurfaceView` of the player

### DIFF
--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -107,6 +107,8 @@ class VideoModule : Module() {
 
       OnViewDestroys {
         VideoManager.unregisterVideoView(it)
+        // Remove relations with mounted players
+        it.videoPlayer = null
       }
 
       OnViewDidUpdateProps { view ->

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -69,7 +69,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
       }
       videoPlayer?.removeListener(this)
       newPlayer?.addListener(this)
-      playerView.player = newPlayer?.player
+      newPlayer?.changePlayerView(playerView)
       field = newPlayer
       newPlayer?.let {
         VideoManager.onVideoPlayerAttachedToView(it, this)

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -2,7 +2,6 @@ package expo.modules.video.player
 
 import android.content.Context
 import android.media.MediaMetadataRetriever
-import android.view.SurfaceView
 import androidx.media3.common.C
 import android.webkit.URLUtil
 import androidx.annotation.OptIn

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -51,6 +51,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
     .forceEnableMediaCodecAsynchronousQueueing()
     .setEnableDecoderFallback(true)
   private var listeners: MutableList<WeakReference<VideoPlayerListener>> = mutableListOf()
+  private var currentPlayerView = WeakReference<PlayerView?>(null)
   val loadControl: VideoPlayerLoadControl = VideoPlayerLoadControl.Builder().build()
   val subtitles: VideoPlayerSubtitles = VideoPlayerSubtitles(this)
   val trackSelector = DefaultTrackSelector(context)
@@ -300,10 +301,9 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
     close()
   }
 
-  fun changePlayerView(playerView: PlayerView) {
-    player.clearVideoSurface()
-    player.setVideoSurfaceView(playerView.videoSurfaceView as SurfaceView?)
-    playerView.player = player
+  fun changePlayerView(playerView: PlayerView?) {
+    PlayerView.switchTargetView(player, currentPlayerView.get(), playerView)
+    currentPlayerView = WeakReference(playerView)
   }
 
   fun prepare() {


### PR DESCRIPTION
# Why

From ExoPlayer javadoc of the `setPlayer` method:

> To transition a Player from targeting one view to another, it's recommended to use switchTargetView(Player, PlayerView, PlayerView) rather than this method. If you do wish to use this method directly, be sure to attach the player to the new view before calling setPlayer(null) to detach it from the old one. This ordering is significantly more efficient and may allow for more seamless transitions.
> Params:
> player – The Player to use, or null to detach the current player. Only players which are accessed on the main thread are supported (player. getApplicationLooper() == Looper. getMainLooper()).

Also noticed that once a VideoView is destroyed with a mounted player the `VideoManager` will keep a reference to it because of not being removed from `videoPlayersToVideoViews`. Included the fix in this PR since it's a one-line fix (setting `        it.videoPlayer = null` in `OnViewDestroy`

# How

Used `switchPlayerView` for changing the player view, as well as ensured that no references to the view are kept after it has been destroyed.

# Test Plan

Tested in BareExpo on Android
