### PR TITLE
[notification] better error when Firebase is not set up

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 💡 Others
 
+- more useful error when Firebase is not set up ([#34694](https://github.com/expo/expo/pull/34694) by [@vonovak](https://github.com/vonovak))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 - [iOS] Swift conversion 6: refactor Record classes. ([#34413](https://github.com/expo/expo/pull/34413) by [@douglowder](https://github.com/douglowder))
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- more useful error when Firebase is not set up ([#34694](https://github.com/expo/expo/pull/34694) by [@vonovak](https://github.com/vonovak))
+- Add better error when Firebase is not set up ([#34694](https://github.com/expo/expo/pull/34694) by [@vonovak](https://github.com/vonovak))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 - [iOS] Swift conversion 6: refactor Record classes. ([#34413](https://github.com/expo/expo/pull/34413) by [@douglowder](https://github.com/douglowder))
 


### PR DESCRIPTION
# Why

Improves error handling in the Android push notifications module by providing clearer error messages when Firebase Messaging is not properly initialized. 

The message usually is `Default FirebaseApp is not initialized in this process com.x.y. Make sure to call FirebaseApp.initializeApp(Context) first.`

which happens when people don't follow the setup fully and forget to provide `googleServicesFile` path in app.config.js

# How

- Added a new `getFirebaseMessagingInstance` helper method to safely handle Firebase initialization
- Updated error messages to include a direct link to FCM credentials setup documentation

# Test Plan

tested locally by not providing a `googleServicesFile` path in app.config.js

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)