### PR TITLE
[go] fix spotlessCheck error

### DIFF
--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -14,6 +14,9 @@ buildscript {
     repositoryUrl = "file:${System.env.HOME}/.m2/repository/"
 
     ndkVersion = "26.1.10909125"
+
+    // For third party modules to get correct react-native directory
+    REACT_NATIVE_NODE_MODULES_DIR = project(':packages:react-native:ReactAndroid').projectDir.getParentFile()
   }
   repositories {
     google()

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemPath.kt
@@ -22,7 +22,7 @@ abstract class FileSystemPath(public var file: File) : SharedObject() {
           // Recursively delete subdirectories
           delete(child)
         } else {
-          if(!child.delete()) {
+          if (!child.delete()) {
             throw UnableToDeleteException("failed to delete '${child.path}'")
           }
         }


### PR DESCRIPTION
# Why

fix android unit test ci error on sdk-52 branch: https://github.com/expo/expo/actions/runs/13160052202/job/36726225920

# How

the problem started from #34114 and we have different versions of `@react-native-picker/picker`. the non-hoisted version in expo-go cannot resolve the correct react-native version.

this pr tries to add the `REACT_NATIVE_NODE_MODULES_DIR` for react-native-picker to get correct react-native path. also fixes a spotless error in expo-file-system

# Test Plan

android unit test ci passed

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
