### PR TITLE
[docs] Add Ruby requirement in setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,9 @@ Manual smoke tests are included in `apps/native-component-list`, which is a good
 
 1. If you are an Expo team member, clone the repository. If you are an external contributor, [fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device. (`git remote add upstream git@github.com:expo/expo.git` 😉). You can use `git clone --depth 1 --single-branch --branch main git@github.com:expo/expo.git`, skipping most of the branches and history to clone it faster.
 2. Install [direnv](https://direnv.net/). On macOS: `brew install direnv`. Don't forget to install the [shell hook](https://direnv.net/docs/hook.html) to your shell profile.
-3. Install [git-lfs](https://git-lfs.github.com/). On macOS: `brew install git-lfs`.
-4. Install [Node LTS](https://nodejs.org/).
+3. Install Ruby 3.3 or later. On macOS: `brew install ruby@3.3`
+4. Install [git-lfs](https://git-lfs.github.com/). On macOS: `brew install git-lfs`.
+5. Install [Node LTS](https://nodejs.org/).
 
 ### Set up documentation
 


### PR DESCRIPTION
# Why

The CONTRIBUTING.md file mentions needing Ruby 3.3 for MacOS but only in the "Setup for iOS" section. This resulted in the issue of direnv giving an error that Ruby 3.3 was needed on MacOS and Linux after following the main setup instructions as discussed in Issue #34650.

# How

I added a step between Install [direnv](https://direnv.net/) and Install [git-lfs](https://git-lfs.github.com/) to install Ruby 3.3 or later. 

I could see the team also wanting to remove the call out in the "Setup for iOS" section now, but I left it in because I felt the current solution is the smallest way to fix the problem. It does have the tradeoff of giving another place that must be updated when the minimum Ruby version has to be updated.

Please let me know if it would be preferred to remove the reference in the "Setup for iOS" section.

# Test Plan

Please correct me if I am wrong, but I believe there is nothing to test here. This is a change in CONTRIBUTING.md, so it is not even covered by the normal [docs] test.

# Checklist

- [ ] N/A ~~I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)~~
- [ ] N/A I believe ~~This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).~~
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) (Please tell me if this is not the case and I will fix it)
