### PR TITLE
fix(cli): use the correct Android SDK default location for Linux

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -39,7 +39,7 @@
 - Use POSIX path when converting route file name in API routes. ([#34307](https://github.com/expo/expo/pull/34307) by [@byCedric](https://github.com/byCedric))
 - Bind debugging infrastructure to `localhost` instead of LAN ip. ([#34368](https://github.com/expo/expo/pull/34368) by [@byCedric](https://github.com/byCedric))
 - Add fallback resolution strategy for dependencies and optional peer dependencies of `expo` and `expo-router` to prevent broken resolution for isolated dependencies and hoisting issues. ([#34286](https://github.com/expo/expo/pull/34286) by [@kitten](https://github.com/kitten))
-- Use the correct default location for Android SDK on Linux `../Android/Sdk`.
+- Use the correct default location for Android SDK on Linux `../Android/Sdk`. ([#34712](https://github.com/expo/expo/pull/34712) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Use POSIX path when converting route file name in API routes. ([#34307](https://github.com/expo/expo/pull/34307) by [@byCedric](https://github.com/byCedric))
 - Bind debugging infrastructure to `localhost` instead of LAN ip. ([#34368](https://github.com/expo/expo/pull/34368) by [@byCedric](https://github.com/byCedric))
 - Add fallback resolution strategy for dependencies and optional peer dependencies of `expo` and `expo-router` to prevent broken resolution for isolated dependencies and hoisting issues. ([#34286](https://github.com/expo/expo/pull/34286) by [@kitten](https://github.com/kitten))
+- Use the correct default location for Android SDK on Linux `../Android/Sdk`.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/platforms/android/AndroidSdk.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidSdk.ts
@@ -10,7 +10,7 @@ import path from 'path';
  */
 const ANDROID_DEFAULT_LOCATION: Readonly<Partial<Record<NodeJS.Platform, string>>> = {
   darwin: path.join(os.homedir(), 'Library', 'Android', 'sdk'),
-  linux: path.join(os.homedir(), 'Android', 'sdk'),
+  linux: path.join(os.homedir(), 'Android', 'Sdk'),
   win32: path.join(os.homedir(), 'AppData', 'Local', 'Android', 'Sdk'),
 };
 

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidSdk-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidSdk-test.ts
@@ -66,7 +66,7 @@ describe(assertSdkRoot, () => {
   });
 
   it('returns default location for Linux', () => {
-    const target = path.join(os.homedir(), 'Android', 'sdk');
+    const target = path.join(os.homedir(), 'Android', 'Sdk');
     vol.fromJSON({ [path.join(target, 'file')]: 'file' });
     setPlatform('linux');
     expect(assertSdkRoot()).toBe(target);


### PR DESCRIPTION
# Why

Fixes #34548

This is a breaking change, so shouldn't backport this to SDK 52 - but keep it for SDK 53 instead.

# How

- Validated that `../Android/Sdk` is the default location for Linux through: https://stackoverflow.com/a/51585165
- [Official Android docs is conflicting](https://developer.android.com/studio/run/emulator-commandline#system-filedir) but also incomplete related to these paths:
  ![AVD location](https://github.com/user-attachments/assets/046972b3-9b14-456e-9c25-58a8378277f6)


# Test Plan

- See updated test

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
