### PR TITLE
fix(cli): do not create proxy sessions with invalid starting or ending characters

### DIFF
--- a/packages/@expo/cli/src/start/server/AsyncNgrok.ts
+++ b/packages/@expo/cli/src/start/server/AsyncNgrok.ts
@@ -234,7 +234,7 @@ export class AsyncNgrok {
     let randomness: string;
     do {
       randomness = crypto.randomBytes(5).toString('base64url');
-    } while (randomness.startsWith('_')); // _ is an invalid character for a hostname
+    } while (!/^[A-Za-z0-9]|[A-Za-z0-9]$/.test(randomness)); // _ is an invalid character for a hostname
 
     await ProjectSettings.setAsync(this.projectRoot, { urlRandomness: randomness });
     debug('Resetting project randomness:', randomness);

--- a/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
+++ b/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
@@ -60,7 +60,7 @@ function getTunnelOptions() {
   do {
     // TODO(cedric): replace this with non-random data generated from server to manage and prevent overlapping sessions
     session = randomBytes(12).toString('base64url');
-  } while (!/^[A-Za-z0-9]/.test(session));
+  } while (!/^[A-Za-z0-9]|[A-Za-z0-9]$/.test(session));
   debug('Session:', session);
   return { session };
 }


### PR DESCRIPTION
# Why

Starting or ending with `-` or `_` is not allowed in URL subdomains. This fixes that.

# How

- Generate proper tunnel session identifiers

# Test Plan

TBD

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
