### PR TITLE
[router]: Fix router playwright tests failing during cleanup

### DIFF
--- a/packages/@expo/cli/e2e/playwright/dev/fast-refresh.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/fast-refresh.test.ts
@@ -61,7 +61,9 @@ test.describe(inputDir, () => {
       return contents.replace(/LAYOUT_VALUE_[\d\w]+/g, 'LAYOUT_VALUE');
     });
 
-    await fsPromise.unlink(appDir + tempRoute);
+    if (fs.existsSync(appDir + tempRoute)) {
+      await fsPromise.unlink(appDir + tempRoute);
+    }
   });
 
   const targetDirectory = path.join(projectRoot, '__e2e__/fast-refresh/app');


### PR DESCRIPTION
# Why

E2E tests are failing as the `temp-route.tsx` may not exist after every test.

# How

Check the file exists before we try and remove it