### PR TITLE
[ios][camera] Fix initial rotation

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [iOS] Fix setting `videoQuality` prop. ([#34082](https://github.com/expo/expo/pull/34082) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix an issue where the camera image is pixelated when using the gl integration. ([#34174](https://github.com/expo/expo/pull/34174) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix setting the camera preview provider. ([#34302](https://github.com/expo/expo/pull/34302) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix initial roation when used with `react-native-screens`.
+- [iOS] Fix initial roation when used with `react-native-screens`. ([#34721](https://github.com/expo/expo/pull/34721) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [iOS] Fix setting `videoQuality` prop. ([#34082](https://github.com/expo/expo/pull/34082) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix an issue where the camera image is pixelated when using the gl integration. ([#34174](https://github.com/expo/expo/pull/34174) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix setting the camera preview provider. ([#34302](https://github.com/expo/expo/pull/34302) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix initial roation when used with `react-native-screens`.
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -134,8 +134,8 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   let onResponsiveOrientationChanged = EventDispatcher()
 
   private var deviceOrientation: UIInterfaceOrientation {
-    UIApplication.shared.connectedScenes.compactMap { $0 as?
-      UIWindowScene
+    UIApplication.shared.connectedScenes.compactMap {
+      $0 as? UIWindowScene
     }.first?.interfaceOrientation ?? .unknown
   }
 

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -134,7 +134,9 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   let onResponsiveOrientationChanged = EventDispatcher()
 
   private var deviceOrientation: UIInterfaceOrientation {
-    window?.windowScene?.interfaceOrientation ?? .unknown
+    UIApplication.shared.connectedScenes.compactMap { $0 as?
+      UIWindowScene
+    }.first?.interfaceOrientation ?? .unknown
   }
 
   required init(appContext: AppContext? = nil) {


### PR DESCRIPTION
# Why
Closes #34592
When using the camera inside a screen from `react-native-screens`, the rotation is always set to portrait on the initial render. This is because we used an older API to determine the screen rotation which would always return `unknown` on the initial render and then default to portrait. Without screens it corrects itself but when screens locks the orientation, the camera never updates after the initial render and renders incorrectly until you manually rotate the device.

# How
Use `UIApplication.shared.connectedScenes` to correctly determine the device orientation.

# Test Plan
Tested in the provided repro and bare-expo.
