### PR TITLE
[client][Android] Remove `releaseWithDevLauncher`/`releaseWithDevMenu`

### DIFF
--- a/packages/expo-dev-client/android/build.gradle
+++ b/packages/expo-dev-client/android/build.gradle
@@ -30,17 +30,6 @@ android {
     buildTypes.each {
       it.buildConfigField 'String', 'VERSION', "\"${defaultConfig.versionName}\""
     }
-
-    releaseWithDevLauncher {
-      initWith release
-      matchingFallbacks = ['release', 'debug']
-    }
-  }
-
-  sourceSets {
-    releaseWithDevLauncher {
-      setRoot 'src/debug'
-    }
   }
 
   buildFeatures {

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -68,11 +68,6 @@ android {
     buildTypes.each {
       it.buildConfigField 'String', 'VERSION', "\"${defaultConfig.versionName}\""
     }
-
-    releaseWithDevLauncher {
-      initWith release
-      matchingFallbacks = ['release', 'debug']
-    }
   }
 
   sourceSets {
@@ -96,9 +91,6 @@ android {
           srcDirs += "src/rn74/debug"
         }
       }
-    }
-    releaseWithDevLauncher {
-      setRoot 'src/debug'
     }
   }
 

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -67,13 +67,6 @@ android {
     versionName '6.0.12'
   }
 
-  buildTypes {
-    releaseWithDevMenu {
-      initWith release
-      matchingFallbacks = ['release', 'debug']
-    }
-  }
-
   sourceSets {
     def rnVersion = getRNVersion()
     main {
@@ -89,10 +82,6 @@ android {
         srcDirs += ['../vendored/react-native-safe-area-context/android/']
 
       }
-    }
-
-    releaseWithDevMenu {
-      setRoot 'src/debug'
     }
   }
   buildFeatures {


### PR DESCRIPTION
# Why

Removes `releaseWithDevLauncher`/`releaseWithDevMenu` variants. 

# How

We've never documented those variants, and probably, no one is using them. Moreover, they can cause some problems when running the `./gradlew build` command. The same config can be achieved by configuring just your app (it can be more tricky, but it's possible). 

# Test Plan

- bare-expo ✅ 