### PR TITLE
[docs] add custom MDX notation for SDK compatibility note

### DIFF
--- a/docs/mdx-plugins/remark-sdk-compatibility.js
+++ b/docs/mdx-plugins/remark-sdk-compatibility.js
@@ -1,0 +1,17 @@
+import { visit } from 'unist-util-visit';
+
+/**
+ * @typedef {import('@types/mdast').Root} Root - https://github.com/syntax-tree/mdast#root
+ */
+
+export default function remarkSDKCompatibility() {
+  /** @param {Root} tree */
+  return tree => {
+    visit(tree, 'text', node => {
+      node.value = node.value.replace(
+        /\^{3}(\d+)/g,
+        (_, sdkVersion) => `(available in Expo SDK ${sdkVersion} or higher)`
+      );
+    });
+  };
+}

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -15,6 +15,7 @@ import remarkCodeTitle from './mdx-plugins/remark-code-title.js';
 import remarkCreateStaticProps from './mdx-plugins/remark-create-static-props.js';
 import remarkExportHeadings from './mdx-plugins/remark-export-headings.js';
 import remarkLinkRewrite from './mdx-plugins/remark-link-rewrite.js';
+import remarkSDKCompatibility from './mdx-plugins/remark-sdk-compatibility.js';
 import navigation from './public/static/constants/navigation.json';
 import { VERSIONS } from './public/static/constants/versions.json';
 import createSitemap from './scripts/create-sitemap.js';
@@ -75,6 +76,7 @@ const nextConfig: NextConfig = {
               remarkCodeTitle,
               remarkExportHeadings,
               remarkLinkRewrite,
+              remarkSDKCompatibility,
               [remarkCreateStaticProps, `{ meta: meta || {}, headings: headings || [] }`],
             ],
             rehypePlugins: [rehypeSlug],


### PR DESCRIPTION
# Why

Fixes ENG-14806

# How

Add custom MDX notation (`^^^` + `number`) for SDK compatibility note via small remark plugin.

I have made sure that the character sequence is unique enough, maybe even `^^` prefix would be fine, but I wanted to be extra safe, to avoid incidental usage.

# Test Plan

The custom notation has been tested out by editing one of the MDX files locally.

# Preview

![Screenshot 2025-02-06 at 13 51 25](https://github.com/user-attachments/assets/0c157bce-8dd5-4c1a-8304-9c3460891514)

![Screenshot 2025-02-06 at 13 52 07](https://github.com/user-attachments/assets/0b429cee-faa3-4246-801f-318b0eb706f8)
