### PR TITLE
[expo-ui] Fix TV compile CI

### DIFF
--- a/.github/workflows/tvos-compile-test.yml
+++ b/.github/workflows/tvos-compile-test.yml
@@ -23,6 +23,7 @@ on:
       - packages/expo-asset/**
       - packages/expo-audio/**
       - packages/expo-blur/**
+      - packages/expo-crypto/**
       - packages/expo-device/**
       - packages/expo-file-system/**
       - packages/expo-font/**
@@ -35,8 +36,12 @@ on:
       - packages/expo-manifests/**
       - packages/expo-modules-autolinking/**
       - packages/expo-modules-core/**
+      - packages/expo-network/**
+      - packages/expo-secure-store/**
       - packages/expo-splash-screen/**
+      - packages/expo-symbols/**
       - packages/expo-structured-headers/**
+      - packages/expo-ui/**
       - packages/expo-updates-interface/**
       - packages/expo-updates/**
       - packages/expo-video/**

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix tvOS compilation. ([#34730](https://github.com/expo/expo/pull/34730) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))

--- a/packages/expo-ui/ios/ContextMenu/ContextMenu.swift
+++ b/packages/expo-ui/ios/ContextMenu/ContextMenu.swift
@@ -63,11 +63,15 @@ struct SinglePressContextMenu<ActivationElement: View>: View {
   let props: ContextMenuProps?
 
   var body: some View {
+    #if !os(tvOS)
     SwiftUI.Menu {
       MenuItems(fromElements: elements, props: props)
     } label: {
       activationElement
     }
+    #else
+    Text("SinglePressContextMenu is not supported on this platform")
+    #endif
   }
 }
 

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -54,11 +54,11 @@ function getExpoDependencyChunks({
             'expo-audio',
             'expo-av',
             'expo-blur',
+            'expo-crypto',
             'expo-image',
             'expo-linear-gradient',
             'expo-linking',
             'expo-localization',
-            'expo-crypto',
             'expo-network',
             'expo-secure-store',
             'expo-symbols',
@@ -367,7 +367,7 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@~0.76.6-0',
+        'react-native': 'npm:react-native-tvos@~0.77.0-0',
         '@react-native-tvos/config-tv': '^0.1.1',
       },
       expo: {


### PR DESCRIPTION
- Fix tvOS compile error in ContextMenu
- Update RNTV version in test configuration
- Add expo-ui and other packages to TV compile CI dependencies

# Test Plan

TV compile CI should pass
