### PR TITLE
[ios][camera] Performance audit

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [Android] Fix an issue where the camera image is pixelated when using the gl integration. ([#34174](https://github.com/expo/expo/pull/34174) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix setting the camera preview provider. ([#34302](https://github.com/expo/expo/pull/34302) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix initial roation when used with `react-native-screens`. ([#34721](https://github.com/expo/expo/pull/34721) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix performance regression.
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [Android] Fix an issue where the camera image is pixelated when using the gl integration. ([#34174](https://github.com/expo/expo/pull/34174) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix setting the camera preview provider. ([#34302](https://github.com/expo/expo/pull/34302) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix initial roation when used with `react-native-screens`. ([#34721](https://github.com/expo/expo/pull/34721) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix performance regression.
+- [iOS] Fix performance regression. ([#34750](https://github.com/expo/expo/pull/34750) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -83,27 +83,48 @@ public final class CameraViewModule: Module, ScannerResultHandler {
         if let type, view.presetCamera != type.toPosition() {
           view.presetCamera = type.toPosition()
         }
+        // the prop has been removed, reset to default
+        if type == nil && view.presetCamera != .back {
+          view.presetCamera = .back
+        }
       }
 
       Prop("flashMode") { (view, flashMode: FlashMode?) in
         if let flashMode, view.flashMode != flashMode {
           view.flashMode = flashMode
         }
+        if flashMode == nil && view.flashMode != .auto {
+          view.flashMode = .auto
+        }
       }
 
       Prop("enableTorch") { (view, enabled: Bool?) in
-        view.torchEnabled = enabled ?? false
+        if let enabled, view.torchEnabled != enabled {
+          view.torchEnabled = enabled
+          return
+        }
+        if enabled == nil && view.torchEnabled {
+          view.torchEnabled = false
+        }
       }
 
       Prop("pictureSize") { (view, pictureSize: PictureSize?) in
         if let pictureSize, view.pictureSize != pictureSize {
           view.pictureSize = pictureSize
+          return
+        }
+        if pictureSize == nil && view.pictureSize != .high {
+          view.pictureSize = .high
         }
       }
 
       Prop("zoom") { (view, zoom: Double?) in
         if let zoom, fabs(view.zoom - zoom) > Double.ulpOfOne {
           view.zoom = zoom
+          return
+        }
+        if zoom == nil && view.zoom != 0 {
+          view.zoom = 0
         }
       }
 
@@ -111,11 +132,18 @@ public final class CameraViewModule: Module, ScannerResultHandler {
         if let mode, view.mode != mode {
           view.mode = mode
         }
+        if mode == nil && view.mode != .picture {
+          view.mode = .picture
+        }
       }
 
       Prop("barcodeScannerEnabled") { (view, scanBarcodes: Bool?) in
         if let scanBarcodes, view.isScanningBarcodes != scanBarcodes {
           view.isScanningBarcodes = scanBarcodes
+          return
+        }
+        if scanBarcodes == nil && view.isScanningBarcodes != false {
+          view.isScanningBarcodes = false
         }
       }
 
@@ -126,56 +154,71 @@ public final class CameraViewModule: Module, ScannerResultHandler {
       }
 
       Prop("mute") { (view, muted: Bool?) in
-        view.isMuted = muted ?? false
+        if let muted, view.isMuted != muted {
+          view.isMuted = muted
+          return
+        }
+        if muted == nil && view.isMuted != false {
+          view.isMuted = false
+        }
       }
 
       Prop("animateShutter") { (view, animate: Bool?) in
+        // Does not call anything that immediately causes any configuration changes
+        // so it's fine to just set it
         view.animateShutter = animate ?? true
       }
 
       Prop("videoQuality") { (view, quality: VideoQuality?) in
-        view.videoQuality = quality ?? .video1080p
+        if let quality, view.videoQuality != quality {
+          view.videoQuality = quality
+          return
+        }
+        if quality == nil && view.videoQuality != .video1080p {
+          view.videoQuality = .video1080p
+        }
       }
 
       Prop("autoFocus") { (view, focusMode: FocusMode?) in
-        view.autoFocus = focusMode?.toAVCaptureFocusMode() ?? .continuousAutoFocus
+        if let focusMode, view.autoFocus != focusMode.toAVCaptureFocusMode() {
+          view.autoFocus = focusMode.toAVCaptureFocusMode()
+          return
+        }
+        if focusMode == nil && view.autoFocus != .continuousAutoFocus {
+          view.autoFocus = .continuousAutoFocus
+        }
       }
 
       Prop("responsiveOrientationWhenOrientationLocked") { (view, responsiveOrientation: Bool?) in
         if let responsiveOrientation, view.responsiveWhenOrientationLocked != responsiveOrientation {
           view.responsiveWhenOrientationLocked = responsiveOrientation
+          return
+        }
+        if responsiveOrientation == nil && view.responsiveWhenOrientationLocked != false {
+          view.responsiveWhenOrientationLocked = false
         }
       }
 
       Prop("mirror") { (view, mirror: Bool?) in
-        if let mirror {
-          view.mirror = mirror
-          return
-        }
-        view.mirror = false
+        // Does not call anything that immediately causes any configuration changes
+        // so it's fine to just set it
+        view.mirror = mirror ?? false
       }
 
       Prop("active") { (view, active: Bool?) in
-        if let active {
+        if let active, view.active != active {
           view.active = active
           return
+        }
+        if active == nil && view.active != true {
+          view.active = true
         }
       }
 
       Prop("videoBitrate") { (view, bitrate: Int?) in
-        if let bitrate {
-          view.videoBitrate = bitrate
-          return
-        }
-        if view.videoBitrate != nil {
-          view.videoBitrate = nil
-        }
-      }
-
-      OnViewDidUpdateProps { view in
-        Task {
-          await view.initCamera()
-        }
+        // Does not call anything that immediately causes any configuration changes
+        // so it's fine to just set it
+        view.videoBitrate = bitrate
       }
 
       AsyncFunction("resumePreview") { view in

--- a/packages/expo-camera/ios/Current/BarcodeScanner.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScanner.swift
@@ -108,9 +108,6 @@ actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
   }
 
   private func addOutputs() async {
-    session.beginConfiguration()
-    defer { session.commitConfiguration() }
-
     delegate = MetaDataDelegate(
       settings: settings,
       previewLayer: previewLayer,
@@ -118,6 +115,7 @@ actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
       zxingEnabled: zxingEnabled,
       metadataResultHandler: self)
 
+    session.beginConfiguration()
     if metadataOutput == nil {
       let output = AVCaptureMetadataOutput()
       output.setMetadataObjectsDelegate(delegate, queue: sessionQueue)
@@ -137,6 +135,7 @@ actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
         videoDataOutput = output
       }
     }
+    session.commitConfiguration()
   }
 
   private func removeOutputs() async {

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -26,7 +26,6 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     mm.gyroUpdateInterval = 0.2
     return mm
   }()
-  private var cameraShouldInit = true
   private var isSessionPaused = false
 
   // MARK: Property Observers
@@ -39,8 +38,8 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
 
   var videoQuality: VideoQuality = .video1080p {
     didSet {
-      Task {
-        await updateSessionPreset(preset: videoQuality.toPreset())
+      sessionQueue.async {
+        self.updateSessionPreset(preset: self.videoQuality.toPreset())
       }
     }
   }
@@ -57,7 +56,9 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
 
   var presetCamera = AVCaptureDevice.Position.back {
     didSet {
-      updateType()
+      sessionQueue.async {
+        self.updateDevice()
+      }
     }
   }
 
@@ -77,31 +78,31 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
 
   var pictureSize = PictureSize.high {
     didSet {
-      Task {
-        await updatePictureSize()
-      }
+      updatePictureSize()
     }
   }
 
   var mode = CameraMode.picture {
     didSet {
-      Task {
-        await setCameraMode()
+      sessionQueue.async {
+        self.setCameraMode()
       }
     }
   }
 
   var isMuted = false {
     didSet {
-      Task {
-        await updateSessionAudioIsMuted()
+      sessionQueue.async {
+        self.updateSessionAudioIsMuted()
       }
     }
   }
 
   var active = true {
     didSet {
-      updateCameraIsActive()
+      sessionQueue.async {
+        self.updateCameraIsActive()
+      }
     }
   }
 
@@ -154,6 +155,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
       name: UIDevice.orientationDidChangeNotification,
       object: nil)
     lifecycleManager?.register(self)
+    initializeCaptureSessionInput()
   }
 
   private func setupPreview() {
@@ -161,44 +163,51 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     previewLayer.needsDisplayOnBoundsChange = true
   }
 
-  func initCamera() async {
-    guard cameraShouldInit else {
+  private func updateDevice() {
+    guard let device = ExpoCameraUtils.device(with: .video, preferring: presetCamera) else {
       return
     }
-    cameraShouldInit = false
-    await initializeCaptureSessionInput()
-  }
-
-  private func updateType() {
-    cameraShouldInit = true
+    
+    session.beginConfiguration()
+    defer { session.commitConfiguration() }
+    if let captureDeviceInput {
+      session.removeInput(captureDeviceInput)
+    }
+    
+    do {
+      let deviceInput = try AVCaptureDeviceInput(device: device)
+      if session.canAddInput(deviceInput) {
+        session.addInput(deviceInput)
+        captureDeviceInput = deviceInput
+        updateZoom()
+      }
+    } catch {
+      onMountError(["message": "Camera could not be started - \(error.localizedDescription)"])
+    }
   }
 
   public func onAppForegrounded() {
     if !session.isRunning && isSessionPaused {
       isSessionPaused = false
-      sessionQueue.async {
-        self.session.startRunning()
-        self.enableTorch()
-      }
+      session.startRunning()
+      enableTorch()
     }
   }
 
   public func onAppBackgrounded() {
     if session.isRunning && !isSessionPaused {
       isSessionPaused = true
-      sessionQueue.async {
-        self.session.stopRunning()
-      }
+      session.stopRunning()
     }
   }
 
-  private func updatePictureSize() async {
+  private func updatePictureSize() {
 #if !targetEnvironment(simulator)
-    session.beginConfiguration()
-    defer { session.commitConfiguration() }
-    let preset = pictureSize.toCapturePreset()
-    if session.canSetSessionPreset(preset) {
-      session.sessionPreset = preset
+    sessionQueue.async {
+      let preset = self.pictureSize.toCapturePreset()
+      if self.session.canSetSessionPreset(preset) {
+        self.session.sessionPreset = preset
+      }
     }
 #endif
   }
@@ -236,18 +245,33 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     device.unlockForConfiguration()
   }
 
-  private func setCameraMode() async {
+  private func setCameraMode() {
     if mode == .video {
       if videoFileOutput == nil {
-        await setupMovieFileCapture()
+        setupMovieFileCapture()
       }
-      await updateSessionAudioIsMuted()
+      updateSessionAudioIsMuted()
     } else {
-      await cleanupMovieFileCapture()
+      cleanupMovieFileCapture()
+    }
+  }
+  
+  private func addBlurEffect() {
+    Task { @MainActor in
+      let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .prominent))
+      visualEffectView.frame = self.bounds
+      visualEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      self.addSubview(visualEffectView)
+      
+      UIView.animate(withDuration: 1, animations: {
+        visualEffectView.alpha = 0
+      }) { _ in
+        visualEffectView.removeFromSuperview()
+      }
     }
   }
 
-  private func startSession() async {
+  private func startSession() {
 #if targetEnvironment(simulator)
     return
 #else
@@ -262,17 +286,19 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
 
     let photoOutput = AVCapturePhotoOutput()
     photoOutput.isLivePhotoCaptureEnabled = false
+    session.beginConfiguration()
     if session.canAddOutput(photoOutput) {
       session.addOutput(photoOutput)
       self.photoOutput = photoOutput
     }
 
     session.sessionPreset = mode == .video ? pictureSize.toCapturePreset() : .photo
-    addErrorNotification()
-    await changePreviewOrientation()
-
-    await barcodeScanner?.maybeStartBarcodeScanning()
     session.commitConfiguration()
+    addErrorNotification()
+    changePreviewOrientation()
+    Task.detached(priority: .userInitiated, operation: {
+      await self.barcodeScanner?.maybeStartBarcodeScanning()
+    })
     updateCameraIsActive()
     onCameraReady()
     enableTorch()
@@ -303,7 +329,9 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
         if !session.isRunning {
           session.startRunning()
         }
-        await updateSessionAudioIsMuted()
+        sessionQueue.async {
+          self.updateSessionAudioIsMuted()
+        }
         onCameraReady()
       }
     }
@@ -611,14 +639,14 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
         self.videoCodecType = codecType
       } else {
         promise.reject(CameraRecordingException(options.codec?.rawValue))
-        await cleanupMovieFileCapture()
+        cleanupMovieFileCapture()
         videoRecordedPromise = nil
         isValidVideoOptions = false
       }
     }
   }
 
-  func updateSessionAudioIsMuted() async {
+  func updateSessionAudioIsMuted() {
     session.beginConfiguration()
     defer { session.commitConfiguration() }
 
@@ -647,21 +675,17 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     }
   }
 
-  func setupMovieFileCapture() async {
+  func setupMovieFileCapture() {
     let output = AVCaptureMovieFileOutput()
     if session.canAddOutput(output) {
-      session.beginConfiguration()
-      defer { session.commitConfiguration() }
       session.addOutput(output)
       videoFileOutput = output
     }
   }
 
-  func cleanupMovieFileCapture() async {
+  func cleanupMovieFileCapture() {
     if let videoFileOutput {
       if session.outputs.contains(videoFileOutput) {
-        session.beginConfiguration()
-        defer { session.commitConfiguration() }
         session.removeOutput(videoFileOutput)
         self.videoFileOutput = nil
       }
@@ -677,8 +701,8 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
 
   public override func removeFromSuperview() {
     super.removeFromSuperview()
-    Task {
-      await stopSession()
+    sessionQueue.async {
+      self.stopSession()
     }
     lifecycleManager?.unregisterAppLifecycleListener(self)
     UIDevice.current.endGeneratingDeviceOrientationNotifications()
@@ -722,15 +746,11 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     videoCodecType = nil
   }
 
-  func setPresetCamera(presetCamera: AVCaptureDevice.Position) {
-    self.presetCamera = presetCamera
-  }
-
   func stopRecording() {
     videoFileOutput?.stopRecording()
   }
 
-  func updateSessionPreset(preset: AVCaptureSession.Preset) async {
+  func updateSessionPreset(preset: AVCaptureSession.Preset) {
 #if !targetEnvironment(simulator)
     if session.canSetSessionPreset(preset) {
       if session.sessionPreset != preset {
@@ -738,36 +758,25 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
         defer { session.commitConfiguration() }
         session.sessionPreset = preset
       }
+    } else {
+      // The selected preset cannot be used on the current device so we fall back to the highest available.
+      if session.sessionPreset != .high {
+        session.beginConfiguration()
+        defer { session.commitConfiguration() }
+        session.sessionPreset = .high
+      }
     }
 #endif
   }
 
-  func initializeCaptureSessionInput() async {
-    session.beginConfiguration()
-
-    guard let device = ExpoCameraUtils.device(with: .video, preferring: presetCamera) else {
-      return
+  func initializeCaptureSessionInput() {
+    sessionQueue.async {
+      self.updateDevice()
+      self.startSession()
     }
-
-    if let captureDeviceInput {
-      session.removeInput(captureDeviceInput)
-    }
-
-    do {
-      let deviceInput = try AVCaptureDeviceInput(device: device)
-
-      if session.canAddInput(deviceInput) {
-        session.addInput(deviceInput)
-        captureDeviceInput = deviceInput
-        updateZoom()
-      }
-    } catch {
-      onMountError(["message": "Camera could not be started - \(error.localizedDescription)"])
-    }
-    await startSession()
   }
 
-  private func stopSession() async {
+  private func stopSession() {
 #if targetEnvironment(simulator)
     return
 #else
@@ -779,7 +788,9 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     for output in session.outputs {
       session.removeOutput(output)
     }
-    await barcodeScanner?.stopBarcodeScanning()
+    Task {
+      await barcodeScanner?.stopBarcodeScanning()
+    }
     session.commitConfiguration()
 
     motionManager.stopAccelerometerUpdates()
@@ -803,13 +814,14 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     }
   }
 
-  @MainActor
-  func changePreviewOrientation() async {
+  func changePreviewOrientation() {
     // We shouldn't access the device orientation anywhere but on the main thread
-    let videoOrientation = ExpoCameraUtils.videoOrientation(for: deviceOrientation)
-    if (previewLayer.connection?.isVideoOrientationSupported) == true {
-      physicalOrientation = ExpoCameraUtils.physicalOrientation(for: deviceOrientation)
-      previewLayer.connection?.videoOrientation = videoOrientation
+    Task { @MainActor in
+      let videoOrientation = ExpoCameraUtils.videoOrientation(for: deviceOrientation)
+      if (previewLayer.connection?.isVideoOrientationSupported) == true {
+        physicalOrientation = ExpoCameraUtils.physicalOrientation(for: deviceOrientation)
+        previewLayer.connection?.videoOrientation = videoOrientation
+      }
     }
   }
 

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -167,13 +167,13 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     guard let device = ExpoCameraUtils.device(with: .video, preferring: presetCamera) else {
       return
     }
-    
+
     session.beginConfiguration()
     defer { session.commitConfiguration() }
     if let captureDeviceInput {
       session.removeInput(captureDeviceInput)
     }
-    
+
     do {
       let deviceInput = try AVCaptureDeviceInput(device: device)
       if session.canAddInput(deviceInput) {
@@ -253,21 +253,6 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
       updateSessionAudioIsMuted()
     } else {
       cleanupMovieFileCapture()
-    }
-  }
-  
-  private func addBlurEffect() {
-    Task { @MainActor in
-      let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .prominent))
-      visualEffectView.frame = self.bounds
-      visualEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-      self.addSubview(visualEffectView)
-      
-      UIView.animate(withDuration: 1, animations: {
-        visualEffectView.alpha = 0
-      }) { _ in
-        visualEffectView.removeFromSuperview()
-      }
     }
   }
 


### PR DESCRIPTION
# Why
While working on #34656, I noticed there is a large performance regression on iOS so I decided to audit the module to find the issues.

# How
It was caused by two primary factors. The move to swift concurrency and oversetting props.

### Swift Concurrency
A combination of misuse on my part and it not being ideally suited to our use case. In many instances I was making changes on the main thread, causing stutters and frame drops. I didn't see this at the time but it seems to have gotten significantly more noticeable. SwiftUI has great primitives for using swift concurrency like the `.task()` modifier but we can't make use of that. In our case we were starting tasks using the `Task` api which by default inherits the thread context it was called in. Moving back to the `seesionQueue` brings performance back to where it should be.

### Props
Props were being set too frequently in some cases causing unnecessary work. We should only make a change if 
1. the prop has changed from the current setting.
2. the prop has been removed so we return to the default setting.

# Test Plan
Bare-expo. The camera now renders instantly and no longer causes hitches in the navigation animation. There is no evidence of dead frames that I can see and changing props no longer causes freezes in the preview. Overall a huge improvement and where I would expect it to be.

Thoroughly tested all functionality. All props respond correctly. Barcode scanning is working. 
