### PR TITLE
[docs] [ENG-14809] Add `on.pull_request_labeled` docs

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -104,7 +104,7 @@ on:
 
 Runs your workflow when a pull request is labeled with a matching label.
 
-With the `labels` array, you can specify which labels, when assigned to your pull request, will trigger the workflow. For example, if you use `labels: ['Test']`, only pull request labeled with `Test` label will trigger the workflow. Defaults to `[]` when not provided, which means no labels will trigger the workflow.
+With the `labels` array, you can specify which labels, when assigned to your pull request, will trigger the workflow. For example, if you use `labels: ['Test']`, only labeling a pull request with the `Test` label will trigger the workflow. Defaults to `[]` when not provided, which means no labels will trigger the workflow.
 
 You can also provide the list of matching labels directly to `on.pull_request_labeled` for simpler syntax.
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -84,6 +84,7 @@ With the `types` array, you can trigger the workflow only on the specified pull 
 - `opened`
 - `reopened`
 - `synchronize`
+- `labeled`
 
 ```yaml
 on:
@@ -97,6 +98,37 @@ on:
     types:
       - 'opened'
       # other event types
+```
+
+### `on.pull_request_labeled`
+
+Runs your workflow when a pull request is labeled with a matching label.
+
+With the `labels` array, you can specify which labels, when assigned to your pull request, will trigger the workflow. For example, if you use `labels: ['Test']`, only pull request labeled with `Test` label will trigger the workflow. Defaults to `[]` when not provided, which means no labels will trigger the workflow.
+
+You can also provide the list of matching labels directly to `on.pull_request_labeled` for simpler syntax.
+
+```yaml
+on:
+  # @info #
+  pull_request_labeled:
+    # @end #
+    labels:
+      - 'Test'
+      - 'Preview'
+      # other labels
+```
+
+or, alternatively:
+
+```yaml
+on:
+  # @info #
+  pull_request_labeled:
+    # @end #
+    - 'Test'
+    - 'Preview'
+    # other labels
 ```
 
 ## `jobs`

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -119,7 +119,7 @@ on:
       # other labels
 ```
 
-or, alternatively:
+Alternatively:
 
 ```yaml
 on:


### PR DESCRIPTION
Added the docs for `on.pull_request_labeled` trigger

See: https://linear.app/expo/issue/ENG-14809/allow-triggering-jobs-from-labeled-prs

# Why

https://linear.app/expo/issue/ENG-14809/allow-triggering-jobs-from-labeled-prs
Added option to trigger the workflow when pull request is labeled. This adds the docs for it.

# How

Added the docs for `on.pull_request_labeled` trigger

# Test Plan

Tested manually

| Before | After |
| - | - |
| ![Screenshot 2025-02-07 at 16 04 32](https://github.com/user-attachments/assets/387d9540-d194-4ce2-bbc1-6b173e7b00c3) | ![Screenshot 2025-02-07 at 16 04 08](https://github.com/user-attachments/assets/8178ecf2-65e9-4a8a-be9c-ea5ca15fa13d) |
| Did not exist | ![Screenshot 2025-02-07 at 16 04 19](https://github.com/user-attachments/assets/ff5ab02f-331f-4551-acc5-d9351376ad7f) |

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
