### PR TITLE
[expo] add ExpoImportMetaRegistry to support import.meta

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -38,7 +38,6 @@
 - [apple] Move `AppDelegate` integration from `expo-modules-core` to `expo` package. ([#34985](https://github.com/expo/expo/pull/34985) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Add EXAppDelegateWrapper import to Expo.h ([#35172](https://github.com/expo/expo/pull/35172) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Refactored `RCTReactNativeFactory` integration. ([#35679](https://github.com/expo/expo/pull/35679) by [@kudo](https://github.com/kudo))
-- Remove `transformOrigin` type override. ([#34183](https://github.com/expo/expo/pull/34183) by [@marklawlor](https://github.com/marklawlor))
 
 ## 52.0.41 - 2025-03-26
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Added `globalThis.ExpoImportMetaRegistry`. ([#34755](https://github.com/expo/expo/pull/34755) by [@kudo](https://github.com/kudo))
+
 ## 53.0.0-preview.0 — 2025-04-04
 
 - Remove `transformOrigin` type override. ([#34183](https://github.com/expo/expo/pull/34183) by [@marklawlor](https://github.com/marklawlor))
@@ -36,6 +38,7 @@
 - [apple] Move `AppDelegate` integration from `expo-modules-core` to `expo` package. ([#34985](https://github.com/expo/expo/pull/34985) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Add EXAppDelegateWrapper import to Expo.h ([#35172](https://github.com/expo/expo/pull/35172) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Refactored `RCTReactNativeFactory` integration. ([#35679](https://github.com/expo/expo/pull/35679) by [@kudo](https://github.com/kudo))
+- Remove `transformOrigin` type override. ([#34183](https://github.com/expo/expo/pull/34183) by [@marklawlor](https://github.com/marklawlor))
 
 ## 52.0.41 - 2025-03-26
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Added `globalThis.ExpoImportMetaRegistry`. ([#34755](https://github.com/expo/expo/pull/34755) by [@kudo](https://github.com/kudo))
+- Added `globalThis.__ExpoImportMetaRegistry`. ([#34755](https://github.com/expo/expo/pull/34755) by [@kudo](https://github.com/kudo))
 
 ## 53.0.0-preview.0 — 2025-04-04
 

--- a/packages/expo/build/Expo.fx.web.d.ts
+++ b/packages/expo/build/Expo.fx.web.d.ts
@@ -1,1 +1,2 @@
+import './winter';
 //# sourceMappingURL=Expo.fx.web.d.ts.map

--- a/packages/expo/build/Expo.fx.web.d.ts.map
+++ b/packages/expo/build/Expo.fx.web.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"Expo.fx.web.d.ts","sourceRoot":"","sources":["../src/Expo.fx.web.tsx"],"names":[],"mappings":""}
+{"version":3,"file":"Expo.fx.web.d.ts","sourceRoot":"","sources":["../src/Expo.fx.web.tsx"],"names":[],"mappings":"AAAA,OAAO,UAAU,CAAC"}

--- a/packages/expo/build/utils/getBundleUrl.d.ts
+++ b/packages/expo/build/utils/getBundleUrl.d.ts
@@ -1,0 +1,2 @@
+export declare function getBundleUrl(): string | null;
+//# sourceMappingURL=getBundleUrl.d.ts.map

--- a/packages/expo/build/utils/getBundleUrl.d.ts.map
+++ b/packages/expo/build/utils/getBundleUrl.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"getBundleUrl.d.ts","sourceRoot":"","sources":["../../src/utils/getBundleUrl.ts"],"names":[],"mappings":"AAEA,wBAAgB,YAAY,IAAI,MAAM,GAAG,IAAI,CAE5C"}

--- a/packages/expo/build/utils/getBundleUrl.native.d.ts
+++ b/packages/expo/build/utils/getBundleUrl.native.d.ts
@@ -1,0 +1,2 @@
+export declare function getBundleUrl(): string | null;
+//# sourceMappingURL=getBundleUrl.native.d.ts.map

--- a/packages/expo/build/utils/getBundleUrl.native.d.ts.map
+++ b/packages/expo/build/utils/getBundleUrl.native.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"getBundleUrl.native.d.ts","sourceRoot":"","sources":["../../src/utils/getBundleUrl.native.ts"],"names":[],"mappings":"AAIA,wBAAgB,YAAY,IAAI,MAAM,GAAG,IAAI,CAU5C"}

--- a/packages/expo/build/utils/getBundleUrl.web.d.ts
+++ b/packages/expo/build/utils/getBundleUrl.web.d.ts
@@ -1,0 +1,2 @@
+export declare function getBundleUrl(): string | null;
+//# sourceMappingURL=getBundleUrl.web.d.ts.map

--- a/packages/expo/build/utils/getBundleUrl.web.d.ts.map
+++ b/packages/expo/build/utils/getBundleUrl.web.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"getBundleUrl.web.d.ts","sourceRoot":"","sources":["../../src/utils/getBundleUrl.web.ts"],"names":[],"mappings":"AAEA,wBAAgB,YAAY,IAAI,MAAM,GAAG,IAAI,CAkB5C"}

--- a/packages/expo/build/winter/ImportMetaRegistry.d.ts
+++ b/packages/expo/build/winter/ImportMetaRegistry.d.ts
@@ -5,6 +5,5 @@
  */
 export declare const ImportMetaRegistry: {
     readonly url: string | null;
-    readonly env: NodeJS.ProcessEnv;
 };
 //# sourceMappingURL=ImportMetaRegistry.d.ts.map

--- a/packages/expo/build/winter/ImportMetaRegistry.d.ts
+++ b/packages/expo/build/winter/ImportMetaRegistry.d.ts
@@ -3,10 +3,8 @@
  * Similar to how it works in the web, but adapted for the RN context
  * https://github.com/wintercg/import-meta-registry
  */
-declare class ImportMetaRegistryClass {
+export declare const ImportMetaRegistry: {
     readonly url: string | null;
     readonly env: NodeJS.ProcessEnv;
-}
-export declare const ImportMetaRegistry: ImportMetaRegistryClass;
-export {};
+};
 //# sourceMappingURL=ImportMetaRegistry.d.ts.map

--- a/packages/expo/build/winter/ImportMetaRegistry.d.ts
+++ b/packages/expo/build/winter/ImportMetaRegistry.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Registry to handle import.meta functionality for React Native environment
+ * Similar to how it works in the web, but adapted for the RN context
+ * https://github.com/wintercg/import-meta-registry
+ */
+declare class ImportMetaRegistryClass {
+    readonly url: string | null;
+    readonly env: NodeJS.ProcessEnv;
+}
+export declare const ImportMetaRegistry: ImportMetaRegistryClass;
+export {};
+//# sourceMappingURL=ImportMetaRegistry.d.ts.map

--- a/packages/expo/build/winter/ImportMetaRegistry.d.ts.map
+++ b/packages/expo/build/winter/ImportMetaRegistry.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ImportMetaRegistry.d.ts","sourceRoot":"","sources":["../../src/winter/ImportMetaRegistry.ts"],"names":[],"mappings":"AAIA;;;;GAIG;AACH,cAAM,uBAAuB;IAC3B,SAAgB,GAAG,gBAAkB;IAErC,SAAgB,GAAG,oBAAe;CACnC;AAED,eAAO,MAAM,kBAAkB,yBAAgC,CAAC"}
+{"version":3,"file":"ImportMetaRegistry.d.ts","sourceRoot":"","sources":["../../src/winter/ImportMetaRegistry.ts"],"names":[],"mappings":"AAIA;;;;GAIG;AACH,eAAO,MAAM,kBAAkB;;;CAO9B,CAAC"}

--- a/packages/expo/build/winter/ImportMetaRegistry.d.ts.map
+++ b/packages/expo/build/winter/ImportMetaRegistry.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ImportMetaRegistry.d.ts","sourceRoot":"","sources":["../../src/winter/ImportMetaRegistry.ts"],"names":[],"mappings":"AAIA;;;;GAIG;AACH,eAAO,MAAM,kBAAkB;;;CAO9B,CAAC"}
+{"version":3,"file":"ImportMetaRegistry.d.ts","sourceRoot":"","sources":["../../src/winter/ImportMetaRegistry.ts"],"names":[],"mappings":"AAIA;;;;GAIG;AACH,eAAO,MAAM,kBAAkB;;CAI9B,CAAC"}

--- a/packages/expo/build/winter/ImportMetaRegistry.d.ts.map
+++ b/packages/expo/build/winter/ImportMetaRegistry.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"ImportMetaRegistry.d.ts","sourceRoot":"","sources":["../../src/winter/ImportMetaRegistry.ts"],"names":[],"mappings":"AAIA;;;;GAIG;AACH,cAAM,uBAAuB;IAC3B,SAAgB,GAAG,gBAAkB;IAErC,SAAgB,GAAG,oBAAe;CACnC;AAED,eAAO,MAAM,kBAAkB,yBAAgC,CAAC"}

--- a/packages/expo/src/Expo.fx.web.tsx
+++ b/packages/expo/src/Expo.fx.web.tsx
@@ -1,3 +1,5 @@
+import './winter';
+
 // When users dangerously import a file inside of react-native, it breaks the web alias.
 // This is one of the most common, and cryptic web errors that users encounter.
 // This conditional side-effect provides a more helpful error message for debugging.

--- a/packages/expo/src/utils/getBundleUrl.native.ts
+++ b/packages/expo/src/utils/getBundleUrl.native.ts
@@ -11,5 +11,5 @@ export function getBundleUrl(): string | null {
     scriptURL = `file://${scriptURL}`;
   }
   const url = new URL(scriptURL);
-  return `${url.protocol}//${url.host}${url.pathname}`;
+  return url.toString();
 }

--- a/packages/expo/src/utils/getBundleUrl.native.ts
+++ b/packages/expo/src/utils/getBundleUrl.native.ts
@@ -1,0 +1,15 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SourceCode from 'react-native/Libraries/NativeModules/specs/NativeSourceCode';
+
+export function getBundleUrl(): string | null {
+  let scriptURL = SourceCode.getConstants().scriptURL;
+  if (scriptURL == null) {
+    return null;
+  }
+  if (scriptURL.startsWith('/')) {
+    scriptURL = `file://${scriptURL}`;
+  }
+  const url = new URL(scriptURL);
+  return `${url.protocol}//${url.host}${url.pathname}`;
+}

--- a/packages/expo/src/utils/getBundleUrl.ts
+++ b/packages/expo/src/utils/getBundleUrl.ts
@@ -1,0 +1,5 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+export function getBundleUrl(): string | null {
+  return null;
+}

--- a/packages/expo/src/utils/getBundleUrl.web.ts
+++ b/packages/expo/src/utils/getBundleUrl.web.ts
@@ -1,7 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 export function getBundleUrl(): string | null {
-  let scriptURL: string | null = null;
+  let scriptURL: string | null | undefined = null;
 
   if (typeof window === 'undefined') {
     // For server runtime, we use the filename of the current script

--- a/packages/expo/src/utils/getBundleUrl.web.ts
+++ b/packages/expo/src/utils/getBundleUrl.web.ts
@@ -1,0 +1,21 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+export function getBundleUrl(): string | null {
+  let scriptURL: string | null = null;
+
+  if (typeof window === 'undefined') {
+    // For server runtime, we use the filename of the current script
+    // @ts-ignore The react-native tsconfig doesn't support CJS
+    scriptURL = 'file://' + __filename;
+  } else {
+    // TODO: Try to support `import.meta.url` when the ecosystem supports ESM,
+    // and jest doesn't throw SyntaxError when accessing `import.meta`.
+    scriptURL = (document.currentScript as HTMLScriptElement)?.src;
+  }
+
+  if (scriptURL == null) {
+    return null;
+  }
+  const url = new URL(scriptURL);
+  return `${url.protocol}//${url.host}${url.pathname}`;
+}

--- a/packages/expo/src/winter/ImportMetaRegistry.ts
+++ b/packages/expo/src/winter/ImportMetaRegistry.ts
@@ -7,10 +7,11 @@ import { getBundleUrl } from '../utils/getBundleUrl';
  * Similar to how it works in the web, but adapted for the RN context
  * https://github.com/wintercg/import-meta-registry
  */
-class ImportMetaRegistryClass {
-  public readonly url = getBundleUrl();
-
-  public readonly env = process.env;
-}
-
-export const ImportMetaRegistry = new ImportMetaRegistryClass();
+export const ImportMetaRegistry = {
+  get url() {
+    return getBundleUrl();
+  },
+  get env() {
+    return process.env;
+  },
+};

--- a/packages/expo/src/winter/ImportMetaRegistry.ts
+++ b/packages/expo/src/winter/ImportMetaRegistry.ts
@@ -1,0 +1,16 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import { getBundleUrl } from '../utils/getBundleUrl';
+
+/**
+ * Registry to handle import.meta functionality for React Native environment
+ * Similar to how it works in the web, but adapted for the RN context
+ * https://github.com/wintercg/import-meta-registry
+ */
+class ImportMetaRegistryClass {
+  public readonly url = getBundleUrl();
+
+  public readonly env = process.env;
+}
+
+export const ImportMetaRegistry = new ImportMetaRegistryClass();

--- a/packages/expo/src/winter/ImportMetaRegistry.ts
+++ b/packages/expo/src/winter/ImportMetaRegistry.ts
@@ -11,7 +11,4 @@ export const ImportMetaRegistry = {
   get url() {
     return getBundleUrl();
   },
-  get env() {
-    return process.env;
-  },
 };

--- a/packages/expo/src/winter/runtime.native.ts
+++ b/packages/expo/src/winter/runtime.native.ts
@@ -30,7 +30,7 @@ install('URL', () => require('./url').URL);
 // https://url.spec.whatwg.org/#urlsearchparams
 install('URLSearchParams', () => require('./url').URLSearchParams);
 
-install('ExpoImportMetaRegistry', () => require('./ImportMetaRegistry').ImportMetaRegistry);
+install('__ExpoImportMetaRegistry', () => require('./ImportMetaRegistry').ImportMetaRegistry);
 
 installFormDataPatch(FormData);
 

--- a/packages/expo/src/winter/runtime.native.ts
+++ b/packages/expo/src/winter/runtime.native.ts
@@ -30,6 +30,8 @@ install('URL', () => require('./url').URL);
 // https://url.spec.whatwg.org/#urlsearchparams
 install('URLSearchParams', () => require('./url').URLSearchParams);
 
+install('ExpoImportMetaRegistry', () => require('./ImportMetaRegistry').ImportMetaRegistry);
+
 installFormDataPatch(FormData);
 
 // Polyfill async iterator symbol for Hermes.

--- a/packages/expo/src/winter/runtime.ts
+++ b/packages/expo/src/winter/runtime.ts
@@ -1,5 +1,5 @@
-Object.defineProperty(globalThis, 'ExpoImportMetaRegistry', {
+Object.defineProperty(globalThis, '__ExpoImportMetaRegistry', {
   value: require('./ImportMetaRegistry').ImportMetaRegistry,
-  enumerable: true,
+  enumerable: false,
   writable: true,
 });

--- a/packages/expo/src/winter/runtime.ts
+++ b/packages/expo/src/winter/runtime.ts
@@ -1,0 +1,5 @@
+Object.defineProperty(globalThis, 'ExpoImportMetaRegistry', {
+  value: require('./ImportMetaRegistry').ImportMetaRegistry,
+  enumerable: true,
+  writable: true,
+});


### PR DESCRIPTION
# Why

close ENG-14578

# How

- add `globalThis.__ExpoImportMetaRegistry` which partially support wintertc's [`import.meta`](https://github.com/wintercg/import-meta-registry). currently only support `import.meta.url`.
- example of the `import.meta.url` in different runtimes
  - ios debug: `http://192.168.1.1:8081/.expo/.virtual-metro-entry.bundle`
  - ios release: `file:///Users/kudo/Library/.../HelloWorld.app/main.jsbundle`
  - ios updates: `file:///Users/kudo/Library/.../Application%20Support/.expo-internal/bundle-df2d3867-c56c-41bb-85f7-ddf954ee5e6.jsbundle`
  - android debug: `http://192.168.1.1:8081/.expo/.virtual-metro-entry.bundle`
  - android release: `assets://index.android.bundle`
  - android updates: `file:///data/user/0/dev.expo.payments/files/.expo-internal/81cd83971c616fcbbcca72864089c99f`
  - web: `http://localhost:8081/packages/expo-router/entry.bundle`
  - server:  `file:///Users/kudo/expo/expo/packages/expo-router/node/render.js.bundle`
- will have babel plugin to transform `import.meta` later

# Test Plan

test `globalThis.__ExpoImportMetaRegistry.url` in different runtimes

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
