### PR TITLE
[babel-preset] add import.meta transform plugin

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add `decorators` option to configure the `@babel/plugin-proposal-decorators` plugin. ([#34647](https://github.com/expo/expo/pull/34647) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `babel-plugin-syntax-hermes-parser` to the server preset for native RSC. ([#34213](https://github.com/expo/expo/pull/34213) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `displayName` to DOM components for better debugging. ([#33369](https://github.com/expo/expo/pull/33369) by [@EvanBacon](https://github.com/EvanBacon))
+- Added `import.meta` transform plugin. ([#34756](https://github.com/expo/expo/pull/34756) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/babel-preset-expo/README.md
+++ b/packages/babel-preset-expo/README.md
@@ -148,6 +148,12 @@ If `undefined` (default), this will be set automatically via `caller.supportsSta
 
 Changes the engine preset in `@react-native/babel-preset` based on the JavaScript engine that is being targeted. In Expo SDK 50 and greater, this is automatically set based on the [`jsEngine`](https://docs.expo.dev/versions/latest/config/app/#jsengine) option in your `app.json`.
 
+### `unstable_transformImportMeta`
+
+Enable that transform that converts `import.meta` to `globalThis.__ExpoImportMetaRegistry`, defaults to `false`.
+
+> **Note:** Use this option at your own risk. If the JavaScript engine supports `import.meta` natively, this transformation may interfere with the native implementation.
+
 ### `enableBabelRuntime`
 
 Passed to `@react-native/babel-preset`.

--- a/packages/babel-preset-expo/build/import-meta-transform-plugin.d.ts
+++ b/packages/babel-preset-expo/build/import-meta-transform-plugin.d.ts
@@ -1,0 +1,4 @@
+import { ConfigAPI, types } from '@babel/core';
+export declare function expoImportMetaTransformPlugin(api: ConfigAPI & {
+    types: typeof types;
+}): babel.PluginObj;

--- a/packages/babel-preset-expo/build/import-meta-transform-plugin.js
+++ b/packages/babel-preset-expo/build/import-meta-transform-plugin.js
@@ -1,0 +1,20 @@
+"use strict";
+// Copyright 2015-present 650 Industries. All rights reserved.
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.expoImportMetaTransformPlugin = void 0;
+function expoImportMetaTransformPlugin(api) {
+    const { types: t } = api;
+    return {
+        name: 'expo-import-meta-transform',
+        visitor: {
+            MetaProperty(path) {
+                const { node } = path;
+                if (node.meta.name === 'import' && node.property.name === 'meta') {
+                    const replacement = t.memberExpression(t.identifier('globalThis'), t.identifier('__ExpoImportMetaRegistry'));
+                    path.replaceWith(replacement);
+                }
+            },
+        },
+    };
+}
+exports.expoImportMetaTransformPlugin = expoImportMetaTransformPlugin;

--- a/packages/babel-preset-expo/build/index.d.ts
+++ b/packages/babel-preset-expo/build/index.d.ts
@@ -67,6 +67,14 @@ type BabelPresetExpoPlatformOptions = {
     };
     /** Enable `typeof window` runtime checks. The default behavior is to minify `typeof window` on web clients to `"object"` and `"undefined"` on servers. */
     minifyTypeofWindow?: boolean;
+    /**
+     * Enable that transform that converts `import.meta` to `globalThis.__ExpoImportMetaRegistry`.
+     *
+     * > **Note:** Use this option at your own risk. If the JavaScript engine supports `import.meta` natively, this transformation may interfere with the native implementation.
+     *
+     * @default `false`
+     */
+    unstable_transformImportMeta?: boolean;
 };
 export type BabelPresetExpoOptions = BabelPresetExpoPlatformOptions & {
     /** Web-specific settings. */

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -181,6 +181,9 @@ function babelPresetExpo(api, options = {}) {
     if (platformOptions.disableImportExportTransform) {
         extraPlugins.push([require('./detect-dynamic-exports').detectDynamicExports]);
     }
+    if (platformOptions.unstable_transformImportMeta === true) {
+        extraPlugins.push(require('./import-meta-transform-plugin').expoImportMetaTransformPlugin);
+    }
     return {
         presets: [
             (() => {

--- a/packages/babel-preset-expo/src/__tests__/import-meta-transform-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/import-meta-transform-plugin.test.ts
@@ -1,0 +1,43 @@
+import * as babel from '@babel/core';
+
+import preset from '..';
+
+function getCaller(props: Record<string, string | boolean>): babel.TransformCaller {
+  return props as unknown as babel.TransformCaller;
+}
+
+const DEF_OPTIONS = {
+  // Ensure this is absolute to prevent the filename from being converted to absolute and breaking CI tests.
+  filename: '/unknown',
+  babelrc: false,
+  presets: [preset],
+  sourceMaps: true,
+  configFile: false,
+  compact: false,
+  comments: true,
+  retainLines: true,
+  caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'ios' }),
+};
+
+it(`transforms import.meta.url to globalThis.__ExpoImportMetaRegistry.url when unstable_transformImportMeta is true`, () => {
+  const options = {
+    ...DEF_OPTIONS,
+    presets: [[preset, { unstable_transformImportMeta: true }]],
+    caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'ios', isDev: true }),
+  };
+
+  const sourceCode = `var url = import.meta.url;`;
+  expect(babel.transform(sourceCode, options)!.code).toMatchInlineSnapshot(
+    `"var url = globalThis.__ExpoImportMetaRegistry.url;"`
+  );
+});
+
+it(`should not transform import.meta by default`, () => {
+  const options = {
+    ...DEF_OPTIONS,
+    caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'ios', isDev: true }),
+  };
+
+  const sourceCode = `var url = import.meta.url;`;
+  expect(babel.transform(sourceCode, options)!.code).toEqual(sourceCode);
+});

--- a/packages/babel-preset-expo/src/import-meta-transform-plugin.ts
+++ b/packages/babel-preset-expo/src/import-meta-transform-plugin.ts
@@ -1,0 +1,25 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import { ConfigAPI, types } from '@babel/core';
+
+export function expoImportMetaTransformPlugin(
+  api: ConfigAPI & { types: typeof types }
+): babel.PluginObj {
+  const { types: t } = api;
+
+  return {
+    name: 'expo-import-meta-transform',
+    visitor: {
+      MetaProperty(path) {
+        const { node } = path;
+        if (node.meta.name === 'import' && node.property.name === 'meta') {
+          const replacement = t.memberExpression(
+            t.identifier('globalThis'),
+            t.identifier('__ExpoImportMetaRegistry')
+          );
+          path.replaceWith(replacement);
+        }
+      },
+    },
+  };
+}

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -99,6 +99,15 @@ type BabelPresetExpoPlatformOptions = {
 
   /** Enable `typeof window` runtime checks. The default behavior is to minify `typeof window` on web clients to `"object"` and `"undefined"` on servers. */
   minifyTypeofWindow?: boolean;
+
+  /**
+   * Enable that transform that converts `import.meta` to `globalThis.__ExpoImportMetaRegistry`.
+   *
+   * > **Note:** Use this option at your own risk. If the JavaScript engine supports `import.meta` natively, this transformation may interfere with the native implementation.
+   *
+   * @default `false`
+   */
+  unstable_transformImportMeta?: boolean;
 };
 
 export type BabelPresetExpoOptions = BabelPresetExpoPlatformOptions & {
@@ -318,6 +327,9 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
 
   if (platformOptions.disableImportExportTransform) {
     extraPlugins.push([require('./detect-dynamic-exports').detectDynamicExports]);
+  }
+  if (platformOptions.unstable_transformImportMeta === true) {
+    extraPlugins.push(require('./import-meta-transform-plugin').expoImportMetaTransformPlugin);
   }
 
   return {


### PR DESCRIPTION
# Why

close ENG-14578

# How

because hermes doesn't support `import.meta` and throws "import.meta' is currently unsupported" error whenever the code has `import.meta`, even to overwrite it as `import.meta = { url: ... }`. we have to transform import.meta to something else before reaching into hermes.

this pr adds a babel plugin to transform `import.meta` to `globalThis.ExpoImportMetaRegistry`

# Test Plan

add unit test and ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
