### PR TITLE
[android][camera] Attempt to fix `setLinearZoom` incompatibility

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [Android] Fix setting the camera preview provider. ([#34302](https://github.com/expo/expo/pull/34302) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix initial roation when used with `react-native-screens`. ([#34721](https://github.com/expo/expo/pull/34721) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix performance regression. ([#34750](https://github.com/expo/expo/pull/34750) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Attempt to fix `setLinearZoom` incompatability with some devices. ([#34757](https://github.com/expo/expo/pull/34757) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -82,9 +82,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.io.File
+import java.lang.Float.max
+import java.lang.Float.min
 import kotlin.math.roundToInt
 import kotlin.properties.Delegates
-import kotlin.text.toFloat
 
 const val ANIMATION_FAST_MILLIS = 50L
 const val ANIMATION_SLOW_MILLIS = 100L
@@ -152,7 +153,7 @@ class ExpoCameraView(
   var zoom: Float = 0f
     set(value) {
       field = value
-      camera?.cameraControl?.setLinearZoom(value.coerceIn(0f, 1f))
+      setCameraZoom(value)
     }
 
   var autoFocus: FocusMode = FocusMode.OFF
@@ -469,7 +470,7 @@ class ExpoCameraView(
             observeCameraState(it.cameraInfo)
           }
           // Set the previous zoom level after recreating the camera
-          camera?.cameraControl?.setLinearZoom(zoom.coerceIn(0f, 1f))
+          setCameraZoom(zoom)
           this.cameraProvider = cameraProvider
         } catch (_: Exception) {
           onMountError(
@@ -579,6 +580,16 @@ class ExpoCameraView(
       )
         .build()
       it.cameraControl.startFocusAndMetering(action)
+    }
+  }
+
+  private fun setCameraZoom(value: Float) {
+    val maxZoomRatio = camera?.cameraInfo?.zoomState?.value?.maxZoomRatio ?: 1f
+    val targetZoomRatio = max(1f, min(maxZoomRatio, value.coerceIn(0f, 1f) * maxZoomRatio))
+    try {
+      camera?.cameraControl?.setZoomRatio(targetZoomRatio)
+    } catch (e: Exception) {
+      camera?.cameraControl?.setLinearZoom(value.coerceIn(0f, 1f))
     }
   }
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -586,11 +586,7 @@ class ExpoCameraView(
   private fun setCameraZoom(value: Float) {
     val maxZoomRatio = camera?.cameraInfo?.zoomState?.value?.maxZoomRatio ?: 1f
     val targetZoomRatio = max(1f, min(maxZoomRatio, value.coerceIn(0f, 1f) * maxZoomRatio))
-    try {
-      camera?.cameraControl?.setZoomRatio(targetZoomRatio)
-    } catch (e: Exception) {
-      camera?.cameraControl?.setLinearZoom(value.coerceIn(0f, 1f))
-    }
+    camera?.cameraControl?.setZoomRatio(targetZoomRatio)
   }
 
   private fun observeCameraState(cameraInfo: CameraInfo) {


### PR DESCRIPTION
# Why
Closes #34749

# How
It seems `setLinearZoom` is not available on all devices. The other option we have is to use `setZoomRatio` which is suppoesed to have wider compatibility. I don't have access to the device with the issue so this is a best effort to attempt a fix. My own device works as before.

# Test Plan
Bare-expo. Zooming works as before.
