### PR TITLE
[linking] make universal linking more prominent

### DIFF
--- a/docs/pages/linking/into-your-app.mdx
+++ b/docs/pages/linking/into-your-app.mdx
@@ -7,7 +7,7 @@ description: Learn how to handle an incoming URL in your React Native and Expo a
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
-This guide provides steps to configure standard **deep links** in your project by adding a custom scheme.
+This guide provides steps to configure standard **deep links** in your project by adding a custom scheme. For production apps, you probably want to (also) set up app [Universal linking](/linking/overview/#universal-linking).
 
 ## Add a custom scheme in app config
 
@@ -47,7 +47,7 @@ Running the above command:
 
 - Opens your app's `/details` screen
 - The `android` or `ios` options specify that the link should be opened on Android or iOS
-- Alternatively, you can open the link by searching for it in the device's native browser. For example, open Safari on iOS and type `myapp://` in the address bar to prompt the device to open your app.
+- Alternatively, you can try opening the link by clicking a link like `<a href="scheme://">Click me</a>` in the device's web browser. Note that entering the link in the address bar may not work as expected - use [universal linking](/linking/overview/#universal-linking) for that ability!
 
 <Collapsible summary="Test a link using Expo Go">
 
@@ -116,4 +116,4 @@ export default function Home() {
 
 If a user does not have your app installed, deep links to your app will not work. Attribution services like [Branch](https://www.branch.io/deep-linking/) offer solutions for conditionally linking to your app or web page.
 
-Universal links is another solution you can use to handle such cases, in which the route to your web page determines whether or not the app is installed. For more details, see [Universal Links](/linking/ios-universal-links/).
+Universal links is another solution you can use to handle such cases, in which the route to your web page determines whether or not the app is installed. For more details, see [Universal linking](/linking/overview/#universal-linking).

--- a/docs/pages/linking/into-your-app.mdx
+++ b/docs/pages/linking/into-your-app.mdx
@@ -9,7 +9,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 This guide provides steps to configure standard **deep links** in your project by adding a custom scheme.
 
-> **info** For most apps, you probably want to set up [Android App/iOS Universal Links](/linking/overview/#universal-linking) instead of the deeps links documented here, or set up both.
+> **info** For most apps, you probably want to set up [Android App/iOS Universal Links](/linking/overview/#universal-linking) instead of the deep links described in this guide or set up both.
 
 ## Add a custom scheme in app config
 

--- a/docs/pages/linking/into-your-app.mdx
+++ b/docs/pages/linking/into-your-app.mdx
@@ -7,7 +7,7 @@ description: Learn how to handle an incoming URL in your React Native and Expo a
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
-This guide provides steps to configure standard **deep links** in your project by adding a custom scheme. For production apps, you probably want to (also) set up [Universal / App Links](/linking/overview/#universal-linking).
+This guide provides steps to configure standard **deep links** in your project by adding a custom scheme. For production apps, you probably want to set up [Android App/iOS Universal Links](/linking/overview/#universal-linking).
 
 ## Add a custom scheme in app config
 
@@ -47,7 +47,7 @@ Running the above command:
 
 - Opens your app's `/details` screen
 - The `android` or `ios` options specify that the link should be opened on Android or iOS
-- Alternatively, you can try opening the link by clicking a link like `<a href="scheme://">Click me</a>` in the device's web browser. Note that entering the link in the address bar may not work as expected - use [universal linking](/linking/overview/#universal-linking) for that ability!
+- Alternatively, you can try opening the link by clicking a link like `<a href="scheme://">Click me</a>` in the device's web browser. Note that entering the link in the address bar may not work as expected, and you can use [universal linking](/linking/overview/#universal-linking) to implement that ability.
 
 <Collapsible summary="Test a link using Expo Go">
 
@@ -116,4 +116,4 @@ export default function Home() {
 
 If a user does not have your app installed, deep links to your app will not work. Attribution services like [Branch](https://www.branch.io/deep-linking/) offer solutions for conditionally linking to your app or web page.
 
-Universal / App Links is another solution you can use to handle such cases. This type of linking allows your app to open when a user clicks follows a HTTP(S) link pointing to your web domain. If the user doesn't have your app installed, the link takes them to your website. For more details, see [universal linking](/linking/overview/#universal-linking).
+Android App/iOS Universal Links is another solution you can use to handle such cases. This type of linking allows your app to open when a user clicks follows an HTTP(S) link pointing to your web domain. If the user doesn't have your app installed, the link takes them to your website. For more details, see [universal linking](/linking/overview/#universal-linking).

--- a/docs/pages/linking/into-your-app.mdx
+++ b/docs/pages/linking/into-your-app.mdx
@@ -7,7 +7,9 @@ description: Learn how to handle an incoming URL in your React Native and Expo a
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
-This guide provides steps to configure standard **deep links** in your project by adding a custom scheme. For production apps, you probably want to set up [Android App/iOS Universal Links](/linking/overview/#universal-linking).
+This guide provides steps to configure standard **deep links** in your project by adding a custom scheme.
+
+> **info** For most apps, you probably want to set up [Android App/iOS Universal Links](/linking/overview/#universal-linking) instead of the deeps links documented here, or set up both.
 
 ## Add a custom scheme in app config
 

--- a/docs/pages/linking/into-your-app.mdx
+++ b/docs/pages/linking/into-your-app.mdx
@@ -7,7 +7,7 @@ description: Learn how to handle an incoming URL in your React Native and Expo a
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
-This guide provides steps to configure standard **deep links** in your project by adding a custom scheme. For production apps, you probably want to (also) set up app [Universal linking](/linking/overview/#universal-linking).
+This guide provides steps to configure standard **deep links** in your project by adding a custom scheme. For production apps, you probably want to (also) set up [Universal / App Links](/linking/overview/#universal-linking).
 
 ## Add a custom scheme in app config
 
@@ -116,4 +116,4 @@ export default function Home() {
 
 If a user does not have your app installed, deep links to your app will not work. Attribution services like [Branch](https://www.branch.io/deep-linking/) offer solutions for conditionally linking to your app or web page.
 
-Universal links is another solution you can use to handle such cases, in which the route to your web page determines whether or not the app is installed. For more details, see [Universal linking](/linking/overview/#universal-linking).
+Universal / App Links is another solution you can use to handle such cases. This type of linking allows your app to open when a user clicks follows a HTTP(S) link pointing to your web domain. If the user doesn't have your app installed, the link takes them to your website. For more details, see [universal linking](/linking/overview/#universal-linking).

--- a/docs/pages/linking/overview.mdx
+++ b/docs/pages/linking/overview.mdx
@@ -68,7 +68,7 @@ This link type allows your app to open when a user clicks an HTTP(S) link pointi
 
 [Deep Links](https://en.wikipedia.org/wiki/Deep_linking) are links to a specific URL-based content inside an app or a website.
 
-For example, by clicking a product advertisement, your app will open on the user's device and they can view that product's details. This product's link that the user clicked may look like:
+For example, by clicking a product advertisement, your app will open on the user's device and they can view that product's details. This product's link that the user clicked may look like (or alternatively be invoked by JavaScript with setting `window.location.href`):
 
 ```html
 <a href="myapp://web-app.com/product">View Product</a>

--- a/docs/pages/linking/overview.mdx
+++ b/docs/pages/linking/overview.mdx
@@ -19,7 +19,7 @@ Linking allows your app to interact with incoming and outgoing URLs. In this pro
 
 There are different linking strategies you handle in your Expo app:
 
-- Linking to your app using your web domain links ([universal linking](#universal-linking) using the `https` scheme)
+- Linking to your app using your web domain links ([universal linking](#universal-linking) using the `https` or `http` scheme)
 - Linking to your app from other apps or websites using a custom scheme (deep links)
 - Linking to other apps from your app (outgoing links)
 
@@ -76,7 +76,7 @@ For example, by clicking a product advertisement, your app will open on the user
 
 This link is constructed by three parts:
 
-- **Scheme**: The URL scheme that identifies the app that should open the URL (example: `myapp://`). It can also be `https` or `http` for non-standard deep links - we recommend [universal linking](#universal-linking) for http(s)-based deep links.
+- **Scheme**: The URL scheme that identifies the app that should open the URL (example: `myapp://`). It can also be `https` or `http` for non-standard deep links. We recommend [universal linking](#universal-linking) for http(s)-based deep links.
 - **Host**: The domain name of the app that should open the URL (example: `web-app.com`).
 - **Path**: The path to the screen that should be opened (example: `/product`). If the path isn't specified, the user is taken to the home screen of the app.
 

--- a/docs/pages/linking/overview.mdx
+++ b/docs/pages/linking/overview.mdx
@@ -20,7 +20,7 @@ Linking allows your app to interact with incoming and outgoing URLs. In this pro
 There are different linking strategies you handle in your Expo app:
 
 - Linking to your app using your web domain links ([universal linking](#universal-linking) using the `https` scheme)
-- Linking to your app from other apps or html links using a custom scheme (deep links)
+- Linking to your app from other apps or websites using a custom scheme (deep links)
 - Linking to other apps from your app (outgoing links)
 
 > **info** **Tip:** Support for incoming links in Expo Go is limited. We recommend using [Development builds](/develop/development-builds/introduction/) to test your app's linking strategies.
@@ -31,7 +31,7 @@ Both Android and iOS implement their own systems for routing web URL's to an app
 
 ### Android App Links
 
-Android App Links are different from [standard deep links](#linking-to-your-app-from-other-apps-or-html-links) as they use regular HTTP and HTTPS schemes and are exclusive to Android devices.
+Android App Links are different from [standard deep links](#linking-to-your-app-from-other-apps-or-websites) as they use regular HTTP and HTTPS schemes and are exclusive to Android devices.
 
 This link type allows your app to always open when a user clicks the link instead of choosing between the browser or another handler from a dialog displayed on the device. If the user doesn't have your app installed, the link takes them to your app's associated website.
 
@@ -49,7 +49,7 @@ This link type allows your app to always open when a user clicks the link instea
 
 ### iOS Universal Links
 
-iOS Universal Links are different from [standard deep links](#linking-to-your-app-from-other-apps-or-html-links) as they use regular HTTP and HTTPS schemes and are exclusive to iOS devices.
+iOS Universal Links are different from [standard deep links](#linking-to-your-app-from-other-apps-or-websites) as they use regular HTTP and HTTPS schemes and are exclusive to iOS devices.
 
 This link type allows your app to open when a user clicks an HTTP(S) link pointing to your web domain. If the user doesn't have your app installed, the link takes them to your app's associated website. You can further configure the website by displaying a banner for the user to open your app using [Apple Smart Banner](/linking/ios-universal-links/#apple-smart-banner).
 
@@ -64,7 +64,7 @@ This link type allows your app to open when a user clicks an HTTP(S) link pointi
   Icon={AppleIcon}
 />
 
-## Linking to your app from other apps or html links
+## Linking to your app from other apps or websites
 
 [Deep Links](https://en.wikipedia.org/wiki/Deep_linking) are links to a specific URL-based content inside an app or a website.
 

--- a/docs/pages/linking/overview.mdx
+++ b/docs/pages/linking/overview.mdx
@@ -19,56 +19,19 @@ Linking allows your app to interact with incoming and outgoing URLs. In this pro
 
 There are different linking strategies you handle in your Expo app:
 
+- Linking to your app using your web domain links ([universal linking](#universal-linking) using the `https` scheme)
+- Linking to your app from other apps or html links using a custom scheme (deep links)
 - Linking to other apps from your app (outgoing links)
-- Linking to your app from other apps or a web browser (incoming links)
-- Linking to specific content within your app (deep links)
-- Redirecting links from your web domain to your app if it is installed (Android App Links and iOS Universal Links); also known as App shortcuts
 
-> **info** **Tip:** We recommend using [Development builds](/develop/development-builds/introduction/) to test your app's linking strategies instead of Expo Go.
-
-## Linking to other apps from your app
-
-Linking to other apps from your app is achieved using a URL based on the target app's URL scheme. This **URL scheme** allows you to reference resources within that native app.
-
-Your app can use a [common URL scheme](/linking/into-other-apps/#common-url-schemes) for default apps, including `https` and `http` (commonly used by web browsers like Chrome, Safari, and so on), and use JavaScript to invoke the URL that launches the corresponding native app.
-
-<BoxLink
-  title="Linking into other apps"
-  description="Learn how to handle common and custom URL schemes to link other apps from your app."
-  href="/linking/into-other-apps/"
-  Icon={BookOpen02Icon}
-/>
-
-## Linking to your app from other apps or a web browser
-
-[Deep Links](https://en.wikipedia.org/wiki/Deep_linking) are links to a specific URL based content inside an app or a website.
-
-For example, by clicking an advertisement of your product, your app will open on the user's device and they can view that product's details. This product's link that the user clicked may look like:
-
-```html
-myapp://web-app.com/product
-```
-
-This link is constructed by three parts:
-
-- **Scheme**: The URL scheme that identifies the app that should open the URL (example: `myapp://`). It can also be `https` or `http` for non-standard deep links.
-- **Host**: The domain name of the app that should open the URL (example: `web-app.com`).
-- **Path**: The path to the screen that should be opened (example: `/product`). If the path isn't specified, the user is taken to the home screen of the app.
-
-<BoxLink
-  title="Linking to your app"
-  description="Learn how to configure custom URL schemes to create a deep link of your app."
-  href="/linking/into-your-app/"
-  Icon={BookOpen02Icon}
-/>
+> **info** **Tip:** Support for incoming links in Expo Go is limited. We recommend using [Development builds](/develop/development-builds/introduction/) to test your app's linking strategies.
 
 ## Universal linking
 
-Both Android and iOS implement their own systems for routing web URL's to an app if the app is installed. On Android, this system is called App Links, and on iOS it is called Universal Links.
+Both Android and iOS implement their own systems for routing web URL's to an app if the app is installed. On Android, this system is called App Links, and on iOS it is called Universal Links. The pre-requisite for both systems is that you have a web domain where you can host a file which verifies you control the domain.
 
 ### Android App Links
 
-Android App Links are different from [standard deep links](#linking-to-your-app-from-other-apps-or-a-web-browser) as they use regular HTTP and HTTPS schemes and are exclusive to Android devices.
+Android App Links are different from [standard deep links](#linking-to-your-app-from-other-apps-or-html-links) as they use regular HTTP and HTTPS schemes and are exclusive to Android devices.
 
 This link type allows your app to always open when a user clicks the link instead of choosing between the browser or another handler from a dialog displayed on the device. If the user doesn't have your app installed, the link takes them to your app's associated website.
 
@@ -86,7 +49,7 @@ This link type allows your app to always open when a user clicks the link instea
 
 ### iOS Universal Links
 
-iOS Universal Links are different from [standard deep links](#linking-to-your-app-from-other-apps-or-a-web-browser) as they use regular HTTP and HTTPS schemes and are exclusive to iOS devices.
+iOS Universal Links are different from [standard deep links](#linking-to-your-app-from-other-apps-or-html-links) as they use regular HTTP and HTTPS schemes and are exclusive to iOS devices.
 
 This link type allows your app to open when a user clicks an HTTP(S) link pointing to your web domain. If the user doesn't have your app installed, the link takes them to your app's associated website. You can further configure the website by displaying a banner for the user to open your app using [Apple Smart Banner](/linking/ios-universal-links/#apple-smart-banner).
 
@@ -101,6 +64,29 @@ This link type allows your app to open when a user clicks an HTTP(S) link pointi
   Icon={AppleIcon}
 />
 
+## Linking to your app from other apps or html links
+
+[Deep Links](https://en.wikipedia.org/wiki/Deep_linking) are links to a specific URL-based content inside an app or a website.
+
+For example, by clicking a product advertisement, your app will open on the user's device and they can view that product's details. This product's link that the user clicked may look like:
+
+```html
+<a href="myapp://web-app.com/product">View Product</a>
+```
+
+This link is constructed by three parts:
+
+- **Scheme**: The URL scheme that identifies the app that should open the URL (example: `myapp://`). It can also be `https` or `http` for non-standard deep links.
+- **Host**: The domain name of the app that should open the URL (example: `web-app.com`).
+- **Path**: The path to the screen that should be opened (example: `/product`). If the path isn't specified, the user is taken to the home screen of the app.
+
+<BoxLink
+  title="Linking to your app"
+  description="Learn how to configure custom URL schemes to create a deep link of your app."
+  href="/linking/into-your-app/"
+  Icon={BookOpen02Icon}
+/>
+
 ## Use Expo Router to handle deep linking
 
 To implement any of the above Linking strategies, **we recommend using** [Expo Router](/router/introduction/) since deep linking is automatically enabled for all of your app's screens.
@@ -109,3 +95,16 @@ To implement any of the above Linking strategies, **we recommend using** [Expo R
 
 - `Link` component from Expo Router can be used to [handle URL schemes to other apps](/linking/into-other-apps/#expo-router)
 - Android App Links and iOS Universal Links require configuring runtime routing in JavaScript for the link in your app. Using Expo Router, you don't have to configure runtime routing separately since deep links for all routes are automatically enabled.
+
+## Linking to other apps from your app
+
+Linking to other apps from your app is achieved using a URL based on the target app's URL scheme. This **URL scheme** allows you to reference resources within that native app.
+
+Your app can use a [common URL scheme](/linking/into-other-apps/#common-url-schemes) for default apps, including `https` and `http` (commonly used by web browsers like Chrome, Safari, and so on), and use JavaScript to invoke the URL that launches the corresponding native app.
+
+<BoxLink
+  title="Linking into other apps"
+  description="Learn how to handle common and custom URL schemes to link other apps from your app."
+  href="/linking/into-other-apps/"
+  Icon={BookOpen02Icon}
+/>

--- a/docs/pages/linking/overview.mdx
+++ b/docs/pages/linking/overview.mdx
@@ -76,7 +76,7 @@ For example, by clicking a product advertisement, your app will open on the user
 
 This link is constructed by three parts:
 
-- **Scheme**: The URL scheme that identifies the app that should open the URL (example: `myapp://`). It can also be `https` or `http` for non-standard deep links.
+- **Scheme**: The URL scheme that identifies the app that should open the URL (example: `myapp://`). It can also be `https` or `http` for non-standard deep links - we recommend [universal linking](#universal-linking) for http(s)-based deep links.
 - **Host**: The domain name of the app that should open the URL (example: `web-app.com`).
 - **Path**: The path to the screen that should be opened (example: `/product`). If the path isn't specified, the user is taken to the home screen of the app.
 

--- a/docs/pages/linking/overview.mdx
+++ b/docs/pages/linking/overview.mdx
@@ -87,7 +87,7 @@ This link is constructed by three parts:
   Icon={BookOpen02Icon}
 />
 
-## Use Expo Router to handle deep linking
+### Use Expo Router to handle deep linking
 
 To implement any of the above Linking strategies, **we recommend using** [Expo Router](/router/introduction/) since deep linking is automatically enabled for all of your app's screens.
 


### PR DESCRIPTION
# Why

Improves the documentation around deep linking and universal linking by reorganizing content. Makes it clearer that universal linking is often desirable for production apps.

# How

- Reorganized the linking overview to prioritize universal linking
- Added clarification about universal linking requirements
- Updated examples to show HTML anchor tags instead of raw URLs
- Clarified limitations of scheme-based deep links in browser address bars

# Test Plan

- didn't test this but please correct me if I'm wrong

# Checklist

- [x] Conforms with the Documentation Writing Style Guide