### PR TITLE
[docs] scroll container tweaks and improvements

### DIFF
--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -72,7 +72,7 @@ export default class DocumentationNestedScrollLayout extends Component<Props> {
           </div>
           <div
             className={mergeClasses(
-              'flex h-[calc(100dvh-60px)] w-full overflow-hidden',
+              'relative flex h-[calc(100dvh-60px)] w-full overflow-hidden',
               'max-lg-gutters:overflow-auto',
               isMobileMenuVisible && 'hidden'
             )}>

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -54,23 +54,25 @@ export default function DocumentationPage({
   const sidebarScrollPosition = process?.browser ? window.__sidebarScroll : 0;
 
   useEffect(() => {
-    router?.events.on('routeChangeStart', url => {
-      if (layoutRef.current) {
+    if (layoutRef.current) {
+      layoutRef.current.contentRef.current?.getScrollRef().current?.focus();
+      router?.events.on('routeChangeStart', url => {
         if (
           RoutesUtils.getPageSection(pathname) !== RoutesUtils.getPageSection(url) ||
-          pathname === '/'
+          pathname === '/' ||
+          !layoutRef.current
         ) {
           window.__sidebarScroll = 0;
         } else {
           window.__sidebarScroll = layoutRef.current.getSidebarScrollTop();
         }
-      }
-    });
-    window.addEventListener('resize', handleResize);
-    return () => {
-      window.removeEventListener('resize', handleResize);
-    };
-  });
+      });
+      window.addEventListener('resize', handleResize);
+      return () => {
+        window.removeEventListener('resize', handleResize);
+      };
+    }
+  }, [layoutRef.current, tableOfContentsRef.current]);
 
   const handleResize = () => {
     if (WindowUtils.getViewportSize().width >= breakpoints.medium + 124) {
@@ -81,7 +83,7 @@ export default function DocumentationPage({
 
   const handleContentScroll = (contentScrollPosition: number) => {
     window.requestAnimationFrame(() => {
-      if (tableOfContentsRef?.current?.handleContentScroll) {
+      if (tableOfContentsRef.current?.handleContentScroll) {
         tableOfContentsRef.current.handleContentScroll(contentScrollPosition);
       }
     });
@@ -140,6 +142,12 @@ export default function DocumentationPage({
           RoutesUtils.isPreviewPath(pathname) ||
           RoutesUtils.isArchivePath(pathname)) && <meta name="robots" content="noindex" />}
       </DocumentationHead>
+      <div
+        className={mergeClasses(
+          'pointer-events-none absolute z-10 h-8 w-[calc(100%-6px)] max-w-screen-xl',
+          'bg-gradient-to-b from-default to-transparent opacity-90'
+        )}
+      />
       <div
         className={mergeClasses(
           'mx-auto px-14 py-10',

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -51,10 +51,14 @@ code {
   @apply bg-palette-blue5;
 }
 
-*:focus-visible {
+*:focus-visible:not(div) {
   @apply rounded-sm;
   outline: 3px solid var(--expo-theme-icon-info);
   outline-offset: 1px;
+}
+
+*:focus-visible:is(div) {
+  outline: 0;
 }
 
 /* Scrollbars */

--- a/docs/ui/components/Sidebar/Sidebar.tsx
+++ b/docs/ui/components/Sidebar/Sidebar.tsx
@@ -22,7 +22,8 @@ export const Sidebar = ({ routes = [] }: SidebarProps) => {
     <nav className="relative w-[280px] bg-default p-4 max-lg-gutters:w-full" data-sidebar>
       <div
         className={mergeClasses(
-          'pointer-events-none fixed left-0 z-10 mt-[-22px] h-8 w-[273px] bg-gradient-to-b from-default to-transparent',
+          'pointer-events-none fixed left-0 z-10 mt-[-22px] h-8 w-[273px]',
+          'bg-gradient-to-b from-default to-transparent opacity-90',
           'max-lg-gutters:hidden'
         )}
       />

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -20,7 +20,7 @@ import { TableOfContentsLink } from '~/ui/components/TableOfContents';
 import { CALLOUT } from '~/ui/components/Text';
 
 const UPPER_SCROLL_LIMIT_FACTOR = 1 / 4;
-const LOWER_SCROLL_LIMIT_FACTOR = 7 / 8;
+const LOWER_SCROLL_LIMIT_FACTOR = 3 / 4;
 const ACTIVE_ITEM_OFFSET_FACTOR = 1 / 20;
 
 export type TableOfContentsProps = PropsWithChildren<{
@@ -146,10 +146,13 @@ export const TableOfContents = forwardRef<
   );
 
   return (
-    <nav className="w-[280px] px-6 pb-10 pt-14" data-sidebar>
+    <nav className="w-[280px] px-6 pb-10 pt-[52px]" data-sidebar>
       <CALLOUT
         weight="medium"
-        className="absolute z-10 -mt-14 mb-2 flex min-h-[32px] w-[248px] select-none items-center gap-2 bg-default pb-2 pt-4">
+        className={mergeClasses(
+          'absolute z-[100] -ml-6 -mt-[52px] flex min-h-[32px] w-[272px] select-none',
+          'items-center gap-2 bg-gradient-to-b from-default from-80% to-transparent py-3 pl-6'
+        )}>
         <LayoutAlt03Icon className="icon-sm" /> On this page
         <Button
           theme="quaternary"

--- a/docs/ui/components/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
+++ b/docs/ui/components/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`TableOfContents correctly matches snapshot 1`] = `
 <div>
   <nav
-    class="w-[280px] px-6 pb-10 pt-14"
+    class="w-[280px] px-6 pb-10 pt-[52px]"
     data-sidebar="true"
   >
     <p
-      class="text-default text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium absolute z-10 -mt-14 mb-2 flex min-h-[32px] w-[248px] select-none items-center gap-2 bg-default pb-2 pt-4"
+      class="text-default text-[14px] leading-[1.5715] tracking-[-0.006rem] font-medium absolute z-[100] -ml-6 -mt-[52px] flex min-h-[32px] w-[272px] select-none items-center gap-2 bg-gradient-to-b from-default from-80% to-transparent py-3 pl-6"
       data-text="true"
     >
       <svg


### PR DESCRIPTION
# Why

Recently we have received feedback about accessibility issue of main scrolling container.

# How

The following changes have been made:
* fix inability to scroll page content via keyboard without interacting with its content first
* fix overflow issue and visual glitch for focused entries in ToC
* convert solid scroll cut off in ToC to fade
* add fade out gradient to the main content container

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2025-02-07 at 17 41 35](https://github.com/user-attachments/assets/34ee7bbb-0990-47cc-8c22-7ba14c1fc22f)