### PR TITLE
[android][fetch] Avoid PromiseAlreadySettledException on canceling expo/fetch requests

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### 🐛 Bug fixes
 
 - Replace inferred rest spread arguments types (and other inferred types) for changes in newer TypeScript versions. ([#34132](https://github.com/expo/expo/pull/34132) by [@kitten](https://github.com/kitten))
-- Avoid PromiseAlreadySettledException on canceling expo/fetch requests. ([#34778](https://github.com/expo/expo/pull/34778) by [@yukukotani](https://github.com/yukukotani))
+- [Android] Avoid `PromiseAlreadySettledException` on canceling `expo/fetch` requests. ([#34778](https://github.com/expo/expo/pull/34778) by [@yukukotani](https://github.com/yukukotani))
 
 ### 💡 Others
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Bug fixes
 
 - Replace inferred rest spread arguments types (and other inferred types) for changes in newer TypeScript versions. ([#34132](https://github.com/expo/expo/pull/34132) by [@kitten](https://github.com/kitten))
+- Avoid PromiseAlreadySettledException on canceling expo/fetch requests. ([#34778](https://github.com/expo/expo/pull/34778) by [@yukukotani](https://github.com/yukukotani))
 
 ### 💡 Others
 

--- a/packages/expo/android/src/main/java/expo/modules/fetch/ExpoFetchModule.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/ExpoFetchModule.kt
@@ -13,6 +13,7 @@ import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.exception.toCodedException
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -33,7 +34,10 @@ class ExpoFetchModule : Module() {
   private val reactContext: ReactContext
     get() = appContext.reactContext as? ReactContext ?: throw Exceptions.ReactContextLost()
 
-  private val moduleCoroutineScope = CoroutineScope(Dispatchers.Default)
+  private val moduleCoroutineScope by lazy {
+    CoroutineScope(appContext.modulesQueue.coroutineContext +
+      CoroutineName("expo.modules.fetch.CoroutineScope"))
+  }
 
   override fun definition() = ModuleDefinition {
     Name("ExpoFetchModule")

--- a/packages/expo/android/src/main/java/expo/modules/fetch/ExpoFetchModule.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/ExpoFetchModule.kt
@@ -15,7 +15,6 @@ import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import okhttp3.JavaNetCookieJar
 import java.net.URL
@@ -35,8 +34,10 @@ class ExpoFetchModule : Module() {
     get() = appContext.reactContext as? ReactContext ?: throw Exceptions.ReactContextLost()
 
   private val moduleCoroutineScope by lazy {
-    CoroutineScope(appContext.modulesQueue.coroutineContext +
-      CoroutineName("expo.modules.fetch.CoroutineScope"))
+    CoroutineScope(
+      appContext.modulesQueue.coroutineContext +
+        CoroutineName("expo.modules.fetch.CoroutineScope")
+    )
   }
 
   override fun definition() = ModuleDefinition {

--- a/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
@@ -8,6 +8,8 @@ import expo.modules.kotlin.sharedobjects.SharedObject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.Response
@@ -17,6 +19,7 @@ import java.io.IOException
 internal class NativeResponse(appContext: AppContext, private val coroutineScope: CoroutineScope) :
   SharedObject(appContext), Callback {
   val sink = ResponseSink()
+  private val lock = Mutex()
   private var state: ResponseState = ResponseState.INITIALIZED
     get() = synchronized(this) { field }
     private set(value) {
@@ -24,7 +27,9 @@ internal class NativeResponse(appContext: AppContext, private val coroutineScope
         field = value
       }
       coroutineScope.launch {
-        this@NativeResponse.stateChangeOnceListeners.removeAll { it(value) }
+        this@NativeResponse.lock.withLock {
+          this@NativeResponse.stateChangeOnceListeners.removeAll { it(value) }
+        }
       }
     }
   private val stateChangeOnceListeners: MutableList<StateChangeListener> = mutableListOf()

--- a/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
@@ -103,6 +103,11 @@ internal class NativeResponse(appContext: AppContext, private val coroutineScope
   //region Callback implementations
 
   override fun onFailure(call: Call, e: IOException) {
+    // Canceled request should be handled by emitRequestCancelled
+    if (e.message === "Canceled") {
+      return
+    }
+
     if (isInvalidState(
         ResponseState.STARTED,
         ResponseState.RESPONSE_RECEIVED,

--- a/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
@@ -8,8 +8,6 @@ import expo.modules.kotlin.sharedobjects.SharedObject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.Response
@@ -19,7 +17,6 @@ import java.io.IOException
 internal class NativeResponse(appContext: AppContext, private val coroutineScope: CoroutineScope) :
   SharedObject(appContext), Callback {
   val sink = ResponseSink()
-  private val lock = Mutex()
   private var state: ResponseState = ResponseState.INITIALIZED
     get() = synchronized(this) { field }
     private set(value) {
@@ -27,9 +24,7 @@ internal class NativeResponse(appContext: AppContext, private val coroutineScope
         field = value
       }
       coroutineScope.launch {
-        this@NativeResponse.lock.withLock {
-          this@NativeResponse.stateChangeOnceListeners.removeAll { it(value) }
-        }
+        this@NativeResponse.stateChangeOnceListeners.removeAll { it(value) }
       }
     }
   private val stateChangeOnceListeners: MutableList<StateChangeListener> = mutableListOf()


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix https://github.com/expo/expo/issues/34772

In Android, `NativeResponse#onFailure` and `NativeResponse#emitRequestCancelled` are called in different threads asynchronously, and sometimes those calls are simultaneous. Both of those functions assigns `ResponseState.ERROR_RECEIVED` to `NativeResponse#state` field ([here](https://github.com/yukukotani/expo/blob/c96ceab92cd14d92ffe61e75fcfb9c5f5039fdd2/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt#L80) and [here](https://github.com/yukukotani/expo/blob/c96ceab92cd14d92ffe61e75fcfb9c5f5039fdd2/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt#L115)).

This causes `stateChangeOnceListeners` to be called twice in parallel [here](https://github.com/yukukotani/expo/blob/c96ceab92cd14d92ffe61e75fcfb9c5f5039fdd2/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt#L26-L28). Then it results in calling `promise.reject` twice and fire `PromiseAlreadySettledException` [here](https://github.com/yukukotani/expo/blob/1d8e5144bd79ca2023fffa53cc280536a9eb3acc/packages/expo/android/src/main/java/expo/modules/fetch/ExpoFetchModule.kt#L130).

# How

<!--
How did you build this feature or fix this bug and why?
-->

Use `Mutex` to ensure calling `stateChangeOnceListeners` sequentially.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Check the repro provided in the original issue

https://github.com/kazuya-sakamoto/urql-stream-issue

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
