### PR TITLE
[updates] fix log for copy resource

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 - Fixed build error on iOS Expo Go. ([#34485](https://github.com/expo/expo/pull/34485) by [@kudo](https://github.com/kudo))
 - Fixed Android unit test errors in BuilDataTest. ([#34510](https://github.com/expo/expo/pull/34510) by [@kudo](https://github.com/kudo))
+- Fixed incorrect error log on Android. ([#34785](https://github.com/expo/expo/pull/34785) by [@kudo](https://github.com/kudo))
 
 ## 0.26.10 - 2024-12-05
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderFiles.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderFiles.kt
@@ -69,7 +69,7 @@ open class LoaderFiles {
       context.resources.openRawResource(id)
         .use { inputStream -> return UpdatesUtils.verifySHA256AndWriteToFile(inputStream, destination, null) }
     } catch (e: Exception) {
-      Log.e(TAG, "Failed to copy asset " + asset.embeddedAssetFilename, e)
+      Log.e(TAG, "Failed to copy resource asset ${asset.resourcesFolder}/${asset.embeddedAssetFilename}", e)
       throw e
     }
   }


### PR DESCRIPTION
# Why

the crash log is incorrect

# How

unlike the asset copy call flow, this method is to copy asset from resources and should have correct log. the `asset.embeddedAssetFilename` is always null in this method. this pr tries to revise the log 

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
