### PR TITLE
[docs] error on ios deployment target

### DIFF
--- a/docs/pages/versions/unversioned/sdk/build-properties.mdx
+++ b/docs/pages/versions/unversioned/sdk/build-properties.mdx
@@ -68,7 +68,7 @@ export default {
             buildToolsVersion: '34.0.0',
           },
           ios: {
-            deploymentTarget: '13.4',
+            deploymentTarget: '15.1',
           },
         },
       ],


### PR DESCRIPTION
"ios.deploymentTarget" needs to be least version 15.1

# Why
when i want to eas build i got error 
![Screenshot error, build deployment ios target](https://github.com/user-attachments/assets/284d6d63-12af-43a2-a9a3-eef9e0ce0492)

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
change ios deployement target 13.4 into 15.1
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
