### PR TITLE
[android][imagepicker] duplicate files stored when picking images from camera

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - [ios] fixed concurrency freeze on low-end iOS devices when selecting multiple images. ([#34585](https://github.com/expo/expo/pull/34585) by [@chrfalch](https://github.com/chrfalch))
-- [android] fixed removal of temporary file after picking image using camera
+- [android] fixed removal of temporary file after picking image using camera ([#34797](https://github.com/expo/expo/pull/34797) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [ios] fixed concurrency freeze on low-end iOS devices when selecting multiple images. ([#34585](https://github.com/expo/expo/pull/34585) by [@chrfalch](https://github.com/chrfalch))
+- [android] fixed removal of temporary file after picking image using camera
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -70,11 +70,16 @@ class ImagePickerModule : Module() {
       ensureTargetActivityIsAvailable(options)
       ensureCameraPermissionsAreGranted()
 
-      val mediaFile = createOutputFile(cacheDirectory, options.nativeMediaTypes.toFileExtension())
-      val uri = mediaFile.toContentUri(context)
-      val contractOptions = options.toCameraContractOptions(uri.toString())
+      val tempFile = createOutputFile(cacheDirectory, options.nativeMediaTypes.toFileExtension())
 
-      launchContract({ cameraLauncher.launch(contractOptions) }, options)
+      try {
+        val uri = tempFile.toContentUri(context)
+        val contractOptions = options.toCameraContractOptions(uri.toString())
+
+        launchContract({ cameraLauncher.launch(contractOptions) }, options)
+      } finally {
+        tempFile.delete()
+      }
     }
 
     AsyncFunction("launchImageLibraryAsync") Coroutine { options: ImagePickerOptions ->


### PR DESCRIPTION
# Why

When picking an image using the `launchCameraAsync` method, inspecting the device's file explorer reveals that two files are created in the cache directory - not only the one returned to the caller. This makes it hard for the caller to control deletion of the file and might cause the cache folder to grow uncontrolled as described in #25728.

# How

This commit fixes this by explicitly deleting the temporary file created as a target for the camera instead of just leaving it.

Closes #25728

# Test Plan

Test in BareExpo - verify that picking an image from library only creates one file using the device explorer.

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
