### PR TITLE
[expo-audio][android] AudioPlayer.kt report currentTime and duration as float

### DIFF
--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -57,8 +57,8 @@ class AudioPlayer(
   private var visualizer: Visualizer? = null
   private var playing = false
 
-  val currentTime get() = player.currentPosition / 1000
-  val duration get() = if (player.duration != C.TIME_UNSET) player.duration / 1000 else 0
+  val currentTime get() = player.currentPosition.toFloat() / 1000
+  val duration get() = if (player.duration != C.TIME_UNSET) player.duration.toFloat() / 1000 else 0
 
   init {
     addPlayerListeners()

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -57,8 +57,8 @@ class AudioPlayer(
   private var visualizer: Visualizer? = null
   private var playing = false
 
-  val currentTime get() = player.currentPosition.toFloat() / 1000
-  val duration get() = if (player.duration != C.TIME_UNSET) player.duration.toFloat() / 1000 else 0
+  val currentTime get() = player.currentPosition / 1000f
+  val duration get() = if (player.duration != C.TIME_UNSET) player.duration / 1000f else 0f
 
   init {
     addPlayerListeners()


### PR DESCRIPTION

# Why

When audio player convert the player position and duration in seconds, it uses integer division so we loose precision.


# How

This fix first converts the position/duration to float so we still get high precision in the reported playback statuses.
