### PR TITLE
[autolinking] update docs for expo-module.config.json

### DIFF
--- a/docs/pages/debugging/create-devtools-plugins.mdx
+++ b/docs/pages/debugging/create-devtools-plugins.mdx
@@ -9,6 +9,8 @@ import { Step } from '~/ui/components/Step';
 
 > **warning** Dev Tools plugins are compatible with SDK 50 and above.
 
+> **Tip**: Check out the [Expo DevTools Plugins](https://github.com/expo/dev-plugins) for complete examples.
+
 You can create a dev tools plugin, whether that's for inspecting aspects of a common framework or library or something specific to your custom code. This guide will walk you through creating a dev tools plugin.
 
 ## What is a dev tools plugin?

--- a/docs/pages/modules/module-config.mdx
+++ b/docs/pages/modules/module-config.mdx
@@ -6,7 +6,7 @@ hideTOC: true
 
 Expo modules are configured in **expo-module.config.json**. This file currently is capable of configuring autolinking and module registration. The following properties are available:
 
-- `platforms` — An array of supported platforms. Acceptable values are `android`, `apple` (or use the more granular `ios` / `macos` / `tvos`) and `web`.
+- `platforms` — An array of supported platforms. Acceptable values are `android`, `apple` (or use the more granular `ios` / `macos` / `tvos`), `web` and `devtools` (see [Create a dev tools plugin](/debugging/create-devtools-plugins)).
 - `apple` — Config with options specific to Apple platforms
   - `modules` — Names of Swift native modules classes to put to the generated modules provider file.
   - `appDelegateSubscribers` — Names of Swift classes that hook into `ExpoAppDelegate` to receive AppDelegate lifecycle events.

--- a/docs/pages/modules/module-config.mdx
+++ b/docs/pages/modules/module-config.mdx
@@ -6,8 +6,8 @@ hideTOC: true
 
 Expo modules are configured in **expo-module.config.json**. This file currently is capable of configuring autolinking and module registration. The following properties are available:
 
-- `platforms` — An array of supported platforms.
-- `ios` — Config with options specific to iOS platform
+- `platforms` — An array of supported platforms. Acceptable values are `android`, `apple` (or use the more granular `ios` / `macos` / `tvos`) and `web`.
+- `apple` — Config with options specific to Apple platforms
   - `modules` — Names of Swift native modules classes to put to the generated modules provider file.
   - `appDelegateSubscribers` — Names of Swift classes that hook into `ExpoAppDelegate` to receive AppDelegate lifecycle events.
 - `android` — Config with options specific to Android platform


### PR DESCRIPTION
# Why

the `ios` entry in expo-module.config.json is marked as deprecated, let's reflect that

# How

update docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
