### PR TITLE
[av][docs] Fix link in Usage section

### DIFF
--- a/docs/pages/versions/unversioned/sdk/av.mdx
+++ b/docs/pages/versions/unversioned/sdk/av.mdx
@@ -74,7 +74,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 ## Usage
 
-On this page, we reference operations on `playbackObject`s. Here is an example of obtaining access to the reference for both sound and video:
+On this page, we reference operations on `playbackObject`. Here is an example of obtaining access to the reference for both sound and video:
 
 ### Example: `Audio.Sound`
 
@@ -89,7 +89,7 @@ const { sound: playbackObject } = await Audio.Sound.createAsync(
 );
 ```
 
-See the [audio documentation](audio.mdx) for further information on `Audio.Sound.createAsync()`.
+See the [audio documentation](audio-av.mdx) for further information on `Audio.Sound.createAsync()`.
 
 ### Example: `Video`
 

--- a/docs/pages/versions/v50.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/av.mdx
@@ -71,7 +71,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 ## Usage
 
-On this page, we reference operations on `playbackObject`s. Here is an example of obtaining access to the reference for both sound and video:
+On this page, we reference operations on `playbackObject`. Here is an example of obtaining access to the reference for both sound and video:
 
 ### Example: `Audio.Sound`
 
@@ -87,7 +87,7 @@ const { sound: playbackObject } = await Audio.Sound.createAsync(
 ...
 ```
 
-See the [audio documentation](audio.mdx) for further information on `Audio.Sound.createAsync()`.
+See the [audio documentation](audio-av.mdx) for further information on `Audio.Sound.createAsync()`.
 
 ### Example: `Video`
 

--- a/docs/pages/versions/v51.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/av.mdx
@@ -71,7 +71,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 ## Usage
 
-On this page, we reference operations on `playbackObject`s. Here is an example of obtaining access to the reference for both sound and video:
+On this page, we reference operations on `playbackObject`. Here is an example of obtaining access to the reference for both sound and video:
 
 ### Example: `Audio.Sound`
 
@@ -86,7 +86,7 @@ const { sound: playbackObject } = await Audio.Sound.createAsync(
 );
 ```
 
-See the [audio documentation](audio.mdx) for further information on `Audio.Sound.createAsync()`.
+See the [audio documentation](audio-av.mdx) for further information on `Audio.Sound.createAsync()`.
 
 ### Example: `Video`
 

--- a/docs/pages/versions/v52.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/av.mdx
@@ -72,7 +72,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 ## Usage
 
-On this page, we reference operations on `playbackObject`s. Here is an example of obtaining access to the reference for both sound and video:
+On this page, we reference operations on `playbackObject`. Here is an example of obtaining access to the reference for both sound and video:
 
 ### Example: `Audio.Sound`
 
@@ -87,7 +87,7 @@ const { sound: playbackObject } = await Audio.Sound.createAsync(
 );
 ```
 
-See the [audio documentation](audio.mdx) for further information on `Audio.Sound.createAsync()`.
+See the [audio documentation](audio-av.mdx) for further information on `Audio.Sound.createAsync()`.
 
 ### Example: `Video`
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on user feedback that link from AV API reference is linked to the wrong Audio API reference.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update the link to redirect to the Audio-AV API reference in the Usage section of AV reference.
- Fix typo in Usage section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Check link.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
