### PR TITLE
[docs] Add info about missing `permission.AD_ID` in Tracking Transparency reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
@@ -8,7 +8,7 @@ platforms: ['android', 'ios', 'tvos']
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import { IOSPermissions } from '~/components/plugins/permissions';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -115,7 +115,11 @@ import * as ExpoTrackingTransparency from 'expo-tracking-transparency';
 
 ### Android
 
-<AndroidPermissions permissions={['com.google.android.gms.permission.AD_ID']} />
+The following permissions are added automatically through the library's **AndroidManifest.xml**.
+
+| Android Permission                        | Description                                                                                                                                                                    |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `com.google.android.gms.permission.AD_ID` | Allows access to the Advertising ID for tracking and analytics. Required for apps targeting Android 13 (API level 33) or higher that use Google Play services' Advertising ID. |
 
 ### iOS
 

--- a/docs/pages/versions/v50.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/tracking-transparency.mdx
@@ -8,7 +8,7 @@ packageName: 'expo-tracking-transparency'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import { IOSPermissions } from '~/components/plugins/permissions';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -117,7 +117,11 @@ import * as ExpoTrackingTransparency from 'expo-tracking-transparency';
 
 ### Android
 
-<AndroidPermissions permissions={['com.google.android.gms.permission.AD_ID']} />
+The following permissions are added automatically through the library's **AndroidManifest.xml**.
+
+| Android Permission                        | Description                                                                                                                                                                    |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `com.google.android.gms.permission.AD_ID` | Allows access to the Advertising ID for tracking and analytics. Required for apps targeting Android 13 (API level 33) or higher that use Google Play services' Advertising ID. |
 
 ### iOS
 

--- a/docs/pages/versions/v51.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/tracking-transparency.mdx
@@ -8,7 +8,7 @@ platforms: ['android', 'ios']
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import { IOSPermissions } from '~/components/plugins/permissions';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -115,7 +115,11 @@ import * as ExpoTrackingTransparency from 'expo-tracking-transparency';
 
 ### Android
 
-<AndroidPermissions permissions={['com.google.android.gms.permission.AD_ID']} />
+The following permissions are added automatically through the library's **AndroidManifest.xml**.
+
+| Android Permission                        | Description                                                                                                                                                                    |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `com.google.android.gms.permission.AD_ID` | Allows access to the Advertising ID for tracking and analytics. Required for apps targeting Android 13 (API level 33) or higher that use Google Play services' Advertising ID. |
 
 ### iOS
 

--- a/docs/pages/versions/v52.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/tracking-transparency.mdx
@@ -8,7 +8,7 @@ platforms: ['android', 'ios', 'tvos']
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import { IOSPermissions } from '~/components/plugins/permissions';
 import {
   ConfigReactNative,
   ConfigPluginExample,
@@ -115,7 +115,11 @@ import * as ExpoTrackingTransparency from 'expo-tracking-transparency';
 
 ### Android
 
-<AndroidPermissions permissions={['com.google.android.gms.permission.AD_ID']} />
+The following permissions are added automatically through the library's **AndroidManifest.xml**.
+
+| Android Permission                        | Description                                                                                                                                                                    |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `com.google.android.gms.permission.AD_ID` | Allows access to the Advertising ID for tracking and analytics. Required for apps targeting Android 13 (API level 33) or higher that use Google Play services' Advertising ID. |
 
 ### iOS
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, details about Android permissions is missing in Expo Tracking Transparency API reference: https://docs.expo.dev/versions/unversioned/sdk/tracking-transparency/#android

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Manually add information about `com.google.android.gms.permission.AD_ID` under Permissions > Android section. Could not find a source and doesn't sync with the automated permissions script.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2025-02-10 at 18 06 13@2x](https://github.com/user-attachments/assets/d865aedf-7aee-430d-9b53-66613497654a)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
