### PR TITLE
[docs] Change wording on bare/installing-updates/#ios to prevent mistakes

### DIFF
--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -108,7 +108,7 @@ Modify **ios/Podfile** to check for the JS engine configuration (JSC or Hermes) 
 
 <DiffBlock source="/static/diffs/expo-updates-ios-podfile.diff" />
 
-Add **Expo.plist** file to **ios/your-project/Supporting** directory using Xcode with the following content to match the contents of **app.json**:
+Using Xcode, add **Expo.plist** file to **ios/your-project/Supporting** with the following content to match the contents of **app.json**:
 
 ```xml Expo.plist
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
# Why

To prevent users adding a file without using Xcode, which will work but silently fail further down the line. From solving a similar issue in: https://discord.com/channels/695411232856997968/1338521372921565294/1338521372921565294.

The wording is already there, but now with a stronger emphasis on using Xcode, so it's harder to miss.

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
