### PR TITLE
[cli] clarify expo go QR code instructions

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Clarify Expo Go instructions for scanning QR Code. ([#34811](https://github.com/expo/expo/pull/34811) by [@betomoedano](https://github.com/betomoedano))
+
 ### 🛠 Breaking changes
 
 - Force NODE_ENV during npx expo export and do not allow overwriting outside of `--dev` flag. ([#34533](https://github.com/expo/expo/pull/34533) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -62,7 +62,9 @@ export class DevServerManagerActions {
         if (options.devClient === false) {
           // TODO: if development build, change this message!
           Log.log(
-            printItem('Scan the QR code above with Expo Go (Android) or the Camera app (iOS)')
+            printItem(
+              'Scan the QR code with Expo Go (Android) or the Camera app (iOS) to open in Expo Go.'
+            )
           );
         } else {
           Log.log(

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -61,11 +61,7 @@ export class DevServerManagerActions {
         Log.log(printItem(chalk`Metro waiting on {underline ${nativeRuntimeUrl}}`));
         if (options.devClient === false) {
           // TODO: if development build, change this message!
-          Log.log(
-            printItem(
-              'Scan the QR code with Expo Go (Android) or the Camera app (iOS) to open in Expo Go.'
-            )
-          );
+          Log.log(printItem('Scan the QR code above to open the project in Expo Go.'));
         } else {
           Log.log(
             printItem(


### PR DESCRIPTION
# Why

Some people assumed Expo Go is only necessary for Android, not for iOS

https://x.com/michaelmemling/status/1888765157385331036?t=2DinSV-ctSUYht8GtM6hLw

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
