### PR TITLE
[audio][docs] Fix code example in Recording sounds section (expo#33956)

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -111,7 +111,10 @@ import { useAudioRecorder, RecordingOptions, AudioModule, RecordingPresets } fro
 export default function App() {
   const audioRecorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
 
-  const record = () => audioRecorder.record();
+  const record = async () => {
+    await audioRecorder.prepareToRecordAsync();
+    audioRecorder.record();
+  }
 
   const stopRecording = async () => {
     // The recording will be available on `audioRecorder.uri`.

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -114,7 +114,7 @@ export default function App() {
   const record = async () => {
     await audioRecorder.prepareToRecordAsync();
     audioRecorder.record();
-  }
+  };
 
   const stopRecording = async () => {
     // The recording will be available on `audioRecorder.uri`.


### PR DESCRIPTION
# Why

When trying to directly copy the `Recording sounds` example from the `expo-audio` docs, you receive an error when attempting to record on Android.

> Recording failed: [Error: Call to function 'AudioRecorder.record' has been rejected.
→ Caused by: java.lang.IllegalStateException]

Closes #33956

![image](https://github.com/user-attachments/assets/00b295b3-aadd-4971-88a8-eb62cc5eedfa)

# How

The code requires you first call `await audioRecorder.prepareToRecordAsync()`, so the code snippet has been updated to reflect this in the documentations.

# Test Plan

Here was the reproducer: https://github.com/frankcalise/expo-voice-recorder/tree/d581af781fea90d2c669128d24f1ebf700a3e9e7

And here is the commit that fixes: https://github.com/frankcalise/expo-voice-recorder/commit/6ee114b160899352c9162b6f8062621a1504e58a
