### PR TITLE
[docs] add eas update bandwidth guide

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -498,6 +498,7 @@ export const eas = [
       makePage('eas-update/codepush.mdx'),
       makePage('eas-update/migrate-from-classic-updates.mdx'),
       makePage('eas-update/trace-update-id-expo-dashboard.mdx'),
+      makePage('eas-update/estimate-bandwidth.mdx'),
       makePage('eas-update/faq.mdx'),
     ]),
   ]),

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -1,6 +1,6 @@
 ---
 title: Estimate bandwidth usage
-description: Learn how to estimate bandwidth usage with EAS Update.
+description: Learn how to estimate bandwidth usage for EAS Update.
 ---
 
 # Understanding update bandwidth usage

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -1,0 +1,51 @@
+---
+title: Estimate bandwidth usage
+description: Learn how to estimate bandwidth usage with EAS Update.
+---
+
+# Understanding Update Bandwidth Usage
+
+EAS Update enables an app to update its own non-native pieces (such as JS, styling, and images) over-the-air. This guide explains how bandwidth is consumed and optimized.
+
+## Bandwidth Calculation Breakdown
+
+Each billing cycle includes a predefined bandwidth allocation, which translates to a specific number of updates your users can download. Here's how we estimate bandwidth usage:
+
+- **Update Size:** The key factor in bandwidth consumption is the size of each update. For example, if an update modifies only the JavaScript portion of your app and is **10 MB uncompressed**, we can further optimize this with compression.
+- **Compression Ratio:** Hermes bytecode, commonly used in React Native apps, achieves an estimated **2.6× compression ratio**. This means the actual downloaded update size is approximately:
+  
+  ```text
+  10 MB / 2.6 ≈ 3.85 MB per update
+  ```
+
+- **Total Downloads:** Given a bandwidth allocation, we estimate how many users can download an update. For example, if your plan includes **1 TiB (1,024 GiB) of bandwidth per billing cycle**, the number of updates that can be downloaded is:
+
+  ```text
+  (1,024 GiB × 1,024 MiB) / 3.85 MiB ≈ 272,935 updates
+  ```
+
+## Measuring Your Actual Update Size
+
+To determine the actual compressed size of your Hermes bundle, run the following command:
+
+```sh
+gzip -9 -k bundle.hbc
+ls -lh bundle.hbc.gz
+```
+
+This will generate a **gzip-compressed** version of your Hermes bundle (`bundle.hbc.gz`) and display its size. You can use this to refine bandwidth calculations based on your app’s real-world update sizes.
+
+## Factors That Affect Bandwidth Consumption
+
+Actual bandwidth usage varies due to:
+
+- **User Behavior:** While theoretical calculations assume every user downloads every update, many users only receive updates when reopening the app, meaning they may skip intermediate updates.
+- **Missing Assets:** Any assets not included in the embedded build but required in the update (e.g., fonts, images, or other dependencies) will need to be downloaded as well, increasing bandwidth usage.
+
+## Best Practices to Optimize Bandwidth Usage
+
+1. **Minimize Update Size:** Avoid bundling unnecessary assets in updates.
+2. **Monitor Usage:** Check your bandwidth metrics to detect unusual spikes or inefficiencies.
+
+
+

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -11,7 +11,7 @@ EAS Update enables an app to update its own non-native pieces (such as JS, styli
 
 Each subscription plan includes a predefined bandwidth allocation per billing cycle, which translates to a specific number of updates your users can download. Here's how we estimate bandwidth usage:
 
-- **Update size:** The key factor in bandwidth consumption is the size of update assets that are not already on the device. If an update only modifies the JavaScript portion of your app, users will only download the new Javascript. To begin an example, if the uncompressed Javascript portion is **10 MB**, compression can further reduce its size.
+- **Update size:** The key factor in bandwidth consumption is the size of update assets that are not already on the device. If an update only modifies the JavaScript portion of your app, users will only download the new Javascript. To begin an example, let's say the uncompressed Javascript portion generated during export is **10 MB**. Compression will further reduce its size.
 - **Compression ratio:** The level of compression depends on the file type. JavaScript and Hermes bytecode (commonly used in React Native apps) can be compressed, while images and icons are not automatically compressed. In the example above, a Hermes bytecode bundle achieves an estimated **2.6× compression ratio**, reducing the actual download size to:
 
   ```text

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -21,7 +21,7 @@ Each subscription plan includes a predefined bandwidth allocation per billing cy
 - **Total Downloads:** Given a bandwidth allocation, we estimate how many users can download an update. For example, if your plan includes **1 TiB (1,024 GiB) of bandwidth per billing cycle**, the number of updates covered by this allocation is:
 
   ```text
-  (1,024 GiB × 1,024 MiB) / 3.85 MiB ≈ 272,935 updates
+  (1,024 GiB × 1,024 MiB/GiB) / 3.85 MiB ≈ 272,935 updates
   ```
 
 ## Measuring your actual update size

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -3,16 +3,16 @@ title: Estimate bandwidth usage
 description: Learn how to estimate bandwidth usage with EAS Update.
 ---
 
-# Understanding Update Bandwidth Usage
+# Understanding update bandwidth usage
 
 EAS Update enables an app to update its own non-native pieces (such as JS, styling, and images) over-the-air. This guide explains how bandwidth is consumed and optimized.
 
-## Bandwidth Calculation Breakdown
+## Bandwidth calculation breakdown
 
-Each billing cycle includes a predefined bandwidth allocation, which translates to a specific number of updates your users can download. Here's how we estimate bandwidth usage:
+Each subscription plan includes a predefined bandwidth allocation per billing cycle, which translates to a specific number of updates your users can download. Here's how we estimate bandwidth usage:
 
-- **Update Size:** The key factor in bandwidth consumption is the size of each update. For example, if an update modifies only the JavaScript portion of your app and is **10 MB uncompressed**, we can further optimize this with compression.
-- **Compression Ratio:** Hermes bytecode, commonly used in React Native apps, achieves an estimated **2.6× compression ratio**. This means the actual downloaded update size is approximately:
+- **Update size:** The key factor in bandwidth consumption is the size of update assets that are not already on the device. If an update only modifies the JavaScript portion of your app, users will only download the new Javascript. To begin an example, if the uncompressed Javascript portion is **10 MB**, compression can further reduce its size.
+- **Compression ratio:** The level of compression depends on the file type. JavaScript and Hermes bytecode (commonly used in React Native apps) can be compressed, while images and icons are not automatically compressed. In the example above, a Hermes bytecode bundle achieves an estimated **2.6× compression ratio**, reducing the actual download size to:
 
   ```text
   10 MB / 2.6 ≈ 3.85 MB per update
@@ -24,7 +24,7 @@ Each billing cycle includes a predefined bandwidth allocation, which translates 
   (1,024 GiB × 1,024 MiB) / 3.85 MiB ≈ 272,935 updates
   ```
 
-## Measuring Your Actual Update Size
+## Measuring your actual update size
 
 To determine the actual compressed size of your Hermes bundle, run the following command:
 
@@ -35,14 +35,14 @@ ls -lh bundle.hbc.gz
 
 This will generate a **gzip-compressed** version of your Hermes bundle (`bundle.hbc.gz`) and display its size. You can use this to refine bandwidth calculations based on your app’s real-world update sizes.
 
-## Factors That Affect Bandwidth Consumption
+## Factors that affect bandwidth consumption
 
 Actual bandwidth usage varies due to:
 
-- **User Behavior:** While theoretical calculations assume every user downloads every update, many users only receive updates when reopening the app, meaning they may skip intermediate updates.
-- **Missing Assets:** Any assets not included in the embedded build but required in the update (e.g., fonts, images, or other dependencies) will need to be downloaded as well, increasing bandwidth usage.
+- **User behavior:** While theoretical calculations assume every user downloads every update, many users only receive updates when reopening the app, meaning they may skip intermediate updates.
+- **Missing assets:** Any assets not included in the embedded build but required in the update (e.g., fonts, images, or other dependencies) will need to be downloaded as well, increasing bandwidth usage.
 
-## Best Practices to Optimize Bandwidth Usage
+## Best practices to optimize bandwidth usage
 
-1. **Minimize Update Size:** Avoid bundling unnecessary assets in updates.
-2. **Monitor Usage:** Check your bandwidth metrics to detect unusual spikes or inefficiencies.
+1. **Minimize update size:** Avoid bundling unnecessary assets in updates.
+2. **Monitor usage:** Check your bandwidth metrics to detect unusual spikes or inefficiencies.

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -41,7 +41,7 @@ This will generate **Brotli- and Gzip-compressed** versions of your Hermes bundl
 Actual bandwidth usage varies due to:
 
 - **User behavior:** Theoretical calculations assume every user downloads every update. However, many users only get updates when they reopen the app, often skipping intermediate updates. As a result, actual bandwidth usage is usually much lower than the theoretical maximum.
-- **Missing assets:** If an update includes assets such as fonts and images that are not already on the device, they will need to be downloaded as well.
+- **Missing assets:** If an update includes assets such as fonts and images that are not already on the device from the build or previously-downloaded updates, they will need to be downloaded as well.
 
 ## Optimizing bandwidth usage
 

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -18,7 +18,7 @@ Each subscription plan includes a predefined bandwidth allocation per billing cy
   10 MB / 2.6 ≈ 3.85 MB per update
   ```
 
-- **Total Downloads:** Given a bandwidth allocation, we estimate how many users can download an update. For example, if your plan includes **1 TiB (1,024 GiB) of bandwidth per billing cycle**, the number of updates that can be downloaded is:
+- **Total Downloads:** Given a bandwidth allocation, we estimate how many users can download an update. For example, if your plan includes **1 TiB (1,024 GiB) of bandwidth per billing cycle**, the number of updates covered by this allocation is:
 
   ```text
   (1,024 GiB × 1,024 MiB) / 3.85 MiB ≈ 272,935 updates

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -13,7 +13,7 @@ Each billing cycle includes a predefined bandwidth allocation, which translates 
 
 - **Update Size:** The key factor in bandwidth consumption is the size of each update. For example, if an update modifies only the JavaScript portion of your app and is **10 MB uncompressed**, we can further optimize this with compression.
 - **Compression Ratio:** Hermes bytecode, commonly used in React Native apps, achieves an estimated **2.6× compression ratio**. This means the actual downloaded update size is approximately:
-  
+
   ```text
   10 MB / 2.6 ≈ 3.85 MB per update
   ```
@@ -46,6 +46,3 @@ Actual bandwidth usage varies due to:
 
 1. **Minimize Update Size:** Avoid bundling unnecessary assets in updates.
 2. **Monitor Usage:** Check your bandwidth metrics to detect unusual spikes or inefficiencies.
-
-
-

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -9,7 +9,7 @@ EAS Update enables an app to update its own non-native pieces (such as JS, styli
 
 ## Bandwidth calculation breakdown
 
-Each subscription plan includes a predefined bandwidth allocation per billing cycle, which translates to a specific number of updates your users can download. Here's how we estimate bandwidth usage:
+Each subscription plan includes a predefined bandwidth allocation per billing cycle. Additionally, customers who purchase extra MAUs through usage-based pricing receive an additional 40 MiB of bandwidth per MAU. This bandwidth determines the number of updates your users can download. Here's how we estimate bandwidth usage:
 
 - **Update size:** The key factor in bandwidth consumption is the size of update assets that are not already on the device. If an update only modifies the JavaScript portion of your app, users will only download the new Javascript. To begin an example, let's say the uncompressed Javascript portion generated during export is **10 MB**. Compression will further reduce its size.
 - **Compression ratio:** The level of compression depends on the file type. JavaScript and Hermes bytecode (commonly used in React Native apps) can be compressed, while images and icons are not automatically compressed. In the example above, a Hermes bytecode bundle achieves an estimated **2.6× compression ratio**, reducing the actual download size to:

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -9,7 +9,7 @@ EAS Update enables an app to update its own non-native pieces (such as JS, styli
 
 ## Bandwidth calculation breakdown
 
-Each subscription plan includes a predefined bandwidth allocation per billing cycle. Additionally, customers who purchase extra MAUs through usage-based pricing receive an additional 40 MiB of bandwidth per MAU. This bandwidth determines the number of updates your users can download. Here's how to estimate bandwidth usage per update:
+Each subscription plan includes a predefined bandwidth allocation per month. Additionally, extra MAUs purchased through usage-based pricing receive an additional 40 MiB of bandwidth per MAU. This bandwidth determines the number of updates your users can download. Here's how to estimate bandwidth usage per update:
 
 - **Update size:** The key factor in bandwidth consumption is the size of update assets that are not already on the device. If an update only modifies the JavaScript portion of your app, users will only download the new Javascript. To begin an example, let's say the uncompressed Javascript portion generated during export is **10 MB**. Compression will further reduce its size.
 - **Compression ratio:** The level of compression depends on the file type. JavaScript and Hermes bytecode (commonly used in React Native apps) can be compressed, while images and icons are not automatically compressed. In the example above, a Hermes bytecode bundle achieves an estimated **2.6× compression ratio**, reducing the actual download size to:
@@ -18,10 +18,11 @@ Each subscription plan includes a predefined bandwidth allocation per billing cy
   10 MB / 2.6 ≈ 3.85 MB update bandwidth size
   ```
 
-- **Total Downloads:** Given a bandwidth allocation, we estimate how many users can download an update. For example, if your plan includes **1 TiB (1,024 GiB) of bandwidth per billing cycle**, the number of updates covered by this allocation is:
+- **Total update bandwidth:** Given a bandwidth allocation, we estimate how many updates can be downloaded. For example, if you have 60,000 MAUs on a production plan, it includes 50,0000 MAU and 1 TiB (1,024 GiB) of bandwidth per month. An additional 10,000 MAUs purchased through usage-based pricing receive an additional 40 MiB of bandwidth per MAU. The total number of updates that can be downloaded is:
 
   ```text
-  (1,024 GiB × 1,024 MiB/GiB) / 3.85 MiB ≈ 272,935 updates
+  (1,024 GiB × 1,024 MiB/GiB) + (10,000 MAU × 40 MiB/MAU) = 1,448,576 MiB per month
+  1,448,576 MiB / 3.85 MiB ≈ 376,254 updates
   ```
 
 ## Measuring your actual update size

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -9,7 +9,7 @@ EAS Update enables an app to update its own non-native pieces (such as JS, styli
 
 ## Bandwidth calculation breakdown
 
-Each subscription plan includes a predefined bandwidth allocation per monthly billing period in addition to its monthly active user (MAU) allocation ([learn more about how MAU are calculated](https://docs.expo.dev/eas-update/faq/#how-are-monthly-updated-users-counted-for-a-billing-cycle)). MAU's beyond the standard allocation are billed at [usage-based pricing rates](https://expo.dev/pricing#update), and each of those additional MAU add an extra 40 MiB to your standard bandwidth allocation. This bandwidth determines the number of updates your users can download before being charged for additional bandwidth usage. 
+Each subscription plan includes a predefined bandwidth allocation per monthly billing period in addition to its monthly active user (MAU) allocation ([learn more about how MAU are calculated](https://docs.expo.dev/eas-update/faq/#how-are-monthly-updated-users-counted-for-a-billing-cycle)). MAU's beyond the standard allocation are billed at [usage-based pricing rates](https://expo.dev/pricing#update), and each of those additional MAU add an extra 40 MiB to your standard bandwidth allocation. This bandwidth determines the number of updates your users can download before being charged for additional bandwidth usage.
 
 Here's how to estimate bandwidth usage per update:
 
@@ -22,10 +22,10 @@ Here's how to estimate bandwidth usage per update:
 
 Given a bandwidth allocation, we estimate how many updates can be downloaded in a monthly billing period before additional bandwidth charges apply. For example, if you have 60,000 MAUs on a production plan, it includes 50,0000 MAU and **1 TiB (1,024 GiB) of bandwidth per month**. An additional 10,000 MAUs purchased through usage-based pricing receives an additional **40 MiB of bandwidth per MAU**. The total number of updates that can be downloaded is:
 
-  ```text
-  (1,024 GiB × 1,024 MiB/GiB) + (10,000 MAU × 40 MiB/MAU) = 1,448,576 MiB per month
-  1,448,576 MiB / 3.85 MiB ≈ 376,254 updates
-  ```
+```text
+(1,024 GiB × 1,024 MiB/GiB) + (10,000 MAU × 40 MiB/MAU) = 1,448,576 MiB per month
+1,448,576 MiB / 3.85 MiB ≈ 376,254 updates
+```
 
 ## Measuring your actual update size
 

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -9,7 +9,7 @@ EAS Update enables an app to update its own non-native pieces (such as JS, styli
 
 ## Bandwidth calculation breakdown
 
-Each subscription plan includes a predefined bandwidth allocation per monthly billing period in addition to its monthly active user (MAU) allocation ([Learn more about how MAU are calculated](https://docs.expo.dev/eas-update/faq/#how-are-monthly-updated-users-counted-for-a-billing-cycle)). MAU's beyond the standard allocation are billed at [usage-based pricing rates](https://expo.dev/pricing#update), and each of those additional MAU add an extra 40 MiB to your standard bandwidth allocation. This bandwidth determines the number of updates your users can download before being charged for additional bandwidth usage. 
+Each subscription plan includes a predefined bandwidth allocation per monthly billing period in addition to its monthly active user (MAU) allocation ([learn more about how MAU are calculated](https://docs.expo.dev/eas-update/faq/#how-are-monthly-updated-users-counted-for-a-billing-cycle)). MAU's beyond the standard allocation are billed at [usage-based pricing rates](https://expo.dev/pricing#update), and each of those additional MAU add an extra 40 MiB to your standard bandwidth allocation. This bandwidth determines the number of updates your users can download before being charged for additional bandwidth usage. 
 
 Here's how to estimate bandwidth usage per update:
 
@@ -20,7 +20,7 @@ Here's how to estimate bandwidth usage per update:
   10 MB / 2.6 ≈ 3.85 MB update bandwidth size
   ```
 
-- **Total update bandwidth:** Given a bandwidth allocation, we estimate how many updates can be downloaded in a monthly billing period before additional bandwidth charges apply. For example, if you have 60,000 MAUs on a production plan, it includes 50,0000 MAU and **1 TiB (1,024 GiB) of bandwidth per month**. An additional 10,000 MAUs purchased through usage-based pricing receives an additional **40 MiB of bandwidth per MAU**. The total number of updates that can be downloaded is:
+Given a bandwidth allocation, we estimate how many updates can be downloaded in a monthly billing period before additional bandwidth charges apply. For example, if you have 60,000 MAUs on a production plan, it includes 50,0000 MAU and **1 TiB (1,024 GiB) of bandwidth per month**. An additional 10,000 MAUs purchased through usage-based pricing receives an additional **40 MiB of bandwidth per MAU**. The total number of updates that can be downloaded is:
 
   ```text
   (1,024 GiB × 1,024 MiB/GiB) + (10,000 MAU × 40 MiB/MAU) = 1,448,576 MiB per month

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -15,7 +15,7 @@ Each subscription plan includes a predefined bandwidth allocation per billing cy
 - **Compression ratio:** The level of compression depends on the file type. JavaScript and Hermes bytecode (commonly used in React Native apps) can be compressed, while images and icons are not automatically compressed. In the example above, a Hermes bytecode bundle achieves an estimated **2.6× compression ratio**, reducing the actual download size to:
 
   ```text
-  10 MB / 2.6 ≈ 3.85 MB per update
+  10 MB / 2.6 ≈ 3.85 MB update bandwidth size
   ```
 
 - **Total Downloads:** Given a bandwidth allocation, we estimate how many users can download an update. For example, if your plan includes **1 TiB (1,024 GiB) of bandwidth per billing cycle**, the number of updates covered by this allocation is:

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -9,7 +9,7 @@ EAS Update enables an app to update its own non-native pieces (such as JS, styli
 
 ## Bandwidth calculation breakdown
 
-Each subscription plan includes a predefined bandwidth allocation per billing cycle. Additionally, customers who purchase extra MAUs through usage-based pricing receive an additional 40 MiB of bandwidth per MAU. This bandwidth determines the number of updates your users can download. Here's how we estimate bandwidth usage:
+Each subscription plan includes a predefined bandwidth allocation per billing cycle. Additionally, customers who purchase extra MAUs through usage-based pricing receive an additional 40 MiB of bandwidth per MAU. This bandwidth determines the number of updates your users can download. Here's how to estimate bandwidth usage per update:
 
 - **Update size:** The key factor in bandwidth consumption is the size of update assets that are not already on the device. If an update only modifies the JavaScript portion of your app, users will only download the new Javascript. To begin an example, let's say the uncompressed Javascript portion generated during export is **10 MB**. Compression will further reduce its size.
 - **Compression ratio:** The level of compression depends on the file type. JavaScript and Hermes bytecode (commonly used in React Native apps) can be compressed, while images and icons are not automatically compressed. In the example above, a Hermes bytecode bundle achieves an estimated **2.6× compression ratio**, reducing the actual download size to:

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -40,8 +40,8 @@ This will generate **Brotli- and Gzip-compressed** versions of your Hermes bundl
 
 Actual bandwidth usage varies due to:
 
-- **User behavior:** While theoretical calculations assume every user downloads every update, many users only receive updates when reopening the app, meaning they may skip intermediate updates.
-- **Missing assets:** Any assets not included in the embedded build but required in the update (e.g., fonts, images, or other dependencies) will need to be downloaded as well, increasing bandwidth usage.
+- **User behavior:** Theoretical calculations assume every user downloads every update. However, many users only get updates when they reopen the app, often skipping intermediate updates. As a result, actual bandwidth usage is usually much lower than the theoretical maximum.
+- **Missing assets:** If an update includes assets such as fonts and images that are not already on the device, they will need to be downloaded as well.
 
 ## Best practices to optimize bandwidth usage
 

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -20,7 +20,7 @@ Here's how to estimate bandwidth usage per update:
   10 MB / 2.6 ≈ 3.85 MB update bandwidth size
   ```
 
-- **Total update bandwidth:** Given a bandwidth allocation, we estimate how many updates can be downloaded. For example, if you have 60,000 MAUs on a production plan, it includes 50,0000 MAU and **1 TiB (1,024 GiB) of bandwidth per month**. An additional 10,000 MAUs purchased through usage-based pricing receives an additional **40 MiB of bandwidth per MAU**. The total number of updates that can be downloaded is:
+- **Total update bandwidth:** Given a bandwidth allocation, we estimate how many updates can be downloaded in a monthly billing period before additional bandwidth charges apply. For example, if you have 60,000 MAUs on a production plan, it includes 50,0000 MAU and **1 TiB (1,024 GiB) of bandwidth per month**. An additional 10,000 MAUs purchased through usage-based pricing receives an additional **40 MiB of bandwidth per MAU**. The total number of updates that can be downloaded is:
 
   ```text
   (1,024 GiB × 1,024 MiB/GiB) + (10,000 MAU × 40 MiB/MAU) = 1,448,576 MiB per month

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -5,7 +5,7 @@ description: Learn how to estimate bandwidth usage for EAS Update.
 
 # Understanding update bandwidth usage
 
-EAS Update enables an app to update its own non-native pieces (such as JS, styling, and images) over-the-air. This guide explains how bandwidth is consumed and optimized.
+EAS Update enables an app to update its own non-native pieces (such as JS, styling, and images) over-the-air. This guide explains how bandwidth is consumed and how consumption can be optimized.
 
 ## Bandwidth calculation breakdown
 

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -26,14 +26,15 @@ Each subscription plan includes a predefined bandwidth allocation per billing cy
 
 ## Measuring your actual update size
 
-To determine the actual compressed size of your Hermes bundle, run the following command:
+To determine the actual compressed size of your Hermes bundle, run the following commands:
 
 ```sh
+brotli -5 -k bundle.hbc
 gzip -9 -k bundle.hbc
-ls -lh bundle.hbc.gz
+ls -lh bundle.hbc.br bundle.hbc.gz
 ```
 
-This will generate a **gzip-compressed** version of your Hermes bundle (`bundle.hbc.gz`) and display its size. You can use this to refine bandwidth calculations based on your app’s real-world update sizes.
+This will generate **Brotli- and Gzip-compressed** versions of your Hermes bundle (bundle.hbc.br and bundle.hbc.gz) and display their sizes. You can use this to refine bandwidth calculations based on your app’s real-world update sizes.
 
 ## Factors that affect bandwidth consumption
 

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -42,7 +42,7 @@ This will generate **Brotli- and Gzip-compressed** versions of your Hermes bundl
 Actual bandwidth usage varies due to:
 
 - **User behavior:** Theoretical calculations assume every user downloads every update. However, many users only get updates when they reopen the app, often skipping intermediate updates. As a result, actual bandwidth usage is usually much lower than the theoretical maximum.
-- **Missing assets:** If an update includes assets such as fonts and images that are not already on the device from the build or previously-downloaded updates, they will need to be downloaded as well.
+- **Missing assets:** If an update includes assets such as fonts and images that are not already on the device from the build or previously downloaded updates, they will need to be downloaded as well.
 
 ## Optimizing bandwidth usage
 

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -43,7 +43,8 @@ Actual bandwidth usage varies due to:
 - **User behavior:** Theoretical calculations assume every user downloads every update. However, many users only get updates when they reopen the app, often skipping intermediate updates. As a result, actual bandwidth usage is usually much lower than the theoretical maximum.
 - **Missing assets:** If an update includes assets such as fonts and images that are not already on the device, they will need to be downloaded as well.
 
-## Best practices to optimize bandwidth usage
+## Optimizing bandwidth usage
 
-1. **Minimize update size:** Avoid bundling unnecessary assets in updates.
-2. **Monitor usage:** Check your bandwidth metrics to detect unusual spikes or inefficiencies.
+1. **Monitor usage first:** The easiest way to manage bandwidth is to track your [usage metrics](https://expo.dev/accounts/[account]/settings/usage) and identify any unusual spikes or inefficiencies.
+2. **Optimize asset size:** Reduce the size of your assets with [this guide](/eas-update/optimize-assets).
+3. **Exclude assets when needed:** Use [asset selection](/eas-update/asset-selection) to reduce the number of assets included with each update. This is an advanced optimization and other approaches should be tried first.

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -9,7 +9,9 @@ EAS Update enables an app to update its own non-native pieces (such as JS, styli
 
 ## Bandwidth calculation breakdown
 
-Each subscription plan includes a predefined bandwidth allocation per month. Additionally, extra MAUs purchased through usage-based pricing receives an additional 40 MiB of bandwidth per MAU. This bandwidth determines the number of updates your users can download. Here's how to estimate bandwidth usage per update:
+Each subscription plan includes a predefined bandwidth allocation per monthly billing period in addition to its monthly active user (MAU) allocation ([Learn more about how MAU are calculated](https://docs.expo.dev/eas-update/faq/#how-are-monthly-updated-users-counted-for-a-billing-cycle)). MAU's beyond the standard allocation are billed at [usage-based pricing rates](https://expo.dev/pricing#update), and each of those additional MAU add an extra 40 MiB to your standard bandwidth allocation. This bandwidth determines the number of updates your users can download before being charged for additional bandwidth usage. 
+
+Here's how to estimate bandwidth usage per update:
 
 - **Update size:** The key factor in bandwidth consumption is the size of update assets that are not already on the device. If an update only modifies the JavaScript portion of your app, users will only download the new Javascript. To begin an example, let's say the uncompressed Javascript portion generated during export is **10 MB**. Compression will further reduce its size.
 - **Compression ratio:** The level of compression depends on the file type. JavaScript and Hermes bytecode (commonly used in React Native apps) can be compressed, while images and icons are not automatically compressed. In the example above, a Hermes bytecode bundle achieves an estimated **2.6× compression ratio**, reducing the actual download size to:

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -9,7 +9,7 @@ EAS Update enables an app to update its own non-native pieces (such as JS, styli
 
 ## Bandwidth calculation breakdown
 
-Each subscription plan includes a predefined bandwidth allocation per month. Additionally, extra MAUs purchased through usage-based pricing receive an additional 40 MiB of bandwidth per MAU. This bandwidth determines the number of updates your users can download. Here's how to estimate bandwidth usage per update:
+Each subscription plan includes a predefined bandwidth allocation per month. Additionally, extra MAUs purchased through usage-based pricing receives an additional 40 MiB of bandwidth per MAU. This bandwidth determines the number of updates your users can download. Here's how to estimate bandwidth usage per update:
 
 - **Update size:** The key factor in bandwidth consumption is the size of update assets that are not already on the device. If an update only modifies the JavaScript portion of your app, users will only download the new Javascript. To begin an example, let's say the uncompressed Javascript portion generated during export is **10 MB**. Compression will further reduce its size.
 - **Compression ratio:** The level of compression depends on the file type. JavaScript and Hermes bytecode (commonly used in React Native apps) can be compressed, while images and icons are not automatically compressed. In the example above, a Hermes bytecode bundle achieves an estimated **2.6× compression ratio**, reducing the actual download size to:
@@ -18,7 +18,7 @@ Each subscription plan includes a predefined bandwidth allocation per month. Add
   10 MB / 2.6 ≈ 3.85 MB update bandwidth size
   ```
 
-- **Total update bandwidth:** Given a bandwidth allocation, we estimate how many updates can be downloaded. For example, if you have 60,000 MAUs on a production plan, it includes 50,0000 MAU and 1 TiB (1,024 GiB) of bandwidth per month. An additional 10,000 MAUs purchased through usage-based pricing receive an additional 40 MiB of bandwidth per MAU. The total number of updates that can be downloaded is:
+- **Total update bandwidth:** Given a bandwidth allocation, we estimate how many updates can be downloaded. For example, if you have 60,000 MAUs on a production plan, it includes 50,0000 MAU and **1 TiB (1,024 GiB) of bandwidth per month**. An additional 10,000 MAUs purchased through usage-based pricing receives an additional **40 MiB of bandwidth per MAU**. The total number of updates that can be downloaded is:
 
   ```text
   (1,024 GiB × 1,024 MiB/GiB) + (10,000 MAU × 40 MiB/MAU) = 1,448,576 MiB per month


### PR DESCRIPTION
# Why

Added documentation to help developers estimate and optimize bandwidth usage for EAS Update. This helps users better understand their bandwidth consumption and plan accordingly for their update distribution strategy.

# How

Created a new documentation page that:
- Explains how bandwidth is calculated for EAS Update
- Provides formulas and examples for estimating update downloads
- Shows how to measure actual update sizes using gzip compression
- Lists factors affecting bandwidth consumption
- Outlines best practices for optimization

# Test Plan

- Verified the new page renders correctly in the documentation navigation
- Confirmed all code examples and calculations are accurate
- Tested the gzip compression command example

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)