### PR TITLE
Update get-started.mdx

### DIFF
--- a/docs/pages/custom-builds/get-started.mdx
+++ b/docs/pages/custom-builds/get-started.mdx
@@ -27,7 +27,7 @@ build:
   name: Hello World!
   steps:
     - run: echo "Hello, world!"
-    - eas/build
+    # A built-in function (optional)
 ```
 
 In a real world scenario, you will call a [built-in function](/custom-builds/schema/#built-in-eas-functions) to trigger the build.

--- a/docs/pages/custom-builds/get-started.mdx
+++ b/docs/pages/custom-builds/get-started.mdx
@@ -30,7 +30,7 @@ build:
     - eas/build
 ```
 
-You need to call either the all-in-one `eas/build` function or the [built-in functions](custom-builds/schema/#built-in-eas-functions) in order to trigger the build.
+In a real world scenario, you will call a [built-in function](/custom-builds/schema/#built-in-eas-functions) to trigger the build.
 
 </Step>
 

--- a/docs/pages/custom-builds/get-started.mdx
+++ b/docs/pages/custom-builds/get-started.mdx
@@ -27,7 +27,10 @@ build:
   name: Hello World!
   steps:
     - run: echo "Hello, world!"
+    - eas/build
 ```
+
+You need to call either the all-in-one `eas/build` function or the [built-in functions](custom-builds/schema/#built-in-eas-functions) in order to trigger the build.
 
 </Step>
 


### PR DESCRIPTION
# Why

Not running `eas/build` or the "wrapped" functions won't trigger a build

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
