### PR TITLE
[metro-runtime] fix broken async import

### DIFF
--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Only reload RSC for a given platform. ([#34216](https://github.com/expo/expo/pull/34216) by [@EvanBacon](https://github.com/EvanBacon))
 - Parse errors with Babel code frames as syntax errors on Windows. ([#34017](https://github.com/expo/expo/pull/34017) by [@byCedric](https://github.com/byCedric))
+- Fixed broken async import. ([#34824](https://github.com/expo/expo/pull/34824) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-runtime/package.json
+++ b/packages/@expo/metro-runtime/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.0",
   "description": "Tools for making advanced Metro bundler features work",
   "sideEffects": true,
-  "main": "src",
+  "main": "src/index.ts",
   "types": "build",
   "homepage": "https://github.com/expo/expo/tree/main/packages/@expo/metro-runtime",
   "keywords": [],


### PR DESCRIPTION
# Why

fix broken async import where lazy bundling doesn't work

# How

a regression since #30300 about the code: https://github.com/expo/expo/blob/b6167feb2e0eadddb851fb3ca9be09d9af7ff706/packages/%40expo/cli/src/start/server/middleware/metroOptions.ts#L62-L72

it returns false always.

# Test Plan

- try `node --print "require('resolve-from')('.', '@expo/metro-runtime')"` on sdk 52 project
- try dynamic import on web and check whether there's fetch request to the chunk

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
