### PR TITLE
[docs] [ENG-14814] Update `on.push` trigger docs with git tag support

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -58,9 +58,13 @@ on:
 
 ### `on.push`
 
-Runs your workflow when you push a commit to matching branches.
+Runs your workflow when you push a commit to matching branches and/or tags.
 
-With the `branches` array, you can trigger the workflow only when those specified branches are pushed to. For example, if you use `branches: ['main']`, only push to the `main` branch will trigger the workflow. Supports globs. Defaults to `['*']` when not provided, which means the workflow will trigger on push events to all branches.
+With the `branches` array, you can trigger the workflow only when those specified branches are pushed to. For example, if you use `branches: ['main']`, only push to the `main` branch will trigger the workflow. Supports globs.
+
+With the `tags` array, you can trigger the workflow only when those specified tags are pushed. For example, if you use `tags: ['v1']`, only the `v1` tag being pushed will trigger the workflow. Supports globs.
+
+When neither `branches` nor `tags` are provided, `branches` defaults to `['*']` and `tags` defaults to `[]`, which means the workflow will trigger on push events to all branches and will not trigger on tag pushes. If only one of the two arrays is provided the other defaults to `[]`.
 
 ```yaml
 on:
@@ -70,7 +74,11 @@ on:
     branches:
       - 'main'
       - 'feature/**'
-      # other branches names and globs
+      # other branch names and globs
+    tags:
+      - 'v1'
+      - 'v2*'
+      # other tag names and globs
 ```
 
 ### `on.pull_request`


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-14814/add-support-for-triggering-workflows-from-git-tags
The `on.push` workflow trigger now supports git tags as well as branches
Companion to: https://github.com/expo/universe/pull/18641

# How

Updated the docs for `on.push` workflow trigger after allowing it utilise the git tag pushes

# Test Plan

Tested manually

| Before | After |
| - | - |
| <img width="1134" alt="Screenshot 2025-02-11 at 12 16 04" src="https://github.com/user-attachments/assets/ec3f84ea-2260-4632-84a6-db4e042d7e81" /> | <img width="1134" alt="Screenshot 2025-02-11 at 12 15 54" src="https://github.com/user-attachments/assets/9ee7f9c5-b99e-42a1-85cd-90f87b136c66" /> |

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
