### PR TITLE
[docs] Update export talks data to include YouTube tutorials

### DIFF
--- a/docs/scripts/generate-llms/utils.js
+++ b/docs/scripts/generate-llms/utils.js
@@ -271,7 +271,7 @@ function processTalks(talks, type = 'video') {
 }
 
 export async function exportTalksData() {
-  const { TALKS, PODCASTS, LIVE_STREAMS } = await import('./talks.js');
+  const { TALKS, PODCASTS, LIVE_STREAMS, YOUTUBE_VIDEOS } = await import('./talks.js');
   return {
     title: 'Additional Resources',
     description: 'Collection of talks, podcasts, and live streams from the Expo team',
@@ -291,6 +291,12 @@ export async function exportTalksData() {
       {
         title: 'Live Streams',
         items: processTalks(LIVE_STREAMS),
+        groups: [],
+        sections: [],
+      },
+      {
+        title: 'YouTube Tutorials',
+        items: processTalks(YOUTUBE_VIDEOS),
         groups: [],
         sections: [],
       },


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Update talks export function to include YouTube tutorials from Additional resources in `llms-txt.js` script.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-02-11 at 16 38 20@2x](https://github.com/user-attachments/assets/3a6cce7a-bdd5-4459-a70b-766e9fcb694f)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
