### PR TITLE
fix(cli): Preserve tunnel session ID across restarts

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Use POSIX path when converting route file name in API routes. ([#34307](https://github.com/expo/expo/pull/34307) by [@byCedric](https://github.com/byCedric))
 - Bind debugging infrastructure to `localhost` instead of LAN ip. ([#34368](https://github.com/expo/expo/pull/34368) by [@byCedric](https://github.com/byCedric))
 - Add fallback resolution strategy for dependencies and optional peer dependencies of `expo` and `expo-router` to prevent broken resolution for isolated dependencies and hoisting issues. ([#34286](https://github.com/expo/expo/pull/34286) by [@kitten](https://github.com/kitten))
+- Preserve proxy leases on webcontainers ([#34831](https://github.com/expo/expo/pull/34831) by [@kitten](https://github.com))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
+++ b/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
@@ -1,6 +1,5 @@
 import * as tunnel from '@expo/ws-tunnel';
 import chalk from 'chalk';
-import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs';
 import { hostname } from 'node:os';
 import * as path from 'node:path';

--- a/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
+++ b/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
@@ -54,10 +54,9 @@ export class AsyncWsTunnel {
 
 // Generate a base-36 string of 5 characters (from 32 bits of randomness)
 function randomStr() {
-  const MASK = (1 << 6) - 1;
   let x = 1 + Math.round(Math.random() * (~1 >>> 0));
   let out = '';
-  for (let i = 0; i < 5; i++, x = x >> 6) out += (x & MASK % 36).toString(36);
+  for (let i = 0; i < 5; i++, x = x >>> 6) out += (x % 36).toString(36);
   return out;
 }
 

--- a/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
+++ b/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
@@ -54,7 +54,7 @@ export class AsyncWsTunnel {
 
 // Generate a base-36 string of 5 characters (from 32 bits of randomness)
 function randomStr() {
-  return (Math.random().toString(36) + "00000").slice(2, 7);
+  return (Math.random().toString(36) + '00000').slice(2, 7);
 }
 
 function getTunnelSession(): string {

--- a/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
+++ b/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
@@ -54,10 +54,7 @@ export class AsyncWsTunnel {
 
 // Generate a base-36 string of 5 characters (from 32 bits of randomness)
 function randomStr() {
-  let x = 1 + Math.round(Math.random() * (~1 >>> 0));
-  let out = '';
-  for (let i = 0; i < 5; i++, x = x >>> 6) out += (x % 36).toString(36);
-  return out;
+  return (Math.random().toString(36) + "00000").slice(2, 7);
 }
 
 function getTunnelSession(): string {

--- a/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
+++ b/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
@@ -61,20 +61,16 @@ function randomStr() {
 }
 
 function getTunnelSession(): string {
+  let session = randomStr() + randomStr() + randomStr();
   if (envIsWebcontainer()) {
     const leaseId = Buffer.from(hostname()).toString('base64url');
     const leaseFile = path.join(tempDir, `_ws_tunnel_lease_${leaseId}`);
     try {
-      const session = fs.readFileSync(leaseFile, 'utf8').trim() || null;
-      if (session) return session;
+      session = fs.readFileSync(leaseFile, 'utf8').trim() || session;
+      fs.writeFileSync(leaseFile, session, 'utf8');
     } catch {}
-    const session = randomStr() + randomStr() + randomStr();
-    fs.writeFileSync(leaseFile, session, 'utf8');
-    return session;
-  } else {
-    const session = randomStr() + randomStr() + randomStr();
-    return session;
   }
+  return session;
 }
 
 function getTunnelOptions() {

--- a/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
+++ b/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
@@ -54,10 +54,10 @@ export class AsyncWsTunnel {
 
 // Generate a base-36 string of 5 characters (from 32 bits of randomness)
 function randomStr() {
-  const MASK = (1 << 5) - 1;
+  const MASK = (1 << 6) - 1;
   let x = 1 + Math.round(Math.random() * (~1 >>> 0));
   let out = '';
-  for (let i = 0; i < 5; i++, x = x >> 5) out += (x & MASK).toString(36);
+  for (let i = 0; i < 5; i++, x = x >> 6) out += (x & MASK % 36).toString(36);
   return out;
 }
 

--- a/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
+++ b/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
@@ -53,6 +53,15 @@ export class AsyncWsTunnel {
   }
 }
 
+// Generate a base-36 string of 5 characters (from 32 bits of randomness)
+function randomStr() {
+  const MASK = (1 << 5) - 1;
+  let x = 1 + Math.round(Math.random() * (~1 >>> 0));
+  let out = '';
+  for (let i = 0; i < 5; i++, x = x >> 5) out += (x & MASK).toString(36);
+  return out;
+}
+
 function getTunnelSession(): string {
   const leaseId = Buffer.from(hostname()).toString('base64url');
   const leaseFile = path.join(tempDir, `_ws_tunnel_lease_${leaseId}`);
@@ -61,10 +70,8 @@ function getTunnelSession(): string {
     session = fs.readFileSync(leaseFile, 'utf8').trim() || null;
   } catch {}
   if (!session) {
-    do {
-      // TODO(cedric): replace this with non-random data generated from server to manage and prevent overlapping sessions
-      session = randomBytes(12).toString('base64url');
-    } while (!/^[A-Za-z0-9]/.test(session));
+    // NOTE(@kitten): Randomness should be about 2.21e+23
+    session = randomStr() + randomStr() + randomStr();
     fs.writeFileSync(leaseFile, session, 'utf8');
   }
   return session;


### PR DESCRIPTION
Supersedes #34716

- Fix tunnel session ID being generated with invalid characters by replacing ID with base-36 sequences (currently a sequence of 15 alphanumeric characters)
- Store tunnel session ID in `/tmp` folder to reuse it. This folder is guaranteed to survive restarts of the `@expo/cli` but will be erased on a tab reload