### PR TITLE
[docs][file-system-next]: correct imports for using legacy FileSystem API

### DIFF
--- a/docs/pages/versions/v52.0.0/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/filesystem-next.mdx
@@ -76,7 +76,7 @@ try {
 ### Using legacy FileSystem API
 
 ```ts example.ts
-import { FileSystem } from 'expo-file-system';
+import * as FileSystem from 'expo-file-system';
 import { File, Paths } from 'expo-file-system/next';
 
 try {


### PR DESCRIPTION
# Why

correct imports for using legacy FileSystem API

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
