### PR TITLE
[notifications]: Fix didNotificationResponseReceived being duplicating fired for pending notification responses

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - fix ios textInput action missing title ([#34866](https://github.com/expo/expo/pull/34866) by [@vonovak](https://github.com/vonovak))
 - [ios] Fixed incorrect `EXNotifications-Swift.h` import. ([#34987](https://github.com/expo/expo/pull/34987) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix `didNotificationResponseReceived` being duplicating fired for pending notification responses. ([#34849](https://github.com/expo/expo/pull/34849) by [@xc2](https://github.com/xc2))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - fix ios textInput action missing title ([#34866](https://github.com/expo/expo/pull/34866) by [@vonovak](https://github.com/vonovak))
 - [ios] Fixed incorrect `EXNotifications-Swift.h` import. ([#34987](https://github.com/expo/expo/pull/34987) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Fix `didNotificationResponseReceived` being duplicating fired for pending notification responses. ([#34849](https://github.com/expo/expo/pull/34849) by [@xc2](https://github.com/xc2))
+- [iOS] fix notification response listener emitting duplicate response events ([#34849](https://github.com/expo/expo/pull/34849) by [@xc2](https://github.com/xc2))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
@@ -161,13 +161,13 @@ EX_REGISTER_SINGLETON_MODULE(NotificationCenterDelegate);
   [_delegates addPointer:(__bridge void * _Nullable)(delegate)];
   if ([delegate respondsToSelector:@selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)]) {
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+
     NSArray *responsesToProcess = [_pendingNotificationResponses copy];
+    [_pendingNotificationResponses removeAllObjects];
 
     for (UNNotificationResponse *response in responsesToProcess) {
       [delegate userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:^{
-        @synchronized (self) {
-          [self->_pendingNotificationResponses removeObject:response];
-        }
+        // completion handler doesn't need to do anything
       }];
     }
   }

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
@@ -161,9 +161,13 @@ EX_REGISTER_SINGLETON_MODULE(NotificationCenterDelegate);
   [_delegates addPointer:(__bridge void * _Nullable)(delegate)];
   if ([delegate respondsToSelector:@selector(userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:)]) {
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-    for (UNNotificationResponse *response in _pendingNotificationResponses) {
+    NSArray *responsesToProcess = [_pendingNotificationResponses copy];
+
+    for (UNNotificationResponse *response in responsesToProcess) {
       [delegate userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:^{
-        [self->_pendingNotificationResponses removeObject:response];
+        @synchronized (self) {
+          [self->_pendingNotificationResponses removeObject:response];
+        }
       }];
     }
   }

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
@@ -163,7 +163,7 @@ EX_REGISTER_SINGLETON_MODULE(NotificationCenterDelegate);
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
     for (UNNotificationResponse *response in _pendingNotificationResponses) {
       [delegate userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:^{
-        // completion handler doesn't need to do anything
+        [self->_pendingNotificationResponses removeObject:response];
       }];
     }
   }


### PR DESCRIPTION
# Why

Fixes #34850

# How

Remove response from pending notification responses list after it is consumed.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
