### PR TITLE
[android][background-task] use one time request to make debugging easier

### DIFF
--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskModule.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskModule.kt
@@ -50,7 +50,7 @@ class BackgroundTaskModule : Module() {
       appContext.reactContext?.let {
         runBlocking {
           val appScopeKey = it.packageName
-          BackgroundTaskScheduler.startWorker(it, appScopeKey)
+          BackgroundTaskScheduler.scheduleWorker(it, appScopeKey)
         }
       } ?: throw MissingContextException()
     }

--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
@@ -82,7 +82,7 @@ object BackgroundTaskScheduler {
     // Get Work manager
     val workManager = WorkManager.getInstance(context)
 
-    // We have two different paths here, since on Android 24-25 we need to use a periodic request
+    // We have two different paths here, since on Android 14-15 we need to use a periodic request
     // builder since the OneTimeWorkRequest doesn't support setting initial delay (which is how we
     // control executing a task periodically - we spawn a One-time work request when backgrounding,
     // and when this is done we spawn a new one. This makes it a lot easier to debug since we can

--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
@@ -184,7 +184,7 @@ object BackgroundTaskScheduler {
     val consumers = taskService.getTaskConsumers(appScopeKey)
     Log.d(TAG, "runTasks: number of consumers ${consumers.size}")
 
-    if (consumers.size == 0) {
+    if (consumers.isEmpty()) {
       return false
     }
 

--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskWork.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskWork.kt
@@ -1,6 +1,7 @@
 package expo.modules.backgroundtask
 
 import android.content.Context
+import android.os.Build
 import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.Data
@@ -21,7 +22,15 @@ class BackgroundTaskWork(context: Context, params: WorkerParameters) : Coroutine
     val appScopeKey = inputData.getString("appScopeKey") ?: throw MissingAppScopeKey()
 
     try {
+      // Run tasks async using the task service. This call will return when the task has finished
+      // ie. When JS task executor has notified the task manager that it is done.
       BackgroundTaskScheduler.runTasks(applicationContext, appScopeKey)
+      // If we are on a newer Android version we're using a One time request and need to spawn new
+      // requests for each run (and also ask to not try to cancel the work, since we're already
+      // finishing the work item when this function returns.
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        BackgroundTaskScheduler.scheduleWorker(applicationContext, appScopeKey, false)
+      }
     } catch (e: Exception) {
       // Wrap exception in Data:
       val outputData = Data.Builder()


### PR DESCRIPTION
# Why

To be able to debug the background tasks better, we should use a one-time request like we do on iOS so that we can force it to run using adb.

# How

This commit fixes this, by using a one-time-request on Android.O or more.

# Test Plan

Test in BareExpo

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
