### PR TITLE
[updates][android] Fix bytesToHex ArrayIndexOutOfBoundsException during conversion

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -18,6 +18,7 @@
 - fix E2E tests in Detox debug build ([#32951](https://github.com/expo/expo/pull/32951) by [@matejkriz](https://github.com/matejkriz))
 - Fix issue where syncing codesigning config for bare projects would clobber existing Expo.plist config ([#34597](https://github.com/expo/expo/pull/34597) by [@brentvatne](https://github.com/brentvatne))
 - Removed Apache Commons IO dependency and fixed crash issue on Android 7. ([#34638](https://github.com/expo/expo/pull/34638) by [@kudo](https://github.com/kudo))
+- [Android] Fix `bytesToHex` `ArrayIndexOutOfBoundsException` during conversion. ([#34855](https://github.com/expo/expo/pull/34855) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesUtilsInstrumentationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesUtilsInstrumentationTest.kt
@@ -86,38 +86,4 @@ class UpdatesUtilsInstrumentationTest {
   fun testgetHeadersMapFromJSONString_throwsNonStringKey() {
     UpdatesUtils.getMapFromJSONString("{7:[\"main\"]}")
   }
-
-  @Test
-  @Throws(Exception::class)
-  fun testBytesToHex_negativeByteInArray() {
-    val hashString = "B04C4878AFAEDEADBEEFCAFEBABE0123456789ABCDEF0123456789ABCDEF0123"
-    val hashBytes = hashString.chunked(2)
-        .map { it.toInt(16).toByte() }
-        .toByteArray()
-
-    Assert.assertEquals(
-      hashString,
-      UpdatesUtils.bytesToHex(hashBytes)
-    )
-  }
-
-  @Test
-  @Throws(Exception::class)
-  fun testBytesToHex_emptyArray() {
-    val hashBytes = ByteArray(0)
-    val expected = ""
-    Assert.assertEquals(expected, UpdatesUtils.bytesToHex(hashBytes))
-  }
-
-  @Test
-  @Throws(Exception::class)
-  fun testBytesToHex_positiveBytesOnly() {
-    // All bytes are in the range 0x00 to 0x7F (positive when interpreted as signed bytes)
-    val hashString = "0123456789ABCDEF"
-    val hashBytes = hashString.chunked(2)
-      .map { it.toInt(16).toByte() }
-      .toByteArray()
-
-    Assert.assertEquals(hashString, UpdatesUtils.bytesToHex(hashBytes))
-  }
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesUtilsInstrumentationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesUtilsInstrumentationTest.kt
@@ -86,4 +86,38 @@ class UpdatesUtilsInstrumentationTest {
   fun testgetHeadersMapFromJSONString_throwsNonStringKey() {
     UpdatesUtils.getMapFromJSONString("{7:[\"main\"]}")
   }
+
+  @Test
+  @Throws(Exception::class)
+  fun testBytesToHex_negativeByteInArray() {
+    val hashString = "B04C4878AFAEDEADBEEFCAFEBABE0123456789ABCDEF0123456789ABCDEF0123"
+    val hashBytes = hashString.chunked(2)
+        .map { it.toInt(16).toByte() }
+        .toByteArray()
+
+    Assert.assertEquals(
+      hashString,
+      UpdatesUtils.bytesToHex(hashBytes)
+    )
+  }
+
+  @Test
+  @Throws(Exception::class)
+  fun testBytesToHex_emptyArray() {
+    val hashBytes = ByteArray(0)
+    val expected = ""
+    Assert.assertEquals(expected, UpdatesUtils.bytesToHex(hashBytes))
+  }
+
+  @Test
+  @Throws(Exception::class)
+  fun testBytesToHex_positiveBytesOnly() {
+    // All bytes are in the range 0x00 to 0x7F (positive when interpreted as signed bytes)
+    val hashString = "0123456789ABCDEF"
+    val hashBytes = hashString.chunked(2)
+      .map { it.toInt(16).toByte() }
+      .toByteArray()
+
+    Assert.assertEquals(hashString, UpdatesUtils.bytesToHex(hashBytes))
+  }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -185,7 +185,7 @@ object UpdatesUtils {
   fun bytesToHex(bytes: ByteArray): String {
     val hexChars = CharArray(bytes.size * 2)
     for (j in bytes.indices) {
-      val v = (bytes[j] and 0xFF.toByte()).toInt()
+      val v = bytes[j].toInt() and 0xFF
       hexChars[j * 2] = HEX_ARRAY[v ushr 4]
       hexChars[j * 2 + 1] = HEX_ARRAY[v and 0x0F]
     }

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
@@ -83,4 +83,32 @@ class UpdatesUtilsTest : TestCase() {
       Assert.assertEquals(expectedName, case.parseContentDispositionNameParameter())
     }
   }
+
+  fun testBytesToHex_negativeByteInArray() {
+    val hashString = "B04C4878AFAEDEADBEEFCAFEBABE0123456789ABCDEF0123456789ABCDEF0123"
+    val hashBytes = hashString.chunked(2)
+        .map { it.toInt(16).toByte() }
+        .toByteArray()
+
+    Assert.assertEquals(
+      hashString,
+      UpdatesUtils.bytesToHex(hashBytes)
+    )
+  }
+
+  fun testBytesToHex_emptyArray() {
+    val hashBytes = ByteArray(0)
+    val expected = ""
+    Assert.assertEquals(expected, UpdatesUtils.bytesToHex(hashBytes))
+  }
+
+  fun testBytesToHex_positiveBytesOnly() {
+    // All bytes are in the range 0x00 to 0x7F (positive when interpreted as signed bytes)
+    val hashString = "0123456789ABCDEF"
+    val hashBytes = hashString.chunked(2)
+      .map { it.toInt(16).toByte() }
+      .toByteArray()
+
+    Assert.assertEquals(hashString, UpdatesUtils.bytesToHex(hashBytes))
+  }
 }

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
@@ -87,8 +87,8 @@ class UpdatesUtilsTest : TestCase() {
   fun testBytesToHex_negativeByteInArray() {
     val hashString = "B04C4878AFAEDEADBEEFCAFEBABE0123456789ABCDEF0123456789ABCDEF0123"
     val hashBytes = hashString.chunked(2)
-        .map { it.toInt(16).toByte() }
-        .toByteArray()
+      .map { it.toInt(16).toByte() }
+      .toByteArray()
 
     Assert.assertEquals(
       hashString,


### PR DESCRIPTION
# Why

Closes ENG-14988

# How

The original code did not properly convert the byte to an unsigned integer, generating negative values when converted to an Int and then causing an `ArrayIndexOutOfBoundsException` when trying to access the `HEX_ARRAY`. By converting the byte to an Int first, then applying the mask 0xFF to ensure the value is treated as unsigned we can ensure the value will always be valid indices for the 16-element HEX_ARRAY.

This PR also adds tests for the cases that originally threw an exception.

# Test Plan

Instrumentation tests should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
