### PR TITLE
[notifications] fix ios textInput action missing title

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- fix ios textInput action missing title ([#34866](https://github.com/expo/expo/pull/34866) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 - Add better error when Firebase is not set up ([#34694](https://github.com/expo/expo/pull/34694) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Records.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Records.swift
@@ -198,10 +198,10 @@ struct CategoryTextInputActionRecord: Record {
     self.submitButtonTitle = textInputAction.textInputButtonTitle
   }
 
-  func toUNTextInputNotificationAction(identifier: String) -> UNTextInputNotificationAction {
+  func toUNTextInputNotificationAction(identifier: String, title: String) -> UNTextInputNotificationAction {
     return UNTextInputNotificationAction(
       identifier: identifier,
-      title: title ?? "",
+      title: title,
       textInputButtonTitle: submitButtonTitle ?? "",
       textInputPlaceholder: placeholder ?? ""
     )
@@ -252,7 +252,7 @@ struct CategoryActionRecord: Record {
       return nil
     }
     if let textInput = textInput {
-      return textInput.toUNTextInputNotificationAction(identifier: identifier)
+      return textInput.toUNTextInputNotificationAction(identifier: identifier, title: buttonTitle)
     }
     var notificationOptions: UNNotificationActionOptions = []
     if let optionsParams = options {


### PR DESCRIPTION
# Why

when calling the below, `buttonTitle` would be ignored. That's because the `CategoryTextInputActionRecord` assumed that `buttonTitle` comes in from JS but as seen below, it does not, it is provided to the "parent". So the fix is to pass it from the parent manually. `submitButtonTitle` and `placeholder` on the other hand, are provided directly.

```
    Notifications.setNotificationCategoryAsync("submit_reply_placeholder", [
      {
        identifier: "reply",
        buttonTitle: "Reply",
        textInput: {
          submitButtonTitle: "Reply",
          placeholder: "Type a reply...",
        },
        options: {
          opensAppToForeground: false,
        },
      },
])
```

# How

pass the title manually

# Test Plan

tested locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
