### PR TITLE
[splash-screen][docs] Add `resizeMode` config plugin property description

### DIFF
--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -163,6 +163,12 @@ You can configure `expo-splash-screen` using its built-in [config plugin](/confi
       description: 'An object containing properties for configuring the splash screen on iOS.',
       default: 'undefined',
     },
+    {
+      name: 'resizeMode',
+      description:
+        'Determines how the image is scaled to fit the container defined by `imageWidth`. Possible values: `contain`, `cover`, and `native`.',
+      default: 'undefined',
+    },
   ]}
 />
 

--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -166,7 +166,7 @@ You can configure `expo-splash-screen` using its built-in [config plugin](/confi
     {
       name: 'resizeMode',
       description:
-        'Determines how the image is scaled to fit the container defined by `imageWidth`. Possible values: `contain`, `cover`, and `native`.',
+        'Determines how the image is scaled to fit the container defined by `imageWidth`. Possible values: `contain`, `cover`, or `native`.',
       default: 'undefined',
     },
   ]}

--- a/docs/pages/versions/v52.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/splash-screen.mdx
@@ -164,7 +164,7 @@ You can configure `expo-splash-screen` using its built-in [config plugin](/confi
     {
       name: 'resizeMode',
       description:
-        'Determines how the image is scaled to fit the container defined by `imageWidth`. Possible values: `contain`, `cover`, and `native`.',
+        'Determines how the image is scaled to fit the container defined by `imageWidth`. Possible values: `contain`, `cover`, or `native`.',
       default: 'undefined',
     },
   ]}

--- a/docs/pages/versions/v52.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/splash-screen.mdx
@@ -161,6 +161,12 @@ You can configure `expo-splash-screen` using its built-in [config plugin](/confi
       description: 'An object containing properties for configuring the splash screen on iOS.',
       default: 'undefined',
     },
+    {
+      name: 'resizeMode',
+      description:
+        'Determines how the image is scaled to fit the container defined by `imageWidth`. Possible values: `contain`, `cover`, and `native`.',
+      default: 'undefined',
+    },
   ]}
 />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Add the missing `resizeMode` property to Splash Screen API's config plugin.

I have confirmed with @alanjhughes that this property was missing from the config plugin.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-02-12 at 23 21 00@2x](https://github.com/user-attachments/assets/96124f15-ee10-47b9-b2bc-685070c2fdb7)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
