### PR TITLE
[docs]: Update env setup instruction in iosPhysicalDevelopmentBuildLo…

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -50,6 +50,6 @@ Run the following command in your project's root directory and select your plugg
 
 > This command runs a development server after building your app. You can skip running `npx expo start` on the next page.
 
-> Update `bundleIdentifier` of `app.json` in the root directory to a unique value, or Xcode won’t properly generate the provisioning profile for signing, causing the launch failure.
+> Add the `ios.bundleIdentifier` in the **app.json** file in the root directory to a unique value so that Xcode generates the provisioning profile for app signing step.
 
 </Step>

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -44,9 +44,9 @@ Run the following command in your project's root directory:
 
 ### Run the project on your device
 
-Add the `ios.bundleIdentifier` in the **app.json** file in the root directory to a unique value so that Xcode generates the provisioning profile for app signing step.
+1. Add the `ios.bundleIdentifier` in the **app.json** file in the root directory to a unique value so that Xcode generates the provisioning profile for the app signing step.
 
-Run the following command in your project's root directory and select your plugged in device from the list:
+2. Run the following command in your project's root directory and select your plugged in device from the list:
 
 <Terminal cmd={['$ npx expo run:ios --device']} />
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -52,6 +52,4 @@ Run the following command in your project's root directory and select your plugg
 
 > This command runs a development server after building your app. You can skip running `npx expo start` on the next page.
 
-
-
 </Step>

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -44,12 +44,14 @@ Run the following command in your project's root directory:
 
 ### Run the project on your device
 
+Add the `ios.bundleIdentifier` in the **app.json** file in the root directory to a unique value so that Xcode generates the provisioning profile for app signing step.
+
 Run the following command in your project's root directory and select your plugged in device from the list:
 
 <Terminal cmd={['$ npx expo run:ios --device']} />
 
 > This command runs a development server after building your app. You can skip running `npx expo start` on the next page.
 
-> Add the `ios.bundleIdentifier` in the **app.json** file in the root directory to a unique value so that Xcode generates the provisioning profile for app signing step.
+
 
 </Step>

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -50,4 +50,6 @@ Run the following command in your project's root directory and select your plugg
 
 > This command runs a development server after building your app. You can skip running `npx expo start` on the next page.
 
+> Update `bundleIdentifier` of `app.json` in the root directory to a unique value, or Xcode won’t properly generate the provisioning profile for signing, causing the launch failure.
+
 </Step>


### PR DESCRIPTION
# Why

Issue https://github.com/expo/expo/issues/34870

Runing deployment build on real ios device needs a unique bundleIdentifier to generate Provisioning Profile for signing.

# How

Add doc about updating the `bundleIdentifier` to a unique value.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
