### PR TITLE
[docs] Add a web deployment page under Deploy section

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -144,6 +144,7 @@ export const home = [
     makePage('deploy/submit-to-app-stores.mdx'),
     makePage('deploy/app-stores-metadata.mdx'),
     makePage('deploy/send-over-the-air-updates.mdx'),
+    makePage('deploy/web.mdx'),
   ]),
   makeSection('Monitor', [makePage('monitoring/services.mdx')]),
   makeSection('More', [makePage('core-concepts.mdx'), makePage('faq.mdx')]),

--- a/docs/pages/deploy/web.mdx
+++ b/docs/pages/deploy/web.mdx
@@ -12,7 +12,7 @@ If you are building a universal app, you can quickly deploy your web app using [
 
 ## Prerequisites
 
-Before you begin, in your project's **app.json** file, ensure that the [`expo.web.output`](/versions/latest/config/app/#output) property either `static` or `server`.
+Before you begin, in your project's **app.json** file, ensure that the [`expo.web.output`](/versions/latest/config/app/#output) property is either `static` or `server`.
 
 ## Export your web project
 

--- a/docs/pages/deploy/web.mdx
+++ b/docs/pages/deploy/web.mdx
@@ -1,0 +1,4 @@
+---
+title: Publish your web app
+description: Learn how to publish your React app.
+---

--- a/docs/pages/deploy/web.mdx
+++ b/docs/pages/deploy/web.mdx
@@ -1,4 +1,43 @@
 ---
 title: Publish your web app
-description: Learn how to publish your React app.
+sidebar_title: Deploy web apps
+description: Learn how to deploy your web app using EAS Hosting.
 ---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+If you are building a universal app, you can quickly deploy your React app using [EAS Hosting](/eas/hosting/introduction/). It is a service for deploying web apps built with Expo Router and React.
+
+## Prerequisites
+
+Before you begin, in your project's **app.json** file, ensure that the [`expo.web.output`](/versions/latest/config/app/#output) property either `static` or `server`.
+
+## Export your web project
+
+To deploy your web app, you need to create a static build of your web project. Export your web project into a **dist** directory by running the following command:
+
+<Terminal cmd={['$ npx expo export --platform web']} />
+
+> Remember to re-run this command every time before deploying when you make changes to your web app.
+
+## Initial deployment
+
+To publish your web app, run the following [EAS CLI](/develop/tools/#eas-cli) command:
+
+<Terminal cmd={['$ eas deploy']} />
+
+After running this command for the first time, you'll be prompted to select a preview subdomain for your project. This subdomain is a prefix used to create a preview URL and is used for production deployments. For example, in `https://test-app--1234.expo.app`, `test-app` is the preview subdomain.
+
+Once your deployment is complete, the EAS CLI will output a preview URL to access your deployed app.
+
+## Production deployment
+
+To create a production deployment, run the following [EAS CLI](/develop/tools/#eas-cli) command:
+
+<Terminal cmd={['$ eas deploy --prod']} />
+
+Once your deployment is complete, the EAS CLI will output a production URL to access your deployed app.
+
+## Learn more
+
+You can learn more about setting up [deployment aliases](/eas/hosting/deployments-and-aliases/), using a [custom domain](/eas/hosting/custom-domain/), or [deploying an API Route](/router/reference/api-routes/#deployment).

--- a/docs/pages/deploy/web.mdx
+++ b/docs/pages/deploy/web.mdx
@@ -6,7 +6,7 @@ description: Learn how to deploy your web app using EAS Hosting.
 
 import { Terminal } from '~/ui/components/Snippet';
 
-If you are building a universal app, you can quickly deploy your React app using [EAS Hosting](/eas/hosting/introduction/). It is a service for deploying web apps built with Expo Router and React.
+If you are building a universal app, you can quickly deploy your web app using [EAS Hosting](/eas/hosting/introduction/). It is a service for deploying web apps built with Expo Router and React.
 
 ## Prerequisites
 

--- a/docs/pages/deploy/web.mdx
+++ b/docs/pages/deploy/web.mdx
@@ -6,6 +6,8 @@ description: Learn how to deploy your web app using EAS Hosting.
 
 import { Terminal } from '~/ui/components/Snippet';
 
+> **warning** **EAS Hosting** is in preview and subject to changes.
+
 If you are building a universal app, you can quickly deploy your web app using [EAS Hosting](/eas/hosting/introduction/). It is a service for deploying web apps built with Expo Router and React.
 
 ## Prerequisites


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on internal feedback.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add a page that covers steps to deploy a web app using EAS Hosting under the Home > Deploy section. The page follows the same convention we've used so far for other pages under the Deploy section, that is, to get started and deploy the complete app to production. 

It doesn't go into much detail about EAS Hosting, but I have linked the relevant pages that a developer might be interested in when going through the steps themselves from EAS Hosting section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See the preview to verify if the instructions and structure of the guide are optimal: /deploy/web/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)