### PR TITLE
[av][docs] Fix link to Audio reference in SDK 51 and 50

### DIFF
--- a/docs/pages/versions/v50.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/av.mdx
@@ -87,7 +87,7 @@ const { sound: playbackObject } = await Audio.Sound.createAsync(
 ...
 ```
 
-See the [audio documentation](audio-av.mdx) for further information on `Audio.Sound.createAsync()`.
+See the [audio documentation](audio.mdx) for further information on `Audio.Sound.createAsync()`.
 
 ### Example: `Video`
 

--- a/docs/pages/versions/v51.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/av.mdx
@@ -86,7 +86,7 @@ const { sound: playbackObject } = await Audio.Sound.createAsync(
 );
 ```
 
-See the [audio documentation](audio-av.mdx) for further information on `Audio.Sound.createAsync()`.
+See the [audio documentation](audio.mdx) for further information on `Audio.Sound.createAsync()`.
 
 ### Example: `Video`
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #34877

# How

<!--
How did you build this feature or fix this bug and why?
-->

 Fix link to Audio reference in SDK 51 and 50 AV references.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs manually and verifying the internal link.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
