### PR TITLE
[core-plugin][Android] Add `publish` task

### DIFF
--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
@@ -20,6 +20,7 @@ abstract class ExpoModulesGradlePlugin : Plugin<Project> {
       applyKotlin(kotlinVersion, kspVersion)
       applyDefaultDependencies()
       applyDefaultAndroidSdkVersions()
+      applyPublishing()
     }
 
     // Adds the expoGradleHelper extension to the gradle instance if it doesn't exist.

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -3,7 +3,12 @@
 package expo.modules.plugin
 
 import com.android.build.gradle.LibraryExtension
+import expo.modules.plugin.android.applyLinerOptions
+import expo.modules.plugin.android.applyPublishingVariant
+import expo.modules.plugin.android.applySDKVersions
+import expo.modules.plugin.android.createReleasePublication
 import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
 import org.gradle.internal.extensions.core.extra
 
 internal fun Project.applyDefaultPlugins() {
@@ -12,6 +17,9 @@ internal fun Project.applyDefaultPlugins() {
   }
   if (!plugins.hasPlugin("kotlin-android")) {
     plugins.apply("kotlin-android")
+  }
+  if (!plugins.hasPlugin("maven-publish")) {
+    plugins.apply("maven-publish")
   }
 }
 
@@ -30,16 +38,32 @@ internal fun Project.applyDefaultDependencies() {
 }
 
 internal fun Project.applyDefaultAndroidSdkVersions() {
-  extensions.getByType(LibraryExtension::class.java).apply {
-    compileSdk = rootProject.extra.safeGet("compileSdkVersion")
-      ?: logger.warnIfNotDefined("compileSdkVersion", 35)
-    defaultConfig {
+  with(androidLibraryExtension()) {
+    applySDKVersions(
+      compileSdk = rootProject.extra.safeGet("compileSdkVersion")
+        ?: logger.warnIfNotDefined("compileSdkVersion", 35),
       minSdk = rootProject.extra.safeGet("minSdkVersion")
-        ?: logger.warnIfNotDefined("minSdkVersion", 24)
+        ?: logger.warnIfNotDefined("minSdkVersion", 24),
       targetSdk = rootProject.extra.safeGet("targetSdkVersion")
         ?: logger.warnIfNotDefined("targetSdkVersion", 34)
-    }
-
-    lintOptions.isAbortOnError = false
+    )
+    applyLinerOptions()
   }
 }
+
+internal fun Project.applyPublishing() {
+  val libraryExtension = androidLibraryExtension()
+
+  libraryExtension
+    .applyPublishingVariant()
+
+  afterEvaluate {
+    publishingExtension()
+      .publications
+      .createReleasePublication(this)
+  }
+}
+
+internal fun Project.androidLibraryExtension() = extensions.getByType(LibraryExtension::class.java)
+
+internal fun Project.publishingExtension() = extensions.getByType(PublishingExtension::class.java)

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/AndroidLibraryExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/AndroidLibraryExtension.kt
@@ -1,0 +1,23 @@
+package expo.modules.plugin.android
+
+import com.android.build.gradle.LibraryExtension
+
+internal fun LibraryExtension.applySDKVersions(compileSdk: Int, minSdk: Int, targetSdk: Int) {
+  this.compileSdk = compileSdk
+  defaultConfig {
+    this@defaultConfig.minSdk = minSdk
+    this@defaultConfig.targetSdk = targetSdk
+  }
+}
+
+internal fun LibraryExtension.applyLinerOptions() {
+  lintOptions.isAbortOnError = false
+}
+
+internal fun LibraryExtension.applyPublishingVariant() {
+  publishing { publishing ->
+    publishing.singleVariant("release") {
+      withSourcesJar()
+    }
+  }
+}

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavePublicationExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavePublicationExtension.kt
@@ -1,0 +1,21 @@
+package expo.modules.plugin.android
+
+import expo.modules.plugin.androidLibraryExtension
+import org.gradle.api.Project
+import org.gradle.api.publish.PublicationContainer
+import org.gradle.api.publish.maven.MavenPublication
+
+internal fun PublicationContainer.createReleasePublication(project: Project) {
+  create("release", MavenPublication::class.java) { mavenPublication->
+    with(mavenPublication) {
+      from(project.components.getByName("release"))
+      groupId = project.group.toString()
+      artifactId = requireNotNull(project.androidLibraryExtension().namespace) {
+        "'android.namespace' is not defined"
+      }
+      version = requireNotNull(project.androidLibraryExtension().defaultConfig.versionName) {
+        "'android.defaultConfig.versionName' is not defined"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

Adds `publishToMavenLocal` task to all of our packages via the module plugin.
First step to achieving pre-building of android libraries. 

# How

Applied and configured `maven-publish` plugin.

# Test Plan


- run `./gradlew :expo-blur:publishToMavenLocal` in `bare-expo`