### PR TITLE
[android][camera] Fix flash

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -20,7 +20,7 @@
 - [iOS] Fix initial roation when used with `react-native-screens`. ([#34721](https://github.com/expo/expo/pull/34721) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix performance regression. ([#34750](https://github.com/expo/expo/pull/34750) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Attempt to fix `setLinearZoom` incompatability with some devices. ([#34757](https://github.com/expo/expo/pull/34757) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fix flash.
+- [Android] Fix flash. ([#34893](https://github.com/expo/expo/pull/34893) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [iOS] Fix initial roation when used with `react-native-screens`. ([#34721](https://github.com/expo/expo/pull/34721) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix performance regression. ([#34750](https://github.com/expo/expo/pull/34750) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Attempt to fix `setLinearZoom` incompatability with some devices. ([#34757](https://github.com/expo/expo/pull/34757) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fix flash.
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -15,7 +15,7 @@ android {
 }
 
 dependencies {
-  def camerax_version = "1.4.0"
+  def camerax_version = "1.4.1"
 
   api "androidx.exifinterface:exifinterface:1.3.7"
   api "androidx.appcompat:appcompat:1.1.0"

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
@@ -199,20 +199,38 @@ class CameraViewModule : Module() {
 
       Prop("facing") { view, facing: CameraType? ->
         facing?.let {
-          if (view.lensFacing != facing) {
+          if (view.lensFacing != it) {
             view.lensFacing = it
+          }
+        } ?: run {
+          if (view.lensFacing != CameraType.BACK) {
+            view.lensFacing = CameraType.BACK
           }
         }
       }
 
       Prop("flashMode") { view, flashMode: FlashMode? ->
         flashMode?.let {
-          view.setCameraFlashMode(it)
+          if (view.flashMode != it) {
+            view.flashMode = it
+          }
+        } ?: run {
+          if (view.flashMode != FlashMode.OFF) {
+            view.flashMode = FlashMode.OFF
+          }
         }
       }
 
       Prop("enableTorch") { view, enabled: Boolean? ->
-        view.enableTorch = enabled ?: false
+        enabled?.let {
+          if (view.enableTorch != it) {
+            view.enableTorch = it
+          }
+        } ?: run {
+          if (view.enableTorch) {
+            view.enableTorch = false
+          }
+        }
       }
 
       Prop("animateShutter") { view, animate: Boolean? ->
@@ -220,42 +238,49 @@ class CameraViewModule : Module() {
       }
 
       Prop("zoom") { view, zoom: Float? ->
-        view.zoom = zoom ?: 0f
+        zoom?.let {
+          if (view.zoom != it) {
+            view.zoom = it
+          }
+        } ?: run {
+          if (view.zoom != 0f) {
+            view.zoom = 0f
+          }
+        }
       }
 
       Prop("mode") { view, mode: CameraMode? ->
         mode?.let {
-          if (view.cameraMode != mode) {
+          if (view.cameraMode != it) {
             view.cameraMode = it
+          }
+        } ?: run {
+          if (view.cameraMode != CameraMode.PICTURE) {
+            view.cameraMode = CameraMode.PICTURE
           }
         }
       }
 
       Prop("mute") { view, muted: Boolean? ->
-        muted?.let {
-          if (it != view.mute) {
-            view.mute = it
-          }
-        }
+        view.mute = muted ?: false
       }
 
       Prop("videoQuality") { view, quality: VideoQuality? ->
         quality?.let {
-          if (view.videoQuality != quality) {
+          if (view.videoQuality != it) {
             view.videoQuality = it
           }
-          return@Prop
-        }
-        if (view.videoQuality != VideoQuality.VIDEO1080P) {
-          view.videoQuality = VideoQuality.VIDEO1080P
+        } ?: run {
+          if (view.videoQuality != VideoQuality.VIDEO1080P) {
+            view.videoQuality = VideoQuality.VIDEO1080P
+          }
         }
       }
 
       Prop("barcodeScannerSettings") { view, settings: BarcodeSettings? ->
-        if (settings == null) {
-          return@Prop
+        settings?.let {
+          view.setBarcodeScannerSettings(it)
         }
-        view.setBarcodeScannerSettings(settings)
       }
 
       Prop("barcodeScannerEnabled") { view, enabled: Boolean? ->
@@ -266,45 +291,61 @@ class CameraViewModule : Module() {
 
       Prop("pictureSize") { view, pictureSize: String? ->
         pictureSize?.let {
-          if (view.pictureSize != pictureSize) {
+          if (view.pictureSize != it) {
             view.pictureSize = it
           }
-          return@Prop
-        }
-        if (view.pictureSize.isNotEmpty()) {
-          view.pictureSize = ""
+        } ?: run {
+          if (view.pictureSize.isNotEmpty()) {
+            view.pictureSize = ""
+          }
         }
       }
 
       Prop("autoFocus") { view, autoFocus: FocusMode? ->
-        view.autoFocus = autoFocus ?: FocusMode.OFF
+        autoFocus?.let {
+          if (view.autoFocus != it) {
+            view.autoFocus = it
+          }
+        } ?: run {
+          if (view.autoFocus != FocusMode.OFF) {
+            view.autoFocus = FocusMode.OFF
+          }
+        }
       }
 
       Prop("ratio") { view, ratio: CameraRatio? ->
-        if (view.ratio != ratio) {
-          view.ratio = ratio
+        ratio?.let {
+          if (view.ratio != it) {
+            view.ratio = it
+          }
+        } ?: run {
+          if (view.ratio != null) {
+            view.ratio = null
+          }
         }
       }
 
       Prop("mirror") { view, mirror: Boolean? ->
         mirror?.let {
-          if (view.mirror != mirror) {
+          if (view.mirror != it) {
             view.mirror = it
-            return@Prop
           }
-        }
-        if (view.mirror != false) {
-          view.mirror = false
+        } ?: run {
+          if (view.mirror) {
+            view.mirror = false
+          }
         }
       }
 
       Prop("videoBitrate") { view, bitrate: Int? ->
         bitrate?.let {
-          view.videoEncodingBitrate = it
-          return@Prop
-        }
-        if (view.videoEncodingBitrate != null) {
-          view.videoEncodingBitrate = null
+          if (view.videoEncodingBitrate != it) {
+            view.videoEncodingBitrate = it
+          }
+        } ?: run {
+          if (view.videoEncodingBitrate != null) {
+            view.videoEncodingBitrate = null
+          }
         }
       }
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -144,6 +144,12 @@ class ExpoCameraView(
       shouldCreateCamera = true
     }
 
+  var flashMode = FlashMode.OFF
+    set(value) {
+      field = value
+      setCameraFlashMode(value)
+    }
+
   var cameraMode: CameraMode = CameraMode.PICTURE
     set(value) {
       field = value
@@ -312,9 +318,7 @@ class ExpoCameraView(
   }
 
   fun setCameraFlashMode(mode: FlashMode) {
-    if (imageCaptureUseCase?.flashMode != mode.mapToLens()) {
-      imageCaptureUseCase?.flashMode = mode.mapToLens()
-    }
+    imageCaptureUseCase?.flashMode = mode.mapToLens()
   }
 
   private fun setTorchEnabled(enabled: Boolean) {
@@ -444,6 +448,7 @@ class ExpoCameraView(
 
         imageCaptureUseCase = ImageCapture.Builder()
           .setResolutionSelector(resolutionSelector)
+          .setFlashMode(flashMode.mapToLens())
           .build()
 
         val videoCapture = createVideoCapture()


### PR DESCRIPTION
# Why
Closes #34887

# How
Fixes a regression with the flash prop. The issue was the flashMode would be set but if another prop needed the camera to be recreated we would lose the flash value and it would reset to off. Part of the problem was again, oversetting the props so I updated the setters, similar to #34750 to ensure they only ever update if necessary.

# Test Plan
bare-expo. Flash is working again and everything else is working as normal.
