### PR TITLE
[expo-modules] Allow converting double to float

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [iOS] Fixes view managers not deallocating when reloading. ([#33760](https://github.com/expo/expo/pull/33760) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fixes `AppContext` is lost in nested converters. ([#34373](https://github.com/expo/expo/pull/34373) by [@lukmccall](https://github.com/lukmccall))
 - Fixed **AppDelegate.mm** methods not be called on iOS. ([#34464](https://github.com/expo/expo/pull/34464) by [@kudo](https://github.com/kudo))
+- Fixed converting double to float. ([#34906](https://github.com/expo/expo/pull/34906) by [@janicduplessis](https://github.com/janicduplessis))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicNumberType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicNumberType.swift
@@ -29,7 +29,7 @@ internal struct DynamicNumberType<NumberType>: AnyDynamicType {
     if let number = value as? NumberType {
       return number
     }
-    if let number = value as? Double, NumberType.self as? Float32.Type != nil {
+    if let number = value as? Double, NumberType.self is Float32.Type {
       // double -> float
       return Float32.init(number)
     }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicNumberType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicNumberType.swift
@@ -29,6 +29,10 @@ internal struct DynamicNumberType<NumberType>: AnyDynamicType {
     if let number = value as? NumberType {
       return number
     }
+    if let number = value as? Double, NumberType.self as? Float32.Type != nil {
+      // double -> float
+      return Float32.init(number)
+    }
     if let number = value as? any BinaryInteger {
       if let IntegerType = NumberType.self as? any BinaryInteger.Type {
         // integer -> another integer


### PR DESCRIPTION
# Why

When working on expo-ui, I had an issue with a Float prop, where certain values would fail to convert and return null, with a warning saying it failed to parse the prop.

This happens for values that cannot be cast directly from double to float.

# How

This adds a case in DynamicNumberType to handle downcasting from double to float.

# Test Plan

Tested in bare-expo that a component with a float prop will accept any decimal value passed from JS.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
