### PR TITLE
chore: five years downloads trend

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a aria-label="Expo is free to use" href="https://github.com/expo/expo/blob/main/LICENSE" target="_blank">
     <img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-success.svg?style=flat-square&color=33CC12" target="_blank" />
   </a>
-  <a aria-label="expo downloads" href="http://www.npmtrends.com/expo" target="_blank">
+  <a aria-label="expo downloads" href="https://npm-compare.com/expo/#timeRange=FIVE_YEARS" target="_blank">
     <img alt="Downloads" src="https://img.shields.io/npm/dm/expo.svg?style=flat-square&labelColor=gray&color=33CC12&label=Downloads" />
   </a>
 </p>


### PR DESCRIPTION
Hi Expo team, 

I’d like to suggest updating the current NPM trends link to npm-compare.com, which supports viewing the trend data for the past five years. Unlike the previous link to npmtrends.com, which does not allow specifying a time range, npm-compare.com offers the ability to show a dynamic chart that visualizes the download trends for [expo](https://npm-compare.com/expo/#timeRange=FIVE_YEARS) over a customizable five-year period.

As a maintainer of npm-compare.com, I believe this enhancement would give users a better understanding of Expo's increasing popularity over the last five years, helping them make more informed decisions. If you need any other features or insights from npm-compare.com that could further benefit Expo, I’d be happy to implement them.

Thank you for considering my suggestion. 

By the way, npm-compare.com supports embedding dynamic images. We may also consider adding this to the README.

```
## Usage Trend

[Usage Trend of expo](https://npm-compare.com/expo#timeRange=FIVE_YEARS)
  
<a href="https://npm-compare.com/expo#timeRange=FIVE_YEARS" target="_blank">
  <img src="https://npm-compare.com/img/npm-trend/FIVE_YEARS/expo.png" width="100%" alt="npm Usage Trend of expo" />
</a>
```