### PR TITLE
[ios][camera] Attempt to fix iPad crash

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -21,7 +21,7 @@
 - [iOS] Fix performance regression. ([#34750](https://github.com/expo/expo/pull/34750) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Attempt to fix `setLinearZoom` incompatability with some devices. ([#34757](https://github.com/expo/expo/pull/34757) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix flash. ([#34893](https://github.com/expo/expo/pull/34893) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Attempts to address crash that occurs more frequently on iPads.
+- [iOS] Attempts to address crash that occurs more frequently on iPads. ([#34915](https://github.com/expo/expo/pull/34915) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [iOS] Fix performance regression. ([#34750](https://github.com/expo/expo/pull/34750) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Attempt to fix `setLinearZoom` incompatability with some devices. ([#34757](https://github.com/expo/expo/pull/34757) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix flash. ([#34893](https://github.com/expo/expo/pull/34893) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Attempts to address crash that occurs more frequently on iPads.
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -187,17 +187,29 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   }
 
   public func onAppForegrounded() {
-    if !session.isRunning && isSessionPaused {
-      isSessionPaused = false
-      session.startRunning()
-      enableTorch()
+    sessionQueue.async { [weak self] in
+      guard let self else {
+        return
+      }
+      if !session.isRunning && isSessionPaused {
+        isSessionPaused = false
+        session.startRunning()
+        if torchEnabled {
+          enableTorch()
+        }
+      }
     }
   }
 
   public func onAppBackgrounded() {
-    if session.isRunning && !isSessionPaused {
-      isSessionPaused = true
-      session.stopRunning()
+    sessionQueue.async { [weak self] in
+      guard let self else {
+        return
+      }
+      if session.isRunning && !isSessionPaused {
+        isSessionPaused = true
+        session.stopRunning()
+      }
     }
   }
 
@@ -794,9 +806,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   }
 
   @objc func orientationChanged() {
-    Task {
-      await changePreviewOrientation()
-    }
+    changePreviewOrientation()
   }
 
   func changePreviewOrientation() {


### PR DESCRIPTION
# Why
Closes #34896
Attempts to fix a crash when the camera calls `startRunning` that seems more prevalent on iPads. I was not able to reproduce on my iPad or phone but see one area that could potentially cause an issue.

# How
Add all calls of start and stop running to the sessionQueue. This means that they should never be called in between calls to begin and commit configuration.

# Test Plan
Tested on both iPad and iOS using the users provided repro and in bare expo. Tested moving from foreground to background and rapidly mounting and unmounting the camera. The issue never occurred.
