### PR TITLE
[cli] fix dom components rendering error when running on tunnel mode

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Bind debugging infrastructure to `localhost` instead of LAN ip. ([#34368](https://github.com/expo/expo/pull/34368) by [@byCedric](https://github.com/byCedric))
 - Add fallback resolution strategy for dependencies and optional peer dependencies of `expo` and `expo-router` to prevent broken resolution for isolated dependencies and hoisting issues. ([#34286](https://github.com/expo/expo/pull/34286) by [@kitten](https://github.com/kitten))
 - Preserve proxy leases on webcontainers ([#34831](https://github.com/expo/expo/pull/34831) by [@kitten](https://github.com))
+- Fixed mixed content error when serving DOM Component using tunnel. ([#34916](https://github.com/expo/expo/pull/34916) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/middleware/DomComponentsMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/DomComponentsMiddleware.ts
@@ -129,7 +129,7 @@ export function getDomComponentHtml(src?: string, { title }: { title?: string } 
     <noscript>DOM Components require <code>javaScriptEnabled</code></noscript>
         <!-- Root element for the DOM component. -->
         <div id="root"></div>
-        ${src ? `<script crossorigin src="${src}"></script>` : ''}
+        ${src ? `<script crossorigin src="${src.replace(/^https?:/, '')}"></script>` : ''}
     </body>
 </html>`;
 }


### PR DESCRIPTION
# Why

having mixed content error when running dom components with tunnel

# How

serve bundle as schemeless `//host/bundle` url

# Test Plan

test router-e2e with tunnel

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
