### PR TITLE
docs: Update navigating-pages.mdx

### DIFF
--- a/docs/pages/router/navigating-pages.mdx
+++ b/docs/pages/router/navigating-pages.mdx
@@ -200,7 +200,7 @@ export function logout() {
 
 The `router` object is immutable and contains the following functions:
 
-- **navigate**: `(href: Href, options: LinkToOptions) => void`. Perform a `navigate` action.
+- **navigate**: Alias for `router.push`. 
 - **push**: `(href: Href, options: LinkToOptions) => void`. Perform a `push` action.
 - **replace**: `(href: Href, options: LinkToOptions) => void`. Perform a `replace` action.
 - **back**: `() => void`. Navigate back to previous route.

--- a/docs/pages/router/navigating-pages.mdx
+++ b/docs/pages/router/navigating-pages.mdx
@@ -200,7 +200,7 @@ export function logout() {
 
 The `router` object is immutable and contains the following functions:
 
-- **navigate**: Alias for `router.push`. 
+- **navigate**: Alias for `router.push`.
 - **push**: `(href: Href, options: LinkToOptions) => void`. Perform a `push` action.
 - **replace**: `(href: Href, options: LinkToOptions) => void`. Perform a `replace` action.
 - **back**: `() => void`. Navigate back to previous route.


### PR DESCRIPTION
# Why

The docs note, [here](https://docs.expo.dev/router/navigating-pages/#understanding-native-navigation), that expo-router v4 made `navigate` an alias of `push`. However, everywhere else in the documentation still treats them as separate functions, which is very confusing. 

I've tried to follow the code to confirm that `navigate` is an alias of `push`, but remained confused: 

* I see separate handling for the `push` vs `navigate` event type in `getNavigateAction`, `node_modules/expo-router/build/global-state/routing.js:157`, here, even though it's ultimately reset to the `navigate` event type.

* I _do_ see `navigate: push` in `node_modules/expo-router/build/rsc/router/client.js:266`, but this seems to be a router version specifically for server-driven components.

This is an attempt to make the docs clearer, and also to get confirmation from the team that `navigate` is indeed an alias of `push`.

# How

Updated the docs with language clarifying the relationship between `push` and `navigate`. 

# Test Plan

Read the doc changes, make sure there are no spelling or style errors, and that the information is correct. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
