### PR TITLE
Fix incorrect property name for babel transformer.

### DIFF
--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -240,7 +240,7 @@ If you want to extend the Babel transformer, import the upstream transformer fro
 ```js metro.transformer.js
 const upstreamTransformer = require('@expo/metro-config/babel-transformer');
 
-module.exports.transform = async ({ src, filename, options }) => {
+module.exports.transformer = async ({ src, filename, options }) => {
   // Do something custom for SVG files...
   if (filename.endsWith('.svg')) {
     src = '...';

--- a/docs/pages/versions/v50.0.0/config/metro.mdx
+++ b/docs/pages/versions/v50.0.0/config/metro.mdx
@@ -380,7 +380,7 @@ If you want to extend the Babel transformer, import the upstream transformer fro
 ```js metro.transformer.js
 const upstreamTransformer = require('@expo/metro-config/babel-transformer');
 
-module.exports.transform = async ({ src, filename, options }) => {
+module.exports.transformer = async ({ src, filename, options }) => {
   // Do something custom for SVG files...
   if (filename.endsWith('.svg')) {
     src = '...';

--- a/docs/pages/versions/v51.0.0/config/metro.mdx
+++ b/docs/pages/versions/v51.0.0/config/metro.mdx
@@ -240,7 +240,7 @@ If you want to extend the Babel transformer, import the upstream transformer fro
 ```js metro.transformer.js
 const upstreamTransformer = require('@expo/metro-config/babel-transformer');
 
-module.exports.transform = async ({ src, filename, options }) => {
+module.exports.transformer = async ({ src, filename, options }) => {
   // Do something custom for SVG files...
   if (filename.endsWith('.svg')) {
     src = '...';

--- a/docs/pages/versions/v52.0.0/config/metro.mdx
+++ b/docs/pages/versions/v52.0.0/config/metro.mdx
@@ -240,7 +240,7 @@ If you want to extend the Babel transformer, import the upstream transformer fro
 ```js metro.transformer.js
 const upstreamTransformer = require('@expo/metro-config/babel-transformer');
 
-module.exports.transform = async ({ src, filename, options }) => {
+module.exports.transformer = async ({ src, filename, options }) => {
   // Do something custom for SVG files...
   if (filename.endsWith('.svg')) {
     src = '...';


### PR DESCRIPTION
# Why

Fix an incorrect property name for documentation on how to extend the babel transformer in the metro configuration.

# How

Changed `transform` to `transformer`.

# Test Plan

N/A.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
