### PR TITLE
[expo-ui] Exclude ColorPicker on tvOS

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -23,7 +23,7 @@
 ### 🐛 Bug fixes
 
 - Fix tvOS compilation. ([#34730](https://github.com/expo/expo/pull/34730) by [@douglowder](https://github.com/douglowder))
-- Exclude `ColorPicker` on tvOS.
+- Exclude `ColorPicker` on tvOS. ([#34929](https://github.com/expo/expo/pull/34929) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### 🐛 Bug fixes
 
 - Fix tvOS compilation. ([#34730](https://github.com/expo/expo/pull/34730) by [@douglowder](https://github.com/douglowder))
+- Exclude `ColorPicker` on tvOS.
 
 ### 💡 Others
 

--- a/packages/expo-ui/ios/ColorPickerView.swift
+++ b/packages/expo-ui/ios/ColorPickerView.swift
@@ -14,7 +14,9 @@ struct ColorPickerView: ExpoSwiftUI.View {
   @EnvironmentObject var props: ColorPickerProps
   @State private var previousHex: String = ""
   @State private var selection: Color = .clear
+
   var body: some View {
+#if !os(tvOS)
     ColorPicker(props.label ?? "", selection: $selection, supportsOpacity: props.supportsOpacity)
       .onAppear {
         selection = props.selection
@@ -28,6 +30,9 @@ struct ColorPickerView: ExpoSwiftUI.View {
           props.onValueChanged(payload)
         }
       }
+#else
+    EmptyView()
+#endif
   }
   private func colorToHex(_ color: Color) -> String {
     let newColor = UIColor(color)


### PR DESCRIPTION
# Why
tvOS job is failing because the `ColorPicker` is not supported.

# How
Exclude it on tvOS

# Test Plan
CI
