### PR TITLE
[docs] Updates wording on workflows docs

### DIFF
--- a/docs/pages/eas/workflows/examples.mdx
+++ b/docs/pages/eas/workflows/examples.mdx
@@ -1,6 +1,6 @@
 ---
-title: Example workflows
-description: Common workflows that are useful for your project.
+title: Example CI/CD workflows
+description: Common CI/CD workflows that are useful for your project.
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
@@ -9,7 +9,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
-The following workflows are examples of how you can use EAS Workflows to automate your development and release processes. They can help you and your team develop, review each other's PRs, and release changes to your users.
+The following CI/CD workflows are examples of how you can use EAS Workflows to automate your development and release processes. They can help you and your team develop, review each other's PRs, and release changes to your users.
 
 ## Development builds workflow
 

--- a/docs/pages/eas/workflows/examples.mdx
+++ b/docs/pages/eas/workflows/examples.mdx
@@ -9,7 +9,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
-The following CI/CD workflows are examples of how you can use EAS Workflows to automate your development and release processes. They can help you and your team develop, review each other's PRs, and release changes to your users.
+The following workflows are examples of how you can use EAS Workflows to automate your development and release processes. They can help you and your team develop, review each other's PRs, and release changes to your users.
 
 ## Development builds workflow
 

--- a/docs/pages/eas/workflows/upgrade.mdx
+++ b/docs/pages/eas/workflows/upgrade.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrade to EAS Workflows
+title: Upgrade from EAS CLI
 description: Learn how to upgrade your development and release processes to use EAS Workflows.
 ---
 


### PR DESCRIPTION
# Why

This PR:
- Adds "CI/CD" to the examples doc for workflows to improve SEO.
- Updates the name of the upgrade doc to better match other upgrade docs. We always say "Upgrade from x" instead of "Upgrade to y".

# Test plan

Make sure the changes read well.

