### PR TITLE
[docs] Add docs for expo-font variable fonts

### DIFF
--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -29,6 +29,10 @@ There are two ways you can add a custom font into your project:
 
 Expo SDK officially supports OTF and TTF font formats across Android, iOS and web platforms. If your font is in another font format, you have to set up advanced configuration to support that format in your project.
 
+### Variable Fonts
+
+Variable Fonts, including variable font implementations in OTF and TTF, do not have support across all platforms. If you want full platform support, you need to extract which specific axis configuration you want to use from your variable font and then save them as separate font files.
+
 ### How to choose between OTF and TTF
 
 If the font you're using have both OTF and TTF versions, prefer OTF. The **.otf** files are smaller than **.ttf** files. Sometimes, OTF also renders slightly better in certain contexts.

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -31,7 +31,7 @@ Expo SDK officially supports OTF and TTF font formats across Android, iOS and we
 
 ### Variable Fonts
 
-Variable fonts, including variable font implementations in OTF and TTF, do not have support across all platforms. For full platform support, use static fonts. Alternatively, use a utility such as [fontTools](https://fonttools.readthedocs.io/en/latest/varLib/mutator.html) to extract the specific axis configuration you want to use from the variable font and save it as separate font file.
+Variable fonts, including variable font implementations in OTF and TTF, do not have support across all platforms. For full platform support, use static fonts. Alternatively, use a utility such as [fontTools](https://fonttools.readthedocs.io/en/latest/varLib/mutator.html) to extract the specific axis configuration you want to use from the variable font and save it as a separate font file.
 
 ### How to choose between OTF and TTF
 

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -31,7 +31,7 @@ Expo SDK officially supports OTF and TTF font formats across Android, iOS and we
 
 ### Variable Fonts
 
-Variable Fonts, including variable font implementations in OTF and TTF, do not have support across all platforms. If you want full platform support, you need to extract which specific axis configuration you want to use from your variable font and then save them as separate font files.
+Variable fonts, including variable font implementations in OTF and TTF, do not have support across all platforms. For full platform support, use static fonts. Alternatively, use a utility such as [fontTools](https://fonttools.readthedocs.io/en/latest/varLib/mutator.html) to extract the specific axis configuration you want to use from the variable font and save it as separate font file.
 
 ### How to choose between OTF and TTF
 


### PR DESCRIPTION
# Why
To prevent developers spending too much time debugging a known limitation in `expo-font` package, we now document that variable fonts do not have full platform support.

Some related issues/PRs:
https://github.com/expo/expo/issues/27647
https://github.com/expo/expo/pull/26082

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
