### PR TITLE
[docs] Make customizing links in expo router more findable

### DIFF
--- a/docs/pages/linking/into-your-app.mdx
+++ b/docs/pages/linking/into-your-app.mdx
@@ -69,7 +69,7 @@ By default, `exp://` is replaced with `http://` when opening a URL in Expo Go. Y
 
 ## Handle URLs
 
-> **info** If you are using [Expo Router](/linking/overview/#use-expo-router-to-handle-deep-linking), you can ignore this section.
+> **info** If you are using [Expo Router](/linking/overview/#use-expo-router-to-handle-deep-linking), you can ignore this section. If you want to manually handle URLs with expo router, see [Customizing links](/router/advanced/native-intent).
 
 You can observe links that launch your app using the [`Linking.useURL()`](/versions/latest/sdk/linking/#useurl) hook from [`expo-linking`](/versions/latest/sdk/linking/).
 

--- a/docs/pages/linking/into-your-app.mdx
+++ b/docs/pages/linking/into-your-app.mdx
@@ -69,7 +69,7 @@ By default, `exp://` is replaced with `http://` when opening a URL in Expo Go. Y
 
 ## Handle URLs
 
-> **info** If you are using [Expo Router](/linking/overview/#use-expo-router-to-handle-deep-linking), you can ignore this section. If you want to manually handle URLs with expo router, see [Customizing links](/router/advanced/native-intent).
+> **info** If you are using [Expo Router](/linking/overview/#use-expo-router-to-handle-deep-linking), you can ignore this section.
 
 You can observe links that launch your app using the [`Linking.useURL()`](/versions/latest/sdk/linking/#useurl) hook from [`expo-linking`](/versions/latest/sdk/linking/).
 

--- a/docs/pages/linking/overview.mdx
+++ b/docs/pages/linking/overview.mdx
@@ -95,6 +95,7 @@ To implement any of the above Linking strategies, **we recommend using** [Expo R
 
 - `Link` component from Expo Router can be used to [handle URL schemes to other apps](/linking/into-other-apps/#expo-router)
 - Android App Links and iOS Universal Links require configuring runtime routing in JavaScript for the link in your app. Using Expo Router, you don't have to configure runtime routing separately since deep links for all routes are automatically enabled.
+- You can still customize linking behavior when using Expo Router, overriding the default behavior for some or all links. see [Customizing links](/router/advanced/native-intent).
 
 ## Linking to other apps from your app
 

--- a/docs/pages/linking/overview.mdx
+++ b/docs/pages/linking/overview.mdx
@@ -95,7 +95,7 @@ To implement any of the above Linking strategies, **we recommend using** [Expo R
 
 - `Link` component from Expo Router can be used to [handle URL schemes to other apps](/linking/into-other-apps/#expo-router)
 - Android App Links and iOS Universal Links require configuring runtime routing in JavaScript for the link in your app. Using Expo Router, you don't have to configure runtime routing separately since deep links for all routes are automatically enabled.
-- You can still customize linking behavior when using Expo Router, overriding the default behavior for some or all links. see [Customizing links](/router/advanced/native-intent).
+- For third-party deep links, you can override the default linking behavior to handle incoming links and send navigation events. See [Customizing links](/router/advanced/native-intent).
 
 ## Linking to other apps from your app
 


### PR DESCRIPTION
# Why
The [docs for customizing `expo-router` deep links](https://docs.expo.dev/router/advanced/native-intent/) don't seem to be referenced at all from the entire "Linking" documentation, even though `expo-router` is referenced in several places. 

This would make it seem like complete documentation for Linking, even when using expo-router, when there is another page that might be relevant.

cc @kadikraman from [a discussion](https://discord.com/channels/695411232856997968/1024598419458764820/1338526983210139730) on the [Expo Developers discord](https://chat.expo.dev/)

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
