### PR TITLE
chore(cli): avoid .expo/readme.md markdown rendering issue

### DIFF
--- a/packages/@expo/cli/src/start/project/dotExpo.ts
+++ b/packages/@expo/cli/src/start/project/dotExpo.ts
@@ -53,11 +53,16 @@ export function ensureDotExpoProjectDirectoryInitialized(projectRoot: string): s
     fs.writeFileSync(
       readmeFilePath,
       `> Why do I have a folder named ".expo" in my project?
+
 The ".expo" folder is created when an Expo project is started using "expo start" command.
+
 > What do the files contain?
+
 - "devices.json": contains information about devices that have recently opened this project. This is used to populate the "Development sessions" list in your development builds.
 - "settings.json": contains the server configuration that is used to serve the application manifest.
+
 > Should I commit the ".expo" folder?
+
 No, you should not share the ".expo" folder. It does not contain any information that is relevant for other developers working on the project, it is specific to your machine.
 Upon project creation, the ".expo" folder is already added to your ".gitignore" file.
 `


### PR DESCRIPTION
# Why

Currently the .expo readme doesn't contain necessary line breaks to ensure correct rendering in various programs such as JetBrains IDEs:

<img width="971" alt="Screenshot 2025-02-17 at 1 31 59 PM" src="https://github.com/user-attachments/assets/9bb165c8-e97d-4549-a792-67fd2b93eb36" />

# How

Add necessary line breaks to resolve the issue.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
