### PR TITLE
[android][image] Fix regression in `loadAsync`

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Fixed `tintColor="currentColor"` conflicts on web. ([#34604](https://github.com/expo/expo/pull/34604) by [@bradleyayers](https://github.com/bradleyayers))
 - [Android] Add headers to `loadAsync` requests. ([#34767](https://github.com/expo/expo/pull/34767) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fixes a regression in `loadAsync` from ([#34767](https://github.com/expo/expo/pull/34767).
+- [Android] Fixes a regression in `loadAsync` from ([#34767](https://github.com/expo/expo/pull/34767). ([#34965](https://github.com/expo/expo/pull/34965) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Fixed `tintColor="currentColor"` conflicts on web. ([#34604](https://github.com/expo/expo/pull/34604) by [@bradleyayers](https://github.com/bradleyayers))
 - [Android] Add headers to `loadAsync` requests. ([#34767](https://github.com/expo/expo/pull/34767) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fixes a regression in `loadAsync` from ([#34767](https://github.com/expo/expo/pull/34767). ([#34965](https://github.com/expo/expo/pull/34965) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fixes a regression in `loadAsync` from [#34767](https://github.com/expo/expo/pull/34767). ([#34965](https://github.com/expo/expo/pull/34965) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed `tintColor="currentColor"` conflicts on web. ([#34604](https://github.com/expo/expo/pull/34604) by [@bradleyayers](https://github.com/bradleyayers))
 - [Android] Add headers to `loadAsync` requests. ([#34767](https://github.com/expo/expo/pull/34767) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fixes a regression in `loadAsync` from ([#34767](https://github.com/expo/expo/pull/34767).
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ImageLoadTask.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ImageLoadTask.kt
@@ -1,16 +1,12 @@
 package expo.modules.image
 
 import com.bumptech.glide.Glide
-import com.bumptech.glide.load.model.GlideUrl
-import com.bumptech.glide.load.model.LazyHeaders
 import expo.modules.image.records.ImageLoadOptions
 import expo.modules.image.records.SourceMap
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.Exceptions
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlin.collections.component1
-import kotlin.collections.component2
 
 open class ImageLoadTask(
   private val appContext: AppContext,
@@ -21,20 +17,15 @@ open class ImageLoadTask(
     val context =
       this@ImageLoadTask.appContext.reactContext ?: throw Exceptions.ReactContextLost()
 
-    val headers = source.headers?.let {
-      LazyHeaders.Builder().apply {
-        it.forEach { (key, value) ->
-          addHeader(key, value)
-        }
-      }.build()
-    }
+    val sourceToLoad = source.createGlideModelProvider(context)
+    val model = sourceToLoad?.getGlideModel()
 
     try {
       val bitmap = withContext(Dispatchers.IO) {
         Glide
           .with(context)
           .asDrawable()
-          .load(headers?.let { GlideUrl(source.uri, headers) } ?: source.uri)
+          .load(model)
           .centerInside()
           .submit(options.maxWidth, options.maxHeight)
           .get()

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ImageLoadTask.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ImageLoadTask.kt
@@ -2,7 +2,6 @@ package expo.modules.image
 
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.model.GlideUrl
-import com.bumptech.glide.load.model.Headers
 import com.bumptech.glide.load.model.LazyHeaders
 import expo.modules.image.records.ImageLoadOptions
 import expo.modules.image.records.SourceMap
@@ -10,7 +9,6 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.Exceptions
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlin.apply
 import kotlin.collections.component1
 import kotlin.collections.component2
 
@@ -29,14 +27,14 @@ open class ImageLoadTask(
           addHeader(key, value)
         }
       }.build()
-    } ?: Headers.DEFAULT
+    }
 
     try {
       val bitmap = withContext(Dispatchers.IO) {
         Glide
           .with(context)
           .asDrawable()
-          .load(GlideUrl(source.uri, headers))
+          .load(headers?.let { GlideUrl(source.uri, headers) } ?: source.uri)
           .centerInside()
           .submit(options.maxWidth, options.maxHeight)
           .get()


### PR DESCRIPTION
# Why
Fixes a regression from #34767 causing the opposite problem where only http requests would load

# How
We need to use `createGlideModelProvider` to correctly parse the various types of url.

# Test Plan
Using the original repro. Remote and local urls both work. Headers are sent correctly.
