### PR TITLE
[docs][expo-router-ui] Fixed typo

### DIFF
--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -108,7 +108,7 @@ Tabs can be switched via a `Link` or using the imperative APIs. However, these A
 
 ### Resetting navigation
 
-The `reset` prop from `TabTrigger` can be used to control when a tab resets its navigation state. The options are `always`, `onLongPress` and `never`. This is particularly useful for a stack navigator nested inside a tab. For example, `<Trigger name="home" reset="always" />` will return the user to the index route inside a tab's nested stack navigator.
+The `reset` prop from `TabTrigger` can be used to control when a tab resets its navigation state. The options are `always`, `onLongPress` and `never`. This is particularly useful for a stack navigator nested inside a tab. For example, `<TabTrigger name="home" reset="always" />` will return the user to the index route inside a tab's nested stack navigator.
 
 ## TabTrigger
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Found another small typo in the custom tabs guide.

https://docs.expo.dev/router/advanced/custom-tabs/#resetting-navigation

This
> This is particularly useful for a stack navigator nested inside a tab. For example, `<Trigger name="home" reset="always" />` will return the user to the index route inside a tab's nested stack navigator.

Should be

> This is particularly useful for a stack navigator nested inside a tab. For example, `<TabTrigger name="home" reset="always" />` will return the user to the index route inside a tab's nested stack navigator.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Updated custom-tabs.mdx
- Ran them locally to see it looks OK

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
