### PR TITLE
[docs] Fix typos and formatting issues in multiple docs

### DIFF
--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -1554,7 +1554,7 @@ build:
 
 Automatically finds and uploads application archive, additional build artifacts, and Xcode logs from the default locations and using the [`buildArtifactPaths`](/eas/json#buildartifactpaths) configuration. Uploads found artifacts to the EAS servers.
 
-```yaml example.yml
+```yaml example.yml|collapseHeight=440
 build:
   name: Build iOS app
   steps:
@@ -1872,7 +1872,7 @@ Using the built-in EAS functions you can recreate the default EAS Build process 
 
 For example, to trigger a build that creates internal distribution build for Android and a simulator build for iOS you can use the following configuration:
 
-```json eas.json
+```json eas.json|collapseHeight=420
 {
   /* @hide ... */ /* @end */
   "build": {
@@ -1910,7 +1910,7 @@ build:
     - eas/find_and_upload_build_artifacts
 ```
 
-```yaml .eas/build/development-build-ios.yml
+```yaml .eas/build/development-build-ios.yml|collapseHeight=440
 build:
   name: Simple simulator iOS build
   steps:

--- a/docs/pages/eas-update/how-it-works.mdx
+++ b/docs/pages/eas-update/how-it-works.mdx
@@ -30,7 +30,7 @@ When we're ready to create a build of our Expo project, we can run `eas build` t
 
 - **Channel:** The channel is a name we can give to multiple builds to identify them easily. It is defined in `eas.json`. For instance, we may have an Android and an iOS build with a channel named "production", while we have another pair of builds with a channel named "staging". Then, we can distribute the builds with the "production" channel to the public app stores, while keeping the "staging" builds on the Play Store Internal Track and TestFlight.
   Later when we publish an update, we can make it available to the builds with the "staging" channel first; then once we test our changes, we can make the update available to the builds with the "production" channel.
-- **Runtime version:** The runtime version describes the JS-native interface defined by the native code layer that runs our app's update layer. It is defined in a project's app config (`app.json`/`app.config.js`). Whenever we make changes to our native code that change our app's JS-native interface, we'll need to update the runtime version. [Learn more.](/eas-update/runtime-versions)
+- **Runtime version:** The runtime version describes the JS-native interface defined by the native code layer that runs our app's update layer. It is defined in a project's [app config](/workflow/configuration/). Whenever we make changes to our native code that change our app's JS-native interface, we'll need to update the runtime version. [Learn more.](/eas-update/runtime-versions)
 - **Platform:** Every build has a platform, such as "Android" or "iOS".
 
 If we made two sets of builds with the channels named "staging" and "production", we could distribute builds to four different places:

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -345,7 +345,7 @@ Evaluate the app config (**app.json**, or **app.config.js**) by running:
 <Terminal cmd={['$ npx expo config']} />
 
 - `--full`: Include all project config data.
-- `--json`: Output in JSON format, useful for converting an `app.config.js` to an `app.config.json`.
+- `--json`: Output in JSON format, useful for converting an **app.config.js** to an **app.config.json**.
 - `-t, --type`: [Type of config](#config-type) to show.
 
 ### Config type

--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -6,7 +6,6 @@ sidebar_title: Custom tabs
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
-import { CODE } from '~/ui/components/Text';
 
 > **warning** Experimentally available in SDK 52 and above. For the React Navigation styled tabs layout that are commonly used in native apps, see [Tabs](/router/advanced/tabs/).
 

--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -6,6 +6,7 @@ sidebar_title: Custom tabs
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
+import { CODE } from '~/ui/components/Text';
 
 > **warning** Experimentally available in SDK 52 and above. For the React Navigation styled tabs layout that are commonly used in native apps, see [Tabs](/router/advanced/tabs/).
 
@@ -92,7 +93,7 @@ The `TabSlot` component renders the current route. `TabSlot` can be nested insid
     </TabTrigger>
   </TabList>
   {/* Customize how `<TabSlot />` is rendered. */}
-  /* @info TabSlot be nested inside custom components */
+  /* @info <CODE>TabSlot</CODE> can be nested inside custom components. */
   <View>
     <View>
       <TabSlot />
@@ -131,7 +132,7 @@ If you need to change the structure of a component, you can override its underly
 ```tsx Custom TabList
 <Tabs>
   <TabSlot />
-  /* @info Change the appearance of the <TabList /> */
+  /* @info Change the appearance of the <CODE>TabList</CODE>. */
   <TabList asChild>
     {/* Render a custom TabList */}
     <CustomTabList>
@@ -148,7 +149,7 @@ If you need to change the structure of a component, you can override its underly
 <Tabs>
   <TabSlot />
   <TabList asChild>
-    /* @info Change the appearance of the <TabTrigger /> */
+    /* @info Change the appearance of the <CODE>TabTrigger</CODE>. */
     <TabTrigger name="home" href="/" asChild>
       {/* Render a custom button */}
       <CustomButton>
@@ -169,7 +170,8 @@ The `TabList` is both the configuration and default appearance of the `Tabs`, bu
   <TabSlot />
   {/* A custom tab bar */}
   <View>
-    /* @info A custom tab bar. TabTrigger's outside of TabList do not need the `href` prop */
+    /* @info A custom tab bar. <CODE>TabTrigger</CODE>'s outside of TabList do not need the{' '}
+    <CODE>href</CODE> prop. */
     <View>
       <TabTrigger name="home">
         <Text>Home</Text>
@@ -180,7 +182,7 @@ The `TabList` is both the configuration and default appearance of the `Tabs`, bu
     </View>
     /* @end */
   </View>
-  /* @info TabList needs to be rendered, but not necessary displayed */
+  /* @info <CODE>TabList</CODE> needs to be rendered, but not necessary displayed. */
   <TabList style={{ display: 'none' }}>
     /* @end */
     <TabTrigger name="home" href="/">

--- a/docs/pages/router/advanced/native-intent.mdx
+++ b/docs/pages/router/advanced/native-intent.mdx
@@ -56,7 +56,7 @@ export function redirectSystemPath({ path, initial }) {
 }
 ```
 
-## Rewrite incoming web deep-links
+## Rewrite incoming web deep links
 
 Handling deep links on the web differs from native platforms, as the initial routing process occurs differently. Expo Router cannot provide a direct counterpart to `+native-intent` for web, as web routing is resolved before the website's JavaScript is executed and will differ based upon deployment output and your chosen provider.
 

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -283,7 +283,7 @@ Notes about automatic server deployment for native apps:
 - Server failures may occur during the `Bundle JavaScript` phase of EAS Build if something was not setup correctly.
 - You can manually deploy the server and set the `origin` URL before building the app if you'd like.
 - Automatic deployment can be force skipped with the environment variable `EXPO_NO_DEPLOY=1`.
-- Automatic deployment does not support `app.config.js` files yet.
+- Automatic deployment does not support [dynamic app config files](/workflow/configuration/#dynamic-configuration) (**app.config.js** and **app.config.ts**) files yet.
 - Logs from the deployment will be written to `.expo/logs/deploy.log`.
 - Deployment will not run in `EXPO_OFFLINE` mode.
 

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -283,7 +283,7 @@ Notes about automatic server deployment for native apps:
 - Server failures may occur during the `Bundle JavaScript` phase of EAS Build if something was not setup correctly.
 - You can manually deploy the server and set the `origin` URL before building the app if you'd like.
 - Automatic deployment can be force skipped with the environment variable `EXPO_NO_DEPLOY=1`.
-- Automatic deployment does not support [dynamic app config files](/workflow/configuration/#dynamic-configuration) (**app.config.js** and **app.config.ts**) files yet.
+- Automatic deployment does not support [dynamic app config](/workflow/configuration/#dynamic-configuration) (**app.config.js** and **app.config.ts**) files yet.
 - Logs from the deployment will be written to `.expo/logs/deploy.log`.
 - Deployment will not run in `EXPO_OFFLINE` mode.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While going through the docs, 
- found different places where dynamic app config files weren't referenced as per the writing style guide
- typos and formatting issues in code annotations

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update dynamic config verbiage and add links to the app config guide
- Fix typos and formatting issues in code annotations
- Fix code block heights in some examples in Custom build schema reference

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Reviewed changes locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
