### PR TITLE
[docs] Fix formatting and typos in Estimate bandwidth usage guide

### DIFF
--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -3,17 +3,19 @@ title: Estimate bandwidth usage
 description: Learn how to estimate bandwidth usage for EAS Update.
 ---
 
-# Understanding update bandwidth usage
+import { Terminal } from '~/ui/components/Snippet';
 
-EAS Update enables an app to update its own non-native pieces (such as JS, styling, and images) over-the-air. This guide explains how bandwidth is consumed and how consumption can be optimized.
+## Understanding update bandwidth usage
+
+EAS Update enables an app to update its own non-native pieces (such as JavaScript, styling, and images) over-the-air. This guide explains how bandwidth is consumed and how consumption can be optimized.
 
 ## Bandwidth calculation breakdown
 
-Each subscription plan includes a predefined bandwidth allocation per monthly billing period in addition to its monthly active user (MAU) allocation ([learn more about how MAU are calculated](https://docs.expo.dev/eas-update/faq/#how-are-monthly-updated-users-counted-for-a-billing-cycle)). MAU's beyond the standard allocation are billed at [usage-based pricing rates](https://expo.dev/pricing#update), and each of those additional MAU add an extra 40 MiB to your standard bandwidth allocation. This bandwidth determines the number of updates your users can download before being charged for additional bandwidth usage.
+Each subscription plan includes a predefined bandwidth allocation per monthly billing period in addition to its monthly active user (MAU) allocation ([learn more about how MAU are calculated](/eas-update/faq/#how-are-monthly-updated-users-counted-for-a-billing-cycle)). MAU's beyond the standard allocation are billed at [usage-based pricing rates](https://expo.dev/pricing#update), and each of those additional MAU add an extra 40 MiB to your standard bandwidth allocation. This bandwidth determines the number of updates your users can download before being charged for additional bandwidth usage.
 
 Here's how to estimate bandwidth usage per update:
 
-- **Update size:** The key factor in bandwidth consumption is the size of update assets that are not already on the device. If an update only modifies the JavaScript portion of your app, users will only download the new Javascript. To begin an example, let's say the uncompressed Javascript portion generated during export is **10 MB**. Compression will further reduce its size.
+- **Update size:** The key factor in bandwidth consumption is the size of update assets that are not already on the device. If an update only modifies the JavaScript portion of your app, users will only download the new JavaScript. To begin an example, let's say the uncompressed JavaScript portion generated during export is **10 MB**. Compression will further reduce its size.
 - **Compression ratio:** The level of compression depends on the file type. JavaScript and Hermes bytecode (commonly used in React Native apps) can be compressed, while images and icons are not automatically compressed. In the example above, a Hermes bytecode bundle achieves an estimated **2.6× compression ratio**, reducing the actual download size to:
 
   ```text
@@ -31,13 +33,16 @@ Given a bandwidth allocation, we estimate how many updates can be downloaded in 
 
 To determine the actual compressed size of your Hermes bundle, run the following commands:
 
-```sh
-brotli -5 -k bundle.hbc
-gzip -9 -k bundle.hbc
-ls -lh bundle.hbc.br bundle.hbc.gz
-```
+<Terminal
+  cmd={[
+    '$ brotli -5 -k bundle.hbc',
+    '$ gzip -9 -k bundle.hbc',
+    '$ ls -lh bundle.hbc.br bundle.hbc.gz',
+  ]}
+  cmdCopy="brotli -5 -k bundle.hbc && gzip -9 -k bundle.hbc && ls -lh bundle.hbc.br bundle.hbc.gz"
+/>
 
-This will generate **Brotli- and Gzip-compressed** versions of your Hermes bundle (bundle.hbc.br and bundle.hbc.gz) and display their sizes. You can use this to refine bandwidth calculations based on your app’s real-world update sizes.
+This will generate **Brotli- and Gzip-compressed** versions of your Hermes bundle (**bundle.hbc.br** and **bundle.hbc.gz**) and display their sizes. You can use this to refine bandwidth calculations based on your app's real-world update sizes.
 
 ## Factors that affect bandwidth consumption
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #34817 

While searching through docs, found the structure of the first section in this doc is incorrect, which causes the following issue:


![CleanShot 2025-02-17 at 19 14 48@2x](https://github.com/user-attachments/assets/37492802-7629-44ec-a8ac-0de553e71f87)


# How

<!--
How did you build this feature or fix this bug and why?
-->

- Fix H1 and convert it to H2 for the first section
- Fix typos and other formatting issues
- Use `Terminal` component to show commands so that a developer can copy/paste it
- Fix internal link reference

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Reviewed the changes locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
