### PR TITLE
Bump minimum macOS version to 11.0

### DIFF
--- a/apps/bare-expo/macos/BareExpo-macOS.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/macos/BareExpo-macOS.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		5142014D2437B4B30078DB4F /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5142014C2437B4B30078DB4F /* AppDelegate.mm */; };
 		514201552437B4B40078DB4F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 514201532437B4B40078DB4F /* Main.storyboard */; };
 		514201582437B4B40078DB4F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 514201572437B4B40078DB4F /* main.m */; };
+		A2022C6326D9C49C1CC23D41 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 6E6919923BB3CB3F3071FB08 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,6 +26,7 @@
 		514201562437B4B40078DB4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		514201572437B4B40078DB4F /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		514201592437B4B40078DB4F /* BareExpo-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "BareExpo-macOS.entitlements"; sourceTree = "<group>"; };
+		6E6919923BB3CB3F3071FB08 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = ../PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		C14F7E627152FEBDBA2906EB /* Pods-ExpoMacOS-macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExpoMacOS-macOS.release.xcconfig"; path = "Target Support Files/Pods-ExpoMacOS-macOS/Pods-ExpoMacOS-macOS.release.xcconfig"; sourceTree = "<group>"; };
 		D34AEDD54AEC68400CFA542E /* libPods-BareExpo-macOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BareExpo-macOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D7A3987D0F2EE3715C517D6F /* Pods-BareExpo-macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BareExpo-macOS.debug.xcconfig"; path = "Target Support Files/Pods-BareExpo-macOS/Pods-BareExpo-macOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -80,6 +82,7 @@
 				514201562437B4B40078DB4F /* Info.plist */,
 				514201572437B4B40078DB4F /* main.m */,
 				514201592437B4B40078DB4F /* BareExpo-macOS.entitlements */,
+				6E6919923BB3CB3F3071FB08 /* PrivacyInfo.xcprivacy */,
 			);
 			path = "BareExpo-macOS";
 			sourceTree = "<group>";
@@ -184,6 +187,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				514201552437B4B40078DB4F /* Main.storyboard in Resources */,
+				A2022C6326D9C49C1CC23D41 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -306,7 +310,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -332,7 +336,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -407,13 +411,10 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				USE_HERMES = false;
 			};
 			name = Debug;
@@ -471,11 +472,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = false;

--- a/apps/bare-expo/macos/PrivacyInfo.xcprivacy
+++ b/apps/bare-expo/macos/PrivacyInfo.xcprivacy
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>0A2A.1</string>
+				<string>3B52.1</string>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+				<string>85F4.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Bump minimum macOS version to 11.0. ([#34980](https://github.com/expo/expo/pull/34980) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🎉 New features
 
 - Add RSC support. ([#34213](https://github.com/expo/expo/pull/34213) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-asset/ios/ExpoAsset.podspec
+++ b/packages/expo-asset/ios/ExpoAsset.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '15.1',
-    :macos => '11.0',
+    :osx => '11.0',
     :tvos => '15.1'
   }
   s.swift_version  = '5.4'

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Bump minimum macOS version to 11.0. ([#34980](https://github.com/expo/expo/pull/34980) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-constants/ios/EXConstants.podspec
+++ b/packages/expo-constants/ios/EXConstants.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms       = {
     :ios => '15.1',
-    :osx => '10.15',
+    :osx => '11.0',
     :tvos => '15.1'
   }
   s.swift_version  = '5.4'

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Bump minimum macOS version to 11.0. ([#34980](https://github.com/expo/expo/pull/34980) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-crypto/ios/ExpoCrypto.podspec
+++ b/packages/expo-crypto/ios/ExpoCrypto.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1',
     :tvos => '15.1',
-    :osx => '10.15'
+    :osx => '11.0'
   }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Bump minimum macOS version to 11.0. ([#34980](https://github.com/expo/expo/pull/34980) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🎉 New features
 
 - [expo-file-system][next] Add options to the create function. ([#32909](https://github.com/expo/expo/pull/32909) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-file-system/ios/ExpoFileSystem.podspec
+++ b/packages/expo-file-system/ios/ExpoFileSystem.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms       = {
     :ios => '15.1',
-    :osx => '10.15',
+    :osx => '11.0',
     :tvos => '15.1'
   }
   s.swift_version  = '5.4'

--- a/packages/expo-file-system/ios/FileSystemHelpers.swift
+++ b/packages/expo-file-system/ios/FileSystemHelpers.swift
@@ -102,7 +102,7 @@ internal func copyPHAsset(fromUrl: URL, toUrl: URL, with resourceManager: PHAsse
 }
 
 internal func isPhotoLibraryStatusAuthorized() -> Bool {
-  if #available(iOS 14, macOS 11, tvOS 14, *) {
+  if #available(iOS 14, tvOS 14, *) {
     let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
     return status == .authorized || status == .limited
   }

--- a/packages/expo-file-system/ios/Next/FileSystemFileHandle.swift
+++ b/packages/expo-file-system/ios/Next/FileSystemFileHandle.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ExpoModulesCore
 
-@available(iOS 14, macOS 11, tvOS 14, *)
+@available(iOS 14, tvOS 14, *)
 internal final class FileSystemFileHandle: SharedRef<FileHandle> {
   let file: FileSystemFile
   let handle: FileHandle

--- a/packages/expo-file-system/ios/Next/FileSystemNextModule.swift
+++ b/packages/expo-file-system/ios/Next/FileSystemNextModule.swift
@@ -2,7 +2,7 @@
 
 import ExpoModulesCore
 
-@available(iOS 14, macOS 11, tvOS 14, *)
+@available(iOS 14, tvOS 14, *)
 public final class FileSystemNextModule: Module {
   public func definition() -> ModuleDefinition {
     Name("FileSystemNext")

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Bump minimum macOS version to 11.0. ([#34980](https://github.com/expo/expo/pull/34980) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🎉 New features
 
 - Support loading expo-font in a `react-server` environment. ([#34736](https://github.com/expo/expo/pull/34736) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-font/ios/ExpoFont.podspec
+++ b/packages/expo-font/ios/ExpoFont.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '15.1',
-    :osx => '10.15',
+    :osx => '11.0',
     :tvos => '15.1'
   }
   s.swift_version  = '5.4'

--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Bump minimum macOS version to 11.0. ([#34980](https://github.com/expo/expo/pull/34980) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-keep-awake/ios/ExpoKeepAwake.podspec
+++ b/packages/expo-keep-awake/ios/ExpoKeepAwake.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms       = {
     :ios => '15.1',
-    :osx => '10.15',
+    :osx => '11.0',
     :tvos => '15.1'
   }
   s.swift_version  = '5.4'

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Bump minimum macOS version to 11.0. ([#34980](https://github.com/expo/expo/pull/34980) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-local-authentication/ios/ExpoLocalAuthentication.podspec
+++ b/packages/expo-local-authentication/ios/ExpoLocalAuthentication.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms = {
     :ios => '15.1',
-    :osx => '10.15'
+    :osx => '11.0'
   }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-mesh-gradient/CHANGELOG.md
+++ b/packages/expo-mesh-gradient/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Bump minimum macOS version to 11.0. ([#34980](https://github.com/expo/expo/pull/34980) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-mesh-gradient/ios/ExpoMeshGradient.podspec
+++ b/packages/expo-mesh-gradient/ios/ExpoMeshGradient.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1',
     :tvos => '15.1',
-    :osx => '10.15',
+    :osx => '11.0',
   }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Bump minimum macOS version to 11.0. ([#34980](https://github.com/expo/expo/pull/34980) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🎉 New features
 
 - [Android] Added support for Jetpack Compose views. ([#33759](https://github.com/expo/expo/pull/33759) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -52,7 +52,7 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms       = {
     :ios => '15.1',
-    :osx => '10.15',
+    :osx => '11.0',
     :tvos => '15.1'
   }
   s.swift_version  = '5.4'

--- a/packages/expo-modules-core/ios/Core/Logging/LogHandlers.swift
+++ b/packages/expo-modules-core/ios/Core/Logging/LogHandlers.swift
@@ -3,7 +3,7 @@
 import os.log
 
 public func createOSLogHandler(category: String) -> LogHandler {
-  if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+  if #available(iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
     return OSLogHandler(category: category)
   }
   return PrintLogHandler()
@@ -23,7 +23,7 @@ public protocol LogHandler {
 /**
  The log handler that uses the new `os.Logger` API.
  */
-@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 internal class OSLogHandler: LogHandler {
   private let osLogger: os.Logger
 

--- a/packages/expo-modules-core/ios/Core/Logging/LogType.swift
+++ b/packages/expo-modules-core/ios/Core/Logging/LogType.swift
@@ -44,7 +44,7 @@ public enum LogType: Int {
   /**
    Maps the log types to the log types used by the `os.log` logger.
    */
-  @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+  @available(iOS 14.0, watchOS 7.0, tvOS 14.0, *)
   public func toOSLogType() -> OSLogType {
     switch self {
     case .trace, .timer, .stacktrace, .debug:

--- a/packages/expo/Expo.podspec
+++ b/packages/expo/Expo.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms       = {
     :ios => '15.1',
-    :osx => '10.15',
+    :osx => '11.0',
     :tvos => '15.1'
   }
   s.source         = { git: 'https://github.com/expo/expo.git' }


### PR DESCRIPTION
# Why

The new React Native macOS 0.77 requires the macOS version to be at least 11.0

# How

- Updates minimum macOS versions in our podspecs
- Update macOS deployment target in BareExpo  
- Clean up code availability for macOS 11.0

# Test Plan

Run BareExpo macOS locally (with some additional patches)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
