### PR TITLE
[notifications][ios] Fixed incorrect `EXNotifications-Swift.h` import

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - fix ios textInput action missing title ([#34866](https://github.com/expo/expo/pull/34866) by [@vonovak](https://github.com/vonovak))
-- [ios] Fixed incorrect `EXNotifications-Swift.h` import.
+- [ios] Fixed incorrect `EXNotifications-Swift.h` import. ([#34987](https://github.com/expo/expo/pull/34987) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - fix ios textInput action missing title ([#34866](https://github.com/expo/expo/pull/34866) by [@vonovak](https://github.com/vonovak))
+- [ios] Fixed incorrect `EXNotifications-Swift.h` import.
 
 ### 💡 Others
 

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationCenterDelegate.m
@@ -4,7 +4,7 @@
 #import <ExpoModulesCore/EXDefines.h>
 #import <EXNotifications/EXNotificationsDelegate.h>
 
-#if __has_include(<ExpoModulesCore/ExpoModulesCore-Swift.h>)
+#if __has_include(<EXNotifications/EXNotifications-Swift.h>)
 #import <EXNotifications/EXNotifications-Swift.h>
 #else
 #import "EXNotifications-Swift.h"


### PR DESCRIPTION
# Why

Fixed incorrect `EXNotifications-Swift.h` import.