### PR TITLE
[docs] Adds outputs to workflow jobs

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -297,6 +297,15 @@ jobs:
       profile: string # optional, default: production
 ```
 
+This job outputs the following properties:
+
+```json
+{
+  "build_id": string,
+  "platform": "ios" | "android" | null,
+}
+```
+
 Build jobs can be customized so that you can execute custom commands during the build process. See [Custom builds](/custom-builds/get-started/) for more information.
 
 #### `deploy`
@@ -337,6 +346,26 @@ jobs:
       sdk_version: string # optional
       runtime_version: string # optional
       simulator: boolean # optional
+```
+
+This job outputs the following properties:
+
+```json
+{
+  "build_id": string,
+  "app_build_version": string | null,
+  "app_identifier": string | null,
+  "app_version": string | null,
+  "channel": string | null,
+  "distribution": "internal" | "store" | null,
+  "fingerprint_hash": string | null,
+  "git_commit_hash": string | null,
+  "platform": "ios" | "android" | null,
+  "profile": string | null,
+  "runtime_version": string | null,
+  "sdk_version": string | null,
+  "simulator": string | null
+}
 ```
 
 #### `submit`

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -364,7 +364,7 @@ This job outputs the following properties:
   "profile": string | null,
   "runtime_version": string | null,
   "sdk_version": string | null,
-  "simulator": string | null
+  "simulator": "true" | "false" | null
 }
 ```
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -302,7 +302,18 @@ This job outputs the following properties:
 ```json
 {
   "build_id": string,
+  "app_build_version": string | null,
+  "app_identifier": string | null,
+  "app_version": string | null,
+  "channel": string | null,
+  "distribution": "internal" | "store" | null,
+  "fingerprint_hash": string | null,
+  "git_commit_hash": string | null,
   "platform": "ios" | "android" | null,
+  "profile": string | null,
+  "runtime_version": string | null,
+  "sdk_version": string | null,
+  "simulator": "true" | "false" | null
 }
 ```
 


### PR DESCRIPTION
# Why

We'd like to document what outputs you can expect from the `build` and `get-build` jobs.

# Screenshots

<img width="665" alt="Screenshot 2025-02-17 at 3 20 51 PM" src="https://github.com/user-attachments/assets/850a649c-4d94-4d22-8a0a-e9de0f8b8244" />

<img width="792" alt="Screenshot 2025-02-17 at 3 19 59 PM" src="https://github.com/user-attachments/assets/d52cd466-f47f-40ec-a0a1-295d435fe7f0" />

# Test Plan

Make sure the changes read well and are accurate.