### PR TITLE
[go] fix downloadAsset build error

### DIFF
--- a/apps/expo-go/ios/Client/HomeAppLoader.swift
+++ b/apps/expo-go/ios/Client/HomeAppLoader.swift
@@ -71,7 +71,7 @@ final class HomeAppLoader: AppLoader {
     }
   }
 
-  override func downloadAsset(_ asset: UpdateAsset) {
+  override func downloadAsset(_ asset: UpdateAsset, extraHeaders: [String: Any]) {
     let urlOnDisk = self.directory.appendingPathComponent(asset.filename)
 
     FileDownloader.assetFilesQueue.async {
@@ -93,7 +93,7 @@ final class HomeAppLoader: AppLoader {
           fromURL: assetUrl,
           verifyingHash: asset.expectedHash,
           toPath: urlOnDisk.path,
-          extraHeaders: asset.extraRequestHeaders ?? [:]
+          extraHeaders: extraHeaders.merging(asset.extraRequestHeaders ?? [:]) { current, _ in current }
         ) { data, response, _ in
           DispatchQueue.global().async {
             self.handleAssetDownload(withData: data, response: response, asset: asset)


### PR DESCRIPTION
# Why

fixes ios expo-go build error: https://github.com/expo/expo/actions/runs/13363533171

```
❌  (../expo-go/ios/Client/HomeAppLoader.swift:74:17)

  72 |   }
  73 | 
> 74 |   override func downloadAsset(_ asset: UpdateAsset) {
     |                 ^ method does not override any method from its superclass
  75 |     let urlOnDisk = self.directory.appendingPathComponent(asset.filename)
  76 | 
  77 |     FileDownloader.assetFilesQueue.async {
```

# How

`downloadAsset` interface was changed since #34453. this pr tries to apply the same change from RemoteAppLoader to HomeAppLoader

# Test Plan

ios expo go build passed

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
