### PR TITLE
[create-expo-nightly] fix expo/expo yarn install error

### DIFF
--- a/packages/create-expo-nightly/src/ExpoRepo.ts
+++ b/packages/create-expo-nightly/src/ExpoRepo.ts
@@ -37,7 +37,13 @@ export async function setupExpoRepoAsync(
   console.log(`Running \`yarn install\` in ${expoRepoPath}`);
   console.time('Installed dependencies in expo repository');
   await setupDependenciesAsync(expoRepoPath, nightlyVersion);
-  await runAsync('yarn', ['install'], { cwd: expoRepoPath });
+  try {
+    await runAsync('yarn', ['install'], { cwd: expoRepoPath });
+  } catch (e) {
+    if (e instanceof Error) {
+      console.warn(`Failed to install dependencies in ${expoRepoPath}`, e.toString());
+    }
+  }
   console.timeEnd('Installed dependencies in expo repository');
 
   return expoRepoPath;


### PR DESCRIPTION
# Why

fixes create-expo-nightly errors on ci
```
'**ERROR** Failed to apply patch for package react-native at path\n' +
  '  \n' +
  '    node_modules/react-native\n' +
  '\n' +
  '  This error was caused because react-native has changed since you\n' +
  '  made the patch file for it. This introduced conflicts with your patch,\n' +
  '  just like a merge conflict in Git when separate incompatible changes are\n' +
  '  made to the same piece of code.\n' +
  '\n' +
  '  Maybe this means your patch file is no longer necessary, in which case\n' +
  '  hooray! Just delete it!\n' +
  '\n' +
  '  Otherwise, you need to generate a new patch file.\n' +
  '\n' +
  '  To generate a new one, just repeat the steps you made to generate the first\n' +
  '  one.\n' +
  '\n' +
  '  i.e. manually make the appropriate file changes, then run \n' +
  '\n' +
  '    patch-package react-native\n' +
  '\n' +
  '  Info:\n' +
  '    Patch file: patches/react-native+0.77.0.patch\n' +
  '    Patch was made for version: 0.77.0\n' +
  '    Installed version: 0.79.0-nightly-[202](https://github.com/expo/expo/actions/runs/13376592555/job/37357063912#step:10:203)50217-acdddef48\n' +
  '\n' +
```

# How

only show warning for the `yarn install` failure

# Test Plan

nightlies ci passed on android: https://github.com/expo/expo/actions/runs/13383396706
(ios still breaks due to RCTReactNativeFactory change and needs a refactoring)

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
