### PR TITLE
chore: Standardize platform key ordering in `expo-module.config.json`

### DIFF
--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- Standardize platform key ordering in `expo-module.config.json`. ([#35003](https://github.com/expo/expo/pull/35003) by [@reichhartd](https://github.com/reichhartd))
 
 ## 0.6.1 — 2024-10-29
 

--- a/packages/expo-maps/expo-module.config.json
+++ b/packages/expo-maps/expo-module.config.json
@@ -1,13 +1,13 @@
 {
   "platforms": ["apple", "android"],
+  "apple": {
+    "modules": ["MapsModule", "AppleMapsModule"]
+  },
   "android": {
     "modules": [
       "expo.modules.maps.MapsModule",
       "expo.modules.maps.GoogleMapsModule",
       "expo.modules.maps.StreetViewModule"
     ]
-  },
-  "apple": {
-    "modules": ["MapsModule", "AppleMapsModule"]
   }
 }

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- Standardize platform key ordering in `expo-module.config.json`. ([#35003](https://github.com/expo/expo/pull/35003) by [@reichhartd](https://github.com/reichhartd))
 
 ## 7.0.0 — 2024-10-22
 

--- a/packages/expo-screen-capture/expo-module.config.json
+++ b/packages/expo-screen-capture/expo-module.config.json
@@ -1,9 +1,9 @@
 {
   "platforms": ["apple", "android", "web"],
-  "android": {
-    "modules": ["expo.modules.screencapture.ScreenCaptureModule"]
-  },
   "apple": {
     "modules": ["ScreenCaptureModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.screencapture.ScreenCaptureModule"]
   }
 }

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- Standardize platform key ordering in `expo-module.config.json`. ([#35003](https://github.com/expo/expo/pull/35003) by [@reichhartd](https://github.com/reichhartd))
 
 ## 8.0.2 - 2024-12-19
 

--- a/packages/expo-screen-orientation/expo-module.config.json
+++ b/packages/expo-screen-orientation/expo-module.config.json
@@ -1,11 +1,11 @@
 {
   "platforms": ["apple", "android"],
-  "android": {
-    "modules": ["expo.modules.screenorientation.ScreenOrientationModule"]
-  },
   "apple": {
     "appDelegateSubscribers": ["ScreenOrientationAppDelegate"],
     "reactDelegateHandlers": ["ScreenOrientationReactDelegateHandler"],
     "modules": ["ScreenOrientationModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.screenorientation.ScreenOrientationModule"]
   }
 }

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Standardize platform key ordering in `expo-module.config.json`. ([#35003](https://github.com/expo/expo/pull/35003) by [@reichhartd](https://github.com/reichhartd))
+
 ## 0.0.2 — 2025-02-11
 
 ### 🎉 New features

--- a/packages/expo-ui/expo-module.config.json
+++ b/packages/expo-ui/expo-module.config.json
@@ -1,9 +1,9 @@
 {
   "platforms": ["apple", "android"],
-  "android": {
-    "modules": ["expo.modules.ui.ExpoUIModule"]
-  },
   "apple": {
     "modules": ["ExpoUIModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.ui.ExpoUIModule"]
   }
 }


### PR DESCRIPTION
# Why

Following up on #33779 this PR standardizes the ordering of platform keys in several modules' config files to match the established convention: `apple` before `android`.

# How

Updated the key ordering in `expo-module.config.json` files for the following packages to place `apple` configurations before `android`:
- `expo-maps`
- `expo-screen-capture`
- `expo-screen-orientation`
- `expo-ui`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
