### PR TITLE
[modules-core][iOS] Fix initializing view definitions on Paper

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [Android] Fixes `AppContext` is lost in nested converters. ([#34373](https://github.com/expo/expo/pull/34373) by [@lukmccall](https://github.com/lukmccall))
 - Fixed **AppDelegate.mm** methods not be called on iOS. ([#34464](https://github.com/expo/expo/pull/34464) by [@kudo](https://github.com/kudo))
 - Fixed converting double to float. ([#34906](https://github.com/expo/expo/pull/34906) by [@janicduplessis](https://github.com/janicduplessis))
+- [iOS] Fixed ViewModuleWrapper initializer on old arch to use the DEFAULT_MODULE_VIEW view from the module as the default view. ([#35007](https://github.com/expo/expo/pull/35007) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
@@ -52,7 +52,7 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
       return
     }
     self.moduleHolder = module.moduleHolder
-    self.viewDefinition = moduleHolder?.definition.views.first?.value
+    self.viewDefinition = moduleHolder?.definition.views[DEFAULT_MODULE_VIEW]
   }
 
   /**

--- a/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewModuleWrapper.swift
@@ -52,6 +52,7 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
       return
     }
     self.moduleHolder = module.moduleHolder
+    self.viewDefinition = moduleHolder?.definition.views.first?.value
   }
 
   /**


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/34293

When using the default initializer to create module instances with Paper (old arch) the viewDefinition does not get defined

# How

Update `ViewModuleWrapper` initializer to use the `DEFAULT_MODULE_VIEW` view from the module as the default view

# Test Plan

Run BareExpo on old arch

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
