### PR TITLE
[docs] Fix `diff` inside of the `brownfield/installing-expo-modules`

### DIFF
--- a/docs/pages/brownfield/installing-expo-modules.mdx
+++ b/docs/pages/brownfield/installing-expo-modules.mdx
@@ -166,24 +166,34 @@ Override `onConfigurationChanged` if you have not done so already.
 Add the following to your `Podfile` in the **ios** directory:
 
 <DiffBlock
-    raw={`
+  raw={`
 diff --git a/ios/Podfile b/ios/Podfile
-index 2d3a979..825a9d4 100644
+index f991b7b..17c24b0 100644
 --- a/ios/Podfile
 +++ b/ios/Podfile
-@@ -1,3 +1,4 @@
+@@ -1 +1,4 @@
++# Expo requires
 +require File.join(File.dirname(\`node --print "require.resolve('expo/package.json')"\`), "scripts/autolinking")
- require Pod::Executable.execute_command('node', ['-p',
-   'require.resolve(
-   "react-native/scripts/react_native_pods.rb",
-@@ -14,6 +15,7 @@ if linkage != nil
- end
-
-target '<YourAppTarget>' do
-
-+use_expo_modules!
-config = use_native_modules!
-`}
++
+ # Resolve react_native_pods.rb with node to allow for hoisting
+@@ -17,3 +20,16 @@ end
+ target 'SimpleTest' do
+-  config = use_native_modules!()
++  # Need to be added inside the target block
++  use_expo_modules!
++
++  config_command = [
++    'node',
++    '--no-warnings',
++    '--eval',
++    'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
++    'react-native-config',
++    '--json',
++    '--platform',
++    'ios'
++  ]
++  config = use_native_modules!(config_command)
+ `}
 />
 
 </Step>

--- a/docs/pages/brownfield/installing-expo-modules.mdx
+++ b/docs/pages/brownfield/installing-expo-modules.mdx
@@ -177,7 +177,7 @@ index f991b7b..17c24b0 100644
 +
  # Resolve react_native_pods.rb with node to allow for hoisting
 @@ -17,3 +20,16 @@ end
- target 'SimpleTest' do
+ target '<YourAppTarget>' do
 -  config = use_native_modules!()
 +  # Need to be added inside the target block
 +  use_expo_modules!


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/34818.
The diff viewer we're using removes some untouched lines, making our docs very confusing. `use_expo_modules needs to be applied inside the `target` block, so I've added a comment to indicate this.  

# Test Plan

<img width="1122" alt="image" src="https://github.com/user-attachments/assets/4092a534-8ee7-48c4-8714-0333cda02f40" />
