### PR TITLE
[updates][iOS] Fix unit tests compilation

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
@@ -203,7 +203,7 @@ public final class UpdatesConfig: NSObject {
     return try UpdatesConfig.config(fromDictionary: config, configOverride: UpdatesConfigOverride.load())
   }
 
-  private static func config(
+  internal static func config(
     fromDictionary config: [String: Any],
     configOverride: UpdatesConfigOverride?
   ) throws -> UpdatesConfig {


### PR DESCRIPTION
# Why

Fixes:
```
./expo/packages/expo-updates/ios/Tests/UpdatesBuildDataSpec.swift:162:27: error: extra argument 'configOverride' in call
          configOverride: configOverride)
```
<img width="973" alt="image" src="https://github.com/user-attachments/assets/92df9597-5d89-4b04-bf7c-bf6ed8120091" />

# Test Plan

- native-tests ✅ 