### PR TITLE
[gl] Implement `compressedTexImage2D` and `compressedTexSubImage2D` WebGL context methods

### DIFF
--- a/apps/test-suite/tests/GLView.js
+++ b/apps/test-suite/tests/GLView.js
@@ -52,6 +52,32 @@ export async function test(
       ).toBe(true);
     });
 
+    it('gets WebGL extensions', async () => {
+      const context = await getContextAsync();
+      expect(
+        context instanceof WebGLRenderingContext || context instanceof WebGL2RenderingContext
+      ).toBe(true);
+
+      const etcExtensions = context.getExtension('WEBGL_compressed_texture_etc');
+
+      if (context instanceof WebGL2RenderingContext) {
+        expect(etcExtensions).toEqual({
+          COMPRESSED_R11_EAC: 37488,
+          COMPRESSED_SIGNED_R11_EAC: 37489,
+          COMPRESSED_RG11_EAC: 37490,
+          COMPRESSED_SIGNED_RG11_EAC: 37491,
+          COMPRESSED_RGB8_ETC2: 37492,
+          COMPRESSED_SRGB8_ETC2: 37493,
+          COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2: 37494,
+          COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2: 37495,
+          COMPRESSED_RGBA8_ETC2_EAC: 37496,
+          COMPRESSED_SRGB8_ALPHA8_ETC2_EAC: 37497,
+        });
+      } else {
+        expect(etcExtensions).toEqual(null);
+      }
+    });
+
     it('takes a snapshot', async () => {
       await getContextAsync();
 

--- a/apps/test-suite/tests/GLView.js
+++ b/apps/test-suite/tests/GLView.js
@@ -133,6 +133,53 @@ export async function test(
         gl.endFrameEXP();
       });
 
+      it(`draws a compressed texture`, async () => {
+        const gl = await getContextAsync();
+
+        const vert = gl.createShader(gl.VERTEX_SHADER);
+        gl.shaderSource(vert, vertexShader);
+        gl.compileShader(vert);
+        const frag = gl.createShader(gl.FRAGMENT_SHADER);
+        gl.shaderSource(frag, fragShader);
+        gl.compileShader(frag);
+
+        const program = gl.createProgram();
+        gl.attachShader(program, vert);
+        gl.attachShader(program, frag);
+        gl.linkProgram(program);
+        gl.useProgram(program);
+
+        const buffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+        const verts = new Float32Array([-2, 0, 0, -2, 2, 2]);
+        gl.bufferData(gl.ARRAY_BUFFER, verts, gl.STATIC_DRAW);
+        const positionAttrib = gl.getAttribLocation(program, 'position');
+        gl.enableVertexAttribArray(positionAttrib);
+        gl.vertexAttribPointer(positionAttrib, 2, gl.FLOAT, false, 0, 0);
+
+        const texture = gl.createTexture();
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+
+        gl.compressedTexImage2D(
+          gl.TEXTURE_2D,
+          0,
+          gl.COMPRESSED_R11_EAC,
+          32,
+          32,
+          0,
+          new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 128, 128, 0, 255])
+        );
+        gl.uniform1i(gl.getUniformLocation(program, 'texture'), 0);
+
+        gl.clearColor(0, 0, 1, 1);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+        gl.drawArrays(gl.TRIANGLES, 0, verts.length / 2);
+        gl.endFrameEXP();
+      });
+
       it(`draws a texture with a TypedArray`, async () => {
         const gl = await getContextAsync();
 
@@ -174,6 +221,57 @@ export async function test(
           2,
           gl.RGBA,
           gl.UNSIGNED_BYTE,
+          new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 128, 128, 0, 255])
+        );
+
+        gl.uniform1i(gl.getUniformLocation(program, 'texture'), 0);
+
+        gl.clearColor(0, 0, 1, 1);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+        gl.drawArrays(gl.TRIANGLES, 0, verts.length / 2);
+        gl.endFrameEXP();
+      });
+
+      it(`draws a compressed texture with a TypedArray`, async () => {
+        const gl = await getContextAsync();
+
+        const vert = gl.createShader(gl.VERTEX_SHADER);
+        gl.shaderSource(vert, vertexShader);
+
+        gl.compileShader(vert);
+        const frag = gl.createShader(gl.FRAGMENT_SHADER);
+        gl.shaderSource(frag, fragShader);
+        gl.compileShader(frag);
+
+        const program = gl.createProgram();
+        gl.attachShader(program, vert);
+        gl.attachShader(program, frag);
+        gl.linkProgram(program);
+        gl.useProgram(program);
+
+        const buffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+        const verts = new Float32Array([-2, 0, 0, -2, 2, 2]);
+        gl.bufferData(gl.ARRAY_BUFFER, verts, gl.STATIC_DRAW);
+        const positionAttrib = gl.getAttribLocation(program, 'position');
+        gl.enableVertexAttribArray(positionAttrib);
+        gl.vertexAttribPointer(positionAttrib, 2, gl.FLOAT, false, 0, 0);
+
+        const texture = gl.createTexture();
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+
+        // Use below to test using a `TypedArray` parameter
+        gl.compressedTexSubImage2D(
+          gl.TEXTURE_2D,
+          0,
+          32,
+          32,
+          2,
+          2,
+          gl.COMPRESSED_R11_EAC,
           new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 128, 128, 0, 255])
         );
 

--- a/apps/test-suite/tests/GLView.js
+++ b/apps/test-suite/tests/GLView.js
@@ -192,7 +192,7 @@ export async function test(
         gl.compressedTexImage2D(
           gl.TEXTURE_2D,
           0,
-          gl.COMPRESSED_R11_EAC,
+          37488,
           32,
           32,
           0,
@@ -297,7 +297,7 @@ export async function test(
           32,
           2,
           2,
-          gl.COMPRESSED_R11_EAC,
+          37488,
           new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 128, 128, 0, 255])
         );
 

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added ASTC compressed texture support for the `compressedTexImage2D` and `compressedTexSubImage2D` WebGL methods.
+- Added ETC compressed texture support for the `compressedTexImage2D` and `compressedTexSubImage2D` WebGL methods.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added ETC compressed texture support for the `compressedTexImage2D` and `compressedTexSubImage2D` WebGL methods.
+- Added ETC compressed texture support for the `compressedTexImage2D` and `compressedTexSubImage2D` WebGL methods. ([#35022](https://github.com/expo/expo/pull/35022) by [@hmallen99](https://github.com/hmallen99))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added ASTC compressed texture support for the `compressedTexImage2D` and `compressedTexSubImage2D` WebGL methods.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-gl/common/EXGLImageUtils.cpp
+++ b/packages/expo-gl/common/EXGLImageUtils.cpp
@@ -136,6 +136,7 @@ std::shared_ptr<uint8_t> loadImage(
   return std::shared_ptr<uint8_t>(nullptr);
 }
 
+// reference: https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glCompressedTexImage2D.xhtml
 GLsizei calculateImageSize(GLsizei width, GLsizei height, GLint internalFormat) {
     switch (internalFormat) {
         case GL_COMPRESSED_R11_EAC:

--- a/packages/expo-gl/common/EXGLImageUtils.cpp
+++ b/packages/expo-gl/common/EXGLImageUtils.cpp
@@ -135,5 +135,23 @@ std::shared_ptr<uint8_t> loadImage(
   }
   return std::shared_ptr<uint8_t>(nullptr);
 }
+
+GLsizei calculateImageSize(GLsizei width, GLsizei height, GLint internalFormat) {
+    switch (internalFormat) {
+        case GL_COMPRESSED_R11_EAC:
+        case GL_COMPRESSED_SIGNED_R11_EAC:
+        case GL_COMPRESSED_RGB8_ETC2:
+        case GL_COMPRESSED_SRGB8_ETC2:
+        case GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2:
+        case GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2:
+            return (width / 4) * (height / 4) * 8;
+        case GL_COMPRESSED_RG11_EAC:
+        case GL_COMPRESSED_SIGNED_RG11_EAC:
+        case GL_COMPRESSED_RGBA8_ETC2_EAC:
+        case GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC:
+        default:
+            return (width / 4) * (height / 4) * 16;
+    }
+}
 } // namespace gl_cpp
 } // namespace expo

--- a/packages/expo-gl/common/EXGLImageUtils.h
+++ b/packages/expo-gl/common/EXGLImageUtils.h
@@ -24,5 +24,7 @@ std::shared_ptr<uint8_t> loadImage(
     int *fileWidth,
     int *fileHeight,
     int *fileComp);
+
+GLsizei calculateImageSize(GLsizei width, GLsizei height, GLint internalFormat);
 } // namespace gl_cpp
 } // namespace expo


### PR DESCRIPTION
# Why
Compressed textures are useful in complex 3D applications where memory usage is a bottleneck and texture quality is not a concern. JavaScript engines like Three.js use `compressedTexImage2D` and `compressedTexSubImage2D` to [implement compressed textures](https://github.com/mrdoob/three.js/blob/4c206121baeccf3be37f5bffcd2962fb2c827f91/src/renderers/webgl/WebGLTextures.js#L961-L974).

However, Expo's WebGL context does not implement `compressedTexImage2D` or `compressedTexSubImage2D`. This limits use of compressed textures in React Native applications. 

Relevant feature request: https://expo.canny.io/feature-requests/p/expo-gl-compressed-2d-texture-support-1

# How

- Implements the `WebGLRenderingContext` methods [compressedTexImage2D](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/compressedTexImage2D) and [compressedTexSubImage2D](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/compressedTexSubImage2D).
    - For `compressedTexImage2D`, the following function signature is implemented: `compressedTexImage2D(target, level, internalformat, width, height, border, srcData)`.
    - For `compressedTexSubImage2D`, the following function signature is implemented: `compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, srcData)`.
    - Function signatures with an `offset` or `srcOffset` argument are not implemented. This matches the existing implementations for `texImage2D` and `texSubImage2D`.
- Implements the `WebGLRenderingContext` method `getExtension` for [WEBGL_compressed_texture_etc](https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_compressed_texture_etc).
- Adds a helper function for calculating compressed texture image size based on the [Khronos specification](https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glCompressedTexImage2D.xhtml).


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- This PR adds e2e tests alongside the existing GLView e2e tests
- To test this locally, you can use an existing three.js compressed texture example: https://github.com/mrdoob/three.js/blob/master/examples/webgl_loader_texture_ktx2.html. I can add this as a minimal reproduction if desired.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
