### PR TITLE
[test-suite][ncl] fix web support

### DIFF
--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -10,7 +10,7 @@ import getStackNavWithConfig from '../navigation/StackConfig';
 import { AudioScreens } from '../screens/Audio/AudioScreen';
 import ExpoApis from '../screens/ExpoApisScreen';
 import { ModulesCoreScreens } from '../screens/ModulesCore/ModulesCoreScreen';
-import { ScreenConfig } from '../types/ScreenConfig';
+import { type ScreenApiItem, type ScreenConfig } from '../types/ScreenConfig';
 
 const Stack = createStackNavigator();
 
@@ -207,6 +207,7 @@ export const Screens: ScreenConfig[] = [
       return optionalRequire(() => require('../screens/ImageManipulatorScreenLegacy'));
     },
     name: 'ImageManipulator (legacy)',
+    route: 'image-manipulator-legacy',
   },
   {
     getComponent() {
@@ -428,12 +429,20 @@ export const Screens: ScreenConfig[] = [
   ...AudioScreens,
 ];
 
+export const screenApiItems: ScreenApiItem[] = Screens.map(({ name, route }) => ({
+  name,
+  route: '/apis/' + (route ?? name.toLowerCase()),
+  isAvailable: true,
+}));
+
 function ExpoApisStackNavigator(props: { navigation: BottomTabNavigationProp<any> }) {
   const { theme } = useTheme();
 
   return (
     <Stack.Navigator {...props} {...getStackNavWithConfig(props.navigation, theme)}>
-      <Stack.Screen name="ExpoApis" options={{ title: 'APIs in Expo SDK' }} component={ExpoApis} />
+      <Stack.Screen name="ExpoApis" options={{ title: 'APIs in Expo SDK' }}>
+        {() => <ExpoApis apis={screenApiItems} />}
+      </Stack.Screen>
       {Screens.map(({ name, options, getComponent }) => (
         <Stack.Screen name={name} key={name} getComponent={getComponent} options={options ?? {}} />
       ))}

--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -14,7 +14,7 @@ import { MapsScreens } from '../screens/ExpoMaps/MapsScreen';
 import { ImageScreens } from '../screens/Image/ImageScreen';
 import { UIScreens } from '../screens/UI/UIScreen';
 import { VideoScreens } from '../screens/Video/VideoScreen';
-import { ScreenConfig } from '../types/ScreenConfig';
+import { type ScreenApiItem, type ScreenConfig } from '../types/ScreenConfig';
 
 const Stack = createStackNavigator();
 
@@ -371,12 +371,14 @@ export const Screens: ScreenConfig[] = [
       return optionalRequire(() => require('../screens/Audio/AV/VideoScreen'));
     },
     name: 'Video (expo-av)',
+    route: 'video-expo-av',
   },
   {
     getComponent() {
       return optionalRequire(() => require('../screens/Video/VideoScreen'));
     },
     name: 'Video (expo-video)',
+    route: 'video-expo-video',
   },
   {
     getComponent() {
@@ -440,15 +442,23 @@ export const Screens: ScreenConfig[] = [
   ...MapsScreens,
 ];
 
+export const screenApiItems: ScreenApiItem[] = Screens.map(({ name, route }) => ({
+  name,
+  route: '/components/' + (route ?? name.toLowerCase()),
+  isAvailable: true,
+}));
+
 function ExpoComponentsStackNavigator(props: { navigation: BottomTabNavigationProp<any> }) {
   const { theme } = useTheme();
   return (
     <Stack.Navigator {...props} {...getStackNavWithConfig(props.navigation, theme)}>
       <Stack.Screen
         name="ExpoComponents"
-        options={{ title: Layout.isSmallDevice ? 'Expo SDK Components' : 'Components in Expo SDK' }}
-        component={ExpoComponents}
-      />
+        options={{
+          title: Layout.isSmallDevice ? 'Expo SDK Components' : 'Components in Expo SDK',
+        }}>
+        {() => <ExpoComponents apis={screenApiItems} />}
+      </Stack.Screen>
       {Screens.map(({ name, getComponent, options }) => (
         <Stack.Screen name={name} key={name} getComponent={getComponent} options={options ?? {}} />
       ))}

--- a/apps/native-component-list/src/screens/ExpoApisScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoApisScreen.tsx
@@ -1,7 +1,9 @@
+import { memo } from 'react';
 import { Platform } from 'react-native';
 
 import ComponentListScreen from './ComponentListScreen';
 import ExpoAPIIcon from '../components/ExpoAPIIcon';
+import { type ScreenApiItem } from '../types/ScreenConfig';
 
 if (Platform.OS !== 'web') {
   // Optionally require expo-notifications as we cannot assume that the module is linked.
@@ -23,83 +25,13 @@ if (Platform.OS !== 'web') {
   });
 }
 
-const screens = [
-  'Accelerometer',
-  'ActionSheet',
-  'Alert',
-  'Appearance',
-  'AppleAuthentication',
-  'Audio',
-  'AsyncStorage',
-  'AuthSession',
-  'BackgroundFetch',
-  'BackgroundTask',
-  'BackgroundLocation',
-  'Battery',
-  'Brightness',
-  'Calendars',
-  'Cellular',
-  'Clipboard',
-  'Constants',
-  'Contacts',
-  'Crypto',
-  'Device',
-  'DocumentPicker',
-  'FileSystem',
-  'Font',
-  'Errors',
-  'Geocoding',
-  'Haptics',
-  'ImageManipulator',
-  'ImageManipulator (legacy)',
-  'ImagePicker',
-  'IntentLauncher',
-  'KeepAwake',
-  'Linking',
-  'LocalAuthentication',
-  'Localization',
-  'Location',
-  'MailComposer',
-  'MediaLibrary',
-  'ModulesCore',
-  'Network',
-  'NetInfo',
-  'Notification',
-  'Pedometer',
-  'Print',
-  'SMS',
-  'NavigationBar',
-  'SafeAreaContext',
-  'ScreenOrientation',
-  'SecureStore',
-  'ScreenCapture',
-  'Sensor',
-  'Sharing',
-  'StatusBar',
-  'StoreReview',
-  'SystemUI',
-  'TaskManager',
-  'TextToSpeech',
-  'TrackingTransparency',
-  'Video Thumbnails',
-  'ViewShot',
-  'WebBrowser',
-];
-
-export const ScreenItems = screens.map((name) => ({
-  name,
-  route: `/apis/${name.toLowerCase()}`,
-  // isAvailable: !!Screens[name],
-  isAvailable: true,
-}));
-
-export default function ExpoApisScreen() {
+export default memo(function ExpoApisScreen({ apis }: { apis: ScreenApiItem[] }) {
   return (
     <ComponentListScreen
       renderItemRight={({ name }: { name: string }) => (
         <ExpoAPIIcon name={name} style={{ marginRight: 10, marginLeft: 6 }} />
       )}
-      apis={ScreenItems}
+      apis={apis}
     />
   );
-}
+});

--- a/apps/native-component-list/src/screens/ExpoComponentsScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoComponentsScreen.tsx
@@ -1,66 +1,16 @@
+import { memo } from 'react';
+
 import ComponentListScreen from './ComponentListScreen';
 import ExpoAPIIcon from '../components/ExpoAPIIcon';
+import { type ScreenApiItem } from '../types/ScreenConfig';
 
-const screens = [
-  'ActivityIndicator',
-  'BlurView',
-  'Button',
-  'Camera',
-  'Checkbox',
-  'ClipboardPasteButton',
-  'DateTimePicker',
-  'DrawerLayoutAndroid',
-  'ExpoMaps',
-  'FlashList',
-  'GL',
-  'GestureHandlerList',
-  'GestureHandlerPinch',
-  'GestureHandlerSwipeable',
-  'HTML',
-  'Image',
-  'LinearGradient',
-  'LivePhoto',
-  'Lottie',
-  'Maps',
-  'MaskedView',
-  'MeshGradient',
-  'Modal',
-  'Picker',
-  'Pressable',
-  'Reanimated',
-  'Skia',
-  'SVG',
-  'Screens',
-  'ScrollView',
-  'SegmentedControl',
-  'Slider',
-  'Switch',
-  'Symbols',
-  'Text',
-  'TextInput',
-  'TouchableBounce',
-  'Touchables',
-  'Video (expo-av)',
-  'Video (expo-video)',
-  'Expo UI',
-  'PagerView',
-  'WebView',
-];
-
-export const ScreenItems = screens.map((name) => ({
-  name,
-  route: `/components/${name.toLowerCase()}`,
-  // isAvailable: !!Screens[name],
-  isAvailable: true,
-}));
-
-export default function ExpoComponentsScreen() {
+export default memo(function ExpoComponentsScreen({ apis }: { apis: ScreenApiItem[] }) {
   return (
     <ComponentListScreen
       renderItemRight={({ name }: { name: string }) => (
         <ExpoAPIIcon name={name} style={{ marginRight: 10, marginLeft: 6 }} />
       )}
-      apis={ScreenItems}
+      apis={apis}
     />
   );
-}
+});

--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -7,12 +7,12 @@ import { Animated, Platform, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import ComponentListScreen from './ComponentListScreen';
-import { ScreenItems as ApiScreenItems } from './ExpoApisScreen';
-import { ScreenItems as ComponentScreenItems } from './ExpoComponentsScreen';
 import ExpoAPIIcon from '../components/ExpoAPIIcon';
 import SearchBar from '../components/SearchBar';
+import { screenApiItems as ApiScreenApiItems } from '../navigation/ExpoApisStackNavigator';
+import { screenApiItems as ComponentScreenApiItems } from '../navigation/ExpoComponentsStackNavigator';
 
-const fuse = new Fuse(ApiScreenItems.concat(ComponentScreenItems), { keys: ['name'] });
+const fuse = new Fuse(ApiScreenApiItems.concat(ComponentScreenApiItems), { keys: ['name'] });
 
 const APPBAR_HEIGHT = Platform.OS === 'ios' ? 50 : 56;
 const TITLE_OFFSET = Platform.OS === 'ios' ? 70 : 56;

--- a/apps/native-component-list/src/types/ScreenConfig.ts
+++ b/apps/native-component-list/src/types/ScreenConfig.ts
@@ -6,3 +6,9 @@ export type ScreenConfig = {
   route?: string;
   options?: object;
 };
+
+export type ScreenApiItem = {
+  name: string;
+  route: string;
+  isAvailable: boolean;
+};

--- a/apps/test-suite/TestModules.js
+++ b/apps/test-suite/TestModules.js
@@ -52,7 +52,6 @@ export function getTestModules() {
     require('./tests/Asset'),
     require('./tests/Constants'),
     require('./tests/FileSystem'),
-    require('./tests/FileSystemNext'),
     require('./tests/Font'),
     require('./tests/ImagePicker'),
     require('./tests/ModulesCore'),
@@ -75,7 +74,7 @@ export function getTestModules() {
   );
 
   if (['android', 'ios'].includes(Platform.OS)) {
-    modules.push(require('./tests/SQLite'));
+    modules.push(require('./tests/FileSystemNext'), require('./tests/SQLite'));
   }
 
   if (Platform.OS === 'android') {


### PR DESCRIPTION
# Why

bare-expo is broken on web.

# How

1. FileSystemNext does not support web. moving it into native only section
2. newer react-navigation doesn't allow route like `ImageManipulator (legacy)` because it's not a valid url for deeplinking
  ```
  getPatternParts.js:37 Uncaught Error: Encountered '(' without preceding ':' in path: imagemanipulator (legacy)
      at getPatternParts (getPatternParts.js:37:15)
      at createConfigItem (getStateFromPath.js:377:34)
      at createNormalizedConfigs (getStateFromPath.js:306:18)
      at getStateFromPath.js:361:24
      at Array.forEach (<anonymous>)
      at createNormalizedConfigs (getStateFromPath.js:360:35)
      at getStateFromPath.js:361:24
      at Array.forEach (<anonymous>)
      at createNormalizedConfigs (getStateFromPath.js:360:35)
      at getStateFromPath.js:140:55
  ```
this pr tries to add custom route for these routes
3. originally ncl uses fixed `route: /apis/${name.toLowerCase()}`. it does not reference custom route for each screens. this pr tries to reference custom routes.
4. it's not ideal to edit two places whenever adding new screen. this pr tries to remove the redundant screen configs.

# Test Plan

bare-expo on web and ios

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
