### PR TITLE
[modules-core] Add target OS check to runTasksWithReason header

### DIFF
--- a/packages/expo-modules-core/ios/Interfaces/TaskManager/EXTaskServiceInterface.h
+++ b/packages/expo-modules-core/ios/Interfaces/TaskManager/EXTaskServiceInterface.h
@@ -66,6 +66,7 @@
               forAppId:(nonnull NSString *)appId
                withUrl:(nonnull NSString *)appUrl;
 
+#if !TARGET_OS_OSX
 /**
  * Executes tasks that supports the provided launch reason.
  */
@@ -73,4 +74,5 @@
                   userInfo:(nullable NSDictionary *)userInfo
          completionHandler:(nullable void (^)(UIBackgroundFetchResult))completionHandler;
 
+#endif
 @end


### PR DESCRIPTION
# Why

expo-modules-core fails to build for macOS because `UIBackgroundFetchResult` is not available

# How

Given that OSX does not provide a direct equivalent of `UIBackgroundFetchResult`for macOS, we can just add a  OS check to the `runTasksWithReason` header

# Test Plan

Run BareExpo for macOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
