### PR TITLE
[module-plugin][Android] Add `canBePublished` flag

### DIFF
--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
@@ -15,12 +15,15 @@ abstract class ExpoModulesGradlePlugin : Plugin<Project> {
     val kotlinVersion = getKotlinVersion(project)
     val kspVersion = getKSPVersion(project, kotlinVersion)
 
+    // Creates a user-facing extension that provides access to the `ExpoGradleHelperExtension`.
+    val expoModuleExtension = project.extensions.create("expoModule", ExpoModuleExtension::class.java, project)
+
     with(project) {
       applyDefaultPlugins()
       applyKotlin(kotlinVersion, kspVersion)
       applyDefaultDependencies()
       applyDefaultAndroidSdkVersions()
-      applyPublishing()
+      applyPublishing(expoModuleExtension)
     }
 
     // Adds the expoGradleHelper extension to the gradle instance if it doesn't exist.
@@ -32,9 +35,6 @@ abstract class ExpoModulesGradlePlugin : Plugin<Project> {
         }
       }
     }
-
-    // Creates a user-facing extension that provides access to the `ExpoGradleHelperExtension`.
-    project.extensions.create("expoModule", ExpoModuleExtension::class.java, project)
   }
 
   private fun getKotlinVersion(project: Project): String {

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -7,6 +7,7 @@ import expo.modules.plugin.android.applyLinerOptions
 import expo.modules.plugin.android.applyPublishingVariant
 import expo.modules.plugin.android.applySDKVersions
 import expo.modules.plugin.android.createReleasePublication
+import expo.modules.plugin.gradle.ExpoModuleExtension
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.internal.extensions.core.extra
@@ -51,13 +52,17 @@ internal fun Project.applyDefaultAndroidSdkVersions() {
   }
 }
 
-internal fun Project.applyPublishing() {
+internal fun Project.applyPublishing(expoModulesExtension: ExpoModuleExtension) {
   val libraryExtension = androidLibraryExtension()
 
   libraryExtension
     .applyPublishingVariant()
 
   afterEvaluate {
+    if (!expoModulesExtension.canBePublished) {
+      return@afterEvaluate
+    }
+
     publishingExtension()
       .publications
       .createReleasePublication(this)

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
@@ -27,4 +27,6 @@ open class ExpoModuleExtension(val project: Project) {
   fun safeExtGet(name: String, default: Any): Any {
     return project.rootProject.extra.safeGet<Any>(name) ?: default
   }
+
+  var canBePublished: Boolean = true
 }


### PR DESCRIPTION
# Why

Adds a `can be published` flag to disable publishing if needed. We probably encounter problems with some of our packages when pre-building. Using this flag, we can temporarily turn off pre-building. 