### PR TITLE
[mesh-gradient] Add macOS version availability check

### DIFF
--- a/packages/expo-mesh-gradient/CHANGELOG.md
+++ b/packages/expo-mesh-gradient/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix building for macOS. ([#35033](https://github.com/expo/expo/pull/35033) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))

--- a/packages/expo-mesh-gradient/ios/MeshGradientView.swift
+++ b/packages/expo-mesh-gradient/ios/MeshGradientView.swift
@@ -8,7 +8,7 @@ struct MeshGradientView: ExpoSwiftUI.View {
 
   var body: some View {
     ZStack(alignment: .topLeading) {
-      let gradient = if #available(iOS 18.0, *) {
+      let gradient = if #available(iOS 18.0, macOS 15.0, *) {
         AnyView(
           MeshGradient(
             width: props.columns,
@@ -24,8 +24,10 @@ struct MeshGradientView: ExpoSwiftUI.View {
       }
 
       if props.mask {
-        gradient.mask(alignment: .topLeading) {
-          Children()
+        if #available(macOS 12.0, *) {
+          gradient.mask(alignment: .topLeading) {
+            Children()
+          }
         }
       } else {
         Group {


### PR DESCRIPTION
# Why

expo-mesh-gradient fails to build for macOS because MeshGradient is only available starting from macOS 15.0

# How

Add macOS version availability check

# Test Plan

Build BareExpo for macOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
