### PR TITLE
[docs] Adds schedule.cron to workflows syntax

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -148,6 +148,20 @@ on:
     # other labels
 ```
 
+### `on.schedule.cron`
+
+Runs your workflow on a schedule using [unix-cron](https://www.ibm.com/docs/en/db2/11.5?topic=task-unix-cron-format) syntax. You can use [crontab guru](https://crontab.guru/) and their [examples](https://crontab.guru/examples.html) to generate cron strings.
+
+- Scheduled workflows will only run on the default branch of the repository. In many cases, this means crons inside workflow files on the `main` branch will be scheduled, while crons inside workflow files in feature branches will not be scheduled.
+- Scheduled workflows may be delayed during periods of high load. High load times include the start of every hour. In rare circumstances, jobs may be skipped or run multiple times. Make sure that your workflows are idempotent and do not have harmful side effects.
+- A workflow can have multiple `cron` schedules.
+
+```yaml
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs at midnight every day
+```
+
 ## `jobs`
 
 A workflow run is made up of one or more jobs.


### PR DESCRIPTION
# Why

Adding documentation for scheduled workflows.

# Screenshot

<img width="1168" alt="Screenshot 2025-02-19 at 10 45 57 AM" src="https://github.com/user-attachments/assets/d6ca1868-efa1-420e-8326-c20732948b5c" />


# Test Plan

Make sure the changes read well.