### PR TITLE
[docs] Add llms.txt script to generate SDK docs data

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -28,4 +28,5 @@ out
 public/llms.txt
 public/llms-full.txt
 public/llms-eas.txt
+public/llms-sdk.txt
 scripts/generate-llms/talks.js

--- a/docs/package.json
+++ b/docs/package.json
@@ -114,6 +114,7 @@
     "remark-validate-links": "^13.0.2",
     "rimraf": "^6.0.1",
     "semver": "^7.6.3",
+    "sitefetch": "^0.0.17",
     "sitemap": "^7.1.1",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.6.3",

--- a/docs/pages/llms.mdx
+++ b/docs/pages/llms.mdx
@@ -9,3 +9,4 @@ At Expo, we support the [llms.txt](https://llmstxt.org/) initiative to provide d
 - [/llms.txt](/llms.txt): A list of all available documentation files
 - [/llms-full.txt](/llms-full.txt): Complete documentation for Expo, including Expo Router, Expo Modules API, development process, and more
 - [/llms-eas.txt](/llms-eas.txt): Complete documentation for the Expo Application Services (EAS)
+- [/llms-sdk.txt](/llms-sdk.txt): Complete documentation for the Expo SDK

--- a/docs/scripts/generate-llms/index.js
+++ b/docs/scripts/generate-llms/index.js
@@ -1,11 +1,13 @@
 import { compileTalksFile } from './compileTalks.js';
 import { generateLlmsEasTxt } from './llms-eas-txt.js';
 import { generateLlmsFullTxt } from './llms-full-txt.js';
+import { generateLlmsSdkTxt } from './llms-sdk.js';
 import { generateLlmsTxt } from './llms-txt.js';
 
 await compileTalksFile();
 
 Promise.allSettled([
+  await generateLlmsSdkTxt(),
   await generateLlmsEasTxt(),
   await generateLlmsFullTxt(),
   await generateLlmsTxt(),

--- a/docs/scripts/generate-llms/llms-sdk.js
+++ b/docs/scripts/generate-llms/llms-sdk.js
@@ -5,7 +5,8 @@ import { fetchSite } from 'sitefetch';
 const OUTPUT_DIRECTORY_NAME = 'public';
 const OUTPUT_FILENAME = 'llms-sdk.txt';
 const TITLE = 'Expo SDK Documentation';
-const DESCRIPTION = 'Documentation for Expo SDK libraries, configuration, and API reference.';
+const DESCRIPTION =
+  'Documentation for Expo SDK libraries, app configuration files, Expo CLI, create-expo-app, and more.';
 const BASE_URL = 'https://docs.expo.dev';
 const PATHS_TO_CRAWL = ['/versions/latest/', '/more/', '/technical-specs/'];
 

--- a/docs/scripts/generate-llms/llms-sdk.js
+++ b/docs/scripts/generate-llms/llms-sdk.js
@@ -78,7 +78,6 @@ async function generateFullMarkdown() {
     for (const [url, pageData] of sortedPages) {
       const normalizedUrl = url.replace(/\/+$/, '').split('?')[0];
 
-      // Skip if we've already processed this URL
       if (uniquePages.has(normalizedUrl)) {
         console.log(`Skipping duplicate URL: ${url}`);
         continue;

--- a/docs/scripts/generate-llms/llms-sdk.js
+++ b/docs/scripts/generate-llms/llms-sdk.js
@@ -1,0 +1,84 @@
+import frontmatter from 'front-matter';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { cleanContent } from './utils.js';
+
+const OUTPUT_DIRECTORY_NAME = 'public';
+const OUTPUT_FILENAME = 'llms-sdk.txt';
+const SDK_VERSION = 'latest';
+const TITLE = 'Expo SDK Documentation';
+const DESCRIPTION = 'Documentation for Expo SDK libraries, configuration, and API reference.';
+
+async function processFile(filePath) {
+  const content = await fs.promises.readFile(filePath, 'utf-8');
+  const { attributes, body } = frontmatter(content);
+
+  let formattedContent = '';
+  if (attributes.title) {
+    formattedContent += `# ${attributes.title}\n\n`;
+  }
+  if (attributes.description) {
+    formattedContent += `${attributes.description}\n\n`;
+  }
+
+  const cleanedContent = cleanContent(body);
+  formattedContent += cleanedContent;
+
+  return formattedContent;
+}
+
+async function generateFullMarkdown() {
+  let fullContent = `# ${TITLE}\n\n${DESCRIPTION}\n\n`;
+
+  const directories = [
+    path.join(process.cwd(), 'pages/versions', SDK_VERSION, 'config'),
+    path.join(process.cwd(), 'pages/versions', SDK_VERSION, 'sdk'),
+  ];
+
+  const indexPath = path.join(process.cwd(), 'pages/versions', SDK_VERSION, 'index.mdx');
+
+  if (fs.existsSync(indexPath)) {
+    const indexContent = await processFile(indexPath);
+    fullContent += indexContent + '\n\n---\n\n';
+  }
+
+  for (const dir of directories) {
+    if (!fs.existsSync(dir)) {
+      console.warn(`Directory does not exist: ${dir}`);
+      continue;
+    }
+
+    const files = await fs.promises.readdir(dir);
+    const mdxFiles = files.filter(file => file.endsWith('.mdx'));
+
+    for (const file of mdxFiles) {
+      const filePath = path.join(dir, file);
+      const content = await processFile(filePath);
+      fullContent += content + '\n\n---\n\n';
+    }
+  }
+
+  return fullContent;
+}
+
+export async function generateLlmsSdkTxt() {
+  try {
+    console.log('Starting SDK documentation generation...');
+
+    const content = await generateFullMarkdown();
+
+    await fs.promises.writeFile(
+      path.join(process.cwd(), OUTPUT_DIRECTORY_NAME, OUTPUT_FILENAME),
+      content
+    );
+
+    console.log(` \x1b[1m\x1b[32m✓\x1b[0m Successfully generated ${OUTPUT_FILENAME}`);
+    process.exit(0);
+  } catch (error) {
+    console.error('Error generating SDK documentation:', error);
+    process.exit(1);
+  }
+}
+
+generateLlmsSdkTxt();

--- a/docs/scripts/generate-llms/llms-sdk.js
+++ b/docs/scripts/generate-llms/llms-sdk.js
@@ -51,7 +51,6 @@ async function processContent(content, url) {
   const normalizedContent = formattedContent.trim().toLowerCase();
 
   if (processedContent.has(normalizedContent)) {
-    console.log(`Skipping duplicate content for: ${url}`);
     return null;
   }
 
@@ -64,7 +63,7 @@ async function generateFullMarkdown() {
 
   try {
     const fetchedContent = await fetchSite(BASE_URL, {
-      match: ['/versions/latest/', '/versions/latest/**'],
+      match: ['/versions/latest/**', '/more/**', '/technical-specs/**'],
       concurrency: 5,
       format: 'markdown',
     });
@@ -72,14 +71,20 @@ async function generateFullMarkdown() {
     const uniquePages = new Map();
 
     const sortedPages = Array.from(fetchedContent.entries())
-      .filter(([url]) => url !== '/' && url.startsWith('/versions/latest/'))
+      .filter(
+        ([url]) =>
+          url !== '/' &&
+          (url.startsWith('/versions/latest/') ||
+            url.startsWith('/more/') ||
+            url.startsWith('/technical-specs/'))
+      )
+
       .sort(([urlA], [urlB]) => urlA.localeCompare(urlB));
 
     for (const [url, pageData] of sortedPages) {
       const normalizedUrl = url.replace(/\/+$/, '').split('?')[0];
 
       if (uniquePages.has(normalizedUrl)) {
-        console.log(`Skipping duplicate URL: ${url}`);
         continue;
       }
 

--- a/docs/scripts/generate-llms/llms-sdk.js
+++ b/docs/scripts/generate-llms/llms-sdk.js
@@ -1,28 +1,54 @@
-import frontmatter from 'front-matter';
 import fs from 'node:fs';
 import path from 'node:path';
-
-import { cleanContent } from './utils.js';
+import { fetchSite } from 'sitefetch';
 
 const OUTPUT_DIRECTORY_NAME = 'public';
 const OUTPUT_FILENAME = 'llms-sdk.txt';
-const SDK_VERSION = 'latest';
 const TITLE = 'Expo SDK Documentation';
 const DESCRIPTION = 'Documentation for Expo SDK libraries, configuration, and API reference.';
+const BASE_URL = 'https://docs.expo.dev';
 
-async function processFile(filePath) {
-  const content = await fs.promises.readFile(filePath, 'utf-8');
-  const { attributes, body } = frontmatter(content);
+function cleanContent(content) {
+  const processContent = content
+
+    .replace(/^#\s+.+\n\n[^\n]+\n\n/m, '')
+    .replace(/^(?:\*\s*){3}$/gm, '')
+    .replace(/^(.+)\n-+\n/gm, '## $1\n')
+    .replace(/\[]\(#[^)]+\)/g, '')
+    .replace(/`-`\s+(`(?:npm|npx)\s+[^`]+`)/g, '$1')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/^#\s+app\s*$/gm, '# app.json/app.config.js reference')
+    .replace(/^#\s+babel\s*$/gm, '# babel.config.js')
+    .replace(/^#\s+metro\s*$/gm, '# metro.config.js')
+    .replace(/^#\s+package-json\s*$/gm, '# package.json')
+    .replace(/(?:^(?: {4}|\t).*$\n?)+/gm, match => {
+      const code = match.replace(/^(?: {4}|\t)/gm, '');
+      return '```\n' + code.trim() + '\n```\n';
+    })
+    .replace(/•\s*/g, '')
+    .replace(
+      /Only for:\s*\n+\s*((?:Android[^]*?|iOS|Web)(?:\s*\n+\s*(?:Android[^]*?|iOS|Web))*)/g,
+      (_, platforms) => 'Only for: ' + platforms.split(/\s*\n+\s*/).join(', ')
+    );
+
+  return processContent;
+}
+
+async function processContent(content, url) {
+  const titleMatch = content.match(/^#\s+(.+)$/m);
+  const title = titleMatch ? titleMatch[1] : path.basename(url);
+  const descriptionMatch = content.match(/^#\s+.+\n\n(.+)$/m);
+  const description = descriptionMatch ? descriptionMatch[1] : '';
 
   let formattedContent = '';
-  if (attributes.title) {
-    formattedContent += `# ${attributes.title}\n\n`;
+  if (title) {
+    formattedContent += `# ${title}\n\n`;
   }
-  if (attributes.description) {
-    formattedContent += `${attributes.description}\n\n`;
+  if (description) {
+    formattedContent += `${description}\n\n`;
   }
 
-  const cleanedContent = cleanContent(body);
+  const cleanedContent = cleanContent(content);
   formattedContent += cleanedContent;
 
   return formattedContent;
@@ -31,54 +57,40 @@ async function processFile(filePath) {
 async function generateFullMarkdown() {
   let fullContent = `# ${TITLE}\n\n${DESCRIPTION}\n\n`;
 
-  const directories = [
-    path.join(process.cwd(), 'pages/versions', SDK_VERSION, 'config'),
-    path.join(process.cwd(), 'pages/versions', SDK_VERSION, 'sdk'),
-  ];
+  try {
+    const fetchedContent = await fetchSite(BASE_URL, {
+      match: ['/versions/latest/', '/versions/latest/**'],
+      concurrency: 5,
+      format: 'markdown',
+    });
 
-  const indexPath = path.join(process.cwd(), 'pages/versions', SDK_VERSION, 'index.mdx');
+    const sortedPages = Array.from(fetchedContent.entries())
+      .filter(([url]) => url !== '/' && url.startsWith('/versions/latest/'))
+      .sort(([urlA], [urlB]) => urlA.localeCompare(urlB));
 
-  if (fs.existsSync(indexPath)) {
-    const indexContent = await processFile(indexPath);
-    fullContent += indexContent + '\n\n---\n\n';
-  }
-
-  for (const dir of directories) {
-    if (!fs.existsSync(dir)) {
-      console.warn(`Directory does not exist: ${dir}`);
-      continue;
+    for (const [url, pageData] of sortedPages) {
+      const processedContent = await processContent(pageData.content, url);
+      fullContent += processedContent + '\n\n---\n\n';
     }
-
-    const files = await fs.promises.readdir(dir);
-    const mdxFiles = files.filter(file => file.endsWith('.mdx'));
-
-    for (const file of mdxFiles) {
-      const filePath = path.join(dir, file);
-      const content = await processFile(filePath);
-      fullContent += content + '\n\n---\n\n';
-    }
+    return fullContent;
+  } catch (error) {
+    console.error('Error fetching or processing content:', error);
+    throw error;
   }
-
-  return fullContent;
 }
 
 export async function generateLlmsSdkTxt() {
   try {
-    console.log('Starting SDK documentation generation...');
-
     const content = await generateFullMarkdown();
 
-    await fs.promises.writeFile(
-      path.join(process.cwd(), OUTPUT_DIRECTORY_NAME, OUTPUT_FILENAME),
-      content
-    );
+    await fs.promises.mkdir(path.join(process.cwd(), OUTPUT_DIRECTORY_NAME), { recursive: true });
+
+    const outputPath = path.join(process.cwd(), OUTPUT_DIRECTORY_NAME, OUTPUT_FILENAME);
+    await fs.promises.writeFile(outputPath, content);
 
     console.log(` \x1b[1m\x1b[32m✓\x1b[0m Successfully generated ${OUTPUT_FILENAME}`);
-    process.exit(0);
   } catch (error) {
     console.error('Error generating SDK documentation:', error);
     process.exit(1);
   }
 }
-
-generateLlmsSdkTxt();

--- a/docs/scripts/generate-llms/utils.js
+++ b/docs/scripts/generate-llms/utils.js
@@ -130,6 +130,7 @@ export function cleanContent(content) {
     }
 
     let processed = part
+      .replace(/<RedirectNotification[^>]*>[\S\s]*?<\/RedirectNotification>/g, '')
       .replace(/\/\*\s*@(?:info|hide)\s*\*\/(?:(?!\/\*\s*@end)[\S\s])*\/\*\s*@end\s*\*\//g, '')
       .replace(/{\s*\/\*\s*todo:\s*[\S\s]*?\*\/\s*}/gi, '')
       .replace(/\/\*\s*@tutinfo(?:\s*<CODE>.*?<\/CODE>)?.*?\*\//g, '')

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1194,6 +1194,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mixmark-io/domino@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@mixmark-io/domino@npm:2.2.0"
+  checksum: 10c0/aa468a15f9217d425220fe6a4b3f9416cbe8e566ee14efc191c6d5cc04fe39338b16a90bbac190f28d44e69465db5f2cf95f479c621ce38060ca6b2a3d346e9d
+  languageName: node
+  linkType: hard
+
 "@next/env@npm:15.1.3":
   version: 15.1.3
   resolution: "@next/env@npm:15.1.3"
@@ -3955,6 +3962,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"boolbase@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "boolbase@npm:1.0.0"
+  checksum: 10c0/e4b53deb4f2b85c52be0e21a273f2045c7b6a6ea002b0e139c744cb6f95e9ec044439a52883b0d74dedd1ff3da55ed140cfdddfed7fb0cccbed373de5dce1bcf
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
@@ -4226,6 +4240,39 @@ __metadata:
   version: 2.0.1
   resolution: "character-reference-invalid@npm:2.0.1"
   checksum: 10c0/2ae0dec770cd8659d7e8b0ce24392d83b4c2f0eb4a3395c955dce5528edd4cc030a794cfa06600fcdd700b3f2de2f9b8e40e309c0011c4180e3be64a0b42e6a1
+  languageName: node
+  linkType: hard
+
+"cheerio-select@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "cheerio-select@npm:2.1.0"
+  dependencies:
+    boolbase: "npm:^1.0.0"
+    css-select: "npm:^5.1.0"
+    css-what: "npm:^6.1.0"
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+    domutils: "npm:^3.0.1"
+  checksum: 10c0/2242097e593919dba4aacb97d7b8275def8b9ec70b00aa1f43335456870cfc9e284eae2080bdc832ed232dabb9eefcf56c722d152da4a154813fb8814a55d282
+  languageName: node
+  linkType: hard
+
+"cheerio@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "cheerio@npm:1.0.0"
+  dependencies:
+    cheerio-select: "npm:^2.1.0"
+    dom-serializer: "npm:^2.0.0"
+    domhandler: "npm:^5.0.3"
+    domutils: "npm:^3.1.0"
+    encoding-sniffer: "npm:^0.2.0"
+    htmlparser2: "npm:^9.1.0"
+    parse5: "npm:^7.1.2"
+    parse5-htmlparser2-tree-adapter: "npm:^7.0.0"
+    parse5-parser-stream: "npm:^7.1.2"
+    undici: "npm:^6.19.5"
+    whatwg-mimetype: "npm:^4.0.0"
+  checksum: 10c0/d0e16925d9c36c879edfaef1c0244c866375a4c7b8d6ccd7ae0ad42da7d26263ea1a3c17b9a1aa5965918deeff2d40ac2e7223824f8e6eca972df3b81316a09f
   languageName: node
   linkType: hard
 
@@ -4511,6 +4558,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-select@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "css-select@npm:5.1.0"
+  dependencies:
+    boolbase: "npm:^1.0.0"
+    css-what: "npm:^6.1.0"
+    domhandler: "npm:^5.0.2"
+    domutils: "npm:^3.0.1"
+    nth-check: "npm:^2.0.1"
+  checksum: 10c0/551c60dba5b54054741032c1793b5734f6ba45e23ae9e82761a3c0ed1acbb8cfedfa443aaba3a3c1a54cac12b456d2012a09d2cd5f0e82e430454c1b9d84d500
+  languageName: node
+  linkType: hard
+
 "css-vendor@npm:^2.0.8":
   version: 2.0.8
   resolution: "css-vendor@npm:2.0.8"
@@ -4518,6 +4578,13 @@ __metadata:
     "@babel/runtime": "npm:^7.8.3"
     is-in-browser: "npm:^1.0.2"
   checksum: 10c0/2538bc37adf72eb79781929dbb8c48e12c6a4b926594ad4134408b3000249f1a50d25be374f0e63f688c863368814aa6cc2e9ea11ea22a7309a7d966b281244c
+  languageName: node
+  linkType: hard
+
+"css-what@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "css-what@npm:6.1.0"
+  checksum: 10c0/a09f5a6b14ba8dcf57ae9a59474722e80f20406c53a61e9aedb0eedc693b135113ffe2983f4efc4b5065ae639442e9ae88df24941ef159c218b231011d733746
   languageName: node
   linkType: hard
 
@@ -4839,12 +4906,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dom-serializer@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "dom-serializer@npm:2.0.0"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.2"
+    entities: "npm:^4.2.0"
+  checksum: 10c0/d5ae2b7110ca3746b3643d3ef60ef823f5f078667baf530cec096433f1627ec4b6fa8c072f09d079d7cda915fd2c7bc1b7b935681e9b09e591e1e15f4040b8e2
+  languageName: node
+  linkType: hard
+
+"domelementtype@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "domelementtype@npm:2.3.0"
+  checksum: 10c0/686f5a9ef0fff078c1412c05db73a0dce096190036f33e400a07e2a4518e9f56b1e324f5c576a0a747ef0e75b5d985c040b0d51945ce780c0dd3c625a18cd8c9
+  languageName: node
+  linkType: hard
+
 "domexception@npm:^4.0.0":
   version: 4.0.0
   resolution: "domexception@npm:4.0.0"
   dependencies:
     webidl-conversions: "npm:^7.0.0"
   checksum: 10c0/774277cd9d4df033f852196e3c0077a34dbd15a96baa4d166e0e47138a80f4c0bdf0d94e4703e6ff5883cec56bb821a6fff84402d8a498e31de7c87eb932a294
+  languageName: node
+  linkType: hard
+
+"domhandler@npm:^5.0.2, domhandler@npm:^5.0.3":
+  version: 5.0.3
+  resolution: "domhandler@npm:5.0.3"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+  checksum: 10c0/bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
+  languageName: node
+  linkType: hard
+
+"domutils@npm:^3.0.1, domutils@npm:^3.1.0":
+  version: 3.2.2
+  resolution: "domutils@npm:3.2.2"
+  dependencies:
+    dom-serializer: "npm:^2.0.0"
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+  checksum: 10c0/47938f473b987ea71cd59e59626eb8666d3aa8feba5266e45527f3b636c7883cca7e582d901531961f742c519d7514636b7973353b648762b2e3bedbf235fada
   languageName: node
   linkType: hard
 
@@ -4910,6 +5015,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encoding-sniffer@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "encoding-sniffer@npm:0.2.0"
+  dependencies:
+    iconv-lite: "npm:^0.6.3"
+    whatwg-encoding: "npm:^3.1.1"
+  checksum: 10c0/b312e0d67f339bec44e021e5210ee8ee90d7b8f9975eb2c79a36fd467eb07709e88dcf62ee20f62ee0d74a13874307d99557852a2de9b448f1e3fb991fc68257
+  languageName: node
+  linkType: hard
+
 "encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
@@ -4929,7 +5044,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.5.0":
+"entities@npm:^4.2.0, entities@npm:^4.5.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 10c0/5b039739f7621f5d1ad996715e53d964035f75ad3b9a4d38c6b3804bb226e282ffeae2443624d8fdd9c47d8e926ae9ac009c54671243f0c3294c26af7cc85250
@@ -5921,6 +6036,7 @@ __metadata:
     remark-validate-links: "npm:^13.0.2"
     rimraf: "npm:^6.0.1"
     semver: "npm:^7.6.3"
+    sitefetch: "npm:^0.0.17"
     sitemap: "npm:^7.1.1"
     tailwindcss: "npm:^3.4.17"
     tippy.js: "npm:^6.3.7"
@@ -6493,6 +6609,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gpt-tokenizer@npm:^2.8.1":
+  version: 2.8.1
+  resolution: "gpt-tokenizer@npm:2.8.1"
+  checksum: 10c0/07229cca5a5ab8db0e1165b27f6ce400bf3509f1ab8946b2c3cddb51470e3bd1f3a56f750d564ee47a38885376bc9340291bfaec07858fdfb385f0445cf48e7e
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
@@ -6504,6 +6627,16 @@ __metadata:
   version: 1.4.0
   resolution: "graphemer@npm:1.4.0"
   checksum: 10c0/e951259d8cd2e0d196c72ec711add7115d42eb9a8146c8eeda5b8d3ac91e5dd816b9cd68920726d9fd4490368e7ed86e9c423f40db87e2d8dfafa00fa17c3a31
+  languageName: node
+  linkType: hard
+
+"happy-dom@npm:^16.5.3":
+  version: 16.8.1
+  resolution: "happy-dom@npm:16.8.1"
+  dependencies:
+    webidl-conversions: "npm:^7.0.0"
+    whatwg-mimetype: "npm:^3.0.0"
+  checksum: 10c0/3e6e4ce3bf67871304fadc7a0e661397b3d6c12de149cafce5a9062b47038a4c12f5f29c2fc9a070be3e56f2b5a1625cc79570e1fd1a30ffea9aa107f844d57b
   languageName: node
   linkType: hard
 
@@ -6695,6 +6828,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"htmlparser2@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "htmlparser2@npm:9.1.0"
+  dependencies:
+    domelementtype: "npm:^2.3.0"
+    domhandler: "npm:^5.0.3"
+    domutils: "npm:^3.1.0"
+    entities: "npm:^4.5.0"
+  checksum: 10c0/394f6323efc265bbc791d8c0d96bfe95984e0407565248521ab92e2dc7668e5ceeca7bc6ed18d408b9ee3b25032c5743368a4280d280332d782821d5d467ad8f
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
@@ -6791,7 +6936,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -9745,6 +9890,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nth-check@npm:^2.0.1":
+  version: 2.1.1
+  resolution: "nth-check@npm:2.1.1"
+  dependencies:
+    boolbase: "npm:^1.0.0"
+  checksum: 10c0/5fee7ff309727763689cfad844d979aedd2204a817fbaaf0e1603794a7c20db28548d7b024692f953557df6ce4a0ee4ae46cd8ebd9b36cfb300b9226b567c479
+  languageName: node
+  linkType: hard
+
 "nwsapi@npm:^2.2.2":
   version: 2.2.16
   resolution: "nwsapi@npm:2.2.16"
@@ -10012,7 +10166,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse5@npm:^7.0.0, parse5@npm:^7.1.1":
+"parse5-htmlparser2-tree-adapter@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "parse5-htmlparser2-tree-adapter@npm:7.1.0"
+  dependencies:
+    domhandler: "npm:^5.0.3"
+    parse5: "npm:^7.0.0"
+  checksum: 10c0/e5a4e0b834c84c9e244b5749f8d007f4baaeafac7a1da2c54be3421ffd9ef8fdec4f198bf55cda22e88e6ba95e9943f6ed5aa3ae5900b39972ebf5dc8c3f4722
+  languageName: node
+  linkType: hard
+
+"parse5-parser-stream@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "parse5-parser-stream@npm:7.1.2"
+  dependencies:
+    parse5: "npm:^7.0.0"
+  checksum: 10c0/e236c61000d38ecad369e725a48506b051cebad8abb00e6d4e8bff7aa85c183820fcb45db1559cc90955bdbbdbd665ea94c41259594e74566fff411478dc7fcb
+  languageName: node
+  linkType: hard
+
+"parse5@npm:^7.0.0, parse5@npm:^7.1.1, parse5@npm:^7.1.2":
   version: 7.2.1
   resolution: "parse5@npm:7.2.1"
   dependencies:
@@ -11707,6 +11880,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sitefetch@npm:^0.0.17":
+  version: 0.0.17
+  resolution: "sitefetch@npm:0.0.17"
+  dependencies:
+    cheerio: "npm:^1.0.0"
+    gpt-tokenizer: "npm:^2.8.1"
+    happy-dom: "npm:^16.5.3"
+    micromatch: "npm:^4.0.8"
+    turndown: "npm:^7.2.0"
+    turndown-plugin-gfm: "npm:^1.0.2"
+  bin:
+    sitefetch: dist/cli.js
+  checksum: 10c0/81d2fa9d84a36072b9a5c66708b3921526120869264d7b761534b7819a4b4e4cb68bbbb87b35423d0c129ab46a922ee42815a8331bc81081f8219a51b2bfa021
+  languageName: node
+  linkType: hard
+
 "sitemap@npm:^7.1.1":
   version: 7.1.2
   resolution: "sitemap@npm:7.1.2"
@@ -12464,6 +12653,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"turndown-plugin-gfm@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "turndown-plugin-gfm@npm:1.0.2"
+  checksum: 10c0/eb9bc20dbb08d5335231f9617d7440f14b35781f14a3a393d8f13fc8205afeb11a0a632d52da4548ab0fa353f315ca265462b24d368faf23258dccbe439182b9
+  languageName: node
+  linkType: hard
+
+"turndown@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "turndown@npm:7.2.0"
+  dependencies:
+    "@mixmark-io/domino": "npm:^2.2.0"
+  checksum: 10c0/6abcdcdf9d35cd79d7a8100a7de1d2226b921d5bd99e73ac14a7ead39c059978f519378913375efb04c68bcfc40f7ffe2dee0ce9ae4d54dc1235b12856a78d4e
+  languageName: node
+  linkType: hard
+
 "type-check@npm:^0.4.0, type-check@npm:~0.4.0":
   version: 0.4.0
   resolution: "type-check@npm:0.4.0"
@@ -12618,6 +12823,13 @@ __metadata:
   version: 6.20.0
   resolution: "undici-types@npm:6.20.0"
   checksum: 10c0/68e659a98898d6a836a9a59e6adf14a5d799707f5ea629433e025ac90d239f75e408e2e5ff086afc3cace26f8b26ee52155293564593fbb4a2f666af57fc59bf
+  languageName: node
+  linkType: hard
+
+"undici@npm:^6.19.5":
+  version: 6.21.1
+  resolution: "undici@npm:6.21.1"
+  checksum: 10c0/d604080e4f8db89b35a63b483b5f96a5f8b19ec9f716e934639345449405809d2997e1dd7212d67048f210e54534143384d712bd9075e4394f0788895ef9ca8e
   languageName: node
   linkType: hard
 
@@ -13146,10 +13358,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"whatwg-encoding@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "whatwg-encoding@npm:3.1.1"
+  dependencies:
+    iconv-lite: "npm:0.6.3"
+  checksum: 10c0/273b5f441c2f7fda3368a496c3009edbaa5e43b71b09728f90425e7f487e5cef9eb2b846a31bd760dd8077739c26faf6b5ca43a5f24033172b003b72cf61a93e
+  languageName: node
+  linkType: hard
+
 "whatwg-mimetype@npm:^3.0.0":
   version: 3.0.0
   resolution: "whatwg-mimetype@npm:3.0.0"
   checksum: 10c0/323895a1cda29a5fb0b9ca82831d2c316309fede0365047c4c323073e3239067a304a09a1f4b123b9532641ab604203f33a1403b5ca6a62ef405bcd7a204080f
+  languageName: node
+  linkType: hard
+
+"whatwg-mimetype@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "whatwg-mimetype@npm:4.0.0"
+  checksum: 10c0/a773cdc8126b514d790bdae7052e8bf242970cebd84af62fb2f35a33411e78e981f6c0ab9ed1fe6ec5071b09d5340ac9178e05b52d35a9c4bcf558ba1b1551df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #34407

# How

<!--
How did you build this feature or fix this bug and why?
-->

Use [sitefetch](https://github.com/egoist/sitefetch/tree/main) library to generate markdown data for pages under Reference. This is done by:
- Adding `scripts/generate-llms/llms-sdk.js` script
- Whch generates `llms-sdk.txt` in the public directory
- Update /llms page to include info about llms-sdk.txt.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview: 
- /llms-sdk.txt
- /llms/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)