### PR TITLE
[modules-plugin][Android] Add `expoPublishToMavenLocal` task

### DIFF
--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   implementation(gradleApi())
   compileOnly("com.android.tools.build:gradle:8.5.0")
   implementation("com.facebook.react:react-native-gradle-plugin")
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 
   testImplementation("junit:junit:4.13.2")
   testImplementation("com.google.truth:truth:1.1.2")

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -3,9 +3,11 @@
 package expo.modules.plugin
 
 import com.android.build.gradle.LibraryExtension
+import expo.modules.plugin.android.PublicationInfo
 import expo.modules.plugin.android.applyLinerOptions
 import expo.modules.plugin.android.applyPublishingVariant
 import expo.modules.plugin.android.applySDKVersions
+import expo.modules.plugin.android.createExpoPublishToMavenLocalTask
 import expo.modules.plugin.android.createReleasePublication
 import expo.modules.plugin.gradle.ExpoModuleExtension
 import org.gradle.api.Project
@@ -62,10 +64,14 @@ internal fun Project.applyPublishing(expoModulesExtension: ExpoModuleExtension) 
     if (!expoModulesExtension.canBePublished) {
       return@afterEvaluate
     }
+    
+    val publicationInfo = PublicationInfo(this)
 
     publishingExtension()
       .publications
-      .createReleasePublication(this)
+      .createReleasePublication(publicationInfo)
+
+    createExpoPublishToMavenLocalTask(publicationInfo)
   }
 }
 

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavePublicationExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavePublicationExtension.kt
@@ -1,21 +1,119 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
 package expo.modules.plugin.android
 
 import expo.modules.plugin.androidLibraryExtension
+import expo.modules.plugin.publishingExtension
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
 import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.component.SoftwareComponent
 import org.gradle.api.publish.PublicationContainer
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.TaskProvider
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.toPath
 
-internal fun PublicationContainer.createReleasePublication(project: Project) {
-  create("release", MavenPublication::class.java) { mavenPublication->
+internal data class PublicationInfo(
+  val components: SoftwareComponent,
+  val groupId: String,
+  val artifactId: String,
+  val version: String,
+) {
+  constructor(
+    project: Project,
+  ) : this(
+    components = project.components.getByName("release"),
+    groupId = project.group.toString(),
+    artifactId = requireNotNull(project.androidLibraryExtension().namespace) {
+      "'android.namespace' is not defined"
+    },
+    version = requireNotNull(project.androidLibraryExtension().defaultConfig.versionName) {
+      "'android.defaultConfig.versionName' is not defined"
+    },
+  )
+
+  fun resolvePath(repositoryPath: Path): Path {
+    val groupPath = groupId.replace('.', '/')
+    val artifactPath = "$groupPath/$artifactId/$version"
+    val publicationPath = repositoryPath.resolve(artifactPath)
+
+    return publicationPath
+  }
+
+  override fun toString(): String {
+    return "$groupId:$artifactId:$version"
+  }
+}
+
+internal fun PublicationContainer.createReleasePublication(publicationInfo: PublicationInfo) {
+  create("release", MavenPublication::class.java) { mavenPublication ->
     with(mavenPublication) {
-      from(project.components.getByName("release"))
-      groupId = project.group.toString()
-      artifactId = requireNotNull(project.androidLibraryExtension().namespace) {
-        "'android.namespace' is not defined"
-      }
-      version = requireNotNull(project.androidLibraryExtension().defaultConfig.versionName) {
-        "'android.defaultConfig.versionName' is not defined"
-      }
+      from(publicationInfo.components)
+      groupId = publicationInfo.groupId
+      artifactId = publicationInfo.artifactId
+      version = publicationInfo.version
     }
   }
 }
+
+internal fun Project.createExpoPublishToMavenLocalTask(publicationInfo: PublicationInfo): TaskProvider<Task> {
+  val publishToMavenLocalTask = tasks.getByName("publishToMavenLocal")
+  return project.tasks.register("expoPublishToMavenLocal") { task ->
+    task.group = "publishing"
+    task.description = "Publishes the library to the local Maven repository"
+
+    task.dependsOn(publishToMavenLocalTask)
+
+    task.doLast {
+      val mavenLocal = publishingExtension().repositories.mavenLocal()
+      val mavenLocalPath = mavenLocal.url.toPath()
+
+      val publicationPath = publicationInfo.resolvePath(mavenLocalPath)
+
+      if (!publicationPath.exists()) {
+        return@doLast
+      }
+
+      logger.quiet("$publicationInfo was published to $publicationPath")
+
+      val expoModuleConfig = layout.projectDirectory.file("../expo-module.config.json").asFile
+      val json = Json {
+        ignoreUnknownKeys = true
+        prettyPrint = true
+        prettyPrintIndent = "  "
+      }
+
+      val jsonElement = json.parseToJsonElement(expoModuleConfig.readText())
+      val newJsonElement = jsonElement.jsonObject.toMutableMap().apply {
+        val newAndroidObject = getOrDefault("android", JsonObject(emptyMap())).jsonObject.toMutableMap().apply {
+          put("released", JsonObject(mapOf(
+            "groupId" to publicationInfo.groupId.toJsonElement(),
+            "artifactId" to publicationInfo.artifactId.toJsonElement(),
+            "version" to publicationInfo.version.toJsonElement(),
+            "repository" to "mavenLocal".toJsonElement(),
+          )))
+        }.toJsonObject()
+        put("android", newAndroidObject)
+      }.toJsonObject()
+
+      val newJsonString = json.encodeToString(JsonObject.serializer(), newJsonElement)
+
+      expoModuleConfig.writeText(newJsonString)
+      providers.exec { env ->
+        env.workingDir(layout.projectDirectory.file(".."))
+        // TODO(@lukmccall): support other package managers
+        env.commandLine("yarn", "prettier", "--write", "expo-module.config.json")
+      }.result.get()
+    }
+  }
+}
+
+private fun String.toJsonElement(): JsonElement = JsonPrimitive(this)
+private fun Map<String, JsonElement>.toJsonObject(): JsonObject = JsonObject(this)

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
@@ -105,6 +105,8 @@ internal fun Project.createExpoPublishToMavenLocalTask(publicationInfo: Publicat
 
       val newJsonString = json.encodeToString(JsonObject.serializer(), newJsonElement)
 
+      logger.quiet("Updating 'expo-module.config.json' in ${expoModuleConfig.parent}")
+
       expoModuleConfig.writeText(newJsonString)
       providers.exec { env ->
         env.workingDir(layout.projectDirectory.file(".."))

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
@@ -93,7 +93,7 @@ internal fun Project.createExpoPublishToMavenLocalTask(publicationInfo: Publicat
       val jsonElement = json.parseToJsonElement(expoModuleConfig.readText())
       val newJsonElement = jsonElement.jsonObject.toMutableMap().apply {
         val newAndroidObject = getOrDefault("android", JsonObject(emptyMap())).jsonObject.toMutableMap().apply {
-          put("released", JsonObject(mapOf(
+          put("publication", JsonObject(mapOf(
             "groupId" to publicationInfo.groupId.toJsonElement(),
             "artifactId" to publicationInfo.artifactId.toJsonElement(),
             "version" to publicationInfo.version.toJsonElement(),


### PR DESCRIPTION
# Why

Adds `expoPublishToMavenLocal` task.
Following https://www.notion.so/expo/Android-Prebuilding-197e5b57352480f2bf59fde4d9aebaaa proposal.

# How

Added a new task, `expoPublishToMavenLocal`, which will do two things:
- trigger the `publishToMavenLocal` 
- modify the `expo-module.config.json` to add information about pre-buildet artifacts

# Test Plan

- run `./gradlew :expo-blur:expoPublishToMavenLocal` in `bare-expo` 