### PR TITLE
[docs] Fix typo in Document Picker reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/document-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/document-picker.mdx
@@ -62,7 +62,7 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
     },
     {
       name: 'kvStoreIdentifier',
-      platorm: 'ios',
+      platform: 'ios',
       description:
         'Overrides the default iOS `com.apple.developer.ubiquity-kvstore-identifier` entitlement, which uses your Apple Team ID and bundle identifier. This may be needed if your app was transferred to another Apple Team after enabling iCloud storage.',
       default: 'undefined',

--- a/docs/pages/versions/v52.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/document-picker.mdx
@@ -62,7 +62,7 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
     },
     {
       name: 'kvStoreIdentifier',
-      platorm: 'ios',
+      platform: 'ios',
       description:
         'Overrides the default iOS `com.apple.developer.ubiquity-kvstore-identifier` entitlement, which uses your Apple Team ID and bundle identifier. This may be needed if your app was transferred to another Apple Team after enabling iCloud storage.',
       default: 'undefined',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Found that iOS platform is missing due to a typo in the Document Picker config plugin properties: https://docs.expo.dev/versions/latest/sdk/document-picker/#configurable-properties

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix the type in prop name in the config plugin section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2025-02-20 at 00 52 03@2x](https://github.com/user-attachments/assets/51acdac2-84cc-466e-8475-3a868f2b5a94)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
