### PR TITLE
[iOS][expo-av] Fixed black screen bug that appears when playing videos with AV1 codec

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### 🐛 Bug fixes
 
+- [expo-av] Fixed black screen bug that appears when playing videos with AV1 codec ([#35053](https://github.com/expo/expo/pull/35053) by [@HezekielT](https://github.com/HezekielT))
 - [iOS] `loadAsync()` promise never settled when given an invalid file uri ([#30020](https://github.com/expo/expo/pull/30020) by [@vonovak](https://github.com/vonovak))
 - Fixed putting app to background stops non-mixable audio playback in other apps on iOS ([#20380](https://github.com/expo/expo/pull/20380) by [@de1acr0ix](https://github.com/de1acr0ix))
 - Fix unhandled promise rejection when start recording fails [#29826](https://github.com/expo/expo/pull/29826) by [@anirudhsama](https://github.com/anirudhsama)

--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.m
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.m
@@ -164,7 +164,7 @@ NSString *const EXAVPlayerDataObserverMetadataKeyPath = @"timedMetadata";
     AVKeyValueStatus status = [avAsset statusOfValueForKey:@"isPlayable" error:&error];
 
     if (status == AVKeyValueStatusLoaded && !avAsset.isPlayable) {
-      NSString *errorMessage = @"Load encountered an error: [AVAsset isPlayable:] returned false. The asset does not contains a playable content or is not supported by the device.";
+      NSString *errorMessage = @"Load encountered an error: [AVAsset isPlayable:] returned false. The asset does not contain a playable content or is not supported by the device.";
       [self _finishLoadWithError:errorMessage];
       return;
     } 

--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.m
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.m
@@ -158,9 +158,16 @@ NSString *const EXAVPlayerDataObserverMetadataKeyPath = @"timedMetadata";
   // unless we preload, the asset will not necessarily load the duration by the time we try to play it.
   // http://stackoverflow.com/questions/20581567/avplayer-and-avfoundationerrordomain-code-11819
   EX_WEAKIFY(self);
-  [avAsset loadValuesAsynchronouslyForKeys:@[ @"duration" ] completionHandler:^{
+  [avAsset loadValuesAsynchronouslyForKeys:@[ @"isPlayable", @"duration" ] completionHandler:^{
     EX_ENSURE_STRONGIFY(self);
+    NSError *error = nil;
+    AVKeyValueStatus status = [avAsset statusOfValueForKey:@"isPlayable" error:&error];
 
+    if (status == AVKeyValueStatusLoaded && !avAsset.isPlayable) {
+      NSString *errorMessage = @"Load encountered an error: [AVAsset isPlayable:] returned false. The asset does not contains a playable content or is not supported by the device.";
+      [self _finishLoadWithError:errorMessage];
+      return;
+    } 
     // We prepare three items for AVQueuePlayer, so when the first finishes playing,
     // second can start playing and the third can start preparing to play.
     AVPlayerItem *firstplayerItem = [AVPlayerItem playerItemWithAsset:avAsset];


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, Apple doesn't fully support videos with AV1 codecs which means when playing those videos on iOS Native devices, the screen becomes black while the audio track plays and no error is thrown which makes it difficult to handle such videos for developers.

More details about AV1 Playback support can be found [here](https://bitmovin.com/blog/av1-playback-support/#av-1-playback-support-news-in-2024)

> Generally speaking, the Chrome browser and Android ecosystem handle AV1 well across phones, tablets, smart TVs and set-top boxes/streaming sticks. Unfortunately, the same cannot be said for Safari and iOS where support had been lacking until the iPhone 15 Pro announcement.

# How

<!--
How did you build this feature or fix this bug and why?
-->

[AVAsset](https://developer.apple.com/documentation/avfoundation/avasset) class has a property called `isPlayable` which can be used to determine if a video asset can be played or not by the device. 

This PR tries to fix the black screen bug by calling `isPlayable` on the video asset inside [`_loadNewPlayer(EXAVPlayerData.m)`](https://github.com/expo/expo/blob/main/packages/expo-av/ios/EXAV/EXAVPlayerData.m#L157-L180) and throwing an error if it is false(!asset.isPlayable) which can then be handled by the developer. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

1. Add a remote or local video asset inside [`VideoScreen.tsx`](https://github.com/expo/expo/blob/6bfa60a61ef5720ce73d8ce3ce7c061f94602866/apps/native-component-list/src/screens/Audio/AV/VideoScreen.tsx#L11-L23)

Here is a sample video with AV1 codec for testing purpose - https://github.com/user-attachments/assets/2b502b64-83c3-4b81-bc7b-b57cf6892ab0

2. run `yarn ios`
3. When the bare-expo app launches, click on `Component` and scroll down and click on `Video (expo-av)`.
4. Play the AV1 video.
5. Verify the screen remains black while the audio track is playing.

https://github.com/user-attachments/assets/bb30a9cc-8ba3-461b-97d3-4d05081df23e



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
