### PR TITLE
[docs] Update `BlockIgnores` in Vale

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -17,5 +17,5 @@ BasedOnStyles = expo-docs
 CommentDelimiters = {/*, */}
 
 # Ignore code surrounded by backticks or plus sign, parameters defaults, URLs and so on.
-BlockIgnores = (?s) <Terminal(\s|\n)[^/>]*?property
+BlockIgnores = (?s)<Terminal.*?/>,
 TokenIgnores = (\x60[^\n\x60]+\x60), ([^\n]+=[^\n]*), (\+[^\n]+\+), (http[^\n]+\[), .github, .gitlab, vscode-, Signing & Capabilities, eas.json, eas-json, .yarn+, yarn: "# yarn", eas+, eas-cli, npx+, Build & deploy, OAuth & Permissions, Languages & Frameworks, typescript, Privacy & Security, Certificates, IDs & Profiles, application/javascript, Motion & Orientation Access, Show devices and ask me again, my-app,  Still having trouble?, "my app runs well locally by crashes immediately when I run a build", my-app, MY_CUSTOM_API_KEY, withMyApiKey, My App, com.my., myFunction, my app, my-plugin, my-module, 'Hello from my TypeScript function!', my-scheme, my-root, Change my environment variables, my custom plugin, my, cocoapods, javascript, Ink & Switch,

--- a/docs/.vale/writing-styles/expo-docs/Consistency.yml
+++ b/docs/.vale/writing-styles/expo-docs/Consistency.yml
@@ -30,7 +30,6 @@ swap:
   IPhone: iPhone
   javascript: JavaScript
   javascript core: JavaScriptCore
-  linux: Linux
   mac os: macOS
   macos: macOS
   MacOS: macOS

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -4,8 +4,6 @@ description: Reference guide for the EAS Workflows configuration file syntax.
 maxHeadingDepth: 5
 ---
 
-{/* vale off */}
-
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
@@ -450,16 +448,20 @@ jobs:
     # @end #
 ```
 
+{/* vale off */}
+
 | Worker                             | vCPU | Memory (GiB RAM) | SSD (GiB) | Notes                                |
 | ---------------------------------- | ---- | ---------------- | --------- | ------------------------------------ |
 | linux-medium                       | 4    | 16               | 14        | Default worker.                      |
 | linux-large                        | 8    | 32               | 28        |                                      |
-| linux-medium-nested-virtualization | 4    | 16               | 14        | Allows running Android emulators.    |
-| linux-large-nested-virtualization  | 4    | 16               | 28        | Allows running Android emulators.    |
-| macos-medium                       | 5    | 12               | 85        | Runs iOS jobs, including simulators. |
-| macos-large                        | 10   | 20               | 85        | Runs iOS jobs, including simulators. |
+| linux-medium-nested-virtualization | 4    | 16               | 14        | Allows running Android Emulators.    |
+| linux-large-nested-virtualization  | 4    | 16               | 28        | Allows running Android Emulators.    |
+| macos-medium                       | 5    | 12               | 85        | Runs iOS jobs, including Simulators. |
+| macos-large                        | 10   | 20               | 85        | Runs iOS jobs, including Simulators. |
 
-Note: For iOS builds and iOS simulator jobs, you must use a `macos-*` worker. For Android emulator jobs, you must use a `linux-*-nested-virtualization` worker.
+{/* vale on */}
+
+Note: For iOS builds and iOS Simulator jobs, you must use a `macos-*` worker. For Android Emulator jobs, you must use a `linux-*-nested-virtualization` worker.
 
 ### `jobs.<job_id>.outputs`
 

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -45,8 +45,6 @@ Configure Tailwind CSS in your Expo project according to the [Tailwind PostCSS d
 
 Install `tailwindcss` and its required peer dependencies. Then, the run initialization command to create **tailwind.config.js** and **post.config.js** files in the root of your project.
 
-{/* vale off */}
-
 <Terminal
   cmd={[
     '# Install Tailwind and its peer dependencies',
@@ -56,8 +54,6 @@ Install `tailwindcss` and its required peer dependencies. Then, the run initiali
     '$ npx tailwindcss init -p',
   ]}
 />
-
-{/* vale on */}
 
 </Step>
 
@@ -135,16 +131,12 @@ You now start your project and use Tailwind CSS classes in your components.
 
 Install `tailwindcss` and its required peer dependencies:
 
-{/* vale off */}
-
 <Terminal
   cmd={[
     '# Install Tailwind and its peer dependencies',
     '$ npx expo add tailwindcss @tailwindcss/postcss postcss -- --dev',
   ]}
 />
-
-{/* vale on */}
 
 </Step>
 

--- a/docs/pages/tutorial/eas/configure-development-build.mdx
+++ b/docs/pages/tutorial/eas/configure-development-build.mdx
@@ -97,8 +97,6 @@ On running, this command:
 
 - Requests verification of the account owner by entering our Expo account credentials and asks if we want to create a new EAS project:
 
-{/* vale off */}
-
 <Terminal
   cmd={[
     '# Output after running eas init',
@@ -108,8 +106,6 @@ On running, this command:
     '✔ Project successfully linked (ID: XXXX-XX-XX-XXXX) (modified app.json)',
   ]}
 />
-
-{/* vale on */}
 
 - Creates EAS project and provides a link to that project which we can open in the Expo dashboard:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

1. `Terminal` component was already ignored by Vale's initialization rules but it seems the regex wasn't working correctly. For example, when running the prose linting command, it was throwing error for the following:

![CleanShot 2025-02-20 at 17 39 28@2x](https://github.com/user-attachments/assets/e7b611f0-e50b-42ef-8e47-6ffeb17a12d7)

This is fixed by updating regex to ignore everything inside `Terminal` under `BlockIgnores`.

2. In EAS Workflows > Syntax reference, `linux` is used as the image name (previously, the whole file was ignored). Under Vale's consistency rule, I've removed the string since this image name is referenced in multiple places and is unnecessary to enforce the rule. Also, fixed the Android Emulator and iOS Simulator capitalization typos.

3. Remove `vale off` comments where we've previously ignored a block of text.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run lint-prose` locally and there should be no errors.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
