### PR TITLE
[modules-core] Add support for macOS AppDelegate subscribers

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [iOS] Support returning `SharedObject`s from a `Promise`. ([#34655](https://github.com/expo/expo/pull/34655) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Support async functions by SwiftUI views ([#34853](https://github.com/expo/expo/pull/34853) by [@jakex7](https://github.com/jakex7))
 - Add ExpoAppDelegate support for macOS. ([#35061](https://github.com/expo/expo/pull/35061) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add support for macOS AppDelegate subscribers ([#35062](https://github.com/expo/expo/pull/35062) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriber.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriber.swift
@@ -11,9 +11,8 @@ open class BaseExpoAppDelegateSubscriber: UIResponder {
   }
 
   #if os(macOS)
-  @available(*, unavailable)
   public required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
+    super.init(coder: coder)
   }
   #endif // os(macOS)
 }

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -11,6 +11,7 @@
 - support react-native 0.77 ([#33946](https://github.com/expo/expo/pull/33946) by [@vonovak](https://github.com/vonovak))
 - Assert that DOM components cannot have `children`. ([#33369](https://github.com/expo/expo/pull/33369) by [@EvanBacon](https://github.com/EvanBacon))
 - Add ExpoAppDelegate support for macOS. ([#35061](https://github.com/expo/expo/pull/35061) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add support for macOS AppDelegate subscribers ([#35062](https://github.com/expo/expo/pull/35062) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -72,13 +72,6 @@ open class ExpoAppDelegate: ExpoAppInstance {
       $0.responds(to: #selector(applicationWillFinishLaunching(_:)))
     }
 
-    // If we can't find a subscriber that implements `willFinishLaunchingWithOptions`, we will delegate the decision if we can handel the passed URL to
-    // the `didFinishLaunchingWithOptions` method by returning `true` here.
-    //  You can read more about how iOS handles deep links here: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application#discussion
-    if parsedSubscribers.isEmpty {
-      return
-    }
-
     parsedSubscribers.forEach { subscriber in
       subscriber.applicationWillFinishLaunching?(notification)
     }
@@ -273,10 +266,8 @@ open class ExpoAppDelegate: ExpoAppInstance {
     let selector = #selector(application(_:didReceiveRemoteNotification:))
     let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
 
-    if !subs.isEmpty {
-      subs.forEach { subscriber in
-        subscriber.application?(application, didReceiveRemoteNotification: userInfo)
-      }
+    subs.forEach { subscriber in
+      subscriber.application?(application, didReceiveRemoteNotification: userInfo)
     }
   }
 #endif

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -268,7 +268,7 @@ open class ExpoAppDelegate: ExpoAppInstance {
 #elseif os(macOS)
   open override func application(
     _ application: NSApplication,
-    didReceiveRemoteNotification userInfo: [String : Any]
+    didReceiveRemoteNotification userInfo: [String: Any]
   ) {
     let selector = #selector(application(_:didReceiveRemoteNotification:))
     let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -322,9 +322,9 @@ open class ExpoAppDelegate: ExpoAppInstance {
     let subs = ExpoAppDelegateSubscriberRepository.subscribers.filter { $0.responds(to: selector) }
     var subscribersLeft = subs.count
     let dispatchQueue = DispatchQueue(label: "expo.application.continueUserActivity", qos: .userInteractive)
-    var allRestorableObjects = [UIUserActivityRestoring]()
+    var allRestorableObjects = [NSUserActivityRestoring]()
 
-    let handler = { (restorableObjects: [UIUserActivityRestoring]?) in
+    let handler = { (restorableObjects: [NSUserActivityRestoring]?) in
       dispatchQueue.sync {
         if let restorableObjects = restorableObjects {
           allRestorableObjects.append(contentsOf: restorableObjects)


### PR DESCRIPTION
# Why

Supporting macOS AppDelegate subscribers vastly increase what developers can create with Expo Modules for macOS, and this will also help us add macOS support for more of our libraries 

# How

Implement functions from `NSApplicationDelegate` protocol equivalent to what we already support for iOS AppDelegate subscribers.

# Test Plan

Run BareExpo macOS locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
