### PR TITLE
[templates] use RN 0.78

### DIFF
--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -31,24 +31,24 @@
     "expo-symbols": "~0.2.0",
     "expo-system-ui": "~4.0.4",
     "expo-web-browser": "~14.0.1",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "react-native": "0.76.3",
-    "react-native-gesture-handler": "~2.20.2",
-    "react-native-reanimated": "~3.16.1",
-    "react-native-safe-area-context": "4.12.0",
-    "react-native-screens": "~4.4.0",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "react-native": "0.78.0",
+    "react-native-gesture-handler": "~2.24.0",
+    "react-native-reanimated": "~3.17.1",
+    "react-native-safe-area-context": "5.2.0",
+    "react-native-screens": "~4.9.1",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.2"
+    "react-native-webview": "~13.13.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/jest": "^29.5.12",
-    "@types/react": "~18.3.12",
-    "@types/react-test-renderer": "^18.3.0",
+    "@types/react": "~19.0.10",
+    "@types/react-test-renderer": "^19.0.0",
     "jest": "^29.2.1",
     "jest-expo": "~52.0.2",
-    "react-test-renderer": "18.3.1",
+    "react-test-renderer": "19.0.0",
     "typescript": "^5.3.3"
   }
 }

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -25,20 +25,20 @@
     "expo-status-bar": "~2.0.0",
     "expo-system-ui": "~4.0.4",
     "expo-web-browser": "~14.0.1",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "react-native": "0.76.3",
-    "react-native-reanimated": "~3.16.1",
-    "react-native-safe-area-context": "4.12.0",
-    "react-native-screens": "~4.4.0",
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "react-native": "0.78.0",
+    "react-native-reanimated": "~3.17.1",
+    "react-native-safe-area-context": "~5.2.0",
+    "react-native-screens": "~4.9.1",
     "react-native-web": "~0.19.13"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
-    "@types/react": "~18.3.12",
+    "@types/react": "~19.0.10",
     "jest": "^29.2.1",
     "jest-expo": "~52.0.2",
-    "react-test-renderer": "18.3.1",
+    "react-test-renderer": "19.0.0",
     "typescript": "~5.3.3"
   }
 }


### PR DESCRIPTION
# Why

when people using the canary release from `main` want to create a new app and test it with react 19 & RN 78, the templates need to be ready for that

# How

update templates


~I'm not sure whether the packages such as `expo-font` should also point to `canary`?~

~If people use wrong versions they could potentially pull in old RN dep alonside the latest and _potentially_ run into odd behavior - example: https://github.com/expo/expo/blob/ffe5af224f75ea68c412c75066be324ff56f337d/packages/expo-navigation-bar/package.json#L37~

~this is the case for `expo-system-ui` which is why it's `canary`~

versions will be updated automatically when we publish the templates with the canary script



# Test Plan

merge and create an app with it I guess

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
