### PR TITLE
[linking] Add macOS support

### DIFF
--- a/apps/bare-expo/macos/BareExpo-macOS/Info.plist
+++ b/apps/bare-expo/macos/BareExpo-macOS/Info.plist
@@ -1,47 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
-	<key>CFBundleIconFile</key>
-	<string></string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
-	<key>CFBundlePackageType</key>
-	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
-	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
-	<key>CFBundleVersion</key>
-	<string>1</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
+		<key>CFBundleDevelopmentRegion</key>
+		<string>$(DEVELOPMENT_LANGUAGE)</string>
+		<key>CFBundleExecutable</key>
+		<string>$(EXECUTABLE_NAME)</string>
+		<key>CFBundleIconFile</key>
+		<string></string>
+		<key>CFBundleIdentifier</key>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+		<key>CFBundleInfoDictionaryVersion</key>
+		<string>6.0</string>
+		<key>CFBundleName</key>
+		<string>$(PRODUCT_NAME)</string>
+		<key>CFBundlePackageType</key>
+		<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+		<key>CFBundleShortVersionString</key>
+		<string>1.0</string>
+		<key>CFBundleVersion</key>
+		<string>1</string>
+		<key>CFBundleURLTypes</key>
+		<array>
 			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
+				<key>CFBundleURLSchemes</key>
+				<array>
+					<string>bareexpo</string>
+				</array>
+			</dict>
+			<dict>
+				<key>CFBundleURLSchemes</key>
+				<array>
+					<string>exp+bare-expo</string>
+				</array>
+			</dict>
+		</array>
+		<key>LSMinimumSystemVersion</key>
+		<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+		<key>NSAppTransportSecurity</key>
+		<dict>
+			<key>NSAllowsArbitraryLoads</key>
+			<true />
+			<key>NSExceptionDomains</key>
+			<dict>
+				<key>localhost</key>
+				<dict>
+					<key>NSExceptionAllowsInsecureHTTPLoads</key>
+					<true />
+				</dict>
 			</dict>
 		</dict>
+		<key>NSMainStoryboardFile</key>
+		<string>Main</string>
+		<key>NSPrincipalClass</key>
+		<string>NSApplication</string>
+		<key>NSSupportsAutomaticTermination</key>
+		<true />
+		<key>NSSupportsSuddenTermination</key>
+		<true />
 	</dict>
-	<key>NSMainStoryboardFile</key>
-	<string>Main</string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
-	<key>NSSupportsAutomaticTermination</key>
-	<true/>
-	<key>NSSupportsSuddenTermination</key>
-	<true/>
-</dict>
 </plist>

--- a/apps/bare-expo/macos/Podfile.lock
+++ b/apps/bare-expo/macos/Podfile.lock
@@ -18,6 +18,8 @@ PODS:
     - ExpoModulesCore
   - ExpoKeepAwake (14.0.1):
     - ExpoModulesCore
+  - ExpoLinking (7.0.3):
+    - ExpoModulesCore
   - ExpoLocalAuthentication (15.0.1):
     - ExpoModulesCore
   - ExpoMeshGradient (0.1.0):
@@ -1777,6 +1779,7 @@ DEPENDENCIES:
   - ExpoFileSystem (from `../../../packages/expo-file-system/ios`)
   - ExpoFont (from `../../../packages/expo-font/ios`)
   - ExpoKeepAwake (from `../../../packages/expo-keep-awake/ios`)
+  - ExpoLinking (from `../../../packages/expo-linking/ios`)
   - ExpoLocalAuthentication (from `../../../packages/expo-local-authentication/ios`)
   - ExpoMeshGradient (from `../../../packages/expo-mesh-gradient/ios`)
   - ExpoModulesCore (from `../../../packages/expo-modules-core`)
@@ -1885,6 +1888,9 @@ EXTERNAL SOURCES:
   ExpoKeepAwake:
     inhibit_warnings: false
     :path: "../../../packages/expo-keep-awake/ios"
+  ExpoLinking:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-linking/ios"
   ExpoLocalAuthentication:
     inhibit_warnings: false
     :path: "../../../packages/expo-local-authentication/ios"
@@ -2053,6 +2059,7 @@ SPEC CHECKSUMS:
   ExpoFileSystem: ddb2bbc2d88d1a15490a37c280d8e69aa53cb931
   ExpoFont: 73d44c5cd85eab8034bc5165ca2230315097d728
   ExpoKeepAwake: 5a84230d022094b50d2ef369fdcae76d0ea44913
+  ExpoLinking: 5addac9b3a9c25b8032efc0d604162427c62912e
   ExpoLocalAuthentication: 6c0a136e19a68e75227bdb60c201cc29fd199b1d
   ExpoMeshGradient: 10206dfd6045700677d876bf58a27f065f4b9f70
   ExpoModulesCore: 11dda0a8dea834f584c4ab0070cbfdca733e8fdf
@@ -2131,6 +2138,6 @@ SPEC CHECKSUMS:
   SocketRocket: 03f7111df1a343b162bf5b06ead333be808e1e0a
   Yoga: 21dd9d47026f46578fd67d9d5a2fc0bb8197096a
 
-PODFILE CHECKSUM: da8cb6efd0293a05846acf4bf269a9dc6ba7ca35
+PODFILE CHECKSUM: 56c8acc7e7eafa2b542cdb57dfc945abb6366b78
 
 COCOAPODS: 1.16.2

--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Add basic support for App Clips. ([#34327](https://github.com/expo/expo/pull/34327) by [@EvanBacon](https://github.com/EvanBacon))
+- Add macOS support. ([#35064](https://github.com/expo/expo/pull/35064) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-linking/ios/ExpoLinking.podspec
+++ b/packages/expo-linking/ios/ExpoLinking.podspec
@@ -12,7 +12,8 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '15.1',
-    :tvos => '15.1'
+    :tvos => '15.1',
+    :osx => '11.0'
   }
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true

--- a/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift
+++ b/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift
@@ -18,7 +18,9 @@ public class LinkingAppDelegateSubscriber: ExpoAppDelegateSubscriber {
   }
 #elseif os(macOS)
   public func application(_ application: NSApplication, open urls: [URL]) {
-    guard let url = urls.first else { return }
+    guard let url = urls.first else {
+      return
+    }
     ExpoLinkingRegistry.shared.initialURL = url
     NotificationCenter.default.post(name: onURLReceivedNotification, object: self, userInfo: ["url": url])
   }

--- a/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift
+++ b/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift
@@ -10,11 +10,19 @@ public class LinkingAppDelegateSubscriber: ExpoAppDelegateSubscriber {
     return false
   }()
 
+#if os(iOS) || os(tvOS)
   public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
     ExpoLinkingRegistry.shared.initialURL = url
     NotificationCenter.default.post(name: onURLReceivedNotification, object: self, userInfo: ["url": url])
     return false
   }
+#elseif os(macOS)
+  public func application(_ application: NSApplication, open urls: [URL]) {
+    guard let url = urls.first else { return }
+    ExpoLinkingRegistry.shared.initialURL = url
+    NotificationCenter.default.post(name: onURLReceivedNotification, object: self, userInfo: ["url": url])
+  }
+#endif
 
   public func application(
     _ application: UIApplication,


### PR DESCRIPTION
# Why

Now that Expo Modules support AppDelegate subscribers we can easily add macOS support to expo-linking

# How

Implement `application(_:open:)`

# Test Plan

Run BareExpo macOS locally

https://github.com/user-attachments/assets/9b1635c0-36e9-40d4-9a2a-5bf0b1eff76f


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
