### PR TITLE
Change datepicker autosizing mode.

### DIFF
--- a/packages/expo-ui/ios/DateTimePickerView.swift
+++ b/packages/expo-ui/ios/DateTimePickerView.swift
@@ -18,7 +18,7 @@ struct DateTimePickerView: ExpoSwiftUI.View {
   var body: some View {
     let displayedComponents = props.displayedComponents.toDatePickerComponent()
 
-    ExpoSwiftUI.AutoSizingStack(shadowNodeProxy: shadowNodeProxy) {
+    ExpoSwiftUI.AutoSizingStack(shadowNodeProxy: shadowNodeProxy, axis: .vertical) {
       DatePicker(props.title, selection: $date, displayedComponents: displayedComponents)
         .onAppear {
           date = props.initialDate ?? Date()


### PR DESCRIPTION
# Why

It makes the datepicker behave correctly, filling the container in the horizontal axis and taking the minimum amount of space needed in the vertical.

It's similar to how we size spinners and imo the expected behaviour.

<img width="418" alt="image" src="https://github.com/user-attachments/assets/51f860db-85ab-45c2-ac83-a28c21b31207" />
<img width="410" alt="image" src="https://github.com/user-attachments/assets/a19b154a-d458-4f8a-a3c4-c292f792a777" />

The red container indictates the component footprint.


# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
