### PR TITLE
[go] fix ios expo go build error

### DIFF
--- a/apps/expo-go/ios/Exponent-Bridging-Header.h
+++ b/apps/expo-go/ios/Exponent-Bridging-Header.h
@@ -4,6 +4,7 @@
 
 #import <ExpoModulesCore/ExpoModulesCore.h>
 #import <ExpoModulesCore-Swift.h>
+#import <Expo-Swift.h>
 #import <EXUpdatesInterface-Swift.h>
 #import <EXUpdates-Swift.h>
 #import <ExpoScreenOrientation-Swift.h>


### PR DESCRIPTION
# Why

fix ios expo-go build error: https://github.com/expo/expo/runs/37515895804
```
cannot find interface declaration for 'EXExpoAppDelegate', superclass of 'AppDelegate'
```

regression from #34985

# How

add Expo-Swift.h to bridging header

# Test Plan

ios expo go ci passed

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
