### PR TITLE
[modules-core] Add SwiftUI views support for macOS

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [iOS] Support async functions by SwiftUI views ([#34853](https://github.com/expo/expo/pull/34853) by [@jakex7](https://github.com/jakex7))
 - Add ExpoAppDelegate support for macOS. ([#35061](https://github.com/expo/expo/pull/35061) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Add support for macOS AppDelegate subscribers ([#35062](https://github.com/expo/expo/pull/35062) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add SwiftUI views support for macOS ([#35078](https://github.com/expo/expo/pull/35078) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/AutoSizingStack.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/AutoSizingStack.swift
@@ -27,7 +27,7 @@ extension ExpoSwiftUI {
     }
 
     public var body: some SwiftUI.View {
-      if #available(iOS 16.0, tvOS 16.0, *) {
+      if #available(iOS 16.0, tvOS 16.0, macOS 13.0, *) {
         if proxy !== ShadowNodeProxy.SHADOW_NODE_MOCK_PROXY {
           content.overlay {
             content.fixedSize(horizontal: axis.contains(.horizontal), vertical: axis.contains(.vertical))

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -26,7 +26,7 @@ extension ExpoSwiftUI {
     private let contentView: any ExpoSwiftUI.View
 
     /**
-     Additiional utilities for controlling shadow node behavior.
+     Additional utilities for controlling shadow node behavior.
      */
     private let shadowNodeProxy: ShadowNodeProxy = ShadowNodeProxy()
 
@@ -44,7 +44,7 @@ extension ExpoSwiftUI {
       self.props = props
       let controller = UIHostingController(rootView: rootView)
 
-      if #available(iOS 16.0, *) {
+      if #available(iOS 16.0, macOS 13.0, *) {
         controller.sizingOptions = [.intrinsicContentSize]
       }
       self.hostingController = controller
@@ -111,7 +111,6 @@ extension ExpoSwiftUI {
       return true
     }
 
-#if os(iOS) || os(tvOS)
 #if RCT_NEW_ARCH_ENABLED
     /**
      Fabric calls this function when mounting (attaching) a child component view.
@@ -144,7 +143,8 @@ extension ExpoSwiftUI {
      Setups layout constraints of the hosting controller view to match the layout set by React.
      */
     private func setupHostingViewConstraints() {
-      guard let view = hostingController.view else {
+      // NSView is not optional in NSViewController in macOS
+      guard let view = hostingController.view as UIView? else {
         return
       }
       view.translatesAutoresizingMaskIntoConstraints = false
@@ -165,12 +165,26 @@ extension ExpoSwiftUI {
       if window != nil, let parentController = reactViewController() {
         parentController.addChild(hostingController)
         addSubview(hostingController.view)
+        #if os(iOS) || os(tvOS)
         hostingController.didMove(toParent: parentController)
+        #endif
         setupHostingViewConstraints()
       } else {
         hostingController.view.removeFromSuperview()
         hostingController.removeFromParent()
       }
+    }
+
+#if os(macOS)
+    public override func reactViewController() -> NSViewController? {
+      var currentView: NSView? = self
+      while let view = currentView {
+        if let viewController = view.nextResponder as? NSViewController {
+          return viewController
+        }
+        currentView = view.superview
+      }
+      return self.window?.contentViewController
     }
 #endif
   }


### PR DESCRIPTION
# Why

SwiftUI views are already supported on iOS and tvOS, there is no reason not to support macOS as well

# How

Add availability checks necessary methods and overwrite `reactViewController` to retrieve the correct reactViewController given that NSViews are not automatically wired up to an NSViewController in the same way that UIViews are in iOS.

# Test Plan

Run BareExpo macOS locally

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/b4a10d03-ef2b-4254-813f-958176d27587" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
