### PR TITLE
[docs] Remove SDK 49 related info from multiple docs

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -27,7 +27,6 @@ When selecting an image for the build you can use the full name provided below o
 - The `sdk-52` alias will be assigned to the image best suited for SDK 52 builds.
 - The `sdk-51` alias will be assigned to the image best suited for SDK 51 builds.
 - The `sdk-50` alias will be assigned to the image best suited for SDK 50 builds.
-- The `sdk-49` alias will be assigned to the image best suited for SDK 49 builds.
 - SDK aliases will be updated with every new SDK release.
 - The `latest` alias will be updated with every new image release.
 

--- a/docs/pages/guides/publishing-websites.mdx
+++ b/docs/pages/guides/publishing-websites.mdx
@@ -21,7 +21,7 @@ An Expo web app can be served locally for testing the production behavior, and d
   Icon={Cloud01Icon}
 />
 
-For SDK 49 and below, you may need the [guide for publishing `webpack` builds](/archive/publishing-websites-webpack/).
+> For SDK 49 and below, you may need the [guide for publishing `webpack` builds](/archive/publishing-websites-webpack/).
 
 ## Output targets
 

--- a/docs/pages/router/advanced/drawer.mdx
+++ b/docs/pages/router/advanced/drawer.mdx
@@ -4,7 +4,6 @@ description: Learn how to use the Drawer layout in Expo Router.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
-import { Tabs, Tab } from '~/ui/components/Tabs';
 
 To use [drawer navigator](https://reactnavigation.org/docs/drawer-based-navigation) you'll need to install some extra dependencies.
 
@@ -16,46 +15,9 @@ To use [drawer navigator](https://reactnavigation.org/docs/drawer-based-navigati
   ]}
 />
 
-<Tabs>
-
-<Tab label="SDK 50 and higher">
-
-No additional configuration is required for SDK 50 and above. [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) is automatically configured in `babel-preset-expo` when you install the library.
-
-</Tab>
-
-<Tab label="SDK 49 and lower">
-
-Update your **babel.config.js** to include the Reanimated babel plugin:
-
-{/* prettier-ignore */}
-```js babel.config.js
-module.exports = {
-  presets: [
-      /* @hide ... */ /* @end */
-    ],
-    plugins: [
-      /* @hide ... */ /* @end */
-      'react-native-reanimated/plugin',
-    ],
-};
-```
-
-After you add the Babel plugin, restart your development server and clear the bundler cache using the command:
-
-<Terminal cmd={['$ npx expo start --clear']} />
-
-> If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
-
-</Tab>
-
-</Tabs>
+No additional configuration is required. [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) is automatically configured in `babel-preset-expo` when you install the library.
 
 ## Usage
-
-<Tabs>
-
-<Tab label="SDK 50 and higher">
 
 Now you can use the `Drawer` layout to create a drawer navigator. You'll need to wrap the `<Drawer />` in a `<GestureHandlerRootView>` to enable gestures. You only need one `<GestureHandlerRootView>` in your component tree. Any nested routes are not required to be wrapped individually.
 
@@ -103,48 +65,3 @@ export default function Layout() {
 ```
 
 > **Note:** Be careful when using `react-native-gesture-handler` on the web. It can increase the JavaScript bundle size significantly. Learn more about using [platform-specific modules](/router/advanced/platform-specific-modules/).
-
-</Tab>
-
-<Tab label="SDK 49 and lower">
-
-Now you can use the `Drawer` layout to create a drawer navigator.
-
-```tsx app/_layout.tsx
-import { Drawer } from 'expo-router/drawer';
-
-export default function Layout() {
-  return <Drawer />;
-}
-```
-
-To edit the drawer navigation menu labels, titles and screen options specific screens are required as follows:
-
-```tsx app/_layout.tsx
-import { Drawer } from 'expo-router/drawer';
-
-export default function Layout() {
-  return (
-    <Drawer>
-      <Drawer.Screen
-        name="index" // This is the name of the page and must match the url from root
-        options={{
-          drawerLabel: 'Home',
-          title: 'overview',
-        }}
-      />
-      <Drawer.Screen
-        name="user/[id]" // This is the name of the page and must match the url from root
-        options={{
-          drawerLabel: 'User',
-          title: 'overview',
-        }}
-      />
-    </Drawer>
-  );
-}
-```
-
-</Tab>
-
-</Tabs>

--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -8,7 +8,6 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { Tabs, Tab } from '~/ui/components/Tabs';
 
 Find the steps below to create a new project with Expo Router library or add it to your existing project.
 
@@ -47,20 +46,13 @@ Make sure your computer is [set up for running an Expo app](/get-started/create-
 
 You'll need to install the following dependencies:
 
-<Tabs>
-  <Tab label="SDK 50 and above">
-    <Terminal cmd={['$ npx expo install expo-router react-native-safe-area-context react-native-screens expo-linking expo-constants expo-status-bar']} />
+<Terminal
+  cmd={[
+    '$ npx expo install expo-router react-native-safe-area-context react-native-screens expo-linking expo-constants expo-status-bar',
+  ]}
+/>
 
-    The above command will install versions of these libraries that are compatible with the Expo SDK version your project is using.
-
-  </Tab>
-  <Tab label="SDK 49 and below">
-    <Terminal cmd={['$ npx expo install expo-router react-native-safe-area-context react-native-screens expo-linking expo-constants expo-status-bar react-native-gesture-handler']} />
-
-    The above command will install versions of these libraries that are compatible with the Expo SDK version your project is using.
-
-  </Tab>
-</Tabs>
+The above command will install versions of these libraries that are compatible with the Expo SDK version your project is using.
 
 </Step>
 
@@ -143,10 +135,6 @@ Then, enable [Metro web](/guides/customizing-metro/#adding-web-support-to-metro)
 
 ### Modify babel.config.js
 
-<Tabs>
-
-<Tab label="SDK 50 and above">
-
 Ensure you use `babel-preset-expo` as the `preset`, in the **babel.config.js** file or delete the file:
 
 ```js babel.config.js
@@ -159,31 +147,6 @@ module.exports = function (api) {
 ```
 
 If you're upgrading from a version of Expo Router that is older than v3, remove the `plugins: ['expo-router/babel']`. `expo-router/babel` was merged in `babel-preset-expo` in SDK 50 (Expo Router v3).
-
-</Tab>
-
-<Tab label="SDK 49 and below">
-
-Add `expo-router/babel` plugin as the last item in the `plugins` array to your project's **babel.config.js**:
-
-{/* prettier-ignore */}
-```js babel.config.js
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-    /* @info Add the following line. */
-    plugins: ['expo-router/babel'],
-    /* @end */
-  };
-};
-```
-
-> **Note**: If your project doesn't have **babel.config.js**, run `npx expo customize babel.config.js` to create one.
-
-</Tab>
-
-</Tabs>
 
 </Step>
 
@@ -201,43 +164,6 @@ After updating the Babel config file, run the following command to clear the bun
 
 ### Update resolutions
 
-<Tabs>
+If you're upgrading from an older version of Expo Router, ensure you remove all outdated Yarn resolutions or npm overrides in your **package.json**. Specifically, remove `metro`, `metro-resolver`, `react-refresh` resolutions from your **package.json**.
 
-<Tab label="SDK 50 and above">
-  If you're upgrading from an older version of Expo Router, ensure you remove all outdated Yarn
-  resolutions or npm overrides in your **package.json**. Specifically, remove `metro`,
-  `metro-resolver`, `react-refresh` resolutions from your **package.json**.
-</Tab>
-
-  <Tab label="SDK 49">
-    Expo Router requires at least `react-refresh@0.14.0`. React Native hasn't upgraded as of SDK 49 and Expo Router v2, so you need to force upgrade your `react-refresh` version by setting a Yarn resolution or npm override.
-
-    <Tabs>
-      <Tab label="Yarn">
-          ```json package.json
-          {
-            /* @hide ... */
-            /* @end */
-            "resolutions": {
-              "react-refresh": "~0.14.0"
-            }
-          }
-          ```
-      </Tab>
-      <Tab label="npm">
-          ```json package.json
-          {
-            /* @hide ... */
-            /* @end */
-            "overrides": {
-              "react-refresh": "~0.14.0"
-            }
-          }
-          ```
-      </Tab>
-    </Tabs>
-
-  </Tab>
-
-</Tabs>
 </Step>

--- a/docs/pages/router/reference/async-routes.mdx
+++ b/docs/pages/router/reference/async-routes.mdx
@@ -5,7 +5,6 @@ description: Learn how to speed up development with async bundling in Expo Route
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
-import { Tabs, Tab } from '~/ui/components/Tabs';
 
 > **warning** Async routes is an experimental feature.
 
@@ -33,10 +32,6 @@ For those familiar with advanced bundling techniques, the async routes feature i
 
 Enable the feature by setting the `asyncRoutes` option in the Expo Router config plugin of your [app config](/versions/latest/config/app/):
 
-<Tabs>
-
-<Tab label="SDK 50 and above">
-
     > SDK 50 and above supports production bundle splitting. Set `asyncRoutes` to `true` to enable it.
 
     ```json app.json
@@ -57,30 +52,6 @@ Enable the feature by setting the `asyncRoutes` option in the Expo Router config
       }
     }
     ```
-
-</Tab>
-
-<Tab label="SDK 49">
-
-    ```json app.json
-    {
-      "expo": {
-        "plugins": [
-          [
-            "expo-router",
-            {
-              "origin": "https://acme.com",
-              "asyncRoutes": "development"
-            }
-          ]
-        ]
-      }
-    }
-    ```
-
-</Tab>
-
-</Tabs>
 
 You can set platform-specific settings (`default`, `android`, `ios` or `web`) for `asyncRoutes` using an object:
 

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -8,7 +8,6 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
-import { Tabs, Tab } from '~/ui/components/Tabs';
 
 See more information about **metro.config.js** in the [customizing Metro guide](/guides/customizing-metro/).
 
@@ -59,10 +58,6 @@ Client environment variable inlining can be disabled with the environment variab
 
 Expo supports CSS in your project. You can import CSS files from any component. CSS Modules are also supported.
 
-<Tabs>
-
-<Tab label="SDK 50 and above">
-
 CSS support is enabled by default. You can disable the feature by setting `isCSSEnabled` in the Metro config.
 
 ```js metro.config.js
@@ -72,23 +67,6 @@ const config = getDefaultConfig(__dirname, {
   isCSSEnabled: false,
 });
 ```
-
-</Tab>
-
-<Tab label="SDK 49">
-
-To enable CSS support, set `isCSSEnabled` to `true` in the Metro config.
-
-```js metro.config.js
-/** @type {import('expo/metro-config').MetroConfig} */
-const config = getDefaultConfig(__dirname, {
-  isCSSEnabled: true,
-});
-```
-
-</Tab>
-
-</Tabs>
 
 ### Global CSS
 
@@ -404,7 +382,7 @@ Expo's Metro config injects build settings that can be used in the client bundle
 
 ## Bundle splitting
 
-> This feature is web-only in SDK 50.
+> This feature is web-only in SDK 50 and above.
 
 In SDK 50, Expo CLI automatically splits web bundles into multiple chunks based on async imports in production. This feature requires `@expo/metro-runtime` to be installed and imported somewhere in the entry bundle (available by default in Expo Router).
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Remove SDK 49 and lower SDK version specific information from multiple docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
