### PR TITLE
[docs] Remove `isNew` frontmatter field from unversioned reference

### DIFF
--- a/docs/pages/versions/unversioned/config/babel.mdx
+++ b/docs/pages/versions/unversioned/config/babel.mdx
@@ -1,7 +1,6 @@
 ---
 title: babel.config.js
 description: A reference for Babel configuration file.
-isNew: true
 ---
 
 import { Terminal } from '~/ui/components/Snippet';

--- a/docs/pages/versions/unversioned/config/package-json.mdx
+++ b/docs/pages/versions/unversioned/config/package-json.mdx
@@ -1,7 +1,6 @@
 ---
 title: package.json
 description: A reference for Expo-specific properties that can be used in the package.json file.
-isNew: true
 ---
 
 import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -5,7 +5,6 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-audio'
 packageName: 'expo-audio'
 iconUrl: '/static/images/packages/expo-av.png'
 platforms: ['android', 'ios', 'web']
-isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/expo.mdx
+++ b/docs/pages/versions/unversioned/sdk/expo.mdx
@@ -5,7 +5,6 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo'
 packageName: 'expo'
 iconUrl: '/static/images/packages/expo.png'
 platforms: ['android', 'ios', 'tvos', 'web']
-isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem-next.mdx
@@ -5,7 +5,6 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-file-system
 packageName: 'expo-file-system'
 iconUrl: '/static/images/packages/expo-file-system.png'
 platforms: ['android', 'ios', 'tvos']
-isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/live-photo.mdx
+++ b/docs/pages/versions/unversioned/sdk/live-photo.mdx
@@ -4,7 +4,6 @@ description: A library that allows displaying Live Photos on iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-live-photo'
 packageName: 'expo-live-photo'
 platforms: ['ios']
-isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/router-ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/router-ui.mdx
@@ -4,7 +4,6 @@ description: An Expo Router submodule that provides headless tab components to c
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'
 platforms: ['android', 'ios', 'tvos', 'web']
-isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/router.mdx
+++ b/docs/pages/versions/unversioned/sdk/router.mdx
@@ -4,7 +4,6 @@ description: A file-based routing library for React Native and web applications.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'
 platforms: ['android', 'ios', 'tvos', 'web']
-isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -5,7 +5,6 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-video'
 packageName: 'expo-video'
 iconUrl: '/static/images/packages/expo-video.png'
 platforms: ['android', 'ios', 'web', 'tvos']
-isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Remove `isNew` frontmatter field from unversioned reference docs for libraries released before SDK 53. This prevents them from appearing in the SDK 53 cut-off section. Libraries added after SDK 52 release retain their `isNew` flag.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
