### PR TITLE
[bare-expo][Android] Adjust memory limit

### DIFF
--- a/apps/bare-expo/android/gradle.properties
+++ b/apps/bare-expo/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx512m -XX:MaxMetaspaceSize=256m
-org.gradle.jvmargs=-Xmx20240M -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 org.gradle.vfs.watch=true
 


### PR DESCRIPTION
# Why

Adjusts memory limit in bare-expo.

# How
The 20 GB value was added by mistake a long time ago. Most users don’t actually have access to that much RAM, which can lead to OOM exceptions. I’ve decided to run some tests to determine how much memory should be allocated for the JVM during compilation. From my initial tests, 8GB has performed quite well compared to other values.

<img width="2600" alt="image" src="https://github.com/user-attachments/assets/f77d17c5-9d58-4b30-95d9-b28c9db87905" />

Those builds aren't 100% clean - I would run more tests in my free time.

