### PR TITLE
[bare-expo] Add compile tests for macOS

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -17,6 +17,9 @@ inputs:
   bare-expo-pods:
     description: 'Restore /apps/bare-expo/ios pods cache'
     required: false
+  bare-expo-macos-pods:
+    description: 'Restore /apps/bare-expo/macos pods cache'
+    required: false
   native-tests-pods:
     description: 'Restore /apps/native-tests/ios pods cache'
     required: false
@@ -60,6 +63,9 @@ outputs:
   bare-expo-pods-hit:
     description: 'Returns true, if /apps/bare-expo/ios pods cache is up-to-date'
     value: steps.bare-expo-pods-cache.outputs.cache-hit
+  bare-expo-macos-pods-hit:
+    description: 'Returns true, if /apps/bare-expo/macos pods cache is up-to-date'
+    value: steps.bare-expo-macos-pods-cache.outputs.cache-hit
   native-tests-pods-hit:
     description: 'Returns true, if /apps/native-tests/ios pods cache is up-to-date'
     value: steps.native-tests-pods-cache.outputs.cache-hit
@@ -127,6 +133,14 @@ runs:
       with:
         path: apps/bare-expo/ios/Pods
         key: ${{ runner.os }}-bare-expo-pods-${{ hashFiles('apps/bare-expo/ios/Podfile.lock') }}
+
+    - name: ♻️ Restore apps/bare-expo/macos/Pods from cache
+      if: inputs.bare-expo-macos-pods == 'true'
+      uses: actions/cache@v4
+      id: bare-expo-macos-pods-cache
+      with:
+        path: apps/bare-expo/macos/Pods
+        key: ${{ runner.os }}-bare-expo-macos-pods-${{ hashFiles('apps/bare-expo/macos/Podfile.lock') }}
 
     - name: ♻️ Restore apps/native-tests/ios/Pods from cache
       if: inputs.native-tests-pods == 'true'

--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -1,0 +1,93 @@
+name: Test Suite macOS
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - .github/workflows/test-suite-macos.yml
+      - packages/expo/**
+      - packages/expo-asset/**
+      - packages/expo-constants/**
+      - packages/expo-crypto/**
+      - packages/expo-file-system/**
+      - packages/expo-font/**
+      - packages/expo-keep-awake/**
+      - packages/expo-linking/**
+      - packages/expo-local-authentication/**
+      - packages/expo-mesh-gradient/**
+      - packages/expo-modules-autolinking/**
+      - packages/expo-modules-core/**
+      - packages/expo-sqlite/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos-build:
+    runs-on: macos-15
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: 🔨 Switch to Xcode 16.0
+        run: sudo xcode-select --switch /Applications/Xcode_16.0.app
+      - name: 🍺 Install required tools
+        run: |
+          brew install watchman || true
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: 💎 Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 3.2.2
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-workspace: 'true'
+          yarn-tools: 'true'
+          bare-expo-macos-pods: 'true'
+      - name: 🧶 Install node modules in root dir
+        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: 🕵️ Debug CocoaPods lockfiles
+        run: git diff Podfile.lock Pods/Manifest.lock
+        working-directory: apps/bare-expo/macos
+        continue-on-error: true
+      - name: 🌳 Display pod environment
+        run: pod env
+        working-directory: apps/bare-expo/macos
+      - name: 🖥️ Run bare-expo macos setup script
+        run: ./scripts/setup-macos-project.sh
+        working-directory: apps/bare-expo/
+      - name: 🥥 Install pods in apps/bare-expo/macos
+        if: steps.expo-caches.outputs.bare-expo-pods-hit != 'true'
+        run: pod install
+        working-directory: apps/bare-expo/macos
+      - name: 🏗️ Build macOS project
+        run: |
+          xcodebuild -workspace macos/BareExpo-macOS.xcworkspace -scheme ExpoMacOS-macOS -sdk macosx -derivedDataPath "macos/build" | xcpretty
+        working-directory: apps/bare-expo
+        timeout-minutes: 55
+        env:
+          EXPO_DEBUG: 1
+          NODE_ENV: production
+      - name: 📸 Upload builds
+        uses: actions/upload-artifact@v4
+        with:
+          name: bare-expo-macos-builds
+          path: apps/bare-expo/macos/build/BareExpo.app
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
+        with:
+          channel: '#expo-ios'
+          status: ${{ job.status }}
+          fields: job,message,ref,eventName,author,took
+          author_name: Test Suite (macOS)

--- a/apps/bare-expo/macos/Podfile
+++ b/apps/bare-expo/macos/Podfile
@@ -7,7 +7,17 @@ prepare_react_native_project!
 
 target 'BareExpo-macOS' do
   platform :macos, '11.0'
-  config = use_native_modules!
+  config_command = [
+    'node',
+    '--no-warnings',
+    '--eval',
+    'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
+    'react-native-config',
+    '--json',
+    '--platform',
+    'ios'
+  ]
+  config = use_native_modules!(config_command)
 
   use_expo_modules!
 

--- a/apps/bare-expo/macos/Podfile.lock
+++ b/apps/bare-expo/macos/Podfile.lock
@@ -49,6 +49,8 @@ PODS:
     - Yoga
   - ExpoSQLite (15.0.3):
     - ExpoModulesCore
+  - ExpoUI (0.0.2):
+    - ExpoModulesCore
   - fast_float (6.1.4)
   - FBLazyVector (0.77.0)
   - fmt (11.0.2)
@@ -1784,6 +1786,7 @@ DEPENDENCIES:
   - ExpoMeshGradient (from `../../../packages/expo-mesh-gradient/ios`)
   - ExpoModulesCore (from `../../../packages/expo-modules-core`)
   - ExpoSQLite (from `../../../packages/expo-sqlite/ios`)
+  - ExpoUI (from `../../../packages/expo-ui/ios`)
   - fast_float (from `../../../node_modules/react-native-macos/third-party-podspecs/fast_float.podspec`)
   - FBLazyVector (from `../../../node_modules/react-native-macos/Libraries/FBLazyVector`)
   - fmt (from `../../../node_modules/react-native-macos/third-party-podspecs/fmt.podspec`)
@@ -1903,6 +1906,9 @@ EXTERNAL SOURCES:
   ExpoSQLite:
     inhibit_warnings: false
     :path: "../../../packages/expo-sqlite/ios"
+  ExpoUI:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-ui/ios"
   fast_float:
     :podspec: "../../../node_modules/react-native-macos/third-party-podspecs/fast_float.podspec"
   FBLazyVector:
@@ -2064,6 +2070,7 @@ SPEC CHECKSUMS:
   ExpoMeshGradient: 10206dfd6045700677d876bf58a27f065f4b9f70
   ExpoModulesCore: 11dda0a8dea834f584c4ab0070cbfdca733e8fdf
   ExpoSQLite: 0a97e8932a344abb39882001ca15307c9f172396
+  ExpoUI: 9a686f0b7b1193bf5f0a8d90007745485b72d9b3
   fast_float: 44983b3bddb2d2ed3021a98be86f60ec8abc9ffd
   FBLazyVector: 553e6ebf09a761967edead2afac79ee59955b01d
   fmt: f6af2d677a106e3e44c9536a4c0c7f03ab53c854
@@ -2138,6 +2145,6 @@ SPEC CHECKSUMS:
   SocketRocket: 03f7111df1a343b162bf5b06ead333be808e1e0a
   Yoga: 21dd9d47026f46578fd67d9d5a2fc0bb8197096a
 
-PODFILE CHECKSUM: 56c8acc7e7eafa2b542cdb57dfc945abb6366b78
+PODFILE CHECKSUM: 9d12e58e194fe3eee9636409586b64f4dde94819
 
 COCOAPODS: 1.16.2

--- a/apps/bare-expo/scripts/setup-macos-project.sh
+++ b/apps/bare-expo/scripts/setup-macos-project.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+remove_dependencies() {
+  local packages=("$@")
+  local filter=""
+  for pkg in "${packages[@]}"; do
+    filter+=" | del(.dependencies[\"$pkg\"]?)"
+  done
+
+  filter="${filter# | }"
+
+  local tmp_file
+  tmp_file=$(mktemp) || return 1
+
+  jq "$filter" package.json > "$tmp_file" && mv "$tmp_file" package.json
+}
+
+echo " ☛  Ensuring macOS project is setup..."
+
+if type "pod" > /dev/null; then
+    echo " ✅ Has CocoaPods CLI"
+else
+  echo " 🛑  ERROR: Missing CocoaPods installation. Run 'sudo gem install cocoapods --pre' to install"
+  exit 1
+fi
+
+RN_MACOS_VERSION=$(jq -r '.dependencies["react-native-macos"]' package.json)
+echo $RN_MACOS_VERSION
+if [[ "$RN_MACOS_VERSION" != "null" ]]; then
+    echo " ✅ React Native macOS installed"
+else
+    RN_MINOR_VERSION=$(jq -r '.dependencies["react-native"] | capture("^(?<major>\\d+)\\.(?<minor>\\d+)") | "\( .major ).\( .minor )"' package.json)
+    echo " ⚠️  Cannot find React Native macOS for this project, attempting to install version $RN_MINOR_VERSION..."
+    yarn add react-native-macos@$RN_MINOR_VERSION
+fi
+
+echo " Removing macOS incompatible dependencies..."
+remove_dependencies "react-native-safe-area-context"
+
+if [ -d "./node_modules" ]; then
+    echo " ✅ Node modules installed"
+else
+    echo " ⚠️  Cannot find node modules for this project, installing..."
+    yarn
+fi
+
+if [ -d "macos/Pods" ]; then
+    echo " ✅ Project CocoaPods installed"
+else
+    echo " ⚠️  Cannot find Pods for this project, installing..."
+    cd ios
+    pod install
+    cd ..
+fi
+

--- a/apps/bare-expo/scripts/setup-macos-project.sh
+++ b/apps/bare-expo/scripts/setup-macos-project.sh
@@ -17,39 +17,15 @@ remove_dependencies() {
 
 echo " ☛  Ensuring macOS project is setup..."
 
-if type "pod" > /dev/null; then
-    echo " ✅ Has CocoaPods CLI"
-else
-  echo " 🛑  ERROR: Missing CocoaPods installation. Run 'sudo gem install cocoapods --pre' to install"
-  exit 1
-fi
+echo " Removing macOS incompatible dependencies..."
+remove_dependencies "react-native-safe-area-context"
 
 RN_MACOS_VERSION=$(jq -r '.dependencies["react-native-macos"]' package.json)
-echo $RN_MACOS_VERSION
 if [[ "$RN_MACOS_VERSION" != "null" ]]; then
     echo " ✅ React Native macOS installed"
 else
     RN_MINOR_VERSION=$(jq -r '.dependencies["react-native"] | capture("^(?<major>\\d+)\\.(?<minor>\\d+)") | "\( .major ).\( .minor )"' package.json)
     echo " ⚠️  Cannot find React Native macOS for this project, attempting to install version $RN_MINOR_VERSION..."
     yarn add react-native-macos@$RN_MINOR_VERSION
-fi
-
-echo " Removing macOS incompatible dependencies..."
-remove_dependencies "react-native-safe-area-context"
-
-if [ -d "./node_modules" ]; then
-    echo " ✅ Node modules installed"
-else
-    echo " ⚠️  Cannot find node modules for this project, installing..."
-    yarn
-fi
-
-if [ -d "macos/Pods" ]; then
-    echo " ✅ Project CocoaPods installed"
-else
-    echo " ⚠️  Cannot find Pods for this project, installing..."
-    cd ios
-    pod install
-    cd ..
 fi
 


### PR DESCRIPTION
# Why

Closes ENG-13378

# How

Add a very basic compile test for macOS using bare-expo just to prevent us from breaking compatibility in future releases 

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
