### PR TITLE
[docs] Use ref_name when publishing name

### DIFF
--- a/docs/pages/eas/workflows/examples.mdx
+++ b/docs/pages/eas/workflows/examples.mdx
@@ -129,7 +129,7 @@ jobs:
     name: Publish preview update
     type: update
     params:
-      branch: ${{ github.ref || 'test' }}
+      branch: ${{ github.ref_name || 'test' }}
 ```
 
 ## Deploy to production workflow

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -260,7 +260,7 @@ The `if` conditional determines if a job should run.
 jobs:
   my_job:
     # @info #
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref_name == 'main' }}
     # @end #
 ```
 

--- a/docs/pages/eas/workflows/upgrade.mdx
+++ b/docs/pages/eas/workflows/upgrade.mdx
@@ -105,7 +105,7 @@ jobs:
     name: Update
     type: update
     params:
-      branch: ${{ github.ref || 'test'}}
+      branch: ${{ github.ref_name || 'test'}}
 ```
 
 Once you have this workflow file, you can kick it off by pushing a commit to any branch, or by running the following command:


### PR DESCRIPTION
# Why

If you use `github.ref`, you'll get `refs/head/main`. Instead we'd like to use `github.ref_name` to output `main`.

# Test Plan

Make sure that the variables are updated in the examples.