### PR TITLE
[docs] change the App.js CFP banner link

### DIFF
--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -47,7 +47,7 @@ export function AppJSBanner() {
       <div className="z-10 flex items-center gap-3">
         <Button
           size="xs"
-          href="https://docs.google.com/forms/d/e/1FAIpQLSeKSqxwrTdJJavOFgK-UA25K-hJPmZ5wnZDY7UUo9ULDuckkA/viewform"
+          href="https://appjs.co/#CFP"
           openInNewTab
           rightSlot={<ArrowUpRightIcon className="icon-xs text-palette-white opacity-75" />}
           className={mergeClasses(


### PR DESCRIPTION
# Why

Instead of direct sheets file link, let's direct people to the App.js website section.

# How

Alter the App.js CFP banner URL to https://appjs.co/#CFP

# Test Plan

Link works.