### PR TITLE
[ios][camera] Move scanner to session queue

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -22,7 +22,7 @@
 - [Android] Attempt to fix `setLinearZoom` incompatability with some devices. ([#34757](https://github.com/expo/expo/pull/34757) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix flash. ([#34893](https://github.com/expo/expo/pull/34893) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Attempts to address crash that occurs more frequently on iPads. ([#34915](https://github.com/expo/expo/pull/34915) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Control barcode scanner on session queue.
+- [iOS] Control barcode scanner on session queue. ([#35107](https://github.com/expo/expo/pull/35107) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Android] Attempt to fix `setLinearZoom` incompatability with some devices. ([#34757](https://github.com/expo/expo/pull/34757) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix flash. ([#34893](https://github.com/expo/expo/pull/34893) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Attempts to address crash that occurs more frequently on iPads. ([#34915](https://github.com/expo/expo/pull/34915) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Control barcode scanner on session queue.
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/BarcodeScanner.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScanner.swift
@@ -3,7 +3,7 @@ import AVFoundation
 
 let BARCODE_TYPES_KEY = "barcodeTypes"
 
-actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
+class BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
   private var onBarcodeScanned: (([String: Any]?) -> Void)?
   var isScanningBarcodes = false
 
@@ -41,9 +41,7 @@ actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
         settings[BARCODE_TYPES_KEY] = value
         let zxingCoveredTypes = Set(zxingBarcodeReaders.keys)
         zxingEnabled = !zxingCoveredTypes.isDisjoint(with: newTypes)
-        Task {
-          await maybeStartBarcodeScanning()
-        }
+        maybeStartBarcodeScanning()
       }
     }
   }
@@ -52,7 +50,7 @@ actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
     self.previewLayer = layer
   }
 
-  func setIsEnabled(_ enabled: Bool) async {
+  func setIsEnabled(_ enabled: Bool) {
     guard isScanningBarcodes != enabled else {
       return
     }
@@ -62,11 +60,11 @@ actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
       if metadataOutput != nil {
         setConnection(enabled: true)
       } else {
-        await maybeStartBarcodeScanning()
+        maybeStartBarcodeScanning()
       }
     } else {
       setConnection(enabled: false)
-      await stopBarcodeScanning()
+      stopBarcodeScanning()
     }
   }
 
@@ -80,13 +78,13 @@ actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
     self.onBarcodeScanned = onBarcodeScanned
   }
 
-  func maybeStartBarcodeScanning() async {
+  func maybeStartBarcodeScanning() {
     guard isScanningBarcodes else {
       return
     }
 
     if metadataOutput == nil || videoDataOutput == nil {
-      await addOutputs()
+      addOutputs()
       if metadataOutput == nil {
         return
       }
@@ -100,14 +98,14 @@ actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
     metadataOutput?.metadataObjectTypes = requestedTypes
   }
 
-  func stopBarcodeScanning() async {
-    await removeOutputs()
+  func stopBarcodeScanning() {
+    removeOutputs()
     if isScanningBarcodes {
       onBarcodeScanned?(nil)
     }
   }
 
-  private func addOutputs() async {
+  private func addOutputs() {
     delegate = MetaDataDelegate(
       settings: settings,
       previewLayer: previewLayer,
@@ -138,7 +136,7 @@ actor BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
     session.commitConfiguration()
   }
 
-  private func removeOutputs() async {
+  private func removeOutputs() {
     session.beginConfiguration()
     defer { session.commitConfiguration() }
 

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -46,7 +46,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
 
   var isScanningBarcodes = false {
     didSet {
-      sessionQueue.async{ [weak self] in
+      sessionQueue.async { [weak self] in
         guard let self else {
           return
         }

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -46,8 +46,11 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
 
   var isScanningBarcodes = false {
     didSet {
-      Task {
-        await barcodeScanner?.setIsEnabled(isScanningBarcodes)
+      sessionQueue.async{ [weak self] in
+        guard let self else {
+          return
+        }
+        barcodeScanner?.setIsEnabled(isScanningBarcodes)
       }
     }
   }
@@ -293,9 +296,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     session.commitConfiguration()
     addErrorNotification()
     changePreviewOrientation()
-    Task.detached(priority: .userInitiated, operation: {
-      await self.barcodeScanner?.maybeStartBarcodeScanning()
-    })
+    barcodeScanner?.maybeStartBarcodeScanning()
     updateCameraIsActive()
     onCameraReady()
     enableTorch()
@@ -335,8 +336,8 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   }
 
   func setBarcodeScannerSettings(settings: BarcodeSettings) {
-    Task {
-      await barcodeScanner?.setSettings([BARCODE_TYPES_KEY: settings.toMetadataObjectType()])
+    sessionQueue.async {
+      self.barcodeScanner?.setSettings([BARCODE_TYPES_KEY: settings.toMetadataObjectType()])
     }
   }
 
@@ -707,13 +708,11 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   }
 
   func updateCameraIsActive() {
-    if session.isRunning == active {
-      return
-    }
-
     sessionQueue.async {
       if self.active {
-        self.session.startRunning()
+        if !self.session.isRunning {
+          self.session.startRunning()
+        }
       } else {
         self.session.stopRunning()
       }
@@ -785,9 +784,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
     for output in session.outputs {
       session.removeOutput(output)
     }
-    Task {
-      await barcodeScanner?.stopBarcodeScanning()
-    }
+    barcodeScanner?.stopBarcodeScanning()
     session.commitConfiguration()
 
     motionManager.stopAccelerometerUpdates()
@@ -823,15 +820,13 @@ public class CameraView: ExpoView, EXAppLifecycleListener,
   private func createBarcodeScanner() -> BarcodeScanner {
     let scanner = BarcodeScanner(session: session, sessionQueue: sessionQueue)
 
-    Task {
-      await scanner.setPreviewLayer(layer: previewLayer)
-      await scanner.setOnBarcodeScanned { [weak self] body in
-        guard let self else {
-          return
-        }
-        if let body {
-          self.onBarcodeScanned(body)
-        }
+    scanner.setPreviewLayer(layer: previewLayer)
+    scanner.setOnBarcodeScanned { [weak self] body in
+      guard let self else {
+        return
+      }
+      if let body {
+        self.onBarcodeScanned(body)
       }
     }
 


### PR DESCRIPTION
# Why
Some users have told me they are seeing crashes when the camera mounts with barcode scanning enabled. I couldn't repro in bare expo but I could in a blank project by navigating quickly between the a screen without the camera and one without.  

# How
The barcode scanner was the only thing not being run on the session queue so I'm moving it back because this was the cause of the problem. It was still running its configuration on another thread when `startRunning` was called. I should have done this with #34750 but didn't see the problem then

# Test Plan
I can no longer reproduce the issue in my test project
