### PR TITLE
[core] fix ios unit test failures

### DIFF
--- a/packages/expo-modules-core/ios/Tests/BlobConvertiblesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/BlobConvertiblesSpec.swift
@@ -46,7 +46,7 @@ final class DataUint8ArrayConvertiblesSpec: ExpoSpec {
         .eval(
           "expo.modules.BlobModule.echoAsync(new Uint8Array([0x00, 0xff])).then((result) => { globalThis.result = result; })"
         )
-      expect(safeBoolEval("globalThis.result instanceof Uint8Array")).toEventually(beTrue(), timeout: .milliseconds(500))
+      expect(safeBoolEval("globalThis.result instanceof Uint8Array")).toEventually(beTrue(), timeout: .milliseconds(2000))
       let array = try runtime.eval("Array.from(globalThis.result)").asArray()
       expect(array[0]?.getInt()) == 0x00
       expect(array[1]?.getInt()) == 0xff
@@ -57,7 +57,7 @@ final class DataUint8ArrayConvertiblesSpec: ExpoSpec {
         .eval(
           "expo.modules.BlobModule.echoMapAsync({ key: new Uint8Array([0x00, 0xff]) }).then((result) => { globalThis.result = result; })"
         )
-      expect(safeBoolEval("globalThis.result != null && globalThis.result.key instanceof Uint8Array")).toEventually(beTrue(), timeout: .milliseconds(500))
+      expect(safeBoolEval("globalThis.result != null && globalThis.result.key instanceof Uint8Array")).toEventually(beTrue(), timeout: .milliseconds(2000))
       let array = try runtime.eval("Array.from(globalThis.result.key)").asArray()
       expect(array[0]?.getInt()) == 0x00
       expect(array[1]?.getInt()) == 0xff

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -359,7 +359,7 @@ class FunctionSpec: ExpoSpec {
             "expo.modules.TestModule.withSharedObject().then((result) => { globalThis.result = result; })"
           )
 
-        expect(safeBoolEval("globalThis.result != null")).toEventually(beTrue(), timeout: .milliseconds(500))
+        expect(safeBoolEval("globalThis.result != null")).toEventually(beTrue(), timeout: .milliseconds(2000))
         let object = try runtime.eval("object = globalThis.result")
         
         expect(object.kind) == .object
@@ -376,7 +376,7 @@ class FunctionSpec: ExpoSpec {
             "expo.modules.TestModule.withSharedObjectPromise().then((result) => { globalThis.result = result; })"
           )
 
-        expect(safeBoolEval("globalThis.result != null")).toEventually(beTrue(), timeout: .milliseconds(500))
+        expect(safeBoolEval("globalThis.result != null")).toEventually(beTrue(), timeout: .milliseconds(2000))
         let object = try runtime.eval("object = globalThis.result")
         
         expect(object.kind) == .object


### PR DESCRIPTION
# Why

try to fix ios unit test failures: https://github.com/expo/expo/actions/runs/13462595159/job/37653498219
```
Failing tests:
	FunctionSpec.JavaScript, returns a SharedObject (async)()
```

# How

increase more timeout for async tests

# Test Plan

ios unit test ci passed

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
