### PR TITLE
fix(metro-config): Prevent bumping specificity for hot-reloaded style tags

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent bumping specificity of hot-reloaded CSS style tags. ([#35123](https://github.com/expo/expo/pull/35123) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 - Drop `fs-extra` in favor of `fs`. ([#35036](https://github.com/expo/expo/pull/35036) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/metro-config/build/transform-worker/css.js
+++ b/packages/@expo/metro-config/build/transform-worker/css.js
@@ -13,7 +13,7 @@ function getHotReplaceTemplate(id) {
     return `style.setAttribute('data-expo-css-hmr', ${attr});
   const previousStyle = document.querySelector('[data-expo-css-hmr=${attr}]');
   if (previousStyle) {
-    previousStyle.parentNode.removeChild(previousStyle);
+    previousStyle.parentNode.replaceChild(style, previousStyle);
   }`;
 }
 exports.getHotReplaceTemplate = getHotReplaceTemplate;
@@ -23,7 +23,7 @@ function wrapDevelopmentCSS(props) {
 const style = document.createElement('style');
 ${getHotReplaceTemplate(props.filename)}
 style.setAttribute('data-expo-loader', 'css');
-head.appendChild(style);
+if (!style.parentNode) head.appendChild(style);
 const css = \`${withBackTicksEscaped}\`;
 if (style.styleSheet){
   style.styleSheet.cssText = css;

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/__snapshots__/css.test.ts.snap
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/__snapshots__/css.test.ts.snap
@@ -4,7 +4,7 @@ exports[`getHotReplaceTemplate should generate the correct template 1`] = `
 "style.setAttribute('data-expo-css-hmr', "foo");
   const previousStyle = document.querySelector('[data-expo-css-hmr="foo"]');
   if (previousStyle) {
-    previousStyle.parentNode.removeChild(previousStyle);
+    previousStyle.parentNode.replaceChild(style, previousStyle);
   }"
 `;
 
@@ -18,10 +18,10 @@ const style = document.createElement('style');
 style.setAttribute('data-expo-css-hmr', "test_css");
   const previousStyle = document.querySelector('[data-expo-css-hmr="test_css"]');
   if (previousStyle) {
-    previousStyle.parentNode.removeChild(previousStyle);
+    previousStyle.parentNode.replaceChild(style, previousStyle);
   }
 style.setAttribute('data-expo-loader', 'css');
-head.appendChild(style);
+if (!style.parentNode) head.appendChild(style);
 const css = \`body { color: red; }\`;
 if (style.styleSheet){
   style.styleSheet.cssText = css;
@@ -36,7 +36,7 @@ exports[`wrapDevelopmentCSS should transform css in dev mode for server componen
 if (typeof __expo_rsc_inject_module === 'function') {
   __expo_rsc_inject_module({
     id: "test.css",
-    code: "(()=>{const head = document.head || document.getElementsByTagName('head')[0];\\nconst style = document.createElement('style');\\nstyle.setAttribute('data-expo-css-hmr', \\"test_css\\");\\n  const previousStyle = document.querySelector('[data-expo-css-hmr=\\"test_css\\"]');\\n  if (previousStyle) {\\n    previousStyle.parentNode.removeChild(previousStyle);\\n  }\\nstyle.setAttribute('data-expo-loader', 'css');\\nhead.appendChild(style);\\nconst css = \`body { color: red; }\`;\\nif (style.styleSheet){\\n  style.styleSheet.cssText = css;\\n} else {\\n  style.appendChild(document.createTextNode(css));\\n}})();",
+    code: "(()=>{const head = document.head || document.getElementsByTagName('head')[0];\\nconst style = document.createElement('style');\\nstyle.setAttribute('data-expo-css-hmr', \\"test_css\\");\\n  const previousStyle = document.querySelector('[data-expo-css-hmr=\\"test_css\\"]');\\n  if (previousStyle) {\\n    previousStyle.parentNode.replaceChild(style, previousStyle);\\n  }\\nstyle.setAttribute('data-expo-loader', 'css');\\nif (!style.parentNode) head.appendChild(style);\\nconst css = \`body { color: red; }\`;\\nif (style.styleSheet){\\n  style.styleSheet.cssText = css;\\n} else {\\n  style.appendChild(document.createTextNode(css));\\n}})();",
   });
 } else {
   throw new Error('RSC SSR CSS injection function is not found (__expo_rsc_inject_module)');

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/__snapshots__/transform-worker.test.ts.snap
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/__snapshots__/transform-worker.test.ts.snap
@@ -12,10 +12,10 @@ const style = document.createElement('style');
 style.setAttribute('data-expo-css-hmr', "acme_module_css");
   const previousStyle = document.querySelector('[data-expo-css-hmr="acme_module_css"]');
   if (previousStyle) {
-    previousStyle.parentNode.removeChild(previousStyle);
+    previousStyle.parentNode.replaceChild(style, previousStyle);
   }
 style.setAttribute('data-expo-loader', 'css');
-head.appendChild(style);
+if (!style.parentNode) head.appendChild(style);
 const css = \`._R_BGG_container{background:red}\`;
 if (style.styleSheet){
   style.styleSheet.cssText = css;
@@ -56,10 +56,10 @@ const style = document.createElement('style');
 style.setAttribute('data-expo-css-hmr', "acme_module_css");
   const previousStyle = document.querySelector('[data-expo-css-hmr="acme_module_css"]');
   if (previousStyle) {
-    previousStyle.parentNode.removeChild(previousStyle);
+    previousStyle.parentNode.replaceChild(style, previousStyle);
   }
 style.setAttribute('data-expo-loader', 'css');
-head.appendChild(style);
+if (!style.parentNode) head.appendChild(style);
 const css = \`._R_BGG_container {
   background: red;
 }
@@ -109,10 +109,10 @@ const style = document.createElement('style');
 style.setAttribute('data-expo-css-hmr', "acme_css");
   const previousStyle = document.querySelector('[data-expo-css-hmr="acme_css"]');
   if (previousStyle) {
-    previousStyle.parentNode.removeChild(previousStyle);
+    previousStyle.parentNode.replaceChild(style, previousStyle);
   }
 style.setAttribute('data-expo-loader', 'css');
-head.appendChild(style);
+if (!style.parentNode) head.appendChild(style);
 const css = \`body {
   background: red;
 }

--- a/packages/@expo/metro-config/src/transform-worker/css.ts
+++ b/packages/@expo/metro-config/src/transform-worker/css.ts
@@ -10,7 +10,7 @@ export function getHotReplaceTemplate(id: string) {
   return `style.setAttribute('data-expo-css-hmr', ${attr});
   const previousStyle = document.querySelector('[data-expo-css-hmr=${attr}]');
   if (previousStyle) {
-    previousStyle.parentNode.removeChild(previousStyle);
+    previousStyle.parentNode.replaceChild(style, previousStyle);
   }`;
 }
 
@@ -21,7 +21,7 @@ export function wrapDevelopmentCSS(props: { src: string; filename: string; react
 const style = document.createElement('style');
 ${getHotReplaceTemplate(props.filename)}
 style.setAttribute('data-expo-loader', 'css');
-head.appendChild(style);
+if (!style.parentNode) head.appendChild(style);
 const css = \`${withBackTicksEscaped}\`;
 if (style.styleSheet){
   style.styleSheet.cssText = css;


### PR DESCRIPTION
# Why

Currently, style tags are inserted in load order and their consistent ordering is mostly preserved and predictable. However, when a style tag is hot reloaded, its specificity is bumped since its previous version is removed and the new style tag is appended, rather than the element being replaced in-place.

# How

- Replace `removeChild(previousStyle)` call with `replaceChild(style, previousStyle)`
- Add `!style.parentNode` check before inserting

# Test Plan

- Updated snapshots
- Manually tested

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
