### PR TITLE
Support custom nodes to unwrap in SwiftUI

### DIFF
--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -29,10 +29,11 @@ public extension ExpoSwiftUIView {
    Returns React's children as SwiftUI views, with any nested HostingViews stripped out.
    */
   func UnwrappedChildren<T: View>( // swiftlint:disable:this identifier_name
+    children: [ExpoSwiftUI.Child]? = nil,
     @ViewBuilder transform: @escaping (_ child: AnyView, _ isHostingView: Bool)
     -> T = { child, _ in  child }
   ) -> some View {
-    guard let children = props.children else {
+    guard let children = children ?? props.children else {
       return AnyView(EmptyView())
     }
     let childrenArray = Array(children)


### PR DESCRIPTION
# Why

I have a new approach working here and it's been great. I can use UnwrappedChildren, but I can pass it a list of children instead of just using props.children. This way, I can have this api:

```tsx
<ContextMenu>
  <ContextMenu.Trigger />
  <ContextMenu.Content />  
```

and then in Swift, I can extract each trigger and content:

```swift
var body: some View {
        let (trigger, content) = extractSubComponents(from: props.children)
        
        if let trigger {
            Menu {
                UnwrappedChildren(children: content)
            } label: {
                UnwrappedChildren(children: [trigger])
            }
        } else {
            UnwrappedChildren()
        }
    }
```

`UnwrappedChildren(children: [trigger])` isn't currently supported.

# How

Add optional support for custom `children`.

# Test Plan

Tested locally, working great.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
