### PR TITLE
[docs] Update llms-sdk script to remove empty links

### DIFF
--- a/docs/scripts/generate-llms/llms-sdk.js
+++ b/docs/scripts/generate-llms/llms-sdk.js
@@ -29,7 +29,8 @@ function cleanContent(content) {
     .replace(
       /Only for:\s*\n+\s*((?:Android[^]*?|iOS|Web)(?:\s*\n+\s*(?:Android[^]*?|iOS|Web))*)/g,
       (_, platforms) => 'Only for: ' + platforms.split(/\s*\n+\s*/).join(', ')
-    );
+    )
+    .replace(/â€ƒ/g, ' ');
 }
 
 async function processContent(content, url) {

--- a/docs/scripts/generate-llms/llms-sdk.js
+++ b/docs/scripts/generate-llms/llms-sdk.js
@@ -14,6 +14,7 @@ const processedContent = new Set();
 
 function cleanContent(content) {
   return content
+    .replace(/\[\]\([^)]+\s+"[^"]+"\)/g, '')
     .replace(/^#\s+.+\n\n[^\n]+\n\n/m, '')
     .replace(/^(?:\*\s*){3}$/gm, '')
     .replace(/^(.+)\n-+\n/gm, '## $1\n')

--- a/docs/scripts/generate-llms/llms-sdk.js
+++ b/docs/scripts/generate-llms/llms-sdk.js
@@ -14,7 +14,7 @@ const processedContent = new Set();
 
 function cleanContent(content) {
   return content
-    .replace(/\[\]\([^)]+\s+"[^"]+"\)/g, '')
+    .replace(/\[]\([^)]+\s+"[^"]+"\)/g, '')
     .replace(/^#\s+.+\n\n[^\n]+\n\n/m, '')
     .replace(/^(?:\*\s*){3}$/gm, '')
     .replace(/^(.+)\n-+\n/gm, '## $1\n')


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

After changes in https://github.com/expo/expo/pull/35089, empty links for Edit and npm buttons are now included in the final output for the SDK docs.

![CleanShot 2025-02-24 at 18 43 48@2x](https://github.com/user-attachments/assets/fd99cae2-3139-4f73-be6d-1f78d20d79e9)

![CleanShot 2025-02-24 at 18 43 37@2x](https://github.com/user-attachments/assets/bb650a84-c464-45bd-a914-36138a91b190)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add a regex to remove empty markdown links from the `llms-sdk.js` output.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run generate-llms` locally and view the output of `public/llms-sdk.txt` file.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
