### PR TITLE
Update @vercel/node in API Routes Vercel section in the Expo docs

### DIFF
--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -549,7 +549,7 @@ Create a Vercel configuration file (**vercel.json**) at the root of your project
   "outputDirectory": "dist/client",
   "functions": {
     "api/index.ts": {
-      "runtime": "@vercel/node@3.0.11",
+      "runtime": "@vercel/node@5.1.8",
       "includeFiles": "dist/server/**"
     }
   },


### PR DESCRIPTION
Fix outdated `@vercel/node` version in the Expo documentation. Version 3 does not support Node.js v22, causing deployment failures on Vercel with the following error:

```bash
> Installing Builder: @vercel/node@3.0.11
Exported: dist
Error: Found invalid Node.js Version: "22.x". Please set Node.js Version to 20.x in your Project Settings to use Node.js 20.
Learn More: http://vercel.link/node-version
```

![Screenshot 2025-02-24 at 14 48 12](https://github.com/user-attachments/assets/6501667e-69b0-4034-b717-c0e501c75d87)


Updating to the latest LTS version of `@vercel/node` resolves this issue and allows deployments to work with Node.js v22.

Upgrading from v3 to v5 is safe since there are no breaking changes in v4 [PR #12734](https://github.com/vercel/vercel/pull/12734/files) or v5 [PR #12746](https://github.com/vercel/vercel/pull/12746/files). The v4 update only included dependency updates and a minor regex change, which was later reverted in v5.

# Why

Vercel supports Node.js v22, but `@vercel/node@3.0.11` only works with Node.js v20. Upgrading ensures that Expo users deploying to Vercel don’t encounter compatibility issues.
# How

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
