### PR TITLE
[docs] Minor updates in multiple docs and tweak heading styles in EAS Hosting callout

### DIFF
--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -27,7 +27,7 @@ A splash screen, also known as a launch screen, is the first screen a user sees 
 
 The [`expo-splash-screen`](/versions/latest/sdk/splash-screen) has a built-in [config plugin](/config-plugins/introduction) that lets you configure properties such as the splash icon and background color.
 
-> **Warning** Do not use Expo Go or a development build to test your splash screen. **Expo Go** renders your app icon while the splash screen is visible, which can interfere with testing. **Development builds** include `expo-dev-client`, which has its own splash screen and may cause conflicts. Instead, use a [preview build](/build/eas-json/#preview-builds) or a [production build](/build/eas-json/#production-builds).
+> **warning** **Do not use Expo Go or a development build to test your splash screen**. Expo Go renders your app icon while the splash screen is visible, which can interfere with testing. Development builds include `expo-dev-client`, which has its own splash screen and may cause conflicts. **Instead, use a [preview build](/build/eas-json/#preview-builds) or a [production build](/build/eas-json/#production-builds)**.
 
 <Step label="1">
 
@@ -134,7 +134,7 @@ To test your new splash screen, build your app for [internal distribution](/tuto
 
 <Collapsible summary="Not using prebuild?">
 
-If your app does not use [Expo Prebuild](/workflow/prebuild) (formerly the _managed workflow_) to generate the native **android** and **iOS** directories, then changes in the app config will have no effect. For more information, see [how you can customize the configuration manually](https://github.com/expo/expo/tree/main/packages/expo-splash-screen#-installation-in-bare-react-native-projects).
+If your app does not use [Expo Prebuild](/workflow/prebuild) (formerly the _managed workflow_) to generate the native **android** and **ios** directories, then changes in the app config will have no effect. For more information, see [how you can customize the configuration manually](https://github.com/expo/expo/tree/main/packages/expo-splash-screen#-installation-in-bare-react-native-projects).
 
 </Collapsible>
 

--- a/docs/pages/eas/workflows/examples.mdx
+++ b/docs/pages/eas/workflows/examples.mdx
@@ -27,7 +27,7 @@ To get started, you'll need to configure your project and devices to build and r
 />
 
 <BoxLink
-  title="Android emulator setup"
+  title="Android Emulator setup"
   description="Get your project ready for development builds."
   href="/get-started/set-up-your-environment/?mode=development-build&platform=android&device=simulated"
   Icon={BookOpen02Icon}
@@ -41,7 +41,7 @@ To get started, you'll need to configure your project and devices to build and r
 />
 
 <BoxLink
-  title="iOS simulator setup"
+  title="iOS Simulator setup"
   description="Get your project ready for development builds."
   href="/get-started/set-up-your-environment/?mode=development-build&platform=ios&device=simulated"
   Icon={BookOpen02Icon}

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -461,7 +461,7 @@ jobs:
 
 {/* vale on */}
 
-> Note: For Android Emulator jobs, you must use a `linux-*-nested-virtualization` worker. For iOS builds and iOS Simulator jobs, you must use a `macos-*` worker.
+> **Note:** For Android Emulator jobs, you must use a `linux-*-nested-virtualization` worker. For iOS builds and iOS Simulator jobs, you must use a `macos-*` worker.
 
 ### `jobs.<job_id>.outputs`
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -456,12 +456,12 @@ jobs:
 | linux-large                        | 8    | 32               | 28        |                                      |
 | linux-medium-nested-virtualization | 4    | 16               | 14        | Allows running Android Emulators.    |
 | linux-large-nested-virtualization  | 4    | 16               | 28        | Allows running Android Emulators.    |
-| macos-medium                       | 5    | 12               | 85        | Runs iOS jobs, including Simulators. |
-| macos-large                        | 10   | 20               | 85        | Runs iOS jobs, including Simulators. |
+| macos-medium                       | 5    | 12               | 85        | Runs iOS jobs, including simulators. |
+| macos-large                        | 10   | 20               | 85        | Runs iOS jobs, including simulators. |
 
 {/* vale on */}
 
-Note: For iOS builds and iOS Simulator jobs, you must use a `macos-*` worker. For Android Emulator jobs, you must use a `linux-*-nested-virtualization` worker.
+> Note: For Android Emulator jobs, you must use a `linux-*-nested-virtualization` worker. For iOS builds and iOS Simulator jobs, you must use a `macos-*` worker.
 
 ### `jobs.<job_id>.outputs`
 

--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -241,7 +241,7 @@ All components also have a hook version giving you control over the render tree.
 
 Using hooks is considered advanced usage of this library. For most use-cases, using the components with `asChild` should give you enough control over the render tree.
 
-If you are developing a custom `<TabTrigger />`, you may also need to develop a custom `<TabList />` as `<TabList />` uses the [`useTabsWithChildren()`](https://docs.expo.dev/versions/latest/sdk/router-ui/#usetabswithchildrenoptions) which requires using the exported `<TabTrigger />` component
+If you are developing a custom `<TabTrigger />`, you may also need to develop a custom `<TabList />` as `<TabList />` uses the [`useTabsWithChildren()`](/versions/latest/sdk/router-ui/#usetabswithchildrenoptions) which requires using the exported `<TabTrigger />` component.
 
 ### Customizing how tab screens are rendered
 

--- a/docs/ui/components/EASHostingShoutoutBanner.tsx
+++ b/docs/ui/components/EASHostingShoutoutBanner.tsx
@@ -5,6 +5,7 @@ import { XIcon } from '@expo/styleguide-icons/outline/XIcon';
 import { useEffect, useState } from 'react';
 
 import { useLocalStorage } from '~/common/useLocalStorage';
+import { HEADLINE } from '~/ui/components/Text';
 
 export function EASHostingShoutoutBanner() {
   const [isLoaded, setIsLoaded] = useState(false);
@@ -74,7 +75,7 @@ export function EASHostingShoutoutBanner() {
           <Cloud01Icon className="icon-lg relative z-10 text-palette-white" />
         </div>
         <div className="relative grid grid-cols-1">
-          <p className="font-medium text-success heading-base">EAS Hosting</p>
+          <HEADLINE className="text-success">EAS Hosting</HEADLINE>
           <p className="text-sm text-success">
             Try the first end-to-end deployment solution for universal app development.
           </p>

--- a/docs/ui/components/EASHostingShoutoutBanner.tsx
+++ b/docs/ui/components/EASHostingShoutoutBanner.tsx
@@ -5,7 +5,6 @@ import { XIcon } from '@expo/styleguide-icons/outline/XIcon';
 import { useEffect, useState } from 'react';
 
 import { useLocalStorage } from '~/common/useLocalStorage';
-import { HEADLINE } from '~/ui/components/Text';
 
 export function EASHostingShoutoutBanner() {
   const [isLoaded, setIsLoaded] = useState(false);
@@ -75,7 +74,7 @@ export function EASHostingShoutoutBanner() {
           <Cloud01Icon className="icon-lg relative z-10 text-palette-white" />
         </div>
         <div className="relative grid grid-cols-1">
-          <HEADLINE className="text-success">EAS Hosting</HEADLINE>
+          <p className="text-base font-medium text-success">EAS Hosting</p>
           <p className="text-sm text-success">
             Try the first end-to-end deployment solution for universal app development.
           </p>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Found minor formatting issues in multiple docs
- The title in the EAS Hosting callout has a smaller font than the description text for mobile views:

![CleanShot 2025-02-24 at 19 34 13](https://github.com/user-attachments/assets/83fecc5e-4e56-473c-b046-9c2a0710ef00)



# How

<!--
How did you build this feature or fix this bug and why?
-->

- Fix minor docs issues
- Use `Headline` component for the title in EAS Hosting callout

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

**Callout changes preview**

![CleanShot 2025-02-24 at 19 33 14](https://github.com/user-attachments/assets/5762182f-c3c5-47c5-b74a-16642983a5a4)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
