### PR TITLE
[android] Fix typo in `applyLinterOptions`

### DIFF
--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -4,7 +4,7 @@ package expo.modules.plugin
 
 import com.android.build.gradle.LibraryExtension
 import expo.modules.plugin.android.PublicationInfo
-import expo.modules.plugin.android.applyLinerOptions
+import expo.modules.plugin.android.applyLinterOptions
 import expo.modules.plugin.android.applyPublishingVariant
 import expo.modules.plugin.android.applySDKVersions
 import expo.modules.plugin.android.createExpoPublishToMavenLocalTask
@@ -50,7 +50,7 @@ internal fun Project.applyDefaultAndroidSdkVersions() {
       targetSdk = rootProject.extra.safeGet("targetSdkVersion")
         ?: logger.warnIfNotDefined("targetSdkVersion", 34)
     )
-    applyLinerOptions()
+    applyLinterOptions()
   }
 }
 

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/AndroidLibraryExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/AndroidLibraryExtension.kt
@@ -10,7 +10,7 @@ internal fun LibraryExtension.applySDKVersions(compileSdk: Int, minSdk: Int, tar
   }
 }
 
-internal fun LibraryExtension.applyLinerOptions() {
+internal fun LibraryExtension.applyLinterOptions() {
   lintOptions.isAbortOnError = false
 }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR renames `applyLinerOptions` to `applyLinterOptions`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
