### PR TITLE
Add Expo Router API Routes video to docs

### DIFF
--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -31,7 +31,7 @@ Server features require a custom server, which can be deployed to EAS or most [o
 
 API Routes are functions that are executed on a server when a route is matched. They can be used to handle sensitive data, such as API keys securely, or implement custom server logic, such as exchanging auth codes for access tokens. API Routes should be executed in a [WinterCG](https://wintercg.org/)-compliant environment.
 
-In Expo, API Routes are defined by creating files in the **app** disrectory with the `+api.ts` extension. For example, the following API route is executed when the route `/hello` is matched.
+In Expo, API Routes are defined by creating files in the **app** directory with the `+api.ts` extension. For example, the following API route is executed when the route `/hello` is matched.
 
 <FileTree files={['app/index.tsx', ['app/hello+api.ts', 'API Route']]} />
 

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -10,6 +10,7 @@ import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tab, Tabs } from '~/ui/components/Tabs';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 Expo Router enables you to write secure server code for all platforms, right in your **app** directory.
 
@@ -21,11 +22,16 @@ export function GET(request: Request) {
 
 Server features require a custom server, which can be deployed to EAS or most [other hosting providers](#deployment).
 
+<VideoBoxLink
+  videoId="2_UzR1wdimI"
+  title="Watch: Expo Router API Routes Handle Requests & Stream Data"
+/>
+
 ## What are API Routes
 
 API Routes are functions that are executed on a server when a route is matched. They can be used to handle sensitive data, such as API keys securely, or implement custom server logic, such as exchanging auth codes for access tokens. API Routes should be executed in a [WinterCG](https://wintercg.org/)-compliant environment.
 
-In Expo, API Routes are defined by creating files in the **app** directory with the `+api.ts` extension. For example, the following API route is executed when the route `/hello` is matched.
+In Expo, API Routes are defined by creating files in the **app** disrectory with the `+api.ts` extension. For example, the following API route is executed when the route `/hello` is matched.
 
 <FileTree files={['app/index.tsx', ['app/hello+api.ts', 'API Route']]} />
 


### PR DESCRIPTION
# Why

Fixes: [ENG-15070](https://linear.app/expo/issue/ENG-15070/add-expo-router-api-routes-video-to-docs)

# Test Plan

Ran docs locally

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
