### PR TITLE
[expo-ui] Fix tvOS breakages

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed converting double to float. ([#34906](https://github.com/expo/expo/pull/34906) by [@janicduplessis](https://github.com/janicduplessis))
 - [iOS] Fixed ViewModuleWrapper initializer on old arch to use the DEFAULT_MODULE_VIEW view from the module as the default view. ([#35007](https://github.com/expo/expo/pull/35007) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix UnimplementedExpoView on macOS. ([#35014](https://github.com/expo/expo/pull/35014) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Fix tvOS breakage. ([#35146](https://github.com/expo/expo/pull/35146) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -44,7 +44,7 @@ extension ExpoSwiftUI {
       self.props = props
       let controller = UIHostingController(rootView: rootView)
 
-      if #available(iOS 16.0, macOS 13.0, *) {
+      if #available(iOS 16.0, tvOS 16.0, macOS 13.0, *) {
         controller.sizingOptions = [.intrinsicContentSize]
       }
       self.hostingController = controller

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix tvOS breakage. ([#35146](https://github.com/expo/expo/pull/35146) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 - Standardize platform key ordering in `expo-module.config.json`. ([#35003](https://github.com/expo/expo/pull/35003) by [@reichhartd](https://github.com/reichhartd))

--- a/packages/expo-ui/ios/DateTimePickerView.swift
+++ b/packages/expo-ui/ios/DateTimePickerView.swift
@@ -16,6 +16,9 @@ struct DateTimePickerView: ExpoSwiftUI.View {
   @State private var date = Date()
 
   var body: some View {
+    #if os(tvOS)
+    return Text("DateTimePicker is not supported on tvOS")
+    #else
     let displayedComponents = props.displayedComponents.toDatePickerComponent()
 
     ExpoSwiftUI.AutoSizingStack(shadowNodeProxy: shadowNodeProxy, axis: .vertical) {
@@ -30,9 +33,11 @@ struct DateTimePickerView: ExpoSwiftUI.View {
         .tint(props.color)
         .foregroundStyle(props.color ?? .accentColor)
     }
+    #endif
   }
 }
 
+#if !os(tvOS)
 private extension View {
   @ViewBuilder
   func applyDatePickerStyle(for style: PickerStyle) -> some View {
@@ -48,6 +53,7 @@ private extension View {
     }
   }
 }
+#endif
 
 enum PickerStyle: String, Enumerable {
   case wheel
@@ -60,7 +66,7 @@ enum DisplayedComponents: String, Enumerable {
   case date
   case hourAndMinute
   case dateAndTime
-
+  #if !os(tvOS)
   func toDatePickerComponent() -> DatePicker.Components {
     switch self {
     case .date:
@@ -71,4 +77,5 @@ enum DisplayedComponents: String, Enumerable {
       return [.date, .hourAndMinute]
     }
   }
+  #endif
 }


### PR DESCRIPTION
# Why

tvOS compile test is failing in main. Need to fix breakages in recently introduced SwiftUI code.

# How

- Disable DateTimePicker for tvOS
- Platform version checks need to have the tvOS version added

# Test Plan

- CI should pass


