### PR TITLE
[docs] Adds prerequisites

### DIFF
--- a/docs/pages/eas/workflows/examples.mdx
+++ b/docs/pages/eas/workflows/examples.mdx
@@ -6,7 +6,7 @@ description: Common CI/CD workflows that are useful for your project.
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 
 The following workflows are examples of how you can use EAS Workflows to automate your development and release processes. They can help you and your team develop, review each other's PRs, and release changes to your users.
@@ -15,9 +15,9 @@ The following workflows are examples of how you can use EAS Workflows to automat
 
 [Development builds](/develop/development-builds/introduction/) are specialized builds of your project that include Expo's developer tools. These types of builds include all native dependencies inside your project, enabling you to run a production-like build of your project on a simulator, emulator, or a physical device.
 
-<Collapsible summary="Prerequisites">
-
-To get started, you'll need to configure your project and devices to build and run development builds. Learn how to set up your environment for development builds with the following guides:
+<Prerequisites summary="Prerequisites" numberOfRequirements={2}>
+  <Requirement number={1} title="Set up your environment">
+    To get started, you'll need to configure your project and devices to build and run development builds. Learn how to set up your environment for development builds with the following guides:
 
 <BoxLink
   title="Android device setup"
@@ -47,7 +47,9 @@ To get started, you'll need to configure your project and devices to build and r
   Icon={BookOpen02Icon}
 />
 
-After you've configured your project and devices, add the following build profiles to your **eas.json** file.
+  </Requirement>
+  <Requirement number={2} title="Create build profiles">
+  After you've configured your project and devices, add the following build profiles to your **eas.json** file.
 
 ```json eas.json
 {
@@ -67,7 +69,8 @@ After you've configured your project and devices, add the following build profil
 }
 ```
 
-</Collapsible>
+  </Requirement>
+</Prerequisites>
 
 The following workflow creates a build for each platform and for both physical devices, Android emulators, and iOS simulators. They all will run in parallel.
 
@@ -105,15 +108,17 @@ Once you've made changes to your project, you can share a preview of your change
 
 You can access preview updates in the development build UI and through scannable QR codes on the Expo dashboard. When publishing a preview on every commit, your team can review changes without pulling the latest changes and running them locally.
 
-<Collapsible summary="Prerequisites">
+<Prerequisites summary="Prerequisites" numberOfRequirements={2}>
+  <Requirement number={1} title="Set up EAS Update">
+    Your project needs to have [EAS Update](/eas-update/introduction/) setup to publish preview updates. You can set up your project with:
 
-Your project needs to have [EAS Update](/eas-update/introduction/) setup to publish preview updates. You can set up your project with:
+    <Terminal cmd={['$ eas update:configure']} />
 
-<Terminal cmd={['$ eas update:configure']} />
-
-After that, you'll need to create new [development builds](/develop/development-builds/create-a-build/).
-
-</Collapsible>
+  </Requirement>
+  <Requirement number={2} title="Create new development builds">
+    After you've configured your project, create new [development builds](/develop/development-builds/create-a-build/) for each platform.
+  </Requirement>
+</Prerequisites>
 
 The following workflow publishes a preview update for every commit on every branch.
 
@@ -136,9 +141,9 @@ jobs:
 
 When you're ready to deliver changes to your users, you can build and submit to the app stores or you can send an over-the-air update. The following workflow detects if you need new builds, and if so, it sends them to the app stores. If new builds are not required, it will send an over-the-air update.
 
-<Collapsible summary="Prerequisites">
-
-To get started, you'll need to set up EAS Build, EAS Submit, and EAS Update.
+<Prerequisites numberOfRequirements={3}>
+  <Requirement number={1} title="Set up EAS Build">
+  To get started, you'll need to set up EAS Build, EAS Submit, and EAS Update.
 
 To set up EAS Build, follow this guide:
 
@@ -148,8 +153,9 @@ To set up EAS Build, follow this guide:
   href="/build/setup/"
   Icon={BookOpen02Icon}
 />
-
-To set up EAS Submit, follow these guides for each app store:
+  </Requirement>
+  <Requirement number={2} title="Set up EAS Submit">
+  To set up EAS Submit, follow these guides for each app store:
 
 <BoxLink
   title="Google Play Store prerequisites"
@@ -164,12 +170,13 @@ To set up EAS Submit, follow these guides for each app store:
   href="/submit/ios/"
   Icon={BookOpen02Icon}
 />
-
-And finally, you'll need to set up EAS Update, which you can do with:
+  </Requirement>
+  <Requirement number={3} title="Set up EAS Update">
+  And finally, you'll need to set up EAS Update, which you can do with:
 
 <Terminal cmd={['$ eas update:configure']} />
-
-</Collapsible>
+  </Requirement>
+</Prerequisites>
 
 The following workflow runs on each push to the `main` branch and performs the following:
 

--- a/docs/pages/eas/workflows/examples.mdx
+++ b/docs/pages/eas/workflows/examples.mdx
@@ -143,33 +143,35 @@ When you're ready to deliver changes to your users, you can build and submit to 
 
 <Prerequisites numberOfRequirements={3}>
   <Requirement number={1} title="Set up EAS Build">
-  To get started, you'll need to set up EAS Build, EAS Submit, and EAS Update.
+    To get started, you'll need to set up EAS Build, EAS Submit, and EAS Update.
 
-To set up EAS Build, follow this guide:
+    To set up EAS Build, follow this guide:
 
-<BoxLink
-  title="EAS Build prerequisites"
-  description="Get your project ready for EAS Build."
-  href="/build/setup/"
-  Icon={BookOpen02Icon}
-/>
+    <BoxLink
+      title="EAS Build prerequisites"
+      description="Get your project ready for EAS Build."
+      href="/build/setup/"
+      Icon={BookOpen02Icon}
+    />
+
   </Requirement>
+
   <Requirement number={2} title="Set up EAS Submit">
-  To set up EAS Submit, follow these guides for each app store:
+    To set up EAS Submit, follow these guides for each app store:
 
-<BoxLink
-  title="Google Play Store prerequisites"
-  description="Get your project ready for Google Play Store submissions."
-  href="/submit/android/"
-  Icon={BookOpen02Icon}
-/>
+    <BoxLink
+      title="Google Play Store prerequisites"
+      description="Get your project ready for Google Play Store submissions."
+      href="/submit/android/"
+      Icon={BookOpen02Icon}
+    />
+    <BoxLink
+      title="Apple App Store prerequisites"
+      description="Get your project ready for Apple App Store submissions."
+      href="/submit/ios/"
+      Icon={BookOpen02Icon}
+    />
 
-<BoxLink
-  title="Apple App Store prerequisites"
-  description="Get your project ready for Apple App Store submissions."
-  href="/submit/ios/"
-  Icon={BookOpen02Icon}
-/>
   </Requirement>
   <Requirement number={3} title="Set up EAS Update">
   And finally, you'll need to set up EAS Update, which you can do with:

--- a/docs/ui/components/Prerequisites/Requirement.tsx
+++ b/docs/ui/components/Prerequisites/Requirement.tsx
@@ -1,0 +1,21 @@
+import { mergeClasses } from '@expo/styleguide';
+import { type PropsWithChildren } from 'react';
+
+type RequirementProps = PropsWithChildren<{
+  title: string;
+  number: number;
+}>;
+
+export function Requirement({ title, number, children }: RequirementProps) {
+  return (
+    <div className={mergeClasses('flex gap-1.5 border-t border-default p-5')}>
+      <p className="mb-2 text-right font-medium">{number}.</p>
+      <div>
+        <p className="mb-2 font-medium">{title}</p>
+        <div className={mergeClasses('last:[&>*]:!mb-0 [&_p]:ml-0 [&_pre>pre]:mt-0')}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/ui/components/Prerequisites/Requirement.tsx
+++ b/docs/ui/components/Prerequisites/Requirement.tsx
@@ -10,7 +10,7 @@ export function Requirement({ title, number, children }: RequirementProps) {
   return (
     <div className={mergeClasses('flex gap-1.5 border-t border-default p-5')}>
       <p className="mb-2 text-right font-medium">{number}.</p>
-      <div>
+      <div className="flex-1">
         <p className="mb-2 font-medium">{title}</p>
         <div className={mergeClasses('last:[&>*]:!mb-0 [&_p]:ml-0 [&_pre>pre]:mt-0')}>
           {children}

--- a/docs/ui/components/Prerequisites/index.tsx
+++ b/docs/ui/components/Prerequisites/index.tsx
@@ -1,0 +1,110 @@
+import { LinkBase, mergeClasses } from '@expo/styleguide';
+import { TriangleDownIcon } from '@expo/styleguide-icons/custom/TriangleDownIcon';
+import { ListIcon } from '@expo/styleguide-icons/outline/ListIcon';
+import { useRouter } from 'next/compat/router';
+import { type ComponentType, type PropsWithChildren, useRef, useEffect } from 'react';
+
+import withHeadingManager, { HeadingManagerProps } from '~/common/withHeadingManager';
+import { PermalinkIcon } from '~/ui/components/Permalink';
+
+import { Requirement } from './Requirement';
+
+type PrerequisitesProps = PropsWithChildren<{
+  /**
+   * The number of requirements for the prerequisites.
+   */
+  numberOfRequirements: number;
+  /**
+   * If the prerequisites should be rendered "open" by default.
+   */
+  open?: boolean;
+  className?: string;
+}>;
+
+const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
+  ({
+    numberOfRequirements = 1,
+    children,
+    className,
+    headingManager,
+    open = false,
+  }: PrerequisitesProps & HeadingManagerProps) => {
+    const router = useRouter();
+    const detailsRef = useRef<HTMLDetailsElement>(null);
+    const anchorId = 'prerequisites';
+
+    // Makes the prerequisite headings unique to make it possible to link to them.
+    const heading = useRef(headingManager.addHeading(anchorId, 1, undefined));
+
+    // Expands collapsible if the current hash matches the heading
+    useEffect(() => {
+      if (router?.asPath) {
+        const splitUrl = router.asPath.split('#');
+        const hash = splitUrl.length ? splitUrl[1] : undefined;
+        if (hash && hash === heading.current.slug) {
+          detailsRef?.current?.setAttribute('open', '');
+        }
+      }
+    }, []);
+
+    return (
+      <details
+        ref={detailsRef}
+        id={anchorId}
+        className={mergeClasses(
+          'mb-3 scroll-m-4 rounded-md border border-default p-0',
+          '[&[open]]:shadow-xs',
+          '[h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3',
+          className
+        )}
+        open={open}>
+        <summary
+          className={mergeClasses(
+            'group m-0 flex cursor-pointer items-center justify-between rounded-md p-1.5 py-3 pr-4',
+            '[details[open]>&]:rounded-b-none',
+            'hocus:bg-subtle'
+          )}>
+          <div className="flex items-center">
+            <div className="ml-1.5 mr-2 mt-[5px] self-baseline">
+              <TriangleDownIcon
+                className={mergeClasses(
+                  'icon-sm text-icon-default',
+                  '-rotate-90 transition-transform duration-200',
+                  '[details[open]>summary_&]:rotate-0'
+                )}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <ListIcon className={mergeClasses('icon-sm text-icon-default')} />
+              <p
+                className={mergeClasses(
+                  'relative inline scroll-m-5',
+                  'group-hover:text-secondary group-hover:[&_code]:text-secondary'
+                )}>
+                Prerequisites
+              </p>
+            </div>
+            <LinkBase
+              href={'#' + heading.current.slug}
+              ref={heading.current.ref}
+              onClick={() => {
+                detailsRef?.current?.setAttribute('open', '');
+              }}
+              className="ml-auto inline rounded-md p-1 hocus:bg-element"
+              aria-label="Permalink">
+              <PermalinkIcon className="icon-sm invisible inline-flex group-hover:visible group-focus-visible:visible" />
+            </LinkBase>
+          </div>
+          <div>
+            <p className="text-xs text-secondary">
+              {numberOfRequirements} requirement{numberOfRequirements === 1 ? '' : 's'}
+            </p>
+          </div>
+        </summary>
+        {children}
+      </details>
+    );
+  }
+);
+
+export { Prerequisites, Requirement };


### PR DESCRIPTION
# Why

Adds a prerequisites components to make these elements stand out more than being collapsibles.

# Screenshots

## Prerequisites collapsed
<img width="660" alt="Screenshot 2025-02-24 at 10 53 54 PM" src="https://github.com/user-attachments/assets/c5ce9bc7-f681-43dc-91e0-2f42d8b77264" />

## Prerequisites hovered
<img width="664" alt="Screenshot 2025-02-24 at 10 53 59 PM" src="https://github.com/user-attachments/assets/584974cf-a0c8-4918-a591-7b0ef551d6b9" />

## Prerequisites open
Example 1:
<img width="660" alt="Screenshot 2025-02-24 at 10 54 05 PM" src="https://github.com/user-attachments/assets/0920a56e-92e4-4abd-8457-1cfcb26decd6" />

Example 2:
<img width="655" alt="Screenshot 2025-02-24 at 10 54 15 PM" src="https://github.com/user-attachments/assets/fa2f3bbc-02ec-4819-a4d3-ab2cc62e6a12" />

# Test Plan

- Click on the prerequisite in the /eas/workflows/examples doc
- Make sure you can see the steps when it's expanded
- Make sure you can navigate to these with the anchor link