### PR TITLE
[bare-expo] reenable r8

### DIFF
--- a/apps/bare-expo/android/gradle.properties
+++ b/apps/bare-expo/android/gradle.properties
@@ -58,4 +58,4 @@ expo.useLegacyPackaging=false
 
 EXPO_ALLOW_GLIDE_LOGS=true
 
-android.enableProguardInReleaseBuilds=false
+android.enableProguardInReleaseBuilds=true


### PR DESCRIPTION
# Why

r8 was temporarily disable from https://github.com/expo/expo/pull/35131#discussion_r1967613614 and later resolved by #35153. let's re-enable r8 back

# How

re-enable r8

# Test Plan

ci passed

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
