### PR TITLE
[bare-expo] Update macOS setup script to fallback to @latest

### DIFF
--- a/apps/bare-expo/scripts/setup-macos-project.sh
+++ b/apps/bare-expo/scripts/setup-macos-project.sh
@@ -25,7 +25,9 @@ if [[ "$RN_MACOS_VERSION" != "null" ]]; then
     echo " ✅ React Native macOS installed"
 else
     RN_MINOR_VERSION=$(jq -r '.dependencies["react-native"] | capture("^(?<major>\\d+)\\.(?<minor>\\d+)") | "\( .major ).\( .minor )"' package.json)
-    echo " ⚠️  Cannot find React Native macOS for this project, attempting to install version $RN_MINOR_VERSION..."
-    yarn add react-native-macos@$RN_MINOR_VERSION
+    echo " ⚠️  Attempting to install react-native-macos@$RN_MINOR_VERSION..."
+    if ! yarn add "react-native-macos@$RN_MINOR_VERSION" --non-interactive --silent; then
+        echo "⚠️  Failed to install react-native-macos@$RN_MINOR_VERSION, falling back to latest version"
+        yarn add react-native-macos@latest
+    fi
 fi
-


### PR DESCRIPTION
# Why

This will fix tests for https://github.com/expo/expo/pull/35050.

React native 0.78 has just some minor changes when compared to 0.77 making react-native-macos 77 "compatible" with react-native 0.78

# How

Update macOS setup script to fallback to installing `@latest` if  

# Test Plan

Run BareExpo macOS locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
