### PR TITLE
[docs][image-manipulator] Update example to use latest API

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagemanipulator.mdx
@@ -29,43 +29,33 @@ files={{
 dependencies={['expo-asset', 'expo-image-manipulator']}>
 
 ```jsx
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Button, Image, StyleSheet, View } from 'react-native';
 import { Asset } from 'expo-asset';
-import { manipulateAsync, FlipType, SaveFormat } from 'expo-image-manipulator';
+import { FlipType, SaveFormat, useImageManipulator } from 'expo-image-manipulator';
+
+const IMAGE = Asset.fromModule(require('./assets/snack-icon.png'));
 
 export default function App() {
-  const [ready, setReady] = useState(false);
-  const [image, setImage] = useState(null);
+  const [image, setImage] = useState(IMAGE);
+  const context = useImageManipulator(IMAGE.uri);
 
-  useEffect(() => {
-    (async () => {
-      const image = Asset.fromModule(require('./assets/snack-icon.png'));
-      await image.downloadAsync();
-      setImage(image);
-      setReady(true);
-    })();
-  }, []);
+  const rotate90andFlip = async () => {
+    context.rotate(90).flip(FlipType.Vertical);
+    const image = await context.renderAsync();
+    const result = await image.saveAsync({
+      format: SaveFormat.PNG,
+    });
 
-  const _rotate90andFlip = async () => {
-    const manipResult = await manipulateAsync(
-      image.localUri || image.uri,
-      [{ rotate: 90 }, { flip: FlipType.Vertical }],
-      { compress: 1, format: SaveFormat.PNG }
-    );
-    setImage(manipResult);
+    setImage(result);
   };
-
-  const _renderImage = () => (
-    <View style={styles.imageContainer}>
-      <Image source={{ uri: image.localUri || image.uri }} style={styles.image} />
-    </View>
-  );
 
   return (
     <View style={styles.container}>
-      {ready && image && _renderImage()}
-      <Button title="Rotate and Flip" onPress={_rotate90andFlip} />
+      <View style={styles.imageContainer}>
+        <Image source={{ uri: image.localUri || image.uri }} style={styles.image} />
+      </View>
+      <Button title="Rotate and Flip" onPress={rotate90andFlip} />
     </View>
   );
 }

--- a/docs/pages/versions/v52.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/imagemanipulator.mdx
@@ -29,43 +29,33 @@ files={{
 dependencies={['expo-asset', 'expo-image-manipulator']}>
 
 ```jsx
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Button, Image, StyleSheet, View } from 'react-native';
 import { Asset } from 'expo-asset';
-import { manipulateAsync, FlipType, SaveFormat } from 'expo-image-manipulator';
+import { FlipType, SaveFormat, useImageManipulator } from 'expo-image-manipulator';
+
+const IMAGE = Asset.fromModule(require('./assets/snack-icon.png'));
 
 export default function App() {
-  const [ready, setReady] = useState(false);
-  const [image, setImage] = useState(null);
+  const [image, setImage] = useState(IMAGE);
+  const context = useImageManipulator(IMAGE.uri);
 
-  useEffect(() => {
-    (async () => {
-      const image = Asset.fromModule(require('./assets/snack-icon.png'));
-      await image.downloadAsync();
-      setImage(image);
-      setReady(true);
-    })();
-  }, []);
+  const rotate90andFlip = async () => {
+    context.rotate(90).flip(FlipType.Vertical);
+    const image = await context.renderAsync();
+    const result = await image.saveAsync({
+      format: SaveFormat.PNG,
+    });
 
-  const _rotate90andFlip = async () => {
-    const manipResult = await manipulateAsync(
-      image.localUri || image.uri,
-      [{ rotate: 90 }, { flip: FlipType.Vertical }],
-      { compress: 1, format: SaveFormat.PNG }
-    );
-    setImage(manipResult);
+    setImage(result);
   };
-
-  const _renderImage = () => (
-    <View style={styles.imageContainer}>
-      <Image source={{ uri: image.localUri || image.uri }} style={styles.image} />
-    </View>
-  );
 
   return (
     <View style={styles.container}>
-      {ready && image && _renderImage()}
-      <Button title="Rotate and Flip" onPress={_rotate90andFlip} />
+      <View style={styles.imageContainer}>
+        <Image source={{ uri: image.localUri || image.uri }} style={styles.image} />
+      </View>
+      <Button title="Rotate and Flip" onPress={rotate90andFlip} />
     </View>
   );
 }


### PR DESCRIPTION
# Why

Docs were using deprecated API.

# How

New basic example with `useImageManipulator` and backport it to SDK 52