### PR TITLE
[docs] Update entry point common question in `registerRootComponent` to link to Expo Router doc

### DIFF
--- a/docs/pages/versions/unversioned/sdk/expo.mdx
+++ b/docs/pages/versions/unversioned/sdk/expo.mdx
@@ -49,7 +49,7 @@ console.log(buffer.length); // 512
 
 ### What if I want to name my main app file something other than App.js or app/\_layout.tsx?
 
-**For projects that do not use [Expo Router](/router/introduction/)**, you can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`, `export default` will not make this component the root for the app if you are using a custom entry file.
+**For projects that do not use [Expo Router](/router/introduction/)**, you can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`. The `export default` will not make this component the root for the app if you are using a custom entry file.
 
 For example, let's say you want to make **src/main.jsx** the entry file for your app &mdash; maybe you don't like having JavaScript files in the project root. First, set this in **package.json**:
 

--- a/docs/pages/versions/unversioned/sdk/expo.mdx
+++ b/docs/pages/versions/unversioned/sdk/expo.mdx
@@ -47,11 +47,11 @@ console.log(buffer.length); // 512
 
 ## Common questions
 
-### What if I want to name my main app file something other than App.js?
+### What if I want to name my main app file something other than App.js or app/\_layout.tsx?
 
-You can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`. The `export default` will not make this component the root of the app if you are using a custom entry file.
+**For projects that do not use [Expo Router](/router/introduction/)**, you can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`, `export default` will not make this component the root for the app if you are using a custom entry file.
 
-For example, you want to make **src/main.jsx** the entry file for your app and organize all of your app's source code in **src** directory. You can set this in **package.json**:
+For example, let's say you want to make **src/main.jsx** the entry file for your app &mdash; maybe you don't like having JavaScript files in the project root. First, set this in **package.json**:
 
 ```json package.json
 {
@@ -71,3 +71,5 @@ function App() {
 
 registerRootComponent(App);
 ```
+
+**For projects that use [Expo Router](/router/introduction/)**, you can create a custom entry point by following these steps from [Expo Router's installation guide](/router/installation/#custom-entry-point-to-initialize-and-load). To use the top-level **src** directory in your Expo Router project, see [src directory reference](/router/reference/src-directory/) for more information.

--- a/docs/pages/versions/unversioned/sdk/register-root-component.mdx
+++ b/docs/pages/versions/unversioned/sdk/register-root-component.mdx
@@ -66,13 +66,11 @@ No return value.
 
 ## Common questions
 
-### What if I want to name my main app file something other than App.js?
+### What if I want to name my main app file something other than App.js or app/\_layout.tsx?
 
-You can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`,
-`export default` will not make this component the root for the app if you are using a custom entry file.
+**For projects that do not use [Expo Router](/router/introduction/)**, you can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`, `export default` will not make this component the root for the app if you are using a custom entry file.
 
-For example, let's say you want to make **src/main.jsx** the entry file for your app - maybe you don't like having JavaScript files in the
-project root. First, set this in **package.json**:
+For example, let's say you want to make **src/main.jsx** the entry file for your app &mdash; maybe you don't like having JavaScript files in the project root. First, set this in **package.json**:
 
 ```json package.json
 {
@@ -80,7 +78,7 @@ project root. First, set this in **package.json**:
 }
 ```
 
-Then in **src/main.jsx**, make sure you call `registerRootComponent` and pass in the component you want to render at the root of the app.
+Then, in **src/main.jsx**, make sure you call `registerRootComponent` and pass in the component you want to render at the root of the app:
 
 ```jsx src/main.jsx
 import { registerRootComponent } from 'expo';
@@ -92,3 +90,5 @@ function App() {
 
 registerRootComponent(App);
 ```
+
+**For projects that use [Expo Router](/router/introduction/)**, you can create a custom entry point by following these steps from [Expo Router's installation guide](/router/installation/#custom-entry-point-to-initialize-and-load). To use the top-level **src** directory in your Expo Router project, see [src directory reference](/router/reference/src-directory/) for more information.

--- a/docs/pages/versions/unversioned/sdk/register-root-component.mdx
+++ b/docs/pages/versions/unversioned/sdk/register-root-component.mdx
@@ -68,7 +68,7 @@ No return value.
 
 ### What if I want to name my main app file something other than App.js or app/\_layout.tsx?
 
-**For projects that do not use [Expo Router](/router/introduction/)**, you can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`, `export default` will not make this component the root for the app if you are using a custom entry file.
+**For projects that do not use [Expo Router](/router/introduction/)**, you can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`. The `export default` will not make this component the root for the app if you are using a custom entry file.
 
 For example, let's say you want to make **src/main.jsx** the entry file for your app &mdash; maybe you don't like having JavaScript files in the project root. First, set this in **package.json**:
 

--- a/docs/pages/versions/unversioned/sdk/register-root-component.mdx
+++ b/docs/pages/versions/unversioned/sdk/register-root-component.mdx
@@ -58,7 +58,7 @@ This function also adds the following dev-only features that are **removed** in 
 
 #### Arguments
 
-- **component (ReactComponent)** -- The React component class that renders the rest of your app.
+- **component (ReactComponent)**: The React component class that renders the rest of your app.
 
 #### Returns
 

--- a/docs/pages/versions/v50.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/register-root-component.mdx
@@ -62,7 +62,7 @@ This function also adds the following dev-only features that are **removed** in 
 
 #### Arguments
 
-- **component (ReactComponent)** -- The React component class that renders the rest of your app.
+- **component (ReactComponent)**: The React component class that renders the rest of your app.
 
 #### Returns
 

--- a/docs/pages/versions/v51.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/register-root-component.mdx
@@ -60,7 +60,7 @@ This function also adds the following dev-only features that are **removed** in 
 
 #### Arguments
 
-- **component (ReactComponent)** -- The React component class that renders the rest of your app.
+- **component (ReactComponent)**: The React component class that renders the rest of your app.
 
 #### Returns
 

--- a/docs/pages/versions/v52.0.0/sdk/expo.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/expo.mdx
@@ -50,7 +50,7 @@ console.log(buffer.length); // 512
 
 ### What if I want to name my main app file something other than App.js or app/\_layout.tsx?
 
-**For projects that do not use [Expo Router](/router/introduction/)**, you can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`, `export default` will not make this component the root for the app if you are using a custom entry file.
+**For projects that do not use [Expo Router](/router/introduction/)**, you can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`. The `export default` will not make this component the root for the app if you are using a custom entry file.
 
 For example, let's say you want to make **src/main.jsx** the entry file for your app &mdash; maybe you don't like having JavaScript files in the project root. First, set this in **package.json**:
 

--- a/docs/pages/versions/v52.0.0/sdk/expo.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/expo.mdx
@@ -48,11 +48,11 @@ console.log(buffer.length); // 512
 
 ## Common questions
 
-### What if I want to name my main app file something other than App.js?
+### What if I want to name my main app file something other than App.js or app/\_layout.tsx?
 
-You can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`. The `export default` will not make this component the root of the app if you are using a custom entry file.
+**For projects that do not use [Expo Router](/router/introduction/)**, you can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`, `export default` will not make this component the root for the app if you are using a custom entry file.
 
-For example, you want to make **src/main.jsx** the entry file for your app and organize all of your app's source code in **src** directory. You can set this in **package.json**:
+For example, let's say you want to make **src/main.jsx** the entry file for your app &mdash; maybe you don't like having JavaScript files in the project root. First, set this in **package.json**:
 
 ```json package.json
 {
@@ -72,3 +72,5 @@ function App() {
 
 registerRootComponent(App);
 ```
+
+**For projects that use [Expo Router](/router/introduction/)**, you can create a custom entry point by following these steps from [Expo Router's installation guide](/router/installation/#custom-entry-point-to-initialize-and-load). To use the top-level **src** directory in your Expo Router project, see [src directory reference](/router/reference/src-directory/) for more information.

--- a/docs/pages/versions/v52.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/register-root-component.mdx
@@ -66,13 +66,11 @@ No return value.
 
 ## Common questions
 
-### What if I want to name my main app file something other than App.js?
+### What if I want to name my main app file something other than App.js or app/\_layout.tsx?
 
-You can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`,
-`export default` will not make this component the root for the app if you are using a custom entry file.
+**For projects that do not use [Expo Router](/router/introduction/)**, you can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`, `export default` will not make this component the root for the app if you are using a custom entry file.
 
-For example, let's say you want to make **src/main.jsx** the entry file for your app - maybe you don't like having JavaScript files in the
-project root. First, set this in **package.json**:
+For example, let's say you want to make **src/main.jsx** the entry file for your app &mdash; maybe you don't like having JavaScript files in the project root. First, set this in **package.json**:
 
 ```json package.json
 {
@@ -80,7 +78,7 @@ project root. First, set this in **package.json**:
 }
 ```
 
-Then in **src/main.jsx**, make sure you call `registerRootComponent` and pass in the component you want to render at the root of the app.
+Then, in **src/main.jsx**, make sure you call `registerRootComponent` and pass in the component you want to render at the root of the app:
 
 ```jsx src/main.jsx
 import { registerRootComponent } from 'expo';
@@ -92,3 +90,5 @@ function App() {
 
 registerRootComponent(App);
 ```
+
+**For projects that use [Expo Router](/router/introduction/)**, you can create a custom entry point by following these steps from [Expo Router's installation guide](/router/installation/#custom-entry-point-to-initialize-and-load). To use the top-level **src** directory in your Expo Router project, see [src directory reference](/router/reference/src-directory/) for more information.

--- a/docs/pages/versions/v52.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/register-root-component.mdx
@@ -68,7 +68,7 @@ No return value.
 
 ### What if I want to name my main app file something other than App.js or app/\_layout.tsx?
 
-**For projects that do not use [Expo Router](/router/introduction/)**, you can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`, `export default` will not make this component the root for the app if you are using a custom entry file.
+**For projects that do not use [Expo Router](/router/introduction/)**, you can set the `"main"` in **package.json** to any file within your project. If you do this, then you need to use `registerRootComponent`. The `export default` will not make this component the root for the app if you are using a custom entry file.
 
 For example, let's say you want to make **src/main.jsx** the entry file for your app &mdash; maybe you don't like having JavaScript files in the project root. First, set this in **package.json**:
 

--- a/docs/pages/versions/v52.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/register-root-component.mdx
@@ -58,7 +58,7 @@ This function also adds the following dev-only features that are **removed** in 
 
 #### Arguments
 
-- **component (ReactComponent)** -- The React component class that renders the rest of your app.
+- **component (ReactComponent)**: The React component class that renders the rest of your app.
 
 #### Returns
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-14120

# How

<!--
How did you build this feature or fix this bug and why?
-->

In the `registerRootComponent` API reference , I've updated the question to include `app/_layout.tsx` file reference and added a new paragraph that links to Expo Router installation guide [here](https://docs.expo.dev/router/installation/#custom-entry-point-to-initialize-and-load) (where setting custom entry point information is covered) and linked to top-level src directory reference guide.

Also, update this FAQ item in the `expo` API reference.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-02-25 at 20 12 50@2x](https://github.com/user-attachments/assets/b757956b-dccf-4c44-a967-a76c5066694b)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
