### PR TITLE
feat: mock patching FormData

### DIFF
--- a/packages/expo/src/winter/__mocks__/winter.ts
+++ b/packages/expo/src/winter/__mocks__/winter.ts
@@ -1,3 +1,0 @@
-jest.mock('../FormData', () => ({
-  installFormDataPatch: jest.fn(),
-}));

--- a/packages/expo/src/winter/__mocks__/winter.ts
+++ b/packages/expo/src/winter/__mocks__/winter.ts
@@ -1,0 +1,3 @@
+jest.mock('../FormData', () => ({
+  installFormDataPatch: jest.fn(),
+}));

--- a/packages/expo/src/winter/__tests__/FormData.test.ios.ts
+++ b/packages/expo/src/winter/__tests__/FormData.test.ios.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-global-assign */
-import { installFormDataPatch, type ExpoFormData } from '../FormData';
+import { type ExpoFormData } from '../FormData';
 
+const { installFormDataPatch } = jest.requireActual('../../FormData');
 const jestFormDataPolyfill = FormData;
 
 beforeAll(() => {

--- a/packages/expo/src/winter/__tests__/FormData.test.ios.ts
+++ b/packages/expo/src/winter/__tests__/FormData.test.ios.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-global-assign */
 import { type ExpoFormData } from '../FormData';
 
-const { installFormDataPatch } = jest.requireActual('../../FormData');
+const { installFormDataPatch } = jest.requireActual('../FormData');
 const jestFormDataPolyfill = FormData;
 
 beforeAll(() => {

--- a/packages/expo/src/winter/fetch/__tests__/convertFormData-test.native.ts
+++ b/packages/expo/src/winter/fetch/__tests__/convertFormData-test.native.ts
@@ -1,13 +1,13 @@
 import RNFormData from 'react-native/Libraries/Network/FormData';
 import { TextDecoder, TextEncoder } from 'util';
 
-import { installFormDataPatch } from '../../FormData';
 import { createBoundary, convertFormDataAsync, joinUint8Arrays } from '../convertFormData';
 
 // @ts-ignore - TextDecoder and TextEncoder are not defined in native jest environments.
 globalThis.TextDecoder ??= TextDecoder;
 globalThis.TextEncoder ??= TextEncoder;
 
+const { installFormDataPatch } = jest.requireActual('../../FormData');
 const ExpoFormData = installFormDataPatch(RNFormData);
 
 describe(convertFormDataAsync, () => {

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed jest error from `FormData`. ([#35162](https://github.com/expo/expo/pull/35162) by [@WoLewicki](https://github.com/WoLewicki))
+
 ### 💡 Others
 
 ## 52.0.4 - 2025-02-14

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -293,5 +293,8 @@ try {
 // Installs web implementations of global things that are normally installed through JSI.
 require('expo-modules-core/src/web/index.web');
 
+jest.doMock('expo/src/winter/FormData', () => ({
+  installFormDataPatch: jest.fn(),
+}));
 // Ensure the environment globals are installed before the first test runs.
 require('expo/src/winter');

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -294,6 +294,8 @@ try {
 require('expo-modules-core/src/web/index.web');
 
 jest.doMock('expo/src/winter/FormData', () => ({
+  // The `installFormDataPatch` function is for native runtime only,
+  // so we don't need to patch `FormData` for the jest runtime.
   installFormDataPatch: jest.fn(),
 }));
 // Ensure the environment globals are installed before the first test runs.


### PR DESCRIPTION
# Why

https://github.com/expo/expo/commit/2aaa092fde832721345502e1142726fd4dddff6e destroyed the flow with testing things using `FormData` in `jest`. Since RN does not patch `FormData` for tests here: https://github.com/facebook/react-native/blob/db4086de9716f89470d59a99cef71c9135202a0e/packages/react-native/jest/setup.js#L70 which makes https://github.com/facebook/react-native/blob/db4086de9716f89470d59a99cef71c9135202a0e/packages/react-native/Libraries/Core/setUpXHR.js#L25C17-L25C25 not being applied. Therefore we don't have `_parts` array in `FormData` and the tests fail.

Shoutout to @Kicu for helping me debug it in Expensify App 🎉 
 
# How

Add a mock for prototype changing to mimic RN behavior. We should think if maybe it is RN which does the things wrong and maybe it should apply the prototype change for tests too? cc @Kudo wdyt about it since you added those changes?

# Test Plan

Run jest tests in any repo using `expo` and try to append something to `FormData` in the test.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
