### PR TITLE
[expo][ios] Add EXAppDelegateWrapper import to Expo.h

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 - [apple] Move `AppDelegate` integration from `expo-modules-core` to `expo` package. ([#34985](https://github.com/expo/expo/pull/34985) by [@lukmccall](https://github.com/lukmccall))
+- [apple] Add EXAppDelegateWrapper import to Expo.h ([#35172](https://github.com/expo/expo/pull/35172) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 52.0.37 - 2025-02-20
 

--- a/packages/expo/ios/Expo.h
+++ b/packages/expo/ios/Expo.h
@@ -1,2 +1,3 @@
 #import <ExpoModulesCore/ExpoModulesCore.h>
 #import <Expo/EXAppDefinesLoader.h>
+#import <Expo/EXAppDelegateWrapper.h>


### PR DESCRIPTION
# Why

When moving `AppDelegate` integration from expo-modules-core to expo on https://github.com/expo/expo/pull/34985 we ended up changing the location of `EXAppDelegateWrapper`, causing EXAppDelegateWrapper's header to no longer be included in `<ExpoModulesCore/ExpoModulesCore.h>`. To ensure that users can still inherit their Objective C AppDelegate's from `EXAppDelegateWrapper`just using the `<Expo/Expo.h>` import we must add`EXAppDelegateWrapper` header to `Expo.h`



# How

Add `EXAppDelegateWrapper` header to `Expo.h`

# Test Plan

Run FabricTester locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
