### PR TITLE
[core][ios] Re-Dispatch `View` `AsyncFunction` calls when the `View` is not registered

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [iOS] Fixed ViewModuleWrapper initializer on old arch to use the DEFAULT_MODULE_VIEW view from the module as the default view. ([#35007](https://github.com/expo/expo/pull/35007) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix UnimplementedExpoView on macOS. ([#35014](https://github.com/expo/expo/pull/35014) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fix tvOS breakage. ([#35146](https://github.com/expo/expo/pull/35146) by [@douglowder](https://github.com/douglowder))
+- [iOS] Fix calls to `AsyncFunction` not working in the initial render of a `View`. ([#35176](https://github.com/expo/expo/pull/35176) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
@@ -135,15 +135,13 @@ public final class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyA
 #if RCT_NEW_ARCH_ENABLED
       // Checks if this is a view function unregistered in the view registry. The check can be performed from the main thread only.
       if retryCount < maxRetryCount,
-      let viewTag = arguments.first as? Int,
-      let uiManager = appContext.reactBridge?.uiManager,
-      self.dynamicArgumentTypes.first is DynamicViewType,
-      Thread.isMainThread, // swiftlint:disable:next legacy_objc_type
-      uiManager.view(forReactTag: NSNumber(value: viewTag)) == nil {
+        let viewTag = arguments.first as? Int,
+        let uiManager = appContext.reactBridge?.uiManager,
+        self.dynamicArgumentTypes.first is DynamicViewType,
+        Thread.isMainThread, // swiftlint:disable:next legacy_objc_type
+        uiManager.view(forReactTag: NSNumber(value: viewTag)) == nil {
         // Schedule the block on the original queue through UI manager if view is missing in the registry.
-        DispatchQueue.main.async {
-          self.dispatchOnQueueUntilViewRegisters(appContext: appContext, arguments: arguments, queue: queue, retryCount: retryCount + 1, block)
-        }
+        self.dispatchOnQueueUntilViewRegisters(appContext: appContext, arguments: arguments, queue: queue, retryCount: retryCount + 1, block)
         return
       }
 #endif


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/33582
Similar to https://github.com/expo/expo/commit/bfe63e33cef041d1b3a1004fed0abefd54504bda

In iOS on new Architecture when a view function is called from the initial render 
```
useEffect({ viewRef.current.someAsyncFunction() },[])
```
it will be called before the view is added to the viewRegistry, which means that the argument conversion will fail (the first argument of the function is the view)

# How

We check for the conditions in which this situation occurs and re-dispatch the function up to three times waiting for the viewManager to get the information about the view. This is sub-optimal, but we don't have access to the scheduler, which would allow us to do this properly.

# Test Plan

Tested in BareExpo on iOS
