### PR TITLE
[module-plugin] Apply publishing in `finalizeDsl`

### DIFF
--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
@@ -2,6 +2,7 @@
 
 package expo.modules.plugin
 
+import com.android.build.api.variant.AndroidComponentsExtension
 import expo.modules.plugin.gradle.ExpoGradleHelperExtension
 import expo.modules.plugin.gradle.ExpoModuleExtension
 import org.gradle.api.Plugin
@@ -23,7 +24,10 @@ abstract class ExpoModulesGradlePlugin : Plugin<Project> {
       applyKotlin(kotlinVersion, kspVersion)
       applyDefaultDependencies()
       applyDefaultAndroidSdkVersions()
-      applyPublishing(expoModuleExtension)
+
+      extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl {
+        applyPublishing(expoModuleExtension)
+      }
     }
 
     // Adds the expoGradleHelper extension to the gradle instance if it doesn't exist.

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -54,17 +54,21 @@ internal fun Project.applyDefaultAndroidSdkVersions() {
   }
 }
 
+/**
+ * Applies the necessary configuration for publishing to the local Maven repository.
+ * It need to be called when DSL is finalized.
+ */
 internal fun Project.applyPublishing(expoModulesExtension: ExpoModuleExtension) {
+  if (!expoModulesExtension.canBePublished) {
+    return
+  }
+
   val libraryExtension = androidLibraryExtension()
 
   libraryExtension
     .applyPublishingVariant()
 
   afterEvaluate {
-    if (!expoModulesExtension.canBePublished) {
-      return@afterEvaluate
-    }
-    
     val publicationInfo = PublicationInfo(this)
 
     publishingExtension()


### PR DESCRIPTION
# Why

Moves applying publishing configuration to the `finalizeDsl` block to not change the publishing variant to the Android release if not needed. 

# Test Plan

- bare-expo and `expoPublishToMavenLocal` ✅ 