### PR TITLE
Fix reset-project script to remove unused dependencies

### DIFF
--- a/templates/expo-template-default/scripts/reset-project.js
+++ b/templates/expo-template-default/scripts/reset-project.js
@@ -3,9 +3,11 @@
 /**
  * This script is used to reset the project to a blank state.
  * It deletes or moves the /app, /components, /hooks, /scripts, and /constants directories to /app-example based on user input and creates a new /app directory with an index.tsx and _layout.tsx file.
+ * If the /app-example directory is deleted, the script also removes related dependencies.
  * You can remove the `reset-project` script from package.json and safely delete this file after running it.
  */
 
+const { execSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const readline = require("readline");
@@ -39,6 +41,21 @@ export default function RootLayout() {
   return <Stack />;
 }
 `;
+
+const dependenciesToRemove = [
+  "@expo/vector-icons",
+  "@react-navigation/bottom-tabs",
+  "@react-navigation/native",
+  "expo-blur",
+  "expo-font",
+  "expo-haptics",
+  "expo-status-bar",
+  "expo-symbols",
+  "expo-web-browser",
+  "@babel/core",
+  "@types/react-test-renderer",
+  "react-test-renderer",
+];
 
 const rl = readline.createInterface({
   input: process.stdin,
@@ -84,6 +101,23 @@ const moveDirectories = async (userInput) => {
     const layoutPath = path.join(newAppDirPath, "_layout.tsx");
     await fs.promises.writeFile(layoutPath, layoutContent);
     console.log("📄 app/_layout.tsx created.");
+
+    // Remove example-related dependencies if /app-example is deleted
+    if (userInput === "n") {
+      const packageManager = process.env.npm_execpath?.includes("yarn")
+      ? "yarn"
+      : process.env.npm_execpath?.includes("pnpm")
+      ? "pnpm"
+      : process.env.npm_execpath?.includes("bun")
+      ? "bun"
+      : "npm";
+
+      console.log(`\n🗑 Removing example-related dependencies with ${packageManager}...`);
+      execSync(
+        `${packageManager} ${packageManager === "npm" ? "uninstall" : "remove"} ${dependenciesToRemove.join(" ")}`,
+        { stdio: "inherit" }
+      );
+    }
 
     console.log("\n✅ Project reset complete. Next steps:");
     console.log(


### PR DESCRIPTION
# Why

Previously, after running the `reset-project` script, unused example-related dependencies were not removed, leaving `package.json` bloated with unnecessary packages. This caused confusion when checking for unused dependencies with `depcheck` and made the dependency list longer than necessary.

This PR ensures that when the user opts to delete example files, the related dependencies are also removed, keeping `package.json` clean and reflecting the actual dependencies used in the project.

# How

- Detects the correct package manager to remove dependencies properly
- Removes example-related dependencies when the user chooses to delete example files 

# Test Plan

1. Check for unused dependencies before running the script with `depcheck`
```bash
➜  expo-script-test git:(main) ✗ depcheck
Unused dependencies
* expo-system-ui
* react-dom
* react-native-gesture-handler
* react-native-web
Unused devDependencies
* @types/jest
* typescript
```

2. Run the reset-project script and remove example files 
```bash
pnpm reset-project  # or yarn reset-project / npm run reset-project / bun reset-project
```
3. Verify that dependencies were removed: 

```bash
➜  expo-script-test git:(main) ✗ depcheck
Unused dependencies
* expo-splash-screen
* expo-system-ui
* react-dom
* react-native-gesture-handler
* react-native-web
Unused devDependencies
* @types/jest
* typescript
```

The only difference is `expo-splash-screen`, but this is a false positive because it is referenced in the `app.json` configuration file.

```json
    "plugins": [
      "expo-router",
      [
        "expo-splash-screen",
        {
          "image": "./assets/images/splash-icon.png",
          "imageWidth": 200,
          "resizeMode": "contain",
          "backgroundColor": "#ffffff"
        }
      ]
    ],
```

The full terminal output for all three steps, executed sequentially.

```bash
➜  expo-script-test git:(main) ✗ depcheck
Unused dependencies
* expo-system-ui
* react-dom
* react-native-gesture-handler
* react-native-web
Unused devDependencies
* @types/jest
* typescript
➜  expo-script-test git:(main) ✗ pnpm reset-project

> expo-script-test@1.0.0 reset-project /Users/lukas/Documents/UpLeveled/expo-script-test
> node ./scripts/reset-project.js

Do you want to move existing files to /app-example instead of deleting them? (Y/n): n
❌ /app deleted.
❌ /components deleted.
❌ /hooks deleted.
❌ /constants deleted.
❌ /scripts deleted.

📁 New /app directory created.
📄 app/index.tsx created.
📄 app/_layout.tsx created.

🗑 Removing example-related dependencies with pnpm...
 WARN  12 deprecated subdependencies found: @babel/plugin-proposal-class-properties@7.18.6, @babel/plugin-proposal-nullish-coalescing-operator@7.18.6, @babel/plugin-proposal-optional-chaining@7.21.0, @xmldom/xmldom@0.7.13, abab@2.0.6, domexception@4.0.0, glob@7.2.3, inflight@1.0.6, rimraf@2.6.3, rimraf@3.0.2, sudo-prompt@8.2.5, sudo-prompt@9.1.1

dependencies:
- @expo/vector-icons ^14.0.2
- @react-navigation/bottom-tabs ^7.2.0
- @react-navigation/native ^7.0.14
- expo-blur ~14.0.3
- expo-font ~13.0.3
- expo-haptics ~14.0.1
- expo-status-bar ~2.0.1
- expo-symbols ~0.2.2
- expo-web-browser ~14.0.2

devDependencies:
- @babel/core ^7.25.2
- @types/react-test-renderer ^18.3.0
- react-test-renderer 18.3.1

 WARN  Issues with peer dependencies found
.
└─┬ jest-expo 52.0.3
  └─┬ react-server-dom-webpack 19.0.0-rc-6230622a1a-20240610
    ├── ✕ unmet peer react@19.0.0-rc-6230622a1a-20240610: found 18.3.1
    └── ✕ unmet peer react-dom@19.0.0-rc-6230622a1a-20240610: found 18.3.1

Packages: +35
+++++++++++++++++++++++++++++++++++
Progress: resolved 1041, reused 50, downloaded 0, added 35, done
Done in 2.7s

✅ Project reset complete. Next steps:
1. Run `npx expo start` to start a development server.
2. Edit app/index.tsx to edit the main screen.
➜  expo-script-test git:(main) ✗ depcheck
Unused dependencies
* expo-splash-screen
* expo-system-ui
* react-dom
* react-native-gesture-handler
* react-native-web
Unused devDependencies
* @types/jest
* typescript
```

## Steps to reproduce

1. Create expo project 
```bash
npx create-expo-app@latest
```
2. Install `depcheck` globally
```bash
npm install -g depcheck
```
3. Run `depcheck` to check for unused dependencies before running the script
```bash
depcheck
```
4. Run the `reset-script` scipt
```bash
pnpm reset-project  # or yarn reset-project / npm run reset-project / bun reset-project
```
5. Run depcheck again to verify dependency removal
```bash
depcheck
```
# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
