### PR TITLE
stb_image PNG: Checks for invalid DEFLATE codes.

### DIFF
--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- stb_image PNG: Checks for invalid DEFLATE codes. ([#35184](https://github.com/expo/expo/pull/35184) by [@manoj23](https://github.com/manoj23))
 
 ### 💡 Others
 

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
 - stb_image PNG: Checks for invalid DEFLATE codes. ([#35184](https://github.com/expo/expo/pull/35184) by [@manoj23](https://github.com/manoj23))
 
 ### 💡 Others

--- a/packages/expo-gl/common/stb_image.h
+++ b/packages/expo-gl/common/stb_image.h
@@ -4010,13 +4010,13 @@ static int stbi__parse_huffman_block(stbi__zbuf *a) {
         a->zout = zout;
         return 1;
       }
+      if (z >= 286) return stbi__err("bad huffman code","Corrupt PNG"); // per DEFLATE, length codes 286 and 287 must not appear in compressed data
       z -= 257;
       len = stbi__zlength_base[z];
       if (stbi__zlength_extra[z])
         len += stbi__zreceive(a, stbi__zlength_extra[z]);
       z = stbi__zhuffman_decode(a, &a->z_distance);
-      if (z < 0)
-        return stbi__err("bad huffman code", "Corrupt PNG");
+      if (z < 0 || z >= 30) return stbi__err("bad huffman code","Corrupt PNG"); // per DEFLATE, distance codes 30 and 31 must not appear in compressed data
       dist = stbi__zdist_base[z];
       if (stbi__zdist_extra[z])
         dist += stbi__zreceive(a, stbi__zdist_extra[z]);

--- a/packages/expo-gl/common/stb_image.h
+++ b/packages/expo-gl/common/stb_image.h
@@ -4010,13 +4010,15 @@ static int stbi__parse_huffman_block(stbi__zbuf *a) {
         a->zout = zout;
         return 1;
       }
-      if (z >= 286) return stbi__err("bad huffman code","Corrupt PNG"); // per DEFLATE, length codes 286 and 287 must not appear in compressed data
+      if (z >= 286) 
+        return stbi__err("bad huffman code", "Corrupt PNG"); // per DEFLATE, length codes 286 and 287 must not appear in compressed data
       z -= 257;
       len = stbi__zlength_base[z];
       if (stbi__zlength_extra[z])
         len += stbi__zreceive(a, stbi__zlength_extra[z]);
       z = stbi__zhuffman_decode(a, &a->z_distance);
-      if (z < 0 || z >= 30) return stbi__err("bad huffman code","Corrupt PNG"); // per DEFLATE, distance codes 30 and 31 must not appear in compressed data
+      if (z < 0 || z >= 30) 
+        return stbi__err("bad huffman code", "Corrupt PNG"); // per DEFLATE, distance codes 30 and 31 must not appear in compressed data
       dist = stbi__zdist_base[z];
       if (stbi__zdist_extra[z])
         dist += stbi__zreceive(a, stbi__zdist_extra[z]);


### PR DESCRIPTION
Specifically, this rejects length codes 286 and 287, and distance codes 30 and 31. This avoids a scenario in which a file could contain a table in which 0 corresponded to length code 287, which would result in writing 0 bits.

Signed-off-by: Neil Bickford <nbickford@nvidia.com>
(cherry pick commit 9f22cc90 from github.com:nothings/stb.git)

# Why



# How

Found this issue with Coverity and found the patch upstream that already fix the issue.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
