### PR TITLE
[updates] Break logger dependency for tests

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogger.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogger.kt
@@ -7,10 +7,14 @@ import expo.modules.core.logging.Logger
 import expo.modules.core.logging.LoggerTimer
 import java.util.Date
 
+interface IUpdatesLogger {
+  fun startTimer(label: String): LoggerTimer
+}
+
 /**
  * Class that implements logging for expo-updates with its own logcat tag
  */
-class UpdatesLogger(context: Context) {
+class UpdatesLogger(context: Context) : IUpdatesLogger {
 
   fun trace(
     message: String,
@@ -112,7 +116,7 @@ class UpdatesLogger(context: Context) {
     logger.fatal(logEntryWithCauseExceptionString(message, exception, code, LogType.Fatal, null, updateId, assetId))
   }
 
-  fun startTimer(label: String): LoggerTimer {
+  override fun startTimer(label: String): LoggerTimer {
     return logger.startTimer { duration ->
       logEntryString(label, UpdatesErrorCode.None, LogType.Timer, duration, null, null)
     }


### PR DESCRIPTION
# Why
I want to make `StateMachineSerialExecutorQueueTest` a unit test and remove it from the instrumentation tests. The more tests we can decouple from the framework, the faster they will run. It only depends on the Android SDK because the `StateMachineSerialExecutorQueue` accepts an `UpdateLogger` instance which requires a context to be created.

# How
Create an Logger interface that can easily be mocked in the tests

# Test Plan
Does not effect existing behaviour. I will follow up with moving the test to the `test` folder. 