### PR TITLE
[updates] Fix runtime version validation warning

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [android] Use more robust mechanism for determining empty multipart bodies. ([#33977](https://github.com/expo/expo/pull/33977) by [@wschurman](https://github.com/wschurman))
 - fix E2E tests in Detox debug build ([#32951](https://github.com/expo/expo/pull/32951) by [@matejkriz](https://github.com/matejkriz))
+- Fix runtime version validation warning ([#35188](https://github.com/expo/expo/pull/35188) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-updates/utils/build/resolveRuntimeVersionAsync.js
+++ b/packages/expo-updates/utils/build/resolveRuntimeVersionAsync.js
@@ -15,6 +15,9 @@ async function resolveRuntimeVersionAsync(projectRoot, platform, fingerprintOpti
     if (!runtimeVersion || typeof runtimeVersion === 'string') {
         return { runtimeVersion: runtimeVersion ?? null, fingerprintSources: null, workflow };
     }
+    if (typeof runtimeVersion !== 'object' || Array.isArray(runtimeVersion)) {
+        throw new Error(`Invalid runtime version: ${JSON.stringify(runtimeVersion)}. Expected a string or an object with a "policy" key. https://docs.expo.dev/eas-update/runtime-versions`);
+    }
     const policy = runtimeVersion.policy;
     if (policy === 'fingerprint') {
         const fingerprint = await (0, createFingerprintAsync_1.createFingerprintAsync)(projectRoot, platform, workflow, fingerprintOptions);

--- a/packages/expo-updates/utils/src/resolveRuntimeVersionAsync.ts
+++ b/packages/expo-updates/utils/src/resolveRuntimeVersionAsync.ts
@@ -28,6 +28,11 @@ export async function resolveRuntimeVersionAsync(
     return { runtimeVersion: runtimeVersion ?? null, fingerprintSources: null, workflow };
   }
 
+  if (typeof runtimeVersion !== 'object' || Array.isArray(runtimeVersion)) {
+    throw new Error(
+      `Invalid runtime version: ${JSON.stringify(runtimeVersion)}. Expected a string or an object with a "policy" key. https://docs.expo.dev/eas-update/runtime-versions`
+    );
+  }
   const policy = runtimeVersion.policy;
 
   if (policy === 'fingerprint') {


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/34951

# How

Add a warning message if `runtimeVersion` is not a string or an object

# Test Plan

Run `eas update` in a managed project and a bare project

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
