### PR TITLE
[docs] Describe workflow defaults

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -210,6 +210,29 @@ jobs:
         run: pwd # prints: /home/expo/workingdir/build/my-app
 ```
 
+## `defaults`
+
+Parameters to use as defaults for all jobs defined in the workflow configuration.
+
+### `defaults.run.working_directory`
+
+Default working directory to run the scripts in. Relative paths like "./assets" or "assets" are resolved from the app's base directory. Absolute paths like "/apps/mobile" are resolved from the repository root.
+
+### `defaults.tools`
+
+Specific versions of tools that should be used for jobs defined in this workflow configuration. Follow each tool's documentation for available values.
+
+| Tool      | Description             |
+| --------- | ----------------------- |
+| node      | Version of Node.js.     |
+| yarn      | Version of Yarn.        |
+| pnpm      | Version of pnpm.        |
+| bun       | Version of Bun.         |
+| ndk       | Version of Android NDK. |
+| bundler   | Version of Bundler.     |
+| fastlane  | Version of fastlane.    |
+| cocoapods | Version of CocoaPods.   |
+
 ## Control flow
 
 You can control when jobs run and what jobs must complete successfully before a job runs using the `needs` and `after` keywords. In addition, you can use the `if` keyword to control whether a job should run based on a condition.

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -216,7 +216,7 @@ Parameters to use as defaults for all jobs defined in the workflow configuration
 
 ### `defaults.run.working_directory`
 
-Default working directory to run the scripts in. Relative paths like "./assets" or "assets" are resolved from the app's base directory. Absolute paths like "/apps/mobile" are resolved from the repository root.
+Default working directory to run the scripts in. Relative paths like "./assets" or "assets" are resolved from the app's base directory.
 
 ### `defaults.tools`
 
@@ -236,7 +236,7 @@ Specific versions of tools that should be used for jobs defined in this workflow
 Example of workflow using `defaults.tools`:
 
 ```yaml .eas/workflows/publish-update.yml
-name: Publish update
+name: Set up custom versions
 defaults:
   tools:
     node: latest
@@ -248,12 +248,12 @@ on:
     branches: ['*']
 
 jobs:
-  # Update will be built using Node 20 etc.
-  update:
-    name: Update
-    type: update
-    params:
-      branch: ${{ github.ref_name || 'test'}}
+  setup:
+    steps:
+      - name: Check Node version
+        run: node --version # should print a concrete version, like 23.9.0
+      - name: Check Yarn version
+        run: yarn --version # should print a concrete version, like 2.4.3
 ```
 
 ## Control flow

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -233,6 +233,28 @@ Specific versions of tools that should be used for jobs defined in this workflow
 | fastlane  | Version of fastlane.    |
 | cocoapods | Version of CocoaPods.   |
 
+Example of workflow using `defaults.tools`:
+
+```yml
+defaults:
+  tools:
+    node: 20
+    yarn: 2.0.1
+    fastlane: latest
+
+on:
+  push:
+    branches: ['*']
+
+jobs:
+  # Update will be built using Node 20 etc.
+  update:
+    name: Update
+    type: update
+    params:
+      branch: ${{ github.ref_name || 'test'}}
+```
+
 ## Control flow
 
 You can control when jobs run and what jobs must complete successfully before a job runs using the `needs` and `after` keywords. In addition, you can use the `if` keyword to control whether a job should run based on a condition.

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -235,12 +235,13 @@ Specific versions of tools that should be used for jobs defined in this workflow
 
 Example of workflow using `defaults.tools`:
 
-```yml
+```yaml .eas/workflows/publish-update.yml
+name: Publish update
 defaults:
   tools:
-    node: 20
-    yarn: 2.0.1
-    fastlane: latest
+    node: latest
+    yarn: '2'
+    fastlane: 2.224.0
 
 on:
   push:

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -222,16 +222,16 @@ Default working directory to run the scripts in. Relative paths like "./assets" 
 
 Specific versions of tools that should be used for jobs defined in this workflow configuration. Follow each tool's documentation for available values.
 
-| Tool      | Description             |
-| --------- | ----------------------- |
-| node      | Version of Node.js.     |
-| yarn      | Version of Yarn.        |
-| pnpm      | Version of pnpm.        |
-| bun       | Version of Bun.         |
-| ndk       | Version of Android NDK. |
-| bundler   | Version of Bundler.     |
-| fastlane  | Version of fastlane.    |
-| cocoapods | Version of CocoaPods.   |
+| Tool        | Description                                                                |
+| ----------- | -------------------------------------------------------------------------- |
+| `node`      | Version of Node.js installed via `nvm`.                                    |
+| `yarn`      | Version of Yarn installed via `npm -g`.                                    |
+| `pnpm`      | Version of pnpm installed via `npm -g`.                                    |
+| `bun`       | Version of Bun installed by passing `bun-v$VERSION` to Bun install script. |
+| `ndk`       | Version of Android NDK installed through `sdkmanager`.                     |
+| `bundler`   | Version of Bundler that will be passed to `gem install -v`.                |
+| `fastlane`  | Version of fastlane that will be passed to `gem install -v`.               |
+| `cocoapods` | Version of CocoaPods that will be passed to `gem install -v`.              |
 
 Example of workflow using `defaults.tools`:
 


### PR DESCRIPTION
# Why

Recently I added `default.tools`. Also noticed that `defaults` in general are not documented so added that too.

# How

<img width="881" alt="Screenshot 2025-02-26 at 22 40 21" src="https://github.com/user-attachments/assets/dfbe4490-4683-4c6d-a8b5-f48281004121" />

# Test Plan

Run docs locally if needed.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
