### PR TITLE
[core][iOS] Add Constant to modules API

### DIFF
--- a/packages/expo-dev-menu/ios/Tests/DevMenuInternalModuleTest.swift
+++ b/packages/expo-dev-menu/ios/Tests/DevMenuInternalModuleTest.swift
@@ -14,7 +14,7 @@ class DevMenuInternalModuleTest: ExpoSpec {
       #else
           let doesDeviceSupportKeyCommands = false
       #endif
-      let constants = module.definition().getConstants()
+      let constants = module.definition().getLegacyConstants()
 
       expect(constants["doesDeviceSupportKeyCommands"] as? Bool).to(equal(doesDeviceSupportKeyCommands))
     }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add SwiftUI views support for macOS ([#35078](https://github.com/expo/expo/pull/35078) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Add common constants to the CoreModule ([#35057](https://github.com/expo/expo/pull/35057) by [@jakex7](https://github.com/jakex7))
 - [Android] Add Constant API ([#35157](https://github.com/expo/expo/pull/35157) by [@jakex7](https://github.com/jakex7))
+- [iOS] Add Constant API ([#35199](https://github.com/expo/expo/pull/35199) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Api/Builders/ObjectDefinitionBuilder.swift
+++ b/packages/expo-modules-core/ios/Api/Builders/ObjectDefinitionBuilder.swift
@@ -22,4 +22,6 @@ extension AsyncFunctionDefinition: AnyObjectDefinitionElement {}
 
 extension PropertyDefinition: AnyObjectDefinitionElement {}
 
+extension ConstantDefinition: AnyObjectDefinitionElement {}
+
 extension ConstantsDefinition: AnyObjectDefinitionElement {}

--- a/packages/expo-modules-core/ios/Api/Factories/ConstantFactories.swift
+++ b/packages/expo-modules-core/ios/Api/Factories/ConstantFactories.swift
@@ -1,5 +1,5 @@
 /**
- Creates the read-only constant with given name. The definition is basically no-op if you don't call `.get(_:)` on it.
+ Creates the read-only constant with the given name. The definition is no-op if you don't call `.get(_:)` on it.
  */
 public func Constant<Value: AnyArgument>(_ name: String) -> ConstantDefinition<Value> {
   return ConstantDefinition(name: name)

--- a/packages/expo-modules-core/ios/Api/Factories/ConstantFactories.swift
+++ b/packages/expo-modules-core/ios/Api/Factories/ConstantFactories.swift
@@ -1,0 +1,13 @@
+/**
+ Creates the read-only constant with given name. The definition is basically no-op if you don't call `.get(_:)` on it.
+ */
+public func Constant<Value: AnyArgument>(_ name: String) -> ConstantDefinition<Value> {
+  return ConstantDefinition(name: name)
+}
+
+/**
+ Creates the read-only constant whose getter doesn't take the owner as an argument.
+ */
+public func Constant<Value: AnyArgument>(_ name: String, @_implicitSelfCapture get: @escaping () -> Value) -> ConstantDefinition<Value> {
+  return ConstantDefinition(name: name, getter: get)
+}

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -401,7 +401,7 @@ public final class AppContext: NSObject {
       // prevent infinite recursion - exclude NativeProxyModule constants
       .filter { $0.name != NativeModulesProxyModule.moduleName }
       .reduce(into: [String: Any]()) { acc, holder in
-        acc[holder.name] = holder.getConstants()
+        acc[holder.name] = holder.getLegacyConstants()
       }
   }
 

--- a/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
@@ -76,7 +76,7 @@ public final class ClassDefinition: ObjectDefinition {
     // Properties are intentionally skipped here — they have to decorate an instance instead of the prototype.
     let prototype = object.getProperty("prototype").getObject()
 
-    decorateWithConstants(object: prototype)
+    try decorateWithConstants(object: prototype, appContext: appContext)
     try decorateWithFunctions(object: prototype, appContext: appContext)
     try decorateWithClasses(object: prototype, appContext: appContext)
     try decorateWithProperties(object: prototype, appContext: appContext)

--- a/packages/expo-modules-core/ios/Core/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Core/ModuleHolder.swift
@@ -48,8 +48,8 @@ public final class ModuleHolder {
   /**
    Merges all `constants` definitions into one dictionary.
    */
-  func getConstants() -> [String: Any?] {
-    return definition.getConstants()
+  func getLegacyConstants() -> [String: Any?] {
+    return definition.getLegacyConstants()
   }
 
   // MARK: Calling functions

--- a/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
@@ -6,7 +6,7 @@ import Foundation
 // The core module that describes the `global.expo` object.
 internal final class CoreModule: Module {
   internal func definition() -> ModuleDefinition {
-    Property("expoModulesCoreVersion") {
+    Constant("expoModulesCoreVersion") {
       let version = CoreModuleHelper.getVersion()
       let components = version.split(separator: "-")[0].split(separator: ".").compactMap { Int($0) }
 
@@ -18,11 +18,11 @@ internal final class CoreModule: Module {
       ]
     }
 
-    Property("cacheDir") {
+    Constant("cacheDir") {
       FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?.path ?? ""
     }
 
-    Property("documentsDir") {
+    Constant("documentsDir") {
       FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.path ?? ""
     }
 

--- a/packages/expo-modules-core/ios/Core/Objects/ConstantDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ConstantDefinition.swift
@@ -26,7 +26,7 @@ public final class ConstantDefinition<ReturnType>: AnyDefinition, AnyConstantDef
   var getter: ClosureType?
 
   /**
-   Initializes an unowned ConstantDefinition without getter function.
+   Initializes an unowned ConstantDefinition without a getter function.
    */
   init(name: String) {
     self.name = name

--- a/packages/expo-modules-core/ios/Core/Objects/ConstantDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ConstantDefinition.swift
@@ -1,0 +1,113 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+protocol AnyConstantDefinition {
+  /**
+   Name of the constant.
+   */
+  var name: String { get }
+
+  /**
+   Creates the JavaScript object representing the constant property descriptor.
+   */
+  func buildDescriptor(appContext: AppContext) throws -> JavaScriptObject
+}
+
+public final class ConstantDefinition<ReturnType>: AnyDefinition, AnyConstantDefinition {
+  typealias ClosureType = () throws -> ReturnType
+
+  /**
+   Name of the constant.
+   */
+  let name: String
+
+  /**
+   Synchronous function that is called when the property is being accessed.
+   */
+  var getter: ClosureType?
+
+  /**
+   Initializes an unowned ConstantDefinition without getter function.
+   */
+  init(name: String) {
+    self.name = name
+  }
+
+  /**
+   Initializes an unowned ConstantDefinition with a getter without arguments.
+   */
+  init(name: String, getter: @escaping () -> ReturnType) {
+    self.name = name
+
+    // Set the getter right away
+    self.get(getter)
+  }
+
+  // MARK: - Modifiers
+
+  /**
+   Modifier that sets constant getter that has no arguments.
+   */
+  @discardableResult
+  public func get(_ getter: @escaping () -> ReturnType) -> Self {
+    self.getter = getter
+    return self
+  }
+
+  // MARK: - Internals
+
+  internal func getValue(appContext: AppContext) throws -> ReturnType? {
+    return try getter?()
+  }
+
+  /**
+   Creates the JavaScript function that will be used as a getter of the constant.
+   */
+  internal func buildGetter(appContext: AppContext) throws -> JavaScriptObject {
+    var prevValue: JavaScriptValue?
+    return try appContext.runtime.createSyncFunction(name, argsCount: 0) { [weak appContext, weak self, name] this, arguments in
+      guard let prevValue else {
+        guard let appContext else {
+          throw Exceptions.AppContextLost()
+        }
+        guard let self else {
+          throw NativeConstantUnavailableException(name)
+        }
+        guard let getter = self.getter else {
+          throw NativeConstantWithoutGetterException(name)
+        }
+        let result = try getter()
+        prevValue = try appContext.converter.toJS(result, ~ReturnType.self)
+        return prevValue!;
+      }
+      return prevValue;
+    }
+  }
+
+  /**
+   Creates the JavaScript object representing the constant property descriptor.
+   */
+  internal func buildDescriptor(appContext: AppContext) throws -> JavaScriptObject {
+    let descriptor = try appContext.runtime.createObject()
+
+    descriptor.setProperty("enumerable", value: true)
+
+    if getter != nil {
+      descriptor.setProperty("get", value: try buildGetter(appContext: appContext))
+    }
+    return descriptor
+  }
+}
+
+// MARK: - Exceptions
+
+internal final class NativeConstantUnavailableException: GenericException<String> {
+  override var reason: String {
+    return "Native constant '\(param)' is no longer available in memory"
+  }
+}
+
+internal final class NativeConstantWithoutGetterException: GenericException<String> {
+  override var reason: String {
+    return "Native constant '\(param)' doesn't have a getter"
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Objects/ConstantDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ConstantDefinition.swift
@@ -64,7 +64,7 @@ public final class ConstantDefinition<ReturnType>: AnyDefinition, AnyConstantDef
    */
   internal func buildGetter(appContext: AppContext) throws -> JavaScriptObject {
     var prevValue: JavaScriptValue?
-    return try appContext.runtime.createSyncFunction(name, argsCount: 0) { [weak appContext, weak self, name] this, arguments in
+    return try appContext.runtime.createSyncFunction(name, argsCount: 0) { [weak appContext, weak self, name] _, _ in
       guard let prevValue else {
         guard let appContext else {
           throw Exceptions.AppContextLost()
@@ -76,10 +76,11 @@ public final class ConstantDefinition<ReturnType>: AnyDefinition, AnyConstantDef
           throw NativeConstantWithoutGetterException(name)
         }
         let result = try getter()
-        prevValue = try appContext.converter.toJS(result, ~ReturnType.self)
-        return prevValue!;
+        let newValue = try appContext.converter.toJS(result, ~ReturnType.self)
+        prevValue = newValue
+        return newValue
       }
-      return prevValue;
+      return prevValue
     }
   }
 

--- a/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
@@ -12,7 +12,12 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
   /**
    An array of constants definitions.
    */
-  let constants: [ConstantsDefinition]
+  let legacyConstants: [ConstantsDefinition]
+
+  /**
+   A map of constants defined by the object.
+   */
+  let constants: [String: AnyConstantDefinition]
 
   /**
    A map of dynamic properties defined by the object.
@@ -34,8 +39,14 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
         dict[function.name] = function
       }
 
-    self.constants = definitions
+    self.legacyConstants = definitions
       .compactMap { $0 as? ConstantsDefinition }
+    
+    self.constants = definitions
+      .compactMap { $0 as? AnyConstantDefinition }
+      .reduce(into: [String: AnyConstantDefinition]()) { dict, constant in
+        dict[constant.name] = constant
+      }
 
     self.properties = definitions
       .compactMap { $0 as? AnyPropertyDefinition }
@@ -53,8 +64,8 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
   /**
    Merges all `constants` definitions into one dictionary.
    */
-  func getConstants() -> [String: Any?] {
-    return constants.reduce(into: [String: Any?]()) { dict, definition in
+  func getLegacyConstants() -> [String: Any?] {
+    return legacyConstants.reduce(into: [String: Any?]()) { dict, definition in
       dict.merge(definition.body()) { $1 }
     }
   }
@@ -68,7 +79,7 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
   }
 
   public func decorate(object: JavaScriptObject, appContext: AppContext) throws {
-    decorateWithConstants(object: object)
+    try decorateWithConstants(object: object, appContext: appContext)
     try decorateWithFunctions(object: object, appContext: appContext)
     try decorateWithProperties(object: object, appContext: appContext)
     try decorateWithClasses(object: object, appContext: appContext)
@@ -76,9 +87,14 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
 
   // MARK: - Internals
 
-  internal func decorateWithConstants(object: JavaScriptObject) {
-    for (key, value) in getConstants() {
+  internal func decorateWithConstants(object: JavaScriptObject, appContext: AppContext) throws {
+    for (key, value) in getLegacyConstants() {
       object.setProperty(key, value: value)
+    }
+    
+    for constant in constants.values {
+      let descriptor = try constant.buildDescriptor(appContext: appContext)
+      object.defineProperty(constant.name, descriptor: descriptor)
     }
   }
 

--- a/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
@@ -41,7 +41,7 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
 
     self.legacyConstants = definitions
       .compactMap { $0 as? ConstantsDefinition }
-    
+
     self.constants = definitions
       .compactMap { $0 as? AnyConstantDefinition }
       .reduce(into: [String: AnyConstantDefinition]()) { dict, constant in
@@ -91,7 +91,7 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
     for (key, value) in getLegacyConstants() {
       object.setProperty(key, value: value)
     }
-    
+
     for constant in constants.values {
       let descriptor = try constant.buildDescriptor(appContext: appContext)
       object.defineProperty(constant.name, descriptor: descriptor)

--- a/packages/expo-modules-core/ios/Tests/ConstantsSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ConstantsSpec.swift
@@ -6,20 +6,23 @@ class ConstantsSpec: ExpoSpec {
   override class func spec() {
     let appContext = AppContext()
 
+    /**
+     Legacy Constants specs
+     */
     it("takes closure resolving to dictionary") {
       let holder = mockModuleHolder(appContext) {
         Constants {
           return ["test": 123]
         }
       }
-      expect(holder.getConstants()["test"] as? Int) == 123
+      expect(holder.getLegacyConstants()["test"] as? Int) == 123
     }
 
     it("takes the dictionary") {
       let holder = mockModuleHolder(appContext) {
         Constants(["test": 123])
       }
-      expect(holder.getConstants()["test"] as? Int) == 123
+      expect(holder.getLegacyConstants()["test"] as? Int) == 123
     }
 
     it("merges multiple constants definitions") {
@@ -27,7 +30,7 @@ class ConstantsSpec: ExpoSpec {
         Constants(["test": 456, "test2": 789])
         Constants(["test": 123])
       }
-      let consts = holder.getConstants()
+      let consts = holder.getLegacyConstants()
       expect(consts["test"] as? Int) == 123
       expect(consts["test2"] as? Int) == 789
     }


### PR DESCRIPTION
# Why

Similar to: https://github.com/expo/expo/pull/35157

# How

The native getter is called only on the property's first access; subsequent calls return the previous value.

# Test Plan

Changed properties in `CoreModule` to `Constant`, now the native getter should be called only once.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
