### PR TITLE
[tools] Add --core option to check-packages

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -59,7 +59,7 @@ jobs:
           else
             # On push event check packages changed since previous remote head.
             # In pull requests and workflow_dispatch events check all packages changed in the entire PR.
-            bin/expotools check-packages --since ${{ github.base_ref || github.event.before || 'main' }}
+            bin/expotools check-packages --since ${{ github.base_ref || github.event.before || 'main' }} --core
           fi
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3

--- a/tools/src/check-packages/getPackagesToCheckAsync.ts
+++ b/tools/src/check-packages/getPackagesToCheckAsync.ts
@@ -17,19 +17,6 @@ async function safeGetMergeBaseAsync(ref: string): Promise<string | null> {
   }
 }
 
-const packagesToCheck: Package[] = [];
-
-/**
- * Adds packages to the list of packages to check. Ignores duplicates.
- */
-function addPackages(packagesToAdd: Package[]) {
-  for (const pkg of packagesToAdd) {
-    if (!packagesToCheck.includes(pkg)) {
-      packagesToCheck.push(pkg);
-    }
-  }
-}
-
 /**
  * Resolves which packages should go through checks based on given options.
  */
@@ -45,16 +32,18 @@ export default async function getPackagesToCheckAsync(options: ActionOptions) {
     return allPackages;
   }
 
+  const packagesToCheck: Set<Package> = new Set();
+
   if (core) {
-    addPackages(
-      allPackages.filter(
-        (pkg) => pkg.packageName === 'expo' || pkg.packageName === 'expo-modules-core'
-      )
-    );
+    allPackages
+      .filter((pkg) => pkg.packageName === 'expo' || pkg.packageName === 'expo-modules-core')
+      .forEach((pkg) => packagesToCheck.add(pkg));
   }
 
   if (packageNames.length > 0) {
-    addPackages(allPackages.filter((pkg) => packageNames.includes(pkg.packageName)));
+    allPackages
+      .filter((pkg) => packageNames.includes(pkg.packageName))
+      .forEach((pkg) => packagesToCheck.add(pkg));
     return packagesToCheck;
   }
 
@@ -70,11 +59,11 @@ export default async function getPackagesToCheckAsync(options: ActionOptions) {
   logger.info(`😺 Using incremental checks since ${formatCommitHash(mergeBase)} commit\n`);
   const changedFiles = await Git.logFilesAsync({ fromCommit: mergeBase });
 
-  addPackages(
-    allPackages.filter((pkg) => {
+  allPackages
+    .filter((pkg) => {
       const pkgPath = pkg.path.replace(/([^\/])$/, '$1/');
       return changedFiles.some(({ path }) => path.startsWith(pkgPath));
     })
-  );
+    .forEach((pkg) => packagesToCheck.add(pkg));
   return packagesToCheck;
 }

--- a/tools/src/check-packages/types.ts
+++ b/tools/src/check-packages/types.ts
@@ -6,6 +6,7 @@ type CheckPackageType = 'package' | 'plugin' | 'cli' | 'utils';
 export type ActionOptions = {
   since: string;
   all: boolean;
+  core: boolean;
   build: boolean;
   test: boolean;
   lint: boolean;

--- a/tools/src/commands/CheckPackages.ts
+++ b/tools/src/commands/CheckPackages.ts
@@ -18,6 +18,7 @@ export default (program: Command) => {
       'main'
     )
     .option('-a, --all', 'Whether to check all packages and ignore `--since` option.', false)
+    .option('-c, --core', 'Whether to add core packages to check.', false)
     .option('--no-build', 'Whether to skip `yarn build` check.', false)
     .option('--no-test', 'Whether to skip `yarn test` check.', false)
     .option('--no-lint', 'Whether to skip `yarn lint` check.', false)


### PR DESCRIPTION
# Why

Core packages like `expo` and `expo-modules-core` should be checked with each run of `check-packages` on CI

# How

Adds `--core` flag to `check-packages` command that adds
* expo
* expo-modules-core
as additional packages to check.

# Test Plan

CI should check `expo` and `expo-modules-core`