### PR TITLE
[bare-expo][test-suite] integrate with sqlite web test

### DIFF
--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -54,4 +54,12 @@ config.serializer.getModulesRunBeforeMainModule = () => {
   return originalGetModulesRunBeforeMainModule();
 };
 
+config.server.enhanceMiddleware = (middleware) => {
+  return (req, res, next) => {
+    res.setHeader('Cross-Origin-Embedder-Policy', 'credentialless');
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    middleware(req, res, next);
+  };
+};
+
 module.exports = config;

--- a/apps/bare-expo/public/expo-sqlite
+++ b/apps/bare-expo/public/expo-sqlite
@@ -1,0 +1,1 @@
+../../../packages/expo-sqlite/public

--- a/apps/test-suite/TestModules.js
+++ b/apps/test-suite/TestModules.js
@@ -70,11 +70,12 @@ export function getTestModules() {
     require('./tests/FirebaseJSSDK'),
     require('./tests/ImageManipulator'),
     require('./tests/Clipboard'),
-    require('./tests/Fetch')
+    require('./tests/Fetch'),
+    require('./tests/SQLite')
   );
 
   if (['android', 'ios'].includes(Platform.OS)) {
-    modules.push(require('./tests/FileSystemNext'), require('./tests/SQLite'));
+    modules.push(require('./tests/FileSystemNext'));
   }
 
   if (Platform.OS === 'android') {


### PR DESCRIPTION
# Why

enable expo-sqlite web test-suite

# How

- enable expo-sqlite for web test.
- the expo-sqlite on web requires `SharedArrayBuffer` for web worker, we should add the COEP and the COOP headers.
- currently we need to put the worker js and wasm module as separate entry point. it's now as prebuit files in `expo-sqlite/public`. this pr creates a symlink for `apps/bare-expo/public/expo-sqlite -> packages/expo-sqlite/public`

# Test Plan

expo-sqlite test-suite passed on web

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
