### PR TITLE
[ci] Check all packages when certain packages changes

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -53,11 +53,8 @@ jobs:
       - name: 🧐 Check packages
         run: |
           echo "Checking packages according to the event name: ${{ github.event_name }}"
-          if [
-            "${{ github.event_name }}" == "schedule" || 
-            "${{ github.event.inputs.checkAll }}" == "check-all" ] ||
-            [git diff --name-only ${{ github.base_ref || github.event.before || 'main' }} | grep -q '^packages/(expo-module-scripts|jest-expo)/']
-          ]; then
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event.inputs.checkAll }}" == "check-all" ]] || 
+             git diff --name-only ${{ github.base_ref || github.event.before || 'main' }} | grep -qE '^packages/(expo-module-scripts|jest-expo)/'; then
             # Check all packages on scheduled events or if requested by workflow_dispatch event.
             bin/expotools check-packages --all
           else

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -53,7 +53,11 @@ jobs:
       - name: 🧐 Check packages
         run: |
           echo "Checking packages according to the event name: ${{ github.event_name }}"
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event.inputs.checkAll }}" == "check-all" ]]; then
+          if [
+            "${{ github.event_name }}" == "schedule" || 
+            "${{ github.event.inputs.checkAll }}" == "check-all" ] ||
+            [git diff --name-only ${{ github.base_ref || github.event.before || 'main' }} | grep -q '^packages/(expo-module-scripts|jest-expo)/']
+          ]; then
             # Check all packages on scheduled events or if requested by workflow_dispatch event.
             bin/expotools check-packages --all
           else

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+_Test change_
+
 ## 4.0.4 - 2025-02-14
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 ### 💡 Others
 
-_Test change_
-
 ## 4.0.4 - 2025-02-14
 
 _This version does not introduce any user-facing changes._


### PR DESCRIPTION
# Why

Changes to packages like `expo-module-scripts` can potentially affect all other packages, so whenever it changes, we should check every package.

# How

Whenever there are changes to `expo-module-scripts` or `jest-expo`, we run `check-packages` with the `--all` flag. If there are any other that could impact every other packages, please let me know so I can add them to the list.

# Test plan

CI for commit https://github.com/expo/expo/pull/35209/commits/ec709a56e4fce56de0a27af525932fd31348114a should check for all packages as I made a change in `expo-module-scripts` (available here https://github.com/expo/expo/actions/runs/13570114027/job/37932661365?pr=35209) (I've reverted it later)