### PR TITLE
[expo-audio][android] resolve asset file path in release build

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixing asset file path resolving. ([#35210](https://github.com/expo/expo/pull/35210) by [@alexplevako](https://github.com/alexplevako))
+
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))


### PR DESCRIPTION
# Why
Audio does not play correctly on the release build of an Android application.
Issue: #34555 

# How
During development, assets are not bundled into the app binary. Instead, they are served dynamically from the development server. In the debug build, the asset URI is a URL pointing to the development server, while in the release build, the asset URI is a file name located in the raw directory. For the release build, you should resolve the asset file path differently.

```kt
  private fun getResourceURI(file: String): Uri {
    val resId = context.resources.getIdentifier(file, "raw", context.packageName)

    return when {
      resId == 0 ->
        Uri.fromFile(File(file))
      else ->
        Uri.Builder()
          .scheme(ContentResolver.SCHEME_ANDROID_RESOURCE)
          .authority(context.packageName)
          .appendPath("raw")
          .appendPath(file)
          .build()
    }
  }
```
# Test Plan
1. Add audio file to the assets
2. Create player `const player = useAudioPlayer(require('@/assets/audio/sound.mp3'))`
3. Play audio `player.play()`
4. Run release build `npx expo run:android --variant Release`

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist
- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
