### PR TITLE
Fix importing `@radix-ui/colors` in CSS files.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix importing `@radix-ui/colors` in CSS files.
+- Fix importing `@radix-ui/colors` in CSS files. ([#35213](https://github.com/expo/expo/pull/35213) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure HMR updates use the same serializer pass as initial bundles. ([#35110](https://github.com/expo/expo/pull/35110) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix async bundling. ([#34986](https://github.com/expo/expo/pull/34986) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix application identifier suggestion. ([#34843](https://github.com/expo/expo/pull/34843) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix importing `@radix-ui/colors` in CSS files.
 - Ensure HMR updates use the same serializer pass as initial bundles. ([#35110](https://github.com/expo/expo/pull/35110) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix async bundling. ([#34986](https://github.com/expo/expo/pull/34986) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix application identifier suggestion. ([#34843](https://github.com/expo/expo/pull/34843) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -121,7 +121,7 @@ describe(withExtendedResolver, () => {
 
     modified.resolver.resolveRequest!(getDefaultRequestContext(), 'react-native', platform);
 
-    expect(getResolveFunc()).toBeCalledTimes(1);
+    expect(getResolveFunc()).toHaveBeenCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
       expect.objectContaining({
         extraNodeModules: {},
@@ -150,7 +150,7 @@ describe(withExtendedResolver, () => {
 
     modified.resolver.resolveRequest!(getDefaultRequestContext(), 'react-native', platform);
 
-    expect(getResolveFunc()).toBeCalledTimes(1);
+    expect(getResolveFunc()).toHaveBeenCalledTimes(1);
 
     expect(getResolveFunc()).toHaveBeenNthCalledWith(
       1,
@@ -176,7 +176,7 @@ describe(withExtendedResolver, () => {
 
     modified.resolver.resolveRequest!(getDefaultRequestContext(), 'react-native', platform);
 
-    expect(getResolveFunc()).toBeCalledTimes(1);
+    expect(getResolveFunc()).toHaveBeenCalledTimes(1);
 
     expect(getResolveFunc()).toHaveBeenNthCalledWith(
       1,
@@ -202,7 +202,7 @@ describe(withExtendedResolver, () => {
 
     modified.resolver.resolveRequest!(getDefaultRequestContext(), 'react-native', platform);
 
-    expect(getResolveFunc()).toBeCalledTimes(1);
+    expect(getResolveFunc()).toHaveBeenCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
       expect.objectContaining({
         mainFields: ['browser', 'module', 'main'],
@@ -225,7 +225,7 @@ describe(withExtendedResolver, () => {
 
     modified.resolver.resolveRequest!(getDefaultRequestContext(), 'react-native', platform);
 
-    expect(getResolveFunc()).toBeCalledTimes(1);
+    expect(getResolveFunc()).toHaveBeenCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
       expect.objectContaining({
         mainFields: ['browser', 'module', 'main'],
@@ -252,7 +252,7 @@ describe(withExtendedResolver, () => {
       platform
     );
 
-    expect(getResolveFunc()).toBeCalledTimes(1);
+    expect(getResolveFunc()).toHaveBeenCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
       expect.objectContaining({
         mainFields: ['browser', 'module', 'main'],
@@ -459,7 +459,7 @@ describe(withExtendedResolver, () => {
       type: 'empty',
     });
 
-    expect(getResolveFunc()).toBeCalledTimes(1);
+    expect(getResolveFunc()).toHaveBeenCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
       expect.objectContaining({
         mainFields: ['browser', 'module', 'main'],
@@ -495,7 +495,7 @@ describe(withExtendedResolver, () => {
       type: 'sourceFile',
     });
 
-    expect(getResolveFunc()).toBeCalledTimes(1);
+    expect(getResolveFunc()).toHaveBeenCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
       expect.objectContaining({
         nodeModulesPaths: ['/node_modules'],
@@ -528,7 +528,7 @@ describe(withExtendedResolver, () => {
       platform
     );
 
-    expect(getResolveFunc()).toBeCalledTimes(1);
+    expect(getResolveFunc()).toHaveBeenCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
       expect.objectContaining({
         mainFields: ['main', 'module'],
@@ -563,7 +563,7 @@ describe(withExtendedResolver, () => {
       platform
     );
 
-    expect(getResolveFunc()).toBeCalledTimes(1);
+    expect(getResolveFunc()).toHaveBeenCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
       {
         customResolverOptions: { environment: 'react-server' },
@@ -605,7 +605,7 @@ describe(withExtendedResolver, () => {
       platform
     );
 
-    expect(getResolveFunc()).toBeCalledTimes(1);
+    expect(getResolveFunc()).toHaveBeenCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
       {
         customResolverOptions: { environment: 'react-server' },
@@ -647,7 +647,7 @@ describe(withExtendedResolver, () => {
       platform
     );
 
-    expect(getResolveFunc()).toBeCalledTimes(1);
+    expect(getResolveFunc()).toHaveBeenCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
       {
         customResolverOptions: { environment: 'node' },
@@ -715,7 +715,7 @@ describe(withExtendedResolver, () => {
       type: 'sourceFile',
     });
 
-    expect(getResolveFunc()).toBeCalledTimes(1);
+    expect(getResolveFunc()).toHaveBeenCalledTimes(1);
     expect(getResolveFunc()).toBeCalledWith(
       expect.anything(),
       '/node_modules/react-native-web/dist/cjs/exports/AppRegistry/AppContainer.js',
@@ -751,7 +751,7 @@ describe(withExtendedResolver, () => {
               );
 
               expect(result.type).toBe('empty');
-              expect(getResolveFunc()).toBeCalledTimes(1);
+              expect(getResolveFunc()).toHaveBeenCalledTimes(1);
             });
           });
 
@@ -805,7 +805,7 @@ describe(withExtendedResolver, () => {
                 `\0node:${name}`
               );
 
-              expect(getResolveFunc()).toBeCalledTimes(0);
+              expect(getResolveFunc()).toHaveBeenCalledTimes(0);
             });
           });
 
@@ -822,10 +822,36 @@ describe(withExtendedResolver, () => {
               '\0node:@babel/runtime/xxx/foo.js'
             );
 
-            expect(getResolveFunc()).toBeCalledTimes(0);
+            expect(getResolveFunc()).toHaveBeenCalledTimes(0);
           });
         });
       });
+    });
+
+    it(`does not apply virtual externals to imports originating in CSS files`, () => {
+      vol.fromJSON(
+        {
+          'node_modules/@radix-ui/colors/green-dark.css': '',
+          mock: '',
+        },
+        '/'
+      );
+
+      const config = getModifiedConfig();
+
+      const result = config.resolver.resolveRequest!(
+        getNodeResolverContext({
+          originModulePath: '/index.css',
+        }),
+        '@radix-ui/colors/green-dark.css',
+        'web'
+      );
+
+      expect(result).toEqual({
+        type: 'empty',
+      });
+
+      expect(getResolveFunc()).toHaveBeenCalledTimes(1);
     });
 
     it(`does not extern source-map-support in server environments that are bundling for standalone exports`, async () => {
@@ -843,7 +869,7 @@ describe(withExtendedResolver, () => {
         type: 'empty',
       });
 
-      expect(getResolveFunc()).toBeCalledTimes(1);
+      expect(getResolveFunc()).toHaveBeenCalledTimes(1);
     });
 
     it(`does not extern source-map-support in client environment`, async () => {
@@ -857,7 +883,7 @@ describe(withExtendedResolver, () => {
         type: 'empty',
       });
 
-      expect(getResolveFunc()).toBeCalledTimes(1);
+      expect(getResolveFunc()).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -911,7 +937,7 @@ describe(withExtendedResolver, () => {
         type: 'sourceFile',
       });
 
-      expect(getResolveFunc()).toBeCalledTimes(1);
+      expect(getResolveFunc()).toHaveBeenCalledTimes(1);
       expect(getResolveFunc()).toBeCalledWith(
         expect.anything(),
         '/node_modules/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js',

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -490,6 +490,11 @@ export function withExtendedResolver(
       if (moduleName.endsWith('/package.json')) {
         return null;
       }
+      // Skip applying JS externals for CSS files.
+      if (/\.(s?css|sass)$/.test(context.originModulePath)) {
+        return null;
+      }
+
       const environment = context.customResolverOptions?.environment;
 
       const strictResolve = getStrictResolver(context, platform);


### PR DESCRIPTION
# Why

- Case for externing files in async bundles for RSC caused and issue with CSS modules that import files.

# How

- We just need to disable the JS externals for CSS.

# Test Plan

- Added a test to ensure modules originating from a CSS file do not apply the externals.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
