### PR TITLE
[CI] TV compile test improvements

### DIFF
--- a/.github/workflows/tvos-compile-test.yml
+++ b/.github/workflows/tvos-compile-test.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     paths:
       - .github/workflows/tvos-compile-test.yml
+      - packages/expo-modules-core/ios/Core/Views/SwiftUI/**
+      - packages/expo-ui/**
       - packages/expo-updates/e2e/setup/create-eas-project-tv.ts
       - packages/expo-updates/e2e/setup/project.ts
   push:

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -368,7 +368,7 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@~0.78.0-0rc4',
+        'react-native': 'npm:react-native-tvos@~0.78.0-0',
         '@react-native-tvos/config-tv': '^0.1.1',
       },
       expo: {


### PR DESCRIPTION
# Why

- Use latest dependencies
- Catch certain breakages at the PR stage instead of waiting for main to break

# How

- Update RNTV version to 0.78 release
- Add SwiftUI code and expo-ui iOS code to the pull request dependencies of the TV compile workflow

# Test Plan

CI should pass

