### PR TITLE
[docs] Update Boxlinks organization in EAS overview and change in beta to in preview for EAS Metadata

### DIFF
--- a/docs/pages/deploy/app-stores-metadata.mdx
+++ b/docs/pages/deploy/app-stores-metadata.mdx
@@ -8,7 +8,7 @@ import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **warning** EAS Metadata is in beta and subject to breaking changes.
+> **warning** EAS Metadata is in preview and subject to breaking changes.
 
 When submitting your app to app stores, you need to provide metadata. This process is lengthy and is often about complex topics that don't apply to your app. After the information you provide gets reviewed and if there is any issue with it, you need to restart this process.
 

--- a/docs/pages/eas/index.mdx
+++ b/docs/pages/eas/index.mdx
@@ -20,10 +20,24 @@ Expo Application Services (EAS) are deeply integrated cloud services for Expo an
 Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links below to learn how to get started.
 
 <BoxLink
+  title="EAS Workflows"
+  description="Automate your development release workflows."
+  href="/eas/workflows/get-started/"
+  Icon={Dataflow01Icon}
+/>
+
+<BoxLink
   title="EAS Build"
   description="Compile and sign Android/iOS apps with custom native code in the cloud."
   href="/build/introduction"
   Icon={BuildIcon}
+/>
+
+<BoxLink
+  title="EAS Hosting (in preview)"
+  description="Deploy Expo Router and React Native web apps and API routes."
+  href="/eas/hosting/introduction"
+  Icon={Cloud01Icon}
 />
 
 <BoxLink
@@ -41,14 +55,7 @@ Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links
 />
 
 <BoxLink
-  title="EAS Hosting (in preview)"
-  description="Deploy Expo Router and React Native web apps and API routes."
-  href="/eas/hosting/introduction"
-  Icon={Cloud01Icon}
-/>
-
-<BoxLink
-  title="EAS Metadata (in beta)"
+  title="EAS Metadata (in preview)"
   description="Upload all app store information required to get your app published."
   href="/eas/metadata/"
   Icon={EasMetadataIcon}
@@ -59,11 +66,4 @@ Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links
   description="View analytics about a project's performance, usage, and reach."
   href="/eas-insights/introduction/"
   Icon={DataIcon}
-/>
-
-<BoxLink
-  title="EAS Workflows"
-  description="Automate your development release workflows."
-  href="/eas/workflows/get-started/"
-  Icon={Dataflow01Icon}
 />

--- a/docs/pages/eas/metadata/config.mdx
+++ b/docs/pages/eas/metadata/config.mdx
@@ -6,7 +6,7 @@ description: Learn about different ways to configure EAS Metadata.
 
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 
-> **warning** EAS Metadata is in beta and subject to breaking changes.
+> **warning** EAS Metadata is in preview and subject to breaking changes.
 
 EAS Metadata is configured by a **store.config.json** file at the _root of your project_.
 

--- a/docs/pages/eas/metadata/faq.mdx
+++ b/docs/pages/eas/metadata/faq.mdx
@@ -4,7 +4,7 @@ sidebar_title: FAQ
 description: Frequently asked questions about EAS Metadata.
 ---
 
-> **warning** EAS Metadata is in beta and subject to breaking changes.
+> **warning** EAS Metadata is in preview and subject to breaking changes.
 
 ## Pitch
 

--- a/docs/pages/eas/metadata/getting-started.mdx
+++ b/docs/pages/eas/metadata/getting-started.mdx
@@ -9,7 +9,7 @@ import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **warning** EAS Metadata is in beta and subject to breaking changes.
+> **warning** EAS Metadata is in preview and subject to breaking changes.
 
 EAS Metadata enables you to automate and maintain your app store presence from the command line. It uses a [**store.config.json**](./config.mdx#static-store-config) file containing all required app information instead of going through multiple different forms. It also tries to find common pitfalls that could cause app rejections with built-in validation.
 

--- a/docs/pages/eas/metadata/index.mdx
+++ b/docs/pages/eas/metadata/index.mdx
@@ -10,7 +10,7 @@ import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **info** EAS Metadata is in beta and subject to breaking changes.
+> **info** EAS Metadata is in preview and subject to breaking changes.
 
 **EAS Metadata** enables you to automate and maintain your app store presence from the command line.
 

--- a/docs/pages/eas/metadata/schema.mdx
+++ b/docs/pages/eas/metadata/schema.mdx
@@ -9,7 +9,7 @@ import { MetadataTable, MetadataSubcategories } from '~/components/plugins/EasMe
 import { Collapsible } from '~/ui/components/Collapsible';
 import { markdownComponents as MD } from '~/ui/components/Markdown';
 
-> **warning** EAS Metadata is in beta and subject to breaking changes.
+> **warning** EAS Metadata is in preview and subject to breaking changes.
 
 The store config in EAS Metadata contains information that otherwise would be provided manually through the app store dashboards.
 This document outlines the structure of the object in your store config.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on feedback from @brentvatne 

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update order of Boxlinks used on EAS overview page
- Change references of "in beta" to "in preview" for EAS Metadata throughout the docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2025-02-28 at 02 44 21](https://github.com/user-attachments/assets/0d6e4fae-ac34-4b85-9497-fbb1d02c1761)


![CleanShot 2025-02-28 at 02 45 10](https://github.com/user-attachments/assets/bc9ae219-6fee-459b-96da-b9b205370d5c)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
