### PR TITLE
[android][updates] Remove AsyncTask from module

### DIFF
--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -138,6 +138,7 @@ dependencies {
   androidTestImplementation 'androidx.test:rules:1.5.0'
   androidTestImplementation "io.mockk:mockk-android:$mockk_version"
   androidTestImplementation "androidx.room:room-testing:$room_version"
+  androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
   androidTestImplementation "org.jetbrains.kotlin:kotlin-test-junit:${kotlinVersion}"
 
   implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}"

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
@@ -7,6 +7,8 @@ import expo.modules.core.logging.PersistentFileLog
 import expo.modules.updates.UpdatesModule
 import expo.modules.updates.logging.UpdatesLogger.Companion.EXPO_UPDATES_LOGGING_TAG
 import expo.modules.updates.logging.UpdatesLogger.Companion.MAX_FRAMES_IN_STACKTRACE
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -17,16 +19,14 @@ import java.util.*
 class UpdatesLoggingTest {
 
   @Before
-  fun setup() {
-    val asyncTestUtil = AsyncTestUtil()
+  fun setup() = runTest {
     val instrumentationContext = InstrumentationRegistry.getInstrumentation().context
     val persistentLog = PersistentFileLog(EXPO_UPDATES_LOGGING_TAG, instrumentationContext)
 
-    asyncTestUtil.asyncMethodRunning = true
-    persistentLog.clearEntries {
-      asyncTestUtil.asyncMethodRunning = false
+    val job = launch {
+      persistentLog.clearEntries {}
     }
-    asyncTestUtil.waitForAsyncMethodToFinish("clearEntries timed out", 1000)
+    job.join()
   }
 
   @Test
@@ -148,7 +148,7 @@ class UpdatesLoggingTest {
   }
 
   @Test
-  fun testNativeMethods() {
+  fun testNativeMethods() = runTest {
     val asyncTestUtil = AsyncTestUtil()
     val instrumentationContext = InstrumentationRegistry.getInstrumentation().context
     val logger = UpdatesLogger(instrumentationContext)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -18,146 +18,156 @@ import java.lang.ref.WeakReference
  * start the process of loading and launching an update, then responds appropriately depending on
  * the callbacks that are invoked.
  */
-class UpdatesController {
-  companion object {
-    private var singletonInstance: IUpdatesController? = null
-    private var overrideConfiguration: UpdatesConfiguration? = null
+object UpdatesController {
+  private var singletonInstance: IUpdatesController? = null
+  private var overrideConfiguration: UpdatesConfiguration? = null
 
-    @JvmStatic val instance: IUpdatesController
-      get() {
-        return checkNotNull(singletonInstance) { "UpdatesController.instance was called before the module was initialized" }
-      }
+  @JvmStatic
+  val instance: IUpdatesController
+    get() {
+      return checkNotNull(singletonInstance) { "UpdatesController.instance was called before the module was initialized" }
+    }
 
-    @JvmStatic fun initializeWithoutStarting(context: Context) {
-      if (singletonInstance != null) {
-        return
+  @JvmStatic
+  fun initializeWithoutStarting(context: Context) {
+    if (singletonInstance != null) {
+      return
+    }
+    val useDeveloperSupport =
+      (context as? ReactApplication)?.reactNativeHost?.useDeveloperSupport ?: false
+    if (useDeveloperSupport && !BuildConfig.EX_UPDATES_NATIVE_DEBUG) {
+      if (BuildConfig.USE_DEV_CLIENT) {
+        val devLauncherController = initializeAsDevLauncherWithoutStarting(context)
+        singletonInstance = devLauncherController
+        UpdatesControllerRegistry.controller = WeakReference(devLauncherController)
+      } else {
+        singletonInstance = DisabledUpdatesController(context, null)
       }
-      val useDeveloperSupport = (context as? ReactApplication)?.reactNativeHost?.useDeveloperSupport ?: false
-      if (useDeveloperSupport && !BuildConfig.EX_UPDATES_NATIVE_DEBUG) {
-        if (BuildConfig.USE_DEV_CLIENT) {
-          val devLauncherController = initializeAsDevLauncherWithoutStarting(context)
-          singletonInstance = devLauncherController
-          UpdatesControllerRegistry.controller = WeakReference(devLauncherController)
-        } else {
-          singletonInstance = DisabledUpdatesController(context, null)
+      return
+    }
+
+    val logger = UpdatesLogger(context)
+
+    val updatesDirectory = try {
+      UpdatesUtils.getOrCreateUpdatesDirectory(context)
+    } catch (e: Exception) {
+      logger.error(
+        "The expo-updates system is disabled due to a storage access error",
+        e,
+        UpdatesErrorCode.InitializationError
+      )
+      singletonInstance = DisabledUpdatesController(context, e)
+      return
+    }
+
+    val updatesConfiguration: UpdatesConfiguration? = overrideConfiguration ?: run {
+      when (UpdatesConfiguration.getUpdatesConfigurationValidationResult(context, null)) {
+        UpdatesConfigurationValidationResult.VALID -> {
+          return@run UpdatesConfiguration(context, null)
         }
-        return
-      }
 
-      val logger = UpdatesLogger(context)
-
-      val updatesDirectory = try {
-        UpdatesUtils.getOrCreateUpdatesDirectory(context)
-      } catch (e: Exception) {
-        logger.error(
-          "The expo-updates system is disabled due to a storage access error",
-          e,
+        UpdatesConfigurationValidationResult.INVALID_NOT_ENABLED -> logger.warn(
+          "The expo-updates system is explicitly disabled. To enable it, set the enabled setting to true.",
           UpdatesErrorCode.InitializationError
         )
-        singletonInstance = DisabledUpdatesController(context, e)
-        return
-      }
 
-      val updatesConfiguration: UpdatesConfiguration? = overrideConfiguration ?: run {
-        when (UpdatesConfiguration.getUpdatesConfigurationValidationResult(context, null)) {
-          UpdatesConfigurationValidationResult.VALID -> {
-            return@run UpdatesConfiguration(context, null)
-          }
-          UpdatesConfigurationValidationResult.INVALID_NOT_ENABLED -> logger.warn(
-            "The expo-updates system is explicitly disabled. To enable it, set the enabled setting to true.",
-            UpdatesErrorCode.InitializationError
-          )
-          UpdatesConfigurationValidationResult.INVALID_MISSING_URL -> logger.warn(
-            "The expo-updates system is disabled due to an invalid configuration. Ensure a valid URL is supplied.",
-            UpdatesErrorCode.InitializationError
-          )
-          UpdatesConfigurationValidationResult.INVALID_MISSING_RUNTIME_VERSION -> logger.warn(
-            "The expo-updates system is disabled due to an invalid configuration. Ensure a runtime version is supplied.",
-            UpdatesErrorCode.InitializationError
-          )
-        }
-        return@run null
-      }
+        UpdatesConfigurationValidationResult.INVALID_MISSING_URL -> logger.warn(
+          "The expo-updates system is disabled due to an invalid configuration. Ensure a valid URL is supplied.",
+          UpdatesErrorCode.InitializationError
+        )
 
-      singletonInstance = if (updatesConfiguration != null) {
-        EnabledUpdatesController(context, updatesConfiguration, updatesDirectory)
-      } else {
-        DisabledUpdatesController(context, null)
+        UpdatesConfigurationValidationResult.INVALID_MISSING_RUNTIME_VERSION -> logger.warn(
+          "The expo-updates system is disabled due to an invalid configuration. Ensure a runtime version is supplied.",
+          UpdatesErrorCode.InitializationError
+        )
       }
+      return@run null
     }
 
-    private fun initializeAsDevLauncherWithoutStarting(context: Context): UpdatesDevLauncherController {
-      check(singletonInstance == null) { "UpdatesController must not be initialized prior to calling initializeAsDevLauncherWithoutStarting" }
+    singletonInstance = if (updatesConfiguration != null) {
+      EnabledUpdatesController(context, updatesConfiguration, updatesDirectory)
+    } else {
+      DisabledUpdatesController(context, null)
+    }
+  }
 
-      var updatesDirectoryException: Exception? = null
-      val updatesDirectory = try {
-        UpdatesUtils.getOrCreateUpdatesDirectory(context)
-      } catch (e: Exception) {
-        updatesDirectoryException = e
+  private fun initializeAsDevLauncherWithoutStarting(context: Context): UpdatesDevLauncherController {
+    check(singletonInstance == null) { "UpdatesController must not be initialized prior to calling initializeAsDevLauncherWithoutStarting" }
+
+    var updatesDirectoryException: Exception? = null
+    val updatesDirectory = try {
+      UpdatesUtils.getOrCreateUpdatesDirectory(context)
+    } catch (e: Exception) {
+      updatesDirectoryException = e
+      null
+    }
+
+    val initialUpdatesConfiguration = overrideConfiguration ?: run {
+      if (UpdatesConfiguration.getUpdatesConfigurationValidationResult(
+          context,
+          null
+        ) == UpdatesConfigurationValidationResult.VALID
+      ) {
+        UpdatesConfiguration(context, null)
+      } else {
         null
       }
-
-      val initialUpdatesConfiguration = overrideConfiguration ?: run {
-        if (UpdatesConfiguration.getUpdatesConfigurationValidationResult(context, null) == UpdatesConfigurationValidationResult.VALID) {
-          UpdatesConfiguration(context, null)
-        } else {
-          null
-        }
-      }
-
-      val instance = UpdatesDevLauncherController(
-        context,
-        initialUpdatesConfiguration,
-        updatesDirectory,
-        updatesDirectoryException
-      )
-      singletonInstance = instance
-      return instance
     }
 
-    /**
-     * Initializes the UpdatesController singleton. This should be called as early as possible in the
-     * application's lifecycle. Can pass additional configuration to this method to set or override
-     * configuration values at runtime rather than just AndroidManifest.xml.
-     * @param context the base context of the application, ideally a [ReactApplication]
-     */
-    @JvmStatic fun initialize(context: Context) {
-      if (singletonInstance == null) {
-        initializeWithoutStarting(context)
-        singletonInstance!!.start()
-      }
-    }
+    val instance = UpdatesDevLauncherController(
+      context,
+      initialUpdatesConfiguration,
+      updatesDirectory,
+      updatesDirectoryException
+    )
+    singletonInstance = instance
+    return instance
+  }
 
-    /**
-     * Overrides the [UpdatesConfiguration] that will be used inside [UpdatesController]
-     * This should be called as early as possible in the application's lifecycle.
-     * Can pass additional configuration to this method to set or override
-     * configuration values at runtime rather than just AndroidManifest.xml.
-     *
-     * @param context the base context of the application, ideally a [ReactApplication]
-     * @param configuration map of configuration pairs to override those from AndroidManifest.xml
-     */
-    @JvmStatic
-    fun overrideConfiguration(context: Context, configuration: Map<String, Any>) {
-      if (singletonInstance != null) {
-        throw AssertionError("The method should be called before UpdatesController.initialize()")
-      }
-      val updatesConfigurationValidationResult = UpdatesConfiguration.getUpdatesConfigurationValidationResult(context, configuration)
-      if (updatesConfigurationValidationResult == UpdatesConfigurationValidationResult.VALID) {
-        overrideConfiguration = UpdatesConfiguration(context, configuration)
-      } else {
-        val logger = UpdatesLogger(context)
-        logger.warn("Failed to overrideConfiguration: invalid configuration: ${updatesConfigurationValidationResult.name}")
-      }
+  /**
+   * Initializes the UpdatesController singleton. This should be called as early as possible in the
+   * application's lifecycle. Can pass additional configuration to this method to set or override
+   * configuration values at runtime rather than just AndroidManifest.xml.
+   * @param context the base context of the application, ideally a [ReactApplication]
+   */
+  @JvmStatic
+  fun initialize(context: Context) {
+    if (singletonInstance == null) {
+      initializeWithoutStarting(context)
+      singletonInstance!!.start()
     }
+  }
 
-    internal fun setUpdatesEventManagerObserver(observer: WeakReference<IUpdatesEventManagerObserver>) {
-      singletonInstance?.eventManager?.observer = observer
-      singletonInstance?.onEventListenerStartObserving()
+  /**
+   * Overrides the [UpdatesConfiguration] that will be used inside [UpdatesController]
+   * This should be called as early as possible in the application's lifecycle.
+   * Can pass additional configuration to this method to set or override
+   * configuration values at runtime rather than just AndroidManifest.xml.
+   *
+   * @param context the base context of the application, ideally a [ReactApplication]
+   * @param configuration map of configuration pairs to override those from AndroidManifest.xml
+   */
+  @JvmStatic
+  fun overrideConfiguration(context: Context, configuration: Map<String, Any>) {
+    if (singletonInstance != null) {
+      throw AssertionError("The method should be called before UpdatesController.initialize()")
     }
+    val updatesConfigurationValidationResult =
+      UpdatesConfiguration.getUpdatesConfigurationValidationResult(context, configuration)
+    if (updatesConfigurationValidationResult == UpdatesConfigurationValidationResult.VALID) {
+      overrideConfiguration = UpdatesConfiguration(context, configuration)
+    } else {
+      val logger = UpdatesLogger(context)
+      logger.warn("Failed to overrideConfiguration: invalid configuration: ${updatesConfigurationValidationResult.name}")
+    }
+  }
 
-    internal fun removeUpdatesEventManagerObserver() {
-      singletonInstance?.eventManager?.observer = null
-    }
+  internal fun setUpdatesEventManagerObserver(observer: WeakReference<IUpdatesEventManagerObserver>) {
+    singletonInstance?.eventManager?.observer = observer
+    singletonInstance?.onEventListenerStartObserving()
+  }
+
+  internal fun removeUpdatesEventManagerObserver() {
+    singletonInstance?.eventManager?.observer = null
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -244,29 +244,29 @@ class UpdatesModule : Module(), IUpdatesEventManagerObserver {
     private val TAG = UpdatesModule::class.java.simpleName
 
     internal suspend fun readLogEntries(context: Context, maxAge: Long) = withContext(Dispatchers.IO) {
-        val reader = UpdatesLogReader(context)
-        val date = Date()
-        val epoch = Date(date.time - maxAge)
-        reader.getLogEntries(epoch)
-          .mapNotNull { UpdatesLogEntry.create(it) }
-          .map { entry ->
-            Bundle().apply {
-              putLong("timestamp", entry.timestamp)
-              putString("message", entry.message)
-              putString("code", entry.code)
-              putString("level", entry.level)
-              if (entry.updateId != null) {
-                putString("updateId", entry.updateId)
-              }
-              if (entry.assetId != null) {
-                putString("assetId", entry.assetId)
-              }
-              if (entry.stacktrace != null) {
-                putStringArray("stacktrace", entry.stacktrace.toTypedArray())
-              }
+      val reader = UpdatesLogReader(context)
+      val date = Date()
+      val epoch = Date(date.time - maxAge)
+      reader.getLogEntries(epoch)
+        .mapNotNull { UpdatesLogEntry.create(it) }
+        .map { entry ->
+          Bundle().apply {
+            putLong("timestamp", entry.timestamp)
+            putString("message", entry.message)
+            putString("code", entry.code)
+            putString("level", entry.level)
+            if (entry.updateId != null) {
+              putString("updateId", entry.updateId)
+            }
+            if (entry.assetId != null) {
+              putString("assetId", entry.assetId)
+            }
+            if (entry.stacktrace != null) {
+              putStringArray("stacktrace", entry.stacktrace.toTypedArray())
             }
           }
-      }
+        }
+    }
 
     internal fun clearLogEntries(context: Context, completionHandler: (_: Exception?) -> Unit) {
       val reader = UpdatesLogReader(context)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -3,7 +3,6 @@ package expo.modules.updates
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.Exceptions
@@ -234,8 +233,8 @@ class UpdatesModule : Module(), IUpdatesEventManagerObserver {
     OnDestroy {
       try {
         moduleScope.cancel()
-      } catch (_: IllegalStateException) {
-        Log.e(TAG, "The scope does not have a job in it")
+      } catch (e: IllegalStateException) {
+        logger.error("The scope does not have a job in it", e)
       }
     }
   }


### PR DESCRIPTION
# Why
Removes `AsyncTask` from the Updates module.
In kotlin, you can create singletons using `object` so I've removed the companion object from the `UpdatesController` and made it a object to make it clear that it is a singleton

# Test Plan
Bare-expo and unit tests

