### PR TITLE
fix(uri-scheme): escape special characters in the URL search parameters before opening on device

### DIFF
--- a/packages/uri-scheme/CHANGELOG.md
+++ b/packages/uri-scheme/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Escape special characters in `npx uri-scheme open <url>`. ([#35229](https://github.com/expo/expo/pull/35229) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 1.3.3 - 2025-02-14

--- a/packages/uri-scheme/src/Android.ts
+++ b/packages/uri-scheme/src/Android.ts
@@ -205,7 +205,7 @@ export function escapeUri(uri: string) {
   if (uriParams?.length) {
     const escapedUriParams = new URLSearchParams(uriParams);
     for (const [key, value] of escapedUriParams.entries()) {
-      escapedUriParams.set(key, encodeURIComponent(value));
+      escapedUriParams.set(key, encodeURIComponent(decodeURIComponent(value)));
     }
 
     return `${protocol}://${escapedUriPath}?${escapedUriParams.toString()}`;

--- a/packages/uri-scheme/src/Android.ts
+++ b/packages/uri-scheme/src/Android.ts
@@ -195,16 +195,14 @@ async function writeConfigAsync(path: string, result: any) {
  *   - `myapp://(tabs)/explore?test=a|b|c` -> `myapp://\(tabs\)/explore?test=a%257Cb%257Cc`
  */
 export function escapeUri(uri: string) {
-  // Split the URI into protocol, path, and params - each have different escaping rules
   const [protocol, uriWithoutProtocol] = uri.split('://', 2);
   const [uriPath, uriParams] = uriWithoutProtocol.split('?', 2);
 
-  // Escape non-escaped URI path special characters
+  // Escape special characters in the URI path using a single backslash
   // See: https://datatracker.ietf.org/doc/html/rfc1738#section-2.2
   const escapedUriPath = uriPath.replace(/(^|[^\\])([$\-_.+!*'(),])/g, '$1\\$2');
 
   if (uriParams?.length) {
-    // Escape every individual search paramter's value
     const escapedUriParams = new URLSearchParams(uriParams);
     for (const [key, value] of escapedUriParams.entries()) {
       escapedUriParams.set(key, encodeURIComponent(value));

--- a/packages/uri-scheme/src/CLI.ts
+++ b/packages/uri-scheme/src/CLI.ts
@@ -71,6 +71,7 @@ buildCommand('remove', ['com.app', 'myapp'])
 buildCommand('open', ['com.app://oauth', 'http://expo.dev'])
   .description('Open a URI scheme in a running simulator or emulator')
   .option('--package <string>', 'The Android package name to use when opening in an emulator')
+  .option('--raw', 'Open the URL without escaping special characters in the search parameters')
   .action(async (uri: string, args: any) => {
     try {
       if (!args.ios && !args.android) {
@@ -81,6 +82,7 @@ buildCommand('open', ['com.app://oauth', 'http://expo.dev'])
         ...args,
         androidPackage: args['package'],
         uri,
+        escapeUriParams: !args.raw,
       });
       await shouldUpdate();
     } catch (error) {

--- a/packages/uri-scheme/src/CLI.ts
+++ b/packages/uri-scheme/src/CLI.ts
@@ -82,7 +82,7 @@ buildCommand('open', ['com.app://oauth', 'http://expo.dev'])
         ...args,
         androidPackage: args['package'],
         uri,
-        escapeUriParams: !args.raw,
+        escapeUri: !args.raw,
       });
       await shouldUpdate();
     } catch (error) {

--- a/packages/uri-scheme/src/Ios.ts
+++ b/packages/uri-scheme/src/Ios.ts
@@ -152,7 +152,7 @@ export function escapeUri(uri: string) {
   const [uriWithoutParams, uriParams] = uri.split('?', 2);
   const escapedUriParams = new URLSearchParams(uriParams);
   for (const [key, value] of escapedUriParams.entries()) {
-    escapedUriParams.set(key, encodeURIComponent(value));
+    escapedUriParams.set(key, encodeURIComponent(decodeURIComponent(value)));
   }
 
   return `${uriWithoutParams}?${escapedUriParams.toString()}`;

--- a/packages/uri-scheme/src/Ios.ts
+++ b/packages/uri-scheme/src/Ios.ts
@@ -139,8 +139,8 @@ function writeConfig(path: string, plistObject: any) {
 }
 
 /**
- * xcrun expects special characters in only the search parameters to be escaped.
- * When this doesn't happen, it also quietly fails by opening the wrong screen.
+ * `xcrun` expects special characters in the search parameters to be escaped.
+ * When you don't escape these special characters, the wrong screen might be opened without warnings.
  *
  * @example
  * - `myapp://(tabs)/explore` -> `myapp://(tabs)/explore`

--- a/packages/uri-scheme/src/Ios.ts
+++ b/packages/uri-scheme/src/Ios.ts
@@ -137,3 +137,23 @@ function formatConfig(plistObject: any): string {
 function writeConfig(path: string, plistObject: any) {
   fs.writeFileSync(path, formatConfig(plistObject));
 }
+
+/**
+ * xcrun expects special characters in only the search parameters to be escaped.
+ * When this doesn't happen, it also quietly fails by opening the wrong screen.
+ *
+ * @example
+ * - `myapp://(tabs)/explore` -> `myapp://(tabs)/explore`
+ * - `myapp://(tabs)/explore?test=a|b|c` -> `myapp://(tabs)/explore?test=a%257Cb%257Cc`
+ */
+export function escapeUri(uri: string) {
+  if (!uri.includes('?')) return uri;
+
+  const [uriWithoutParams, uriParams] = uri.split('?', 2);
+  const escapedUriParams = new URLSearchParams(uriParams);
+  for (const [key, value] of escapedUriParams.entries()) {
+    escapedUriParams.set(key, encodeURIComponent(value));
+  }
+
+  return `${uriWithoutParams}?${escapedUriParams.toString()}`;
+}

--- a/packages/uri-scheme/src/URIScheme.ts
+++ b/packages/uri-scheme/src/URIScheme.ts
@@ -57,21 +57,6 @@ function ensureUriString(uri: any): string {
 }
 
 /**
- * Escape the URI search parameters when using special characters.
- * This may be required by adb or xcrun in order to open the URI properly.
- */
-function escapeUriSearchParams(uri: string): string {
-  if (!uri.includes('?')) return uri;
-
-  const [uriWithoutParams, uriParams] = uri.split('?', 2);
-  const params = new URLSearchParams(uriParams);
-  for (const [key, value] of params.entries()) {
-    params.set(key, encodeURIComponent(value));
-  }
-  return `${uriWithoutParams}?${params.toString()}`;
-}
-
-/**
  * Normalize a URI scheme prefix according to [RFC 2396](http://www.ietf.org/rfc/rfc2396.txt).
  *
  * @param uri URI scheme prefix to validate
@@ -171,17 +156,18 @@ export async function removeAsync(options: Options): Promise<string[]> {
 export async function openAsync(
   options: Pick<Options, 'uri' | 'ios' | 'android' | 'projectRoot'> & {
     androidPackage?: string;
-    escapeUriParams?: boolean;
+    escapeUri?: boolean;
   }
 ): Promise<void> {
   options.uri = ensureUriString(options.uri);
-  options.uri = options.escapeUriParams ? escapeUriSearchParams(options.uri) : options.uri;
 
   if (options.ios) {
+    if (options.escapeUri) options.uri = Ios.escapeUri(options.uri);
     logPlatformMessage('iOS', `Opening URI "${options.uri}" in simulator`);
     await Ios.openAsync(options);
   }
   if (options.android) {
+    if (options.escapeUri) options.uri = Android.escapeUri(options.uri);
     logPlatformMessage('Android', `Opening URI "${options.uri}" in emulator`);
     await Android.openAsync(options);
   }

--- a/packages/uri-scheme/src/URIScheme.ts
+++ b/packages/uri-scheme/src/URIScheme.ts
@@ -57,6 +57,21 @@ function ensureUriString(uri: any): string {
 }
 
 /**
+ * Escape the URI search parameters when using special characters.
+ * This may be required by adb or xcrun in order to open the URI properly.
+ */
+function escapeUriSearchParams(uri: string): string {
+  if (!uri.includes('?')) return uri;
+
+  const [uriWithoutParams, uriParams] = uri.split('?', 2);
+  const params = new URLSearchParams(uriParams);
+  for (const [key, value] of params.entries()) {
+    params.set(key, encodeURIComponent(value));
+  }
+  return `${uriWithoutParams}?${params.toString()}`;
+}
+
+/**
  * Normalize a URI scheme prefix according to [RFC 2396](http://www.ietf.org/rfc/rfc2396.txt).
  *
  * @param uri URI scheme prefix to validate
@@ -154,9 +169,13 @@ export async function removeAsync(options: Options): Promise<string[]> {
 }
 
 export async function openAsync(
-  options: Pick<Options, 'uri' | 'ios' | 'android' | 'projectRoot'> & { androidPackage?: string }
+  options: Pick<Options, 'uri' | 'ios' | 'android' | 'projectRoot'> & {
+    androidPackage?: string;
+    escapeUriParams?: boolean;
+  }
 ): Promise<void> {
   options.uri = ensureUriString(options.uri);
+  options.uri = options.escapeUriParams ? escapeUriSearchParams(options.uri) : options.uri;
 
   if (options.ios) {
     logPlatformMessage('iOS', `Opening URI "${options.uri}" in simulator`);

--- a/packages/uri-scheme/src/__tests__/Android.test.ts
+++ b/packages/uri-scheme/src/__tests__/Android.test.ts
@@ -1,0 +1,23 @@
+import { escapeUri } from '../Android';
+
+describe(escapeUri, () => {
+  it('escapes special characters in URI path', () => {
+    expect(escapeUri('myapp://normal/characters')).toBe('myapp://normal/characters');
+    expect(escapeUri('myapp://(special)/characters')).toBe('myapp://\\(special\\)/characters');
+    expect(escapeUri('myapp://(spec)/(cial)/characters')).toBe(
+      'myapp://\\(spec\\)/\\(cial\\)/characters'
+    );
+  });
+
+  it('escapes special charactes in URI search parameter values', () => {
+    expect(escapeUri('myapp://home?test=normal')).toBe('myapp://home?test=normal');
+    expect(escapeUri('myapp://home?test=a|b|c')).toBe('myapp://home?test=a%257Cb%257Cc');
+    expect(escapeUri('myapp://home?test=@1')).toBe('myapp://home?test=%25401');
+  });
+
+  it('escapes special characters in both URI path and search parameter values', () => {
+    expect(escapeUri('myapp://(spec)/(cial)/characters?pipes=a|b|c&at=@1')).toBe(
+      'myapp://\\(spec\\)/\\(cial\\)/characters?pipes=a%257Cb%257Cc&at=%25401'
+    );
+  });
+});

--- a/packages/uri-scheme/src/__tests__/Android.test.ts
+++ b/packages/uri-scheme/src/__tests__/Android.test.ts
@@ -20,4 +20,11 @@ describe(escapeUri, () => {
       'myapp://\\(spec\\)/\\(cial\\)/characters?pipes=a%257Cb%257Cc&at=%25401'
     );
   });
+
+  it('does not escape already escaped input', () => {
+    expect('my-custom-app://\\(escaped\\)/already').toBe('my-custom-app://\\(escaped\\)/already');
+    expect(
+      escapeUri('myapp://\\(spec\\)/\\(cial\\)/characters?pipes=a%257Cb%257Cc&at=%25401')
+    ).toBe('myapp://\\(spec\\)/\\(cial\\)/characters?pipes=a%257Cb%257Cc&at=%25401');
+  });
 });

--- a/packages/uri-scheme/src/__tests__/Ios.test.ts
+++ b/packages/uri-scheme/src/__tests__/Ios.test.ts
@@ -8,4 +8,13 @@ describe(escapeUri, () => {
       'myapp://(app)/home?test=a%257Cb%257Cc'
     );
   });
+
+  it('does not escape already escaped input', () => {
+    expect(escapeUri('my-custom-app://(app)/home?test=%25401')).toBe(
+      'my-custom-app://(app)/home?test=%25401'
+    );
+    expect(escapeUri('myapp://(app)/home?test=a%257Cb%257Cc')).toBe(
+      'myapp://(app)/home?test=a%257Cb%257Cc'
+    );
+  });
 });

--- a/packages/uri-scheme/src/__tests__/Ios.test.ts
+++ b/packages/uri-scheme/src/__tests__/Ios.test.ts
@@ -1,0 +1,11 @@
+import { escapeUri } from '../Ios';
+
+describe(escapeUri, () => {
+  it('escapes special charactes in URI search parameter values', () => {
+    expect(escapeUri('myapp://home?test=normal')).toBe('myapp://home?test=normal');
+    expect(escapeUri('myapp://(app)/home?test=@1')).toBe('myapp://(app)/home?test=%25401');
+    expect(escapeUri('myapp://(app)/home?test=a|b|c')).toBe(
+      'myapp://(app)/home?test=a%257Cb%257Cc'
+    );
+  });
+});


### PR DESCRIPTION
# Why

Fixes #35192, #34105 

# How

This adds automatic special characters escaping when running `npx uri-scheme open ..`. Unfortunately, the URI provided is technically not a URL, usually the host is missing - so we can't use `new URL` parsing. And both Android and iOS are behaving slightly different when it comes to these escaping rules.

Because there isn't a lot of documentation out there that indicates exactly what character needs to be escaped and how, I also added a new `--raw` flag to disable URI escaping fully. That way, users can still run as-is through an opt-in.

# Test Plan

- `bun create expo ./test-urischeme`
- Set the **app.json** `scheme` to `testuri`
- Modify the **app/(tabs)/explore.tsx** file to render the search parameters
  ```tsx
  export default function TabTwoScreen() {
    const params = useLocalSearchParams();

    return (
      <SafeAreaView>
        <View style={{ margin: 16 }}>
          {Object.entries(params).map(([key, value]) => (
            <View key={key}>
              <ThemedText type="defaultSemiBold">{key}</ThemedText>
              <ThemedText>{value}</ThemedText>
            </View>
          ))}
        </View>
      </SafeAreaView>
    );
  }
  ```
- Create production builds for both Android and iOS
  - `bun expo run android --variant release`
  - `bun expo run ios --configuration Release`
- Test URLs through:
  - `npx uri-scheme open "testuri://explore"`
  - `npx uri-scheme open "testuri://(tabs)/explore"`
  - `npx uri-scheme open "testuri://explore?test=a|b|c"`
  - `npx uri-scheme open "testuri://(tabs)/explore?test=a|b|c&other=@1"`
  - _All of these URLs should open the correct screen + show the right data on both Android & iOS_

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
