### PR TITLE
[html-elements] Add bigint type check for React 19

### DIFF
--- a/packages/html-elements/src/primitives/createDevView.tsx
+++ b/packages/html-elements/src/primitives/createDevView.tsx
@@ -6,7 +6,11 @@ function useChildren(inputChildren: React.ReactNode) {
     const children: React.ReactNode[] = [];
     React.Children.forEach(inputChildren, (child) => {
       if (child == null || typeof child === 'boolean') {
-      } else if (typeof child === 'string' || typeof child === 'number') {
+      } else if (
+        typeof child === 'string' ||
+        typeof child === 'number' ||
+        typeof child === 'bigint'
+      ) {
         // Wrap text in a Text component.
         let message = `Invalid raw text as a child of View: "${child}"${
           child === '' ? ` [empty string]` : ''

--- a/packages/html-elements/tsconfig.json
+++ b/packages/html-elements/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "./build"
   },
   "include": ["./src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__rsc_tests__/*"]
 }


### PR DESCRIPTION
# Why

Fix type error:

```
src/primitives/createDevView.tsx:21:28 - error TS2322: Type 'bigint | ReactElement<unknown, string | JSXElementConstructor<any>> | Iterable<ReactNode> | ReactPortal | Promise<...>' is not assignable to type 'object'.
  Type 'bigint' is not assignable to type 'object'.

21       } else if ('type' in child && typeof child?.type === 'string' && Platform.OS !== 'web') {
                              ~~~~~


Found 1 error in src/primitives/createDevView.tsx:21
```