### PR TITLE
[html-elements] fix tests

### DIFF
--- a/packages/html-elements/src/css/__tests__/createSafeStyledView.test.native.tsx
+++ b/packages/html-elements/src/css/__tests__/createSafeStyledView.test.native.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
+import * as React from 'react';
 
 import View from '../../primitives/View';
 import { createSafeStyledView } from '../createSafeStyledView';
@@ -18,8 +18,8 @@ afterAll(() => {
   console.warn = originalConsoleWarn;
 });
 
-it(`strips invalid style properties`, () => {
-  const tree = renderer.create(
+it('strips invalid style properties', () => {
+  const { toJSON } = render(
     <Safe
       style={{
         transitionDuration: '200ms',
@@ -27,29 +27,28 @@ it(`strips invalid style properties`, () => {
       }}
     />
   );
-  //   expect(tree.root.children[0]).toHaveStyle({ position: 'absolute' });
-  expect(tree).toMatchSnapshot();
+  expect(toJSON()).toMatchSnapshot();
 });
 
-it(`replaces invalid position with "relative"`, () => {
-  const tree = renderer.create(
+it('replaces invalid position with "relative"', () => {
+  const { toJSON } = render(
     <Safe
       style={{
         position: 'fixed',
       }}
     />
   );
-  expect(tree).toMatchSnapshot();
+  expect(toJSON()).toMatchSnapshot();
   expect(console.warn).toBeCalledWith(`Unsupported position: 'fixed'`);
 });
 
-it(`mocks out visibility: hidden by lowering the opacity`, () => {
-  const tree = renderer.create(
+it('mocks out visibility: hidden by lowering the opacity', () => {
+  const { toJSON } = render(
     <Safe
       style={{
         visibility: 'hidden',
       }}
     />
   );
-  expect(tree).toMatchSnapshot();
+  expect(toJSON()).toMatchSnapshot();
 });

--- a/packages/html-elements/src/elements/__tests__/Anchor-test.tsx
+++ b/packages/html-elements/src/elements/__tests__/Anchor-test.tsx
@@ -1,14 +1,10 @@
 import 'react-native';
-
-import React from 'react';
-import renderer, { act } from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
+import * as React from 'react';
 
 import { A } from '../Anchor';
 
-it(`renders A`, () => {
-  let tree;
-  act(() => {
-    tree = renderer.create(<A href="#" target="_parent" />);
-  });
-  expect(tree).toMatchSnapshot();
+it('renders A', () => {
+  const { toJSON } = render(<A href="#" target="_parent" />);
+  expect(toJSON()).toMatchSnapshot();
 });

--- a/packages/html-elements/src/elements/__tests__/Headings-test.tsx
+++ b/packages/html-elements/src/elements/__tests__/Headings-test.tsx
@@ -1,14 +1,13 @@
 import 'react-native';
-
-import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
+import * as React from 'react';
 
 import * as Headings from '../Headings';
 
-for (const name of Object.keys(Headings)) {
+const headingComponentNames = Object.keys(Headings);
+
+it.each(headingComponentNames)('renders %s', (name) => {
   const Heading = Headings[name];
-  it(`renders ${name}`, () => {
-    const tree = renderer.create(<Heading />);
-    expect(tree).toMatchSnapshot();
-  });
-}
+  const { toJSON } = render(<Heading />);
+  expect(toJSON()).toMatchSnapshot();
+});

--- a/packages/html-elements/src/elements/__tests__/Layout-test.tsx
+++ b/packages/html-elements/src/elements/__tests__/Layout-test.tsx
@@ -1,41 +1,40 @@
 import 'react-native';
-
-import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
+import * as React from 'react';
 
 import { Article, Aside, Footer, Header, Main, Nav, Section } from '../Layout';
 
-it(`renders Footer`, () => {
-  const tree = renderer.create(<Footer />);
-  expect(tree).toMatchSnapshot();
+it('renders Footer', () => {
+  const { toJSON } = render(<Footer />);
+  expect(toJSON()).toMatchSnapshot();
 });
 
-it(`renders Nav`, () => {
-  const tree = renderer.create(<Nav />);
-  expect(tree).toMatchSnapshot();
+it('renders Nav', () => {
+  const { toJSON } = render(<Nav />);
+  expect(toJSON()).toMatchSnapshot();
 });
 
-it(`renders Aside`, () => {
-  const tree = renderer.create(<Aside />);
-  expect(tree).toMatchSnapshot();
+it('renders Aside', () => {
+  const { toJSON } = render(<Aside />);
+  expect(toJSON()).toMatchSnapshot();
 });
 
-it(`renders Header`, () => {
-  const tree = renderer.create(<Header />);
-  expect(tree).toMatchSnapshot();
+it('renders Header', () => {
+  const { toJSON } = render(<Header />);
+  expect(toJSON()).toMatchSnapshot();
 });
 
-it(`renders Main`, () => {
-  const tree = renderer.create(<Main />);
-  expect(tree).toMatchSnapshot();
+it('renders Main', () => {
+  const { toJSON } = render(<Main />);
+  expect(toJSON()).toMatchSnapshot();
 });
 
-it(`renders Section`, () => {
-  const tree = renderer.create(<Section />);
-  expect(tree).toMatchSnapshot();
+it('renders Section', () => {
+  const { toJSON } = render(<Section />);
+  expect(toJSON()).toMatchSnapshot();
 });
 
-it(`renders Article`, () => {
-  const tree = renderer.create(<Article />);
-  expect(tree).toMatchSnapshot();
+it('renders Article', () => {
+  const { toJSON } = render(<Article />);
+  expect(toJSON()).toMatchSnapshot();
 });

--- a/packages/html-elements/src/elements/__tests__/Lists-test.tsx
+++ b/packages/html-elements/src/elements/__tests__/Lists-test.tsx
@@ -1,21 +1,17 @@
 import 'react-native';
-
-import React from 'react';
-import renderer, { act } from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
+import * as React from 'react';
 
 import { LI, UL } from '../Lists';
 
-it(`renders UL nested in LI`, () => {
-  let tree;
-  act(() => {
-    tree = renderer.create(
-      <LI>
+it('renders UL nested in LI', () => {
+  const { toJSON } = render(
+    <LI>
+      <LI>item</LI>
+      <UL>
         <LI>item</LI>
-        <UL>
-          <LI>item</LI>
-        </UL>
-      </LI>
-    );
-  });
-  expect(tree).toMatchSnapshot();
+      </UL>
+    </LI>
+  );
+  expect(toJSON()).toMatchSnapshot();
 });

--- a/packages/html-elements/src/elements/__tests__/Rules-test.tsx
+++ b/packages/html-elements/src/elements/__tests__/Rules-test.tsx
@@ -1,11 +1,10 @@
 import 'react-native';
-
-import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
+import * as React from 'react';
 
 import { HR } from '../Rules';
 
-it(`renders HR`, () => {
-  const tree = renderer.create(<HR />);
-  expect(tree).toMatchSnapshot();
+it('renders HR', () => {
+  const { toJSON } = render(<HR />);
+  expect(toJSON()).toMatchSnapshot();
 });

--- a/packages/html-elements/src/elements/__tests__/Table-test.tsx
+++ b/packages/html-elements/src/elements/__tests__/Table-test.tsx
@@ -1,39 +1,45 @@
 import 'react-native';
-
-import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
+import * as React from 'react';
 
 import { Table, THead, TBody, TFoot, TR, TH, TD, Caption } from '../Table';
 
-it(`renders Table`, () => {
-  const tree = renderer.create(<Table />);
-  expect(tree).toMatchSnapshot();
+it('renders Table', () => {
+  const { toJSON } = render(<Table />);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders THead`, () => {
-  const tree = renderer.create(<THead />);
-  expect(tree).toMatchSnapshot();
+
+it('renders THead', () => {
+  const { toJSON } = render(<THead />);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders TBody`, () => {
-  const tree = renderer.create(<TBody />);
-  expect(tree).toMatchSnapshot();
+
+it('renders TBody', () => {
+  const { toJSON } = render(<TBody />);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders TFoot`, () => {
-  const tree = renderer.create(<TFoot />);
-  expect(tree).toMatchSnapshot();
+
+it('renders TFoot', () => {
+  const { toJSON } = render(<TFoot />);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders TH`, () => {
-  const tree = renderer.create(<TH>Header</TH>);
-  expect(tree).toMatchSnapshot();
+
+it('renders TH', () => {
+  const { toJSON } = render(<TH>Header</TH>);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders TR`, () => {
-  const tree = renderer.create(<TR />);
-  expect(tree).toMatchSnapshot();
+
+it('renders TR', () => {
+  const { toJSON } = render(<TR />);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders TD`, () => {
-  const tree = renderer.create(<TD>Column</TD>);
-  expect(tree).toMatchSnapshot();
+
+it('renders TD', () => {
+  const { toJSON } = render(<TD>Column</TD>);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders Caption`, () => {
-  const tree = renderer.create(<Caption>Caption</Caption>);
-  expect(tree).toMatchSnapshot();
+
+it('renders Caption', () => {
+  const { toJSON } = render(<Caption>Caption</Caption>);
+  expect(toJSON()).toMatchSnapshot();
 });

--- a/packages/html-elements/src/elements/__tests__/Text-test.tsx
+++ b/packages/html-elements/src/elements/__tests__/Text-test.tsx
@@ -1,7 +1,6 @@
 import 'react-native';
-
-import React from 'react';
-import renderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
+import * as React from 'react';
 
 import {
   B,
@@ -21,69 +20,83 @@ import {
   Time,
 } from '../Text';
 
-it(`renders P`, () => {
-  const tree = renderer.create(<P>demo</P>);
-  expect(tree).toMatchSnapshot();
+it('renders P', () => {
+  const { toJSON } = render(<P>demo</P>);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders B`, () => {
-  const tree = renderer.create(<B>demo</B>);
-  expect(tree).toMatchSnapshot();
+
+it('renders B', () => {
+  const { toJSON } = render(<B>demo</B>);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders Span`, () => {
-  const tree = renderer.create(<Span>demo</Span>);
-  expect(tree).toMatchSnapshot();
+
+it('renders Span', () => {
+  const { toJSON } = render(<Span>demo</Span>);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders Strong`, () => {
-  const tree = renderer.create(<Strong>demo</Strong>);
-  expect(tree).toMatchSnapshot();
+
+it('renders Strong', () => {
+  const { toJSON } = render(<Strong>demo</Strong>);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders Del`, () => {
-  const tree = renderer.create(<Del>demo</Del>);
-  expect(tree).toMatchSnapshot();
+
+it('renders Del', () => {
+  const { toJSON } = render(<Del>demo</Del>);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders S`, () => {
-  const tree = renderer.create(<S>demo</S>);
-  expect(tree).toMatchSnapshot();
+
+it('renders S', () => {
+  const { toJSON } = render(<S>demo</S>);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders I`, () => {
-  const tree = renderer.create(<I>demo</I>);
-  expect(tree).toMatchSnapshot();
+
+it('renders I', () => {
+  const { toJSON } = render(<I>demo</I>);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders EM`, () => {
-  const tree = renderer.create(<EM>demo</EM>);
-  expect(tree).toMatchSnapshot();
+
+it('renders EM', () => {
+  const { toJSON } = render(<EM>demo</EM>);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders BR`, () => {
-  const tree = renderer.create(<BR />);
-  expect(tree).toMatchSnapshot();
+
+it('renders BR', () => {
+  const { toJSON } = render(<BR />);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders Code`, () => {
-  const tree = renderer.create(<Code />);
-  expect(tree).toMatchSnapshot();
+
+it('renders Code', () => {
+  const { toJSON } = render(<Code />);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders Q`, () => {
-  const tree = renderer.create(<Q>demo</Q>);
-  expect(tree).toMatchSnapshot();
+
+it('renders Q', () => {
+  const { toJSON } = render(<Q>demo</Q>);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders BlockQuote`, () => {
-  const tree = renderer.create(<BlockQuote />);
-  expect(tree).toMatchSnapshot();
+
+it('renders BlockQuote', () => {
+  const { toJSON } = render(<BlockQuote />);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders Mark`, () => {
-  const tree = renderer.create(<Mark />);
-  expect(tree).toMatchSnapshot();
+
+it('renders Mark', () => {
+  const { toJSON } = render(<Mark />);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders Time`, () => {
-  const tree = renderer.create(<Time dateTime="2001-05-15T19:00">May 15</Time>);
-  expect(tree).toMatchSnapshot();
+
+it('renders Time', () => {
+  const { toJSON } = render(<Time dateTime="2001-05-15T19:00">May 15</Time>);
+  expect(toJSON()).toMatchSnapshot();
 });
-it(`renders Pre`, () => {
-  const tree = renderer.create(
+
+it('renders Pre', () => {
+  const { toJSON } = render(
     <Pre>{`
     body {
       color: red;
     }
   `}</Pre>
   );
-  expect(tree).toMatchSnapshot();
+  expect(toJSON()).toMatchSnapshot();
 });

--- a/packages/html-elements/src/elements/__tests__/__snapshots__/Anchor-test.tsx.snap.web
+++ b/packages/html-elements/src/elements/__tests__/__snapshots__/Anchor-test.tsx.snap.web
@@ -5,6 +5,7 @@ exports[`renders A 1`] = `
   className="css-text-146c3p1"
   dir="auto"
   href="#"
+  ref={[Function]}
   role="link"
   target="_parent"
 />

--- a/packages/html-elements/src/elements/__tests__/__snapshots__/Headings-test.tsx.snap.web
+++ b/packages/html-elements/src/elements/__tests__/__snapshots__/Headings-test.tsx.snap.web
@@ -5,6 +5,7 @@ exports[`renders H1 1`] = `
   aria-level={1}
   className="css-text-146c3p1 r-fontSize-6e8ixz r-fontWeight-vw2c0b r-marginBlock-19oforl"
   dir="auto"
+  ref={[Function]}
   role="heading"
 />
 `;
@@ -14,6 +15,7 @@ exports[`renders H2 1`] = `
   aria-level={2}
   className="css-text-146c3p1 r-fontSize-1lijs1h r-fontWeight-vw2c0b r-marginBlock-1u31v3z"
   dir="auto"
+  ref={[Function]}
   role="heading"
 />
 `;
@@ -23,6 +25,7 @@ exports[`renders H3 1`] = `
   aria-level={3}
   className="css-text-146c3p1 r-fontSize-tg2c11 r-fontWeight-vw2c0b r-marginBlock-11nzuo4"
   dir="auto"
+  ref={[Function]}
   role="heading"
 />
 `;
@@ -32,6 +35,7 @@ exports[`renders H4 1`] = `
   aria-level={4}
   className="css-text-146c3p1 r-fontSize-bzi31h r-fontWeight-vw2c0b r-marginBlock-1hga0el"
   dir="auto"
+  ref={[Function]}
   role="heading"
 />
 `;
@@ -41,6 +45,7 @@ exports[`renders H5 1`] = `
   aria-level={5}
   className="css-text-146c3p1 r-fontSize-n230yh r-fontWeight-vw2c0b r-marginBlock-1946khe"
   dir="auto"
+  ref={[Function]}
   role="heading"
 />
 `;
@@ -50,6 +55,7 @@ exports[`renders H6 1`] = `
   aria-level={6}
   className="css-text-146c3p1 r-fontSize-ydqdv4 r-fontWeight-vw2c0b r-marginBlock-1jm7qrm"
   dir="auto"
+  ref={[Function]}
   role="heading"
 />
 `;

--- a/packages/html-elements/src/elements/__tests__/__snapshots__/Layout-test.tsx.snap.web
+++ b/packages/html-elements/src/elements/__tests__/__snapshots__/Layout-test.tsx.snap.web
@@ -4,6 +4,7 @@ exports[`renders Article 1`] = `
 <article
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
   role="article"
 />
 `;
@@ -12,6 +13,7 @@ exports[`renders Aside 1`] = `
 <aside
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
   role="complementary"
 />
 `;
@@ -20,6 +22,7 @@ exports[`renders Footer 1`] = `
 <footer
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
   role="contentinfo"
 />
 `;
@@ -28,6 +31,7 @@ exports[`renders Header 1`] = `
 <header
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
   role="banner"
 />
 `;
@@ -36,6 +40,7 @@ exports[`renders Main 1`] = `
 <main
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
   role="main"
 />
 `;
@@ -44,6 +49,7 @@ exports[`renders Nav 1`] = `
 <nav
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
   role="navigation"
 />
 `;
@@ -52,6 +58,7 @@ exports[`renders Section 1`] = `
 <section
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
   role="region"
 />
 `;

--- a/packages/html-elements/src/elements/__tests__/__snapshots__/Lists-test.tsx.snap.web
+++ b/packages/html-elements/src/elements/__tests__/__snapshots__/Lists-test.tsx.snap.web
@@ -4,11 +4,13 @@ exports[`renders UL nested in LI 1`] = `
 <li
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
   role="listitem"
 >
   <li
     className="css-text-146c3p1"
     dir="auto"
+    ref={[Function]}
     role="listitem"
   >
     item
@@ -16,11 +18,13 @@ exports[`renders UL nested in LI 1`] = `
   <ul
     className="css-view-175oi2r"
     dir={null}
+    ref={[Function]}
     role="list"
   >
     <li
       className="css-text-146c3p1"
       dir="auto"
+      ref={[Function]}
       role="listitem"
     >
       item

--- a/packages/html-elements/src/elements/__tests__/__snapshots__/Rules-test.tsx.snap.web
+++ b/packages/html-elements/src/elements/__tests__/__snapshots__/Rules-test.tsx.snap.web
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders HR 1`] = `<hr />`;
+exports[`renders HR 1`] = `
+<hr
+  ref={null}
+/>
+`;

--- a/packages/html-elements/src/elements/__tests__/__snapshots__/Table-test.tsx.snap.web
+++ b/packages/html-elements/src/elements/__tests__/__snapshots__/Table-test.tsx.snap.web
@@ -4,6 +4,7 @@ exports[`renders Caption 1`] = `
 <caption
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
 >
   Caption
 </caption>
@@ -13,6 +14,7 @@ exports[`renders TBody 1`] = `
 <tbody
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
 />
 `;
 
@@ -20,6 +22,7 @@ exports[`renders TD 1`] = `
 <td
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
 >
   Column
 </td>
@@ -29,6 +32,7 @@ exports[`renders TFoot 1`] = `
 <tfoot
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
 />
 `;
 
@@ -36,6 +40,7 @@ exports[`renders TH 1`] = `
 <th
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
 >
   Header
 </th>
@@ -45,6 +50,7 @@ exports[`renders THead 1`] = `
 <thead
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
 />
 `;
 
@@ -52,6 +58,7 @@ exports[`renders TR 1`] = `
 <tr
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
 />
 `;
 
@@ -59,5 +66,6 @@ exports[`renders Table 1`] = `
 <table
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
 />
 `;

--- a/packages/html-elements/src/elements/__tests__/__snapshots__/Text-test.tsx.snap.web
+++ b/packages/html-elements/src/elements/__tests__/__snapshots__/Text-test.tsx.snap.web
@@ -4,6 +4,7 @@ exports[`renders B 1`] = `
 <div
   className="css-text-146c3p1 r-fontWeight-vw2c0b"
   dir="auto"
+  ref={[Function]}
 >
   demo
 </div>
@@ -13,6 +14,7 @@ exports[`renders BR 1`] = `
 <div
   className="css-text-146c3p1 r-height-10rkof1 r-width-1h2t8mc"
   dir="auto"
+  ref={[Function]}
 />
 `;
 
@@ -20,6 +22,7 @@ exports[`renders BlockQuote 1`] = `
 <div
   className="css-view-175oi2r r-marginBlock-11nzuo4"
   dir={null}
+  ref={[Function]}
 />
 `;
 
@@ -27,6 +30,7 @@ exports[`renders Code 1`] = `
 <div
   className="css-text-146c3p1 r-fontFamily-1pm8pkb r-fontWeight-majxgm"
   dir="auto"
+  ref={[Function]}
 />
 `;
 
@@ -34,6 +38,7 @@ exports[`renders Del 1`] = `
 <div
   className="css-text-146c3p1 r-textDecorationLine-142tt33 r-textDecorationStyle-1a2p6p6"
   dir="auto"
+  ref={[Function]}
 >
   demo
 </div>
@@ -43,6 +48,7 @@ exports[`renders EM 1`] = `
 <div
   className="css-text-146c3p1 r-fontStyle-36ujnk"
   dir="auto"
+  ref={[Function]}
 >
   demo
 </div>
@@ -52,6 +58,7 @@ exports[`renders I 1`] = `
 <div
   className="css-text-146c3p1 r-fontStyle-36ujnk"
   dir="auto"
+  ref={[Function]}
 >
   demo
 </div>
@@ -61,6 +68,7 @@ exports[`renders Mark 1`] = `
 <div
   className="css-text-146c3p1 r-backgroundColor-98uye2 r-color-cqee49"
   dir="auto"
+  ref={[Function]}
 />
 `;
 
@@ -68,6 +76,7 @@ exports[`renders P 1`] = `
 <div
   className="css-text-146c3p1 r-marginBlock-11nzuo4"
   dir="auto"
+  ref={[Function]}
 >
   demo
 </div>
@@ -77,6 +86,7 @@ exports[`renders Pre 1`] = `
 <div
   className="css-text-146c3p1 r-fontFamily-1pm8pkb r-fontWeight-majxgm r-marginBlock-11nzuo4"
   dir="auto"
+  ref={[Function]}
 >
   
     body {
@@ -90,6 +100,7 @@ exports[`renders Q 1`] = `
 <div
   className="css-text-146c3p1 r-fontStyle-36ujnk"
   dir="auto"
+  ref={[Function]}
 >
   "
   demo
@@ -101,6 +112,7 @@ exports[`renders S 1`] = `
 <div
   className="css-text-146c3p1 r-textDecorationLine-142tt33 r-textDecorationStyle-1a2p6p6"
   dir="auto"
+  ref={[Function]}
 >
   demo
 </div>
@@ -110,6 +122,7 @@ exports[`renders Span 1`] = `
 <div
   className="css-text-146c3p1"
   dir="auto"
+  ref={[Function]}
 >
   demo
 </div>
@@ -119,6 +132,7 @@ exports[`renders Strong 1`] = `
 <div
   className="css-text-146c3p1 r-fontWeight-vw2c0b"
   dir="auto"
+  ref={[Function]}
 >
   demo
 </div>
@@ -128,6 +142,7 @@ exports[`renders Time 1`] = `
 <div
   className="css-text-146c3p1"
   dir="auto"
+  ref={[Function]}
 >
   May 15
 </div>

--- a/packages/html-elements/src/primitives/__tests__/__snapshots__/createDevView.test.tsx.snap.web
+++ b/packages/html-elements/src/primitives/__tests__/__snapshots__/createDevView.test.tsx.snap.web
@@ -4,15 +4,18 @@ exports[`warns about unwrapped strings 1`] = `
 <div
   className="css-view-175oi2r"
   dir={null}
+  ref={[Function]}
 >
   <div
     className="css-text-146c3p1 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af r-backgroundColor-1kfbv51 r-color-jwli3a"
     dir="auto"
+    ref={[Function]}
   >
     Unwrapped text: "
     <span
       className="css-textHasAncestor-1jxf684"
       dir={null}
+      ref={[Function]}
       style={
         {
           "fontWeight": "bold",

--- a/packages/html-elements/src/primitives/__tests__/createDevView.test.tsx
+++ b/packages/html-elements/src/primitives/__tests__/createDevView.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import { render } from '@testing-library/react-native';
+import * as React from 'react';
 import { Platform, View as NativeView } from 'react-native';
-import renderer from 'react-test-renderer';
 
 import { createDevView } from '../createDevView';
 
@@ -18,34 +18,36 @@ afterAll(() => {
   console.warn = originalConsoleWarn;
 });
 
-it(`renders`, () => {
+it('renders', () => {
   // Ensure no errors
-  renderer
-    .create(
+  expect(() =>
+    render(
       <View>
         <View />
       </View>
     )
-    .toJSON();
+  ).not.toThrow();
 });
 
-it(`asserts react-dom elements`, () => {
+it('asserts react-dom elements', () => {
   const instance = (
     <View>
       <div />
     </View>
   );
+
   if (Platform.OS === 'web') {
     // Ensure no errors
-    expect(() => renderer.create(instance)).not.toThrowError();
+    expect(() => render(instance)).not.toThrow();
   } else {
-    expect(() => renderer.create(instance)).toThrowError(/Using unsupported React DOM element/);
+    expect(() => render(instance)).toThrow(/Using unsupported React DOM element/);
   }
 });
 
-it(`warns about unwrapped strings`, () => {
+it('warns about unwrapped strings', () => {
   // Ensure no errors
-  expect(renderer.create(<View>Hey</View>).toJSON()).toMatchSnapshot();
+  const { toJSON } = render(<View>Hey</View>);
+  expect(toJSON()).toMatchSnapshot();
 
   expect(console.warn).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
# Why

tests were failing

# How

use https://github.com/callstack/react-native-testing-library/releases/tag/v13.1.0 instead of react-test-renderer which is deprecated

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
