### PR TITLE
[default-template] updated the variant resolution.

### DIFF
--- a/templates/expo-template-default/components/ThemedText.tsx
+++ b/templates/expo-template-default/components/ThemedText.tsx
@@ -5,7 +5,7 @@ import { useThemeColor } from '@/hooks/useThemeColor';
 export type ThemedTextProps = TextProps & {
   lightColor?: string;
   darkColor?: string;
-  type?: 'default' | 'title' | 'defaultSemiBold' | 'subtitle' | 'link';
+  type?: keyof typeof styles;
 };
 
 export function ThemedText({
@@ -21,11 +21,7 @@ export function ThemedText({
     <Text
       style={[
         { color },
-        type === 'default' ? styles.default : undefined,
-        type === 'title' ? styles.title : undefined,
-        type === 'defaultSemiBold' ? styles.defaultSemiBold : undefined,
-        type === 'subtitle' ? styles.subtitle : undefined,
-        type === 'link' ? styles.link : undefined,
+        styles[type],
         style,
       ]}
       {...rest}

--- a/templates/expo-template-default/components/__tests__/__snapshots__/ThemedText-test.tsx.snap
+++ b/templates/expo-template-default/components/__tests__/__snapshots__/ThemedText-test.tsx.snap
@@ -12,10 +12,6 @@ exports[`renders correctly 1`] = `
         "lineHeight": 24,
       },
       undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
     ]
   }
 >


### PR DESCRIPTION
# Why
I was trying to build a small app for personal use and decided to go with expo. It had been a while, since last time. So, I decided to checkout the default template. It was packed with good components that I can use in my application with small tweaks. 

I found the variant resolution in `ThemedText` component could improve without changing any functionality.
I personally think this is a bit cleaner approach.
> Would love to know if there are any hidden drawbacks to this approach.

# Test Plan
I ran the test that was provided, which was failing and then I corrected the test case
to account for the changes which made it pass.