### PR TITLE
[json file] fix failing test assertions

### DIFF
--- a/packages/@expo/json-file/src/__tests__/JsonFile-test.ts
+++ b/packages/@expo/json-file/src/__tests__/JsonFile-test.ts
@@ -80,7 +80,8 @@ describe('async', () => {
     vol.fromJSON({ [testFilename]: loadFixture('syntax-error.json') });
 
     await expect(JsonFile.readAsync(testFilename)).rejects.toThrowError(
-      /Cause: SyntaxError: Unexpected string in JSON at position 602/
+      // based on node version you may get different error messages
+      /Cause: SyntaxError: (Unexpected string|Expected ':' after property name) in JSON at position 602/
     );
   });
 
@@ -221,7 +222,8 @@ describe('sync', () => {
     vol.fromJSON({ [testFilename]: loadFixture('syntax-error.json') });
 
     expect(() => JsonFile.read(testFilename)).toThrow(
-      /Cause: SyntaxError: Unexpected string in JSON at position 602/
+      // based on node version you may get different error messages
+      /Cause: SyntaxError: (Unexpected string|Expected ':' after property name) in JSON at position 602/
     );
   });
 


### PR DESCRIPTION
# Why

tests are failing on newer node versions

# How

fix test expectations

# Test Plan

tests pass

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)