### PR TITLE
[expo-config] fix failing test

### DIFF
--- a/packages/@expo/config/src/__tests__/fixtures/external-error/app.config.js
+++ b/packages/@expo/config/src/__tests__/fixtures/external-error/app.config.js
@@ -1,4 +1,4 @@
-// import an external file that using invalid import/export syntax
+// import an external file that using invalid import/export
 import './other';
 
 module.exports = {};

--- a/packages/@expo/config/src/__tests__/fixtures/external-error/other.js
+++ b/packages/@expo/config/src/__tests__/fixtures/external-error/other.js
@@ -1,2 +1,2 @@
-// import/export is not supported in external files
-import 'fs';
+// on old node versions, even import statements for valid modules are not supported
+import 'some-nonexistent-module';


### PR DESCRIPTION
# Why

tests are failing on newer node versions

# How

fix test expectations

# Test Plan

green CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)