### PR TITLE
[ci] update actions to node 22

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 'lts/*'
       - name: 👀 Check out repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 22
       - name: 👀 Check out repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 'lts/*'
       - name: 👀 Check out repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 22
       - name: 👀 Check out repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/bare-diffs.yml
+++ b/.github/workflows/bare-diffs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 'lts/*'
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/bare-diffs.yml
+++ b/.github/workflows/bare-diffs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 22
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/create-expo-app.yml
+++ b/.github/workflows/create-expo-app.yml
@@ -44,7 +44,7 @@ jobs:
           # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
           # TODO(cedric): swap `latest` back once the issue is resolved
           bun-version: latest
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - name: ♻️ Restore caches

--- a/.github/workflows/fingerprint.yml
+++ b/.github/workflows/fingerprint.yml
@@ -36,7 +36,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: 🚀 Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -29,7 +29,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -33,7 +33,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -46,7 +46,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 'lts/*'
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -46,7 +46,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 22
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -23,7 +23,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches

--- a/.github/workflows/test-suite-lint.yml
+++ b/.github/workflows/test-suite-lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 'lts/*'
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/test-suite-lint.yml
+++ b/.github/workflows/test-suite-lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 22
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -145,7 +145,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 'lts/*'
       - name: 🔨 Use JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -145,7 +145,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: 22
       - name: 🔨 Use JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -161,7 +161,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: 🔨 Use JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/tvos-compile-test.yml
+++ b/.github/workflows/tvos-compile-test.yml
@@ -69,7 +69,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(yarn global bin)" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/updates-e2e-bricking-measures-disabled.yml
+++ b/.github/workflows/updates-e2e-bricking-measures-disabled.yml
@@ -41,7 +41,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(yarn global bin)" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/updates-e2e-cli.yml
+++ b/.github/workflows/updates-e2e-cli.yml
@@ -27,7 +27,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(yarn global bin)" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/updates-e2e-disabled.yml
+++ b/.github/workflows/updates-e2e-disabled.yml
@@ -41,7 +41,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(yarn global bin)" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/updates-e2e-error-recovery.yml
+++ b/.github/workflows/updates-e2e-error-recovery.yml
@@ -41,7 +41,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(yarn global bin)" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/updates-e2e-fingerprint.yml
+++ b/.github/workflows/updates-e2e-fingerprint.yml
@@ -43,7 +43,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(yarn global bin)" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/updates-e2e-startup.yml
+++ b/.github/workflows/updates-e2e-startup.yml
@@ -41,7 +41,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(yarn global bin)" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -67,7 +67,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(yarn global bin)" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "yarn-deduplicate": "^6.0.2"
   },
   "volta": {
-    "node": "20.12.2"
+    "node": "22.14.0"
   }
 }

--- a/packages/@expo/cli/e2e/__tests__/export/server-env.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-env.test.ts
@@ -8,6 +8,12 @@ runExportSideEffects();
 const projectRoot = getRouterE2ERoot();
 
 it(`asserts the server env isn't correct`, async () => {
+  const [major] = process.versions.node.split('.').map(Number);
+  if (major >= 23) {
+    expect(true).toBe(true);
+    // `--no-experimental-fetch` is a legacy flag fetch it not experimental in Node.js 23+
+    return;
+  }
   await expect(
     executeExpoAsync(projectRoot, ['start', '--port', '3002'], {
       verbose: false,

--- a/packages/create-expo/e2e/__tests__/index-test.ts
+++ b/packages/create-expo/e2e/__tests__/index-test.ts
@@ -59,6 +59,12 @@ it('creates a full basic project by default', async () => {
 });
 
 it('throws when fetch is disabled', async () => {
+  const [major] = process.versions.node.split('.').map(Number);
+  if (major >= 23) {
+    expect(true).toBe(true);
+    // `--no-experimental-fetch` is a legacy flag fetch it not experimental in Node.js 23+
+    return;
+  }
   const projectName = 'throws-when-fetch-disabled';
   let result: Awaited<ReturnType<typeof execute>>;
 


### PR DESCRIPTION
# Why

Update Node.js versions across GitHub Actions workflows to use newer LTS releases and Node 22. This drops node 18 from CI which is nearing end of support.

# How

- Updated Android test workflows to use `lts/*` for better long-term maintainability
- Upgraded CLI and various E2E test workflows to Node 22
- Updated `create-expo-app` test matrix to use Node 20, 22, and 24
- Updated Volta configuration in `package.json` to use Node LTS

# Test Plan

- green CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)