### PR TITLE
[ncl] Persist navigation over refreshes and remove duplicated screens

### DIFF
--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -14,7 +14,7 @@ import { type ScreenApiItem, type ScreenConfig } from '../types/ScreenConfig';
 
 const Stack = createStackNavigator();
 
-export const Screens: ScreenConfig[] = [
+export const ScreensList: ScreenConfig[] = [
   {
     getComponent() {
       return optionalRequire(() => require('../screens/ModulesCore/ModulesCoreScreen'));
@@ -425,11 +425,11 @@ export const Screens: ScreenConfig[] = [
     },
     name: 'ViewShot',
   },
-  ...ModulesCoreScreens,
-  ...AudioScreens,
 ];
 
-export const screenApiItems: ScreenApiItem[] = Screens.map(({ name, route }) => ({
+export const Screens: ScreenConfig[] = [...ScreensList, ...ModulesCoreScreens, ...AudioScreens];
+
+export const screenApiItems: ScreenApiItem[] = ScreensList.map(({ name, route }) => ({
   name,
   route: '/apis/' + (route ?? name.toLowerCase()),
   isAvailable: true,

--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -18,7 +18,7 @@ import { type ScreenApiItem, type ScreenConfig } from '../types/ScreenConfig';
 
 const Stack = createStackNavigator();
 
-export const Screens: ScreenConfig[] = [
+const ScreensList: ScreenConfig[] = [
   {
     getComponent() {
       return optionalRequire(() => require('../screens/DrawerLayoutAndroidScreen'));
@@ -435,6 +435,11 @@ export const Screens: ScreenConfig[] = [
     },
     name: 'MeshGradient',
   },
+];
+
+export const Screens: ScreenConfig[] = [
+  ...ScreensList,
+
   ...CameraScreens,
   ...ImageScreens,
   ...VideoScreens,
@@ -442,7 +447,7 @@ export const Screens: ScreenConfig[] = [
   ...MapsScreens,
 ];
 
-export const screenApiItems: ScreenApiItem[] = Screens.map(({ name, route }) => ({
+export const screenApiItems: ScreenApiItem[] = ScreensList.map(({ name, route }) => ({
   name,
   route: '/components/' + (route ?? name.toLowerCase()),
   isAvailable: true,

--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -11,6 +11,7 @@ import { Layout } from '../constants';
 import { CameraScreens } from '../screens/Camera/CameraScreen';
 import ExpoComponents from '../screens/ExpoComponentsScreen';
 import { MapsScreens } from '../screens/ExpoMaps/MapsScreen';
+import { GLScreens } from '../screens/GL/GLScreen';
 import { ImageScreens } from '../screens/Image/ImageScreen';
 import { UIScreens } from '../screens/UI/UIScreen';
 import { VideoScreens } from '../screens/Video/VideoScreen';
@@ -134,150 +135,6 @@ const ScreensList: ScreenConfig[] = [
     },
     name: 'GL',
     options: { title: 'Examples of GL use' },
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/ClearToBlueScreen'));
-    },
-    name: 'ClearToBlue',
-    options: { title: 'Clear to blue' },
-    route: 'gl/cleartoblue',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/BasicTextureScreen'));
-    },
-    name: 'BasicTexture',
-    options: { title: 'Basic texture use' },
-    route: 'gl/basictexture',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/GLViewScreen'));
-    },
-    name: 'GLViewScreen',
-    options: { title: 'GLView example' },
-    route: 'gl/glviewscreen',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/GLMaskScreen'));
-    },
-    name: 'Mask',
-    options: { title: 'MaskedView integration' },
-    route: 'gl/mask',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/GLSnapshotsScreen'));
-    },
-    name: 'Snapshots',
-    options: { title: 'Taking snapshots' },
-    route: 'gl/snapshots',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/GLThreeComposerScreen'));
-    },
-    name: 'THREEComposer',
-    options: { title: 'three.js glitch and film effects' },
-    route: 'gl/threecomposer',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/GLThreeDepthStencilBufferScreen'));
-    },
-    name: 'THREEDepthStencilBuffer',
-    options: { title: 'three.js depth and stencil buffer' },
-    route: 'gl/threedepthstencilbuffer',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/GLThreeSpriteScreen'));
-    },
-    name: 'THREESprite',
-    options: { title: 'three.js sprite rendering' },
-    route: 'gl/threesprite',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/ProcessingInAndOutScreen'));
-    },
-    name: 'ProcessingInAndOut',
-    options: { title: "'In and out' from openprocessing.org" },
-    route: 'gl/processinginandout',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/ProcessingNoClearScreen'));
-    },
-    name: 'ProcessingNoClear',
-    options: { title: 'Draw without clearing screen with processing.js' },
-    route: 'gl/processingnoclear',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/PIXIBasicScreen'));
-    },
-    name: 'PIXIBasic',
-    options: { title: 'Basic pixi.js use' },
-    route: 'gl/pixibasic',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/PIXISpriteScreen'));
-    },
-    name: 'PIXISprite',
-    options: { title: 'pixi.js sprite rendering' },
-    route: 'gl/pixisprite',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/GLCameraScreen'));
-    },
-    name: 'GLCamera',
-    options: { title: 'Expo.Camera integration' },
-    route: 'gl/glcamera',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/WebGL2TransformFeedbackScreen'));
-    },
-    name: 'WebGL2TransformFeedback',
-    options: { title: 'WebGL2 - Transform feedback' },
-    route: 'gl/webgl2transformfeedback',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/CanvasScreen'));
-    },
-    name: 'Canvas',
-    options: { title: 'Canvas example - expo-2d-context' },
-    route: 'gl/canvas',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/GLHeadlessRenderingScreen'));
-    },
-    name: 'HeadlessRendering',
-    options: { title: 'Headless rendering' },
-    route: 'gl/headlessrendering',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/GLReanimatedExample'));
-    },
-    name: 'ReanimatedWorklets',
-    options: { title: 'Reanimated worklets + gesture handler' },
-    route: 'gl/reanimated',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/GL/GLViewOnBusyThread'));
-    },
-    name: 'GLViewOnBusyThread',
-    options: { title: 'Creating GLView when a thread is busy' },
-    route: 'gl/busythread',
   },
   {
     getComponent() {
@@ -440,6 +297,7 @@ const ScreensList: ScreenConfig[] = [
 export const Screens: ScreenConfig[] = [
   ...ScreensList,
 
+  ...GLScreens,
   ...CameraScreens,
   ...ImageScreens,
   ...VideoScreens,

--- a/apps/native-component-list/src/navigation/StackConfig.tsx
+++ b/apps/native-component-list/src/navigation/StackConfig.tsx
@@ -1,4 +1,5 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { HeaderStyleInterpolators } from '@react-navigation/stack';
 import { ThemeType } from 'ThemeProvider';
@@ -27,26 +28,51 @@ export default function getStackConfig(navigation: BottomTabNavigationProp<any>,
         color: theme.text.default,
       },
       headerPressColorAndroid: theme.icon.info,
-      headerRight: () => (
-        <View
-          style={{
-            flexDirection: 'row',
-            alignItems: 'center',
-            marginRight: 16,
-            marginBottom: 4,
-            gap: 14,
-          }}>
-          <TouchableOpacity onPress={() => navigation.navigate('searchNavigator')}>
-            <Ionicons
-              name="search"
-              size={Platform.OS === 'ios' ? 22 : 25}
-              color={theme.icon.info}
-            />
-          </TouchableOpacity>
-          {/* This toggler does not work properly, it only updates the navigation and not the body UI */}
-          {/* <ThemeToggler /> */}
-        </View>
-      ),
+      headerRight: () => <HeaderRightComponent navigation={navigation} theme={theme} />,
     }),
   };
 }
+
+const IS_NAV_PERSISTED = 'PERSIST_NAV_STATE';
+const HeaderRightComponent = ({
+  navigation,
+  theme,
+}: {
+  navigation: BottomTabNavigationProp<any>;
+  theme: ThemeType;
+}) => {
+  const [isNavPersisted, setIsNavPersisted] = React.useState(false);
+  React.useEffect(() => {
+    AsyncStorage.getItem(IS_NAV_PERSISTED).then((value) => setIsNavPersisted(!!value));
+  }, []);
+
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginRight: 16,
+        marginBottom: 4,
+        gap: 14,
+      }}>
+      <TouchableOpacity
+        onPress={() => {
+          (isNavPersisted
+            ? AsyncStorage.removeItem(IS_NAV_PERSISTED)
+            : AsyncStorage.setItem(IS_NAV_PERSISTED, 'enabled')
+          ).then(() => setIsNavPersisted(!isNavPersisted));
+        }}>
+        <Ionicons
+          name={isNavPersisted ? 'lock-closed' : 'lock-open'}
+          size={Platform.OS === 'ios' ? 22 : 25}
+          color={isNavPersisted ? theme.icon.info : theme.icon.default}
+        />
+      </TouchableOpacity>
+      <TouchableOpacity onPress={() => navigation.navigate('searchNavigator')}>
+        <Ionicons name="search" size={Platform.OS === 'ios' ? 22 : 25} color={theme.icon.info} />
+      </TouchableOpacity>
+      {/* This toggler does not work properly, it only updates the navigation and not the body UI */}
+      {/* <ThemeToggler /> */}
+    </View>
+  );
+};

--- a/apps/native-component-list/src/screens/GL/GLScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/GLScreen.tsx
@@ -1,121 +1,162 @@
 import * as React from 'react';
 
-import ComponentListScreen from '../ComponentListScreen';
+import { optionalRequire } from '../../navigation/routeBuilder';
+import ComponentListScreen, { ListElement } from '../ComponentListScreen';
 
-const screens = [
+export const GLScreens = [
   {
-    screenName: 'ClearToBlue',
-    isAvailable: true,
-    name: 'Clear to blue',
-    route: '/components/gl/cleartoblue',
+    name: 'ClearToBlue',
+    getComponent() {
+      return optionalRequire(() => require('./ClearToBlueScreen'));
+    },
+    options: { title: 'Clear to blue' },
+    route: 'gl/cleartoblue',
   },
   {
-    screenName: 'BasicTexture',
-    isAvailable: true,
-    name: 'Basic texture use',
-    route: '/components/gl/basictexture',
+    name: 'BasicTexture',
+    getComponent() {
+      return optionalRequire(() => require('./BasicTextureScreen'));
+    },
+    options: { title: 'Basic texture use' },
+    route: 'gl/basictexture',
   },
   {
-    screenName: 'GLViewScreen',
-    isAvailable: true,
-    name: 'GLView example',
-    route: '/components/gl/glviewscreen',
+    name: 'GLViewScreen',
+    getComponent() {
+      return optionalRequire(() => require('./GLViewScreen'));
+    },
+    options: { title: 'GLView example' },
+    route: 'gl/glviewscreen',
   },
   {
-    screenName: 'Mask',
-    isAvailable: true,
-    name: 'MaskedView integration',
-
-    route: '/components/gl/mask',
+    name: 'Mask',
+    getComponent() {
+      return optionalRequire(() => require('./GLMaskScreen'));
+    },
+    options: { title: 'MaskedView integration' },
+    route: 'gl/mask',
   },
   {
-    screenName: 'Snapshots',
-    isAvailable: true,
-    name: 'Taking snapshots',
-
-    route: '/components/gl/snapshots',
+    name: 'Snapshots',
+    getComponent() {
+      return optionalRequire(() => require('./GLSnapshotsScreen'));
+    },
+    options: { title: 'Taking snapshots' },
+    route: 'gl/snapshots',
   },
   {
-    screenName: 'THREEComposer',
-    isAvailable: true,
-    name: 'three.js glitch and film effects',
-
-    route: '/components/gl/threecomposer',
+    name: 'THREEComposer',
+    getComponent() {
+      return optionalRequire(() => require('./GLThreeComposerScreen'));
+    },
+    options: { title: 'three.js glitch and film effects' },
+    route: 'gl/threecomposer',
   },
   {
-    screenName: 'THREEDepthStencilBuffer',
-    isAvailable: true,
-    name: 'three.js depth and stencil buffer',
-    route: '/components/gl/threedepthstencilbuffer',
+    name: 'THREEDepthStencilBuffer',
+    getComponent() {
+      return optionalRequire(() => require('./GLThreeDepthStencilBufferScreen'));
+    },
+    options: { title: 'three.js depth and stencil buffer' },
+    route: 'gl/threedepthstencilbuffer',
   },
   {
-    screenName: 'THREESprite',
-    isAvailable: true,
-    name: 'three.js sprite rendering',
-    route: '/components/gl/threesprite',
+    name: 'THREESprite',
+    getComponent() {
+      return optionalRequire(() => require('./GLThreeSpriteScreen'));
+    },
+    options: { title: 'three.js sprite rendering' },
+    route: 'gl/threesprite',
   },
   {
-    screenName: 'ProcessingInAndOut',
-    isAvailable: true,
-    name: "'In and out' from openprocessing.org",
-    route: '/components/gl/processinginandout',
+    name: 'ProcessingInAndOut',
+    getComponent() {
+      return optionalRequire(() => require('./ProcessingInAndOutScreen'));
+    },
+    options: { title: "'In and out' from openprocessing.org" },
+    route: 'gl/processinginandout',
   },
   {
-    screenName: 'ProcessingNoClear',
-    isAvailable: true,
-    name: 'Draw without clearing screen with processing.js',
-    route: '/components/gl/processingnoclear',
+    name: 'ProcessingNoClear',
+    getComponent() {
+      return optionalRequire(() => require('./ProcessingNoClearScreen'));
+    },
+    options: { title: 'Draw without clearing screen with processing.js' },
+    route: 'gl/processingnoclear',
   },
   {
-    screenName: 'PIXIBasic',
-    isAvailable: true,
-    name: 'Basic pixi.js use',
-    route: '/components/gl/pixibasic',
+    name: 'PIXIBasic',
+    getComponent() {
+      return optionalRequire(() => require('./PIXIBasicScreen'));
+    },
+    options: { title: 'Basic pixi.js use' },
+    route: 'gl/pixibasic',
   },
   {
-    screenName: 'PIXISprite',
-    isAvailable: true,
-    name: 'pixi.js sprite rendering',
-    route: '/components/gl/pixisprite',
+    name: 'PIXISprite',
+    getComponent() {
+      return optionalRequire(() => require('./PIXISpriteScreen'));
+    },
+    options: { title: 'pixi.js sprite rendering' },
+    route: 'gl/pixisprite',
   },
   {
-    screenName: 'GLCamera',
-    isAvailable: true,
-    name: 'Expo.Camera integration',
-    route: '/components/gl/glcamera',
+    name: 'GLCamera',
+    getComponent() {
+      return optionalRequire(() => require('./GLCameraScreen'));
+    },
+    options: { title: 'Expo.Camera integration' },
+    route: 'gl/glcamera',
   },
   {
-    screenName: 'WebGL2TransformFeedback',
-    isAvailable: true,
-    name: 'WebGL2 - Transform feedback',
-    route: '/components/gl/webgl2transformfeedback',
+    name: 'WebGL2TransformFeedback',
+    getComponent() {
+      return optionalRequire(() => require('./WebGL2TransformFeedbackScreen'));
+    },
+    options: { title: 'WebGL2 - Transform feedback' },
+    route: 'gl/webgl2transformfeedback',
   },
   {
-    screenName: 'Canvas',
-    isAvailable: true,
-    name: 'Canvas example - expo-2d-context',
-    route: '/components/gl/canvas',
+    name: 'Canvas',
+    getComponent() {
+      return optionalRequire(() => require('./CanvasScreen'));
+    },
+    options: { title: 'Canvas example - expo-2d-context' },
+    route: 'gl/canvas',
   },
   {
-    screenName: 'HeadlessRendering',
-    isAvailable: true,
-    name: 'Headless rendering',
-    route: '/components/gl/headlessrendering',
+    name: 'HeadlessRendering',
+    getComponent() {
+      return optionalRequire(() => require('./GLHeadlessRenderingScreen'));
+    },
+    options: { title: 'Headless rendering' },
+    route: 'gl/headlessrendering',
   },
   {
-    screenName: 'ReanimatedWorklets',
-    isAvailable: true,
-    name: 'Reanimated worklets + gesture handler',
-    route: '/components/gl/reanimated',
+    name: 'ReanimatedWorklets',
+    getComponent() {
+      return optionalRequire(() => require('./GLReanimatedExample'));
+    },
+    options: { title: 'Reanimated worklets + gesture handler' },
+    route: 'gl/reanimated',
   },
   {
-    screenName: 'GLViewOnBusyThread',
-    isAvailable: true,
-    name: 'Creating GLView when a thread is busy',
-    route: '/components/gl/busythread',
+    name: 'GLViewOnBusyThread',
+    getComponent() {
+      return optionalRequire(() => require('./GLViewOnBusyThread'));
+    },
+    options: { title: 'Creating GLView when a thread is busy' },
+    route: 'gl/busythread',
   },
 ];
 
 export default function GLScreen() {
-  return <ComponentListScreen apis={screens} />;
+  const apis: ListElement[] = GLScreens.map((screen) => {
+    return {
+      name: screen.name,
+      isAvailable: true,
+      route: `/components/${screen.route}`,
+    };
+  });
+  return <ComponentListScreen apis={apis} />;
 }

--- a/apps/test-suite/AppNavigator.js
+++ b/apps/test-suite/AppNavigator.js
@@ -28,20 +28,6 @@ const transitionSpec = shouldDisableTransition ? { open: spec, close: spec } : u
 export default function AppNavigator(props) {
   const { theme } = useTheme();
 
-  React.useLayoutEffect(() => {
-    if (props.navigation) {
-      props.navigation.setOptions({
-        title: 'Tests',
-        tabBarLabel: 'Tests',
-        tabBarIcon: ({ focused }) => {
-          const color = focused ? theme.icon.info : theme.icon.default;
-          return <MaterialCommunityIcons name="format-list-checks" size={27} color={color} />;
-        },
-        tabBarBackground: () => <TabBackground />,
-      });
-    }
-  }, [props.navigation]);
-
   return (
     <Stack.Navigator
       {...props}
@@ -82,6 +68,19 @@ export default function AppNavigator(props) {
       <Stack.Screen name="run" component={RunTests} options={{ title: 'Test Runner' }} />
     </Stack.Navigator>
   );
+}
+
+AppNavigator.navigationOptions = {
+  title: 'Tests',
+  tabBarLabel: 'Tests',
+  tabBarIcon: TabBarIcon,
+  tabBarBackground: () => <TabBackground />,
+};
+
+function TabBarIcon({ focused }) {
+  const { theme } = useTheme();
+  const color = focused ? theme.icon.info : theme.icon.default;
+  return <MaterialCommunityIcons name="format-list-checks" size={27} color={color} />;
 }
 
 function TabBackground() {


### PR DESCRIPTION
# Why

To improve experience using NCL and make our lives easier.

# How

* Deduplicate nested screens
* Add lock to nav header to persist navigation state over refreshes/rebuilds