### PR TITLE
[docs] Update Vale dependency and configuration

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -9,7 +9,7 @@ IgnoredClasses= whitesapce-pre, prose-code
 SkippedScopes = script, style, pre, figure, code, tt, tr, td, span
 
 # Settings applied to md/mdx format.
-[*.md]
+[*.{md,mdx}]
 
 # List of styles to load
 BasedOnStyles = expo-docs

--- a/docs/package.json
+++ b/docs/package.json
@@ -86,7 +86,7 @@
     "@types/prismjs": "^1.26.5",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
-    "@vvago/vale": "^3.9.2",
+    "@vvago/vale": "^3.9.6",
     "acorn": "^8.14.0",
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.9",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3430,9 +3430,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vvago/vale@npm:^3.9.2":
-  version: 3.9.3
-  resolution: "@vvago/vale@npm:3.9.3"
+"@vvago/vale@npm:^3.9.6":
+  version: 3.9.6
+  resolution: "@vvago/vale@npm:3.9.6"
   dependencies:
     axios: "npm:^1.4.0"
     rimraf: "npm:^5.0.0"
@@ -3440,7 +3440,7 @@ __metadata:
     unzipper: "npm:^0.10.14"
   bin:
     vale: bin/vale
-  checksum: 10c0/0d05173f93e7a23065ce5bb7381b2fccb4c71eb18a82b76233eff7c06df7e31a95f3393e8e42073c3eaf7798a6a7e67d9e8f760dc61cb6ad61c2f8634fc06a22
+  checksum: 10c0/2483f9b472c20e87c376f8b3b6c17b313cbaf223519bcc5120d96b54b3d5e91c1a44786f1dba637bfdce9a6e36604fdcc7c0e1a8baeeeb5ce4930cc62a2a9160
   languageName: node
   linkType: hard
 
@@ -5982,7 +5982,7 @@ __metadata:
     "@types/prismjs": "npm:^1.26.5"
     "@types/react": "npm:^18.3.12"
     "@types/react-dom": "npm:^18.3.1"
-    "@vvago/vale": "npm:^3.9.2"
+    "@vvago/vale": "npm:^3.9.6"
     acorn: "npm:^8.14.0"
     autoprefixer: "npm:^10.4.20"
     axios: "npm:^1.7.9"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Upgrade Vale dependency.
- After Vale version 3.9.4, the glob pattern to match the `.mdx` files has changed. Vale's configuration does not recognize `*.mdx` and `*.md ' same anymore. All format specific patterns are required to be defined separately as specified in Vale's documentation here: https://vale.sh/docs/vale-ini#format-specific-settings.
 - To fix this, upgrade format-specific configuration to `[*.{md,mdx}]` in `.vale.ini`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

After upgrading dependency and Vale's configuration, run `yarn run lint-proser on a sample text:

![CleanShot 2025-03-03 at 16 58 48@2x](https://github.com/user-attachments/assets/45c031e0-5e83-4645-a9ca-201ebeb5cbb6)

In the above screenshot, Vale is detecting the problems in the sample text as expected. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
