### PR TITLE
fix(cli): ensure `UsbmuxClient` can load binary plist pair record data from Apple devices

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix `static` and `server` projects not starting up correctly when project path contains URI-unsafe characters like spaces. ([#34289](https://github.com/expo/expo/pull/34289) by [@kitten](https://github.com/kitten))
 - Add fallback resolution strategy for dependencies and optional peer dependencies of `expo` and `expo-router` to prevent broken resolution for isolated dependencies and hoisting issues. ([#34286](https://github.com/expo/expo/pull/34286) by [@kitten](https://github.com/kitten))
 - Preserve proxy leases on webcontainers ([#34831](https://github.com/expo/expo/pull/34831) by [@kitten](https://github.com))
+- Ensure `UsbmuxClient` can load binary plist pair record data from Apple devices. ([#35262](https://github.com/expo/expo/pull/35262) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/UsbmuxdClient.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/UsbmuxdClient.ts
@@ -190,7 +190,8 @@ export class UsbmuxdClient extends ServiceClient<UsbmuxProtocolClient> {
       const BPLIST_MAGIC = Buffer.from('bplist00');
       if (BPLIST_MAGIC.compare(resp.PairRecordData, 0, 8) === 0) {
         debug('Binary plist pair record detected.');
-        return parsePlistBuffer(resp.PairRecordData)[0];
+        const pairRecords = parsePlistBuffer(resp.PairRecordData);
+        return Array.isArray(pairRecords) ? pairRecords[0] : pairRecords;
       } else {
         // TODO: use parsePlistBuffer
         return plist.parse(resp.PairRecordData.toString()) as any; // TODO: type guard

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/__tests__/UsbmuxdClient-test.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/__tests__/UsbmuxdClient-test.ts
@@ -46,4 +46,52 @@ describe('connect', () => {
       /There was an error connecting to the USB connected device \(id: 7, port: 8080\)/
     );
   });
+
+  it('returns binary pair record data', async () => {
+    const socket = mockSocket();
+    const client = new UsbmuxdClient(socket);
+    const protocolClient = client['protocolClient'];
+
+    // Fake the response to `ReadPairRecord`
+    protocolClient.sendMessage = jest.fn(async () => ({
+      PairRecordData: createBinaryRecordPairList(),
+    }));
+
+    const pairRecord = await client.readPairRecord('00000000-0000000000000000');
+
+    expect(protocolClient.sendMessage).toHaveBeenCalledWith({
+      messageType: 'ReadPairRecord',
+      extraFields: { PairRecordID: '00000000-0000000000000000' },
+    });
+
+    expect(pairRecord).toMatchObject({
+      DeviceCertificate: expect.any(Buffer),
+      HostPrivateKey: expect.any(Buffer),
+      HostCertificate: expect.any(Buffer),
+      RootPrivateKey: expect.any(Buffer),
+      RootCertificate: expect.any(Buffer),
+      EscrowBag: expect.any(Buffer),
+      SystemBUID: '00000000-0000-0000-0000-000000000000',
+      HostID: '00000000-0000-0000-0000-000000000000',
+      WiFiMACAddress: '00:00:00:00:00:00',
+    });
+  });
 });
+
+/**
+ * This returns a new buffer containing a fake record pair.
+ * It was created using `bplist-creator` and contains an array with a single object:
+ *   - DeviceCertificate: Buffer - fake RSA certificate
+ *   - HostPrivateKey: Buffer - fake RSA certificate
+ *   - HostCertificate: Buffer - fake RSA certificate
+ *   - RootPrivateKey: Buffer - fake RSA certificate
+ *   - RootCertificate: Buffer - fake RSA certificate
+ *   - SystemBUID: String - fake UUID
+ *   - HostID: String - fake UUID
+ *   - WiFiMACAddress: String - fake mac address
+ *   - EscrowBag: Buffer - fake binary data
+ */
+function createBinaryRecordPairList() {
+  // eslint-disable-next-line
+  return Buffer.from([98,112,108,105,115,116,48,48,217,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,15,16,17,95,16,17,68,101,118,105,99,101,67,101,114,116,105,102,105,99,97,116,101,94,72,111,115,116,80,114,105,118,97,116,101,75,101,121,95,16,15,72,111,115,116,67,101,114,116,105,102,105,99,97,116,101,94,82,111,111,116,80,114,105,118,97,116,101,75,101,121,95,16,15,82,111,111,116,67,101,114,116,105,102,105,99,97,116,101,90,83,121,115,116,101,109,66,85,73,68,86,72,111,115,116,73,68,89,69,115,99,114,111,119,66,97,103,94,87,105,70,105,77,65,67,65,100,100,114,101,115,115,79,16,69,45,45,45,45,45,66,69,71,73,78,32,67,69,82,84,73,70,73,67,65,84,69,45,45,45,45,45,10,70,65,75,69,67,69,82,84,73,70,73,67,65,84,69,10,45,45,45,45,45,69,78,68,32,67,69,82,84,73,70,73,67,65,84,69,45,45,45,45,45,79,16,69,45,45,45,45,45,66,69,71,73,78,32,67,69,82,84,73,70,73,67,65,84,69,45,45,45,45,45,10,70,65,75,69,67,69,82,84,73,70,73,67,65,84,69,10,45,45,45,45,45,69,78,68,32,67,69,82,84,73,70,73,67,65,84,69,45,45,45,45,45,79,16,69,45,45,45,45,45,66,69,71,73,78,32,67,69,82,84,73,70,73,67,65,84,69,45,45,45,45,45,10,70,65,75,69,67,69,82,84,73,70,73,67,65,84,69,10,45,45,45,45,45,69,78,68,32,67,69,82,84,73,70,73,67,65,84,69,45,45,45,45,45,79,16,69,45,45,45,45,45,66,69,71,73,78,32,67,69,82,84,73,70,73,67,65,84,69,45,45,45,45,45,10,70,65,75,69,67,69,82,84,73,70,73,67,65,84,69,10,45,45,45,45,45,69,78,68,32,67,69,82,84,73,70,73,67,65,84,69,45,45,45,45,45,79,16,69,45,45,45,45,45,66,69,71,73,78,32,67,69,82,84,73,70,73,67,65,84,69,45,45,45,45,45,10,70,65,75,69,67,69,82,84,73,70,73,67,65,84,69,10,45,45,45,45,45,69,78,68,32,67,69,82,84,73,70,73,67,65,84,69,45,45,45,45,45,95,16,36,48,48,48,48,48,48,48,48,45,48,48,48,48,45,48,48,48,48,45,48,48,48,48,45,48,48,48,48,48,48,48,48,48,48,48,48,79,16,32,206,45,193,159,211,251,129,201,174,214,65,183,21,2,174,8,4,129,192,54,122,18,186,255,220,102,10,67,38,254,75,240,95,16,17,48,48,58,48,48,58,48,48,58,48,48,58,48,48,58,48,48,0,8,0,27,0,47,0,62,0,80,0,95,0,113,0,124,0,131,0,141,0,156,0,228,1,44,1,116,1,188,2,4,2,43,2,78,0,0,0,0,0,0,2,1,0,0,0,0,0,0,0,18,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,98]);
+}


### PR DESCRIPTION
# Why

Fixes #34942

# How

With the help of @EldinHb, who provided the debug logs, it looked like the pair record data that was supposed to be returned from the `UsbmuxdClient.readPairRecord` method never returned the pair record. To test this further, @EldinHb tested a potential fix where don't expect the binary plist pair record data to be an array - and that seems to have worked.

I've added a unit test to test this even more. The data returned from the `parsePlistBuffer` method already changes the data from array to object, so the "pop the first item from the array" in the `UsbmuxdClient.readPairRecord` is incorrect.

# Test Plan

- See added test.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
