### PR TITLE
fix(expo-dev-launcher): add default `null` value to `UrlDropdown` ref to unblock canaries

### DIFF
--- a/packages/expo-dev-launcher/bundle/components/UrlDropdown.tsx
+++ b/packages/expo-dev-launcher/bundle/components/UrlDropdown.tsx
@@ -44,7 +44,7 @@ export function UrlDropdown({ onSubmit, isLoading, inputValue, setInputValue }: 
     },
   };
 
-  const ref = React.useRef<NativeTextInput>();
+  const ref = React.useRef<NativeTextInput>(null);
   const [open, setOpen] = React.useState(false);
   const [isValidUrl, setIsValidUrl] = React.useState(validateUrl(inputValue));
 


### PR DESCRIPTION
# Why

The latest scheduled canaries deployment failed due to bundling issues in the `expo-dev-launcher`. See https://github.com/expo/expo/actions/runs/13621545526/job/38071817215#step:7:962

<img width="942" alt="image" src="https://github.com/user-attachments/assets/2cc6a053-24cf-46f6-a8b5-aed9f8abbe9d" />

# How

- Added missing default value for `React.useRef<..>(null)`

# Test Plan

- `cd packages/expo-dev-launcher`
- `npm pack`
- Should succeed without errors

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
