### PR TITLE
refactor(cli): drop `tempy` as dependency for SDK 53

### DIFF
--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -98,7 +98,6 @@
     "structured-headers": "^0.4.1",
     "tar": "^6.2.1",
     "temp-dir": "^2.0.0",
-    "tempy": "^0.7.1",
     "terminal-link": "^2.1.1",
     "undici": "^6.18.2",
     "unique-string": "~2.0.0",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -97,10 +97,8 @@
     "stacktrace-parser": "^0.1.10",
     "structured-headers": "^0.4.1",
     "tar": "^6.2.1",
-    "temp-dir": "^2.0.0",
     "terminal-link": "^2.1.1",
     "undici": "^6.18.2",
-    "unique-string": "~2.0.0",
     "wrap-ansi": "^7.0.0",
     "ws": "^8.12.1"
   },

--- a/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
+++ b/packages/@expo/cli/src/start/server/AsyncWsTunnel.ts
@@ -1,9 +1,8 @@
 import * as tunnel from '@expo/ws-tunnel';
 import chalk from 'chalk';
 import * as fs from 'node:fs';
-import { hostname } from 'node:os';
+import { tmpdir, hostname } from 'node:os';
 import * as path from 'node:path';
-import tempDir from 'temp-dir';
 
 import * as Log from '../../log';
 import { env, envIsWebcontainer } from '../../utils/env';
@@ -61,7 +60,7 @@ function getTunnelSession(): string {
   let session = randomStr() + randomStr() + randomStr();
   if (envIsWebcontainer()) {
     const leaseId = Buffer.from(hostname()).toString('base64url');
-    const leaseFile = path.join(tempDir, `_ws_tunnel_lease_${leaseId}`);
+    const leaseFile = path.join(tmpdir(), `_ws_tunnel_lease_${leaseId}`);
     try {
       session = fs.readFileSync(leaseFile, 'utf8').trim() || session;
     } catch {}

--- a/packages/@expo/cli/src/utils/__mocks__/createTempPath.ts
+++ b/packages/@expo/cli/src/utils/__mocks__/createTempPath.ts
@@ -1,9 +1,9 @@
+import { randomBytes } from 'crypto';
 import os from 'os';
 import path from 'path';
-import uniqueString from 'unique-string';
 
 export function createTempDirectoryPath(): string {
-  return path.join(os.tmpdir(), uniqueString());
+  return path.join(os.tmpdir(), randomBytes(16).toString('hex'));
 }
 
 export function createTempFilePath(name = ''): string {

--- a/packages/@expo/cli/src/utils/createTempPath.ts
+++ b/packages/@expo/cli/src/utils/createTempPath.ts
@@ -1,9 +1,11 @@
+import { randomBytes } from 'crypto';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
-import tempDir from 'temp-dir';
-import uniqueString from 'unique-string';
 
-const uniqueTempPath = (): string => path.join(tempDir, uniqueString());
+const uniqueTempPath = (): string => {
+  return path.join(os.tmpdir(), randomBytes(16).toString('hex'));
+};
 
 // Functionally equivalent to: https://github.com/sindresorhus/tempy/blob/943ade0c935367117adbe2b690516ebc94139c6d/index.js#L43-L47
 export function createTempDirectoryPath(): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6808,20 +6808,6 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-del@^6.0.0:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/del/-/del-6.1.1.tgz#3b70314f1ec0aa325c6b14eb36b95786671edb7a"
-  integrity sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==
-  dependencies:
-    globby "^11.0.1"
-    graceful-fs "^4.2.4"
-    is-glob "^4.0.1"
-    is-path-cwd "^2.2.0"
-    is-path-inside "^3.0.2"
-    p-map "^4.0.0"
-    rimraf "^3.0.2"
-    slash "^3.0.0"
-
 delaunator@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/delaunator/-/delaunator-4.0.1.tgz#3d779687f57919a7a418f8ab947d3bddb6846957"
@@ -9665,12 +9651,7 @@ is-object@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.2.tgz#a56552e1c665c9e950b4a025461da87e72f86fcf"
   integrity sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==
 
-is-path-cwd@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
-  integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
-
-is-path-inside@^3.0.2, is-path-inside@^3.0.3:
+is-path-inside@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
@@ -15152,17 +15133,6 @@ temp-dir@^2.0.0, temp-dir@~2.0.0:
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
   integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
 
-tempy@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.7.1.tgz#5a654e6dbd1747cdd561efb112350b55cd9c1d46"
-  integrity sha512-vXPxwOyaNVi9nyczO16mxmHGpl6ASC5/TVhRRHpqeYHvKQm58EaWNvZXxAhR0lYYnBOQFjXjhzeLsaXdjxLjRg==
-  dependencies:
-    del "^6.0.0"
-    is-stream "^2.0.0"
-    temp-dir "^2.0.0"
-    type-fest "^0.16.0"
-    unique-string "^2.0.0"
-
 terminal-link@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
@@ -15518,11 +15488,6 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.16.0.tgz#3240b891a78b0deae910dbeb86553e552a148860"
-  integrity sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==
-
 type-fest@^0.18.0:
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
@@ -15718,7 +15683,7 @@ unique-slug@^4.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
-unique-string@^2.0.0, unique-string@~2.0.0:
+unique-string@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==


### PR DESCRIPTION
# Why

We've removed this dependency in the past in #30832, but added it back for `npx expo install expo@next --fix`. Since SDK 52, we don't use this library anymore - so it should be safe to remove for SDK 53.

# How

- Dropped `tempy` as a dependency from `@expo/cli`.

# Test Plan

- Hard to test now, but should be straight forward for SDK 53.
- `bun create expo ./test-upgrade`
- `cd ./test-upgrade`
- `bun expo install expo@52 --fix`
- `bun expo install expo@53 --fix` (or maybe canary version?)
- Should work fine.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
