### PR TITLE
refactor(cli): phase-out `@expo/rudder-sdk-node` client in favor of the `FetchClient`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -40,7 +40,7 @@
 - Drop `fs-extra` in favor of `fs`. ([#35036](https://github.com/expo/expo/pull/35036) by [@kitten](https://github.com/kitten))
 - Drop `fast-glob` in favor of `glob`. ([#35082](https://github.com/expo/expo/pull/35082) by [@kitten](https://github.com/kitten))
 - Move Expo Atlas out of experimental phase by renaming environment variable to `EXPO_ATLAS`. ([#35260](https://github.com/expo/expo/pull/35260) by [@byCedric](https://github.com/byCedric))
-- Phase out `@expo/rudder-sdk-node` usage in telemetry.
+- Phase out `@expo/rudder-sdk-node` usage in telemetry. ([#35271](https://github.com/expo/expo/pull/35271) by [@byCedric](https://github.com/byCedric))
 
 ## 0.22.18 - 2025-02-20
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Drop `fs-extra` in favor of `fs`. ([#35036](https://github.com/expo/expo/pull/35036) by [@kitten](https://github.com/kitten))
 - Drop `fast-glob` in favor of `glob`. ([#35082](https://github.com/expo/expo/pull/35082) by [@kitten](https://github.com/kitten))
 - Move Expo Atlas out of experimental phase by renaming environment variable to `EXPO_ATLAS`. ([#35260](https://github.com/expo/expo/pull/35260) by [@byCedric](https://github.com/byCedric))
+- Phase out `@expo/rudder-sdk-node` usage in telemetry.
 
 ## 0.22.18 - 2025-02-20
 

--- a/packages/@expo/cli/src/utils/telemetry/Telemetry.ts
+++ b/packages/@expo/cli/src/utils/telemetry/Telemetry.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 
 import { FetchClient } from './clients/FetchClient';
-import { RudderDetachedClient } from './clients/RudderDetachedClient';
+import { FetchDetachedClient } from './clients/FetchDetachedClient';
 import { TelemetryClient, TelemetryClientStrategy, TelemetryRecord } from './types';
 import { createContext } from './utils/context';
 import { getAnonymousId } from '../../api/user/UserSettings';
@@ -32,7 +32,7 @@ type TelemetryActor = Required<Pick<TelemetryOptions, 'anonymousId' | 'sessionId
 
 export class Telemetry {
   private context = createContext();
-  private client: TelemetryClient = new RudderDetachedClient();
+  private client: TelemetryClient = new FetchDetachedClient();
   private actor: TelemetryActor;
 
   /** A list of all events, recorded before the telemetry was fully initialized */
@@ -135,13 +135,11 @@ export class Telemetry {
 
 function createClientFromStrategy(strategy: TelemetryOptions['strategy']) {
   // When debugging, use the actual Rudderstack client, but lazy load it
-  if (env.EXPO_NO_TELEMETRY_DETACH || strategy === 'debug') {
-    const { RudderClient } =
-      require('./clients/RudderClient') as typeof import('./clients/RudderClient');
-    return new RudderClient();
+  if (env.EXPO_NO_TELEMETRY_DETACH || strategy === 'debug' || strategy === 'instant') {
+    return new FetchClient();
   }
 
-  return strategy === 'instant' ? new FetchClient() : new RudderDetachedClient();
+  return new FetchDetachedClient();
 }
 
 /** Generate a unique message ID using a random hash and UUID */

--- a/packages/@expo/cli/src/utils/telemetry/__tests__/index.test.ts
+++ b/packages/@expo/cli/src/utils/telemetry/__tests__/index.test.ts
@@ -16,7 +16,7 @@ it('returns non-detached client when `env.EXPO_NO_TELEMETRY_DETACH` is true', ()
   setEnv('EXPO_NO_TELEMETRY_DETACH', 'true');
   jest.isolateModules(() => {
     const { getTelemetry } = require('../') as typeof import('../');
-    expect(getTelemetry()?.strategy).toBe('debug');
+    expect(getTelemetry()?.strategy).toBe('instant');
   });
 });
 

--- a/packages/@expo/cli/src/utils/telemetry/clients/FetchDetachedClient.ts
+++ b/packages/@expo/cli/src/utils/telemetry/clients/FetchDetachedClient.ts
@@ -1,0 +1,59 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { createTempFilePath } from '../../createTempPath';
+import type { TelemetryClient, TelemetryClientStrategy, TelemetryRecordInternal } from '../types';
+
+const debug = require('debug')('expo:telemetry:client:detached') as typeof console.log;
+
+export class FetchDetachedClient implements TelemetryClient {
+  /** This client should be used for short-lived commands */
+  readonly strategy: TelemetryClientStrategy = 'detached';
+  /** All recorded telemetry events */
+  private records: TelemetryRecordInternal[] = [];
+
+  abort() {
+    return this.records;
+  }
+
+  record(record: TelemetryRecordInternal[]) {
+    this.records.push(
+      ...record.map((record) => ({
+        ...record,
+        originalTimestamp: record.sentAt,
+      }))
+    );
+  }
+
+  async flush() {
+    try {
+      if (!this.records.length) {
+        return debug('No records to flush, skipping...');
+      }
+
+      const file = createTempFilePath('expo-telemetry.json');
+      const data = JSON.stringify({ records: this.records });
+
+      this.records = [];
+
+      await fs.promises.mkdir(path.dirname(file), { recursive: true });
+      await fs.promises.writeFile(file, data);
+
+      const child = spawn(process.execPath, [require.resolve('./flushFetchDetached'), file], {
+        detached: true,
+        windowsHide: true,
+        shell: false,
+        stdio: 'ignore',
+      });
+
+      child.unref();
+    } catch (error) {
+      // This could fail if any direct or indirect imports change during an upgrade to the `expo` dependency via `npx expo install --fix`,
+      // since this file may no longer be present after the upgrade, but before the process under the old Expo CLI version is terminated.
+      debug('Exception while initiating detached flush:', error);
+    }
+
+    debug('Detached flush started');
+  }
+}

--- a/packages/@expo/cli/src/utils/telemetry/clients/flushFetchDetached.ts
+++ b/packages/@expo/cli/src/utils/telemetry/clients/flushFetchDetached.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs';
+
+import { FetchClient } from './FetchClient';
+import type { TelemetryRecordInternal } from '../types';
+
+const telemetryFile = process.argv[2];
+
+flush()
+  .catch(() => fs.promises.unlink(telemetryFile))
+  .finally(() => process.exit(0));
+
+async function flush() {
+  if (!telemetryFile) return;
+
+  let json: string;
+  let data: { records: TelemetryRecordInternal[] };
+
+  try {
+    json = await fs.promises.readFile(telemetryFile, 'utf8');
+    data = JSON.parse(json) as any;
+  } catch (error: any) {
+    if (error.code === 'ENOENT') return;
+    throw error;
+  }
+
+  if (data.records.length) {
+    const client = new FetchClient();
+    await client.record(data.records);
+    await client.flush();
+  }
+
+  await fs.promises.unlink(telemetryFile);
+}


### PR DESCRIPTION
# Why

The Rudder SDK package is still using `node-fetch` and is considered to be a huge library for what it does. This PR phases out usage of the `@expo/rudder-sdk-node`, so we can drop this package as dependency fully for SDK 53.

# How

- Removed usage of `@expo/rudder-sdk-node` in telemetry.
- Added `FetchDetachedClient` to still maintain detached telemetry support.

# Test Plan

- This can only be tested in a canary release

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
