### PR TITLE
[video][ios] Fix the Now Playing notification disappearing after the video is paused

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - [Web] Fix `playbackRate` not being applied in the setup function.([#34182](https://github.com/expo/expo/pull/34182) by [@behenate](https://github.com/behenate))
 - Fix safe area insets not updating for native controls on iOS. ([#32864](https://github.com/expo/expo/pull/32864) by [@behenate](https://github.com/behenate))
+- [iOS] Fix the Now Playing notification disappearing after the video is paused. ([#35273](https://github.com/expo/expo/pull/35273) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -105,7 +105,7 @@ class VideoManager {
       audioSessionCategoryOptions.remove(.duckOthers)
     }
 
-    if audioSession.categoryOptions != audioSessionCategoryOptions {
+    if audioSession.categoryOptions != audioSessionCategoryOptions || audioSession.category != .playback || audioSession.mode != .moviePlayback {
       do {
         try audioSession.setCategory(.playback, mode: .moviePlayback, options: audioSessionCategoryOptions)
       } catch {
@@ -121,9 +121,6 @@ class VideoManager {
         log.warn("Failed to activate the audio session. This might cause issues with audio playback. \(error.localizedDescription)")
       }
     }
-
-    // The now playing notification requires correct audio session category, notify the manager of about the change.
-    NowPlayingManager.shared.refreshNowPlaying()
   }
 
   private func findAudioMixingMode() -> AudioMixingMode? {
@@ -132,6 +129,9 @@ class VideoManager {
     })
     var audioMixingMode: AudioMixingMode = .mixWithOthers
 
+    if playingPlayers.isEmpty {
+      return nil
+    }
     for videoPlayer in playingPlayers where (audioMixingMode.priority()) < videoPlayer.audioMixingMode.priority() {
       audioMixingMode = videoPlayer.audioMixingMode
     }


### PR DESCRIPTION
# Why

Part of a minor audit of Now Playing for iOS (1/3)
Fixes https://github.com/expo/expo/issues/33785
The Now Playing notification disappears on iOS after the video is paused

# How

The `if` statement in `VideoManager` is too restrictive. We also have to check if the playback category and mode are correct. 
Calling the `NowPlayingManager` from the function also turned out to be unnecessary after fixes from the next PR are applied. 
Moreover the `findAudioMixingMode` would incorrectly return the audio mixing to be set as `mixWithOthers` while the audio mixing mode was unset. Those three things caused the notification to disappear after the video is paused


# Test Plan

Tested in BareExpo on an iPhone 13
