### PR TITLE
[video][ios] Fix a race condition in setting the targets for the Now Playing controls

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [Web] Fix `playbackRate` not being applied in the setup function.([#34182](https://github.com/expo/expo/pull/34182) by [@behenate](https://github.com/behenate))
 - Fix safe area insets not updating for native controls on iOS. ([#32864](https://github.com/expo/expo/pull/32864) by [@behenate](https://github.com/behenate))
 - [iOS] Fix the Now Playing notification disappearing after the video is paused. ([#35273](https://github.com/expo/expo/pull/35273) by [@behenate](https://github.com/behenate))
+- [iOS] Fix a race condition in setting the targets for the Now Playing controls causing the controls to sometimes not work. ([#35274](https://github.com/expo/expo/pull/35274) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Part of a minor audit of Now Playing for iOS (2/3)

When the Now Playing notification is disabled and enabled again the controls are sometimes inactive or only some of them work.

# How

When we disable and re-enable the controls we call `removeNowPlayingTargets` and then `addNowPlayingTargets` right after that. I believe that underneath the calls to the command center are re-dispatched and somehow the individual line call order is mismatched, which causes the control targets to be added and removed at the same time. This means that some of the time all of them work correctly, and some of the time only some or none of them work. 

Dispatching the removal and addition of the targets from the main queue seems to fix the issue.

# Test Plan

Tested in BareExpo on iPhone 13.
