### PR TITLE
[docs] [ENG-14983] Update `on.push` trigger docs regarding ignoring branches

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -78,13 +78,14 @@ on:
     branches:
       - main
       - feature/**
-      - !feature/test-**
-      # other branch names and globs
+      - !feature/test-** # other branch names and globs
+
+
     tags:
       - v1
       - v2*
-      - !preview**
-      # other tag names and globs
+      - !v2-preview** # other tag names and globs
+
 ```
 
 ### `on.pull_request`

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -64,9 +64,9 @@ on:
 
 Runs your workflow when you push a commit to matching branches and/or tags.
 
-With the `branches` list, you can trigger the workflow only when those specified branches are pushed to. For example, if you use `branches: ['main']`, only pushes to the `main` branch will trigger the workflow. Supports globs.
+With the `branches` list, you can trigger the workflow only when those specified branches are pushed to. For example, if you use `branches: ['main']`, only pushes to the `main` branch will trigger the workflow. Supports globs. By using the `!` prefix you can specify branches to ignore (you still need to provide at least one branch pattern without it).
 
-With the `tags` list, you can trigger the workflow only when those specified tags are pushed. For example, if you use `tags: ['v1']`, only the `v1` tag being pushed will trigger the workflow. Supports globs.
+With the `tags` list, you can trigger the workflow only when those specified tags are pushed. For example, if you use `tags: ['v1']`, only the `v1` tag being pushed will trigger the workflow. Supports globs. By using the `!` prefix you can specify tags to ignore (you still need to provide at least one tag pattern without it).
 
 When neither `branches` nor `tags` are provided, `branches` defaults to `['*']` and `tags` defaults to `[]`, which means the workflow will trigger on push events to all branches and will not trigger on tag pushes. If only one of the two lists is provided the other defaults to `[]`.
 
@@ -78,10 +78,12 @@ on:
     branches:
       - main
       - feature/**
+      - !feature/test-**
       # other branch names and globs
     tags:
       - v1
       - v2*
+      - !preview**
       # other tag names and globs
 ```
 


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-14983/allow-ignore-branch-definition-in-workflow-triggers
Companion to: https://github.com/expo/universe/pull/18646
Allowed ignore branch patterns in `on.push` trigger config

# How

Updated the docs for `on.push` workflow trigger after allowing for ignore branch patterns

# Test Plan

Tested manually

| Before | After |
| - | - |
| <img width="1108" alt="Screenshot 2025-03-04 at 11 19 17" src="https://github.com/user-attachments/assets/9b747922-729a-43ea-8adf-1669e027236b" /> | <img width="1108" alt="Screenshot 2025-03-04 at 11 37 08" src="https://github.com/user-attachments/assets/7d836a82-abb9-44a3-8c77-2de0890007d3" /> |

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
