### PR TITLE
[ios][1/3] Fix Swift 6 errors - Fix non-final `Sendable` Exceptions

### DIFF
--- a/packages/expo-application/CHANGELOG.md
+++ b/packages/expo-application/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 6.0.2 - 2025-01-10
 

--- a/packages/expo-application/ios/ApplicationExceptions.swift
+++ b/packages/expo-application/ios/ApplicationExceptions.swift
@@ -1,18 +1,18 @@
 import ExpoModulesCore
 
-internal class UrlDocumentDirectoryException: Exception {
+internal final class UrlDocumentDirectoryException: Exception {
   override var reason: String {
     "Unable to get url for document directory"
   }
 }
 
-internal class InstallationTimeException: Exception {
+internal final class InstallationTimeException: Exception {
   override var reason: String {
     "Unable to get installation time of this application"
   }
 }
 
-internal class DateCastException: Exception {
+internal final class DateCastException: Exception {
   override var reason: String {
     "Invalid date format"
   }

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Deprecate `expo-asset/tools/hashAssetFiles` in favor of built-in hashing support in `expo/metro-config`. ([#34208](https://github.com/expo/expo/pull/34208) by [@EvanBacon](https://github.com/EvanBacon))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - Drop `invariant` and `md5-file` dependencies. ([#35328](https://github.com/expo/expo/pull/35328) by [@kitten](https://github.com/kitten))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 11.0.4 - 2025-02-19
 

--- a/packages/expo-asset/ios/AssetModule.swift
+++ b/packages/expo-asset/ios/AssetModule.swift
@@ -1,13 +1,13 @@
 import ExpoModulesCore
 import CryptoKit
 
-internal class UnableToDownloadAssetException: GenericException<URL> {
+internal final class UnableToDownloadAssetException: GenericException<URL> {
   override var reason: String {
     "Unable to download asset from url: '\(param.absoluteString)'"
   }
 }
 
-internal class UnableToSaveAssetToDirectoryException: GenericException<URL> {
+internal final class UnableToSaveAssetToDirectoryException: GenericException<URL> {
   override var reason: String {
     "Unable to save asset to directory: '\(param.absoluteString)'"
   }

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 0.3.5 - 2025-02-19
 

--- a/packages/expo-audio/ios/AudioExceptions.swift
+++ b/packages/expo-audio/ios/AudioExceptions.swift
@@ -1,42 +1,42 @@
 import ExpoModulesCore
 
-internal class InvalidCategoryException: GenericException<String> {
+internal final class InvalidCategoryException: GenericException<String> {
   override var reason: String {
     "`\(param)` is not a valid audio category"
   }
 }
 
-internal class AudioStateException: GenericException<String> {
+internal final class AudioStateException: GenericException<String> {
   override var reason: String {
     "Failed to change audio state: \(param)"
   }
 }
 
-internal class AudioPermissionsException: Exception {
+internal final class AudioPermissionsException: Exception {
   override var reason: String {
     "Recording permission has not been granted"
   }
 }
 
-internal class InvalidAudioModeException: GenericException<String> {
+internal final class InvalidAudioModeException: GenericException<String> {
   override var reason: String {
     "Impossible audio mode: \(param)"
   }
 }
 
-internal class RecordingDisabledException: Exception {
+internal final class RecordingDisabledException: Exception {
   override var reason: String {
     "Recording not allowed on iOS. Enable with Audio.setAudioModeAsync"
   }
 }
 
-internal class NoInputFoundException: Exception {
+internal final class NoInputFoundException: Exception {
   override var reason: String {
     "No input port found"
   }
 }
 
-internal class PreferredInputFoundException: GenericException<String> {
+internal final class PreferredInputFoundException: GenericException<String> {
   override var reason: String {
     "Preferred input '\(param)' not found!"
   }

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 13.0.5 - 2025-01-27
 

--- a/packages/expo-background-fetch/ios/BackgroundFetchExceptions.swift
+++ b/packages/expo-background-fetch/ios/BackgroundFetchExceptions.swift
@@ -1,12 +1,12 @@
 import ExpoModulesCore
 
-internal class BackgroundFetchDisabled: Exception {
+internal final class BackgroundFetchDisabled: Exception {
   override var reason: String {
     "Background Fetch has not been configured. To enable it, add `fetch` to `UIBackgroundModes` in the application's Info.plist file"
   }
 }
 
-internal class TaskManagerNotFound: Exception {
+internal final class TaskManagerNotFound: Exception {
   override var reason: String {
     "TaskManager not found. Are you sure that Expo modules are properly linked?"
   }

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 7.0.1 - 2025-01-10
 

--- a/packages/expo-clipboard/ios/ClipboardExceptions.swift
+++ b/packages/expo-clipboard/ios/ClipboardExceptions.swift
@@ -2,13 +2,13 @@
 
 import ExpoModulesCore
 
-internal class InvalidImageException: GenericException<String> {
+internal final class InvalidImageException: GenericException<String> {
   override var reason: String {
     "Invalid base64 image: \(param.prefix(32))\(param.count > 32 ? "..." : "")"
   }
 }
 
-internal class PasteFailureException: Exception {
+internal final class PasteFailureException: Exception {
   override var reason: String {
     "Failed to get item from clipboard"
   }

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Use the `src` folder as the Metro target. ([#33781](https://github.com/expo/expo/pull/33781) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 14.0.5 - 2025-01-31
 

--- a/packages/expo-contacts/ios/ContactsExceptions.swift
+++ b/packages/expo-contacts/ios/ContactsExceptions.swift
@@ -1,90 +1,90 @@
 import ExpoModulesCore
 
-internal class FailedToFetchContactsException: Exception {
+internal final class FailedToFetchContactsException: Exception {
   override var reason: String {
     "Error while fetching contacts"
   }
 }
 
-internal class FailedToCacheContacts: Exception {
+internal final class FailedToCacheContacts: Exception {
   override var reason: String {
     "Failed to cache contacts"
   }
 }
 
-internal class FailedToGetContactException: GenericException<String> {
+internal final class FailedToGetContactException: GenericException<String> {
   override var reason: String {
     "Failed to get contact with id: \(param)"
   }
 }
 
-internal class FailedToGetGroupException: GenericException<String> {
+internal final class FailedToGetGroupException: GenericException<String> {
   override var reason: String {
     "Failed to get group with id: \(param)"
   }
 }
 
-internal class FailedToSaveException: Exception {
+internal final class FailedToSaveException: Exception {
   override var reason: String {
     "Failed to provide a contact identifier"
   }
 }
 
-internal class FilePermissionException: GenericException<String?> {
+internal final class FilePermissionException: GenericException<String?> {
   override var reason: String {
     "File '\(String(describing: param))' isn't readable."
   }
 }
 
-internal class FailedToOpenImageException: Exception {
+internal final class FailedToOpenImageException: Exception {
   override var reason: String {
     "Could not open provided image"
   }
 }
 
-internal class FetchContainersException: Exception {
+internal final class FetchContainersException: Exception {
   override var reason: String {
     "Error fetching containers"
   }
 }
 
-internal class FetchGroupException: GenericException<String> {
+internal final class FetchGroupException: GenericException<String> {
   override var reason: String {
     "Failed to get group for name: \(param)"
   }
 }
 
-internal class GroupQueryException: Exception {
+internal final class GroupQueryException: Exception {
   override var reason: String {
     "Failed to get groups"
   }
 }
 
-internal class FailedToUnifyContactException: Exception {
+internal final class FailedToUnifyContactException: Exception {
   override var reason: String {
     "Failed to unify contact"
   }
 }
 
-internal class FailedToCreateViewControllerException: Exception {
+internal final class FailedToCreateViewControllerException: Exception {
   override var reason: String {
     "Could not build controller, invalid props"
   }
 }
 
-internal class FailedToFindContactException: Exception {
+internal final class FailedToFindContactException: Exception {
   override var reason: String {
     "Failed to find contact"
   }
 }
 
-internal class ContactPickingInProgressException: Exception {
+internal final class ContactPickingInProgressException: Exception {
   override var reason: String {
     "Different contact picking in progress. Await other contact picking first"
   }
 }
 
-internal class ContactManipulationInProgressException: Exception {
+internal final class ContactManipulationInProgressException: Exception {
   override var reason: String {
     "Different contact manipulation in progress. Await other contact manipulation first"
   }

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 14.0.2 - 2025-01-10
 

--- a/packages/expo-crypto/ios/CryptoModule.swift
+++ b/packages/expo-crypto/ios/CryptoModule.swift
@@ -73,13 +73,13 @@ private func digest(algorithm: DigestAlgorithm, output: TypedArray, data: TypedA
   _ = algorithm.digest(data.rawPointer, UInt32(data.byteLength), outputPtr)
 }
 
-private class LossyConversionException: Exception {
+private final class LossyConversionException: Exception {
   override var reason: String {
     "Unable to convert given string without losing some information"
   }
 }
 
-private class FailedGeneratingRandomBytesException: GenericException<OSStatus> {
+private final class FailedGeneratingRandomBytesException: GenericException<OSStatus> {
   override var reason: String {
     "Generating random bytes has failed with OSStatus code: \(param)"
   }

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 - [web] Add option to disable file reader to read base64 from file on successfull picking. ([#34739](https://github.com/expo/expo/pull/34739) by [@danilaplee](https://github.com/danilaplee))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 13.0.3 - 2025-02-07
 

--- a/packages/expo-document-picker/ios/Exceptions.swift
+++ b/packages/expo-document-picker/ios/Exceptions.swift
@@ -1,18 +1,18 @@
 import ExpoModulesCore
 
-internal class InvalidFileException: Exception {
+internal final class InvalidFileException: Exception {
   override var reason: String {
     "Unable to get file size"
   }
 }
 
-internal class PickingInProgressException: Exception {
+internal final class PickingInProgressException: Exception {
   override var reason: String {
     "Different document picking in progress. Await other document picking first"
   }
 }
 
-internal class MissingViewControllerException: Exception {
+internal final class MissingViewControllerException: Exception {
   override var reason: String {
     "Could not find the current ViewController"
   }

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 18.0.11 - 2025-02-19
 

--- a/packages/expo-file-system/ios/Next/FileSystemNextExceptions.swift
+++ b/packages/expo-file-system/ios/Next/FileSystemNextExceptions.swift
@@ -1,55 +1,55 @@
 import Foundation
 import ExpoModulesCore
 
-internal class CopyOrMoveDirectoryToFileException: Exception {
+internal final class CopyOrMoveDirectoryToFileException: Exception {
   override var reason: String {
     "Unable to copy or move a directory to a file"
   }
 }
 
-internal class UnableToDownloadException: GenericException<String> {
+internal final class UnableToDownloadException: GenericException<String> {
   override var reason: String {
     "Unable to download a file: \(param)"
   }
 }
 
-internal class InvalidTypeFileException: Exception {
+internal final class InvalidTypeFileException: Exception {
   override var reason: String {
     "A folder with the same name already exists in the file location"
   }
 }
 
-internal class InvalidTypeDirectoryException: Exception {
+internal final class InvalidTypeDirectoryException: Exception {
   override var reason: String {
     "A file with the same name already exists in the directory location"
   }
 }
 
-internal class UnableToGetFileSizeException: GenericException<String> {
+internal final class UnableToGetFileSizeException: GenericException<String> {
   override var reason: String {
     "Unable to get file size: \(param)"
   }
 }
 
-internal class UnableToDeleteException: GenericException<String> {
+internal final class UnableToDeleteException: GenericException<String> {
   override var reason: String {
     "Unable to delete file or directory: \(param)"
   }
 }
 
-internal class UnableToCreateException: GenericException<String> {
+internal final class UnableToCreateException: GenericException<String> {
   override var reason: String {
     "Unable to create file or directory: \(param)"
   }
 }
 
-internal class UnableToReadHandleException: GenericException<String> {
+internal final class UnableToReadHandleException: GenericException<String> {
   override var reason: String {
     "Unable to read from a file handle: \(param)"
   }
 }
 
-internal class DestinationAlreadyExistsException: Exception {
+internal final class DestinationAlreadyExistsException: Exception {
   override var reason: String {
     "Destination already exists"
   }

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 13.0.6 - 2025-01-10
 

--- a/packages/expo-image-manipulator/ios/ImageManipulatorExceptions.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulatorExceptions.swift
@@ -3,79 +3,79 @@
 import CoreGraphics
 import ExpoModulesCore
 
-internal class ImageContextLostException: Exception {
+internal final class ImageContextLostException: Exception {
   override var reason: String {
     "Image context has been lost"
   }
 }
 
-internal class ImageDrawingFailedException: Exception {
+internal final class ImageDrawingFailedException: Exception {
   override var reason: String {
     "Drawing the new image failed"
   }
 }
 
-internal class ImageNotFoundException: Exception {
+internal final class ImageNotFoundException: Exception {
   override var reason: String {
     "Image cannot be found"
   }
 }
 
-internal class ImageColorSpaceNotFoundException: Exception {
+internal final class ImageColorSpaceNotFoundException: Exception {
   override var reason: String {
     "The image does not specify any color space"
   }
 }
 
-internal class ImageInvalidCropException: Exception {
+internal final class ImageInvalidCropException: Exception {
   override var reason: String {
     "Invalid crop options has been passed. Please make sure the requested crop rectangle is inside source image"
   }
 }
 
-internal class ImageCropFailedException: GenericException<CGRect> {
+internal final class ImageCropFailedException: GenericException<CGRect> {
   override var reason: String {
     "Cropping the image to rectangle (x: \(param.origin.x), y: \(param.origin.y), width: \(param.width), height: \(param.height)) has failed"
   }
 }
 
-internal class NoImageInContextException: Exception {
+internal final class NoImageInContextException: Exception {
   override var reason: String {
     "Could not read the image from the drawing context"
   }
 }
 
-internal class ImageLoaderNotFoundException: Exception {
+internal final class ImageLoaderNotFoundException: Exception {
   override var reason: String {
     "ImageLoader module not found, make sure 'expo-image-loader' is linked correctly"
   }
 }
 
-internal class FileSystemNotFoundException: Exception {
+internal final class FileSystemNotFoundException: Exception {
   override var reason: String {
     "FileSystem module not found, make sure 'expo-file-system' is linked correctly"
   }
 }
 
-internal class FileSystemReadPermissionException: GenericException<String> {
+internal final class FileSystemReadPermissionException: GenericException<String> {
   override var reason: String {
     "File '\(param)' is not readable"
   }
 }
 
-internal class ImageLoadingFailedException: GenericException<String> {
+internal final class ImageLoadingFailedException: GenericException<String> {
   override var reason: String {
     "Could not load the image: \(param)"
   }
 }
 
-internal class CorruptedImageDataException: Exception {
+internal final class CorruptedImageDataException: Exception {
   override var reason: String {
     "Cannot create image data for given image format"
   }
 }
 
-internal class ImageWriteFailedException: GenericException<String> {
+internal final class ImageWriteFailedException: GenericException<String> {
   override var reason: String {
     "Writing image data to the file has failed: \(param)"
   }

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 16.0.6 - 2025-02-10
 

--- a/packages/expo-image-picker/ios/ImagePickerExceptions.swift
+++ b/packages/expo-image-picker/ios/ImagePickerExceptions.swift
@@ -2,139 +2,139 @@
 
 import ExpoModulesCore
 
-internal class PermissionsModuleNotFoundException: Exception {
+internal final class PermissionsModuleNotFoundException: Exception {
   override var reason: String {
     "Permissions module not found. Are you sure that Expo modules are properly linked?"
   }
 }
 
-internal class FileSystemModuleNotFoundException: Exception {
+internal final class FileSystemModuleNotFoundException: Exception {
   override var reason: String {
     "FileSystem module not found. Are you sure that Expo modules are properly linked?"
   }
 }
 
-internal class LoggerModuleNotFoundException: Exception {
+internal final class LoggerModuleNotFoundException: Exception {
   override var reason: String {
     "Logger module not found. Are you sure that Expo modules are properly linked?"
   }
 }
 
-internal class MissingCameraPermissionException: Exception {
+internal final class MissingCameraPermissionException: Exception {
   override var reason: String {
     "Missing camera or camera roll permission"
   }
 }
 
-internal class MissingMicrophonePermissionException: Exception {
+internal final class MissingMicrophonePermissionException: Exception {
   override var reason: String {
     "Missing microphone permission. Please enable it with the `expo-image-picker` config plugin"
   }
 }
 
-internal class MissingPhotoLibraryPermissionException: Exception {
+internal final class MissingPhotoLibraryPermissionException: Exception {
   override var reason: String {
     "Missing photo library permission"
   }
 }
 
-internal class CameraUnavailableOnSimulatorException: Exception {
+internal final class CameraUnavailableOnSimulatorException: Exception {
   override var reason: String {
     "Camera not available on simulator"
   }
 }
 
-internal class MultiselectUnavailableException: Exception {
+internal final class MultiselectUnavailableException: Exception {
   override var reason: String {
     "Multiple selection is only available on iOS 14+"
   }
 }
 
-internal class MissingCurrentViewControllerException: Exception {
+internal final class MissingCurrentViewControllerException: Exception {
   override var reason: String {
     "Cannot determine currently presented view controller"
   }
 }
 
-internal class MaxDurationWhileEditingExceededException: Exception {
+internal final class MaxDurationWhileEditingExceededException: Exception {
   override var reason: String {
     "'videoMaxDuration' limits to 600 when 'allowsEditing=true'"
   }
 }
 
-internal class InvalidMediaTypeException: GenericException<String?> {
+internal final class InvalidMediaTypeException: GenericException<String?> {
   override var reason: String {
     "Cannot handle '\(param ?? "nil")' media type"
   }
 }
 
-internal class FailedToCreateGifException: Exception {
+internal final class FailedToCreateGifException: Exception {
   override var reason: String {
     "Failed to create image destination for GIF export"
   }
 }
 
-internal class FailedToExportGifException: Exception {
+internal final class FailedToExportGifException: Exception {
   override var reason: String {
     "Failed to export requested GIF"
   }
 }
 
-internal class FailedToWriteImageException: Exception {
+internal final class FailedToWriteImageException: Exception {
   override var reason: String {
     "Failed to write data to a file"
   }
 }
 
-internal class FailedToReadImageException: Exception {
+internal final class FailedToReadImageException: Exception {
   override var reason: String {
     "Failed to read picked image"
   }
 }
 
-internal class FailedToReadImageDataException: Exception {
+internal final class FailedToReadImageDataException: Exception {
   override var reason: String {
     "Failed to read data from a file"
   }
 }
 
-internal class FailedToReadVideoSizeException: Exception {
+internal final class FailedToReadVideoSizeException: Exception {
   override var reason: String {
     "Failed to read the video size"
   }
 }
 
-internal class FailedToReadVideoException: Exception {
+internal final class FailedToReadVideoException: Exception {
   override var reason: String {
     "Failed to read picked video"
   }
 }
 
-internal class FailedToTranscodeVideoException: Exception {
+internal final class FailedToTranscodeVideoException: Exception {
   override var reason: String {
     "Failed to transcode picked video"
   }
 }
 
-internal class UnsupportedVideoExportPresetException: GenericException<String> {
+internal final class UnsupportedVideoExportPresetException: GenericException<String> {
   override var reason: String {
     "Video cannot be transcoded with export preset: \(param)"
   }
 }
 
-internal class FailedToPickVideoException: Exception {
+internal final class FailedToPickVideoException: Exception {
   override var reason: String {
     "Video could not be picked"
   }
 }
 
-internal class FailedToReadImageDataForBase64Exception: Exception {
+internal final class FailedToReadImageDataForBase64Exception: Exception {
   override var reason: String {
     "Failed to read image data to perform base64 encoding"
   }
 }
 
-internal class FailedToPickLivePhotoException: Exception {
+internal final class FailedToPickLivePhotoException: Exception {
   override var reason: String {
     "Failed to read the selected item as a live photo"
   }

--- a/packages/expo-live-photo/CHANGELOG.md
+++ b/packages/expo-live-photo/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 0.0.2 - 2025-01-10
 

--- a/packages/expo-live-photo/ios/LivePhotoExceptions.swift
+++ b/packages/expo-live-photo/ios/LivePhotoExceptions.swift
@@ -3,7 +3,7 @@
 import Foundation
 import ExpoModulesCore
 
-internal class InvalidSourceException: GenericException<String> {
+internal final class InvalidSourceException: GenericException<String> {
   override var reason: String {
     "Provided source is not a valid LivePhotoAsset: \(param)"
   }

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 17.0.6 - 2025-02-14
 

--- a/packages/expo-media-library/ios/MediaLibraryExceptions.swift
+++ b/packages/expo-media-library/ios/MediaLibraryExceptions.swift
@@ -2,139 +2,139 @@ import ExpoModulesCore
 
 let defaultErrorMessage = "unspecified error"
 
-internal class MediaLibraryPermissionsException: Exception {
+internal final class MediaLibraryPermissionsException: Exception {
   override var reason: String {
     "Media Library permission is required to do this operation"
   }
 }
 
-internal class EmptyFileExtensionException: Exception {
+internal final class EmptyFileExtensionException: Exception {
   override var reason: String {
     "Could not get the file's extension - it was empty."
   }
 }
 
-internal class UnsupportedAssetTypeException: GenericException<String> {
+internal final class UnsupportedAssetTypeException: GenericException<String> {
   override var reason: String {
     "This URL does not contain a valid asset type: \(param)"
   }
 }
 
-internal class UnreadableAssetException: GenericException<String> {
+internal final class UnreadableAssetException: GenericException<String> {
   override var reason: String {
     "File \(param) isn't readable"
   }
 }
 
-internal class SaveAssetException: GenericException<(any Error)?> {
+internal final class SaveAssetException: GenericException<(any Error)?> {
   override var reason: String {
     "Asset couldn't be saved to photo library: \(param?.localizedDescription ?? defaultErrorMessage)"
   }
 }
 
-internal class MissingPListKeyException: GenericException<String> {
+internal final class MissingPListKeyException: GenericException<String> {
   override var reason: String {
     "This app is missing \(param). Add this entry to your bundle's Info.plist"
   }
 }
 
-internal class MissingFileException: GenericException<String> {
+internal final class MissingFileException: GenericException<String> {
   override var reason: String {
     "Couldn't open file: \(param). Make sure if this file exists"
   }
 }
 
-internal class SaveVideoException: Exception {
+internal final class SaveVideoException: Exception {
   override var reason: String {
     "This video couldn't be saved to the Camera Roll album"
   }
 }
 
-internal class SaveAlbumException: GenericException<(any Error)?> {
+internal final class SaveAlbumException: GenericException<(any Error)?> {
   override var reason: String {
     "Couldn't add assets to album: \(param?.localizedDescription ?? defaultErrorMessage)"
   }
 }
 
-internal class RemoveFromAlbumException: GenericException<(any Error)?> {
+internal final class RemoveFromAlbumException: GenericException<(any Error)?> {
   override var reason: String {
     "Couldn't remove assets from album: \(param?.localizedDescription ?? defaultErrorMessage)"
   }
 }
 
-internal class RemoveAssetsException: GenericException<(any Error)?> {
+internal final class RemoveAssetsException: GenericException<(any Error)?> {
   override var reason: String {
     "Couldn't remove assets: \(param?.localizedDescription ?? defaultErrorMessage)"
   }
 }
 
-internal class UnsupportedAssetException: Exception {
+internal final class UnsupportedAssetException: Exception {
   override var reason: String {
     "This file type is not supported yet"
   }
 }
 
-internal class NotEnoughPermissionsException: Exception {
+internal final class NotEnoughPermissionsException: Exception {
   override var reason: String {
     "Access to all photos is required to do this operation"
   }
 }
 
-internal class FailedToAddAssetException: GenericException<(any Error)?> {
+internal final class FailedToAddAssetException: GenericException<(any Error)?> {
   override var reason: String {
     "Unable to add asset to the new album: \(param?.localizedDescription ?? defaultErrorMessage)"
   }
 }
 
-internal class CreateAlbumFailedException: GenericException<(any Error)?> {
+internal final class CreateAlbumFailedException: GenericException<(any Error)?> {
   override var reason: String {
     "Could not create album: \(param?.localizedDescription ?? defaultErrorMessage)"
   }
 }
 
-internal class DeleteAlbumFailedException: GenericException<(any Error)?> {
+internal final class DeleteAlbumFailedException: GenericException<(any Error)?> {
   override var reason: String {
     "Could not delete album: \(param?.localizedDescription ?? defaultErrorMessage)"
   }
 }
 
-internal class CursorException: Exception {
+internal final class CursorException: Exception {
   override var reason: String {
     "Couldn't find cursor"
   }
 }
 
-internal class SortByKeyException: GenericException<String> {
+internal final class SortByKeyException: GenericException<String> {
   override var reason: String {
     "SortBy key \"\(param)\" is not supported"
   }
 }
 
-internal class PermissionsModuleNotFoundException: Exception {
+internal final class PermissionsModuleNotFoundException: Exception {
   override var reason: String {
     "Permissions module not found. Are you sure that Expo modules are properly linked?"
   }
 }
 
-internal class ExportSessionFailedException: Exception {
+internal final class ExportSessionFailedException: Exception {
   override var reason: String {
     "Failed to export the requested video"
   }
 }
 
-internal class ExportSessionCancelledException: Exception {
+internal final class ExportSessionCancelledException: Exception {
   override var reason: String {
     "Exporting session cancelled"
   }
 }
 
-internal class ExportSessionUnknownException: Exception {
+internal final class ExportSessionUnknownException: Exception {
   override var reason: String {
     "Could not export the requested video"
   }
 }
 
-internal class InvalidPathException: Exception {
+internal final class InvalidPathException: Exception {
   override var reason: String {
     "Failed to create video path"
   }

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 7.0.5 - 2025-01-10
 

--- a/packages/expo-network/ios/Exceptions.swift
+++ b/packages/expo-network/ios/Exceptions.swift
@@ -1,6 +1,6 @@
 import ExpoModulesCore
 
-internal class IpAddressException: GenericException<Int32> {
+internal final class IpAddressException: GenericException<Int32> {
   override var reason: String {
     "No network interfaces could be retrieved. getifaddrs() failed with error number: \(param)"
   }

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 14.0.3 - 2025-01-10
 

--- a/packages/expo-print/ios/ExpoPrintExceptions.swift
+++ b/packages/expo-print/ios/ExpoPrintExceptions.swift
@@ -1,66 +1,66 @@
 import ExpoModulesCore
 
-internal class PrinterPickerException: GenericException<String?> {
+internal final class PrinterPickerException: GenericException<String?> {
   override var reason: String {
     "There was a problem with the printer picker: '\(param ?? "unknown error")'"
   }
 }
 
-internal class ViewControllerNotFoundException: Exception {
+internal final class ViewControllerNotFoundException: Exception {
   override var reason: String {
     "Could not find the current view controller"
   }
 }
 
-internal class PickerCanceledException: Exception {
+internal final class PickerCanceledException: Exception {
   override var reason: String {
     "Printer picker has been cancelled"
   }
 }
 
-internal class PdfNotRenderedException: GenericException<String?> {
+internal final class PdfNotRenderedException: GenericException<String?> {
   override var reason: String {
     "Error occurred while printing to PDF: '\(param ?? "unknown error")'"
   }
 }
 
-internal class PdfSavingException: Exception {
+internal final class PdfSavingException: Exception {
   override var reason: String {
     "Error occurred while saving the PDF"
   }
 }
 
-internal class UnsupportedFormatException: GenericException<String?> {
+internal final class UnsupportedFormatException: GenericException<String?> {
   override var reason: String {
     "Given format '\(param ?? "unknown")' is not supported"
   }
 }
 
-internal class FileOpeningException: Exception {
+internal final class FileOpeningException: Exception {
   override var reason: String {
     "Error occurred while opening the file"
   }
 }
 
-internal class InvalidUrlException: Exception {
+internal final class InvalidUrlException: Exception {
   override var reason: String {
     "The specified url is not valid for printing"
   }
 }
 
-internal class NoPrintDataException: Exception {
+internal final class NoPrintDataException: Exception {
   override var reason: String {
     "No data to print. You must specify `uri` or `html` option"
   }
 }
 
-internal class PrintingJobFailedException: GenericException<String?> {
+internal final class PrintingJobFailedException: GenericException<String?> {
   override var reason: String {
     "Printing job encountered an error: '\(param ?? "unknown error")'"
   }
 }
 
-internal class PrintIncompleteException: Exception {
+internal final class PrintIncompleteException: Exception {
   override var reason: String {
     "Printing did not complete"
   }

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 - Standardize platform key ordering in `expo-module.config.json`. ([#35003](https://github.com/expo/expo/pull/35003) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 8.0.4 - 2025-01-10
 

--- a/packages/expo-screen-orientation/ios/ScreenOrientationExceptions.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationExceptions.swift
@@ -1,12 +1,12 @@
 import ExpoModulesCore
 
-internal class InvalidOrientationLockException: Exception {
+internal final class InvalidOrientationLockException: Exception {
   override var reason: String {
     "Invalid screen orientation lock"
   }
 }
 
-internal class UnsupportedOrientationLockException: GenericException<ModuleOrientationLock?> {
+internal final class UnsupportedOrientationLockException: GenericException<ModuleOrientationLock?> {
   override var reason: String {
     guard let param = param else {
       return "This device does not support the requested orientation"

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 14.0.1 - 2025-01-10
 

--- a/packages/expo-secure-store/ios/SecureStoreExceptions.swift
+++ b/packages/expo-secure-store/ios/SecureStoreExceptions.swift
@@ -1,24 +1,24 @@
 import ExpoModulesCore
 
-internal class InvalidKeyException: Exception {
+internal final class InvalidKeyException: Exception {
   override var reason: String {
     "Invalid key"
   }
 }
 
-internal class MissingPlistKeyException: Exception {
+internal final class MissingPlistKeyException: Exception {
   override var reason: String {
     "You must set `NSFaceIDUsageDescription` in your Info.plist file to use the `requireAuthentication` option"
   }
 }
 
-internal class SecAccessControlError: GenericException<Int?> {
+internal final class SecAccessControlError: GenericException<Int?> {
   override var reason: String {
     return "Unable to construct SecAccessControl: \(param.map { "code " + String($0) } ?? "unknown error")"
   }
 }
 
-internal class KeyChainException: GenericException<OSStatus> {
+internal final class KeyChainException: GenericException<OSStatus> {
   override var reason: String {
     switch param {
     case errSecUnimplemented:

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 13.0.1 - 2025-01-10
 

--- a/packages/expo-sharing/ios/Exceptions.swift
+++ b/packages/expo-sharing/ios/Exceptions.swift
@@ -1,24 +1,24 @@
 import ExpoModulesCore
 
-internal class FilePermissionException: Exception {
+internal final class FilePermissionException: Exception {
   override var reason: String {
     "You don't have access to the provided file"
   }
 }
 
-internal class MissingCurrentViewControllerException: Exception {
+internal final class MissingCurrentViewControllerException: Exception {
   override var reason: String {
     "Cannot determine currently presented view controller"
   }
 }
 
-internal class UnsupportedTypeException: Exception {
+internal final class UnsupportedTypeException: Exception {
   override var reason: String {
     "Could not share file since there were no apps registered for its type"
   }
 }
 
-internal class FilePermissionModuleException: Exception {
+internal final class FilePermissionModuleException: Exception {
   override var reason: String {
     "File permission module not found"
   }

--- a/packages/expo-sms/CHANGELOG.md
+++ b/packages/expo-sms/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 13.0.1 - 2025-01-10
 

--- a/packages/expo-sms/ios/SMSExceptions.swift
+++ b/packages/expo-sms/ios/SMSExceptions.swift
@@ -1,36 +1,36 @@
 import ExpoModulesCore
 
-internal class SMSUnavailableException: Exception {
+internal final class SMSUnavailableException: Exception {
   override var reason: String {
     "SMS service is not available"
   }
 }
 
-internal class SMSPendingException: Exception {
+internal final class SMSPendingException: Exception {
   override var reason: String {
     "SMS sending in progress, await the old request and then try again"
   }
 }
 
-internal class SMSSendingException: GenericException<String> {
+internal final class SMSSendingException: GenericException<String> {
   override var reason: String {
     param
   }
 }
 
-internal class SMSFileException: GenericException<String> {
+internal final class SMSFileException: GenericException<String> {
   override var reason: String {
     "Failed to attach file: \(param)"
   }
 }
 
-internal class SMSMimeTypeException: GenericException<String> {
+internal final class SMSMimeTypeException: GenericException<String> {
   override var reason: String {
     "Failed to find UTI for mimeType: \(param)"
   }
 }
 
-internal class SMSUriException: GenericException<String> {
+internal final class SMSUriException: GenericException<String> {
   override var reason: String {
     "Invalid file uri: \(param)"
   }

--- a/packages/expo-speech/CHANGELOG.md
+++ b/packages/expo-speech/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 13.0.1 - 2025-01-10
 

--- a/packages/expo-speech/ios/SpeechExceptions.swift
+++ b/packages/expo-speech/ios/SpeechExceptions.swift
@@ -1,6 +1,6 @@
 import ExpoModulesCore
 
-class InvalidVoiceException: GenericException<String> {
+internal final class InvalidVoiceException: GenericException<String> {
   override var reason: String {
     "Cannot find voice with identifier: \(param)!"
   }

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed resolving libsql binary issue on iOS. ([#34529](https://github.com/expo/expo/pull/34529) by [@kudo](https://github.com/kudo))
 - Removed deprecated CR-SQLite integration. ([#35097](https://github.com/expo/expo/pull/35097) by [@kudo](https://github.com/kudo))
 - Remove prebuilt worker on Web. ([#35311](https://github.com/expo/expo/pull/35311) by [@kudo](https://github.com/kudo))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 15.1.2 - 2025-02-05
 

--- a/packages/expo-sqlite/ios/Exceptions.swift
+++ b/packages/expo-sqlite/ios/Exceptions.swift
@@ -1,6 +1,6 @@
 import ExpoModulesCore
 
-internal class DatabaseException: Exception {
+internal final class DatabaseException: Exception {
   override var code: String {
     "E_SQLITE_OPEN_DATABASE"
   }
@@ -10,7 +10,7 @@ internal class DatabaseException: Exception {
   }
 }
 
-internal class DatabaseInvalidPathException: GenericException<String> {
+internal final class DatabaseInvalidPathException: GenericException<String> {
   override var code: String {
     "E_SQLITE_INVALID_PATH"
   }
@@ -20,7 +20,7 @@ internal class DatabaseInvalidPathException: GenericException<String> {
   }
 }
 
-internal class DeleteDatabaseException: GenericException<String> {
+internal final class DeleteDatabaseException: GenericException<String> {
   override var code: String {
     "E_SQLITE_DELETE_DATABASE"
   }
@@ -30,7 +30,7 @@ internal class DeleteDatabaseException: GenericException<String> {
   }
 }
 
-internal class DatabaseNotFoundException: GenericException<String> {
+internal final class DatabaseNotFoundException: GenericException<String> {
   override var code: String {
     "E_SQLITE_DELETE_DATABASE"
   }
@@ -40,7 +40,7 @@ internal class DatabaseNotFoundException: GenericException<String> {
   }
 }
 
-internal class DeleteDatabaseFileException: GenericException<String> {
+internal final class DeleteDatabaseFileException: GenericException<String> {
   override var code: String {
     "E_SQLITE_DELETE_DATABASE"
   }
@@ -50,7 +50,7 @@ internal class DeleteDatabaseFileException: GenericException<String> {
   }
 }
 
-internal class InvalidSqlException: Exception {
+internal final class InvalidSqlException: Exception {
   override var reason: String {
     "sql argument must be a string"
   }
@@ -62,19 +62,19 @@ internal final class InvalidArgumentsException: GenericException<String> {
   }
 }
 
-internal class InvalidBindParameterException: Exception {
+internal final class InvalidBindParameterException: Exception {
   override var reason: String {
     "Invalid bind parameter"
   }
 }
 
-internal class AccessClosedResourceException: Exception {
+internal final class AccessClosedResourceException: Exception {
   override var reason: String {
     "Access to closed resource"
   }
 }
 
-internal class SQLiteErrorException: GenericException<String> {
+internal final class SQLiteErrorException: GenericException<String> {
   override var code: String {
     "ERR_INTERNAL_SQLITE_ERROR"
   }
@@ -84,7 +84,7 @@ internal class SQLiteErrorException: GenericException<String> {
   }
 }
 
-internal class InvalidConvertibleException: GenericException<String> {
+internal final class InvalidConvertibleException: GenericException<String> {
 }
 
 internal final class UnsupportedOperationException: GenericException<String?> {

--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 8.0.1 - 2025-01-10
 

--- a/packages/expo-store-review/ios/StoreReviewExceptions.swift
+++ b/packages/expo-store-review/ios/StoreReviewExceptions.swift
@@ -1,6 +1,6 @@
 import ExpoModulesCore
 
-internal class MissingCurrentWindowSceneException: Exception {
+internal final class MissingCurrentWindowSceneException: Exception {
   override var reason: String {
     "Cannot determine the current window scene in which to present the modal for requesting a review."
   }

--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 9.0.3 - 2025-01-10
 

--- a/packages/expo-video-thumbnails/ios/VideoThumbnailsExceptions.swift
+++ b/packages/expo-video-thumbnails/ios/VideoThumbnailsExceptions.swift
@@ -1,18 +1,18 @@
 import ExpoModulesCore
 
-internal class FileSystemReadPermissionException: GenericException<String> {
+internal final class FileSystemReadPermissionException: GenericException<String> {
   override var reason: String {
     "File '\(param)' is not readable"
   }
 }
 
-internal class ImageWriteFailedException: GenericException<String> {
+internal final class ImageWriteFailedException: GenericException<String> {
   override var reason: String {
     "Writing image data to the file has failed: \(param)"
   }
 }
 
-internal class CorruptedImageDataException: Exception {
+internal final class CorruptedImageDataException: Exception {
   override var reason: String {
     "Cannot create image data for saving of the thumbnail of the given video"
   }

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 - [iOS] SharedRef: migrate from `pointer` to `ref` ([#30359](https://github.com/expo/expo/pull/30359) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 
 ## 2.0.5 - 2025-01-10
 

--- a/packages/expo-video/ios/VideoExceptions.swift
+++ b/packages/expo-video/ios/VideoExceptions.swift
@@ -4,49 +4,49 @@ import ExpoModulesCore
 
 private let defaultCause = "unknown cause"
 
-internal class PictureInPictureUnsupportedException: Exception {
+internal final class PictureInPictureUnsupportedException: Exception {
   override var reason: String {
     "Picture in picture is not supported on this device"
   }
 }
 
-internal class DRMUnsupportedException: GenericException<DRMType> {
+internal final class DRMUnsupportedException: GenericException<DRMType> {
   override var reason: String {
     "DRMType: `\(param)` is unsupported on iOS"
   }
 }
 
-internal class DRMLoadException: GenericException<String?> {
+internal final class DRMLoadException: GenericException<String?> {
   override var reason: String {
     "Failed to decrypt the video stream: \(param ?? defaultCause)"
   }
 }
 
-internal class PlayerException: GenericException<String?> {
+internal final class PlayerException: GenericException<String?> {
   override var reason: String {
     "Failed to initialise the player: \(param ?? defaultCause)"
   }
 }
 
-internal class PlayerItemLoadException: GenericException<String?> {
+internal final class PlayerItemLoadException: GenericException<String?> {
   override var reason: String {
     "Failed to load the player item: \(param ?? defaultCause)"
   }
 }
 
-internal class CachingAssetInitializationException: GenericException<URL?> {
+internal final class CachingAssetInitializationException: GenericException<URL?> {
   override var reason: String {
     "Failed to initialize a caching asset. The provided url: \(param?.absoluteString ?? "nil") doesn't have a valid scheme for caching"
   }
 }
 
-internal class VideoCacheException: GenericException<String?> {
+internal final class VideoCacheException: GenericException<String?> {
   override var reason: String {
     param ?? "Unexpected expo-video cache error"
   }
 }
 
-internal class VideoCacheUnsupportedFormatException: GenericException<String> {
+internal final class VideoCacheUnsupportedFormatException: GenericException<String> {
   override var reason: String {
     "The server responded with a resource with mimeType: \(param) which cannot be played with caching enabled"
   }


### PR DESCRIPTION
# Why

We need to fix warnings that will become errors in the future. This is the first of three PR's.
This one fixes this warning:
```
Non-final class 'PictureInPictureUnsupportedException' cannot conform to 'Sendable'; use '@unchecked Sendable'; this is an error in the Swift 6 language mode
```

# How

Makes all of our exceptions final so that they can conform to `Sendable` without being marked as `@unchecked`

# Test Plan

Tested in BareExpo on iOS. The project compiles without the Swift 6 `Sendable` warning.
