### PR TITLE
[fix][android][tests][updates] fixed complicated solution

### DIFF
--- a/packages/expo-modules-core/android/src/rn74/expo/modules/rncompatibility/ReactNativeFeatureFlags.kt
+++ b/packages/expo-modules-core/android/src/rn74/expo/modules/rncompatibility/ReactNativeFeatureFlags.kt
@@ -4,15 +4,11 @@ package expo.modules.rncompatibility
 
 import com.facebook.react.config.ReactFeatureFlags
 
-interface IReactNativeFeatureFlagsProvider {
-  val enableBridgelessArchitecture: Boolean
-}
-
 /**
  * A compatibility helper of
  * `com.facebook.react.config.ReactFeatureFlags` and
  * `com.facebook.react.internal.featureflags.ReactNativeFeatureFlags`
  */
-object ReactNativeFeatureFlags : IReactNativeFeatureFlagsProvider {
-  override val enableBridgelessArchitecture = ReactFeatureFlags.enableBridgelessArchitecture
+object ReactNativeFeatureFlags {
+  val enableBridgelessArchitecture = ReactFeatureFlags.enableBridgelessArchitecture
 }

--- a/packages/expo-modules-core/android/src/rn77/expo/modules/rncompatibility/ReactNativeFeatureFlags.kt
+++ b/packages/expo-modules-core/android/src/rn77/expo/modules/rncompatibility/ReactNativeFeatureFlags.kt
@@ -2,15 +2,11 @@ package expo.modules.rncompatibility
 
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 
-interface IReactNativeFeatureFlagsProvider {
-  val enableBridgelessArchitecture: Boolean
-}
-
 /**
  * A compatibility helper of
  * `com.facebook.react.config.ReactFeatureFlags` and
  * `com.facebook.react.internal.featureflags.ReactNativeFeatureFlags`
  */
-object ReactNativeFeatureFlags : IReactNativeFeatureFlagsProvider {
-  override val enableBridgelessArchitecture = ReactNativeFeatureFlags.enableBridgelessArchitecture()
+object ReactNativeFeatureFlags {
+  val enableBridgelessArchitecture = ReactNativeFeatureFlags.enableBridgelessArchitecture()
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/errorrecovery/ErrorRecoveryTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/errorrecovery/ErrorRecoveryTest.kt
@@ -3,7 +3,6 @@ package expo.modules.updates.errorrecovery
 import android.os.Message
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
-import expo.modules.rncompatibility.IReactNativeFeatureFlagsProvider
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.launcher.Launcher
 import expo.modules.updates.logging.UpdatesLogger
@@ -17,14 +16,12 @@ class ErrorRecoveryTest {
   private var mockDelegate: ErrorRecoveryDelegate = mockk()
   private val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
   private val updatesLogger = UpdatesLogger(context.filesDir)
-  private var errorRecovery: ErrorRecovery = ErrorRecovery(updatesLogger, mockk<IReactNativeFeatureFlagsProvider>())
+  private var errorRecovery: ErrorRecovery = ErrorRecovery(updatesLogger, enableBridgelessArchitecture = true)
 
   @Before
   fun setup() {
     mockDelegate = mockk(relaxed = true)
-    val mockFeatureFlagsProvider = mockk<IReactNativeFeatureFlagsProvider>()
-    every { mockFeatureFlagsProvider.enableBridgelessArchitecture } returns true
-    errorRecovery = ErrorRecovery(updatesLogger, mockFeatureFlagsProvider)
+    errorRecovery = ErrorRecovery(updatesLogger, enableBridgelessArchitecture = true)
     errorRecovery.initialize(mockDelegate)
     errorRecovery.handler = spyk(ErrorRecoveryHandler(errorRecovery.handlerThread.looper, mockDelegate, UpdatesLogger(context.filesDir)))
     // make handler run synchronously

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt
@@ -8,7 +8,6 @@ import com.facebook.react.bridge.ReactMarker.MarkerListener
 import com.facebook.react.bridge.ReactMarkerConstants
 import com.facebook.react.devsupport.ReleaseDevSupportManager
 import com.facebook.react.devsupport.interfaces.DevSupportManager
-import expo.modules.rncompatibility.IReactNativeFeatureFlagsProvider
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
 import java.lang.ref.WeakReference
@@ -28,7 +27,7 @@ import java.lang.ref.WeakReference
  */
 class ErrorRecovery(
   private val logger: UpdatesLogger,
-  private val reactNativeFeatureFlagsProvider: IReactNativeFeatureFlagsProvider
+  private val enableBridgelessArchitecture: Boolean = true
 ) {
   internal val handlerThread = HandlerThread("expo-updates-error-recovery")
   internal lateinit var handler: Handler
@@ -98,7 +97,7 @@ class ErrorRecovery(
   }
 
   private fun registerErrorHandler(devSupportManager: DevSupportManager) {
-    if (reactNativeFeatureFlagsProvider.enableBridgelessArchitecture) {
+    if (enableBridgelessArchitecture) {
       registerErrorHandlerImplBridgeless()
     } else {
       registerErrorHandlerImplBridge(devSupportManager)
@@ -131,7 +130,7 @@ class ErrorRecovery(
   }
 
   private fun unregisterErrorHandler() {
-    if (reactNativeFeatureFlagsProvider.enableBridgelessArchitecture) {
+    if (enableBridgelessArchitecture) {
       unregisterErrorHandlerImplBridgeless()
     } else {
       unregisterErrorHandlerImplBridge()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -65,7 +65,7 @@ class StartupProcedure(
 
   var emergencyLaunchException: Exception? = null
     private set
-  private val errorRecovery = ErrorRecovery(logger, ReactNativeFeatureFlags)
+  private val errorRecovery = ErrorRecovery(logger, ReactNativeFeatureFlags.enableBridgelessArchitecture)
   private var remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
 
   // TODO: move away from DatabaseHolder pattern to Handler thread


### PR DESCRIPTION
# Why

In #34363 a bit of an over-engineered solution was added to fix a failing ErrorRecovery test after we added RN 0.77 (ReactNativeFeatureFlags was implemented a bit differently).

# How

The fix removes the complex solution and adds a much simpler one as suggested by @Kudo.

# Test Plan

Run Android tests in BareExpo

# Checklist

- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
