### PR TITLE
[docs] Add blurb about per-update rollout clobbering

### DIFF
--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -39,6 +39,7 @@ When ending an update-based rollout, you have two options:
 ### Working with rollouts
 
 - Only one update can be rolled out on a branch at one time.
+- When a rollout is in progress, it must be ended using one of the options above before a new update (with the same runtime version) can be published. This prevents accidentally clobbering the rollout.
 - To see the state of the rollout, use the `eas update:list` or `eas update:view` commands.
 
 ## Branch-based rollouts


### PR DESCRIPTION
# Why

When a per-update rollout is in progress, one is prevented from accidentally clobbering it. This adds a note about that behavior to the doc.

# How

Add note.

# Test Plan

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
