### PR TITLE
chore(create-expo): Upgrade to `tar@7`

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Drop `fast-glob` in favor of `glob`. ([#35082](https://github.com/expo/expo/pull/35082) by [@kitten](https://github.com/kitten))
+- Upgrade to `tar@6` ([#35315](https://github.com/expo/expo/pull/35315) by [@kitten](https://github.com/kitten))
 
 ## 3.1.6 - 2025-02-14
 

--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -47,7 +47,6 @@
     "@types/node": "^18.19.34",
     "@types/picomatch": "^2.3.3",
     "@types/prompts": "2.0.14",
-    "@types/tar": "^6.1.2",
     "@vercel/ncc": "^0.38.1",
     "arg": "^5.0.2",
     "chalk": "^4.0.0",
@@ -59,7 +58,7 @@
     "ora": "3.4.0",
     "picomatch": "^2.3.1",
     "prompts": "^2.4.2",
-    "tar": "^6.2.1",
+    "tar": "^7.4.3",
     "update-check": "^1.5.4"
   }
 }

--- a/packages/create-expo/src/Examples.ts
+++ b/packages/create-expo/src/Examples.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import prompts from 'prompts';
 import { Readable, Stream } from 'stream';
-import tar from 'tar';
+import { extract as tarExtract } from 'tar';
 import { promisify } from 'util';
 
 import {
@@ -106,7 +106,7 @@ export async function downloadAndExtractExampleAsync(root: string, name: string)
   await pipeline(
     // @ts-expect-error see https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/65542
     Readable.fromWeb(response.body),
-    tar.extract(
+    tarExtract(
       {
         cwd: root,
         onentry: createEntryResolver(projectName),

--- a/packages/create-expo/src/createFileTransform.ts
+++ b/packages/create-expo/src/createFileTransform.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import picomatch from 'picomatch';
-import { type ReadEntry } from 'tar';
+import type { ReadEntry } from 'tar';
 
 const debug = require('debug')('expo:init:fileTransform') as typeof console.log;
 

--- a/packages/create-expo/src/utils/npm.ts
+++ b/packages/create-expo/src/utils/npm.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { Stream } from 'stream';
-import tar from 'tar';
+import { extract as tarExtract, TarOptionsWithAliases } from 'tar';
 import { promisify } from 'util';
 
 import { env } from './env';
@@ -19,7 +19,7 @@ export type ExtractProps = {
   strip?: number;
   fileList?: string[];
   disableCache?: boolean;
-  filter?: tar.ExtractOptions['filter'];
+  filter?: TarOptionsWithAliases['filter'];
 };
 
 // @ts-ignore
@@ -128,7 +128,7 @@ export async function extractNpmTarballAsync(
 
   await pipeline(
     stream,
-    tar.extract(
+    tarExtract(
       {
         cwd,
         filter,


### PR DESCRIPTION
Related #35314

# Why

Upgrade `@expo/cli` to `tar@7`. This aligns us with the related PR for `@expo/cli`.

# How

- Upgrade to `tar@7`
- Update imports

# Test Plan

- [x] Retest `downloadAndExtractNpmModuleAsync`
  - Tested via `create-expo/build/index.js --template`
- [x] Retest `downloadAndExtractExampleAsync`
  - Tested via `create-expo/build/index.js --example`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
