### PR TITLE
chore(jest-expo): Drop `fbemitter`

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Drop `fbemitter` in favor of internal logic. ([#35318](https://github.com/expo/expo/pull/35319) by [@kitten](https://github.com/kitten)
+
 ### 💡 Others
 
 ## 52.0.6 - 2025-03-11

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -42,7 +42,6 @@
     "@jest/create-cache-key-function": "^29.2.1",
     "@jest/globals": "^29.2.1",
     "babel-jest": "^29.2.1",
-    "fbemitter": "^3.0.0",
     "find-up": "^5.0.0",
     "jest-environment-jsdom": "^29.2.1",
     "jest-snapshot": "^29.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8039,13 +8039,6 @@ fbemitter@^2.1.1:
   dependencies:
     fbjs "^0.8.4"
 
-fbemitter@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/fbemitter/-/fbemitter-3.0.0.tgz#00b2a1af5411254aab416cd75f9e6289bee4bff3"
-  integrity sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==
-  dependencies:
-    fbjs "^3.0.0"
-
 fbjs-css-vars@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"


### PR DESCRIPTION
Related #35317 #35318

# Why

Dropping `fbemitter`, since it isn't really used in this codebase and a dependency we're trying to remove.

**Why are we looking to drop `fbemitter`?**
- `fbemitter` is archived and deprecated (See ENG-14598)
- `fbemitter -> fbjs -> promise` is causing downstream problems for users
- `fbemitter` has largely been phased out in `expo` and the remaining places it's used in are replaced trivially
- part of our ongoing effort to clean up our dependencies (reducing install size and Metro scan speeds) and to maintain our older code

# How

- Replace mocks using `fbemitter` with mocks using custom emitting logic

# Test Plan

- n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
