### PR TITLE
Fix missing escape in expo-router docs

### DIFF
--- a/packages/expo-router/src/useFocusEffect.ts
+++ b/packages/expo-router/src/useFocusEffect.ts
@@ -28,7 +28,7 @@ export type EffectCallback = () => undefined | void | (() => void);
  *     // Callback should be wrapped in `React.useCallback` to avoid running the effect too often.
  *     useCallback(() => {
  *       // Invoked whenever the route is focused.
- *       console.log('Hello, I'm focused!');
+ *       console.log('Hello, I\'m focused!');
  *
  *       // Return function is invoked whenever the route gets out of focus.
  *       return () => {


### PR DESCRIPTION
# Why

This will fix the wrong formatting here:
![CleanShot 2025-03-05 at 12 57 12@2x](https://github.com/user-attachments/assets/31da0000-9473-4a30-9a86-96e86ace9bfe)

https://docs.expo.dev/versions/latest/sdk/router/#usefocuseffecteffect-do_not_pass_a_second_prop

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
