### PR TITLE
chore(expo-asset): Sync changes from `@expo/metro-config` and drop unused dependencies

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Deprecate `expo-asset/tools/hashAssetFiles` in favor of built-in hashing support in `expo/metro-config`. ([#34208](https://github.com/expo/expo/pull/34208) by [@EvanBacon](https://github.com/EvanBacon))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- Drop `invariant` and `md5-file` dependencies. ([#35328](https://github.com/expo/expo/pull/35328) by [@kitten](https://github.com/kitten))
 
 ## 11.0.4 - 2025-02-19
 

--- a/packages/expo-asset/package.json
+++ b/packages/expo-asset/package.json
@@ -49,8 +49,7 @@
   },
   "dependencies": {
     "@expo/image-utils": "^0.6.0",
-    "expo-constants": "~17.0.0",
-    "invariant": "^2.2.4"
+    "expo-constants": "~17.0.0"
   },
   "devDependencies": {
     "@testing-library/react-native": "^13.1.0",

--- a/packages/expo-asset/package.json
+++ b/packages/expo-asset/package.json
@@ -50,8 +50,7 @@
   "dependencies": {
     "@expo/image-utils": "^0.6.0",
     "expo-constants": "~17.0.0",
-    "invariant": "^2.2.4",
-    "md5-file": "^3.2.3"
+    "invariant": "^2.2.4"
   },
   "devDependencies": {
     "@testing-library/react-native": "^13.1.0",

--- a/packages/expo-asset/tools/hashAssetFiles.js
+++ b/packages/expo-asset/tools/hashAssetFiles.js
@@ -2,10 +2,23 @@
 
 'use strict';
 
-const md5File = require('md5-file/promise');
+const crypto = require('crypto');
+const fs = require('fs');
+
+// NOTE(Mar 5, 2025): Copied over from #34208 in case we won't be able to remove this file by the time SDK 53 is finalized.
+function getMD5ForFilePathAsync(path) {
+  return new Promise((resolve, reject) => {
+    const output = crypto.createHash('md5');
+    const input = fs.createReadStream(path);
+    input.on('error', (err) => reject(err));
+    output.on('error', (err) => reject(err));
+    output.once('readable', () => resolve(output.read().toString('hex')));
+    input.pipe(output);
+  });
+}
 
 module.exports = function hashAssetFiles(asset) {
-  return Promise.all(asset.files.map(md5File)).then((hashes) => {
+  return Promise.all(asset.files.map(getMD5ForFilePathAsync)).then((hashes) => {
     asset.fileHashes = hashes;
 
     // Convert the `../` segments of the server URL to `_` to support monorepos.


### PR DESCRIPTION
# Why

In #34208, @EvanBacon removed the need for `hashAssetFiles` and the logic is being moved to `@expo/metro-config`. While we're hoping to remove this file for SDK 53 entirely, in case we don't and in the meantime, it'd be great to drop this dependency to make the dependency graph of canary releases representative of this future removal.

Specifically, the `md5-file` dependency isn't being used in the new implementation (since it was replaced with a few lines of custom code) and can be sync'ed back to this file. A comment was left to clarify this.

It also seems like `invariant` isn't actually used but being specified as a dependency.

# How

- Sync md5 utility back from `@expo/metro-config` based on #34208 
- Remove `md5-file` dependency
- Remove unused `invariant` dependency

# Test Plan

- Manually tested against an SDK 52 project

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
