### PR TITLE
[templates] react 19 override for npm

### DIFF
--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -16,6 +16,9 @@
     "react": "19.0.0",
     "react-native": "0.78.0"
   },
+  "overrides": {
+    "react": "19.0.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.20.0"
   }

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -16,6 +16,9 @@
     "react": "19.0.0",
     "react-native": "0.78.0"
   },
+  "overrides": {
+    "react": "19.0.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -16,6 +16,9 @@
     "react": "19.0.0",
     "react-native": "0.78.0"
   },
+  "overrides": {
+    "react": "19.0.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.20.0"
   }

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -41,6 +41,9 @@
     "react-native-web": "~0.19.13",
     "react-native-webview": "~13.13.2"
   },
+  "overrides": {
+    "react": "19.0.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/jest": "^29.5.12",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -33,6 +33,9 @@
     "react-native-screens": "~4.9.1",
     "react-native-web": "~0.19.13"
   },
+  "overrides": {
+    "react": "19.0.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",


### PR DESCRIPTION
# Why

using the canary templates with npm installs react 18 along with 19, causing runtime issues: `Warning: Error: A React Element from an older version of React was rendered. This is not supported`

# How

add `override` to the templates.

# Test Plan

tested locally with npm (that was the only one having issues - one still needs to use `npm install --force or --legacy-peer-deps` because of React Native Web's dep on react 18)

yarn 1 and 4.7.0 only install react 19 so they work okay

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
