### PR TITLE
[docs] updates wording on EAS CLI and Workflows doc

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -482,4 +482,5 @@ const RENAMED_PAGES: Record<string, string> = {
   '/eas-workflows/jobs/': '/eas/workflows/syntax/#jobs',
   '/eas-workflows/control-flow/': '/eas/workflows/syntax/#control-flow',
   '/eas-workflows/variables/': '/eas/workflows/syntax/#jobsjob_idoutputs',
+  '/eas-workflows/upgrade/': '/eas/workflows/automating-eas-cli/',
 };

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -388,7 +388,7 @@ export const eas = [
     makePage('eas/workflows/get-started.mdx'),
     makePage('eas/workflows/examples.mdx'),
     makePage('eas/workflows/syntax.mdx'),
-    makePage('eas/workflows/upgrade.mdx'),
+    makePage('eas/workflows/automating-eas-cli.mdx'),
   ]),
   makeSection('EAS Build', [
     makePage('build/introduction.mdx'),

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -321,6 +321,7 @@ redirects[eas-workflows/triggers]=eas/workflows/syntax/#on
 redirects[eas-workflows/jobs]=eas/workflows/syntax/#jobs
 redirects[eas-workflows/control-flow]=eas/workflows/syntax/#control-flow
 redirects[eas-workflows/variables]=eas/workflows/syntax/#jobsjob_idoutputs
+redirects[eas-workflows/upgrade]=eas/workflows/automating-eas-cli
 
 # After adding distribution section under EAS
 redirects[distribution/publishing-websites]=guides/publishing-websites

--- a/docs/pages/eas/workflows/automating-eas-cli.mdx
+++ b/docs/pages/eas/workflows/automating-eas-cli.mdx
@@ -1,6 +1,6 @@
 ---
-title: Upgrade from EAS CLI
-description: Learn how to upgrade your development and release processes to use EAS Workflows.
+title: Automating EAS CLI commands
+description: Learn how to automate sequences of EAS CLI commands with EAS Workflows.
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
@@ -8,9 +8,9 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
-If you're using EAS CLI to build, submit, and update your app, you can upgrade to EAS Workflows to automate your development and release processes. EAS Workflows can build, submit, and update your app, while also running other jobs like Maestro tests, unit tests, custom scripts, and more.
+If you're using EAS CLI to build, submit, and update your app, you can automate sequences of commands with EAS Workflows. EAS Workflows can build, submit, and update your app, while also running other jobs like Maestro tests, unit tests, custom scripts, and more.
 
-Below you'll find how to set up your project to use EAS Workflows, followed by common examples of EAS CLI commands and how to convert them to EAS Workflows.
+Below you'll find how to set up your project to use EAS Workflows, followed by common examples of EAS CLI commands and how you can run them using EAS Workflows.
 
 ## Configure your project
 
@@ -20,13 +20,13 @@ EAS Workflows require a GitHub repository that's linked to your EAS project to r
 - Follow the UI to install the GitHub app.
 - Select the GitHub repository that matches the Expo project and connect it.
 
-## EAS Build
+## Creating builds
 
-You can make a build of your project using EAS CLI with the `eas build` command. To make an iOS build with the `production` build profile, you'd run the following EAS CLI command:
+You can make a build of your project using EAS CLI with the `eas build` command. To make an iOS build with the `production` build profile, you could run the following EAS CLI command:
 
 <Terminal cmd={['$ eas build --platform ios --profile production']} />
 
-To convert this into a workflow, create a workflow file named **.eas/workflows/build-ios-production.yml** at the root of your project.
+To write this command as a workflow, create a workflow file named **.eas/workflows/build-ios-production.yml** at the root of your project.
 
 Inside **build-ios-production.yml**, you can use the following workflow to kick off a job that creates an iOS build with the `production` build profile.
 
@@ -46,19 +46,19 @@ jobs:
       profile: production
 ```
 
-Once you have this workflow file, you can kick it off by pushing a commit to the `main` branch, or by running the following command:
+Once you have this workflow file, you can kick it off by pushing a commit to the `main` branch, or by running the following EAS CLI command:
 
 <Terminal cmd={['$ eas workflow:run build-ios-production.yml']} />
 
 You can provide parameters to make Android builds or use other build profiles. Learn more about build job parameters with the [build job documentation](/eas/workflows/syntax/#build).
 
-## EAS Submit
+## Submitting builds
 
-You can submit your app to the app stores using EAS CLI with the `eas submit` command. To submit an iOS app, you'd run the following EAS CLI command:
+You can submit your app to the app stores using EAS CLI with the `eas submit` command. To submit an iOS app, you could run the following EAS CLI command:
 
 <Terminal cmd={['$ eas submit --platform ios']} />
 
-To convert this into a workflow, create a workflow file named **.eas/workflows/submit-ios.yml** at the root of your project.
+To write this command as a workflow, create a workflow file named **.eas/workflows/submit-ios.yml** at the root of your project.
 
 Inside **submit-ios.yml**, you can use the following workflow to kick off a job that submits an iOS app.
 
@@ -77,19 +77,19 @@ jobs:
       platform: ios
 ```
 
-Once you have this workflow file, you can kick it off by pushing a commit to the `main` branch, or by running the following command:
+Once you have this workflow file, you can kick it off by pushing a commit to the `main` branch, or by running the following EAS CLI command:
 
 <Terminal cmd={['$ eas workflow:run submit-ios.yml']} />
 
 You can provide parameters to submit other platforms or use other submit profiles. Learn more about submit job parameters with the [submit job documentation](/eas/workflows/syntax/#submit).
 
-## EAS Update
+## Publishing updates
 
-You can update your app using EAS CLI with the `eas update` command. To update your app, you'd run the following EAS CLI command:
+You can update your app using EAS CLI with the `eas update` command. To update your app, you could run the following EAS CLI command:
 
 <Terminal cmd={['$ eas update --auto']} />
 
-To convert this into a workflow, create a workflow file named **.eas/workflows/publish-update.yml** at the root of your project.
+To write this command as a workflow, create a workflow file named **.eas/workflows/publish-update.yml** at the root of your project.
 
 Inside **publish-update.yml**, you can use the following workflow to kick off a job that sends and over-the-air update.
 
@@ -108,7 +108,7 @@ jobs:
       branch: ${{ github.ref_name || 'test'}}
 ```
 
-Once you have this workflow file, you can kick it off by pushing a commit to any branch, or by running the following command:
+Once you have this workflow file, you can kick it off by pushing a commit to any branch, or by running the following EAS CLI command:
 
 <Terminal cmd={['$ eas workflow:run publish-update.yml']} />
 


### PR DESCRIPTION
# Why

This doc used to say "Upgrading from EAS CLI" which implied that there was a binary state where you would either use EAS CLI or use EAS Workflows, which is not true nor the intent. So, updating this to be more accurate and to be more about automating sequences of commands you'd usually run with EAS CLI.

# Screenshot

<img width="1655" alt="Screenshot 2025-03-05 at 9 36 58 PM" src="https://github.com/user-attachments/assets/346c803d-69b3-40b9-8dd5-be93e66bbd7a" />


# Test Plan

Make sure the changes read well. Also make sure that it feels like you can still use EAS CLI along with EAS Workflows.