### PR TITLE
[docs] Add fingerprint pre-packaged job

### DIFF
--- a/docs/pages/eas/workflows/examples.mdx
+++ b/docs/pages/eas/workflows/examples.mdx
@@ -188,23 +188,7 @@ on:
 jobs:
   fingerprint:
     name: Fingerprint
-    outputs:
-      android_fingerprint_hash: ${{ steps.fingerprint_step_id.outputs.android_fingerprint_hash }}
-      ios_fingerprint_hash: ${{ steps.fingerprint_step_id.outputs.ios_fingerprint_hash }}
-    steps:
-      - uses: eas/checkout
-      - uses: eas/install_node_modules
-      - name: Install additional tools
-        run: sudo apt-get update -y && sudo apt-get install -y jq
-      - name: Set fingerprint variables
-        id: fingerprint_step_id
-        run: |
-          ANDROID_FINGERPRINT=$(npx expo-updates fingerprint:generate --platform android)
-          ANDROID_FINGERPRINT_HASH=$(echo $ANDROID_FINGERPRINT | jq -r '.hash')
-          IOS_FINGERPRINT=$(npx expo-updates fingerprint:generate --platform ios)
-          IOS_FINGERPRINT_HASH=$(echo $IOS_FINGERPRINT | jq -r '.hash')
-          set-output ios_fingerprint_hash $IOS_FINGERPRINT_HASH
-          set-output android_fingerprint_hash $ANDROID_FINGERPRINT_HASH
+    type: fingerprint
   get_android_build:
     name: Check for existing android build
     needs: [fingerprint]

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -398,17 +398,13 @@ jobs:
 
 > **warning** This job type only supports [CNG (managed)](/workflow/continuous-native-generation/) workflows. If you commit your **android** or **ios** directories, the fingerprint job won't work.
 
-You can then use the results of the fingerprint job when looking for existing build:
+This job outputs the following properties:
 
-```yaml
-jobs:
-  get_ios_build:
-    name: Check for existing ios build
-    needs: [fingerprint]
-    type: get-build
-    params:
-      fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
-      profile: production
+```json
+{
+  "android_fingerprint_hash": string,
+  "ios_fingerprint_hash": string,
+}
 ```
 
 #### `get-build`

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -384,6 +384,33 @@ jobs:
       prod: boolean # optional
 ```
 
+#### `fingerprint`
+
+```yaml
+jobs:
+  my_job:
+    # @info #
+    type: fingerprint
+    # @end #
+```
+
+Calculates fingerprint of iOS and Android builds.
+
+> **warning** This job type only supports CNG (managed) workflows. If you commit your `/android` or `/ios` directories the fingerprint job won't work.
+
+You can then use the results of the fingerprint job when looking for existing build:
+
+```yaml
+jobs:
+  get_ios_build:
+    name: Check for existing ios build
+    needs: [fingerprint]
+    type: get-build
+    params:
+      fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
+      profile: production
+```
+
 #### `get-build`
 
 Retrieves an existing build from EAS that matches the provided parameters.

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -386,6 +386,8 @@ jobs:
 
 #### `fingerprint`
 
+Calculates fingerprint of Android and iOS builds.
+
 ```yaml
 jobs:
   my_job:
@@ -394,9 +396,7 @@ jobs:
     # @end #
 ```
 
-Calculates fingerprint of iOS and Android builds.
-
-> **warning** This job type only supports CNG (managed) workflows. If you commit your `/android` or `/ios` directories the fingerprint job won't work.
+> **warning** This job type only supports [CNG (managed)](/workflow/continuous-native-generation/) workflows. If you commit your **android** or **ios** directories, the fingerprint job won't work.
 
 You can then use the results of the fingerprint job when looking for existing build:
 


### PR DESCRIPTION
# Why

Fingeprint pre-packaged job is released.

# How

![Screenshot 2025-03-06 at 13 29 13](https://github.com/user-attachments/assets/4dec4f91-ff30-414f-b77e-56e218364c2e)

# Test Plan

CI should pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
