### PR TITLE
refactor(plist): upgrade `xmlbuilder` to `15.1.1` to dedupe dependencies

### DIFF
--- a/packages/@expo/plist/CHANGELOG.md
+++ b/packages/@expo/plist/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Upgrade to `xmlbuilder@^15.1.1` and `@xmldom/xmldom@^0.8.8` to dedupe dependencies.
+- Upgrade to `xmlbuilder@^15.1.1` and `@xmldom/xmldom@^0.8.8` to dedupe dependencies. ([#35342](https://github.com/expo/expo/pull/35342) by [@byCedric](https://github.com/byCedric))
 
 ## 0.2.2 - 2025-02-14
 

--- a/packages/@expo/plist/CHANGELOG.md
+++ b/packages/@expo/plist/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Upgrade `xmlbuilder` to `15.1.1` to dedupe dependencies.
+
 ## 0.2.2 - 2025-02-14
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/plist/CHANGELOG.md
+++ b/packages/@expo/plist/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Upgrade `xmlbuilder` to `15.1.1` to dedupe dependencies.
+- Upgrade to `xmlbuilder@^15.1.1` and `@xmldom/xmldom@^0.8.8` to dedupe dependencies.
 
 ## 0.2.2 - 2025-02-14
 

--- a/packages/@expo/plist/package.json
+++ b/packages/@expo/plist/package.json
@@ -30,7 +30,7 @@
     "build"
   ],
   "dependencies": {
-    "@xmldom/xmldom": "~0.7.7",
+    "@xmldom/xmldom": "^0.8.8",
     "base64-js": "^1.2.3",
     "xmlbuilder": "^15.1.1"
   },

--- a/packages/@expo/plist/package.json
+++ b/packages/@expo/plist/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@xmldom/xmldom": "~0.7.7",
     "base64-js": "^1.2.3",
-    "xmlbuilder": "^14.0.0"
+    "xmlbuilder": "^15.1.1"
   },
   "devDependencies": {
     "@types/base64-js": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4606,6 +4606,11 @@
   dependencies:
     tslib "^2.3.0"
 
+"@xmldom/xmldom@^0.8.8":
+  version "0.8.10"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
+  integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
+
 "@xmldom/xmldom@~0.7.7":
   version "0.7.9"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.9.tgz#7f9278a50e737920e21b297b8a35286e9942c056"
@@ -12649,12 +12654,13 @@ playwright@1.43.1, playwright@^1.40.1:
     fsevents "2.3.2"
 
 plist@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.5.tgz#2cbeb52d10e3cdccccf0c11a63a85d830970a987"
-  integrity sha512-83vX4eYdQp3vP9SxuYgEM/G/pJQqLUz/V/xzPrzruLs7fz7jxGQ1msZ/mg1nwZxUSuOp4sb+/bEIbRrbzZRxDA==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/plist/-/plist-3.1.0.tgz#797a516a93e62f5bde55e0b9cc9c967f860893c9"
+  integrity sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==
   dependencies:
+    "@xmldom/xmldom" "^0.8.8"
     base64-js "^1.5.1"
-    xmlbuilder "^9.0.7"
+    xmlbuilder "^15.1.1"
 
 plur@^4.0.0:
   version "4.0.0"
@@ -16560,15 +16566,10 @@ xml2js@0.6.0:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
 
-xmlbuilder@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-14.0.0.tgz#876b5aec4f05ffd5feb97b0a871c855d16fbeb8c"
-  integrity sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==
-
-xmlbuilder@^9.0.7:
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
-  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+xmlbuilder@^15.1.1:
+  version "15.1.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
+  integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
 
 xmlbuilder@~11.0.0:
   version "11.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4611,11 +4611,6 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
-"@xmldom/xmldom@~0.7.7":
-  version "0.7.9"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.9.tgz#7f9278a50e737920e21b297b8a35286e9942c056"
-  integrity sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA==
-
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"


### PR DESCRIPTION
# Why

This bumps `xmlbuilder` to `15.1.1` in `@expo/plist` to avoid having to install multiple versions of this package when installing `expo`.

# How

- `xmlbuilder` - Checked for breaking changes in the [CHANGELOGS](https://github.com/oozcitak/xmlbuilder-js/blob/master/CHANGELOG.md) (there seem to be none)
- `@xmldom/xmldom` - Checked for breaking changes in the [CHANGELOGS](https://github.com/xmldom/xmldom/blob/master/CHANGELOG.md) (there seem to be none affecting us)
- Updated the lockfile

# Test Plan

- See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
