### PR TITLE
[guides] Add directory name formatting guideline in Docs writing style guide

### DIFF
--- a/guides/Expo Documentation Writing Style Guide.md
+++ b/guides/Expo Documentation Writing Style Guide.md
@@ -179,12 +179,19 @@ We, sometimes, have buttons that lead to an Expo Snack. Use title case for these
 - Correct: Try this example on Snack
 - Incorrect: Try This Example On Snack
 
-### Filenames as bold text
+### File and directory names as bold text
 
-Filenames are used as bold text in the markdown files.
+File and directory names are used as bold text in the markdown files.
 
-- Correct: Your app's configuration is located in **app.json/app.config.js**
-- Incorrect: Your app's configuration is loaded in `app.json/app.config.js`
+Example:
+
+- Correct: Your app's configuration is located in **app.json/app.config.js**.
+- Incorrect: Your app's configuration is loaded in `app.json/app.config.js`.
+
+Example:
+
+- Correct: If you commit your **android** or **ios** directories, it won't work.
+- Incorrect: If you commit your `android` or `ios` directories, it won't work.
 
 ### Capitalization
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the writing style guide only mentions to format filenames as bold text. However, for consistency throughout the documents, we reference directory name(s) as bold text.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Changed the section title from "Filenames as bold text" to "File and directory names as bold text" and provided examples for correct and incorrect usage.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff and proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
