### PR TITLE
[video][android] Fix `ConcurrentModificationException` for `VideoPlayer`

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix ConcurrentModificationException app crashes ([#35356](https://github.com/expo/expo/pull/35356) by [@voslartomas](https://github.com/voslartomas))
 - [Web] Fix `playbackRate` not being applied in the setup function.([#34182](https://github.com/expo/expo/pull/34182) by [@behenate](https://github.com/behenate))
 - Fix safe area insets not updating for native controls on iOS. ([#32864](https://github.com/expo/expo/pull/32864) by [@behenate](https://github.com/behenate))
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/AudioFocusManager.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/AudioFocusManager.kt
@@ -25,7 +25,7 @@ class AudioFocusManager(private val appContext: AppContext) : AudioManager.OnAud
   private var currentFocusRequest: AudioFocusRequest? = null
   private var currentMixingMode: AudioMixingMode = AudioMixingMode.MIX_WITH_OTHERS
   private val anyPlayerRequiresFocus: Boolean
-    get() = players.any {
+    get() = players.toList().any {
       playerRequiresFocus(it)
     }
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/AudioFocusManager.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/AudioFocusManager.kt
@@ -184,9 +184,8 @@ class AudioFocusManager(private val appContext: AppContext) : AudioManager.OnAud
   // Utils
 
   private fun playerRequiresFocus(weakPlayer: WeakReference<VideoPlayer>): Boolean {
-    return weakPlayer.get()?.let {
-      (!it.muted && it.playing && it.volume > 0) || it.audioMixingMode == AudioMixingMode.DO_NOT_MIX
-    } ?: false
+    val player = weakPlayer?.get() ?: return false  // Return false if player is null
+    return (!player.muted && player.playing && player.volume > 0) || player.audioMixingMode == AudioMixingMode.DO_NOT_MIX
   }
 
   private fun pausePlayerIfUnmuted(weakPlayer: WeakReference<VideoPlayer>) {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/AudioFocusManager.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/AudioFocusManager.kt
@@ -226,7 +226,9 @@ class AudioFocusManager(private val appContext: AppContext) : AudioManager.OnAud
   }
 
   private fun findAudioMixingMode(): AudioMixingMode {
-    val mixingModes = players.mapNotNull { player ->
+    val playersSnapshot = players.toList()
+
+    val mixingModes = playersSnapshot.mapNotNull { player ->
       player.get()?.takeIf { it.playing }?.audioMixingMode
     }
     if (mixingModes.isEmpty()) {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/AudioFocusManager.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/AudioFocusManager.kt
@@ -184,7 +184,7 @@ class AudioFocusManager(private val appContext: AppContext) : AudioManager.OnAud
   // Utils
 
   private fun playerRequiresFocus(weakPlayer: WeakReference<VideoPlayer>): Boolean {
-    val player = weakPlayer?.get() ?: return false  // Return false if player is null
+    val player = weakPlayer?.get() ?: return false // Return false if player is null
     return (!player.muted && player.playing && player.volume > 0) || player.audioMixingMode == AudioMixingMode.DO_NOT_MIX
   }
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
@@ -136,10 +136,12 @@ class ExpoVideoPlaybackService : MediaSessionService() {
 
   private fun cleanup() {
     hideAllNotifications()
-    mediaSessions.forEach { (_, session) ->
+
+    val sessionsToRelease = ArrayList(mediaSessions.values)
+    mediaSessions.clear()
+    for (session in sessionsToRelease) {
       session.release()
     }
-    mediaSessions.clear()
   }
 
   private fun hidePlayerNotification(player: ExoPlayer) {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
@@ -137,7 +137,7 @@ class ExpoVideoPlaybackService : MediaSessionService() {
   private fun cleanup() {
     hideAllNotifications()
 
-    val sessionsToRelease = ArrayList(mediaSessions.values)
+    val sessionsToRelease = mediaSessions.values.toList()
     mediaSessions.clear()
     for (session in sessionsToRelease) {
       session.release()

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -378,7 +378,10 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
 
   private fun sendEvent(event: PlayerEvent) {
     // Emits to the native listeners
-    event.emit(this, listeners.mapNotNull { it.get() })
+    val listenersSnapshot = listeners.mapNotNull { it.get() }
+
+    event.emit(this, listenersSnapshot)
+
     // Emits to the JS side
     if (event.emitToJS) {
       emit(event.name, event.jsEventPayload)

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -378,10 +378,9 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
 
   private fun sendEvent(event: PlayerEvent) {
     // Emits to the native listeners
-    val listenersSnapshot = listeners.mapNotNull { it.get() }
+    val listenersSnapshot = listeners.toList().mapNotNull { it.get() }
 
     event.emit(this, listenersSnapshot)
-
     // Emits to the JS side
     if (event.emitToJS) {
       emit(event.name, event.jsEventPayload)

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -378,9 +378,10 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
 
   private fun sendEvent(event: PlayerEvent) {
     // Emits to the native listeners
-    val listenersSnapshot = listeners.toList().mapNotNull { it.get() }
+    val listenersSnapshot = listeners.toList()
 
-    event.emit(this, listenersSnapshot)
+    event.emit(this, listenersSnapshot.mapNotNull { it.get() })
+
     // Emits to the JS side
     if (event.emitToJS) {
       emit(event.name, event.jsEventPayload)

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -378,9 +378,9 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
 
   private fun sendEvent(event: PlayerEvent) {
     // Emits to the native listeners
-    val listenersSnapshot = listeners.toList()
+    val listenersSnapshot = listeners.toList().mapNotNull { it.get() }
 
-    event.emit(this, listenersSnapshot.mapNotNull { it.get() })
+    event.emit(this, listenersSnapshot)
 
     // Emits to the JS side
     if (event.emitToJS) {


### PR DESCRIPTION
# Why

We recently added expo-video instead of react-native-video into our app, which is using Instagram like feed, where are multiple videos loading and unloading all the time while swiping and on lower level Android devices we noticed crashes due to ConcurrentModificationException.

Here are all exceptions, we were able to find so far.

```
java.util.ConcurrentModificationException: null
    at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1029)
    at java.util.ArrayList$Itr.next(ArrayList.java:982)
    at expo.modules.video.AudioFocusManager.findAudioMixingMode(AudioFocusManager.kt:255)
    at expo.modules.video.AudioFocusManager.updateAudioFocus(AudioFocusManager.kt:221)
    at expo.modules.video.AudioFocusManager.onMutedChanged(AudioFocusManager.kt:127)
    at expo.modules.video.player.PlayerEvent.emit(PlayerEvent.kt:107)
    at expo.modules.video.player.VideoPlayer.sendEvent(VideoPlayer.kt:334)
    at expo.modules.video.player.VideoPlayer.muted_delegate$lambda$3(VideoPlayer.kt:96)
    at expo.modules.video.player.VideoPlayer.$r8$lambda$VMJq-RrjsP198e1hKEDkgH9D4qk
    at expo.modules.video.player.VideoPlayer$$ExternalSyntheticLambda3.invoke(D8$$SyntheticClass:0)
    at expo.modules.video.delegates.IgnoreSameSet.setValue(IgnoreSameSet.kt:22)
    at expo.modules.video.player.VideoPlayer.setMuted(VideoPlayer.kt:94)
    at expo.modules.video.VideoModule$definition$1$4$4$1.invokeSuspend(VideoModule.kt:126)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
    at android.os.Handler.handleCallback(Handler.java:958)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:230)
    at android.os.Looper.loop(Looper.java:319)
    at android.app.ActivityThread.main(ActivityThread.java:9063)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:588)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1103)
```

and

```
java.util.ConcurrentModificationException: null
    at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:1061)
    at java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:1096)
    at java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:1093)
    at expo.modules.video.playbackService.ExpoVideoPlaybackService.cleanup(ExpoVideoPlaybackService.kt:184)
    at expo.modules.video.playbackService.ExpoVideoPlaybackService.onTaskRemoved(ExpoVideoPlaybackService.kt:102)
    at android.app.ActivityThread.handleServiceArgs(ActivityThread.java:4788)
    at android.app.ActivityThread.-$$Nest$mhandleServiceArgs
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2266)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loopOnce(Looper.java:201)
    at android.os.Looper.loop(Looper.java:288)
    at android.app.ActivityThread.main(ActivityThread.java:8061)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:703)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:911)
```

and

```
java.util.ConcurrentModificationException: null
    at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1111)
    at java.util.ArrayList$Itr.next(ArrayList.java:1064)
    at expo.modules.video.player.VideoPlayer.sendEvent(VideoPlayer.kt:382)
    at expo.modules.video.player.VideoPlayer.access$sendEvent(VideoPlayer.kt:41)
    at expo.modules.video.player.VideoPlayer$playerListener$1.onTrackSelectionParametersChanged(VideoPlayer.kt:182)
    at androidx.media3.exoplayer.ExoPlayerImpl.lambda$setTrackSelectionParameters$6(ExoPlayerImpl.java:1270)
    at androidx.media3.exoplayer.ExoPlayerImpl$$ExternalSyntheticLambda18.invoke(D8$$SyntheticClass:0)
    at androidx.media3.common.util.ListenerSet$ListenerHolder.invoke(ListenerSet.java:339)
    at androidx.media3.common.util.ListenerSet.lambda$queueEvent$0(ListenerSet.java:223)
    at androidx.media3.common.util.ListenerSet$$ExternalSyntheticLambda1.run(D8$$SyntheticClass:0)
    at androidx.media3.common.util.ListenerSet.flushEvents(ListenerSet.java:245)
    at androidx.media3.common.util.ListenerSet.sendEvent(ListenerSet.java:260)
    at androidx.media3.exoplayer.ExoPlayerImpl.setTrackSelectionParameters(ExoPlayerImpl.java:1268)
    at expo.modules.video.player.VideoPlayerSubtitles.setSubtitlesEnabled(VideoPlayerSubtitles.kt:45)
    at expo.modules.video.player.VideoPlayer$1.invokeSuspend(VideoPlayer.kt:239)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
    at android.os.Handler.handleCallback(Handler.java:958)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:257)
    at android.os.Looper.loop(Looper.java:368)
    at android.app.ActivityThread.main(ActivityThread.java:8839)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:572)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1049)
```

and

```
java.util.ConcurrentModificationException: null
    at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1111)
    at java.util.ArrayList$Itr.next(ArrayList.java:1064)
    at expo.modules.video.AudioFocusManager.findAudioMixingMode(AudioFocusManager.kt:255)
    at expo.modules.video.AudioFocusManager.updateAudioFocus(AudioFocusManager.kt:221)
    at expo.modules.video.AudioFocusManager.onMutedChanged(AudioFocusManager.kt:127)
    at expo.modules.video.player.PlayerEvent.emit(PlayerEvent.kt:107)
    at expo.modules.video.player.VideoPlayer.sendEvent(VideoPlayer.kt:336)
    at expo.modules.video.player.VideoPlayer.muted_delegate$lambda$3(VideoPlayer.kt:96)
    at expo.modules.video.player.VideoPlayer.$r8$lambda$VMJq-RrjsP198e1hKEDkgH9D4qk
    at expo.modules.video.player.VideoPlayer$$ExternalSyntheticLambda3.invoke(D8$$SyntheticClass:0)
    at expo.modules.video.delegates.IgnoreSameSet.setValue(IgnoreSameSet.kt:22)
    at expo.modules.video.player.VideoPlayer.setMuted(VideoPlayer.kt:94)
    at expo.modules.video.VideoModule$definition$1$4$4$1.invokeSuspend(VideoModule.kt:126)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
    at android.os.Handler.handleCallback(Handler.java:959)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loopOnce(Looper.java:249)
    at android.os.Looper.loop(Looper.java:337)
    at android.app.ActivityThread.main(ActivityThread.java:9597)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:615)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:935)
```

and 

```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object java.lang.ref.WeakReference.get()' on a null object reference
  at expo.modules.video.AudioFocusManager.playerRequiresFocus (AudioFocusManager.kt:187)
  at expo.modules.video.AudioFocusManager.getAnyPlayerRequiresFocus (AudioFocusManager.kt:29)
  at expo.modules.video.AudioFocusManager.onIsPlayingChanged (AudioFocusManager.kt:115)
  at expo.modules.video.player.PlayerEvent.emit (PlayerEvent.kt:99)
  at expo.modules.video.player.VideoPlayer.sendEvent (VideoPlayer.kt:336)
  at expo.modules.video.player.VideoPlayer.playing_delegate$lambda$0 (VideoPlayer.kt:62)
  at expo.modules.video.player.VideoPlayer.$r8$lambda$mkYlk0Rq-SkI40uTMnln9NzY2B0 (Unknown Source)
  at expo.modules.video.player.VideoPlayer$$ExternalSyntheticLambda0.invoke (D8$$SyntheticClass)
  at expo.modules.video.delegates.IgnoreSameSet.setValue (IgnoreSameSet.kt:22)
  at expo.modules.video.player.VideoPlayer.setPlaying (VideoPlayer.kt:61)
  at expo.modules.video.player.VideoPlayer$playerListener$1.onIsPlayingChanged (VideoPlayer.kt:157)
  at androidx.media3.exoplayer.ExoPlayerImpl.lambda$updatePlaybackInfo$24 (ExoPlayerImpl.java:2174)
  at androidx.media3.exoplayer.ExoPlayerImpl$$ExternalSyntheticLambda21.invoke (D8$$SyntheticClass)
  at androidx.media3.common.util.ListenerSet$ListenerHolder.invoke (ListenerSet.java:339)
  at androidx.media3.common.util.ListenerSet.lambda$queueEvent$0 (ListenerSet.java:223)
  at androidx.media3.common.util.ListenerSet$$ExternalSyntheticLambda1.run (D8$$SyntheticClass)
  at androidx.media3.common.util.ListenerSet.flushEvents (ListenerSet.java:245)
  at androidx.media3.exoplayer.ExoPlayerImpl.updatePlaybackInfo (ExoPlayerImpl.java:2182)
  at androidx.media3.exoplayer.ExoPlayerImpl.updatePlaybackInfoForPlayWhenReadyAndSuppressionReasonStates (ExoPlayerImpl.java:2823)
  at androidx.media3.exoplayer.ExoPlayerImpl.updatePlayWhenReady (ExoPlayerImpl.java:2804)
  at androidx.media3.exoplayer.ExoPlayerImpl.setPlayWhenReady (ExoPlayerImpl.java:833)
  at androidx.media3.common.BasePlayer.pause (BasePlayer.java:119)
  at expo.modules.video.VideoModule$definition$1$4$31$1.invokeSuspend (VideoModule.kt:277)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:33)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:104)
  at android.os.Handler.handleCallback (Handler.java:959)
  at android.os.Handler.dispatchMessage (Handler.java:100)
  at android.os.Looper.loopOnce (Looper.java:249)
  at android.os.Looper.loop (Looper.java:337)
  at android.app.ActivityThread.main (ActivityThread.java:9403)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:614)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1004)
```

# How

It seems like on couple of places code is trying to access list, which is being manipulated in another thread (probably), so we just copied over list in place of cleanup.

# Test Plan

We deployed patch with these changes and exceptions are gone.
