### PR TITLE
fix(cli): Silence missing favicon file error.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 🐛 Bug fixes
 
-- Silence missing favicon file error.
+- Silence missing favicon file error. ([#35357](https://github.com/expo/expo/pull/35357) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix importing `@radix-ui/colors` in CSS files. ([#35213](https://github.com/expo/expo/pull/35213) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure HMR updates use the same serializer pass as initial bundles. ([#35110](https://github.com/expo/expo/pull/35110) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix async bundling. ([#34986](https://github.com/expo/expo/pull/34986) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- Silence missing favicon file error.
 - Fix importing `@radix-ui/colors` in CSS files. ([#35213](https://github.com/expo/expo/pull/35213) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure HMR updates use the same serializer pass as initial bundles. ([#35110](https://github.com/expo/expo/pull/35110) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix async bundling. ([#34986](https://github.com/expo/expo/pull/34986) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/middleware/FaviconMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/FaviconMiddleware.ts
@@ -34,7 +34,11 @@ export class FaviconMiddleware extends ExpoMiddleware {
       faviconImageData = data.source;
       debug('✅ Generated favicon successfully.');
     } catch (error: any) {
+      // Pass through on ENOENT errors
       debug('Failed to generate favicon from Expo config:', error);
+      if (error.code === 'ENOENT') {
+        return next();
+      }
       return next(error);
     }
     // Respond with the generated favicon file

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/FaviconMiddleware.test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/FaviconMiddleware.test.ts
@@ -132,5 +132,5 @@ it(`fails when favicon from Expo config is invalid`, async () => {
   );
 
   expect(next).toBeCalledTimes(1);
-  expect(next).toBeCalledWith(expect.any(Error));
+  expect(next).toBeCalledWith();
 });


### PR DESCRIPTION
# Why

This pull request includes a bug fix to handle missing favicon files gracefully and updates the changelog to reflect this fix. The changes are primarily focused on error handling in the `FaviconMiddleware`.

Bug Fixes:

* [`packages/@expo/cli/src/start/server/middleware/FaviconMiddleware.ts`](diffhunk://#diff-5eaf98dff66c77281db0569bbd3afeacf926fd2ff733f2cefcf18582293d0606R37-R41): Added a condition to bypass errors when the favicon file is not found (`ENOENT` error).

Documentation:

* [`packages/@expo/cli/CHANGELOG.md`](diffhunk://#diff-dced9f7f9eaad1257a4d1786ee6facb5010790cec922eb8662e33a83923c7f7dR18): Updated the changelog to include the fix for silencing missing favicon file errors.