### PR TITLE
test(cli): update outdated test assertions for DOM components export

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/export-dom-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-dom-test.ts
@@ -121,12 +121,12 @@ describe('Export DOM Components', () => {
             },
             {
               ext: 'html',
-              path: expect.pathMatching('www.bundle/0d914ff01e0706fa289727a1827eb669.html'),
+              path: expect.pathMatching('www.bundle/03adb2b4e2c93e6e2c5369dee2b739db.html'),
             },
 
             {
               ext: 'js',
-              path: expect.pathMatching('www.bundle/fc92d9d574db535d76833227be1e7df7.js'),
+              path: expect.pathMatching('www.bundle/37ac4f564839044a1c83ce693d93817b.js'),
             },
 
             {
@@ -277,9 +277,9 @@ describe('Export DOM Components', () => {
 
       'metadata.json',
 
-      'www.bundle/0d914ff01e0706fa289727a1827eb669.html',
+      'www.bundle/03adb2b4e2c93e6e2c5369dee2b739db.html',
+      'www.bundle/37ac4f564839044a1c83ce693d93817b.js',
       'www.bundle/f85bc9fc5dd55297c7f68763d859ab65.css',
-      'www.bundle/fc92d9d574db535d76833227be1e7df7.js',
     ]);
   });
 });


### PR DESCRIPTION
# Why

Introduced in #35290, this resolves some outdated test assertions in CLI E2E tests.

# How

- Updated file hashes based on running the test locally
- ~~When using `linkExpoPackage(Dev)`, these are now marked as `overrides` and `resolutions` to force this specific version in transitive dependencies~~
  - Doesn't work on Windows, as `npm pack` is failing on Windows due to `expo-module-scripts` not supporting Windows :| cc @brentvatne  

# Test Plan

- See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
