### PR TITLE
[ui][android] dismiss context menu on tap menu item

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 - Drop section polyfill for Android ([#35305](https://github.com/expo/expo/pull/35305) by [@aleqsio](https://github.com/aleqsio))
 - Standardize platform key ordering in `expo-module.config.json`. ([#35003](https://github.com/expo/expo/pull/35003) by [@reichhartd](https://github.com/reichhartd))
+- Dismiss context menu when a menu item is tapped on Android ([#35365](https://github.com/expo/expo/pull/35365) by [@fobos531](https://github.com/fobos531))
 
 ## 0.0.2 — 2025-02-11
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/ContextMenu.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/ContextMenu.kt
@@ -20,6 +20,7 @@ import expo.modules.kotlin.views.ExpoComposeView
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.dp
@@ -47,7 +48,7 @@ private fun SectionTitle(text: String) {
 }
 
 @Composable
-fun FlatMenu(elements: Array<ContextMenuElement>, sectionTitle: String?, dispatchers: ContextMenuDispatchers) {
+fun FlatMenu(elements: Array<ContextMenuElement>, sectionTitle: String?, dispatchers: ContextMenuDispatchers, expanded: MutableState<Boolean>) {
   sectionTitle?.takeIf { !it.isEmpty() }?.let {
     SectionTitle(it)
   }
@@ -68,6 +69,7 @@ fun FlatMenu(elements: Array<ContextMenuElement>, sectionTitle: String?, dispatc
         text = { Text(it.text) },
         onClick = {
           dispatchers.buttonPressed(ContextMenuButtonPressedEvent(id))
+          expanded.value = false
         }
       )
     }
@@ -95,13 +97,14 @@ fun FlatMenu(elements: Array<ContextMenuElement>, sectionTitle: String?, dispatc
           dispatchers.switchCheckedChanged(
             ContextMenuSwitchValueChangeEvent(!it.value, id)
           )
+          expanded.value = false
         }
       )
     }
 
     element.submenu?.let {
       HorizontalDivider()
-      FlatMenu(it.elements, it.button.text, dispatchers)
+      FlatMenu(it.elements, it.button.text, dispatchers, expanded)
     }
   }
 }
@@ -163,7 +166,8 @@ class ContextMenu(context: Context, appContext: AppContext) : ExpoComposeView<Co
               dispatchers = ContextMenuDispatchers(
                 buttonPressed = onContextMenuButtonPressed,
                 switchCheckedChanged = onContextMenuSwitchValueChanged
-              )
+              ),
+              expanded = expanded
             )
           }
         }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

I was suprised to see that the context menu on Android was not dismissed when tapping a button. I can see how it could be useful for switches/checkboxes, but I think it would be better to keep it consistent with iOS behavior where it dismisses on any action. At the very least, I would keep it for regular buttons.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Changed the expanded state

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Observe context menu being dismissed when any entry is pressed.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
