### PR TITLE
Fixed missing code in section 4 documentation

### DIFF
--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -548,7 +548,7 @@ export default function EmojiList({ onSelect, onCloseModal }: Props) {
 
   return (
     <FlatList
-      horizontal
+      horizontal={true}
       showsHorizontalScrollIndicator={Platform.OS === 'web'}
       data={emoji}
       contentContainerStyle={styles.listContainer}


### PR DESCRIPTION
Setting the horizontal property of <FlatList> is missing in the documentation





# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
If not, looks like default behavior of vertical scrolling is in place and could not scroll to the right to uncover the emojis. Cheers!

# How

<!--
How did you build this feature or fix this bug and why?
-->

How: Changed from '<FlatList horizontal ...' to <FlatList horizontal={true}'
Why: just saw a typo and think it would be helpful for other beginners like me

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested with Expo Go and the scrolling worked

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
