### PR TITLE
[cli] export:embed should create tmp assets directory if needed 

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- export:embed should create tmp assets directory if needed. ([#35387](https://github.com/expo/expo/pull/35387) by [@douglowder](https://github.com/douglowder))
 - Silence missing favicon file error. ([#35357](https://github.com/expo/expo/pull/35357) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix importing `@radix-ui/colors` in CSS files. ([#35213](https://github.com/expo/expo/pull/35213) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure HMR updates use the same serializer pass as initial bundles. ([#35110](https://github.com/expo/expo/pull/35110) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/export/__tests__/persistMetroAssets.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/persistMetroAssets.test.ts
@@ -81,6 +81,7 @@ describe(persistMetroAssetsAsync, () => {
         '/input/a.png',
         '/input/a@2x.png',
         '/input/a@3x.png',
+        '/output', // output assets directory should always be created
       ]);
     });
 

--- a/packages/@expo/cli/src/export/embed/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/embed/resolveOptions.ts
@@ -1,6 +1,5 @@
 import { resolveEntryPoint } from '@expo/config/paths';
 import arg from 'arg';
-import { mkdirSync, existsSync } from 'fs';
 import type { OutputOptions } from 'metro/src/shared/types';
 import canonicalize from 'metro-core/src/canonicalize';
 import os from 'os';
@@ -129,9 +128,6 @@ export function resolveEagerOptionsAsync(
   if (!assetsDest) {
     destination ??= getTemporaryPath();
     assetsDest = path.join(destination, 'assets');
-    if (!existsSync(assetsDest)) {
-      mkdirSync(assetsDest, { recursive: true });
-    }
   }
 
   if (!bundleOutput) {

--- a/packages/@expo/cli/src/export/embed/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/embed/resolveOptions.ts
@@ -1,6 +1,6 @@
 import { resolveEntryPoint } from '@expo/config/paths';
 import arg from 'arg';
-import { mkdirSync, existsSync } from 'fs-extra';
+import { mkdirSync, existsSync } from 'fs';
 import type { OutputOptions } from 'metro/src/shared/types';
 import canonicalize from 'metro-core/src/canonicalize';
 import os from 'os';

--- a/packages/@expo/cli/src/export/embed/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/embed/resolveOptions.ts
@@ -1,5 +1,6 @@
 import { resolveEntryPoint } from '@expo/config/paths';
 import arg from 'arg';
+import { mkdirSync, existsSync } from 'fs-extra';
 import type { OutputOptions } from 'metro/src/shared/types';
 import canonicalize from 'metro-core/src/canonicalize';
 import os from 'os';
@@ -128,6 +129,9 @@ export function resolveEagerOptionsAsync(
   if (!assetsDest) {
     destination ??= getTemporaryPath();
     assetsDest = path.join(destination, 'assets');
+    if (!existsSync(assetsDest)) {
+      mkdirSync(assetsDest, { recursive: true });
+    }
   }
 
   if (!bundleOutput) {

--- a/packages/@expo/cli/src/export/persistMetroAssets.ts
+++ b/packages/@expo/cli/src/export/persistMetroAssets.ts
@@ -45,7 +45,8 @@ export async function persistMetroAssetsAsync(
     return;
   }
 
-  // For iOS, we need to ensure that the outputDirectory actually exists
+  // For iOS, we need to ensure that the outputDirectory exists.
+  // The bundle code and images build phase script always tries to access this folder
   if (platform === 'ios' && !fs.existsSync(outputDirectory)) {
     fs.mkdirSync(outputDirectory, { recursive: true });
   }

--- a/packages/@expo/cli/src/export/persistMetroAssets.ts
+++ b/packages/@expo/cli/src/export/persistMetroAssets.ts
@@ -45,8 +45,8 @@ export async function persistMetroAssetsAsync(
     return;
   }
 
-  // Ensure that the outputDirectory actually exists
-  if (!fs.existsSync(outputDirectory)) {
+  // For iOS, we need to ensure that the outputDirectory actually exists
+  if (platform === 'ios' && !fs.existsSync(outputDirectory)) {
     fs.mkdirSync(outputDirectory, { recursive: true });
   }
 

--- a/packages/@expo/cli/src/export/persistMetroAssets.ts
+++ b/packages/@expo/cli/src/export/persistMetroAssets.ts
@@ -45,6 +45,11 @@ export async function persistMetroAssetsAsync(
     return;
   }
 
+  // Ensure that the outputDirectory actually exists
+  if (!fs.existsSync(outputDirectory)) {
+    fs.mkdirSync(outputDirectory, { recursive: true });
+  }
+
   let assetsToCopy: AssetData[] = [];
 
   // TODO: Use `files` as below to defer writing files


### PR DESCRIPTION
# Why

If an app has only the JS bundle, and no other assets, the iOS "Bundle React Native code and images" task will fail for release builds.

Repro:

- Create a new app with the `blank-typescript` template
- Remove the status bar import and markup from `App.tsx`
- Do a clean prebuild
- `npx expo run:ios --configuration Release`

# How

In export:embed, after creating the JS bundle, add a check to see if the assets directory exists, and create it if needed.

# Test Plan

- The above repro should succeed in building the release build for iOS
- CI should pass