### PR TITLE
[expo-updates] Support brownfield apps with EX_UPDATES_CUSTOM_INIT flag

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 🎉 New features
 
 - Add new state machine context about startup procedure. ([#32433](https://github.com/expo/expo/pull/32433) by [@wschurman](https://github.com/wschurman))
+- Support brownfield apps with EX_UPDATES_CUSTOM_INIT flag. ([#35391](https://github.com/expo/expo/pull/35391) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -60,6 +60,10 @@ def getBoolStringFromPropOrEnv(String name, Boolean defaultValue) {
 // debug builds. (default false)
 def exUpdatesNativeDebug = getBoolStringFromPropOrEnv("EX_UPDATES_NATIVE_DEBUG", false)
 
+// If true, app is using custom code to initialize expo-updates, so default initialization code
+// will be disabled.
+def exUpdatesCustomInit = getBoolStringFromPropOrEnv("EX_UPDATES_CUSTOM_INIT", false)
+
 // If true, code will run that delays app loading until updates is initialized, to prevent ANR issues.
 // (default true)
 def exUpdatesAndroidDelayLoadApp = getBoolStringFromPropOrEnv("EX_UPDATES_ANDROID_DELAY_LOAD_APP", true)
@@ -79,6 +83,7 @@ android {
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     buildConfigField("boolean", "EX_UPDATES_NATIVE_DEBUG", exUpdatesNativeDebug)
+    buildConfigField("boolean", "EX_UPDATES_CUSTOM_INIT", exUpdatesCustomInit)
     buildConfigField("boolean", "EX_UPDATES_ANDROID_DELAY_LOAD_APP", exUpdatesAndroidDelayLoadApp)
     buildConfigField("boolean", "USE_DEV_CLIENT", useDevClient.toString())
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
@@ -108,7 +108,7 @@ interface IUpdatesController {
       this["runtimeVersion"] = runtimeVersion ?: ""
       this["checkAutomatically"] = checkOnLaunch.toJSString()
       this["channel"] = requestHeaders["expo-channel-name"] ?: ""
-      this["shouldDeferToNativeForAPIMethodAvailabilityInDevelopment"] = shouldDeferToNativeForAPIMethodAvailabilityInDevelopment || BuildConfig.EX_UPDATES_NATIVE_DEBUG
+      this["shouldDeferToNativeForAPIMethodAvailabilityInDevelopment"] = shouldDeferToNativeForAPIMethodAvailabilityInDevelopment || UpdatesPackage.isUsingNativeDebug
       this["initialContext"] = initialContext.bundle
 
       if (launchedUpdate != null) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -35,7 +35,7 @@ object UpdatesController {
     }
     val useDeveloperSupport =
       (context as? ReactApplication)?.reactNativeHost?.useDeveloperSupport ?: false
-    if (useDeveloperSupport && !BuildConfig.EX_UPDATES_NATIVE_DEBUG) {
+    if (useDeveloperSupport && !UpdatesPackage.isUsingNativeDebug) {
       if (BuildConfig.USE_DEV_CLIENT) {
         val devLauncherController = initializeAsDevLauncherWithoutStarting(context)
         singletonInstance = devLauncherController

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -121,6 +121,6 @@ class UpdatesPackage : Package {
   companion object {
     private val TAG = UpdatesPackage::class.java.simpleName
     val isUsingNativeDebug = BuildConfig.EX_UPDATES_NATIVE_DEBUG
-    val isUsingCustomInit = BuildConfig.EX_UPDATES_CUSTOM_INIT
+    internal val isUsingCustomInit = BuildConfig.EX_UPDATES_CUSTOM_INIT
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -56,12 +56,12 @@ class UpdatesPackage : Package {
   override fun createReactActivityHandlers(activityContext: Context): List<ReactActivityHandler> {
     val handler = object : ReactActivityHandler {
       override fun getDelayLoadAppHandler(activity: ReactActivity, reactNativeHost: ReactNativeHost): ReactActivityHandler.DelayLoadAppHandler? {
-        if (!BuildConfig.EX_UPDATES_ANDROID_DELAY_LOAD_APP || useCustomInit) {
+        if (!BuildConfig.EX_UPDATES_ANDROID_DELAY_LOAD_APP || isUsingCustomInit) {
           return null
         }
         val context = activity.applicationContext
         val useDeveloperSupport = reactNativeHost.useDeveloperSupport
-        if (!useDeveloperSupport || BuildConfig.EX_UPDATES_NATIVE_DEBUG) {
+        if (!useDeveloperSupport || isUsingNativeDebug) {
           return ReactActivityHandler.DelayLoadAppHandler { whenReadyRunnable ->
             CoroutineScope(Dispatchers.IO).launch {
               startUpdatesController(context)
@@ -75,7 +75,7 @@ class UpdatesPackage : Package {
       @WorkerThread
       private suspend fun startUpdatesController(context: Context) {
         withContext(Dispatchers.IO) {
-          if (!UpdatesPackage.useCustomInit) {
+          if (!UpdatesPackage.isUsingCustomInit) {
             UpdatesController.initialize(context)
             // Call the synchronous `launchAssetFile()` function to wait for updates ready
             UpdatesController.instance.launchAssetFile
@@ -120,7 +120,7 @@ class UpdatesPackage : Package {
 
   companion object {
     private val TAG = UpdatesPackage::class.java.simpleName
-    val useNativeDebug = BuildConfig.EX_UPDATES_NATIVE_DEBUG
-    val useCustomInit = BuildConfig.EX_UPDATES_CUSTOM_INIT
+    val isUsingNativeDebug = BuildConfig.EX_UPDATES_NATIVE_DEBUG
+    val isUsingCustomInit = BuildConfig.EX_UPDATES_CUSTOM_INIT
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.withContext
  * applicable environments.
  */
 class UpdatesPackage : Package {
-  private val useNativeDebug = BuildConfig.EX_UPDATES_NATIVE_DEBUG
 
   override fun createReactNativeHostHandlers(context: Context): List<ReactNativeHostHandler> {
     val handler: ReactNativeHostHandler = object : ReactNativeHostHandler {
@@ -57,7 +56,7 @@ class UpdatesPackage : Package {
   override fun createReactActivityHandlers(activityContext: Context): List<ReactActivityHandler> {
     val handler = object : ReactActivityHandler {
       override fun getDelayLoadAppHandler(activity: ReactActivity, reactNativeHost: ReactNativeHost): ReactActivityHandler.DelayLoadAppHandler? {
-        if (!BuildConfig.EX_UPDATES_ANDROID_DELAY_LOAD_APP) {
+        if (!BuildConfig.EX_UPDATES_ANDROID_DELAY_LOAD_APP || useCustomInit) {
           return null
         }
         val context = activity.applicationContext
@@ -76,9 +75,11 @@ class UpdatesPackage : Package {
       @WorkerThread
       private suspend fun startUpdatesController(context: Context) {
         withContext(Dispatchers.IO) {
-          UpdatesController.initialize(context)
-          // Call the synchronous `launchAssetFile()` function to wait for updates ready
-          UpdatesController.instance.launchAssetFile
+          if (!UpdatesPackage.useCustomInit) {
+            UpdatesController.initialize(context)
+            // Call the synchronous `launchAssetFile()` function to wait for updates ready
+            UpdatesController.instance.launchAssetFile
+          }
         }
       }
 
@@ -119,5 +120,7 @@ class UpdatesPackage : Package {
 
   companion object {
     private val TAG = UpdatesPackage::class.java.simpleName
+    val useNativeDebug = BuildConfig.EX_UPDATES_NATIVE_DEBUG
+    val useCustomInit = BuildConfig.EX_UPDATES_CUSTOM_INIT
   }
 }

--- a/packages/expo-updates/e2e/fixtures/project_files/eas.json
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas.json
@@ -24,9 +24,6 @@
     },
     "updates_testing_debug": {
       "extends": "base",
-      "env": {
-        "EX_UPDATES_NATIVE_DEBUG": "1"
-      },
       "android": {
         "applicationArchivePath": "eas.json",
         "gradleCommand": ":app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug",
@@ -42,9 +39,6 @@
     },
     "updates_testing_release": {
       "extends": "base",
-      "env": {
-        "EX_UPDATES_NATIVE_DEBUG": "1"
-      },
       "android": {
         "gradleCommand": ":app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release",
         "withoutCredentials": true

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -760,7 +760,6 @@ export async function initAsync(
   await spawnAsync(localCliBin, ['prebuild', '--no-install', '--template', localTemplatePathName], {
     env: {
       ...process.env,
-      EX_UPDATES_NATIVE_DEBUG: '1',
       EXPO_DEBUG: '1',
       CI: '1',
     },
@@ -807,6 +806,18 @@ export async function initAsync(
     ].join('\n'),
     'utf-8'
   );
+
+  // Add native debug to iOS Podfile.properties.json
+  const podfilePropertiesJsonPath = path.join(projectRoot, 'ios', 'Podfile.properties.json');
+  const podfilePropertiesJsonString = await fs.readFile(podfilePropertiesJsonPath, {
+    encoding: 'utf-8',
+  });
+  const podfilePropertiesJson: any = JSON.parse(podfilePropertiesJsonString);
+  podfilePropertiesJson.updatesNativeDebug = 'true';
+  await fs.writeFile(podfilePropertiesJsonPath, JSON.stringify(podfilePropertiesJson, null, 2), {
+    encoding: 'utf-8',
+  });
+
   await fs.appendFile(
     path.join(projectRoot, 'android', 'app', 'build.gradle'),
     [

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -786,7 +786,7 @@ export async function initAsync(
   // enable proguard on Android
   await fs.appendFile(
     path.join(projectRoot, 'android', 'gradle.properties'),
-    '\nandroid.enableProguardInReleaseBuilds=true\nEXPO_UPDATES_NATIVE_DEBUG=true',
+    '\nandroid.enableProguardInReleaseBuilds=true\nEX_UPDATES_NATIVE_DEBUG=true',
     'utf-8'
   );
 

--- a/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
+++ b/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.Locale
+import java.util.Properties
 
 abstract class ExpoUpdatesPlugin : Plugin<Project> {
   override fun apply(project: Project) {
@@ -26,7 +27,7 @@ abstract class ExpoUpdatesPlugin : Plugin<Project> {
     val entryFile = detectedEntryFile(reactExtension)
     val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
 
-    if (System.getenv("EX_UPDATES_NATIVE_DEBUG") == "1") {
+    if (isNativeDebuggingEnabled(reactExtension)) {
       logger.warn("Disable all react.debuggableVariants because EX_UPDATES_NATIVE_DEBUG=1")
       reactExtension.debuggableVariants.set(listOf())
     }
@@ -125,4 +126,11 @@ private fun detectedEntryFile(config: ReactExtension): File {
     File(reactRoot, "index.android.js").exists() -> File(reactRoot, "index.android.js")
     else -> File(reactRoot, "index.js")
   }
+}
+
+private fun isNativeDebuggingEnabled(config: ReactExtension): Boolean {
+  if (System.getenv("EX_UPDATES_NATIVE_DEBUG") == "1") {
+    return true
+  }
+  return config.project.findProperty("EX_UPDATES_NATIVE_DEBUG") == "true"
 }

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -43,17 +43,26 @@ Pod::Spec.new do |s|
   end
   install_modules_dependencies(s)
 
-  other_c_flags = '$(inherited)'
-  other_swift_flags = '$(inherited)'
+  other_debug_c_flags = '$(inherited)'
+  other_debug_swift_flags = '$(inherited)'
+  other_release_c_flags = '$(inherited)'
+  other_release_swift_flags = '$(inherited)'
 
   ex_updates_native_debug = ENV['EX_UPDATES_NATIVE_DEBUG'] == '1'
+  ex_updates_custom_init = ENV['EX_UPDATES_CUSTOM_INIT'] == '1'
   if ex_updates_native_debug
-    other_c_flags << ' -DEX_UPDATES_NATIVE_DEBUG=1'
-    other_swift_flags << ' -DEX_UPDATES_NATIVE_DEBUG'
+    other_debug_c_flags << ' -DEX_UPDATES_NATIVE_DEBUG=1'
+    other_debug_swift_flags << ' -DEX_UPDATES_NATIVE_DEBUG'
+  end
+  if ex_updates_custom_init
+    other_debug_c_flags << ' -DEX_UPDATES_CUSTOM_INIT=1'
+    other_debug_swift_flags << ' -DEX_UPDATES_CUSTOM_INIT'
+    other_release_c_flags << ' -DEX_UPDATES_CUSTOM_INIT=1'
+    other_release_swift_flags << ' -DEX_UPDATES_CUSTOM_INIT'
   end
   if use_dev_client
-    other_c_flags << ' -DUSE_DEV_CLIENT=1'
-    other_swift_flags << ' -DUSE_DEV_CLIENT'
+    other_debug_c_flags << ' -DUSE_DEV_CLIENT=1'
+    other_debug_swift_flags << ' -DUSE_DEV_CLIENT'
   end
 
   s.pod_target_xcconfig = {
@@ -61,8 +70,10 @@ Pod::Spec.new do |s|
     'GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS' => 'YES',
     'DEFINES_MODULE' => 'YES',
     'SWIFT_COMPILATION_MODE' => 'wholemodule',
-    'OTHER_CFLAGS[config=*Debug*]' => other_c_flags,
-    'OTHER_SWIFT_FLAGS[config=*Debug*]' => other_swift_flags
+    'OTHER_CFLAGS[config=*Debug*]' => other_debug_c_flags,
+    'OTHER_SWIFT_FLAGS[config=*Debug*]' => other_debug_swift_flags,
+    'OTHER_CFLAGS[config=*Release*]' => other_release_c_flags,
+    'OTHER_SWIFT_FLAGS[config=*Release*]' => other_release_swift_flags
   }
   s.user_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '"${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/Swift Compatibility Header"',

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -3,9 +3,20 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 podfile_properties = JSON.parse(File.read("#{Pod::Config.instance.installation_root}/Podfile.properties.json")) rescue {}
 
+ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
+if ENV['EX_UPDATES_NATIVE_DEBUG'] != '1'
+  ENV['EX_UPDATES_NATIVE_DEBUG'] = podfile_properties['updatesNativeDebug'] == 'true' ? '1' : '0'
+end
+if ENV['EX_UPDATES_CUSTOM_INIT'] != '1'
+  ENV['EX_UPDATES_CUSTOM_INIT'] = podfile_properties['updatesCustomInit'] == 'true' ? '1' : '0'
+end
+
 use_dev_client = false
 begin
-  use_dev_client = `node --print "require('expo-dev-client/package.json').version" 2>/dev/null`.length > 0
+  # No dev client if we are using native debug
+  if ENV['EX_UPDATES_NATIVE_DEBUG'] != '1'
+    use_dev_client = `node --print "require('expo-dev-client/package.json').version" 2>/dev/null`.length > 0
+  end
 rescue
   use_dev_client = false
 end

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -22,6 +22,10 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     initialProperties: [AnyHashable: Any]?,
     launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> UIView? {
+    if UpdatesUtils.isUsingCustomInitialization() {
+      return nil
+    }
+
     AppController.initializeWithoutStarting()
     let controller = AppController.sharedInstance
     if !controller.isActiveController {
@@ -59,6 +63,9 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
   // MARK: AppControllerDelegate implementations
 
   public func appController(_ appController: AppControllerInterface, didStartWithSuccess success: Bool) {
+    if UpdatesUtils.isUsingCustomInitialization() {
+      return
+    }
     guard let reactDelegate = self.reactDelegate else {
       fatalError("`reactDelegate` should not be nil")
     }

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -133,8 +133,16 @@ public final class UpdatesUtils: NSObject {
     }
   }
 
-  internal static func isNativeDebuggingEnabled() -> Bool {
+  public static func isNativeDebuggingEnabled() -> Bool {
 #if EX_UPDATES_NATIVE_DEBUG
+    return true
+#else
+    return false
+#endif
+  }
+
+  internal static func isUsingCustomInitialization() -> Bool {
+#if EX_UPDATES_CUSTOM_INIT
     return true
 #else
     return false

--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -6,6 +6,8 @@ podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties
 
 ENV['RCT_NEW_ARCH_ENABLED'] = podfile_properties['newArchEnabled'] == 'true' ? '1' : '0'
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
+ENV['EX_UPDATES_NATIVE_DEBUG'] = podfile_properties['EX_UPDATES_NATIVE_DEBUG'] == 'true' ? '1' : '0'
+ENV['EX_UPDATES_CUSTOM_INIT'] = podfile_properties['EX_UPDATES_CUSTOM_INIT'] == 'true' ? '1' : '0'
 
 platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
 install! 'cocoapods',

--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -6,12 +6,6 @@ podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties
 
 ENV['RCT_NEW_ARCH_ENABLED'] = podfile_properties['newArchEnabled'] == 'true' ? '1' : '0'
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
-if ENV['EX_UPDATES_NATIVE_DEBUG'] != '1'
-  ENV['EX_UPDATES_NATIVE_DEBUG'] = podfile_properties['updatesNativeDebug'] == 'true' ? '1' : '0'
-end
-if ENV['EX_UPDATES_CUSTOM_INIT'] != '1'
-  ENV['EX_UPDATES_CUSTOM_INIT'] = podfile_properties['updatesCustomInit'] == 'true' ? '1' : '0'
-end
 
 platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
 install! 'cocoapods',

--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -6,8 +6,12 @@ podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties
 
 ENV['RCT_NEW_ARCH_ENABLED'] = podfile_properties['newArchEnabled'] == 'true' ? '1' : '0'
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
-ENV['EX_UPDATES_NATIVE_DEBUG'] = podfile_properties['EX_UPDATES_NATIVE_DEBUG'] == 'true' ? '1' : '0'
-ENV['EX_UPDATES_CUSTOM_INIT'] = podfile_properties['EX_UPDATES_CUSTOM_INIT'] == 'true' ? '1' : '0'
+if ENV['EX_UPDATES_NATIVE_DEBUG'] != '1'
+  ENV['EX_UPDATES_NATIVE_DEBUG'] = podfile_properties['updatesNativeDebug'] == 'true' ? '1' : '0'
+end
+if ENV['EX_UPDATES_CUSTOM_INIT'] != '1'
+  ENV['EX_UPDATES_CUSTOM_INIT'] = podfile_properties['updatesCustomInit'] == 'true' ? '1' : '0'
+end
 
 platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
 install! 'cocoapods',


### PR DESCRIPTION
# Why

Brownfield apps that show React Native views within a custom view controller or activity, need to have control over expo-updates startup.

# How

- New env variable EX_UPDATES_CUSTOM_INIT
- When this flag is set, automatic startup is disabled
- `EXUpdates.podspec` detects this and native debug setting in `Podfile.properties.json`
- Additions to `expo-updates-gradle-plugin` to correctly detect native debug

# Test Plan

- Changes to E2E setup so generated projects use the improvements in podspec and gradle plugin
- Manual testing in https://github.com/expo/CustomRNView
- CI should pass

