### PR TITLE
[notifications] fix non-repeating scheduled notifications

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- fix non-repeating scheduled notifications ([#35393](https://github.com/expo/expo/pull/35393) by [@vonovak](https://github.com/vonovak))
 - fix ios textInput action missing title ([#34866](https://github.com/expo/expo/pull/34866) by [@vonovak](https://github.com/vonovak))
 - [ios] Fixed incorrect `EXNotifications-Swift.h` import. ([#34987](https://github.com/expo/expo/pull/34987) by [@lukmccall](https://github.com/lukmccall))
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/triggers/NotificationTriggers.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/triggers/NotificationTriggers.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.core.os.bundleOf
 import expo.modules.notifications.notifications.interfaces.NotificationTrigger
 import expo.modules.notifications.notifications.interfaces.SchedulableNotificationTrigger
-import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import java.io.Serializable
 import java.util.Calendar
@@ -111,10 +110,12 @@ class MonthlyTrigger(override val channelId: String?, val day: Int, val hour: In
  * * trigger around …000 timestamp.*
  */
 @Parcelize
-class TimeIntervalTrigger(override val channelId: String?, val timeInterval: Long, val isRepeating: Boolean) : ChannelAwareTrigger(channelId), SchedulableNotificationTrigger {
-  @IgnoredOnParcel
-  private var triggerDate = Date(Date().time + timeInterval * 1000)
-
+class TimeIntervalTrigger(
+  override val channelId: String?,
+  val timeInterval: Long,
+  val isRepeating: Boolean,
+  private var triggerDate: Date = Date(Date().time + timeInterval * 1000)
+) : ChannelAwareTrigger(channelId), SchedulableNotificationTrigger {
   override fun toBundle() = bundleWithChannelId(
     "type" to "timeInterval",
     "repeats" to isRepeating,


### PR DESCRIPTION
# Why

fixes #34782

# How

- Refactored `TimeIntervalTrigger` to parcelize `triggerDate`. That was the behavior before https://github.com/expo/expo/pull/31856. I did that by introducing a constructor parameter, which I also used in the test to verify `nextTriggerDate` will return `null` when `triggerDate` is in the past 
- Moved notification trigger tests from androidTest to test directory to utilize Robolectric for faster testing


# Test Plan

- I previously reproduced this from the snippet in https://github.com/expo/expo/issues/34782#issuecomment-2661468120 and it now works
- All tests pass in the new Robolectric test environment

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)