### PR TITLE
[docs] [ENG-15143] Update docs of `on.pull_request` trigger

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -92,7 +92,7 @@ on:
 
 Runs your workflow when you create or update a pull request that targets one of the matching branches.
 
-With the `branches` list, you can trigger the workflow only when those specified branches are the target of the pull request. For example, if you use `branches: ['main']`, only pull requests to merge into the main branch will trigger the workflow. Supports globs. Defaults to `['*']` when not provided, which means the workflow will trigger on pull request events to all branches.
+With the `branches` list, you can trigger the workflow only when those specified branches are the target of the pull request. For example, if you use `branches: ['main']`, only pull requests to merge into the main branch will trigger the workflow. Supports globs. Defaults to `['*']` when not provided, which means the workflow will trigger on pull request events to all branches. By using the `!` prefix you can specify branches to ignore (you still need to provide at least one branch pattern without it).
 
 With the `types` list, you can trigger the workflow only on the specified pull request event types. For example, if you use `types: ['opened']`, only the `pull_request.opened` event (sent when a pull request is first opened) will trigger the workflow. Defaults to `['opened', 'reopened', 'synchronize']` when not provided. Supported event types:
 
@@ -109,7 +109,9 @@ on:
     branches:
       - main
       - feature/**
-      # other branch names and globs
+      - !feature/test-** # other branch names and globs
+
+
     types:
       - opened
       # other event types


### PR DESCRIPTION
Updated the docs regarding ignoring branches with `on.pull_request` trigger

See: https://linear.app/expo/issue/ENG-15143/allow-ignore-branch-definition-in-onpull-request-workflow-triggers

# Why

https://linear.app/expo/issue/ENG-15143/allow-ignore-branch-definition-in-onpull-request-workflow-triggers
Allowed ignoring branches with `on.pull_request` trigger. This updates the docs, similarly to what has been done with `on.push`.
Companion to: https://github.com/expo/universe/pull/19132

# How

Updated the docs regarding ignoring branches with `on.pull_request` trigger

# Test Plan

Tested manually

| Before | After |
| - | - |
| ![Screenshot 2025-03-10 at 12 12 01](https://github.com/user-attachments/assets/6cd504ae-6ef6-41fc-a27b-4f34fb25b95c) | ![Screenshot 2025-03-10 at 12 14 05](https://github.com/user-attachments/assets/075e236e-89db-4255-9286-47627219cb7d) |

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
