### PR TITLE
[expo-notifications][iOS] fix double-presentation of scheduled notification

### DIFF
--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/SchedulerModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/SchedulerModule.swift
@@ -53,14 +53,7 @@ public class SchedulerModule: Module {
           if let error = error {
             promise.reject("ERR_NOTIFICATIONS_FAILED_TO_SCHEDULE", "Failed to schedule notification, \(error)")
           } else {
-            promise.resolve()
-          }
-          UNUserNotificationCenter.current().add(request) {error in
-            if let error = error {
-              promise.reject("ERR_NOTIFICATIONS_FAILED_TO_SCHEDULE", "Failed to schedule notification, \(error)")
-            } else {
-              promise.resolve(identifier)
-            }
+            promise.resolve(identifier)
           }
         }
       } catch {


### PR DESCRIPTION
# Why

scheduleNotificationAsync would present a notification twice

# How

present only once

# Test Plan

tested locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
