### PR TITLE
[expo-store-review][iOS] fix activationState must be used from main thread only

### DIFF
--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix activationState must be used from main thread only ([#35403](https://github.com/expo/expo/pull/35403) by [@dylancom](https://github.com/dylancom))
+
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-store-review/ios/StoreReviewModule.swift
+++ b/packages/expo-store-review/ios/StoreReviewModule.swift
@@ -10,10 +10,10 @@ public class StoreReviewModule: Module {
     }
 
     AsyncFunction("requestReview") {
-      guard let currentScene = getForegroundActiveScene() else {
-        throw MissingCurrentWindowSceneException()
-      }
-      Task { @MainActor in
+      try await MainActor.run {
+        guard let currentScene = getForegroundActiveScene() else {
+          throw MissingCurrentWindowSceneException()
+        }
         if #available(iOS 16.0, *) {
           AppStore.requestReview(in: currentScene)
         } else {


### PR DESCRIPTION
# Why
Xcode warning in code:
<img width="459" alt="Scherm­afbeelding 2025-03-10 om 15 58 19" src="https://github.com/user-attachments/assets/eac9796d-919d-4fd2-af22-dfc672004d53" />

Also in the logs it shows a warning when executing the requestReview method.

# How

I made sure that `getForegroundActiveScene()` also get's called on the main thread.

# Test Plan

Without this change Xcode warns that the code is executed in background while it should be executed on the main thread.