### PR TITLE
[docs] Update Support for Android and iOS versions to include Xcode version

### DIFF
--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -95,10 +95,12 @@ Packages in the Expo SDK are intended to support the target React Native version
 
 ## Support for Android and iOS versions
 
-Each version of Expo SDK supports a minimum OS version of Android and iOS. For Android, the `compileSdkVersion` is defined which tells the [Gradle](https://developer.android.com/studio/build) which Android SDK version to use to compile the app. This also means that you can use the Android API features included in that SDK version and from the previous versions.
+Each version of Expo SDK supports a minimum OS version of Android and iOS. For Android, the `compileSdkVersion` is defined which tells the [Gradle](https://developer.android.com/studio/build) which Android SDK version to use to compile the app. This also means that you can use the Android API features included in that SDK version and from the previous versions. For iOS, the [Xcode](https://developer.apple.com/news/upcoming-requirements/) tells the minimum Xcode SDK version to use to compile the app.
 
-| Expo SDK version | Android version | `compileSdkVersion` | iOS version |
-| ---------------- | --------------- | ------------------- | ----------- |
-| 52.0.0           | 6+              | 35                  | 15.1+       |
-| 51.0.0           | 6+              | 34                  | 13.4+       |
-| 50.0.0           | 6+              | 34                  | 13.4+       |
+| Expo SDK version | Android version | `compileSdkVersion` | iOS version | Xcode version |
+| ---------------- | --------------- | ------------------- | ----------- | ------------- |
+| 52.0.0           | 6+              | 35                  | 15.1+       | 16.0          |
+| 51.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
+| 50.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
+
+When deciding whether to upgrade your Expo SDK version, consider both Expo's SDK version and app store submission requirements, as described in the above table. Google Play Store and Apple App Store periodically increase their minimum required OS versions and API levels, which are required for new app submissions. Expo has no control over the app store requirements, and you should check [Google](https://developer.android.com/studio/build) and [Apple](https://developer.apple.com/news/upcoming-requirements/) for the current store submission requirements.

--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -99,7 +99,7 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version | Xcode version |
 | ---------------- | --------------- | ------------------- | ----------- | ------------- |
-| 52.0.0           | 6+              | 35                  | 15.1+       | 16.0          |
+| 52.0.0           | 6+              | 35                  | 15.1+       | 16.0 +        |
 | 51.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
 | 50.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
 

--- a/docs/pages/versions/v50.0.0/index.mdx
+++ b/docs/pages/versions/v50.0.0/index.mdx
@@ -91,10 +91,12 @@ Packages in the Expo SDK are intended to support the target React Native version
 
 ## Support for Android and iOS versions
 
-Each version of Expo SDK supports a minimum OS version of Android and iOS. For Android, the `compileSdkVersion` is defined which tells the [Gradle](https://developer.android.com/studio/build) which Android SDK version to use to compile the app. This also means that you can use the Android API features included in that SDK version and from the previous versions.
+Each version of Expo SDK supports a minimum OS version of Android and iOS. For Android, the `compileSdkVersion` is defined which tells the [Gradle](https://developer.android.com/studio/build) which Android SDK version to use to compile the app. This also means that you can use the Android API features included in that SDK version and from the previous versions. For iOS, the [Xcode](https://developer.apple.com/news/upcoming-requirements/) tells the minimum Xcode SDK version to use to compile the app.
 
-| Expo SDK version | Android version | `compileSdkVersion` | iOS version |
-| ---------------- | --------------- | ------------------- | ----------- |
-| 50.0.0           | 6+              | 34                  | 13.4+       |
-| 49.0.0           | 5+              | 33                  | 13+         |
-| 48.0.0           | 5+              | 33                  | 13+         |
+| Expo SDK version | Android version | `compileSdkVersion` | iOS version | Xcode version |
+| ---------------- | --------------- | ------------------- | ----------- | ------------- |
+| 50.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
+| 49.0.0           | 5+              | 33                  | 13+         | 15.4          |
+| 48.0.0           | 5+              | 33                  | 13+         | -             |
+
+When deciding whether to upgrade your Expo SDK version, consider both Expo's SDK version and app store submission requirements, as described in the above table. Google Play Store and Apple App Store periodically increase their minimum required OS versions and API levels, which are required for new app submissions. Expo has no control over the app store requirements, and you should check [Google](https://developer.android.com/studio/build) and [Apple](https://developer.apple.com/news/upcoming-requirements/) for the current store submission requirements.

--- a/docs/pages/versions/v51.0.0/index.mdx
+++ b/docs/pages/versions/v51.0.0/index.mdx
@@ -95,10 +95,12 @@ Packages in the Expo SDK are intended to support the target React Native version
 
 ## Support for Android and iOS versions
 
-Each version of Expo SDK supports a minimum OS version of Android and iOS. For Android, the `compileSdkVersion` is defined which tells the [Gradle](https://developer.android.com/studio/build) which Android SDK version to use to compile the app. This also means that you can use the Android API features included in that SDK version and from the previous versions.
+Each version of Expo SDK supports a minimum OS version of Android and iOS. For Android, the `compileSdkVersion` is defined which tells the [Gradle](https://developer.android.com/studio/build) which Android SDK version to use to compile the app. This also means that you can use the Android API features included in that SDK version and from the previous versions. For iOS, the [Xcode](https://developer.apple.com/news/upcoming-requirements/) tells the minimum Xcode SDK version to use to compile the app.
 
-| Expo SDK version | Android version | `compileSdkVersion` | iOS version |
-| ---------------- | --------------- | ------------------- | ----------- |
-| 51.0.0           | 6+              | 34                  | 13.4+       |
-| 50.0.0           | 6+              | 34                  | 13.4+       |
-| 49.0.0           | 5+              | 33                  | 13+         |
+| Expo SDK version | Android version | `compileSdkVersion` | iOS version | Xcode version |
+| ---------------- | --------------- | ------------------- | ----------- | ------------- |
+| 51.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
+| 50.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
+| 49.0.0           | 5+              | 33                  | 13+         | 15.4          |
+
+When deciding whether to upgrade your Expo SDK version, consider both Expo's SDK version and app store submission requirements, as described in the above table. Google Play Store and Apple App Store periodically increase their minimum required OS versions and API levels, which are required for new app submissions. Expo has no control over the app store requirements, and you should check [Google](https://developer.android.com/studio/build) and [Apple](https://developer.apple.com/news/upcoming-requirements/) for the current store submission requirements.

--- a/docs/pages/versions/v52.0.0/index.mdx
+++ b/docs/pages/versions/v52.0.0/index.mdx
@@ -95,10 +95,12 @@ Packages in the Expo SDK are intended to support the target React Native version
 
 ## Support for Android and iOS versions
 
-Each version of Expo SDK supports a minimum OS version of Android and iOS. For Android, the `compileSdkVersion` is defined which tells the [Gradle](https://developer.android.com/studio/build) which Android SDK version to use to compile the app. This also means that you can use the Android API features included in that SDK version and from the previous versions.
+Each version of Expo SDK supports a minimum OS version of Android and iOS. For Android, the `compileSdkVersion` is defined which tells the [Gradle](https://developer.android.com/studio/build) which Android SDK version to use to compile the app. This also means that you can use the Android API features included in that SDK version and from the previous versions. For iOS, the [Xcode](https://developer.apple.com/news/upcoming-requirements/) tells the minimum Xcode SDK version to use to compile the app.
 
-| Expo SDK version | Android version | `compileSdkVersion` | iOS version |
-| ---------------- | --------------- | ------------------- | ----------- |
-| 52.0.0           | 6+              | 35                  | 15.1+       |
-| 51.0.0           | 6+              | 34                  | 13.4+       |
-| 50.0.0           | 6+              | 34                  | 13.4+       |
+| Expo SDK version | Android version | `compileSdkVersion` | iOS version | Xcode version |
+| ---------------- | --------------- | ------------------- | ----------- | ------------- |
+| 52.0.0           | 6+              | 35                  | 15.1+       | 16.0          |
+| 51.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
+| 50.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
+
+When deciding whether to upgrade your Expo SDK version, consider both Expo's SDK version and app store submission requirements, as described in the above table. Google Play Store and Apple App Store periodically increase their minimum required OS versions and API levels, which are required for new app submissions. Expo has no control over the app store requirements, and you should check [Google](https://developer.android.com/studio/build) and [Apple](https://developer.apple.com/news/upcoming-requirements/) for the current store submission requirements.

--- a/docs/pages/versions/v52.0.0/index.mdx
+++ b/docs/pages/versions/v52.0.0/index.mdx
@@ -99,7 +99,7 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version | Xcode version |
 | ---------------- | --------------- | ------------------- | ----------- | ------------- |
-| 52.0.0           | 6+              | 35                  | 15.1+       | 16.0          |
+| 52.0.0           | 6+              | 35                  | 15.1+       | 16.0+         |
 | 51.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
 | 50.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15167

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update "Support for Android and iOS versions":
- Add a Xcode version column for each Expo SDK
- Add description that explains that the minimum Xcode version is used to compile the app
- Describe the caveat that the minimum `compileSdkVersion` and Xcode version are app store requirements (not Expo), controlled by app stores, and add links to check these requirements.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-03-11 at 11 49 45@2x](https://github.com/user-attachments/assets/0ab5f1be-71a0-4a1b-afd7-2978ca311a84)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
