### PR TITLE
[docs] Add a second redirect for EAS Workflows automating EAS CLI page

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -483,4 +483,5 @@ const RENAMED_PAGES: Record<string, string> = {
   '/eas-workflows/control-flow/': '/eas/workflows/syntax/#control-flow',
   '/eas-workflows/variables/': '/eas/workflows/syntax/#jobsjob_idoutputs',
   '/eas-workflows/upgrade/': '/eas/workflows/automating-eas-cli/',
+  '/eas/workflows/upgrade/': '/eas/workflows/automating-eas-cli/',
 };

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -322,6 +322,7 @@ redirects[eas-workflows/jobs]=eas/workflows/syntax/#jobs
 redirects[eas-workflows/control-flow]=eas/workflows/syntax/#control-flow
 redirects[eas-workflows/variables]=eas/workflows/syntax/#jobsjob_idoutputs
 redirects[eas-workflows/upgrade]=eas/workflows/automating-eas-cli
+redirects[eas/workflows/upgrade]=eas/workflows/automating-eas-cli
 
 # After adding distribution section under EAS
 redirects[distribution/publishing-websites]=guides/publishing-websites


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Partial fix for #35379 (I have already opened up a PR in website to fix the link in the banner).
As mentioned in the issue, the URL structure has changed twice and that's why the redirect fails for the new structure. I am not sure where else we've linked the old URL structure so to be safe, let's add this redirect.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Running docs locally and checking the redirect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
