### PR TITLE
[notifications] update readme for new scheduleNotificationAsync signature

### DIFF
--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -258,6 +258,7 @@ await Notifications.scheduleNotificationAsync({
     sound: 'mySoundFile.wav', // Provide ONLY the base filename
   },
   trigger: {
+    type: SchedulableTriggerInputTypes.TIME_INTERVAL,
     seconds: 2,
     channelId: 'new-emails',
   },
@@ -288,6 +289,7 @@ await Notifications.scheduleNotificationAsync({
     sound: 'email-sound.wav', // <- for Android below 8.0
   },
   trigger: {
+    type: SchedulableTriggerInputTypes.TIME_INTERVAL,
     seconds: 2,
     channelId: 'new-emails', // <- for Android 8.0+, see definition above
   },
@@ -980,6 +982,7 @@ Notifications.scheduleNotificationAsync({
     body: 'Change sides!',
   },
   trigger: {
+    type: SchedulableTriggerInputTypes.TIME_INTERVAL,
     seconds: 60,
   },
 });
@@ -995,6 +998,7 @@ Notifications.scheduleNotificationAsync({
     title: 'Remember to drink water!,
   },
   trigger: {
+    type: SchedulableTriggerInputTypes.TIME_INTERVAL,
     seconds: 60 * 20,
     repeats: true
   },
@@ -1014,7 +1018,10 @@ Notifications.scheduleNotificationAsync({
   content: {
     title: 'Happy new hour!',
   },
-  trigger,
+  trigger: {
+    type: SchedulableTriggerInputTypes.DATE,
+    date: trigger,
+  },
 });
 ```
 
@@ -1042,7 +1049,7 @@ async function scheduleAndCancel() {
     content: {
       title: 'Hey!',
     },
-    trigger: { seconds: 5, repeats: true },
+    trigger: { type: SchedulableTriggerInputTypes.TIME_INTERVAL, seconds: 5, repeats: true },
   });
   await Notifications.cancelScheduledNotificationAsync(identifier);
 }


### PR DESCRIPTION
# Why

Updates the notification trigger examples in the documentation to explicitly specify the trigger type which is now required.

# How

Added the `type` property with appropriate `SchedulableTriggerInputTypes` to all notification trigger examples in the README.

# Test Plan



# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)