### PR TITLE
[notifications] update Send notifications with FCM and APNs docs

### DIFF
--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -108,7 +108,7 @@ async function sendFCMv1Notification() {
 }
 ```
 
-The `experienceId` and `scopeKey` fields are only applicable to usage with Expo Go (prior to SDK 53, when push notifications support was removed from Expo Go). Otherwise, your notifications will not go through to your app. FCM has a list of supported fields in the [notification payload](https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support), and you can see which ones are supported by `expo-notifications` on Android by looking at the [FirebaseRemoteMessage](/versions/latest/sdk/notifications/#firebaseremotemessage).
+The `experienceId` and `scopeKey` fields are only applicable when using Expo Go (from SDK 53, push notifications support is removed from Expo Go). Otherwise, your notifications will not go through to your app. FCM has a list of supported fields in the [notification payload](https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support), and you can see which ones are supported by `expo-notifications` on Android by looking at the [FirebaseRemoteMessage](/versions/latest/sdk/notifications/#firebaseremotemessage).
 
 FCM also provides some [server-side libraries in a few different languages](https://firebase.google.com/docs/cloud-messaging/send-message#node.js) you can use instead of raw `fetch` requests.
 

--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -4,7 +4,7 @@ hideFromSearch: true
 description: Learn how to send notifications with FCM and APNs.
 ---
 
-You may need finer-grained control over your notifications, so communicating directly with FCM and APNs may be necessary. The Expo platform does not lock you into using Expo Application Services, and the `expo-notifications` API is push-service agnostic.
+You may need finer-grained control over your notifications, in which case communicating directly with FCM and APNs may be necessary. The Expo platform does not lock you into using Expo Application Services, and the `expo-notifications` API is push-service agnostic.
 
 > **Note**: This guide does not aim to be a comprehensive resource for sending notifications via FCM or APNs. We recommend you read the official documentation to make sure you're following the latest instructions.
 
@@ -108,7 +108,7 @@ async function sendFCMv1Notification() {
 }
 ```
 
-**The `experienceId` and `scopeKey` fields are required**. Otherwise, your notifications will not go through to your app. FCM has a list of supported fields in the [notification payload](https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support), and you can see which ones are supported by `expo-notifications` on Android by looking at the [FirebaseRemoteMessage](/versions/latest/sdk/notifications/#firebaseremotemessage).
+The `experienceId` and `scopeKey` fields are only applicable to usage with Expo Go (prior to SDK 53, when push notifications support was removed from Expo Go). Otherwise, your notifications will not go through to your app. FCM has a list of supported fields in the [notification payload](https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support), and you can see which ones are supported by `expo-notifications` on Android by looking at the [FirebaseRemoteMessage](/versions/latest/sdk/notifications/#firebaseremotemessage).
 
 FCM also provides some [server-side libraries in a few different languages](https://firebase.google.com/docs/cloud-messaging/send-message#node.js) you can use instead of raw `fetch` requests.
 


### PR DESCRIPTION
# Why

Updates the documentation to clarify that `experienceId` and `scopeKey` fields are only required for Expo Go (prior to SDK 53).

# How

update docs

# Test Plan


# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)