### PR TITLE
[3/n] Upgrade RN templates to 0.79.0-rc.0

### DIFF
--- a/templates/expo-template-bare-minimum/android/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/expo-template-bare-minimum/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -14,7 +14,7 @@
     "expo": "canary",
     "expo-status-bar": "~2.0.0",
     "react": "19.0.0",
-    "react-native": "0.78.0"
+    "react-native": "0.79.0-rc.0"
   },
   "overrides": {
     "react": "19.0.0"

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -14,7 +14,7 @@
     "expo": "canary",
     "expo-status-bar": "~2.0.0",
     "react": "19.0.0",
-    "react-native": "0.78.0"
+    "react-native": "0.79.0-rc.0"
   },
   "overrides": {
     "react": "19.0.0"

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -14,7 +14,7 @@
     "expo": "canary",
     "expo-status-bar": "~2.0.0",
     "react": "19.0.0",
-    "react-native": "0.78.0"
+    "react-native": "0.79.0-rc.0"
   },
   "overrides": {
     "react": "19.0.0"

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -33,7 +33,7 @@
     "expo-web-browser": "~14.0.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "react-native": "0.78.0",
+    "react-native": "0.79.0-rc.0",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-reanimated": "~3.17.1",
     "react-native-safe-area-context": "5.2.0",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "expo-web-browser": "~14.0.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "react-native": "0.78.0",
+    "react-native": "0.79.0-rc.0",
     "react-native-reanimated": "~3.17.1",
     "react-native-safe-area-context": "~5.2.0",
     "react-native-screens": "~4.9.1",


### PR DESCRIPTION
# Why
closes ENG-15224

# How
Update the templates for React Native 0.79

# Test Plan
CI

