### PR TITLE
[maps][docs] Fix internal link for CameraPosition type

### DIFF
--- a/docs/components/plugins/api/APIStaticData.ts
+++ b/docs/components/plugins/api/APIStaticData.ts
@@ -172,18 +172,21 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
     SharedObject: '/versions/v52.0.0/sdk/expo/#sharedobject',
     SharedRef: '/versions/v52.0.0/sdk/expo/#sharedref',
     BufferOptions: '/versions/v52.0.0/sdk/video/#bufferoptions-1',
+    CameraPosition: '/versions/v52.0.0/sdk/maps/#cameraposition-2',
   },
   'v53.0.0': {
     EventEmitter: '/versions/v53.0.0/sdk/expo/#eventemitter',
     NativeModule: '/versions/v53.0.0/sdk/expo/#nativemodule',
     SharedObject: '/versions/v53.0.0/sdk/expo/#sharedobject',
     SharedRef: '/versions/v53.0.0/sdk/expo/#sharedref',
+    CameraPosition: '/versions/v53.0.0/sdk/maps/#cameraposition-2',
   },
   latest: {
     EventEmitter: '/versions/latest/sdk/expo/#eventemitter',
     NativeModule: '/versions/latest/sdk/expo/#nativemodule',
     SharedObject: '/versions/latest/sdk/expo/#sharedobject',
     SharedRef: '/versions/latest/sdk/expo/#sharedref',
+    CameraPosition: '/versions/latest/sdk/maps/#cameraposition-2',
   },
   unversioned: {
     EventEmitter: '/versions/unversioned/sdk/expo/#eventemitter',
@@ -192,6 +195,7 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
     SharedRef: '/versions/unversioned/sdk/expo/#sharedref',
     Href: '/versions/unversioned/sdk/router/#href-1',
     BufferOptions: '/versions/unversioned/sdk/video/#bufferoptions-1',
+    CameraPosition: '/versions/unversioned/sdk/maps/#cameraposition-2',
   },
 };
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15194

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update `sdkVersionHardcodedTypeLinks` for `cameraposition-2` under SDK 52, 53, latest, and unversioned for Expo Maps reference.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run docs locally and open: http://localhost:3002/versions/unversioned/sdk/maps/#cameraposition
- Then, click `CameraPostion` type hyperlink. It should navigate to the Type definition of the same name property.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
