### PR TITLE
[ios][2/3] Fix Swift 6 errors - Fix non-exhaustive switch warnings

### DIFF
--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
 
 ## 7.1.3 - 2025-01-10
 

--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
-- [iOS] Fix warnings which will become errors in Swift 6. ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35428](https://github.com/expo/expo/pull/35428) by [@behenate](https://github.com/behenate))
 
 ## 7.1.3 - 2025-01-10
 

--- a/packages/expo-apple-authentication/ios/AppleAuthenticationUtils.swift
+++ b/packages/expo-apple-authentication/ios/AppleAuthenticationUtils.swift
@@ -1,4 +1,5 @@
 import AuthenticationServices
+import ExpoModulesCore
 
 func credentialStateToInt(_ credentialState: ASAuthorizationAppleIDProvider.CredentialState) -> Int {
   switch credentialState {
@@ -10,6 +11,9 @@ func credentialStateToInt(_ credentialState: ASAuthorizationAppleIDProvider.Cred
     return 2
   case .transferred:
     return 3
+  @unknown default:
+    log.error("Unhandled `ASAuthorizationAppleIDProvider.CredentialState` value: \(credentialState), returning `notFound` as fallback. Add the missing case as soon as possible.")
+    return 2
   }
 }
 
@@ -20,6 +24,9 @@ func realUserStatusToInt(_ status: ASUserDetectionStatus?) -> Int {
   case .likelyReal:
     return 2
   case .unsupported, .none:
+    return 3
+  @unknown default:
+    log.error("Unhandled `ASUserDetectionStatus` value: \(String(describing: status)), returning `unsupported` as fallback. Add the missing case as soon as possible.")
     return 3
   }
 }

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
-- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate)), ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
 
 ## 13.0.5 - 2025-01-27
 

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
-- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate)), ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate)), ([#35428](https://github.com/expo/expo/pull/35428) by [@behenate](https://github.com/behenate))
 
 ## 13.0.5 - 2025-01-27
 

--- a/packages/expo-background-fetch/ios/BackgroundFetchModule.swift
+++ b/packages/expo-background-fetch/ios/BackgroundFetchModule.swift
@@ -37,12 +37,16 @@ public class BackgroundFetchModule: Module {
   }
 
   private func getStatus() -> BackgroundFetchStatus {
-    switch UIApplication.shared.backgroundRefreshStatus {
+    let backgroundRefreshStatus = UIApplication.shared.backgroundRefreshStatus
+    switch backgroundRefreshStatus {
     case .restricted:
       return .restricted
     case .available:
       return .available
     case .denied:
+      return .denied
+    @unknown default:
+      log.error("Unhandled `UIBackgroundRefreshStatus` value: \(backgroundRefreshStatus), returning `denied` as fallback. Add the missing case as soon as possible.")
       return .denied
     }
   }

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [ios][calendar] Use EXPermissionStatus instead of CalendarPermissionsStatus in calendar permissions requesters ([#33453](https://github.com/expo/expo/pull/33453) by [@ryanduffin](https://github.com/ryanduffin)
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
 
 ## 14.0.6 - 2025-01-10
 

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [ios][calendar] Use EXPermissionStatus instead of CalendarPermissionsStatus in calendar permissions requesters ([#33453](https://github.com/expo/expo/pull/33453) by [@ryanduffin](https://github.com/ryanduffin)
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
-- [iOS] Fix warnings which will become errors in Swift 6. ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35428](https://github.com/expo/expo/pull/35428) by [@behenate](https://github.com/behenate))
 
 ## 14.0.6 - 2025-01-10
 

--- a/packages/expo-calendar/ios/Conversions/EnumConversions.swift
+++ b/packages/expo-calendar/ios/Conversions/EnumConversions.swift
@@ -13,6 +13,9 @@ func eventAvailabilityToString(_ availability: EKEventAvailability) -> String {
     return "tentative"
   case .unavailable:
     return "unavailable"
+  @unknown default:
+    log.error("Unhandled `EKEventAvailability` value: \(availability), returning `notSupported` as fallback. Add the missing case as soon as possible.")
+    return "notSupported"
   }
 }
 
@@ -26,6 +29,9 @@ func eventStatusToString(_ status: EKEventStatus) -> String {
     return "tentative"
   case .canceled:
     return "cancelled"
+  @unknown default:
+    log.error("Unhandled `EKEventStatus` value: \(status), returning `none` as fallback. Add the missing case as soon as possible.")
+    return "none"
   }
 }
 
@@ -43,6 +49,9 @@ func sourceToString(type: EKSourceType) -> String {
     return "subscribed"
   case .birthdays:
     return "birthdays"
+  @unknown default:
+    log.error("Unhandled `EKSourceType` value: \(type), returning `local` as fallback. Add the missing case as soon as possible.")
+    return "local"
   }
 }
 
@@ -58,6 +67,9 @@ func participantToString(role: EKParticipantRole) -> String {
     return "chair"
   case .nonParticipant:
     return "notParticipant"
+  @unknown default:
+    log.error("Unhandled `EKParticipantRole` value: \(role), returning `unknown` as fallback. Add the missing case as soon as possible.")
+    return "unknown"
   }
 }
 
@@ -86,6 +98,9 @@ func participantTypeToString(type: EKParticipantType) -> String {
     return "group"
   case .resource:
     return "resource"
+  @unknown default:
+    log.error("Unhandled `EKParticipantType` value: \(type), returning `unknown` as fallback. Add the missing case as soon as possible.")
+    return "unknown"
   }
 }
 
@@ -107,6 +122,9 @@ func participantStatusToString(status: EKParticipantStatus) -> String {
     return "completed"
   case .inProcess:
     return "inProcess"
+  @unknown default:
+    log.error("Unhandled `EKParticipantStatus` value: \(status), returning `unknown` as fallback. Add the missing case as soon as possible.")
+    return "unknown"
   }
 }
 
@@ -120,6 +138,9 @@ func recurrenceToString(frequency: EKRecurrenceFrequency) -> String {
     return "monthly"
   case .yearly:
     return "yearly"
+  @unknown default:
+    log.error("Unhandled `EKRecurrenceFrequency` value: \(frequency), returning `daily` as fallback. Add the missing case as soon as possible.")
+    return "daily"
   }
 }
 

--- a/packages/expo-calendar/ios/Requesters/CalendarPermissionsRequester.swift
+++ b/packages/expo-calendar/ios/Requesters/CalendarPermissionsRequester.swift
@@ -31,7 +31,7 @@ public class CalendarPermissionsRequester: NSObject, EXPermissionsRequester {
     }
 
     switch permissions {
-    case .restricted, .denied:
+    case .restricted, .denied, .writeOnly:
       status = EXPermissionStatusDenied
     case .notDetermined:
       status = EXPermissionStatusUndetermined

--- a/packages/expo-calendar/ios/Requesters/RemindersPermissionsRequester.swift
+++ b/packages/expo-calendar/ios/Requesters/RemindersPermissionsRequester.swift
@@ -31,7 +31,7 @@ public class RemindersPermissionRequester: NSObject, EXPermissionsRequester {
     }
 
     switch permissions {
-    case .restricted, .denied:
+    case .restricted, .denied, .writeOnly:
       status = EXPermissionStatusDenied
     case .notDetermined:
       status = EXPermissionStatusUndetermined

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 - Add warning when rendering `children` in the `CameraView`. ([#34969](https://github.com/expo/expo/pull/34969) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
 
 ## 16.0.8 - 2024-11-29
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -30,7 +30,7 @@
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 - Add warning when rendering `children` in the `CameraView`. ([#34969](https://github.com/expo/expo/pull/34969) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix warnings which will become errors in Swift 6. ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35428](https://github.com/expo/expo/pull/35428) by [@behenate](https://github.com/behenate))
 
 ## 16.0.8 - 2024-11-29
 

--- a/packages/expo-camera/ios/Current/VisionScannerDelegate.swift
+++ b/packages/expo-camera/ios/Current/VisionScannerDelegate.swift
@@ -1,4 +1,5 @@
 import VisionKit
+import ExpoModulesCore
 
 protocol ScannerResultHandler {
   func onItemScanned(result: [String: Any])
@@ -18,6 +19,9 @@ class VisionScannerDelegate: NSObject, DataScannerViewControllerDelegate {
       case .barcode(let code):
         handler.onItemScanned(result: BarcodeScannerUtils.visionDataScannerObjectToDictionary(item: code))
       case .text(let text):
+        return
+      @unknown default:
+        log.error("Unhandled `RecognizedItem` value: \(item), returning `nil` as fallback. Add the missing case as soon as possible.")
         return
       }
     }

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Use the `src` folder as the Metro target. ([#33781](https://github.com/expo/expo/pull/33781) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
-- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate)), ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
 
 ## 14.0.5 - 2025-01-31
 

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Use the `src` folder as the Metro target. ([#33781](https://github.com/expo/expo/pull/33781) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
-- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate)), ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate)), ([#35428](https://github.com/expo/expo/pull/35428) by [@behenate](https://github.com/behenate))
 
 ## 14.0.5 - 2025-01-31
 

--- a/packages/expo-contacts/ios/Serialization.swift
+++ b/packages/expo-contacts/ios/Serialization.swift
@@ -581,6 +581,8 @@ private func encodeContainerType(_ type: CNContainerType) -> String {
     return "exchange"
   case .cardDAV:
     return "cardDAV"
+  case .unassigned:
+    fallthrough
   @unknown default:
     return "unassigned"
   }

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Update `ImageProps` type so `children` are omitted. ([#33210](https://github.com/expo/expo/pull/33210) by [@ashaller2017](https://github.com/ashaller2017))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
 
 ## 2.0.6 - 2025-02-19
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Update `ImageProps` type so `children` are omitted. ([#33210](https://github.com/expo/expo/pull/33210) by [@ashaller2017](https://github.com/ashaller2017))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Fix warnings which will become errors in Swift 6. ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35428](https://github.com/expo/expo/pull/35428) by [@behenate](https://github.com/behenate))
 
 ## 2.0.6 - 2025-02-19
 

--- a/packages/expo-image/ios/ImageCacheType.swift
+++ b/packages/expo-image/ios/ImageCacheType.swift
@@ -16,6 +16,9 @@ enum ImageCacheType: String, Enumerable {
       return .disk
     case .memory:
       return .memory
+    @unknown default:
+      log.error("Unhandled `SDImageCacheType` value: \(sdImageCacheType), returning `none` as fallback. Add the missing case as soon as possible.")
+      return .none
     }
   }
 }

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -21,6 +21,9 @@ func cacheTypeToString(_ cacheType: SDImageCacheType) -> String {
   case .memory, .all:
     // `all` doesn't make much sense, so we treat it as `memory`.
     return "memory"
+  @unknown default:
+    log.error("Unhandled `SDImageCacheType` value: \(cacheType), returning `none` as fallback. Add the missing case as soon as possible.")
+    return "none"
   }
 }
 

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
 
 ## 16.0.1 - 2025-01-10
 

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Fix warnings which will become errors in Swift 6. ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35428](https://github.com/expo/expo/pull/35428) by [@behenate](https://github.com/behenate))
 
 ## 16.0.1 - 2025-01-10
 

--- a/packages/expo-localization/ios/LocalizationModule.swift
+++ b/packages/expo-localization/ios/LocalizationModule.swift
@@ -123,6 +123,9 @@ public class LocalizationModule: Module {
       return "roc"
     case .iso8601:
       return "iso8601"
+    @unknown default:
+      log.error("Unhandled `Calendar.Identifier` value: \(calendar.identifier), returning `iso8601` as fallback. Add the missing case as soon as possible.")
+      return "iso8601"
     }
   }
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
-- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate)), ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
 
 ## 17.0.6 - 2025-02-14
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
-- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate)), ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate)), ([#35428](https://github.com/expo/expo/pull/35428) by [@behenate](https://github.com/behenate))
 
 ## 17.0.6 - 2025-02-14
 

--- a/packages/expo-media-library/ios/MediaLibraryUtilities.swift
+++ b/packages/expo-media-library/ios/MediaLibraryUtilities.swift
@@ -50,6 +50,9 @@ func stringifyAlbumType(type: PHAssetCollectionType) -> String {
     return "moment"
   case .smartAlbum:
     return "smartAlbum"
+  @unknown default:
+    log.error("Unhandled `PHAssetCollectionType` value: \(type), returning `album` as fallback. Add the missing case as soon as possible.")
+    return "album"
   }
 }
 

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -13,7 +13,7 @@
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 - Standardize platform key ordering in `expo-module.config.json`. ([#35003](https://github.com/expo/expo/pull/35003) by [@reichhartd](https://github.com/reichhartd))
-- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate)), ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
 
 ## 8.0.4 - 2025-01-10
 

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -13,7 +13,7 @@
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 - Standardize platform key ordering in `expo-module.config.json`. ([#35003](https://github.com/expo/expo/pull/35003) by [@reichhartd](https://github.com/reichhartd))
-- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate)), ([#35289](https://github.com/expo/expo/pull/35289) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate)), ([#35428](https://github.com/expo/expo/pull/35428) by [@behenate](https://github.com/behenate))
 
 ## 8.0.4 - 2025-01-10
 

--- a/packages/expo-screen-orientation/ios/enums/ModuleOrientation.swift
+++ b/packages/expo-screen-orientation/ios/enums/ModuleOrientation.swift
@@ -19,6 +19,9 @@ enum ModuleOrientation: Int, Enumerable {
       return .landscapeRight
     case .unknown:
       return .unknown
+    @unknown default:
+      log.error("Unhandled `UIInterfaceOrientation` value: \(interfaceOrientation), returning `unknown` as fallback. Add the missing case as soon as possible.")
+      return .unknown
     }
   }
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -26,7 +26,7 @@
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 - [iOS] SharedRef: migrate from `pointer` to `ref` ([#30359](https://github.com/expo/expo/pull/30359) by [@behenate](https://github.com/behenate))
-- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
+- [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate)), ([#35428](https://github.com/expo/expo/pull/35428) by [@behenate](https://github.com/behenate))
 
 ## 2.0.5 - 2025-01-10
 

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -347,6 +347,9 @@ class VideoPlayerObserver {
       } else {
         status = .readyToPlay
       }
+    @unknown default:
+      log.error("Unhandled `AVPlayerItem.Status` value: \(playerItem.status), returning `.loading` as fallback. Add the missing case as soon as possible.")
+      status = .loading
     }
 
     if let player, !loadedCurrentItem && (status == .readyToPlay || status == .error) {


### PR DESCRIPTION
# Why

Re-opening of https://github.com/expo/expo/pull/35289 as I accidentaly merged it too early

Some of the `switch` statements are non-exhaustive or were marked by apple as possible to change in the future, which adds the following warning:
```
Switch covers known cases, but 'ASAuthorizationAppleIDProvider.CredentialState' may have additional unknown values, possibly added in future versions; this is an error in the Swift 6 language mode
```

# How

Added missing cases, when the statements were marked as possible to change I added a `@unknown default` case that will log an error and fallback to a value

# Test Plan

Tested in BareExpo on iOS (compile-only)
