### PR TITLE
[gha] speed up docs workflow checkout step

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: 👀 Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 30000
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
# Why

Looks like setting a `0` as `fetch-depth` have some unwanted side effects, like fetching all branches. We can avoid that by setting quite high depth value, which exceeds the number of commits in the repo.

# How

Set docs workflow checkout `fetch-depth` to `30000`. The docs pages update dates should still works correctly after the change.

# Test Plan

Confirm that update dates in PR preview matches those from PROD deployment.

# Preview

### Before

![Screenshot 2025-03-11 at 14 58 54](https://github.com/user-attachments/assets/9ac4687e-d96c-4422-99b6-b71f67f82129)

### After

![Screenshot 2025-03-11 at 15 00 07](https://github.com/user-attachments/assets/250d4c28-45bb-433c-bf05-1f4991dc334e)
