### PR TITLE
Add disclaimer when reusing videoplayer instances

### DIFF
--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -293,6 +293,8 @@ import { createVideoPlayer } from 'expo-video';
 const player = createVideoPlayer(videoSource);
 ```
 
+> **warning** On Android, mounting multiple VideoView components at the same time with the same VideoPlayer instance will not work due to a platform limitation. See [issue](https://github.com/expo/expo/issues/35012)
+
 ### Caching videos
 
 If your app frequently replays the same video, caching can be utilized to minimize network usage and enhance user experience, albeit at the cost of increased device storage usage. `expo-video` supports video caching on `Android` and `iOS` platforms. This feature can be activated by setting the [`useCaching`](#videosource) property of a [`VideoSource`](#videosource) object to `true`.

--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -293,7 +293,7 @@ import { createVideoPlayer } from 'expo-video';
 const player = createVideoPlayer(videoSource);
 ```
 
-> **warning** On Android, mounting multiple VideoView components at the same time with the same VideoPlayer instance will not work due to a platform limitation. See [issue](https://github.com/expo/expo/issues/35012)
+> **warning** On Android, mounting multiple `VideoView` components at the same time with the same `VideoPlayer` instance will not work due to a [platform limitation](https://github.com/expo/expo/issues/35012)
 
 ### Caching videos
 

--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -293,7 +293,7 @@ import { createVideoPlayer } from 'expo-video';
 const player = createVideoPlayer(videoSource);
 ```
 
-> **warning** On Android, mounting multiple `VideoView` components at the same time with the same `VideoPlayer` instance will not work due to a [platform limitation](https://github.com/expo/expo/issues/35012)
+> **warning** On Android, mounting multiple `VideoView` components at the same time with the same `VideoPlayer` instance will not work due to a [platform limitation](https://github.com/expo/expo/issues/35012).
 
 ### Caching videos
 

--- a/docs/pages/versions/v52.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/video.mdx
@@ -294,7 +294,7 @@ import { createVideoPlayer } from 'expo-video';
 const player = createVideoPlayer(videoSource);
 ```
 
-> **warning** On Android, mounting multiple VideoView components at the same time with the same VideoPlayer instance will not work due to a platform limitation. See [issue](https://github.com/expo/expo/issues/35012)
+> **warning** On Android, mounting multiple `VideoView` components at the same time with the same `VideoPlayer` instance will not work due to a [platform limitation](https://github.com/expo/expo/issues/35012)
 
 ## API
 

--- a/docs/pages/versions/v52.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/video.mdx
@@ -294,7 +294,7 @@ import { createVideoPlayer } from 'expo-video';
 const player = createVideoPlayer(videoSource);
 ```
 
-> **warning** On Android, mounting multiple `VideoView` components at the same time with the same `VideoPlayer` instance will not work due to a [platform limitation](https://github.com/expo/expo/issues/35012)
+> **warning** On Android, mounting multiple `VideoView` components at the same time with the same `VideoPlayer` instance will not work due to a [platform limitation](https://github.com/expo/expo/issues/35012).
 
 ## API
 

--- a/docs/pages/versions/v52.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/video.mdx
@@ -294,6 +294,8 @@ import { createVideoPlayer } from 'expo-video';
 const player = createVideoPlayer(videoSource);
 ```
 
+> **warning** On Android, mounting multiple VideoView components at the same time with the same VideoPlayer instance will not work due to a platform limitation. See [issue](https://github.com/expo/expo/issues/35012)
+
 ## API
 
 ```js


### PR DESCRIPTION
# Why

See https://github.com/expo/expo/issues/35012

My team bumped into an issue where we reused a `VideoPlayer` instance across pages with React Navigation. In the origin page the `VideoView` is not unmounted and this causes a black screen, when going back and forth. Adding this disclaimer might help others

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
