### PR TITLE
[cli] Add requestId to API error

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Bump Metro typescript declarations to `0.81.3`. ([#35306](https://github.com/expo/expo/pull/35306) by [@byCedric](https://github.com/byCedric))
 - Upgrade to `minimatch@9` ([#35313](https://github.com/expo/expo/pull/35313) by [@kitten](https://github.com/kitten))
 - Upgrade to `tar@7` ([#35314](https://github.com/expo/expo/pull/35314) by [@kitten](https://github.com/kitten))
+- Add requestId to API error ([#35442](https://github.com/expo/expo/pull/35442) by [@wschurman](https://github.com/wschurman))
 
 ## 0.22.20 - 2025-03-14
 

--- a/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
+++ b/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
@@ -29,11 +29,12 @@ it('converts Expo APIv2 error to ApiV2Error', async () => {
           stack: 'line 1: hello',
           details: { who: 'world' },
           metadata: { an: 'object' },
+          requestId: '123',
         },
       ],
     });
 
-  expect.assertions(6);
+  expect.assertions(7);
 
   try {
     await fetchAsync('test', { method: 'POST' });
@@ -44,6 +45,7 @@ it('converts Expo APIv2 error to ApiV2Error', async () => {
     expect(error.expoApiV2ErrorDetails).toEqual({ who: 'world' });
     expect(error.expoApiV2ErrorMetadata).toEqual({ an: 'object' });
     expect(error.expoApiV2ErrorServerStack).toEqual('line 1: hello');
+    expect(error.expoApiV2RequestId).toEqual('123');
   }
 });
 
@@ -56,11 +58,12 @@ it('converts Expo APIv2 error to ApiV2Error (invalid password)', async () => {
           code: 'AUTHENTICATION_ERROR',
           message: 'Your username, email, or password was incorrect.',
           isTransient: false,
+          requestId: '123',
         },
       ],
     });
 
-  expect.assertions(3);
+  expect.assertions(4);
 
   try {
     await fetchAsync('test', { method: 'POST' });
@@ -68,6 +71,7 @@ it('converts Expo APIv2 error to ApiV2Error (invalid password)', async () => {
     expect(error).toBeInstanceOf(ApiV2Error);
     expect(error.message).toEqual('Your username, email, or password was incorrect.');
     expect(error.expoApiV2ErrorCode).toEqual('AUTHENTICATION_ERROR');
+    expect(error.expoApiV2RequestId).toEqual('123');
   }
 });
 

--- a/packages/@expo/cli/src/api/rest/client.ts
+++ b/packages/@expo/cli/src/api/rest/client.ts
@@ -22,6 +22,7 @@ export class ApiV2Error extends Error {
   readonly expoApiV2ErrorDetails?: JSONValue;
   readonly expoApiV2ErrorServerStack?: string;
   readonly expoApiV2ErrorMetadata?: object;
+  readonly expoApiV2RequestId?: string;
 
   constructor(response: {
     message: string;
@@ -29,6 +30,7 @@ export class ApiV2Error extends Error {
     stack?: string;
     details?: JSONValue;
     metadata?: object;
+    requestId: string;
   }) {
     super(response.message);
     this.code = response.code;
@@ -36,6 +38,11 @@ export class ApiV2Error extends Error {
     this.expoApiV2ErrorDetails = response.details;
     this.expoApiV2ErrorServerStack = response.stack;
     this.expoApiV2ErrorMetadata = response.metadata;
+    this.expoApiV2RequestId = response.requestId;
+  }
+
+  toString() {
+    return `${super.toString()}${env.EXPO_DEBUG && this.expoApiV2RequestId ? ` (Request Id: ${this.expoApiV2RequestId})` : ''}`;
   }
 }
 


### PR DESCRIPTION
# Why

Same as https://github.com/expo/eas-cli/pull/2941 but for `@expo/cli`. We want to show the request ID returned as part of the error when `EXPO_DEBUG` is set.

Closes ENG-15210.

# How

Add field, override `toString` which is called from the toplevel command error handler.

# Test Plan

```
EXPO_DEBUG=1 nexpo login
✔ Email or username … <fake>
✔ Password … *****
ApiV2Error: Your username, email, or password was incorrect. (Request Id: e2c98628-95c1-435f-9e44-faf06464539e)
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
