### PR TITLE
[docs][iOS][location] added note on iOS plist deprecation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -61,6 +61,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
     {
       name: 'locationAlwaysPermission',
       platform: 'ios',
+      deprecated: true,
       description:
         'A string to set the [`NSLocationAlwaysUsageDescription`](#permission-nslocationalwaysusagedescription) permission message.',
       default: '"Allow $(PRODUCT_NAME) to use your location"',
@@ -68,6 +69,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
     {
       name: 'locationWhenInUsePermission',
       platform: 'ios',
+      deprecated: true,
       description:
         'A string to set the [`NSLocationWhenInUseUsageDescription`](#permission-nslocationwheninuseusagedescription) permission message.',
       default: '"Allow $(PRODUCT_NAME) to use your location"',
@@ -323,3 +325,5 @@ The following usage description keys are used by this library:
     'NSLocationWhenInUseUsageDescription',
   ]}
 />
+
+**NSLocationAlwaysUsageDescription** and **NSLocationWhenInUseUsageDescription** are deprecated in favor of **NSLocationAlwaysAndWhenInUseUsageDescription** from iOS 11.

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -61,6 +61,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
     {
       name: 'locationAlwaysPermission',
       platform: 'ios',
+      deprecated: true,
       description:
         'A string to set the [`NSLocationAlwaysUsageDescription`](#permission-nslocationalwaysusagedescription) permission message.',
       default: '"Allow $(PRODUCT_NAME) to use your location"',
@@ -68,6 +69,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
     {
       name: 'locationWhenInUsePermission',
       platform: 'ios',
+      deprecated: true,
       description:
         'A string to set the [`NSLocationWhenInUseUsageDescription`](#permission-nslocationwheninuseusagedescription) permission message.',
       default: '"Allow $(PRODUCT_NAME) to use your location"',
@@ -323,3 +325,5 @@ The following usage description keys are used by this library:
     'NSLocationWhenInUseUsageDescription',
   ]}
 />
+
+**NSLocationAlwaysUsageDescription** and **NSLocationWhenInUseUsageDescription** are deprecated in favor of **NSLocationAlwaysAndWhenInUseUsageDescription** from iOS 11.


### PR DESCRIPTION
# Why

From iOS 11 NSLocationAlwaysUsageDescription and NSLocationWhenInUseUsageDescription are deprecated and NSLocationAlwaysAndWhenInUseUsageDescription should be used instead, just as it is done in the doc example.

# How

Added clear instructions about this in the docs, also marked config-plugin properties as deprecated in the docs.

# Test Plan

Read the docs.

# Checklist

- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
