### PR TITLE
[iOS][location] Add scope to foreground and background iOS permissions as pr. documentation

### DIFF
--- a/apps/test-suite/tests/Location.js
+++ b/apps/test-suite/tests/Location.js
@@ -69,6 +69,7 @@ export async function test(t) {
         const permission = await Location.requestForegroundPermissionsAsync();
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
+        t.expect(permission.scope).toBe('whenInUse');
       });
     });
 
@@ -77,6 +78,7 @@ export async function test(t) {
         const permission = await Location.getForegroundPermissionsAsync();
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
+        t.expect(permission.scope).toBe('whenInUse');
       });
     });
 
@@ -85,6 +87,7 @@ export async function test(t) {
         const permission = await Location.requestBackgroundPermissionsAsync();
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
+        t.expect(permission.scope).toBe('always');
       });
     });
 
@@ -93,6 +96,7 @@ export async function test(t) {
         const permission = await Location.getBackgroundPermissionsAsync();
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
+        t.expect(permission.scope).toBe('always');
       });
     });
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 💡 Others
 
+- On iOS, added setting the scope value as per our documentation.
 - On Android, remove dependency on `smart-location-lib`. ([#33609](https://github.com/expo/expo/pull/33609) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 💡 Others
 
-- On iOS, added setting the scope value as per our documentation.
+- On iOS, added setting the scope value as per our documentation. ([#35452](https://github.com/expo/expo/pull/35452) by [@chrfalch](https://github.com/chrfalch))
 - On Android, remove dependency on `smart-location-lib`. ([#33609](https://github.com/expo/expo/pull/33609) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 

--- a/packages/expo-location/ios/Requesters/EXBackgroundLocationPermissionRequester.m
+++ b/packages/expo-location/ios/Requesters/EXBackgroundLocationPermissionRequester.m
@@ -93,7 +93,7 @@ static SEL alwaysAuthorizationSelector;
     }
   }
   
-  return @{ @"status": @(status) };
+  return @{ @"status": @(status), @"scope": @(systemStatus == kCLAuthorizationStatusAuthorizedWhenInUse ? "whenInUse" : systemStatus == kCLAuthorizationStatusAuthorizedAlways ? "always" : "none") };
 }
 
 @end

--- a/packages/expo-location/ios/Requesters/EXForegroundPermissionRequester.m
+++ b/packages/expo-location/ios/Requesters/EXForegroundPermissionRequester.m
@@ -54,7 +54,7 @@ static SEL whenInUseAuthorizationSelector;
     }
   }
   
-  return @{ @"status": @(status) };
+  return @{ @"status": @(status), @"scope": @(systemStatus == kCLAuthorizationStatusAuthorizedWhenInUse ? "whenInUse" : systemStatus == kCLAuthorizationStatusAuthorizedAlways ? "always" : "none") };
 }
 
 @end


### PR DESCRIPTION
# Why

In the docs we refer to a field called scope on iOS in the LocationPermissionResponse which is not set by the foreground/background permission requestors.

# How

This PR fixes this by setting it. It might not seem super important, but it is documented and we should "do as we say".

Added some tests to verify that this field is set as well.

# Test Plan

- Test in BareExpo's Location test screen
- Run tests in Bareexpo
- 
# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- 