### PR TITLE
[docs][iOS][location] Added collapsible section that tries to explain iOS location permissions

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -175,7 +175,7 @@ To use location tracking or Geofencing in the background, you must request the a
 iOS permissions are divided into the two categories `When In Use` and `Always` and maps to Expo's foreground and background location permissions requested via:
 
 - [`requestForegroundPermissionsAsync`](#locationrequestforegroundpermissionsasync) maps to `When In Use`
-- [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) → `Always`
+- [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) maps to `Always`
 
 > **NOTE:** When requesting `When In Use` authorization, the user can grant **temporary access** by selecting `Allow Once` in the system permission dialog. This authorization will be valid **only for the current app session** and is automatically revoked when the app is closed.
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -183,7 +183,7 @@ iOS permissions are divided into the two categories `When In Use` and `Always` a
 
 Unfortunately, **iOS does not provide a way to detect whether the user selected `Allow Once` or `Allow While Using the App`**. Both responses result in `When In Use` authorization.
 
-If the user selected `Allow Once` and you subsequently call [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) in the same session, the system **will not show another prompt**. Instead the request will **silently fail** and the returned background permission status will be **denied**.
+If the user selected `Allow Once` and you subsequently call [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) in the same session, the system **will not show another prompt**. Instead, the request will **silently fail**, and the returned background permission status will be **denied**.
 
 **Handling "Allow Once" scenarios**
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -199,7 +199,7 @@ function openSettings() {
 
 **Incremental Permission Requests**
 
-It is possible to request foreground location access first, then ask for background location access later. This can improve the user experience by requesting permissions only when necessary.
+It is possible to request foreground location access first and then ask for background location access later. This can improve the user experience by requesting permissions only when necessary.
 
 **Requesting Background Permissions Directly**
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -187,7 +187,7 @@ If the user selected `Allow Once` and you subsequently call [`requestBackgroundP
 
 **Handling "Allow Once" scenarios**
 
-If you suspect the user selected `Allow Once` and need to request background permissions, they must **manually enable background location** in the Settings app:
+If you suspect the user selected `Allow Once` and needs to request background permissions, they must **manually enable background location** in the Settings app. You can use `Linking` to open the Settings app within your app:
 
 ```js
 import { Linking } from 'react-native';

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -201,7 +201,7 @@ function openSettings() {
 
 It is possible to request foreground location access first and then ask for background location access later. This can improve the user experience by requesting permissions only when necessary.
 
-**Requesting Background Permissions Directly**
+**Requesting Background Permissions directly**
 
 If you call [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) without first requesting foreground permissions, iOS treats it as a request for both `When In Use` and `Always` authorization. The system will then prompt the user for `When In Use` access, and the `Always` authorization prompt will be displayed when the system determines that `Always` authorization is required.
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -171,6 +171,44 @@ To use location tracking or Geofencing in the background, you must request the a
 - On Android, you must request both foreground and background permissions.
 - On iOS, it must be granted with the `Always` option using [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync).
 
+<Collapsible summary="Expo and iOS permissions">
+iOS permissions are divided into the two categories `When In Use` and `Always` and maps to Expo's foreground and background location permissions requested via:
+
+- [`requestForegroundPermissionsAsync`](#locationrequestforegroundpermissionsasync) → `When In Use`
+- [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) → `Always`
+
+> **NOTE:** When requesting `When In Use` authorization, the user can grant **temporary access** by selecting `Allow Once` in the system permission dialog. This authorization will be valid **only for the current app session** and is automatically revoked when the app is closed.
+
+**Detecting "Allow Once" versus "Allow While Using the App"**
+
+Unfortunately, **iOS does not provide a way to detect whether the user selected `Allow Once` or `Allow While Using the App`**. Both responses result in `When In Use` authorization.
+
+If the user selected `Allow Once` and you subsequently call [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) in the same session, the system **will not show another prompt**. Instead the request will **silently fail** and the returned background permission status will be **denied**.
+
+**Handling "Allow Once" scenarios**
+
+If you suspect the user selected `Allow Once` and need to request background permissions, they must **manually enable background location** in the Settings app:
+
+```js
+import { Linking } from 'react-native';
+
+function openSettings() {
+  Linking.openURL('app-settings:');
+}
+```
+
+**Incremental Permission Requests**
+
+It is possible to request foreground location access first, then ask for background location access later. This can improve the user experience by requesting permissions only when necessary.
+
+**Requesting Background Permissions Directly**
+
+If you call [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) without first requesting foreground permissions, iOS treats it as a request for both `When In Use` and `Always` authorization. The system will then prompt the user for `When In Use` access, and the `Always` authorization prompt will be displayed when the system determines that `Always` authorization is required.
+
+Remember that the user has the option of granting your app `When In Use` authorization instead. You must always be prepared to run with `When In Use` permission.
+
+</Collapsible>
+
 ## Usage
 
 If you're using the Android Emulator or iOS Simulator, ensure that [Location is enabled](#enable-emulator-location).

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -174,7 +174,7 @@ To use location tracking or Geofencing in the background, you must request the a
 <Collapsible summary="Expo and iOS permissions">
 iOS permissions are divided into the two categories `When In Use` and `Always` and maps to Expo's foreground and background location permissions requested via:
 
-- [`requestForegroundPermissionsAsync`](#locationrequestforegroundpermissionsasync) → `When In Use`
+- [`requestForegroundPermissionsAsync`](#locationrequestforegroundpermissionsasync) maps to `When In Use`
 - [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) → `Always`
 
 > **NOTE:** When requesting `When In Use` authorization, the user can grant **temporary access** by selecting `Allow Once` in the system permission dialog. This authorization will be valid **only for the current app session** and is automatically revoked when the app is closed.

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -197,7 +197,7 @@ function openSettings() {
 }
 ```
 
-**Incremental Permission Requests**
+**Incremental permission requests**
 
 It is possible to request foreground location access first and then ask for background location access later. This can improve the user experience by requesting permissions only when necessary.
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -177,7 +177,7 @@ iOS permissions are divided into the two categories `When In Use` and `Always` a
 - [`requestForegroundPermissionsAsync`](#locationrequestforegroundpermissionsasync) maps to `When In Use`
 - [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) maps to `Always`
 
-> **NOTE:** When requesting `When In Use` authorization, the user can grant **temporary access** by selecting `Allow Once` in the system permission dialog. This authorization will be valid **only for the current app session** and is automatically revoked when the app is closed.
+> **Note:** When requesting `When In Use` authorization, the user can grant **temporary access** by selecting `Allow Once` in the system permission dialog. This authorization will be valid **only for the current app session** and is automatically revoked when the app is closed.
 
 **Detecting "Allow Once" versus "Allow While Using the App"**
 

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -174,20 +174,20 @@ To use location tracking or Geofencing in the background, you must request the a
 <Collapsible summary="Expo and iOS permissions">
 iOS permissions are divided into the two categories `When In Use` and `Always` and maps to Expo's foreground and background location permissions requested via:
 
-- [`requestForegroundPermissionsAsync`](#locationrequestforegroundpermissionsasync) → `When In Use`
-- [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) → `Always`
+- [`requestForegroundPermissionsAsync`](#locationrequestforegroundpermissionsasync) maps to `When In Use`
+- [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) maps to `Always`
 
-> **NOTE:** When requesting `When In Use` authorization, the user can grant **temporary access** by selecting `Allow Once` in the system permission dialog. This authorization will be valid **only for the current app session** and is automatically revoked when the app is closed.
+> **Note:** When requesting `When In Use` authorization, the user can grant **temporary access** by selecting `Allow Once` in the system permission dialog. This authorization will be valid **only for the current app session** and is automatically revoked when the app is closed.
 
 **Detecting "Allow Once" versus "Allow While Using the App"**
 
 Unfortunately, **iOS does not provide a way to detect whether the user selected `Allow Once` or `Allow While Using the App`**. Both responses result in `When In Use` authorization.
 
-If the user selected `Allow Once` and you subsequently call [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) in the same session, the system **will not show another prompt**. Instead the request will **silently fail** and the returned background permission status will be **denied**.
+If the user selected `Allow Once` and you subsequently call [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) in the same session, the system **will not show another prompt**. Instead, the request will **silently fail**, and the returned background permission status will be **denied**.
 
 **Handling "Allow Once" scenarios**
 
-If you suspect the user selected `Allow Once` and need to request background permissions, they must **manually enable background location** in the Settings app:
+If you suspect the user selected `Allow Once` and needs to request background permissions, they must **manually enable background location** in the Settings app. You can use `Linking` to open the Settings app within your app:
 
 ```js
 import { Linking } from 'react-native';
@@ -197,11 +197,11 @@ function openSettings() {
 }
 ```
 
-**Incremental Permission Requests**
+**Incremental permission requests**
 
-It is possible to request foreground location access first, then ask for background location access later. This can improve the user experience by requesting permissions only when necessary.
+It is possible to request foreground location access first and then ask for background location access later. This can improve the user experience by requesting permissions only when necessary.
 
-**Requesting Background Permissions Directly**
+**Requesting Background Permissions directly**
 
 If you call [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) without first requesting foreground permissions, iOS treats it as a request for both `When In Use` and `Always` authorization. The system will then prompt the user for `When In Use` access, and the `Always` authorization prompt will be displayed when the system determines that `Always` authorization is required.
 

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -171,6 +171,44 @@ To use location tracking or Geofencing in the background, you must request the a
 - On Android, you must request both foreground and background permissions.
 - On iOS, it must be granted with the `Always` option using [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync).
 
+<Collapsible summary="Expo and iOS permissions">
+iOS permissions are divided into the two categories `When In Use` and `Always` and maps to Expo's foreground and background location permissions requested via:
+
+- [`requestForegroundPermissionsAsync`](#locationrequestforegroundpermissionsasync) → `When In Use`
+- [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) → `Always`
+
+> **NOTE:** When requesting `When In Use` authorization, the user can grant **temporary access** by selecting `Allow Once` in the system permission dialog. This authorization will be valid **only for the current app session** and is automatically revoked when the app is closed.
+
+**Detecting "Allow Once" versus "Allow While Using the App"**
+
+Unfortunately, **iOS does not provide a way to detect whether the user selected `Allow Once` or `Allow While Using the App`**. Both responses result in `When In Use` authorization.
+
+If the user selected `Allow Once` and you subsequently call [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) in the same session, the system **will not show another prompt**. Instead the request will **silently fail** and the returned background permission status will be **denied**.
+
+**Handling "Allow Once" scenarios**
+
+If you suspect the user selected `Allow Once` and need to request background permissions, they must **manually enable background location** in the Settings app:
+
+```js
+import { Linking } from 'react-native';
+
+function openSettings() {
+  Linking.openURL('app-settings:');
+}
+```
+
+**Incremental Permission Requests**
+
+It is possible to request foreground location access first, then ask for background location access later. This can improve the user experience by requesting permissions only when necessary.
+
+**Requesting Background Permissions Directly**
+
+If you call [`requestBackgroundPermissionsAsync`](#locationrequestbackgroundpermissionsasync) without first requesting foreground permissions, iOS treats it as a request for both `When In Use` and `Always` authorization. The system will then prompt the user for `When In Use` access, and the `Always` authorization prompt will be displayed when the system determines that `Always` authorization is required.
+
+Remember that the user has the option of granting your app `When In Use` authorization instead. You must always be prepared to run with `When In Use` permission.
+
+</Collapsible>
+
 ## Usage
 
 If you're using the Android Emulator or iOS Simulator, ensure that [Location is enabled](#enable-emulator-location).

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 💡 Others
 
+- On iOS, added setting the scope value as per our documentation.
 - On Android, remove dependency on `smart-location-lib`. ([#33609](https://github.com/expo/expo/pull/33609) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -13,7 +13,6 @@
 
 ### 💡 Others
 
-- On iOS, added setting the scope value as per our documentation.
 - On Android, remove dependency on `smart-location-lib`. ([#33609](https://github.com/expo/expo/pull/33609) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 


### PR DESCRIPTION
# Why

Location permissions are a bit complex on iOS, and we have a few issues and complaints about our SDK not working as expected.

# How

This commit tries to fix this by adding a new section explaining how it relates to the Expo permissions and how it is working on iOS

# Test Plan

- Read the docs! :) 

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
