### PR TITLE
[sqlite] add ios implementation for session extension

### DIFF
--- a/apps/bare-expo/ios/BareExpo.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/BareExpo.xcodeproj/project.pbxproj
@@ -380,12 +380,10 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-BareExpoMain-BareExpoTests/Pods-BareExpoMain-BareExpoTests-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ExpoSQLite/crsqlite.framework/crsqlite",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/crsqlite.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -505,12 +503,10 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-BareExpoMain-BareExpo/Pods-BareExpoMain-BareExpo-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ExpoSQLite/crsqlite.framework/crsqlite",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/crsqlite.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3323,83 +3323,83 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  BenchmarkingModule: 0b3e5a6c6da1b307bcde22f82ab4c826a1b422a0
+  BenchmarkingModule: 3549f9ab20c3630235351b4a6691eafcaaf5c377
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EASClient: d15d70e334b019ae5649609011cda761defe4b1a
-  EXApplication: 88ebf1a95f85faa5d2df160016d61f2d060e9438
-  EXAV: fc9706da25733f79db3305035ee3bc6174a6590c
-  EXConstants: 422549594e8d96723453ae23498537d45de21197
-  EXImageLoader: e5da974e25b13585c196b658a440720c075482d5
+  EASClient: 720af5473430a688e792ffa91f33d11fe72fcb89
+  EXApplication: e1ad9c950c98b2b134578092c948b10b403f3ea7
+  EXAV: 9773c9799767c9925547b05e41a26a0240bb8ef2
+  EXConstants: ce04ec1ab4b0b9e0f8a6c39211ce51e6ea61797a
+  EXImageLoader: 759063a65ab016b836f73972d3bb25404888713d
   EXJSONUtils: 01fc7492b66c234e395dcffdd5f53439c5c29c93
-  EXManifests: 8de88191fe548cd5aeafa4228ed92283b483b923
-  EXNotifications: 799b34c0218b6e1ff93c34bf61da5af63f443956
-  Expo: 606e42ef9a77e7b623801506e0a70e227e9d0aac
-  expo-dev-client: efd9785534d9facffebd23bb9d105e5eb71fd04f
-  expo-dev-launcher: 7ef430dff3a04411f38aac7f042826451ab905aa
-  expo-dev-menu: 3d3ae412a602cdeb152ef5cd1608026c16d86b36
+  EXManifests: f30a0c5d3d6cad8db9c01bab579e0aa0df5d3cb2
+  EXNotifications: 3b6c5a91673a5fe7eae005c1fa79889f645111aa
+  Expo: 24ec4e242d7cb4bc0095beeb984ac1006a8782e1
+  expo-dev-client: 8c99b4979086a27f19e773e96ef10219102a5c4f
+  expo-dev-launcher: cfef0430ea54f4f5bad49f508c2dd3e2b92d8c78
+  expo-dev-menu: e6fabad04c45708f535aa0456e9e74769f8268e9
   expo-dev-menu-interface: 4baf2f8b3b79ce37cf4b900e4b3ba6df3384f0a1
-  ExpoAppleAuthentication: 97195d0bb6676f83160b6a9fad020e90116319b9
-  ExpoAsset: 82a35cb4b4090b33c9c34488efcba6722188332b
-  ExpoAudio: db4fa2fa2f84fc113e8075fad160771c8c08278f
-  ExpoBackgroundFetch: a25a06f2c45c943d3efc64db9d737a63a527e7c6
-  ExpoBackgroundTask: 85f57ec3f6c6d7a954a076574efc662e2c619451
-  ExpoBattery: 65c86b6622731b142fd15cbf827462a72de01d4e
-  ExpoBlur: 2b92367da8158eeaee9bfa940d82512a09c8e0c6
-  ExpoBrightness: 436b9c602654c987e90270efe11fcfa5fc64ac07
-  ExpoCalendar: e473431b8645f63a23b1ca4ec502717694904ee5
-  ExpoCamera: 178a707fd4d2a780d18683694bdd717737df2e5f
-  ExpoCellular: 54732b5ec7c0d6656cd209d26e2e546c05a11995
-  ExpoClipboard: 8c704e60118cbdc5588a12abf02aec73ea404346
-  ExpoContacts: d7fd420dfd4f934435e808213948cadfa9fdc42c
-  ExpoCrypto: a7696ff7c5c1ddea5ed9a8c762d525cc0bfec606
-  ExpoDevice: 449822f2c45660c1ce83283dd51c67fe5404996c
-  ExpoDocumentPicker: cb4e43f58f0b5806e15db9baac36c6d99d19ffdf
-  ExpoDomWebView: 7265146b80ac30b0609acb86603040792e20abd3
-  ExpoFileSystem: 48b15dcdaa2441b3a6e7ab6672c237ec17754e72
-  ExpoFont: 60ac23a809b1cbdbfa8d5ee36a40b952278b4ddd
-  ExpoGL: 9e4ac36b4dfeba548728f835c72fe895364ec3e7
-  ExpoHaptics: 1cfd8cc43fe34722cd94e3bfda934948316a4eb9
-  ExpoImage: 8af6e284f0f20d9d1ae75d0a5dadf20e5b0b64a1
-  ExpoImageManipulator: 797e6f2eb209cc47bda2fd12904c96787b94dd5d
-  ExpoImagePicker: 4eff722eec3f969b3978a8a3b64efbe52f800905
-  ExpoInsights: 474fa4567a5fd940d868a017a2361b39ac4c9197
-  ExpoKeepAwake: b126ab6275e421b1cc4b356d6be3fdc0d56730a4
-  ExpoLinearGradient: 18148bd38f98fa0229c1f9df23393b32ab6d2d32
-  ExpoLinking: f712bbe586a499e6a0d00848d62311afa60bd614
-  ExpoLivePhoto: af5f921ba2f0f431c7422522d293fc7a34f0aadd
-  ExpoLocalAuthentication: 9d38ef2dd4108ffe03a926853ad6936c06b74b1e
-  ExpoLocalization: d81f70d53db94b31e4a0b1e11007424ea1011a1c
-  ExpoLocation: 1f193245a788fb827302fb7f7e0a3aad128d4a2b
-  ExpoMailComposer: f82da39ce31e55f6cfa487fd9fc52849837a658c
-  ExpoMaps: 8e317d0782cec7cc4d93b272c49b5eded8d409e3
-  ExpoMediaLibrary: d09fa24426216bd0d54e580cdd107e93f3c0a970
-  ExpoMeshGradient: d7cd67709796751501fb55701050ff7ec2d17121
-  ExpoModulesCore: 4219d6e77570fc41cf0a54e1469da0bd1c6711f4
-  ExpoModulesTestCore: fdbc6584854c6a5e3cfcc06b35a17f6d6dc39939
-  ExpoNetwork: 4a77370a1edf593200f9b5f06703a3b61397ef9b
-  ExpoPrint: 9f4d4bb7c597e6e9b225f7c6a4fc38602fc00374
-  ExpoScreenCapture: 4695c6c999a497327f9935133fd0e61547d7c21c
-  ExpoScreenOrientation: 30312845f8b3d51c11b660c59703dc107441155a
-  ExpoSecureStore: c9fa9d97af1472ddd579bc319762c1eb704afae9
-  ExpoSensors: 65914a390cdcb39aeed8441809d7d10adad3b23e
-  ExpoSharing: cfc87a3a494eb071f8814b79649ba78d135cc424
-  ExpoSMS: 693d98df9d4433c68e7454e8cac30c6aa4bb090f
-  ExpoSpeech: 2834afa2de1f25766f20f2eb7fb44e3c6e60d73a
-  ExpoSplashScreen: 8fe6e54b8b734a997da3c21d84b3ef61faa1bbf6
-  ExpoSQLite: ea7e0e0ef68ad3f351601649faefc01a586eab1b
-  ExpoStoreReview: f38ed71ee04dfc02dde63a05f925f001cebba5d8
-  ExpoSymbols: ed2f35e4a0290ff242eb295bd47adff2e46f5bfc
-  ExpoSystemUI: a8ec6d0bc06ebd5231c63c4f039a061544bf10ce
-  ExpoTrackingTransparency: 8d6e977989498b5067afa3501fafce805277a1a5
-  ExpoUI: 573838c97e1d37ae06ee84fd31d65dd2373ddc94
-  ExpoVideo: e6031e0f2a95c6df7ffbe116019f7882c55a9394
-  ExpoVideoThumbnails: 5572e98fac313bfdc86f7d7915354f13a364ed38
-  ExpoWebBrowser: b658ba8a9161f1b54afb279591cfce2cb73330fa
+  ExpoAppleAuthentication: 218e275c9bf19963247a198c450ce3852e6a9342
+  ExpoAsset: 6e707be0cb7e792faa06e42d8ebc85600921af89
+  ExpoAudio: ee3c2a6d63c84ab9f72c0ee330ee7a135ec15eee
+  ExpoBackgroundFetch: a3080ab72736b60441adf5f452919426c62e0533
+  ExpoBackgroundTask: 0a81fb8ea62e12ab313d3074ee5a6c195a0c47d4
+  ExpoBattery: 71bb388c37c3bcd0e87077e06e95780ea34fa6c8
+  ExpoBlur: 562b3da84d3cd79016c411671eaf71a404266415
+  ExpoBrightness: ce777f6a365592f745428cb0acc9066b400182e8
+  ExpoCalendar: c063db1cf7b5c9a11930745cb75bb5ee9ce68029
+  ExpoCamera: 0e504ac6907bddc915770c19f001dc361ce55f0b
+  ExpoCellular: c7ae03fd9480e6a4296a5632c35ab00ddaea4783
+  ExpoClipboard: 166ca8c13ca1041f5ba619a211f59427ab5da8a7
+  ExpoContacts: 209f0739c712bf808413c691722ce1bb1e2ea0af
+  ExpoCrypto: a5c0a86f3e7a4cf3e99ab6c4bb9733fc13e2a747
+  ExpoDevice: e24dd19a43065182eb246bc0e7f84186862f1e83
+  ExpoDocumentPicker: 4a89fd8a0cb90010214a416c858d7dece1c1eb10
+  ExpoDomWebView: 71d9f0808dce43b9f36b45a8c091c242dfa7b372
+  ExpoFileSystem: ddb2bbc2d88d1a15490a37c280d8e69aa53cb931
+  ExpoFont: 73d44c5cd85eab8034bc5165ca2230315097d728
+  ExpoGL: 3e7c3b8478a6783d737103b33b9c11235deb6675
+  ExpoHaptics: 6ef4fe4bd9db68df4d5d30bcbc4e37db77727970
+  ExpoImage: 89f672e47b391a749b56fecb3e2a8d6d68b9b379
+  ExpoImageManipulator: 774eb1a17c5db07944d6f9000650d422ebb3ce47
+  ExpoImagePicker: 440a560c9bfc63edae854d08b9f12f75bd11c112
+  ExpoInsights: 98f3aeaafd8481e5c0983ce3a59ebd594f1339aa
+  ExpoKeepAwake: 5a84230d022094b50d2ef369fdcae76d0ea44913
+  ExpoLinearGradient: 7ca3b1d1625a1ab85c129abce4a3cdc78a9500a3
+  ExpoLinking: 5addac9b3a9c25b8032efc0d604162427c62912e
+  ExpoLivePhoto: e50e26d529b71b998c948db4d2d4e9f7b7b088f3
+  ExpoLocalAuthentication: 6c0a136e19a68e75227bdb60c201cc29fd199b1d
+  ExpoLocalization: 8e37268a715b82b36fbb5e361efd5fe65a39c208
+  ExpoLocation: e0c5b5212381b0b800a2c1f715be823d17c51b05
+  ExpoMailComposer: 63589e1cbfa08220b2e650eecac0457be61ddd69
+  ExpoMaps: b84e936b1c90ec650f8b6e9f1979f7479c3a28f6
+  ExpoMediaLibrary: 778e8fd37b0172f8a7984c0ab1b3a1f91a837eef
+  ExpoMeshGradient: 10206dfd6045700677d876bf58a27f065f4b9f70
+  ExpoModulesCore: aa12329104020250449b4310ffb9ec23b44abfce
+  ExpoModulesTestCore: c81e21fd6ff61a212f3053d172aa163ad0db4d49
+  ExpoNetwork: f07b371f7e143812980075fda6768702c154a0a0
+  ExpoPrint: 3f9f5a5a19dbda5b30963d5bf078918f024aa29d
+  ExpoScreenCapture: 14768e6fe66412d678862858f5c2e0241b7f84b7
+  ExpoScreenOrientation: 0af273ce3e6e59cb55bae9b5b6e8d5e2d1aee95d
+  ExpoSecureStore: 06c3192d58ed167f619af3d53797c055f5ada785
+  ExpoSensors: 55eef9972309aa8ec26bf5922040453e4c5cf7df
+  ExpoSharing: 39a198e64bf522948fe60e270e49a0c7757912c1
+  ExpoSMS: 884d6627c0848795ff9492fbfc7ba6087111e344
+  ExpoSpeech: 27bb25844919711ebf0e201ce0bef2897d3693c7
+  ExpoSplashScreen: 43692d041bf848883410ed9d8836871ca5cf4d6a
+  ExpoSQLite: d79d134aa51e09131a680d40449207681c258cfb
+  ExpoStoreReview: f3439c43f13fa497cfe07d16b095f39101ed5548
+  ExpoSymbols: 81d7f433d7a7b20658029eae524a4fa93627159e
+  ExpoSystemUI: 50e8cc9cd38bfbbca20d250f76f8548c0a8ba24c
+  ExpoTrackingTransparency: 10b0304d6d2b95ea41391bf92684c1078f633e39
+  ExpoUI: c1b456de61acbd18c030498acc0821a087e75d64
+  ExpoVideo: 85750319df61d76237b5952fca5a9f39504c6b9b
+  ExpoVideoThumbnails: 8b6bbe3cb76dd2225910667b896b27855bbda694
+  ExpoWebBrowser: f08aaf1c8a02af8a768d83793186cb6d2c69f529
   EXStructuredHeaders: 09c70347b282e3d2507e25fb4c747b1b885f87f6
-  EXTaskManager: e8d0b6df01d6c8b4ab6e137dcad9eedb6b5452ce
-  EXUpdates: 34fe381ff83a3d53a018c54a1e15a5e9ec1f7e0b
-  EXUpdatesInterface: 7c977640bdd8b85833c19e3959ba46145c5719db
+  EXTaskManager: 8e915e1120894daead363cf31ff85cd4d182cd89
+  EXUpdates: d058f908357f7a924c64c33c1bfdfa619e2a3a17
+  EXUpdatesInterface: 1dcebac98ac5dad4289e6ff2bd5616822e894397
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 6fe148afcef2e3213e484758e3459609d40d57f5
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
@@ -3409,7 +3409,7 @@ SPEC CHECKSUMS:
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: 7574bf7cffd008efa8bcec28eda0bc36e0a8cbd6
+  lottie-react-native: 9c9e9d7b1e076241892bb7f5c91fa9132cbdecd5
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
@@ -3420,74 +3420,74 @@ SPEC CHECKSUMS:
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
   React: b229c49ed5898dab46d60f61ed5a0bfa2ee2fadb
   React-callinvoker: 2ac508e92c8bd9cf834cc7d7787d94352e4af58f
-  React-Core: 325b4f6d9162ae8b9a6ff42fe78e260eb124180d
-  React-CoreModules: 558041e5258f70cd1092f82778d07b8b2ff01897
-  React-cxxreact: 8fff17cbe76e6a8f9991b59552e1235429f9c74b
+  React-Core: 13cdd1558d0b3f6d9d5a22e14d89150280e79f02
+  React-CoreModules: b07a6744f48305405e67c845ebf481b6551b712a
+  React-cxxreact: 1055a86c66ac35b4e80bd5fb766aed5f494dfff4
   React-debug: 0a5fcdbacc6becba0521e910c1bcfdb20f32a3f6
-  React-defaultsnativemodule: 618dc50a0fad41b489997c3eb7aba3a74479fd14
-  React-domnativemodule: 7ba599afb6c2a7ec3eb6450153e2efe0b8747e9a
-  React-Fabric: 252112089d2c63308f4cbfade4010b6606db67d1
-  React-FabricComponents: 3c0f75321680d14d124438ab279c64ec2a3d13c4
-  React-FabricImage: 728b8061cdec2857ca885fd605ee03ad43ffca98
+  React-defaultsnativemodule: 4bb28fc97fee5be63a9ebf8f7a435cfe8ba69459
+  React-domnativemodule: b36a11c2597243d7563985028c51ece988d8ae33
+  React-Fabric: afc561718f25b2cd800b709d934101afe376a12c
+  React-FabricComponents: f4e0a4e18a27bf6d39cbf2a0b42f37a92fa4e37f
+  React-FabricImage: 37d8e8b672eda68a19d71143eb65148084efb325
   React-featureflags: 19682e02ef5861d96b992af16a19109c3dfc1200
-  React-featureflagsnativemodule: 23528c7e7d50782b7ef0804168ba40bbaf1e86ab
-  React-graphics: fefe48f71bfe6f48fd037f59e8277b12e91b6be1
-  React-hermes: a9a0c8377627b5506ef9a7b6f60a805c306e3f51
-  React-idlecallbacksnativemodule: 7e2b6a3b70e042f89cd91dbd73c479bb39a72a7e
-  React-ImageManager: e3300996ac2e2914bf821f71e2f2c92ae6e62ae2
-  React-jserrorhandler: fa75876c662e5d7e79d6efc763fc9f4c88e26986
-  React-jsi: f3f51595cc4c089037b536368f016d4742bf9cf7
-  React-jsiexecutor: cca6c232db461e2fd213a11e9364cfa6fdaa20eb
-  React-jsinspector: 2bd4c9fddf189d6ec2abf4948461060502582bef
-  React-jsinspectortracing: a417d8a0ad481edaa415734b4dac81e3e5ee7dc6
-  React-jsitracing: 1ff7172c5b0522cbf6c98d82bdbb160e49b5804e
-  React-logger: 018826bfd51b9f18e87f67db1590bc510ad20664
-  React-Mapbuffer: 3c11cee7737609275c7b66bd0b1de475f094cedf
-  React-microtasksnativemodule: 843f352b32aacbe13a9c750190d34df44c3e6c2c
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-pager-view: ab2ded73ab3700491ba089aa6322adbe65218f32
-  react-native-safe-area-context: 7e513d737b0b5c1d10bbe0e5fcc9f925a7be144c
-  react-native-segmented-control: 7578bb8808205cc5d09fbb026eb32829d7b0b56f
-  react-native-slider: 54e7f67e9e4c92c0edac77bbf58abfaf1f60055f
-  react-native-view-shot: 9634a350da3f31648ede3e2cf021368529f9c273
-  react-native-webview: 17925de8b97a7002765194d8b3b25a82ea9f749c
-  React-NativeModulesApple: 88433b6946778bea9c153e27b671de15411bf225
-  React-perflogger: 9e8d3c0dc0194eb932162812a168aa5dc662f418
-  React-performancetimeline: 5a2d6efef52bdcefac079c7baa30934978acd023
+  React-featureflagsnativemodule: d7cddf6d907b4e5ab84f9e744b7e88461656e48c
+  React-graphics: b0f78580cdaf5800d25437e3d41cc6c3d83b7aea
+  React-hermes: 71186f872c932e4574d5feb3ed754dda63a0b3bd
+  React-idlecallbacksnativemodule: dd2af19cdd3bc55149d17a2409ed72b694dfbe9c
+  React-ImageManager: a77dde8d5aa6a2b6962c702bf3a47695ef0aa32b
+  React-jserrorhandler: 9c14e89f12d5904257a79aaf84a70cd2e5ac07ba
+  React-jsi: 0775a66820496769ad83e629f0f5cce621a57fc7
+  React-jsiexecutor: 2cf5ba481386803f3c88b85c63fa102cba5d769e
+  React-jsinspector: 8052d532bb7a98b6e021755674659802fb140cc5
+  React-jsinspectortracing: bdd8fd0adcb4813663562e7874c5842449df6d8a
+  React-jsitracing: 2bab3bf55de3d04baf205def375fa6643c47c794
+  React-logger: 795cd5055782db394f187f9db0477d4b25b44291
+  React-Mapbuffer: 0502faf46cab8fb89cfc7bf3e6c6109b6ef9b5de
+  React-microtasksnativemodule: 663bc64e3a96c5fc91081923ae7481adc1359a78
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-pager-view: cba0b1eec276fb3d8198f04ffada78b0a1702c0a
+  react-native-safe-area-context: 9c33120e9eac7741a5364cc2d9f74665049b76b3
+  react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
+  react-native-slider: 7885fc2db0361d294b75f0b523040160ce98d526
+  react-native-view-shot: 07361cddea495c4ba9525877cebaddfaa02d0c3b
+  react-native-webview: 0ddb59b30cf225f2ba3125fd03c24e7d33ac68a8
+  React-NativeModulesApple: 16fbd5b040ff6c492dacc361d49e63cba7a6a7a1
+  React-perflogger: ab51b7592532a0ea45bf6eed7e6cae14a368b678
+  React-performancetimeline: bc2e48198ec814d578ac8401f65d78a574358203
   React-RCTActionSheet: 592674cf61142497e0e820688f5a696e41bf16dd
-  React-RCTAnimation: e6d669872f9b3b4ab9527aab283b7c49283236b7
-  React-RCTAppDelegate: de2343fe08be4c945d57e0ecce44afcc7dd8fc03
-  React-RCTBlob: 3e2dce94c56218becc4b32b627fc2293149f798d
-  React-RCTFabric: cac2c033381d79a5956e08550b0220cb2d78ea93
-  React-RCTFBReactNativeSpec: d10ca5e0ccbfeac8c047361fedf8e4ac653887b6
-  React-RCTImage: dc04b176c022d12a8f55ae7a7279b1e091066ae0
-  React-RCTLinking: 88f5e37fe4f26fbc80791aa2a5f01baf9b9a3fd5
-  React-RCTNetwork: f213693565efbd698b8e9c18d700a514b49c0c8e
-  React-RCTSettings: a2d32a90c45a3575568cad850abc45924999b8a5
-  React-RCTText: 54cdcd1cbf6f6a91dc6317f5d2c2b7fc3f6bf7a0
-  React-RCTVibration: 11dae0e7f577b5807bb7d31e2e881eb46f854fd4
+  React-RCTAnimation: 8fbb8dba757b49c78f4db403133ab6399a4ce952
+  React-RCTAppDelegate: 7f88baa8cb4e5d6c38bb4d84339925c70c9ac864
+  React-RCTBlob: f89b162d0fe6b570a18e755eb16cbe356d3c6d17
+  React-RCTFabric: 8ad6d875abe6e87312cef90e4b15ef7f6bed72e6
+  React-RCTFBReactNativeSpec: 8c29630c2f379c729300e4c1e540f3d1b78d1936
+  React-RCTImage: ccac9969940f170503857733f9a5f63578e106e1
+  React-RCTLinking: d82427bbf18415a3732105383dff119131cadd90
+  React-RCTNetwork: 12ad4d0fbde939e00251ca5ca890da2e6825cc3c
+  React-RCTSettings: e7865bf9f455abf427da349c855f8644b5c39afa
+  React-RCTText: 2cdfd88745059ec3202a0842ea75a956c7d6f27d
+  React-RCTVibration: a3a1458e6230dfd64b3768ebc0a4aac430d9d508
   React-rendererconsistency: 64e897e00d2568fd8dfe31e2496f80e85c0aaad1
-  React-rendererdebug: 41ce452460c44bba715d9e41d5493a96de277764
+  React-rendererdebug: a3f6d3ae7d2fa0035885026756281c07ee32479e
   React-rncore: 58748c2aa445f56b99e5118dad0aedb51c40ce9f
-  React-RuntimeApple: 7785ed0d8ae54da65a88736bb63ca97608a6d933
-  React-RuntimeCore: 6029ea70bc77f98cfd43ebe69217f14e93ba1f12
+  React-RuntimeApple: f0fda7bacabd32daa099cfda8f07466c30acd149
+  React-RuntimeCore: 683ee0b6a76d4b4bf6fbf83a541895b4887cc636
   React-runtimeexecutor: a188df372373baf5066e6e229177836488799f80
-  React-RuntimeHermes: a264609c28b796edfffc8ae4cb8fad1773ab948b
-  React-runtimescheduler: 23ec3a1e0fb1ec752d1a9c1fb15258c30bfc7222
+  React-RuntimeHermes: 907c8e9bec13ea6466b94828c088c24590d4d0b6
+  React-runtimescheduler: a2e2a39125dd6426b5d8b773f689d660cd7c5f60
   React-timing: bb220a53a795ed57976a4855c521f3de2f298fe5
-  React-utils: 3b054aaebe658fc710a8d239d0e4b9fd3e0b78f9
-  ReactAppDependencyProvider: a1fb08dfdc7ebc387b2e54cfc9decd283ed821d8
-  ReactCodegen: f45fa6e29005179c14309d8f6b09f39d12a8ccb1
-  ReactCommon: 0c097b53f03d6bf166edbcd0915da32f3015dd90
-  RNCAsyncStorage: 6c619a6d28e188d33efbd39df77a2c3933d9ca72
-  RNCMaskedView: 308c763227e237d4d260bd8841870e099572bb3e
-  RNCPicker: cfb51a08c6e10357d9a65832e791825b0747b483
-  RNDateTimePicker: b49449a7da91211c6fcc60acd346a0ddf0d25256
-  RNFlashList: d6f5c8e04ae8ce8e27693cd98c0297abce8f4c54
-  RNGestureHandler: 8b1080a6db0be82dbca18550d6212b885bfab6b2
-  RNReanimated: 18eb72cb1adc341c103723558e08fdea4851c5a7
-  RNScreens: fb427360b2ad917997d779b2b63a946182ce9ce1
-  RNSVG: 8126581b369adf6a0004b6a6cab1a55e3002d5b0
+  React-utils: 300d8bbb6555dcffaca71e7a0663201b5c7edbbc
+  ReactAppDependencyProvider: f2e81d80afd71a8058589e19d8a134243fa53f17
+  ReactCodegen: fe312e4c030c81f4a29dff5c694a5ef16d556df6
+  ReactCommon: 3d39389f8e2a2157d5c999f8fba57bd1c8f226f0
+  RNCAsyncStorage: cb52fe44ef589ac407cfe26da409b539354caa9a
+  RNCMaskedView: 18c76ebdf9752bb75652829f99f6c3d1318cc864
+  RNCPicker: ffbd7b9fc7c1341929e61dbef6219f7860f57418
+  RNDateTimePicker: 8fcea61ffc2b8ee230ad29c7f423dc639359780c
+  RNFlashList: 02eeae97ff66bf61219471c514fbe17cc2542a8a
+  RNGestureHandler: 9b05fab9a0b48fe48c968de7dbb9ca38a2b4f7ab
+  RNReanimated: 0aad82a8ddb4e29a59ba48cd407ee674f70c5861
+  RNScreens: 2faba2591006e59fa14b9b665599ce29435a749a
+  RNSVG: 8588ee1ca9b2e6fd2c99466e35b3db0e9f81bb40
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Added web support. ([#35207](https://github.com/expo/expo/pull/35207) by [@kudo](https://github.com/kudo))
-- Added [Session Extension](https://www.sqlite.org/sessionintro.html) support. ([#35457](https://github.com/expo/expo/pull/35457), [#35458](https://github.com/expo/expo/pull/35458) by [@kudo](https://github.com/kudo))
+- Added [Session Extension](https://www.sqlite.org/sessionintro.html) support. ([#35457](https://github.com/expo/expo/pull/35457), [#35458](https://github.com/expo/expo/pull/35458), [#35459](https://github.com/expo/expo/pull/35459) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-sqlite/ios/ExpoSQLite.podspec
+++ b/packages/expo-sqlite/ios/ExpoSQLite.podspec
@@ -35,6 +35,7 @@ Pod::Spec.new do |s|
   end
 
   sqlite_cflags = '-DHAVE_USLEEP=1 -DSQLITE_ENABLE_LOCKING_STYLE=0 -DSQLITE_ENABLE_BYTECODE_VTAB=1'
+  sqlite_cflags << ' -DSQLITE_ENABLE_SESSION=1 -DSQLITE_ENABLE_PREUPDATE_HOOK=1'
   unless podfile_properties['expo.sqlite.enableFTS'] === 'false'
     sqlite_cflags << ' -DSQLITE_ENABLE_FTS4=1 -DSQLITE_ENABLE_FTS3_PARENTHESIS=1 -DSQLITE_ENABLE_FTS5=1'
   end
@@ -52,10 +53,14 @@ Pod::Spec.new do |s|
   end
   Pod::UI.message("SQLite build flags: #{sqlite_cflags}")
 
+  # Consistent SQLite build flags for Swift module exposing from the umbrella header
+  swift_flags = sqlite_cflags.split(' ').map { |flag| "-Xcc #{flag}" }.join(' ')
+
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     'OTHER_CFLAGS' => '$(inherited) ' + sqlite_cflags,
+    'OTHER_SWIFT_FLAGS' => '$(inherited) ' + swift_flags,
   }
 
   s.source_files = "**/*.{c,h,m,swift}"

--- a/packages/expo-sqlite/ios/NativeSession.swift
+++ b/packages/expo-sqlite/ios/NativeSession.swift
@@ -1,0 +1,13 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+
+final class NativeSession: SharedObject, Equatable {
+  var pointer: OpaquePointer?
+
+  // MARK: - Equatable
+
+  static func == (lhs: NativeSession, rhs: NativeSession) -> Bool {
+    return lhs.pointer == rhs.pointer
+  }
+}

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -73,6 +73,8 @@ public final class SQLiteModule: Module {
       try ensureDatabasePathExists(path: databasePath)
     }
 
+    // MARK: - NativeDatabase
+
     // swiftlint:disable:next closure_body_length
     Class(NativeDatabase.self) {
       Constructor { (databasePath: String, options: OpenDatabaseOptions, serializedData: Data?) -> NativeDatabase in
@@ -142,7 +144,16 @@ public final class SQLiteModule: Module {
       Function("prepareSync") { (database: NativeDatabase, statement: NativeStatement, source: String) in
         try prepareStatement(database: database, statement: statement, source: source)
       }
+
+      AsyncFunction("createSessionAsync") { (database: NativeDatabase, session: NativeSession, dbName: String) in
+        try sessionCreate(database: database, session: session, dbName: dbName)
+      }
+      Function("createSessionSync") { (database: NativeDatabase, session: NativeSession, dbName: String) in
+        try sessionCreate(database: database, session: session, dbName: dbName)
+      }
     }
+
+    // MARK: - NativeStatement
 
     // swiftlint:disable:next closure_body_length
     Class(NativeStatement.self) {
@@ -194,6 +205,64 @@ public final class SQLiteModule: Module {
       }
       Function("finalizeSync") { (statement: NativeStatement, database: NativeDatabase) in
         try finalize(statement: statement, database: database)
+      }
+    }
+
+    // MARK: - NativeSession
+
+    // swiftlint:disable:next closure_body_length
+    Class(NativeSession.self) {
+      Constructor {
+        return NativeSession()
+      }
+
+      AsyncFunction("attachAsync") { (session: NativeSession, database: NativeDatabase, table: String?) in
+        try sessionAttach(database: database, session: session, table: table)
+      }
+      Function("attachSync") { (session: NativeSession, database: NativeDatabase, table: String?) in
+        try sessionAttach(database: database, session: session, table: table)
+      }
+
+      AsyncFunction("enableAsync") { (session: NativeSession, database: NativeDatabase, enabled: Bool) in
+        try sessionEnable(database: database, session: session, enabled: enabled)
+      }
+      Function("enableSync") { (session: NativeSession, database: NativeDatabase, enabled: Bool) in
+        try sessionEnable(database: database, session: session, enabled: enabled)
+      }
+
+      AsyncFunction("closeAsync") { (session: NativeSession, database: NativeDatabase) in
+        try sessionClose(database: database, session: session)
+      }
+      Function("closeSync") { (session: NativeSession, database: NativeDatabase) in
+        try sessionClose(database: database, session: session)
+      }
+
+      AsyncFunction("createChangesetAsync") { (session: NativeSession, database: NativeDatabase) -> Data in
+        return try sessionCreateChangeset(database: database, session: session)
+      }
+      Function("createChangesetSync") { (session: NativeSession, database: NativeDatabase) -> Data in
+        return try sessionCreateChangeset(database: database, session: session)
+      }
+
+      AsyncFunction("createInvertedChangesetAsync") { (session: NativeSession, database: NativeDatabase) -> Data in
+        return try sessionCreateInvertedChangeset(database: database, session: session)
+      }
+      Function("createInvertedChangesetSync") { (session: NativeSession, database: NativeDatabase) -> Data in
+        return try sessionCreateInvertedChangeset(database: database, session: session)
+      }
+
+      AsyncFunction("applyChangesetAsync") { (session: NativeSession, database: NativeDatabase, changeset: Data) in
+        try sessionApplyChangeset(database: database, session: session, changeset: changeset)
+      }
+      Function("applyChangesetSync") { (session: NativeSession, database: NativeDatabase, changeset: Data) in
+        try sessionApplyChangeset(database: database, session: session, changeset: changeset)
+      }
+
+      AsyncFunction("invertChangesetAsync") { (session: NativeSession, database: NativeDatabase, changeset: Data) -> Data in
+        return try sessionInvertChangeset(database: database, session: session, changeset: changeset)
+      }
+      Function("invertChangesetSync") { (session: NativeSession, database: NativeDatabase, changeset: Data) -> Data in
+        return try sessionInvertChangeset(database: database, session: session, changeset: changeset)
       }
     }
   }
@@ -338,7 +407,8 @@ public final class SQLiteModule: Module {
       if ret == SQLITE_ROW {
         columnValuesList.append(try getColumnValues(statement: statement))
         continue
-      } else if ret == SQLITE_DONE {
+      }
+      if ret == SQLITE_DONE {
         break
       }
       throw SQLiteErrorException(convertSqlLiteErrorToString(database))
@@ -601,5 +671,98 @@ public final class SQLiteModule: Module {
     if result != SQLITE_OK {
       throw SQLiteErrorException(convertSqlLiteErrorToString(database))
     }
+  }
+
+  // MARK: - Session Extension
+
+  private func sessionCreate(database: NativeDatabase, session: NativeSession, dbName: String) throws {
+    try maybeThrowForClosedDatabase(database)
+    let db = dbName.cString(using: .utf8)
+    if exsqlite3session_create(database.pointer, db, &session.pointer) != SQLITE_OK {
+      throw SQLiteErrorException(convertSqlLiteErrorToString(database))
+    }
+  }
+
+  private func sessionAttach(database: NativeDatabase, session: NativeSession, table: String?) throws {
+    try maybeThrowForClosedDatabase(database)
+    let tableName = table?.cString(using: .utf8)
+    if exsqlite3session_attach(session.pointer, tableName) != SQLITE_OK {
+      throw SQLiteErrorException(convertSqlLiteErrorToString(database))
+    }
+  }
+
+  private func sessionEnable(database: NativeDatabase, session: NativeSession, enabled: Bool) throws {
+    try maybeThrowForClosedDatabase(database)
+    exsqlite3session_enable(session.pointer, enabled ? 1 : 0)
+  }
+
+  private func sessionClose(database: NativeDatabase, session: NativeSession) throws {
+    try maybeThrowForClosedDatabase(database)
+    exsqlite3session_delete(session.pointer)
+  }
+
+  private func sessionCreateChangeset(database: NativeDatabase, session: NativeSession) throws -> Data {
+    try maybeThrowForClosedDatabase(database)
+    var size: Int32 = 0
+    var buffer: UnsafeMutableRawPointer?
+    if exsqlite3session_changeset(session.pointer, &size, &buffer) != SQLITE_OK {
+      throw SQLiteErrorException(convertSqlLiteErrorToString(database))
+    }
+    guard let buffer else {
+      throw SQLiteErrorException(convertSqlLiteErrorToString(database))
+    }
+    defer { exsqlite3_free(buffer) }
+    return Data(bytes: buffer, count: Int(size))
+  }
+
+  private func sessionCreateInvertedChangeset(database: NativeDatabase, session: NativeSession) throws -> Data {
+    do {
+      let changeset = try sessionCreateChangeset(database: database, session: session)
+      return try sessionInvertChangeset(database: database, session: session, changeset: changeset)
+    } catch {
+      throw error
+    }
+  }
+
+  private func sessionApplyChangeset(database: NativeDatabase, session: NativeSession, changeset: Data) throws {
+    try maybeThrowForClosedDatabase(database)
+    try changeset.withUnsafeBytes {
+      let buffer = UnsafeMutableRawPointer(mutating: $0.baseAddress)
+      if exsqlite3changeset_apply(
+        database.pointer,
+        Int32(changeset.count),
+        buffer,
+        nil,
+        { _, _, _ -> Int32 in
+          return SQLITE_CHANGESET_REPLACE
+        },
+        nil
+      ) != SQLITE_OK {
+        throw SQLiteErrorException(convertSqlLiteErrorToString(database))
+      }
+    }
+  }
+
+  private func sessionInvertChangeset(database: NativeDatabase, session: NativeSession, changeset: Data) throws -> Data {
+    try maybeThrowForClosedDatabase(database)
+    var result: Data?
+    try changeset.withUnsafeBytes {
+      let inBuffer = UnsafeMutableRawPointer(mutating: $0.baseAddress)
+      var outSize: Int32 = 0
+      var outBuffer: UnsafeMutableRawPointer?
+
+      if exsqlite3changeset_invert(Int32(changeset.count), inBuffer, &outSize, &outBuffer) != SQLITE_OK {
+        throw SQLiteErrorException(convertSqlLiteErrorToString(database))
+      }
+      guard let outBuffer else {
+        throw SQLiteErrorException(convertSqlLiteErrorToString(database))
+      }
+      defer { exsqlite3_free(outBuffer) }
+      result = Data(bytes: outBuffer, count: Int(outSize))
+    }
+    guard let result else {
+      throw SQLiteErrorException(convertSqlLiteErrorToString(database))
+    }
+    return result
   }
 }


### PR DESCRIPTION
# Why

add sqlite [session extension](https://www.sqlite.org/sessionintro.html) support for livestore syncing
close ENG-14324

# How

- add ios implementation
- update bare-expo podfile.lock and xcodeproj

# Test Plan

ci passed on upstack pr

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
