### PR TITLE
[sqlite] add android implementation for session extension

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Added web support. ([#35207](https://github.com/expo/expo/pull/35207) by [@kudo](https://github.com/kudo))
-- Added [Session Extension](https://www.sqlite.org/sessionintro.html) support. ([#35457](https://github.com/expo/expo/pull/35457), [#35458](https://github.com/expo/expo/pull/35458), [#35459](https://github.com/expo/expo/pull/35459) by [@kudo](https://github.com/kudo))
+- Added [Session Extension](https://www.sqlite.org/sessionintro.html) support. ([#35457](https://github.com/expo/expo/pull/35457), [#35458](https://github.com/expo/expo/pull/35458), [#35459](https://github.com/expo/expo/pull/35459), [#35461](https://github.com/expo/expo/pull/35461) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -24,6 +24,7 @@ if (ext.USE_SQLCIPHER) {
 
 def getSQLiteBuildFlags() {
   def buildFlags = '-DSQLITE_ENABLE_BYTECODE_VTAB=1 -DSQLITE_TEMP_STORE=2'
+  buildFlags <<= ' -DSQLITE_ENABLE_SESSION=1 -DSQLITE_ENABLE_PREUPDATE_HOOK=1'
   if (findProperty('expo.sqlite.enableFTS') != 'false') {
     buildFlags <<= ' -DSQLITE_ENABLE_FTS4=1 -DSQLITE_ENABLE_FTS3_PARENTHESIS=1 -DSQLITE_ENABLE_FTS5=1'
   }

--- a/packages/expo-sqlite/android/src/main/cpp/NativeDatabaseBinding.h
+++ b/packages/expo-sqlite/android/src/main/cpp/NativeDatabaseBinding.h
@@ -43,6 +43,8 @@ public:
   // helpers
   jni::local_ref<jni::JString> convertSqlLiteErrorToString();
 
+  sqlite3 *rawdb() { return db; }
+
 private:
   explicit NativeDatabaseBinding(
       jni::alias_ref<NativeDatabaseBinding::jhybridobject> jThis)

--- a/packages/expo-sqlite/android/src/main/cpp/NativeSessionBinding.cpp
+++ b/packages/expo-sqlite/android/src/main/cpp/NativeSessionBinding.cpp
@@ -1,0 +1,130 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#include "NativeSessionBinding.h"
+
+#include "Exceptions.h"
+
+namespace expo {
+
+void NativeSessionBinding::registerNatives() {
+  registerHybrid({
+      makeNativeMethod("initHybrid", NativeSessionBinding::initHybrid),
+      makeNativeMethod("sqlite3session_create",
+                       NativeSessionBinding::sqlite3session_create),
+      makeNativeMethod("sqlite3session_attach",
+                       NativeSessionBinding::sqlite3session_attach),
+      makeNativeMethod("sqlite3session_enable",
+                       NativeSessionBinding::sqlite3session_enable),
+      makeNativeMethod("sqlite3session_delete",
+                       NativeSessionBinding::sqlite3session_delete),
+      makeNativeMethod("sqlite3session_changeset",
+                       NativeSessionBinding::sqlite3session_changeset),
+      makeNativeMethod("sqlite3session_changeset_inverted",
+                       NativeSessionBinding::sqlite3session_changeset_inverted),
+      makeNativeMethod("sqlite3changeset_apply",
+                       NativeSessionBinding::sqlite3changeset_apply),
+      makeNativeMethod("sqlite3changeset_invert",
+                       NativeSessionBinding::sqlite3changeset_invert),
+  });
+}
+
+// static
+jni::local_ref<NativeSessionBinding::jhybriddata>
+NativeSessionBinding::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  return makeCxxInstance(jThis);
+}
+
+int NativeSessionBinding::sqlite3session_create(
+    jni::alias_ref<NativeDatabaseBinding::javaobject> db,
+    const std::string &dbName) {
+  return ::exsqlite3session_create(db->cthis()->rawdb(), dbName.c_str(),
+                                   &session);
+}
+
+int NativeSessionBinding::sqlite3session_attach(
+    jni::alias_ref<jni::JString> tableName) {
+  if (tableName) {
+    return ::exsqlite3session_attach(session, tableName->toStdString().c_str());
+  }
+  return ::exsqlite3session_attach(session, nullptr);
+}
+
+int NativeSessionBinding::sqlite3session_enable(bool enabled) {
+  return ::exsqlite3session_enable(session, enabled ? 1 : 0);
+}
+
+void NativeSessionBinding::sqlite3session_delete() {
+  ::exsqlite3session_delete(session);
+}
+
+jni::local_ref<jni::JArrayByte>
+NativeSessionBinding::sqlite3session_changeset() {
+  int size = 0;
+  void *buffer = nullptr;
+  int result = ::exsqlite3session_changeset(session, &size, &buffer);
+  if (result != SQLITE_OK || !buffer) {
+    return nullptr;
+  }
+  auto byteArray = jni::JArrayByte::newArray(size);
+  byteArray->setRegion(0, size, reinterpret_cast<const signed char *>(buffer));
+  ::exsqlite3_free(buffer);
+  return byteArray;
+}
+
+jni::local_ref<jni::JArrayByte>
+NativeSessionBinding::sqlite3session_changeset_inverted() {
+  int inSize = 0;
+  void *inBuffer = nullptr;
+  int result = ::exsqlite3session_changeset(session, &inSize, &inBuffer);
+  if (result != SQLITE_OK || !inBuffer) {
+    return nullptr;
+  }
+
+  int outSize = 0;
+  void *outBuffer = nullptr;
+  result = ::exsqlite3changeset_invert(inSize, inBuffer, &outSize, &outBuffer);
+  if (result != SQLITE_OK || !outBuffer) {
+    ::exsqlite3_free(inBuffer);
+    return nullptr;
+  }
+  auto byteArray = jni::JArrayByte::newArray(outSize);
+  byteArray->setRegion(0, outSize,
+                       reinterpret_cast<const signed char *>(outBuffer));
+  ::exsqlite3_free(outBuffer);
+  return byteArray;
+}
+
+int NativeSessionBinding::sqlite3changeset_apply(
+    jni::alias_ref<NativeDatabaseBinding::javaobject> db,
+    jni::alias_ref<jni::JArrayByte> changeset) {
+  int size = static_cast<int>(changeset->size());
+  auto buffer = changeset->getRegion(0, size);
+  auto onConflict = [](void *pCtx, int eConflict,
+                       ::exsqlite3_changeset_iter *pIter) -> int {
+    return SQLITE_CHANGESET_REPLACE;
+  };
+  return ::exsqlite3changeset_apply(db->cthis()->rawdb(), size, buffer.get(),
+                                    nullptr, onConflict, nullptr);
+}
+
+jni::local_ref<jni::JArrayByte> NativeSessionBinding::sqlite3changeset_invert(
+    jni::alias_ref<jni::JArrayByte> changeset) {
+  int inSize = static_cast<int>(changeset->size());
+  auto inBuffer = changeset->getRegion(0, inSize);
+
+  int outSize = 0;
+  void *outBuffer = nullptr;
+
+  int result =
+      ::exsqlite3changeset_invert(inSize, inBuffer.get(), &outSize, &outBuffer);
+  if (result != SQLITE_OK || !outBuffer) {
+    return nullptr;
+  }
+  auto byteArray = jni::JArrayByte::newArray(outSize);
+  byteArray->setRegion(0, outSize,
+                       reinterpret_cast<const signed char *>(outBuffer));
+  ::exsqlite3_free(outBuffer);
+  return byteArray;
+}
+
+} // namespace expo

--- a/packages/expo-sqlite/android/src/main/cpp/NativeSessionBinding.h
+++ b/packages/expo-sqlite/android/src/main/cpp/NativeSessionBinding.h
@@ -1,0 +1,52 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <string>
+
+#include "NativeDatabaseBinding.h"
+#include "sqlite3.h"
+
+namespace jni = facebook::jni;
+
+namespace expo {
+
+class NativeSessionBinding : public jni::HybridClass<NativeSessionBinding> {
+public:
+  static constexpr auto kJavaDescriptor =
+      "Lexpo/modules/sqlite/NativeSessionBinding;";
+
+  static void registerNatives();
+
+  // sqlite3session bindings
+  int sqlite3session_create(
+      jni::alias_ref<NativeDatabaseBinding::javaobject> db,
+      const std::string &dbName);
+  int sqlite3session_attach(jni::alias_ref<jni::JString> tableName);
+  int sqlite3session_enable(bool enabled);
+  void sqlite3session_delete();
+  jni::local_ref<jni::JArrayByte> sqlite3session_changeset();
+  jni::local_ref<jni::JArrayByte> sqlite3session_changeset_inverted();
+  int sqlite3changeset_apply(
+      jni::alias_ref<NativeDatabaseBinding::javaobject> db,
+      jni::alias_ref<jni::JArrayByte> changeset);
+  jni::local_ref<jni::JArrayByte>
+  sqlite3changeset_invert(jni::alias_ref<jni::JArrayByte> changeset);
+
+private:
+  explicit NativeSessionBinding(
+      jni::alias_ref<NativeSessionBinding::jhybridobject> jThis) {}
+
+private:
+  static jni::local_ref<jhybriddata>
+  initHybrid(jni::alias_ref<jhybridobject> jThis);
+
+private:
+  friend HybridBase;
+  friend NativeDatabaseBinding;
+
+  ::exsqlite3_session *session;
+};
+
+} // namespace expo

--- a/packages/expo-sqlite/android/src/main/cpp/SQLite3Main.cpp
+++ b/packages/expo-sqlite/android/src/main/cpp/SQLite3Main.cpp
@@ -3,11 +3,13 @@
 #include <fbjni/fbjni.h>
 
 #include "NativeDatabaseBinding.h"
+#include "NativeSessionBinding.h"
 #include "NativeStatementBinding.h"
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
   return facebook::jni::initialize(vm, [] {
     expo::NativeDatabaseBinding::registerNatives();
+    expo::NativeSessionBinding::registerNatives();
     expo::NativeStatementBinding::registerNatives();
   });
 }

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeSession.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeSession.kt
@@ -1,0 +1,16 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+package expo.modules.sqlite
+
+import expo.modules.kotlin.sharedobjects.SharedRef
+
+internal class NativeSession : SharedRef<NativeSessionBinding>(NativeSessionBinding()) {
+  override fun sharedObjectDidRelease() {
+    super.sharedObjectDidRelease()
+    this.ref.close()
+  }
+
+  override fun equals(other: Any?): Boolean {
+    return other is NativeSession && this.ref == other.ref
+  }
+}

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeSessionBinding.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeSessionBinding.kt
@@ -1,0 +1,41 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+package expo.modules.sqlite
+
+import com.facebook.jni.HybridData
+import expo.modules.core.interfaces.DoNotStrip
+import java.io.Closeable
+
+@Suppress("KotlinJniMissingFunction")
+@DoNotStrip
+internal class NativeSessionBinding : Closeable {
+  @DoNotStrip
+  private val mHybridData: HybridData
+
+  init {
+    mHybridData = initHybrid()
+  }
+
+  override fun close() {
+    mHybridData.resetNative()
+  }
+
+  // region sqlite3session bindings
+
+  external fun sqlite3session_create(db: NativeDatabaseBinding, dbName: String): Int
+  external fun sqlite3session_attach(tableName: String?): Int
+  external fun sqlite3session_enable(enabled: Boolean): Int
+  external fun sqlite3session_delete()
+  external fun sqlite3session_changeset(): ByteArray?
+  external fun sqlite3session_changeset_inverted(): ByteArray?
+  external fun sqlite3changeset_apply(db: NativeDatabaseBinding, changeset: ByteArray): Int
+  external fun sqlite3changeset_invert(changeset: ByteArray): ByteArray?
+
+  // endregion
+
+  // region internals
+
+  private external fun initHybrid(): HybridData
+
+  // endregion
+}


### PR DESCRIPTION
# Why

add sqlite [session extension](https://www.sqlite.org/sessionintro.html) support for livestore syncing
close ENG-14324

# How

- add android implementation

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
