### PR TITLE
Upgrade readiness status of React Server Components.

### DIFF
--- a/docs/pages/guides/server-components.mdx
+++ b/docs/pages/guides/server-components.mdx
@@ -9,7 +9,7 @@ import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
-> Experimentally available in **SDK 52 and above**. This is a very early preview and not ready for production or wide use yet. This initial version is meant to help library authors understand universal React Server Components and add support in their libraries.
+> Experimentally available in **SDK 52 and above**. This is a beta release and subject to breaking changes.
 
 React Server Components enable a number of exciting capabilities, including:
 
@@ -544,7 +544,7 @@ The CSS will be hoisted into the client bundle from the server.
 
 ## Deployment
 
-> Avoid using universal Server Components in production as they are not stable yet. We'll streamline all of this to a single command in the future.
+> Universal React Server Components are still in beta.
 
 ### Web
 
@@ -563,7 +563,7 @@ Then you can host it locally with `npx expo serve` or deploy it to the cloud:
 
 ### Native
 
-You can experimentally deploy your native React Server Components by following the server deployment guide:
+You can deploy your native React Server Components by following the server deployment guide:
 
 <BoxLink
   title="Deploy native servers to EAS"

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### 💡 Others
 
-- Upgrade readiness status of React Server Components.
+- Upgrade readiness status of React Server Components. ([#35467](https://github.com/expo/expo/pull/35467) by [@EvanBacon](https://github.com/EvanBacon))
 - Add tests for `Worker` and `require.unstable_resolveWorker()`. ([#34938](https://github.com/expo/expo/pull/34938) by [@EvanBacon](https://github.com/EvanBacon))
 - Replace cacache in fetch cache with lighter implementation. ([#34983](https://github.com/expo/expo/pull/34983) by [@EvanBacon](https://github.com/EvanBacon))
 - Move getAccountUsername from `@expo/config` to CLI for internal usage ([#33249](https://github.com/expo/expo/pull/33249) by [@wschurman](https://github.com/wschurman))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### 💡 Others
 
+- Upgrade readiness status of React Server Components.
 - Add tests for `Worker` and `require.unstable_resolveWorker()`. ([#34938](https://github.com/expo/expo/pull/34938) by [@EvanBacon](https://github.com/EvanBacon))
 - Replace cacache in fetch cache with lighter implementation. ([#34983](https://github.com/expo/expo/pull/34983) by [@EvanBacon](https://github.com/EvanBacon))
 - Move getAccountUsername from `@expo/config` to CLI for internal usage ([#33249](https://github.com/expo/expo/pull/33249) by [@wschurman](https://github.com/wschurman))

--- a/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
@@ -304,7 +304,7 @@ it('runs `npx expo export:embed --platform android` with source maps', async () 
   );
 
   // Ensure the experimental module resolution warning is logged
-  expect(stderr).toBe('Fast resolver is enabled.');
+  expect(stderr).toMatch('Fast resolver is enabled.');
 
   const outputDir = path.join(projectRoot, output);
 

--- a/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
@@ -304,7 +304,7 @@ it('runs `npx expo export:embed --platform android` with source maps', async () 
   );
 
   // Ensure the experimental module resolution warning is logged
-  expect(stderr).toBe('Experimental module resolution is enabled.');
+  expect(stderr).toBe('Fast resolver is enabled.');
 
   const outputDir = path.join(projectRoot, output);
 

--- a/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
@@ -271,7 +271,7 @@ it('runs `npx expo export:embed --platform android` with source maps', async () 
   await fs.promises.mkdir(path.join(projectRoot, output));
 
   // `npx expo export:embed`
-  const { stderr } = await executeExpoAsync(
+  const { stdout } = await executeExpoAsync(
     projectRoot,
     // yarn expo export:embed --platform android --dev false --reset-cache --entry-file /Users/cedric/Desktop/test-expo-29656/node_modules/expo/AppEntry.js --bundle-output /Users/cedric/Desktop/test-expo-29656/android/app/build/generated/assets/createBundleReleaseJsAndAssets/index.android.bundle --assets-dest /Users/cedric/Desktop/test-expo-29656/android/app/build/generated/res/createBundleReleaseJsAndAssets
     // --sourcemap-output /Users/cedric/Desktop/test-expo-29656/android/app/build/intermediates/sourcemaps/react/release/index.android.bundle.packager.map --minify false
@@ -304,7 +304,7 @@ it('runs `npx expo export:embed --platform android` with source maps', async () 
   );
 
   // Ensure the experimental module resolution warning is logged
-  expect(stderr).toMatch('Fast resolver is enabled.');
+  expect(stdout).toMatch('Fast resolver is enabled.');
 
   const outputDir = path.join(projectRoot, output);
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -139,13 +139,8 @@ export async function loadMetroConfigAsync(
 
   if (serverActionsEnabled) {
     Log.warn(
-      `Experimental React Server Functions are enabled. Production exports are not supported yet.`
+      `React Server Functions (beta) are enabled. Route rendering mode: ${exp.experiments?.reactServerComponentRoutes ? 'server' : 'client'}`
     );
-    if (!exp.experiments?.reactServerComponentRoutes) {
-      Log.warn(
-        `- React Server Component routes are NOT enabled. Routes will render in client mode.`
-      );
-    }
   }
 
   config = await withMetroMultiPlatformAsync(projectRoot, {

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { ExpoConfig, Platform } from '@expo/config';
+import chalk from 'chalk';
 import fs from 'fs';
 import Bundler from 'metro/src/Bundler';
 import { ConfigT } from 'metro-config';
@@ -154,16 +155,13 @@ export function withExtendedResolver(
   }
 ) {
   if (isReactServerComponentsEnabled) {
-    Log.warn(
-      `Experimental React Server Components is enabled. Production exports are not supported yet.`
-    );
+    Log.warn(`React Server Components (beta) is enabled.`);
+  }
+  if (isReactCanaryEnabled) {
+    Log.warn(`Experimental React 19 canary is enabled.`);
   }
   if (isFastResolverEnabled) {
-    Log.warn(`Experimental module resolution is enabled.`);
-  }
-
-  if (isReactCanaryEnabled) {
-    Log.warn(`Experimental React Canary version is enabled.`);
+    Log.log(chalk.dim`Fast resolver is enabled.`);
   }
 
   const defaultResolver = metroResolver.resolve;


### PR DESCRIPTION
# Why

- Production RSC can now be deployed to EAS Hosting and from EAS Build making them much closer to being stable.
