### PR TITLE
[iOS][location] Add guards to avoid parameter crash in task service and background location

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Added guards to avoid task options to crash the app.
 - [iOS] Added error handler to the streaming location/heading methods since these can fail while streaming ([#35004](https://github.com/expo/expo/pull/35004) by [@chrfalch](https://github.com/chrfalch))
 
 ## 18.0.6 - 2025-02-10

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Added guards to avoid task options to crash the app.
+- [iOS] Added guards to avoid task options to crash the app. ([#35477](https://github.com/expo/expo/pull/35477) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Added error handler to the streaming location/heading methods since these can fail while streaming ([#35004](https://github.com/expo/expo/pull/35004) by [@chrfalch](https://github.com/chrfalch))
 
 ## 18.0.6 - 2025-02-10

--- a/packages/expo-location/ios/TaskConsumers/EXLocationTaskConsumer.m
+++ b/packages/expo-location/ios/TaskConsumers/EXLocationTaskConsumer.m
@@ -68,11 +68,10 @@
     EXLocationAccuracy accuracy = [options[@"accuracy"] unsignedIntegerValue] ?: EXLocationAccuracyBalanced;
 
     locationManager.desiredAccuracy = [EXLocation CLLocationAccuracyFromOption:accuracy];
-    locationManager.distanceFilter = [options[@"distanceInterval"] doubleValue] ?: kCLDistanceFilterNone;
-    locationManager.activityType = [EXLocation CLActivityTypeFromOption:[options[@"activityType"] integerValue]];
-    locationManager.pausesLocationUpdatesAutomatically = [options[@"pausesUpdatesAutomatically"] boolValue];
-
-    locationManager.showsBackgroundLocationIndicator = [options[@"showsBackgroundLocationIndicator"] boolValue];
+    locationManager.distanceFilter = [self numberToDouble:options[@"distanceInterval"] defaultValue:kCLDistanceFilterNone];
+    locationManager.activityType = [EXLocation CLActivityTypeFromOption:[self numberToInteger:options[@"activityType"] defaultValue:CLActivityTypeOther]];
+    locationManager.pausesLocationUpdatesAutomatically = [self numberToBool:options[@"pausesUpdatesAutomatically"] defaultValue:true];
+    locationManager.showsBackgroundLocationIndicator = [self numberToBool:options[@"showsBackgroundLocationIndicator"] defaultValue:false];
 
     [locationManager startUpdatingLocation];
     [locationManager startMonitoringSignificantLocationChanges];
@@ -172,7 +171,17 @@
 
 - (double)numberToDouble:(NSNumber *)number defaultValue:(double)defaultValue
 {
-  return number == nil ? defaultValue : [number doubleValue];
+  return [number isEqual:[NSNull null]] || number == nil ? defaultValue : [number doubleValue];
+}
+
+- (NSInteger)numberToInteger:(NSNumber *)number defaultValue:(NSInteger)defaultValue
+{
+  return [number isEqual:[NSNull null]] || number == nil ? defaultValue : [number integerValue];
+}
+
+- (BOOL)numberToBool:(NSNumber *)number defaultValue:(BOOL)defaultValue
+{
+  return [number isEqual:[NSNull null]] || number == nil ? defaultValue : [number boolValue];
 }
 
 + (NSArray<NSDictionary *> *)_exportLocations:(NSArray<CLLocation *> *)locations

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Added guards to avoid crashing the app if we try to write task results that contains NSNull values
+- [iOS] Added guards to avoid crashing the app if we try to write task results that contains NSNull values ([#35477](https://github.com/expo/expo/pull/35477) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Added guards to avoid crashing the app if we try to write task results that contains NSNull values
+
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))


### PR DESCRIPTION
# Why

Parameter cleanup:

When passing task options to set up the CLLocationManager the options struct may contain keys with undefined (from JS) values - which will end up as NSNull values and crash the app. This can be seen in the API/BackgroundLocation example in BareExpo where some of the option fields are undefined.

In BareExpo's Background Location demo screen I'm seeing a crash when we try to store the output from a new location in our user defaults because it might contain NSNull values.

# How

- Added fix to read options with defaults and both nil/NSNull checks
- Added methods for sanitizing dictionaries before storing them in the NSUserDefaults.

# Test Plan

- Run API/BackgroundLocation demo in BareExpo (remove `<MapView` to be able to run this demo in `apps/native-component-list/src/screens/Location/BackgroundLocationMapScreen.tsx`)
- Click "Start Tracking"
- Observe that BareExpo crashes when trying to read options in `EXLocationTaskConsumer.m` for parameters that are NSNull and in `EXTaskService.m` in `_saveConfigWithDictionary` when storing to NSUserDefaults.
- Apply fix
- This should no longer crash


# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
