### PR TITLE
[ios][location] don't restart all services on error

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Remove restarting all services when CLLocationManager reports an error
+- [iOS] Remove restarting all services when CLLocationManager reports an error ([#35478](https://github.com/expo/expo/pull/35478) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Add missing ProGuard rule to fix task consumer failed ([#34098](https://github.com/expo/expo/pull/34098) by [@cornejobarraza](https://github.com/cornejobarraza))
 - [iOS] `startLocationUpdatesAsync` should not require background permissions ([#33617](https://github.com/expo/expo/pull/33617) by [@andrejpavlovic](https://github.com/andrejpavlovic)
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Remove restarting all services when CLLocationManager reports an error
 - [Android] Add missing ProGuard rule to fix task consumer failed ([#34098](https://github.com/expo/expo/pull/34098) by [@cornejobarraza](https://github.com/cornejobarraza))
 - [iOS] `startLocationUpdatesAsync` should not require background permissions ([#33617](https://github.com/expo/expo/pull/33617) by [@andrejpavlovic](https://github.com/andrejpavlovic)
 

--- a/packages/expo-location/ios/TaskConsumers/EXLocationTaskConsumer.m
+++ b/packages/expo-location/ios/TaskConsumers/EXLocationTaskConsumer.m
@@ -91,15 +91,7 @@
 
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error
 {
-  if (error.domain == kCLErrorDomain) {
-    // This error might happen when the device is not able to find out the location. Try to restart monitoring location.
-    [manager stopUpdatingLocation];
-    [manager stopMonitoringSignificantLocationChanges];
-    [manager startUpdatingLocation];
-    [manager startMonitoringSignificantLocationChanges];
-  } else {
-    [_task executeWithData:nil withError:error];
-  }
+  [_task executeWithData:nil withError:error];
 }
 
 # pragma mark - internal


### PR DESCRIPTION
# Why

When CLLocationManager reports an error in our TaskConsumer we shouldn't need to restart location updates and monitoring - just handle the error through the task system. This caused the location manager to spit out errors over and over again since each error would try to restart - creating a new error (if the error is persistent, like if location services are unavailable for a while).

# How

This commit fixes this by removing the restart logic. This is now similar to how the TaskConsumer for monitoring regions are doing it.

# Test Plan

- Run in BareExpo on Simulator and start tracking background locations (remember to remove `<MapView` from the BackgroundLocationsScreen.tsx to be able to test)
- Set navigation simulation to "None" (Features -> Location -> "None") to provoke an error
- Observe that we're not seeing a lot of restart tries in the log window.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
