### PR TITLE
[video][android] Fix touch events not being emitted for `VideoView`

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -36,6 +36,7 @@ _This version does not introduce any user-facing changes._
 - [iOS] Fix the Now Playing notification disappearing after the video is paused. ([#35273](https://github.com/expo/expo/pull/35273) by [@behenate](https://github.com/behenate))
 - [iOS] Fix a race condition in setting the targets for the Now Playing controls causing the controls to sometimes not work. ([#35274](https://github.com/expo/expo/pull/35274) by [@behenate](https://github.com/behenate))
 - [iOS] Fix disabling the Now Playing controls for multiple players at the same time causing the notification to break. ([#35275](https://github.com/expo/expo/pull/35275) by [@behenate](https://github.com/behenate))
+- [Android] Fix touch events not being emitted for `VideoView`. ([#35479](https://github.com/expo/expo/pull/35479) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoManager.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoManager.kt
@@ -34,7 +34,7 @@ object VideoManager {
   }
 
   fun registerVideoView(videoView: VideoView) {
-    videoViews[videoView.id] = videoView
+    videoViews[videoView.videoViewId] = videoView
   }
 
   fun getVideoView(id: String): VideoView {
@@ -42,7 +42,7 @@ object VideoManager {
   }
 
   fun unregisterVideoView(videoView: VideoView) {
-    videoViews.remove(videoView.id)
+    videoViews.remove(videoView.videoViewId)
   }
 
   fun registerVideoPlayer(videoPlayer: VideoPlayer) {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -160,7 +160,7 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
 
   fun enterFullscreen() {
     val intent = Intent(context, FullscreenPlayerActivity::class.java)
-    intent.putExtra(VideoManager.INTENT_PLAYER_KEY, id)
+    intent.putExtra(VideoManager.INTENT_PLAYER_KEY, videoViewId)
     // Set before starting the activity to avoid entering PiP unintentionally
     isInFullscreen = true
     currentActivity.startActivity(intent)

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.graphics.Color
 import android.os.Build
 import android.util.Rational
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -14,6 +15,10 @@ import android.widget.ImageButton
 import androidx.fragment.app.FragmentActivity
 import androidx.media3.common.Tracks
 import androidx.media3.ui.PlayerView
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.events.EventDispatcher
+import com.facebook.react.uimanager.events.TouchEventCoalescingKeyHelper
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
@@ -24,12 +29,13 @@ import expo.modules.video.player.VideoPlayerListener
 import expo.modules.video.utils.applyAutoEnterPiP
 import expo.modules.video.utils.applyRectHint
 import expo.modules.video.utils.calculateRectHint
+import expo.modules.video.utils.dispatchMotionEvent
 import java.util.UUID
 
 // https://developer.android.com/guide/topics/media/media3/getting-started/migration-guide#improvements_in_media3
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 class VideoView(context: Context, appContext: AppContext) : ExpoView(context, appContext), VideoPlayerListener {
-  val id: String = UUID.randomUUID().toString()
+  val videoViewId: String = UUID.randomUUID().toString()
   val playerView: PlayerView = PlayerView(context.applicationContext)
   val onPictureInPictureStart by EventDispatcher<Unit>()
   val onPictureInPictureStop by EventDispatcher<Unit>()
@@ -50,9 +56,11 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
   private val currentActivity = appContext.throwingActivity
   private val decorView = currentActivity.window.decorView
   private val rootView = decorView.findViewById<ViewGroup>(android.R.id.content)
+  private val touchEventCoalescingKeyHelper = TouchEventCoalescingKeyHelper()
 
   private val rootViewChildrenOriginalVisibility: ArrayList<Int> = arrayListOf()
   private var pictureInPictureHelperTag: String? = null
+  private var reactNativeEventDispatcher: EventDispatcher? = null
 
   // We need to keep track of the target surface view visibility, but only apply it when `useExoShutter` is false.
   var shouldHideSurfaceView: Boolean = true
@@ -138,6 +146,8 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
         ViewGroup.LayoutParams.MATCH_PARENT
       )
     )
+
+    reactNativeEventDispatcher = UIManagerHelper.getEventDispatcher(appContext.reactContext as ReactContext, id)
   }
 
   fun applySurfaceViewVisibility() {
@@ -299,6 +309,34 @@ class VideoView(context: Context, appContext: AppContext) : ExpoView(context, ap
         .commitAllowingStateLoss()
     }
     applyAutoEnterPiP(currentActivity, false)
+  }
+
+  // After adding the `PlayerView` to the hierarchy the touch events stop being emitted to the JS side.
+  // The only workaround I have found is to dispatch the touch events manually using the `EventDispatcher`.
+  // The behavior is different when the native controls are enabled and disabled.
+  override fun onTouchEvent(event: MotionEvent?): Boolean {
+    if (!useNativeControls) {
+      event?.eventTime?.let {
+        touchEventCoalescingKeyHelper.addCoalescingKey(it)
+        reactNativeEventDispatcher?.dispatchMotionEvent(this@VideoView, event, touchEventCoalescingKeyHelper)
+      }
+    }
+    if (event?.actionMasked == MotionEvent.ACTION_UP) {
+      performClick()
+    }
+    // Mark the event as handled
+    return true
+  }
+
+  override fun onInterceptTouchEvent(event: MotionEvent?): Boolean {
+    if (useNativeControls) {
+      event?.eventTime?.let {
+        touchEventCoalescingKeyHelper.addCoalescingKey(it)
+        reactNativeEventDispatcher?.dispatchMotionEvent(this@VideoView, MotionEvent.obtainNoHistory(event), touchEventCoalescingKeyHelper)
+      }
+    }
+    // Return false to receive all other events before the target `onTouchEvent`
+    return false
   }
 
   companion object {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/EventDispatcherUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/EventDispatcherUtils.kt
@@ -1,0 +1,43 @@
+package expo.modules.video.utils
+
+import android.util.Log
+import android.view.MotionEvent
+import android.view.View
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.events.EventDispatcher
+import com.facebook.react.uimanager.events.TouchEvent
+import com.facebook.react.uimanager.events.TouchEventCoalescingKeyHelper
+import com.facebook.react.uimanager.events.TouchEventType
+
+internal fun EventDispatcher.dispatchMotionEvent(view: View, event: MotionEvent?, touchEventCoalescingKeyHelper: TouchEventCoalescingKeyHelper) {
+  if (event == null) {
+    return
+  }
+
+  try {
+    val event = TouchEvent.obtain(
+      UIManagerHelper.getSurfaceId(view),
+      view.id,
+      event.toTouchEventType(),
+      event,
+      event.eventTime,
+      event.x,
+      event.y,
+      touchEventCoalescingKeyHelper
+    )
+    dispatchEvent(event)
+  } catch (e: RuntimeException) {
+    // We are not expecting any issues, but we want to prevent crashes in case the dispatch fails for any reason.
+    Log.e("EventDispatcherUtils", "Error dispatching touch event", e)
+  }
+}
+
+private fun MotionEvent.toTouchEventType(): TouchEventType {
+  return when (this.actionMasked) {
+    MotionEvent.ACTION_DOWN -> TouchEventType.START
+    MotionEvent.ACTION_UP -> TouchEventType.END
+    MotionEvent.ACTION_MOVE -> TouchEventType.MOVE
+    MotionEvent.ACTION_CANCEL -> TouchEventType.CANCEL
+    else -> TouchEventType.CANCEL
+  }
+}


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/34630
The `PlayerView` from `ExoPlayer` seems to be handling the touch events in a way that prevents them from being dispatched to RN.

# How

Created a workaround with `onTouchEvent` and `onInterceptTouchEvent` in order to re-dispatch correct events to the RN side when they are received. 
I had to rename `VideoView.id` to `VideoView.videoViewId`, because I was unknowingly overriding an existing id used by React Native for view identification.

# Test Plan

Tested in BareExpo on an Android 15 device

