### PR TITLE
[video][ios] Fix memory leaks caused by the uninvalidated subtitles observer

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix memory leaks caused by the uninvalidated subtitles observer. ([#31781](https://github.com/expo/expo/pull/31781) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 2.0.5 — 2025-01-10

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -209,6 +209,7 @@ class VideoPlayerObserver {
     playbackBufferEmptyObserver?.invalidate()
     playerItemStatusObserver?.invalidate()
     NotificationCenter.default.removeObserver(playerItemObserver as Any)
+    NotificationCenter.default.removeObserver(currentSubtitlesObserver as Any)
   }
 
   func startOrUpdateTimeUpdates(forInterval interval: Double) {


### PR DESCRIPTION
# Why

The `currentSubtitlesObserver` is not being invalidated when the player is released causing leaks of the `PlayerItem` 

# How

Invalidate the observer in the `invalidateCurrentPlayerItemObservers` function.

# Test Plan

Tested in Bare Expo sdk-52 branch on iOS 18 simulator

