### PR TITLE
[ncl] Remove import from NewAppScreen

### DIFF
--- a/apps/native-component-list/src/screens/DateTimePickerScreen.tsx
+++ b/apps/native-component-list/src/screens/DateTimePickerScreen.tsx
@@ -20,7 +20,17 @@ import {
   TextInputProps,
   Button,
 } from 'react-native';
-import { Colors } from 'react-native/Libraries/NewAppScreen';
+
+// Copied from react-native/Libraries/NewAppScreen/components/Colors.js
+const Colors = {
+  primary: '#1292B4',
+  white: '#FFF',
+  lighter: '#F3F3F3',
+  light: '#DAE1E7',
+  dark: '#444',
+  darker: '#222',
+  black: '#000',
+};
 
 export const DAY_OF_WEEK = Object.freeze({
   Sunday: 0,


### PR DESCRIPTION
# Why
This is a weird import and it causes other things to be pulled into the NCL bundle that should not be there.

# How
Copy the `Colors` object from `react-native/Libraries/NewAppScreen/components/Colors.js` and drop the import

# Test Plan
Bare-expo - example works as normal
