### PR TITLE
[doctor] Output formatting fixes, stop overusing stderr

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Drop `fast-glob` in favor of `glob`. ([#35082](https://github.com/expo/expo/pull/35082) by [@kitten](https://github.com/kitten))
+- Output formatting improvements ([#35483](https://github.com/expo/expo/pull/35483) by [@keith-kurak](https://github.com/keith-kurak))
 
 ## 1.12.7 — 2025-02-14
 

--- a/packages/expo-doctor/src/__tests__/doctor.test.ts
+++ b/packages/expo-doctor/src/__tests__/doctor.test.ts
@@ -274,27 +274,15 @@ describe(printFailedCheckIssueAndAdvice, () => {
     expect(jest.mocked(Log.log)).not.toHaveBeenCalled();
   });
 
-  // these errors print in-line so they're easier to associate with the origianl check
-  it(`Does not print when check throws an error`, () => {
-    jest.mocked(Log.log).mockReset();
-    printFailedCheckIssueAndAdvice({
-      result: { isSuccessful: false, issues: [], advice: '' },
-      check: new MockUnexpectedThrowCheck(),
-      error: new Error('Some error'),
-      duration: 0,
-    });
-    expect(jest.mocked(Log.log)).not.toHaveBeenCalled();
-  });
-
   it(`Prints issues when check fails`, () => {
-    jest.mocked(Log.warn).mockReset();
+    jest.mocked(Log.log).mockReset();
     printFailedCheckIssueAndAdvice({
       result: { isSuccessful: false, issues: ['issue1', 'issue2'], advice: '' },
       check: new MockFailedCheck(),
       duration: 0,
     });
-    expect(jest.mocked(Log.warn).mock.calls[1][0]).toContain('issue1');
-    expect(jest.mocked(Log.warn).mock.calls[2][0]).toContain('issue2');
+    expect(jest.mocked(Log.log).mock.calls[1][0]).toContain('issue1');
+    expect(jest.mocked(Log.log).mock.calls[2][0]).toContain('issue2');
   });
   it(`Prints advice when check fails if available`, () => {
     jest.mocked(Log.log).mockReset();
@@ -303,6 +291,6 @@ describe(printFailedCheckIssueAndAdvice, () => {
       check: new MockFailedCheck(),
       duration: 0,
     });
-    expect(jest.mocked(Log.log).mock.calls[0][0]).toContain('advice');
+    expect(jest.mocked(Log.log).mock.calls[2][0]).toContain('advice');
   });
 });

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -73,14 +73,14 @@ export async function printFailedCheckIssueAndAdvice(job: DoctorCheckRunnerJob) 
     return;
   }
 
-  Log.warn(chalk.red(`✖ [${job.check.description}]`));
+  Log.log(chalk.red(`✖ ${job.check.description}`));
 
   if (result.issues.length) {
     for (const issue of result.issues) {
-      Log.warn(chalk.yellow(`${issue}`));
+      Log.log(chalk.yellow(issue.replace(/^/gm, '  ')));
     }
     if (result.advice) {
-      Log.log(chalk.green(`Advice: ${result.advice}`));
+      Log.log(chalk.green(`Advice: ${result.advice}`.replace(/^/gm, '  ')));
     }
     Log.log();
   }
@@ -179,7 +179,9 @@ export async function actionAsync(projectRoot: string, showVerboseTestResults: b
         }
       }
       Log.exit(
-        `${failedJobs.length} ${failedJobs.length === 1 ? 'check' : 'checks'} failed, indicating possible issues with the project.`
+        chalk.red(
+          `${failedJobs.length} ${failedJobs.length === 1 ? 'check' : 'checks'} failed, indicating possible issues with the project.`
+        )
       );
     } else {
       Log.log(


### PR DESCRIPTION
# Why
- Brent suggested getting rid of the square brackets around test names
- I usually turn on "output stream labels" in EAS Build, and found it annoying that every line of every warning was labeled as "[stderr]"
  - I'm also wondering if that's related to why some messages are showing out of sequence on EAS Build (e.g., advice sometimes shows before an issue). If this doesn't fix that, I'll follow-up
- Some other small formatting fixes

# How
See above

# Test Plan
<img width="412" alt="image" src="https://github.com/user-attachments/assets/21017367-e680-4f3a-b9b6-9390618ab744" />

<img width="751" alt="image" src="https://github.com/user-attachments/assets/a3b0554b-cd42-406f-9430-c012dd6509a4" />

<img width="779" alt="image" src="https://github.com/user-attachments/assets/6370c189-77f5-4b6a-9b28-fecad2ad7ddc" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
