### PR TITLE
[docs] Document how to use .easignore to add files to a build archive

### DIFF
--- a/docs/pages/build-reference/easignore.mdx
+++ b/docs/pages/build-reference/easignore.mdx
@@ -26,7 +26,8 @@ Copy the content of the **.gitignore** file into the **.easignore** file. Then, 
 ```bash .easignore
 # Copy everything from your .gitignore file here
 
-# Additional ignores specific to EAS builds
+# Ignore files that EAS Build doesn't need to build your app
+/docs
 
 # Ignore native directories (if you are using EAS Build)
 /android
@@ -49,3 +50,17 @@ Save the file and trigger a new build.
 </Step>
 
 You've successfully configured your **.easignore** file.
+
+### Adding files to your project upload with .easignore
+
+In addition to ignoring additional files beyond what is in your gitignore file, you can also use the **.easignore** file to include files with your EAS Build upload that are not committed to source control. This is useful if you have custom scripts that generate temporary files needed for your build process just prior to build. To upload a file not in source control to EAS Build, add it to the **.easignore** file with a `!` prefix, along with the rest of your .gitignore contents. The `!` prefixed file should be last , so it takes precedence over any prior rules that would ignore it.
+
+```bash .easignore
+# Copy everything from your .gitignore file here
+
+/android
+/ios
+
+# Include a file not in source control
+!temp_file.json
+```

--- a/docs/pages/build-reference/easignore.mdx
+++ b/docs/pages/build-reference/easignore.mdx
@@ -51,7 +51,7 @@ Save the file and trigger a new build.
 
 You've successfully configured your **.easignore** file.
 
-### Adding files to your project upload with .easignore
+## Adding files to your project upload with .easignore
 
 In addition to ignoring additional files beyond what is in your gitignore file, you can also use the **.easignore** file to include files with your EAS Build upload that are not committed to source control. This is useful if you have custom scripts that generate temporary files needed for your build process just prior to build. To upload a file not in source control to EAS Build, add it to the **.easignore** file with a `!` prefix, along with the rest of your .gitignore contents. The `!` prefixed file should be last , so it takes precedence over any prior rules that would ignore it.
 

--- a/docs/pages/build-reference/easignore.mdx
+++ b/docs/pages/build-reference/easignore.mdx
@@ -26,7 +26,7 @@ Copy the content of the **.gitignore** file into the **.easignore** file. Then, 
 ```bash .easignore
 # Copy everything from your .gitignore file here
 
-# Ignore files that EAS Build doesn't need to build your app
+# Ignore files and directories that EAS Build doesn't need to build your app
 /docs
 
 # Ignore native directories (if you are using EAS Build)

--- a/docs/pages/build-reference/easignore.mdx
+++ b/docs/pages/build-reference/easignore.mdx
@@ -53,7 +53,7 @@ You've successfully configured your **.easignore** file.
 
 ## Adding files to your project upload with .easignore
 
-In addition to ignoring additional files beyond what is in your gitignore file, you can also use the **.easignore** file to include files with your EAS Build upload that are not committed to source control. This is useful if you have custom scripts that generate temporary files needed for your build process just prior to build. To upload a file not in source control to EAS Build, add it to the **.easignore** file with a `!` prefix, along with the rest of your .gitignore contents. The `!` prefixed file should be last , so it takes precedence over any prior rules that would ignore it.
+In addition to ignoring additional files beyond what is in your gitignore file, you can also use the **.easignore** file to include files with your EAS Build upload that are not committed to source control. This is useful if you have custom scripts that generate temporary files needed for your build process just prior to build. To upload a file not in source control to EAS Build, add it to the **.easignore** file with a `!` prefix, along with the rest of your .gitignore contents. The `!` prefixed file should be last, so it takes precedence over any prior rules that would ignore it.
 
 ```bash .easignore
 # Copy everything from your .gitignore file here


### PR DESCRIPTION
# Why
It's not uncommon, I've answered this question a few times, thought I would document it specifically

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
