### PR TITLE
[docs] Fix code annotation in multiple tab bars example

### DIFF
--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -164,13 +164,13 @@ If you need to change the structure of a component, you can override its underly
 
 The `TabList` is both the configuration and default appearance of the `Tabs`, but it is not the only way to render a tab bar. By hiding the `TabList`, you can construct custom tab bars using `TabTrigger`.
 
+{/* prettier-ignore */}
 ```tsx Multiple tab bars example
 <Tabs>
   <TabSlot />
   {/* A custom tab bar */}
   <View>
-    /* @info A custom tab bar. <CODE>TabTrigger</CODE>'s outside of TabList do not need the{' '}
-    <CODE>href</CODE> prop. */
+    /* @info A custom tab bar. <CODE>TabTrigger</CODE>'s outside of TabList do not need the <CODE>href</CODE> prop. */
     <View>
       <TabTrigger name="home">
         <Text>Home</Text>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the code annotation is broken because of the newline character.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Use `prettier-ignore` annotation to ignore the auto-format.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-03-13 at 23 07 11](https://github.com/user-attachments/assets/c22f9055-4f9c-47a7-a2ce-c2caf2c615eb)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
