### PR TITLE
[docs] fix Reference sidebar entries ordering

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -721,7 +721,7 @@ function makePage(file) {
 
   const result = {
     // TODO(cedric): refactor name into title
-    name: data.title,
+    name: data.sidebar_title ?? data.title,
     // TODO(cedric): refactor href into url
     href: url,
     isNew: data.isNew ?? undefined,


### PR DESCRIPTION
# Why

Fixes ENG-15195

# How

Prefer `sidebar_title` as a page name, if it is set. This should fix the order of pages in the Reference section.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2025-03-13 at 19 00 38](https://github.com/user-attachments/assets/eb0d810a-884d-40e0-a30e-07e911de9c05)

