### PR TITLE
[docs] fix tabs content appearance, fix duplicated slugs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui.mdx
@@ -23,7 +23,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 ## Examples
 
-### Button
+### Button component
 
 <Tabs>
 <Tab label="Android">
@@ -55,7 +55,7 @@ import { Button } from '@expo/ui/components/Button';
 </Tab>
 </Tabs>
 
-### Picker (segmented variant)
+### Picker component (segmented variant)
 
 <Tabs>
 <Tab label="Android">
@@ -87,7 +87,7 @@ import { Picker } from '@expo/ui/components/Picker';
 </Tab>
 </Tabs>
 
-### Picker (wheel variant) (iOS only)
+### Picker component (wheel variant) (iOS only)
 
 <Tabs>
 <Tab label="iOS">
@@ -117,7 +117,7 @@ import { Picker } from '@expo/ui/components/Picker';
 </Tab>
 </Tabs>
 
-### Switch
+### Switch component
 
 <Tabs>
 <Tab label="iOS">
@@ -142,7 +142,7 @@ import { Switch } from '@expo/ui/components/Switch';
 </Tab>
 </Tabs>
 
-### Switch (checkbox variant)
+### Switch component (checkbox variant)
 
 <Tabs>
 <Tab label="iOS">

--- a/docs/ui/components/Tabs/Tabs.tsx
+++ b/docs/ui/components/Tabs/Tabs.tsx
@@ -60,7 +60,8 @@ const InnerTabs = ({
       <TabPanels
         className={mergeClasses(
           'px-5 py-4',
-          '[&_pre]:first-of-type:mt-1 [&_ul]:mb-3',
+          '[&_ul]:mb-3',
+          'first:[&_figure]:mt-1 first:[&_pre]:mt-1',
           'last:[&>div>*]:!mb-0'
         )}>
         {children}


### PR DESCRIPTION
# Why

Spotted that due to examples section matching components name we have the duplicated slugs. Unfortunately MDX page content and JSDoc renderer does not share the same pool of slugs, and don't know about each other existence, which is a root cause for this issue.

# How

Alter the examples section headers to avoid the duplication and linking issues.

Additionally, I have corrected the styling on Tabs content wrapper, so first block elements like code block or content spotlight does not include additional spacing.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2025-03-13 at 19 24 28](https://github.com/user-attachments/assets/a536b1eb-b8d7-4a33-8a71-17d40afc9981)

