### PR TITLE
[docs][location] added explanation of deferred locations

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -211,7 +211,7 @@ Remember that the user has the option of granting your app `When In Use` authori
 
 </Collapsible>
 
-## Deferred Locations
+## Deferred locations
 
 When using background locations, you can configure the location manager to defer updates. This helps save battery by reducing update frequency. You can set updates to trigger only after the device has moved a certain distance or after a specified time interval.
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -211,6 +211,14 @@ Remember that the user has the option of granting your app `When In Use` authori
 
 </Collapsible>
 
+## Deferred Locations
+
+When using background locations, you can configure the location manager to defer updates. This helps save battery by reducing update frequency. You can set updates to trigger only after the device has moved a certain distance or after a specified time interval.
+
+Deferred updates are configured through [LocationTaskOptions](#locationtaskoptions) using the [deferredUpdatesDistance](#locationtaskoptions), [deferredUpdatesInterval](#locationtaskoptions) and [deferredTimeout](#locationtaskoptions) properties.
+
+> Deferred locations apply only when the app is in the background.
+
 ## Usage
 
 If you're using the Android Emulator or iOS Simulator, ensure that [Location is enabled](#enable-emulator-location).

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -215,7 +215,7 @@ Remember that the user has the option of granting your app `When In Use` authori
 
 When using background locations, you can configure the location manager to defer updates. This helps save battery by reducing update frequency. You can set updates to trigger only after the device has moved a certain distance or after a specified time interval.
 
-Deferred updates are configured through [LocationTaskOptions](#locationtaskoptions) using the [deferredUpdatesDistance](#locationtaskoptions), [deferredUpdatesInterval](#locationtaskoptions) and [deferredTimeout](#locationtaskoptions) properties.
+Deferred updates are configured through [`LocationTaskOptions`](#locationtaskoptions) using the [`deferredUpdatesDistance`](#locationtaskoptions), [`deferredUpdatesInterval`](#locationtaskoptions) and [`deferredTimeout`](#locationtaskoptions) properties.
 
 > Deferred locations apply only when the app is in the background.
 

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -211,7 +211,7 @@ Remember that the user has the option of granting your app `When In Use` authori
 
 </Collapsible>
 
-## Deferred Locations
+## Deferred locations
 
 When using background locations, you can configure the location manager to defer updates. This helps save battery by reducing update frequency. You can set updates to trigger only after the device has moved a certain distance or after a specified time interval.
 

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -211,6 +211,14 @@ Remember that the user has the option of granting your app `When In Use` authori
 
 </Collapsible>
 
+## Deferred Locations
+
+When using background locations, you can configure the location manager to defer updates. This helps save battery by reducing update frequency. You can set updates to trigger only after the device has moved a certain distance or after a specified time interval.
+
+Deferred updates are configured through [LocationTaskOptions](#locationtaskoptions) using the [deferredUpdatesDistance](#locationtaskoptions), [deferredUpdatesInterval](#locationtaskoptions) and [deferredTimeout](#locationtaskoptions) properties.
+
+> Deferred locations apply only when the app is in the background.
+
 ## Usage
 
 If you're using the Android Emulator or iOS Simulator, ensure that [Location is enabled](#enable-emulator-location).

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -215,7 +215,7 @@ Remember that the user has the option of granting your app `When In Use` authori
 
 When using background locations, you can configure the location manager to defer updates. This helps save battery by reducing update frequency. You can set updates to trigger only after the device has moved a certain distance or after a specified time interval.
 
-Deferred updates are configured through [LocationTaskOptions](#locationtaskoptions) using the [deferredUpdatesDistance](#locationtaskoptions), [deferredUpdatesInterval](#locationtaskoptions) and [deferredTimeout](#locationtaskoptions) properties.
+Deferred updates are configured through [`LocationTaskOptions`](#locationtaskoptions) using the [`deferredUpdatesDistance`](#locationtaskoptions), [`deferredUpdatesInterval`](#locationtaskoptions) and [`deferredTimeout`](#locationtaskoptions) properties.
 
 > Deferred locations apply only when the app is in the background.
 


### PR DESCRIPTION
# Why

Deferred locations are documented but not explained - ie. it is not clear when they apply.

# How

This commit fixes this by adding a separate section about deferred locations.

Updates both unversioned and sdk-52

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
