### PR TITLE
chore(server): Remove `^7.0.0` from `undici` range for `@expo/server` for Node 18 (SDK 52 only)

### DIFF
--- a/packages/@expo/server/CHANGELOG.md
+++ b/packages/@expo/server/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Constrain `undici` to `^6.18.2`, since `^7.0.0` drops Node 18 support which we still support for SDK 52. ([#35507](https://github.com/expo/expo/pull/35507) by [@kitten](https://github.com/kitten))
+
 ## 0.5.2 — 2025-03-11
 
 ### 💡 Others

--- a/packages/@expo/server/package.json
+++ b/packages/@expo/server/package.json
@@ -38,7 +38,7 @@
     "abort-controller": "^3.0.0",
     "debug": "^4.3.4",
     "source-map-support": "~0.5.21",
-    "undici": "^6.18.2 || ^7.0.0"
+    "undici": "^6.18.2"
   },
   "devDependencies": {
     "@netlify/functions": "^1.4.0",


### PR DESCRIPTION
Resolves #35496

# Why

`unidic@7` drops Node 18 support, which I wasn't aware of when backporting a change. Since we still had another dependency on `undici@^6` this went unnoticed. We're still supporting Node 18 in SDK 52 until it's EOL (by SDK 53 / canary).

# How

Remove `^7.0.0` version range from `undici` install.

# Test Plan

- n/a; `^6` is already used in tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
