### PR TITLE
[docs] Add support for page rank meta attributes for Algolia search

### DIFF
--- a/docs/components/DocumentationHead.tsx
+++ b/docs/components/DocumentationHead.tsx
@@ -1,11 +1,7 @@
 import NextHead from 'next/head';
 import type { PropsWithChildren } from 'react';
 
-type HeadProps = PropsWithChildren<{
-  title?: string;
-  description?: string;
-  canonicalUrl?: string;
-}>;
+type HeadProps = PropsWithChildren<{ title?: string; description?: string; canonicalUrl?: string }>;
 
 const BASE_OG_URL = 'https://og.expo.dev/?theme=docs';
 
@@ -46,6 +42,7 @@ const DocumentationHead = ({ title, description, canonicalUrl, children }: HeadP
       />
       <meta property="twitter:image" content={OGImageURL} />
       <meta name="google-site-verification" content="izrqNurn_EXfYbNIFgVIhEXkkZk9DleELH4UouM8s3k" />
+
       {children}
     </NextHead>
   );

--- a/docs/components/DocumentationHead.tsx
+++ b/docs/components/DocumentationHead.tsx
@@ -1,14 +1,29 @@
 import NextHead from 'next/head';
 import type { PropsWithChildren } from 'react';
 
-type HeadProps = PropsWithChildren<{ title?: string; description?: string; canonicalUrl?: string }>;
+type HeadProps = PropsWithChildren<{
+  title?: string;
+  description?: string;
+  canonicalUrl?: string;
+  searchRank?: number;
+  searchLevel?: number;
+  searchPosition?: number;
+}>;
 
 const BASE_OG_URL = 'https://og.expo.dev/?theme=docs';
 
 const BASE_TITLE = 'Expo Documentation';
 const BASE_DESCRIPTION = `Expo is an open-source platform for making universal native apps for Android, iOS, and the web with JavaScript and React.`;
 
-const DocumentationHead = ({ title, description, canonicalUrl, children }: HeadProps) => {
+const DocumentationHead = ({
+  title,
+  description,
+  canonicalUrl,
+  searchRank,
+  searchLevel,
+  searchPosition,
+  children,
+}: HeadProps) => {
   const OGImageURL = `${BASE_OG_URL}&title=${encodeURIComponent(title ?? BASE_TITLE)}&description=${encodeURIComponent(description ?? BASE_DESCRIPTION)}`;
 
   return (
@@ -42,6 +57,13 @@ const DocumentationHead = ({ title, description, canonicalUrl, children }: HeadP
       />
       <meta property="twitter:image" content={OGImageURL} />
       <meta name="google-site-verification" content="izrqNurn_EXfYbNIFgVIhEXkkZk9DleELH4UouM8s3k" />
+
+      {/* Search ranking metadata for Algolia */}
+      {searchRank !== undefined && <meta name="searchRank" content={String(searchRank)} />}
+      {searchLevel !== undefined && <meta name="searchLevel" content={String(searchLevel)} />}
+      {searchPosition !== undefined && (
+        <meta name="searchPosition" content={String(searchPosition)} />
+      )}
 
       {children}
     </NextHead>

--- a/docs/components/DocumentationHead.tsx
+++ b/docs/components/DocumentationHead.tsx
@@ -5,9 +5,6 @@ type HeadProps = PropsWithChildren<{
   title?: string;
   description?: string;
   canonicalUrl?: string;
-  searchRank?: number;
-  searchLevel?: number;
-  searchPosition?: number;
 }>;
 
 const BASE_OG_URL = 'https://og.expo.dev/?theme=docs';
@@ -15,15 +12,7 @@ const BASE_OG_URL = 'https://og.expo.dev/?theme=docs';
 const BASE_TITLE = 'Expo Documentation';
 const BASE_DESCRIPTION = `Expo is an open-source platform for making universal native apps for Android, iOS, and the web with JavaScript and React.`;
 
-const DocumentationHead = ({
-  title,
-  description,
-  canonicalUrl,
-  searchRank,
-  searchLevel,
-  searchPosition,
-  children,
-}: HeadProps) => {
+const DocumentationHead = ({ title, description, canonicalUrl, children }: HeadProps) => {
   const OGImageURL = `${BASE_OG_URL}&title=${encodeURIComponent(title ?? BASE_TITLE)}&description=${encodeURIComponent(description ?? BASE_DESCRIPTION)}`;
 
   return (
@@ -57,14 +46,6 @@ const DocumentationHead = ({
       />
       <meta property="twitter:image" content={OGImageURL} />
       <meta name="google-site-verification" content="izrqNurn_EXfYbNIFgVIhEXkkZk9DleELH4UouM8s3k" />
-
-      {/* Search ranking metadata for Algolia */}
-      {searchRank !== undefined && <meta name="searchRank" content={String(searchRank)} />}
-      {searchLevel !== undefined && <meta name="searchLevel" content={String(searchLevel)} />}
-      {searchPosition !== undefined && (
-        <meta name="searchPosition" content={String(searchPosition)} />
-      )}
-
       {children}
     </NextHead>
   );

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -145,7 +145,11 @@ export default function DocumentationPage({
           RoutesUtils.isPreviewPath(pathname) ||
           RoutesUtils.isArchivePath(pathname)) && <meta name="robots" content="noindex" />}
         {searchRank && <meta name="searchRank" content={String(searchRank)} />}
-        {searchLevel && <meta name="searchLevel" content={String(searchLevel)} />}
+        {searchLevel ? (
+          <meta name="searchLevel" content={String(searchLevel)} />
+        ) : (
+          <meta name="searchLevel" content={String(searchRank)} />
+        )}
         {searchPosition && <meta name="searchPosition" content={String(searchPosition)} />}
       </DocumentationHead>
       <div

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -40,6 +40,9 @@ export default function DocumentationPage({
   platforms,
   hideTOC,
   modificationDate,
+  searchRank,
+  searchLevel,
+  searchPosition,
 }: DocPageProps) {
   const [isMobileMenuVisible, setMobileMenuVisible] = useState(false);
   const { version } = usePageApiVersion();
@@ -141,6 +144,9 @@ export default function DocumentationPage({
         {(version === 'unversioned' ||
           RoutesUtils.isPreviewPath(pathname) ||
           RoutesUtils.isArchivePath(pathname)) && <meta name="robots" content="noindex" />}
+        {searchRank && <meta name="searchRank" content={String(searchRank)} />}
+        {searchLevel && <meta name="searchLevel" content={String(searchLevel)} />}
+        {searchPosition && <meta name="searchPosition" content={String(searchPosition)} />}
       </DocumentationHead>
       <div
         className={mergeClasses(

--- a/docs/components/DocumentationPageWrapper.tsx
+++ b/docs/components/DocumentationPageWrapper.tsx
@@ -39,7 +39,10 @@ export function DocumentationPageWrapper(props: DocumentationElementsProps) {
               packageName={props.meta.packageName}
               iconUrl={props.meta.iconUrl}
               modificationDate={props.meta.modificationDate}
-              platforms={props.meta.platforms}>
+              platforms={props.meta.platforms}
+              searchRank={props.meta.searchRank}
+              searchLevel={props.meta.searchLevel}
+              searchPosition={props.meta.searchPosition}>
               {props.children}
             </DocumentationPage>
           </PageApiVersionProvider>

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -3,7 +3,6 @@ title: Run EAS Build locally with local flag
 sidebar_title: Run EAS Build locally
 description: Learn how to use EAS Build locally on your machine or a custom infrastructure using the --local flag.
 searchRank: 80
-searchLevel: 80
 searchPosition: 1
 ---
 

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -4,7 +4,7 @@ sidebar_title: Run EAS Build locally
 description: Learn how to use EAS Build locally on your machine or a custom infrastructure using the --local flag.
 searchRank: 80
 searchLevel: 80
-searchPosition: 0
+searchPosition: 1
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -2,6 +2,9 @@
 title: Run EAS Build locally with local flag
 sidebar_title: Run EAS Build locally
 description: Learn how to use EAS Build locally on your machine or a custom infrastructure using the --local flag.
+searchRank: 80
+searchLevel: 80
+searchPosition: 0
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -2,6 +2,9 @@
 title: Create a development build
 description: Learn how to create development builds for a project.
 sidebar_title: Create a build
+searchRank: 97
+level: 97
+position: 2
 ---
 
 import { GraduationHat01Icon } from '@expo/styleguide-icons/outline/GraduationHat01Icon';

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -3,7 +3,6 @@ title: Create a development build
 description: Learn how to create development builds for a project.
 sidebar_title: Create a build
 searchRank: 97
-searchLevel: 97
 searchPosition: 2
 ---
 

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -3,8 +3,8 @@ title: Create a development build
 description: Learn how to create development builds for a project.
 sidebar_title: Create a build
 searchRank: 97
-level: 97
-position: 2
+searchLevel: 97
+searchPosition: 2
 ---
 
 import { GraduationHat01Icon } from '@expo/styleguide-icons/outline/GraduationHat01Icon';

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -2,6 +2,9 @@
 title: Introduction to development builds
 sidebar_title: Introduction
 description: Why use development builds and how to get started.
+searchRank: 98
+level: 98
+position: 1
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -3,8 +3,8 @@ title: Introduction to development builds
 sidebar_title: Introduction
 description: Why use development builds and how to get started.
 searchRank: 98
-level: 98
-position: 1
+searchLevel: 98
+searchPosition: 1
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -3,7 +3,6 @@ title: Introduction to development builds
 sidebar_title: Introduction
 description: Why use development builds and how to get started.
 searchRank: 98
-searchLevel: 98
 searchPosition: 1
 ---
 

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -3,7 +3,6 @@ title: EAS Update
 sidebar_title: Introduction
 description: An introduction to EAS Update which is a hosted service for projects using the expo-updates library.
 searchRank: 99
-searchLevel: 99
 searchPosition: 2
 ---
 

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -3,8 +3,8 @@ title: EAS Update
 sidebar_title: Introduction
 description: An introduction to EAS Update which is a hosted service for projects using the expo-updates library.
 searchRank: 99
-level: 99
-position: 2
+searchLevel: 99
+searchPosition: 2
 ---
 
 import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon';

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -2,6 +2,9 @@
 title: EAS Update
 sidebar_title: Introduction
 description: An introduction to EAS Update which is a hosted service for projects using the expo-updates library.
+searchRank: 99
+level: 99
+position: 2
 ---
 
 import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon';

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -3,7 +3,6 @@ title: Create a production build locally
 sidebar_title: Production
 description: Learn how to create a production build for your Expo app locally.
 searchRank: 75
-searchLevel: 75
 searchPosition: 10
 ---
 

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -2,6 +2,9 @@
 title: Create a production build locally
 sidebar_title: Production
 description: Learn how to create a production build for your Expo app locally.
+searchRank: 75
+searchLevel: 75
+searchPosition: 10
 ---
 
 import { GoogleAppStoreIcon } from '@expo/styleguide-icons/custom/AndroidIcon';

--- a/docs/pages/technical-specs/expo-updates-1.mdx
+++ b/docs/pages/technical-specs/expo-updates-1.mdx
@@ -2,6 +2,9 @@
 modificationDate: March 13, 2023
 title: Expo Updates v1
 description: Version 1
+searchRank: 1
+level: 1
+position: 999
 ---
 
 ## Introduction

--- a/docs/pages/technical-specs/expo-updates-1.mdx
+++ b/docs/pages/technical-specs/expo-updates-1.mdx
@@ -3,8 +3,8 @@ modificationDate: March 13, 2023
 title: Expo Updates v1
 description: Version 1
 searchRank: 1
-level: 1
-position: 999
+searchLevel: 1
+searchPosition: 999
 ---
 
 ## Introduction

--- a/docs/pages/technical-specs/expo-updates-1.mdx
+++ b/docs/pages/technical-specs/expo-updates-1.mdx
@@ -3,7 +3,6 @@ modificationDate: March 13, 2023
 title: Expo Updates v1
 description: Version 1
 searchRank: 1
-searchLevel: 1
 searchPosition: 999
 ---
 

--- a/docs/pages/versions/v52.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/updates.mdx
@@ -6,7 +6,6 @@ packageName: 'expo-updates'
 iconUrl: '/static/images/packages/expo-updates.png'
 platforms: ['android', 'ios', 'tvos']
 searchRank: 100
-searchLevel: 100
 searchPosition: 1
 ---
 

--- a/docs/pages/versions/v52.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/updates.mdx
@@ -6,8 +6,8 @@ packageName: 'expo-updates'
 iconUrl: '/static/images/packages/expo-updates.png'
 platforms: ['android', 'ios', 'tvos']
 searchRank: 100
-level: 100
-position: 1
+searchLevel: 100
+searchPosition: 1
 ---
 
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';

--- a/docs/pages/versions/v52.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/updates.mdx
@@ -5,6 +5,9 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-52/packages/expo-updates'
 packageName: 'expo-updates'
 iconUrl: '/static/images/packages/expo-updates.png'
 platforms: ['android', 'ios', 'tvos']
+searchRank: 100
+level: 100
+position: 1
 ---
 
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -10,6 +10,9 @@ export type PageMetadata = {
   hideTOC?: boolean;
   platforms?: string[];
   modificationDate?: string;
+  searchRank?: number;
+  searchLevel?: number;
+  searchPosition?: number;
 };
 
 /**


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This pull request adds new metadata fields to the documentation pages to improve search functionality. The changes primarily involve adding `searchRank`, `searchLevel`, and `searchPosition` properties to various documentation files as a page's frontmatter and included in `meta` tags for that page.

To read further about how applying page ranking this way is possible with Algolia's crawler, see: https://support.algolia.com/hc/en-us/articles/10129936206353-How-do-I-apply-ranking-to-DocSearch-via-crawler.

# How

- Added `searchRank`, `searchLevel`, and `searchPosition` properties to the `DocPageProps` interface and utilized them in the `DocumentationPage` component. 
-  Updated the `PageMetadata` type to include `searchRank`, `searchLevel`, and `searchPosition`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


### Updates to Individual Documentation Files:

* Added `searchRank`, `searchLevel`, and `searchPosition` metadata to various `.mdx` files to enhance search indexing:
  * `docs/pages/build-reference/local-builds.mdx`
  * `docs/pages/develop/development-builds/create-a-build.mdx`
  * `docs/pages/develop/development-builds/introduction.mdx`
  * `docs/pages/eas-update/introduction.mdx`
  * `docs/pages/guides/local-app-production.mdx`
  * `docs/pages/technical-specs/expo-updates-1.mdx`
  * `docs/pages/versions/v52.0.0/sdk/updates.mdx`

Adding these attributes will help us conduct further tests to control these values from docs source.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
