### PR TITLE
chore(cli): bump Metro types to `0.82.0`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Bump Metro typescript declarations to `0.81.3`. ([#35306](https://github.com/expo/expo/pull/35306) by [@byCedric](https://github.com/byCedric))
 - Upgrade to `minimatch@9` ([#35313](https://github.com/expo/expo/pull/35313) by [@kitten](https://github.com/kitten))
 - Upgrade to `tar@7` ([#35314](https://github.com/expo/expo/pull/35314) by [@kitten](https://github.com/kitten))
+- Bump Metro typescript declarations to `0.82.0`. ([#35522](https://github.com/expo/expo/pull/35522) by [@byCedric](https://github.com/byCedric))
 
 ## 0.22.19 - 2025-03-11
 

--- a/packages/@expo/cli/ts-declarations/metro-babel-transformer/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-babel-transformer/index.d.ts
@@ -4,7 +4,7 @@ declare module 'metro-babel-transformer' {
   export { default } from 'metro-babel-transformer/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-babel-transformer/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-babel-transformer/src/index.js
 declare module 'metro-babel-transformer/src/index' {
   import type * as _babel_types from '@babel/types';
   import type { BabelFileMetadata, TransformOptions } from '@babel/core';

--- a/packages/@expo/cli/ts-declarations/metro-cache-key/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-cache-key/index.d.ts
@@ -3,7 +3,7 @@ declare module 'metro-cache-key' {
   export { default } from 'metro-cache-key/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-cache-key/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-cache-key/src/index.js
 declare module 'metro-cache-key/src/index' {
   function getCacheKey(files: string[]): string;
   export default getCacheKey;

--- a/packages/@expo/cli/ts-declarations/metro-config/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-config/index.d.ts
@@ -9,7 +9,7 @@ declare module 'metro-config/src/configTypes' {
   export * from 'metro-config/src/configTypes.flow';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-config/src/configTypes.flow.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/configTypes.flow.js
 declare module 'metro-config/src/configTypes.flow' {
   import type { IntermediateStackFrame } from 'metro/src/Server/symbolicate';
   import type { HandleFunction, Server } from 'connect';
@@ -303,7 +303,7 @@ declare module 'metro-config/src/configTypes.flow' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-config/src/defaults/defaults.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/defaults/defaults.js
 declare module 'metro-config/src/defaults/defaults' {
   import type { RootPerfLogger } from 'metro-config/src/configTypes.flow';
   export const assetExts: any;
@@ -317,11 +317,12 @@ declare module 'metro-config/src/defaults/defaults' {
   export const noopPerfLoggerFactory: () => RootPerfLogger;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-config/src/defaults/index.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/defaults/index.js
 declare module 'metro-config/src/defaults/index' {
-  // See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-config/src/defaults/index.js
+  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/defaults/index.js
 
   // NOTE(cedric): This file can't be typed properly due to complex CJS structures
+  // NOTE(cedric): This file has lots more exports, but neither of them should be used directly by Expo
 
   import type { ConfigT } from 'metro-config/src/configTypes.flow';
   export default interface getDefaultConfig {
@@ -330,15 +331,15 @@ declare module 'metro-config/src/defaults/index' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-config/src/defaults/validConfig.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/defaults/validConfig.js
 declare module 'metro-config/src/defaults/validConfig' {
   const $$EXPORT_DEFAULT_DECLARATION$$: () => any;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-config/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/index.js
 declare module 'metro-config/src/index' {
-  // See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-config/src/index.js
+  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/index.js
 
   // NOTE(cedric): Metro uses this weird Flow syntax /*:: */ to override the exported types...
   export type * from 'metro-config/src/configTypes.flow';
@@ -346,7 +347,7 @@ declare module 'metro-config/src/index' {
   export { loadConfig, mergeConfig, resolveConfig } from 'metro-config/src/loadConfig';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-config/src/loadConfig.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/loadConfig.js
 declare module 'metro-config/src/loadConfig' {
   import type { ConfigT, InputConfigT, YargArguments } from 'metro-config/src/configTypes.flow';
   type CosmiConfigResult = {

--- a/packages/@expo/cli/ts-declarations/metro-core/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-core/index.d.ts
@@ -1,21 +1,22 @@
 // #region metro-core
 declare module 'metro-core' {
   export * from 'metro-core/src/index';
+  export { default } from 'metro-core/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-core/src/canonicalize.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-core/src/canonicalize.js
 declare module 'metro-core/src/canonicalize' {
   function canonicalize(key: string, value: any): any;
   export default canonicalize;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-core/src/errors.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-core/src/errors.js
 declare module 'metro-core/src/errors' {
   export { default as AmbiguousModuleResolutionError } from 'metro-core/src/errors/AmbiguousModuleResolutionError';
   export { default as PackageResolutionError } from 'metro-core/src/errors/PackageResolutionError';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-core/src/errors/AmbiguousModuleResolutionError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-core/src/errors/AmbiguousModuleResolutionError.js
 declare module 'metro-core/src/errors/AmbiguousModuleResolutionError' {
   import type { DuplicateHasteCandidatesError } from 'metro-file-map';
   class AmbiguousModuleResolutionError extends Error {
@@ -26,7 +27,7 @@ declare module 'metro-core/src/errors/AmbiguousModuleResolutionError' {
   export default AmbiguousModuleResolutionError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-core/src/errors/PackageResolutionError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-core/src/errors/PackageResolutionError.js
 declare module 'metro-core/src/errors/PackageResolutionError' {
   import type { InvalidPackageError } from 'metro-resolver';
   class PackageResolutionError extends Error {
@@ -42,7 +43,7 @@ declare module 'metro-core/src/errors/PackageResolutionError' {
   export default PackageResolutionError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-core/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-core/src/index.js
 declare module 'metro-core/src/index' {
   export { default as AmbiguousModuleResolutionError } from 'metro-core/src/errors/AmbiguousModuleResolutionError';
   export { default as Logger } from 'metro-core/src/Logger';
@@ -50,7 +51,7 @@ declare module 'metro-core/src/index' {
   export { default as Terminal } from 'metro-core/src/Terminal';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-core/src/Logger.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-core/src/Logger.js
 declare module 'metro-core/src/Logger' {
   import type { BundleOptions } from 'metro/src/shared/types.flow';
   export type ActionLogEntryData = {
@@ -91,7 +92,7 @@ declare module 'metro-core/src/Logger' {
   export function log(logEntry: LogEntry): LogEntry;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-core/src/Terminal.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-core/src/Terminal.js
 declare module 'metro-core/src/Terminal' {
   import type * as _nodeStream from 'node:stream';
   import type * as _nodeNet from 'node:net';

--- a/packages/@expo/cli/ts-declarations/metro-file-map/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-file-map/index.d.ts
@@ -4,7 +4,7 @@ declare module 'metro-file-map' {
   export { default } from 'metro-file-map/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/cache/DiskCacheManager.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/cache/DiskCacheManager.js
 declare module 'metro-file-map/src/cache/DiskCacheManager' {
   import type {
     BuildParameters,
@@ -35,7 +35,7 @@ declare module 'metro-file-map/src/cache/DiskCacheManager' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/constants.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/constants.js
 declare module 'metro-file-map/src/constants' {
   const constants: {
     DEPENDENCY_DELIM: '\0';
@@ -56,13 +56,13 @@ declare module 'metro-file-map/src/constants' {
   export default constants;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/crawlers/node/hasNativeFindSupport.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/crawlers/node/hasNativeFindSupport.js
 declare module 'metro-file-map/src/crawlers/node/hasNativeFindSupport' {
   function hasNativeFindSupport(): Promise<boolean>;
   export default hasNativeFindSupport;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/crawlers/node/index.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/crawlers/node/index.js
 declare module 'metro-file-map/src/crawlers/node/index' {
   import type { CanonicalPath, CrawlerOptions, FileData } from 'metro-file-map/src/flow-types';
   const $$EXPORT_DEFAULT_DECLARATION$$: (options: CrawlerOptions) => Promise<{
@@ -72,7 +72,7 @@ declare module 'metro-file-map/src/crawlers/node/index' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/crawlers/watchman/index.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/crawlers/watchman/index.js
 declare module 'metro-file-map/src/crawlers/watchman/index' {
   import type {
     CanonicalPath,
@@ -88,7 +88,7 @@ declare module 'metro-file-map/src/crawlers/watchman/index' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/crawlers/watchman/planQuery.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/crawlers/watchman/planQuery.js
 declare module 'metro-file-map/src/crawlers/watchman/planQuery' {
   import type { WatchmanQuery, WatchmanQuerySince } from 'fb-watchman';
   export function planQuery(
@@ -105,7 +105,7 @@ declare module 'metro-file-map/src/crawlers/watchman/planQuery' {
   };
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/flow-types.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/flow-types.js
 declare module 'metro-file-map/src/flow-types' {
   import type { PerfLogger, PerfLoggerFactory, RootPerfLogger } from 'metro-config';
   export type { PerfLoggerFactory, PerfLogger };
@@ -241,7 +241,7 @@ declare module 'metro-file-map/src/flow-types' {
     files: FileSystemState;
     pluginState?: null | SerializableState;
   }>;
-  type V8Serializable = {};
+  type V8Serializable = object;
   export interface FileMapPlugin<SerializableState = V8Serializable> {
     readonly name: string;
     initialize(initOptions: FileMapPluginInitOptions<SerializableState>): Promise<void>;
@@ -472,7 +472,7 @@ declare module 'metro-file-map/src/flow-types' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/index.js
 declare module 'metro-file-map/src/index' {
   import type {
     BuildParameters,
@@ -705,7 +705,7 @@ declare module 'metro-file-map/src/index' {
   export default FileMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/lib/checkWatchmanCapabilities.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/checkWatchmanCapabilities.js
 declare module 'metro-file-map/src/lib/checkWatchmanCapabilities' {
   function checkWatchmanCapabilities(requiredCapabilities: readonly string[]): Promise<{
     version: string;
@@ -713,35 +713,18 @@ declare module 'metro-file-map/src/lib/checkWatchmanCapabilities' {
   export default checkWatchmanCapabilities;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/lib/dependencyExtractor.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/dependencyExtractor.js
 declare module 'metro-file-map/src/lib/dependencyExtractor' {
   export function extract(code: any): void;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/lib/DuplicateHasteCandidatesError.js
-declare module 'metro-file-map/src/lib/DuplicateHasteCandidatesError' {
-  import type { DuplicatesSet } from 'metro-file-map/src/flow-types';
-  export class DuplicateHasteCandidatesError extends Error {
-    hasteName: string;
-    platform: string | null;
-    supportsNativePlatform: boolean;
-    duplicatesSet: DuplicatesSet;
-    constructor(
-      name: string,
-      platform: string,
-      supportsNativePlatform: boolean,
-      duplicatesSet: DuplicatesSet
-    );
-  }
-}
-
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/lib/fast_path.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/fast_path.js
 declare module 'metro-file-map/src/lib/fast_path' {
   export function relative(rootDir: string, filename: string): string;
   export function resolve(rootDir: string, normalPath: string): string;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/lib/FileProcessor.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/FileProcessor.js
 declare module 'metro-file-map/src/lib/FileProcessor' {
   import type { FileMetaData, PerfLogger } from 'metro-file-map/src/flow-types';
   type ProcessFileRequest = Readonly<{
@@ -797,19 +780,19 @@ declare module 'metro-file-map/src/lib/FileProcessor' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/lib/normalizePathSeparatorsToPosix.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/normalizePathSeparatorsToPosix.js
 declare module 'metro-file-map/src/lib/normalizePathSeparatorsToPosix' {
   let normalizePathSeparatorsToPosix: (string: string) => string;
   export default normalizePathSeparatorsToPosix;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/lib/normalizePathSeparatorsToSystem.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/normalizePathSeparatorsToSystem.js
 declare module 'metro-file-map/src/lib/normalizePathSeparatorsToSystem' {
   let normalizePathSeparatorsToSystem: (string: string) => string;
   export default normalizePathSeparatorsToSystem;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/lib/RootPathUtils.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/RootPathUtils.js
 declare module 'metro-file-map/src/lib/RootPathUtils' {
   export class RootPathUtils {
     constructor(rootDir: string);
@@ -830,7 +813,7 @@ declare module 'metro-file-map/src/lib/RootPathUtils' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/lib/rootRelativeCacheKeys.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/rootRelativeCacheKeys.js
 declare module 'metro-file-map/src/lib/rootRelativeCacheKeys' {
   import type { BuildParameters } from 'metro-file-map/src/flow-types';
   function rootRelativeCacheKeys(buildParameters: BuildParameters): {
@@ -840,7 +823,7 @@ declare module 'metro-file-map/src/lib/rootRelativeCacheKeys' {
   export default rootRelativeCacheKeys;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/lib/sorting.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/sorting.js
 declare module 'metro-file-map/src/lib/sorting' {
   export function compareStrings(a: null | string, b: null | string): number;
   export function chainComparators<T>(
@@ -848,7 +831,7 @@ declare module 'metro-file-map/src/lib/sorting' {
   ): (a: T, b: T) => number;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/lib/TreeFS.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/TreeFS.js
 declare module 'metro-file-map/src/lib/TreeFS' {
   import type {
     FileData,
@@ -1015,7 +998,7 @@ declare module 'metro-file-map/src/lib/TreeFS' {
   export default TreeFS;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/plugins/haste/computeConflicts.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/plugins/haste/computeConflicts.js
 declare module 'metro-file-map/src/plugins/haste/computeConflicts' {
   import type { HasteMapItem } from 'metro-file-map/src/flow-types';
   type Conflict = {
@@ -1033,7 +1016,7 @@ declare module 'metro-file-map/src/plugins/haste/computeConflicts' {
   ): Conflict[];
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/plugins/haste/DuplicateHasteCandidatesError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/plugins/haste/DuplicateHasteCandidatesError.js
 declare module 'metro-file-map/src/plugins/haste/DuplicateHasteCandidatesError' {
   import type { DuplicatesSet } from 'metro-file-map/src/flow-types';
   export class DuplicateHasteCandidatesError extends Error {
@@ -1050,7 +1033,7 @@ declare module 'metro-file-map/src/plugins/haste/DuplicateHasteCandidatesError' 
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/plugins/haste/getPlatformExtension.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/plugins/haste/getPlatformExtension.js
 declare module 'metro-file-map/src/plugins/haste/getPlatformExtension' {
   function getPlatformExtension(
     file: string,
@@ -1059,7 +1042,7 @@ declare module 'metro-file-map/src/plugins/haste/getPlatformExtension' {
   export default getPlatformExtension;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/plugins/haste/HasteConflictsError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/plugins/haste/HasteConflictsError.js
 declare module 'metro-file-map/src/plugins/haste/HasteConflictsError' {
   import type { HasteConflict } from 'metro-file-map/src/flow-types';
   export class HasteConflictsError extends Error {
@@ -1068,7 +1051,7 @@ declare module 'metro-file-map/src/plugins/haste/HasteConflictsError' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/plugins/HastePlugin.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/plugins/HastePlugin.js
 declare module 'metro-file-map/src/plugins/HastePlugin' {
   import type {
     Console,
@@ -1130,7 +1113,7 @@ declare module 'metro-file-map/src/plugins/HastePlugin' {
   export default HastePlugin;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/plugins/MockPlugin.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/plugins/MockPlugin.js
 declare module 'metro-file-map/src/plugins/MockPlugin' {
   import type {
     FileMapDelta,
@@ -1161,13 +1144,13 @@ declare module 'metro-file-map/src/plugins/MockPlugin' {
   export default MockPlugin;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/plugins/mocks/getMockName.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/plugins/mocks/getMockName.js
 declare module 'metro-file-map/src/plugins/mocks/getMockName' {
   const getMockName: (filePath: string) => string;
   export default getMockName;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/Watcher.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/Watcher.js
 declare module 'metro-file-map/src/Watcher' {
   import type {
     Console,
@@ -1238,7 +1221,7 @@ declare module 'metro-file-map/src/Watcher' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/watchers/AbstractWatcher.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/watchers/AbstractWatcher.js
 declare module 'metro-file-map/src/watchers/AbstractWatcher' {
   import type { WatcherBackend, WatcherBackendChangeEvent } from 'metro-file-map/src/flow-types';
   export type Listeners = Readonly<{
@@ -1269,7 +1252,7 @@ declare module 'metro-file-map/src/watchers/AbstractWatcher' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/watchers/common.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/watchers/common.js
 declare module 'metro-file-map/src/watchers/common' {
   import type { ChangeEventMetadata } from 'metro-file-map/src/flow-types';
   import type { Stats } from 'fs';
@@ -1310,13 +1293,13 @@ declare module 'metro-file-map/src/watchers/common' {
   export function typeFromStat(stat: Stats): null | undefined | ChangeEventMetadata['type'];
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/watchers/FallbackWatcher.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/watchers/FallbackWatcher.js
 declare module 'metro-file-map/src/watchers/FallbackWatcher' {
   const $$EXPORT_DEFAULT_DECLARATION$$: any;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/watchers/NativeWatcher.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/watchers/NativeWatcher.js
 declare module 'metro-file-map/src/watchers/NativeWatcher' {
   import { AbstractWatcher } from 'metro-file-map/src/watchers/AbstractWatcher';
   /**
@@ -1356,7 +1339,7 @@ declare module 'metro-file-map/src/watchers/NativeWatcher' {
   export default NativeWatcher;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/watchers/RecrawlWarning.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/watchers/RecrawlWarning.js
 declare module 'metro-file-map/src/watchers/RecrawlWarning' {
   class RecrawlWarning {
     static RECRAWL_WARNINGS: RecrawlWarning[];
@@ -1370,7 +1353,7 @@ declare module 'metro-file-map/src/watchers/RecrawlWarning' {
   export default RecrawlWarning;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/watchers/WatchmanWatcher.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/watchers/WatchmanWatcher.js
 declare module 'metro-file-map/src/watchers/WatchmanWatcher' {
   import type { WatcherOptions } from 'metro-file-map/src/watchers/common';
   import type { Client, WatchmanFileChange, WatchmanSubscriptionEvent } from 'fb-watchman';
@@ -1403,12 +1386,12 @@ declare module 'metro-file-map/src/watchers/WatchmanWatcher' {
   export default WatchmanWatcher;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/worker.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/worker.js
 declare module 'metro-file-map/src/worker' {
   export function worker(data: any): void;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-file-map/src/workerExclusionList.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/workerExclusionList.js
 declare module 'metro-file-map/src/workerExclusionList' {
   const extensions: any;
   export default extensions;

--- a/packages/@expo/cli/ts-declarations/metro-resolver/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-resolver/index.d.ts
@@ -3,7 +3,7 @@ declare module 'metro-resolver' {
   export * from 'metro-resolver/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/createDefaultContext.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/createDefaultContext.js
 declare module 'metro-resolver/src/createDefaultContext' {
   import type { ResolutionContext } from 'metro-resolver/src/types';
   import type { TransformResultDependency } from 'metro/src/DeltaBundler/types.flow';
@@ -24,7 +24,7 @@ declare module 'metro-resolver/src/createDefaultContext' {
   export default createDefaultContext;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/errors/FailedToResolveNameError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/FailedToResolveNameError.js
 declare module 'metro-resolver/src/errors/FailedToResolveNameError' {
   class FailedToResolveNameError extends Error {
     dirPaths: readonly string[];
@@ -34,7 +34,7 @@ declare module 'metro-resolver/src/errors/FailedToResolveNameError' {
   export default FailedToResolveNameError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/errors/FailedToResolvePathError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/FailedToResolvePathError.js
 declare module 'metro-resolver/src/errors/FailedToResolvePathError' {
   import type { FileAndDirCandidates } from 'metro-resolver/src/types';
   class FailedToResolvePathError extends Error {
@@ -44,7 +44,7 @@ declare module 'metro-resolver/src/errors/FailedToResolvePathError' {
   export default FailedToResolvePathError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/errors/FailedToResolveUnsupportedError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/FailedToResolveUnsupportedError.js
 declare module 'metro-resolver/src/errors/FailedToResolveUnsupportedError' {
   class FailedToResolveUnsupportedError extends Error {
     constructor(message: string);
@@ -52,14 +52,14 @@ declare module 'metro-resolver/src/errors/FailedToResolveUnsupportedError' {
   export default FailedToResolveUnsupportedError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/errors/formatFileCandidates.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/formatFileCandidates.js
 declare module 'metro-resolver/src/errors/formatFileCandidates' {
   import type { FileCandidates } from 'metro-resolver/src/types';
   function formatFileCandidates(candidates: FileCandidates): string;
   export default formatFileCandidates;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/errors/InvalidPackageConfigurationError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/InvalidPackageConfigurationError.js
 declare module 'metro-resolver/src/errors/InvalidPackageConfigurationError' {
   /**
    * Raised when a package contains an invalid `package.json` configuration.
@@ -77,7 +77,7 @@ declare module 'metro-resolver/src/errors/InvalidPackageConfigurationError' {
   export default InvalidPackageConfigurationError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/errors/InvalidPackageError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/InvalidPackageError.js
 declare module 'metro-resolver/src/errors/InvalidPackageError' {
   import type { FileCandidates } from 'metro-resolver/src/types';
   class InvalidPackageError extends Error {
@@ -95,7 +95,7 @@ declare module 'metro-resolver/src/errors/InvalidPackageError' {
   export default InvalidPackageError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/errors/PackageImportNotResolvedError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/PackageImportNotResolvedError.js
 declare module 'metro-resolver/src/errors/PackageImportNotResolvedError' {
   /**
    * Raised when package imports do not define or permit a target subpath in the
@@ -114,7 +114,7 @@ declare module 'metro-resolver/src/errors/PackageImportNotResolvedError' {
   export default PackageImportNotResolvedError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/errors/PackagePathNotExportedError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/PackagePathNotExportedError.js
 declare module 'metro-resolver/src/errors/PackagePathNotExportedError' {
   /**
    * Raised when package exports do not define or permit a target subpath in the
@@ -124,9 +124,9 @@ declare module 'metro-resolver/src/errors/PackagePathNotExportedError' {
   export default PackagePathNotExportedError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/index.js
 declare module 'metro-resolver/src/index' {
-  // See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/index.js
+  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/index.js
 
   export type {
     AssetFileResolution,
@@ -147,12 +147,13 @@ declare module 'metro-resolver/src/index' {
   // NOTE(cedric): the flow translation API can't resolve types when using inline requires in object properties
   export { default as FailedToResolveNameError } from 'metro-resolver/src/errors/FailedToResolveNameError';
   export { default as FailedToResolvePathError } from 'metro-resolver/src/errors/FailedToResolvePathError';
+  export { default as FailedToResolveUnsupportedError } from 'metro-resolver/src/errors/FailedToResolveUnsupportedError';
   export { default as formatFileCandidates } from 'metro-resolver/src/errors/formatFileCandidates';
   export { default as InvalidPackageError } from 'metro-resolver/src/errors/InvalidPackageError';
   export { default as resolve } from 'metro-resolver/src/resolve';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/PackageExportsResolve.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/PackageExportsResolve.js
 declare module 'metro-resolver/src/PackageExportsResolve' {
   import type { ExportsField, FileResolution, ResolutionContext } from 'metro-resolver/src/types';
   export function resolvePackageTargetFromExports(
@@ -165,7 +166,7 @@ declare module 'metro-resolver/src/PackageExportsResolve' {
   ): FileResolution;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/PackageImportsResolve.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/PackageImportsResolve.js
 declare module 'metro-resolver/src/PackageImportsResolve' {
   import type { ExportsLikeMap, FileResolution, ResolutionContext } from 'metro-resolver/src/types';
   /**
@@ -188,7 +189,7 @@ declare module 'metro-resolver/src/PackageImportsResolve' {
   ): FileResolution;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/PackageResolve.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/PackageResolve.js
 declare module 'metro-resolver/src/PackageResolve' {
   import type { PackageInfo, ResolutionContext } from 'metro-resolver/src/types';
   /**
@@ -222,7 +223,7 @@ declare module 'metro-resolver/src/PackageResolve' {
   ): string | false;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/resolve.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/resolve.js
 declare module 'metro-resolver/src/resolve' {
   import type { Resolution, ResolutionContext } from 'metro-resolver/src/types';
   function resolve(
@@ -233,7 +234,7 @@ declare module 'metro-resolver/src/resolve' {
   export default resolve;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/resolveAsset.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/resolveAsset.js
 declare module 'metro-resolver/src/resolveAsset' {
   import type { AssetResolution, ResolutionContext } from 'metro-resolver/src/types';
   /**
@@ -245,7 +246,7 @@ declare module 'metro-resolver/src/resolveAsset' {
   export default resolveAsset;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/types.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/types.js
 declare module 'metro-resolver/src/types' {
   import type { TransformResultDependency } from 'metro/src/DeltaBundler/types.flow';
   export type Result<TResolution, TCandidates> =
@@ -454,7 +455,7 @@ declare module 'metro-resolver/src/types' {
   };
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/utils/isAssetFile.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/utils/isAssetFile.js
 declare module 'metro-resolver/src/utils/isAssetFile' {
   /**
    * Determine if a file path should be considered an asset file based on the
@@ -464,7 +465,7 @@ declare module 'metro-resolver/src/utils/isAssetFile' {
   export default isAssetFile;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/utils/isSubpathDefinedInExportsLike.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/utils/isSubpathDefinedInExportsLike.js
 declare module 'metro-resolver/src/utils/isSubpathDefinedInExportsLike' {
   /**
    * Identifies whether the given subpath is defined in the given "exports"-like
@@ -478,7 +479,7 @@ declare module 'metro-resolver/src/utils/isSubpathDefinedInExportsLike' {
   ): boolean;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/utils/matchSubpathFromExportsLike.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/utils/matchSubpathFromExportsLike.js
 declare module 'metro-resolver/src/utils/matchSubpathFromExportsLike' {
   import type { NormalizedExportsLikeMap, ResolutionContext } from 'metro-resolver/src/types';
   /**
@@ -499,7 +500,7 @@ declare module 'metro-resolver/src/utils/matchSubpathFromExportsLike' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/utils/matchSubpathPattern.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/utils/matchSubpathPattern.js
 declare module 'metro-resolver/src/utils/matchSubpathPattern' {
   /**
    * If a subpath pattern expands to the passed subpath, return the subpath match
@@ -510,7 +511,7 @@ declare module 'metro-resolver/src/utils/matchSubpathPattern' {
   export function matchSubpathPattern(subpathPattern: string, subpath: string): string | null;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/utils/reduceExportsLikeMap.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/utils/reduceExportsLikeMap.js
 declare module 'metro-resolver/src/utils/reduceExportsLikeMap' {
   /**
    * Reduce an "exports"-like mapping to a flat subpath mapping after resolving
@@ -524,7 +525,7 @@ declare module 'metro-resolver/src/utils/reduceExportsLikeMap' {
   ): FlattenedExportMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-resolver/src/utils/toPosixPath.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/utils/toPosixPath.js
 declare module 'metro-resolver/src/utils/toPosixPath' {
   /**
    * Replace path separators in the passed string to coerce to a POSIX path. This

--- a/packages/@expo/cli/ts-declarations/metro-runtime/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-runtime/index.d.ts
@@ -1,7 +1,7 @@
 // #region metro-runtime
 // metro-runtime has no entrypoint
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-runtime/src/modules/asyncRequire.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/modules/asyncRequire.js
 declare module 'metro-runtime/src/modules/asyncRequire' {
   type DependencyMapPaths =
     | null
@@ -17,12 +17,12 @@ declare module 'metro-runtime/src/modules/asyncRequire' {
   export default asyncRequire;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-runtime/src/modules/empty-module.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/modules/empty-module.js
 declare module 'metro-runtime/src/modules/empty-module' {
   // This has no exports
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-runtime/src/modules/HMRClient.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/modules/HMRClient.js
 declare module 'metro-runtime/src/modules/HMRClient' {
   import type { HmrUpdate } from 'metro-runtime/src/modules/types.flow';
   import EventEmitter from 'metro-runtime/src/modules/vendor/eventemitter3';
@@ -45,18 +45,13 @@ declare module 'metro-runtime/src/modules/HMRClient' {
   export default HMRClient;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-runtime/src/modules/null-module.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/modules/null-module.js
 declare module 'metro-runtime/src/modules/null-module' {
   const $$EXPORT_DEFAULT_DECLARATION$$: null;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// NOTE(cedric): this is a manual change, to avoid having to import `../types.flow`
-declare module 'metro-runtime/src/modules/types' {
-  export * from 'metro-runtime/src/modules/types.flow';
-}
-
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-runtime/src/modules/types.flow.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/modules/types.flow.js
 declare module 'metro-runtime/src/modules/types.flow' {
   export type ModuleMap = readonly [number, string][];
   export type Bundle = {
@@ -149,8 +144,10 @@ declare module 'metro-runtime/src/modules/types.flow' {
     | HmrErrorMessage;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-runtime/src/modules/vendor/eventemitter3.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/modules/vendor/eventemitter3.js
 declare module 'metro-runtime/src/modules/vendor/eventemitter3' {
+  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/modules/vendor/eventemitter3.js
+
   /**
    * `object` should be in either of the following forms:
    * ```
@@ -234,7 +231,7 @@ declare module 'metro-runtime/src/modules/vendor/eventemitter3' {
   export default EventEmitter;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-runtime/src/polyfills/require.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/polyfills/require.js
 declare module 'metro-runtime/src/polyfills/require' {
   type ArrayIndexable<T> = {
     readonly [indexer: number]: T;

--- a/packages/@expo/cli/ts-declarations/metro-source-map/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-source-map/index.d.ts
@@ -3,7 +3,7 @@ declare module 'metro-source-map' {
   export * from 'metro-source-map/src/source-map';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/B64Builder.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/B64Builder.js
 declare module 'metro-source-map/src/B64Builder' {
   /**
    * Efficient builder for base64 VLQ mappings strings.
@@ -32,7 +32,7 @@ declare module 'metro-source-map/src/B64Builder' {
   export default B64Builder;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/BundleBuilder.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/BundleBuilder.js
 declare module 'metro-source-map/src/BundleBuilder' {
   import type { IndexMap, IndexMapSection, MixedSourceMap } from 'metro-source-map/src/source-map';
   export class BundleBuilder {
@@ -52,14 +52,14 @@ declare module 'metro-source-map/src/BundleBuilder' {
   export function createIndexMap(file: string, sections: IndexMapSection[]): IndexMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/composeSourceMaps.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/composeSourceMaps.js
 declare module 'metro-source-map/src/composeSourceMaps' {
   import type { MixedSourceMap } from 'metro-source-map/src/source-map';
   function composeSourceMaps(maps: readonly MixedSourceMap[]): MixedSourceMap;
   export default composeSourceMaps;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/Consumer/AbstractConsumer.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/AbstractConsumer.js
 declare module 'metro-source-map/src/Consumer/AbstractConsumer' {
   import type {
     GeneratedPositionLookup,
@@ -82,12 +82,9 @@ declare module 'metro-source-map/src/Consumer/AbstractConsumer' {
   export default AbstractConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/Consumer/constants.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/constants.js
 declare module 'metro-source-map/src/Consumer/constants' {
-  // import type { Number0, Number1 } from 'ob1';
-  // NOTE(cedric): ob1 is not typed
-  type Number0 = number;
-  type Number1 = number;
+  import type { Number0, Number1 } from 'ob1';
   export type IterationOrder = unknown;
   export type LookupBias = unknown;
   export const FIRST_COLUMN: Number0;
@@ -101,7 +98,7 @@ declare module 'metro-source-map/src/Consumer/constants' {
   export function lookupBiasToString(x: LookupBias): string;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/Consumer/createConsumer.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/createConsumer.js
 declare module 'metro-source-map/src/Consumer/createConsumer' {
   import type { MixedSourceMap } from 'metro-source-map/src/source-map';
   import type { IConsumer } from 'metro-source-map/src/Consumer/types.flow';
@@ -109,7 +106,7 @@ declare module 'metro-source-map/src/Consumer/createConsumer' {
   export default createConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/Consumer/DelegatingConsumer.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/DelegatingConsumer.js
 declare module 'metro-source-map/src/Consumer/DelegatingConsumer' {
   import type { MixedSourceMap } from 'metro-source-map/src/source-map';
   import type { LookupBias } from 'metro-source-map/src/Consumer/constants';
@@ -141,12 +138,12 @@ declare module 'metro-source-map/src/Consumer/DelegatingConsumer' {
   export default DelegatingConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/Consumer/index.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/index.js
 declare module 'metro-source-map/src/Consumer/index' {
   export { default as DelegatingConsumer } from 'metro-source-map/src/Consumer/DelegatingConsumer';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/Consumer/MappingsConsumer.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/MappingsConsumer.js
 declare module 'metro-source-map/src/Consumer/MappingsConsumer' {
   import type { BasicSourceMap } from 'metro-source-map/src/source-map';
   import type {
@@ -179,7 +176,7 @@ declare module 'metro-source-map/src/Consumer/MappingsConsumer' {
   export default MappingsConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/Consumer/normalizeSourcePath.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/normalizeSourcePath.js
 declare module 'metro-source-map/src/Consumer/normalizeSourcePath' {
   function normalizeSourcePath(
     sourceInput: string,
@@ -190,7 +187,7 @@ declare module 'metro-source-map/src/Consumer/normalizeSourcePath' {
   export default normalizeSourcePath;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/Consumer/positionMath.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/positionMath.js
 declare module 'metro-source-map/src/Consumer/positionMath' {
   import type { GeneratedOffset } from 'metro-source-map/src/Consumer/types.flow';
   // import type { Number0, Number1 } from 'ob1';
@@ -211,7 +208,7 @@ declare module 'metro-source-map/src/Consumer/positionMath' {
   >(pos: T, offset: GeneratedOffset): T;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/Consumer/search.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/search.js
 declare module 'metro-source-map/src/Consumer/search' {
   export function greatestLowerBound<T, U>(
     elements: readonly T[],
@@ -220,7 +217,7 @@ declare module 'metro-source-map/src/Consumer/search' {
   ): null | undefined | number;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/Consumer/SectionsConsumer.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/SectionsConsumer.js
 declare module 'metro-source-map/src/Consumer/SectionsConsumer' {
   import type { IndexMap } from 'metro-source-map/src/source-map';
   import type {
@@ -248,7 +245,7 @@ declare module 'metro-source-map/src/Consumer/SectionsConsumer' {
   export default SectionsConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/Consumer/types.flow.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/types.flow.js
 declare module 'metro-source-map/src/Consumer/types.flow' {
   import type { IterationOrder, LookupBias } from 'metro-source-map/src/Consumer/constants';
   // import type { Number0, Number1 } from 'ob1';
@@ -292,7 +289,7 @@ declare module 'metro-source-map/src/Consumer/types.flow' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/encode.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/encode.js
 declare module 'metro-source-map/src/encode' {
   /**
    * Encodes a number to base64 VLQ format and appends it to the passed-in buffer
@@ -307,7 +304,7 @@ declare module 'metro-source-map/src/encode' {
   export default encode;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/generateFunctionMap.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/generateFunctionMap.js
 declare module 'metro-source-map/src/generateFunctionMap' {
   import type * as _babel_types from '@babel/types';
   import type { FBSourceFunctionMap } from 'metro-source-map/src/source-map';
@@ -334,7 +331,7 @@ declare module 'metro-source-map/src/generateFunctionMap' {
   ): readonly RangeMapping[];
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/Generator.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Generator.js
 declare module 'metro-source-map/src/Generator' {
   import type {
     BasicSourceMap,
@@ -418,7 +415,7 @@ declare module 'metro-source-map/src/Generator' {
   export default Generator;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-source-map/src/source-map.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/source-map.js
 declare module 'metro-source-map/src/source-map' {
   import type { IConsumer } from 'metro-source-map/src/Consumer/types.flow';
   import Generator from 'metro-source-map/src/Generator';

--- a/packages/@expo/cli/ts-declarations/metro-transform-plugins/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-transform-plugins/index.d.ts
@@ -3,7 +3,7 @@ declare module 'metro-transform-plugins' {
   export * from 'metro-transform-plugins/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-transform-plugins/src/addParamsToDefineCall.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/addParamsToDefineCall.js
 declare module 'metro-transform-plugins/src/addParamsToDefineCall' {
   /**
    * Simple way of adding additional parameters to the end of the define calls.
@@ -15,7 +15,7 @@ declare module 'metro-transform-plugins/src/addParamsToDefineCall' {
   export default addParamsToDefineCall;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-transform-plugins/src/constant-folding-plugin.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/constant-folding-plugin.js
 declare module 'metro-transform-plugins/src/constant-folding-plugin' {
   import type { PluginObj } from '@babel/core';
   import type $$IMPORT_TYPEOF_1$$ from '@babel/traverse';
@@ -29,7 +29,7 @@ declare module 'metro-transform-plugins/src/constant-folding-plugin' {
   export default constantFoldingPlugin;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-transform-plugins/src/import-export-plugin.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/import-export-plugin.js
 declare module 'metro-transform-plugins/src/import-export-plugin' {
   import type * as _babel_types from '@babel/types';
   import type { PluginObj } from '@babel/core';
@@ -67,9 +67,9 @@ declare module 'metro-transform-plugins/src/import-export-plugin' {
   export default importExportPlugin;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-transform-plugins/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/index.js
 declare module 'metro-transform-plugins/src/index' {
-  // See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-transform-plugins/src/index.js
+  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/index.js
 
   // NOTE(cedric): this is quite a complicated CJS export, this can't be automatically typed
 
@@ -86,7 +86,7 @@ declare module 'metro-transform-plugins/src/index' {
   export function getTransformPluginCacheKeyFiles(): string[];
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-transform-plugins/src/inline-plugin.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/inline-plugin.js
 declare module 'metro-transform-plugins/src/inline-plugin' {
   import type { PluginObj } from '@babel/core';
   import type * as $$IMPORT_TYPEOF_1$$ from '@babel/types';
@@ -110,7 +110,7 @@ declare module 'metro-transform-plugins/src/inline-plugin' {
   export default inlinePlugin;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-transform-plugins/src/inline-requires-plugin.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/inline-requires-plugin.js
 declare module 'metro-transform-plugins/src/inline-requires-plugin' {
   import type * as _babel_core from '@babel/core';
   type Babel = typeof _babel_core;
@@ -130,7 +130,7 @@ declare module 'metro-transform-plugins/src/inline-requires-plugin' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-transform-plugins/src/normalizePseudoGlobals.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/normalizePseudoGlobals.js
 declare module 'metro-transform-plugins/src/normalizePseudoGlobals' {
   import type * as _babel_types from '@babel/types';
   export type Options = {
@@ -140,7 +140,7 @@ declare module 'metro-transform-plugins/src/normalizePseudoGlobals' {
   export default normalizePseudoglobals;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-transform-plugins/src/utils/createInlinePlatformChecks.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/utils/createInlinePlatformChecks.js
 declare module 'metro-transform-plugins/src/utils/createInlinePlatformChecks' {
   import type { Scope } from '@babel/traverse';
   import type * as _babel_types from '@babel/types';

--- a/packages/@expo/cli/ts-declarations/metro-transform-worker/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-transform-worker/index.d.ts
@@ -3,7 +3,7 @@ declare module 'metro-transform-worker' {
   export * from 'metro-transform-worker/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-transform-worker/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-worker/src/index.js
 declare module 'metro-transform-worker/src/index' {
   // NOTE(cedric): this is a manual change exporting this existing Flow type for reuse in Expo
   import type * as _babel_types from '@babel/types';
@@ -121,7 +121,7 @@ declare module 'metro-transform-worker/src/index' {
   export { default as getCacheKey } from 'metro-cache-key';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-transform-worker/src/utils/assetTransformer.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-worker/src/utils/assetTransformer.js
 declare module 'metro-transform-worker/src/utils/assetTransformer' {
   import type { File } from '@babel/types';
   import type { BabelTransformerArgs } from 'metro-babel-transformer';
@@ -134,7 +134,7 @@ declare module 'metro-transform-worker/src/utils/assetTransformer' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro-transform-worker/src/utils/getMinifier.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-worker/src/utils/getMinifier.js
 declare module 'metro-transform-worker/src/utils/getMinifier' {
   import type { Minifier } from 'metro-transform-worker/src/index';
   function getMinifier(minifierPath: string): Minifier;

--- a/packages/@expo/cli/ts-declarations/metro/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro/index.d.ts
@@ -4,7 +4,7 @@ declare module 'metro' {
   export { default } from 'metro/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/Assets.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/Assets.js
 declare module 'metro/src/Assets' {
   export type AssetInfo = {
     readonly files: string[];
@@ -70,7 +70,7 @@ declare module 'metro/src/Assets' {
   export function isAssetTypeAnImage(type: string): boolean;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/Bundler.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/Bundler.js
 declare module 'metro/src/Bundler' {
   import type { TransformResultWithSource } from 'metro/src/DeltaBundler';
   import type { TransformOptions } from 'metro/src/DeltaBundler/Worker';
@@ -100,7 +100,7 @@ declare module 'metro/src/Bundler' {
   export default Bundler;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/Bundler/util.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/Bundler/util.js
 declare module 'metro/src/Bundler/util' {
   import type { AssetDataWithoutFiles } from 'metro/src/Assets';
   import type { ModuleTransportLike } from 'metro/src/shared/types.flow';
@@ -120,18 +120,18 @@ declare module 'metro/src/Bundler/util' {
   ): File;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/cli-utils.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/cli-utils.js
 declare module 'metro/src/cli-utils' {
   export const watchFile: (filename: string, callback: () => any) => Promise<void>;
   export const makeAsyncCommand: <T>(command: (argv: T) => Promise<void>) => (argv: T) => void;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/cli.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/cli.js
 declare module 'metro/src/cli' {
   // This has no exports
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/cli/parseKeyValueParamArray.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/cli/parseKeyValueParamArray.js
 declare module 'metro/src/cli/parseKeyValueParamArray' {
   function coerceKeyValueArray(keyValueArray: readonly string[]): {
     [key: string]: string;
@@ -139,7 +139,7 @@ declare module 'metro/src/cli/parseKeyValueParamArray' {
   export default coerceKeyValueArray;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/commands/build.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/commands/build.js
 // NOTE(cedric): yargs is custom-typed in metro
 // declare module 'metro/src/commands/build' {
 //   import type { ModuleObject } from 'yargs';
@@ -154,7 +154,7 @@ declare module 'metro/src/cli/parseKeyValueParamArray' {
 //   export default $$EXPORT_DEFAULT_DECLARATION$$;
 // }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/commands/dependencies.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/commands/dependencies.js
 // NOTE(cedric): yargs is custom-typed in metro
 // declare module 'metro/src/commands/dependencies' {
 //   import type { ModuleObject } from 'yargs';
@@ -169,7 +169,7 @@ declare module 'metro/src/cli/parseKeyValueParamArray' {
 //   export default $$EXPORT_DEFAULT_DECLARATION$$;
 // }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/commands/serve.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/commands/serve.js
 // NOTE(cedric): yargs is custom-typed in metro
 // declare module 'metro/src/commands/serve' {
 //   import type { ModuleObject } from 'yargs';
@@ -184,7 +184,7 @@ declare module 'metro/src/cli/parseKeyValueParamArray' {
 //   export default $$EXPORT_DEFAULT_DECLARATION$$;
 // }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler.js
 declare module 'metro/src/DeltaBundler' {
   import type {
     DeltaResult,
@@ -236,7 +236,7 @@ declare module 'metro/src/DeltaBundler' {
   export default DeltaBundler;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/buildSubgraph.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/buildSubgraph.js
 declare module 'metro/src/DeltaBundler/buildSubgraph' {
   import type { RequireContext } from 'metro/src/lib/contextModule';
   import type {
@@ -260,7 +260,7 @@ declare module 'metro/src/DeltaBundler/buildSubgraph' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/DeltaCalculator.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/DeltaCalculator.js
 declare module 'metro/src/DeltaBundler/DeltaCalculator' {
   import type { DeltaResult, Options } from 'metro/src/DeltaBundler/types.flow';
   import { Graph } from 'metro/src/DeltaBundler/Graph';
@@ -299,7 +299,7 @@ declare module 'metro/src/DeltaBundler/DeltaCalculator' {
   export default DeltaCalculator;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/getTransformCacheKey.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/getTransformCacheKey.js
 declare module 'metro/src/DeltaBundler/getTransformCacheKey' {
   import type { TransformerConfig } from 'metro/src/DeltaBundler/Worker';
   function getTransformCacheKey(opts: {
@@ -310,7 +310,7 @@ declare module 'metro/src/DeltaBundler/getTransformCacheKey' {
   export default getTransformCacheKey;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Graph.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Graph.js
 declare module 'metro/src/DeltaBundler/Graph' {
   /**
    * Portions of this code are based on the Synchronous Cycle Collection
@@ -434,14 +434,14 @@ declare module 'metro/src/DeltaBundler/Graph' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/mergeDeltas.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/mergeDeltas.js
 declare module 'metro/src/DeltaBundler/mergeDeltas' {
   import type { DeltaBundle } from 'metro-runtime/src/modules/types.flow';
   function mergeDeltas(delta1: DeltaBundle, delta2: DeltaBundle): DeltaBundle;
   export default mergeDeltas;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Serializers/baseJSBundle.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/baseJSBundle.js
 declare module 'metro/src/DeltaBundler/Serializers/baseJSBundle' {
   import type { Module, ReadOnlyGraph, SerializerOptions } from 'metro/src/DeltaBundler/types.flow';
   import type { Bundle } from 'metro-runtime/src/modules/types.flow';
@@ -454,7 +454,7 @@ declare module 'metro/src/DeltaBundler/Serializers/baseJSBundle' {
   export default baseJSBundle;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Serializers/getAllFiles.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/getAllFiles.js
 declare module 'metro/src/DeltaBundler/Serializers/getAllFiles' {
   import type { Module, ReadOnlyGraph } from 'metro/src/DeltaBundler/types.flow';
   type Options = {
@@ -469,7 +469,7 @@ declare module 'metro/src/DeltaBundler/Serializers/getAllFiles' {
   export default getAllFiles;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Serializers/getAssets.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/getAssets.js
 declare module 'metro/src/DeltaBundler/Serializers/getAssets' {
   import type { AssetData } from 'metro/src/Assets';
   import type { Module, ReadOnlyDependencies } from 'metro/src/DeltaBundler/types.flow';
@@ -487,7 +487,7 @@ declare module 'metro/src/DeltaBundler/Serializers/getAssets' {
   export default getAssets;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Serializers/getExplodedSourceMap.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/getExplodedSourceMap.js
 declare module 'metro/src/DeltaBundler/Serializers/getExplodedSourceMap' {
   import type { Module } from 'metro/src/DeltaBundler/types.flow';
   import type { FBSourceFunctionMap, MetroSourceMapSegmentTuple } from 'metro-source-map';
@@ -505,7 +505,7 @@ declare module 'metro/src/DeltaBundler/Serializers/getExplodedSourceMap' {
   ): ExplodedSourceMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Serializers/getRamBundleInfo.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/getRamBundleInfo.js
 declare module 'metro/src/DeltaBundler/Serializers/getRamBundleInfo' {
   import type { ModuleTransportLike } from 'metro/src/shared/types.flow';
   import type { Module, ReadOnlyGraph, SerializerOptions } from 'metro/src/DeltaBundler/types.flow';
@@ -533,13 +533,13 @@ declare module 'metro/src/DeltaBundler/Serializers/getRamBundleInfo' {
   export default getRamBundleInfo;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Serializers/helpers/getInlineSourceMappingURL.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/helpers/getInlineSourceMappingURL.js
 declare module 'metro/src/DeltaBundler/Serializers/helpers/getInlineSourceMappingURL' {
   function getInlineSourceMappingURL(sourceMap: string): string;
   export default getInlineSourceMappingURL;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Serializers/helpers/getSourceMapInfo.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/helpers/getSourceMapInfo.js
 declare module 'metro/src/DeltaBundler/Serializers/helpers/getSourceMapInfo' {
   import type { Module } from 'metro/src/DeltaBundler/types.flow';
   import type { FBSourceFunctionMap, MetroSourceMapSegmentTuple } from 'metro-source-map';
@@ -562,7 +562,7 @@ declare module 'metro/src/DeltaBundler/Serializers/helpers/getSourceMapInfo' {
   export default getSourceMapInfo;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Serializers/helpers/getTransitiveDependencies.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/helpers/getTransitiveDependencies.js
 declare module 'metro/src/DeltaBundler/Serializers/helpers/getTransitiveDependencies' {
   import type { ReadOnlyGraph } from 'metro/src/DeltaBundler/types.flow';
   function getTransitiveDependencies<T>(path: string, graph: ReadOnlyGraph<T>): Set<string>;
@@ -575,7 +575,7 @@ declare module 'metro/src/DeltaBundler/Serializers/helpers/js.js' {
   export * from 'metro/src/DeltaBundler/Serializers/helpers/js';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Serializers/helpers/js.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/helpers/js.js
 declare module 'metro/src/DeltaBundler/Serializers/helpers/js' {
   import type { MixedOutput, Module } from 'metro/src/DeltaBundler/types.flow';
   import type { JsOutput } from 'metro-transform-worker';
@@ -598,7 +598,7 @@ declare module 'metro/src/DeltaBundler/Serializers/helpers/js' {
   export function wrapModule(module: Module, options: Options): string;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Serializers/helpers/processModules.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/helpers/processModules.js
 declare module 'metro/src/DeltaBundler/Serializers/helpers/processModules' {
   import type { Module } from 'metro/src/DeltaBundler/types.flow';
   function processModules(
@@ -616,7 +616,7 @@ declare module 'metro/src/DeltaBundler/Serializers/helpers/processModules' {
   export default processModules;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Serializers/hmrJSBundle.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/hmrJSBundle.js
 declare module 'metro/src/DeltaBundler/Serializers/hmrJSBundle' {
   import type { EntryPointURL } from 'metro/src/HmrServer';
   import type { DeltaResult, ReadOnlyGraph } from 'metro/src/DeltaBundler/types.flow';
@@ -640,7 +640,7 @@ declare module 'metro/src/DeltaBundler/Serializers/hmrJSBundle' {
   export default hmrJSBundle;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Serializers/sourceMapGenerator.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/sourceMapGenerator.js
 declare module 'metro/src/DeltaBundler/Serializers/sourceMapGenerator' {
   import type { Module } from 'metro/src/DeltaBundler/types.flow';
   import { fromRawMappings, fromRawMappingsNonBlocking } from 'metro-source-map';
@@ -660,7 +660,7 @@ declare module 'metro/src/DeltaBundler/Serializers/sourceMapGenerator' {
   ): ReturnType<typeof fromRawMappingsNonBlocking>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Serializers/sourceMapObject.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/sourceMapObject.js
 declare module 'metro/src/DeltaBundler/Serializers/sourceMapObject' {
   import type { Module } from 'metro/src/DeltaBundler/types.flow';
   import type { SourceMapGeneratorOptions } from 'metro/src/DeltaBundler/Serializers/sourceMapGenerator';
@@ -675,7 +675,7 @@ declare module 'metro/src/DeltaBundler/Serializers/sourceMapObject' {
   ): Promise<MixedSourceMap>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Serializers/sourceMapString.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/sourceMapString.js
 declare module 'metro/src/DeltaBundler/Serializers/sourceMapString' {
   import type { Module } from 'metro/src/DeltaBundler/types.flow';
   import type { SourceMapGeneratorOptions } from 'metro/src/DeltaBundler/Serializers/sourceMapGenerator';
@@ -689,31 +689,28 @@ declare module 'metro/src/DeltaBundler/Serializers/sourceMapString' {
   ): Promise<string>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Transformer.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Transformer.js
 declare module 'metro/src/DeltaBundler/Transformer' {
   import type { TransformResult, TransformResultWithSource } from 'metro/src/DeltaBundler';
   import type { TransformOptions } from 'metro/src/DeltaBundler/Worker';
   import type { ConfigT } from 'metro-config/src/configTypes.flow';
   import WorkerFarm from 'metro/src/DeltaBundler/WorkerFarm';
   import { Cache } from 'metro-cache';
-  type LazySha1Fn = ($$PARAM_0$$: string) => Promise<{
+  type GetOrComputeSha1Fn = ($$PARAM_0$$: string) => Promise<{
     content?: Buffer;
     sha1: string;
   }>;
-  type EagerSha1Fn = ($$PARAM_0$$: string) => string;
   class Transformer {
     _config: ConfigT;
     _cache: Cache<TransformResult>;
     _baseHash: string;
-    _getSha1: EagerSha1Fn | LazySha1Fn;
+    _getSha1: GetOrComputeSha1Fn;
     _workerFarm: WorkerFarm;
     constructor(
       config: ConfigT,
-      getSha1FnOrOpts:
-        | Readonly<{
-            unstable_getOrComputeSha1: LazySha1Fn;
-          }>
-        | EagerSha1Fn
+      opts: Readonly<{
+        getOrComputeSha1: GetOrComputeSha1Fn;
+      }>
     );
     transformFile(
       filePath: string,
@@ -730,7 +727,7 @@ declare module 'metro/src/DeltaBundler/types' {
   export * from 'metro/src/DeltaBundler/types.flow';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/types.flow.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/types.flow.js
 declare module 'metro/src/DeltaBundler/types.flow' {
   import type * as _babel_types from '@babel/types';
   import type { RequireContext } from 'metro/src/lib/contextModule';
@@ -880,16 +877,16 @@ declare module 'metro/src/DeltaBundler/types.flow' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Worker.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Worker.js
 declare module 'metro/src/DeltaBundler/Worker' {
-  // See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Worker.js
+  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Worker.js
 
   // NOTE(cedric): Metro uses this weird Flow syntax /*:: */ to override the exported types...
   export * from 'metro/src/DeltaBundler/Worker.flow';
   export { default } from 'metro/src/DeltaBundler/Worker.flow';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/Worker.flow.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Worker.flow.js
 declare module 'metro/src/DeltaBundler/Worker.flow' {
   import type { TransformResult } from 'metro/src/DeltaBundler/types.flow';
   import type { LogEntry } from 'metro-core/src/Logger';
@@ -919,7 +916,7 @@ declare module 'metro/src/DeltaBundler/Worker.flow' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/DeltaBundler/WorkerFarm.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/WorkerFarm.js
 declare module 'metro/src/DeltaBundler/WorkerFarm' {
   import type { TransformResult } from 'metro/src/DeltaBundler';
   import type { TransformerConfig, TransformOptions, Worker } from 'metro/src/DeltaBundler/Worker';
@@ -961,7 +958,7 @@ declare module 'metro/src/DeltaBundler/WorkerFarm' {
   export default WorkerFarm;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/HmrServer.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/HmrServer.js
 declare module 'metro/src/HmrServer' {
   import type { GraphOptions } from 'metro/src/shared/types.flow';
   import type { ConfigT, RootPerfLogger } from 'metro-config';
@@ -1042,7 +1039,7 @@ declare module 'metro/src/HmrServer' {
   export default HmrServer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/IncrementalBundler.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/IncrementalBundler.js
 declare module 'metro/src/IncrementalBundler' {
   import type { DeltaResult, Graph, Module } from 'metro/src/DeltaBundler';
   import type {
@@ -1130,7 +1127,7 @@ declare module 'metro/src/IncrementalBundler' {
   export default IncrementalBundler;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/IncrementalBundler/GraphNotFoundError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/IncrementalBundler/GraphNotFoundError.js
 declare module 'metro/src/IncrementalBundler/GraphNotFoundError' {
   import type { GraphId } from 'metro/src/lib/getGraphId';
   class GraphNotFoundError extends Error {
@@ -1140,7 +1137,7 @@ declare module 'metro/src/IncrementalBundler/GraphNotFoundError' {
   export default GraphNotFoundError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/IncrementalBundler/ResourceNotFoundError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/IncrementalBundler/ResourceNotFoundError.js
 declare module 'metro/src/IncrementalBundler/ResourceNotFoundError' {
   class ResourceNotFoundError extends Error {
     resourcePath: string;
@@ -1149,7 +1146,7 @@ declare module 'metro/src/IncrementalBundler/ResourceNotFoundError' {
   export default ResourceNotFoundError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/IncrementalBundler/RevisionNotFoundError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/IncrementalBundler/RevisionNotFoundError.js
 declare module 'metro/src/IncrementalBundler/RevisionNotFoundError' {
   import type { RevisionId } from 'metro/src/IncrementalBundler';
   class RevisionNotFoundError extends Error {
@@ -1159,9 +1156,9 @@ declare module 'metro/src/IncrementalBundler/RevisionNotFoundError' {
   export default RevisionNotFoundError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/index.js
 declare module 'metro/src/index' {
-  // See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/index.js
+  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/index.js
 
   // NOTE(cedric): Metro uses this weird Flow syntax /*:: */ to override the exported types...
   export * from 'metro/src/index.flow';
@@ -1190,7 +1187,7 @@ declare module 'metro/src/index' {
   export { default as Server } from 'metro/src/Server';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/index.flow.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/index.flow.js
 declare module 'metro/src/index.flow' {
   import type * as _ws from 'ws';
   import type { ReadOnlyGraph } from 'metro/src/DeltaBundler';
@@ -1316,7 +1313,7 @@ declare module 'metro/src/index.flow' {
   export const attachMetroCli: (yargs: Yargs, options?: AttachMetroCLIOptions) => Yargs;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/BatchProcessor.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/BatchProcessor.js
 declare module 'metro/src/lib/BatchProcessor' {
   type ProcessBatch<TItem, TResult> = (batch: TItem[]) => Promise<TResult[]>;
   type BatchProcessorOptions = {
@@ -1354,7 +1351,7 @@ declare module 'metro/src/lib/BatchProcessor' {
   export default BatchProcessor;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/bundleToString.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/bundleToString.js
 declare module 'metro/src/lib/bundleToString' {
   import type { Bundle, BundleMetadata } from 'metro-runtime/src/modules/types.flow';
   /**
@@ -1367,7 +1364,7 @@ declare module 'metro/src/lib/bundleToString' {
   export default bundleToString;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/contextModule.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/contextModule.js
 declare module 'metro/src/lib/contextModule' {
   import type {
     ContextMode,
@@ -1390,7 +1387,7 @@ declare module 'metro/src/lib/contextModule' {
   export function fileMatchesContext(testPath: string, context: RequireContext): boolean;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/contextModuleTemplates.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/contextModuleTemplates.js
 declare module 'metro/src/lib/contextModuleTemplates' {
   import type { ContextMode } from 'metro/src/ModuleGraph/worker/collectDependencies';
   /**
@@ -1409,9 +1406,9 @@ declare module 'metro/src/lib/contextModuleTemplates' {
   ): string;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/CountingSet.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/CountingSet.js
 declare module 'metro/src/lib/CountingSet' {
-  // See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/CountingSet.js
+  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/CountingSet.js
 
   export interface ReadOnlyCountingSet<T> extends Iterable<T> {
     get size(): number;
@@ -1458,19 +1455,19 @@ declare module 'metro/src/lib/CountingSet' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/countLines.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/countLines.js
 declare module 'metro/src/lib/countLines' {
   const countLines: (string: string) => number;
   export default countLines;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/createModuleIdFactory.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/createModuleIdFactory.js
 declare module 'metro/src/lib/createModuleIdFactory' {
   function createModuleIdFactory(): (path: string) => number;
   export default createModuleIdFactory;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/createWebsocketServer.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/createWebsocketServer.js
 declare module 'metro/src/lib/createWebsocketServer' {
   import ws from 'ws';
   type WebsocketServiceInterface<T> = {
@@ -1505,13 +1502,13 @@ declare module 'metro/src/lib/createWebsocketServer' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/debounceAsyncQueue.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/debounceAsyncQueue.js
 declare module 'metro/src/lib/debounceAsyncQueue' {
   function debounceAsyncQueue<T>(fn: () => Promise<T>, delay: number): () => Promise<T>;
   export default debounceAsyncQueue;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/formatBundlingError.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/formatBundlingError.js
 declare module 'metro/src/lib/formatBundlingError' {
   import type { FormattedError } from 'metro-runtime/src/modules/types.flow';
   export type CustomError = Error & {
@@ -1528,7 +1525,7 @@ declare module 'metro/src/lib/formatBundlingError' {
   export default formatBundlingError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/getAppendScripts.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/getAppendScripts.js
 declare module 'metro/src/lib/getAppendScripts' {
   import type { Module } from 'metro/src/DeltaBundler';
   type Options<T extends number | string> = Readonly<{
@@ -1551,7 +1548,7 @@ declare module 'metro/src/lib/getAppendScripts' {
   export default getAppendScripts;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/getGraphId.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/getGraphId.js
 declare module 'metro/src/lib/getGraphId' {
   import type { TransformInputOptions } from 'metro/src/DeltaBundler/types.flow';
   import type { ResolverInputOptions } from 'metro/src/shared/types.flow';
@@ -1569,13 +1566,13 @@ declare module 'metro/src/lib/getGraphId' {
   export default getGraphId;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/getMaxWorkers.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/getMaxWorkers.js
 declare module 'metro/src/lib/getMaxWorkers' {
   const $$EXPORT_DEFAULT_DECLARATION$$: (workers: null | undefined | number) => number;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/getPreludeCode.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/getPreludeCode.js
 declare module 'metro/src/lib/getPreludeCode' {
   function getPreludeCode($$PARAM_0$$: {
     readonly extraVars?: {
@@ -1588,7 +1585,7 @@ declare module 'metro/src/lib/getPreludeCode' {
   export default getPreludeCode;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/getPrependedScripts.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/getPrependedScripts.js
 declare module 'metro/src/lib/getPrependedScripts' {
   import type Bundler from 'metro/src/Bundler';
   import type { TransformInputOptions } from 'metro/src/DeltaBundler/types.flow';
@@ -1614,7 +1611,7 @@ declare module 'metro/src/lib/getPrependedScripts' {
   export default getPrependedScripts;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/JsonReporter.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/JsonReporter.js
 declare module 'metro/src/lib/JsonReporter' {
   import type { Writable } from 'stream';
   export type SerializedError = {
@@ -1640,7 +1637,7 @@ declare module 'metro/src/lib/JsonReporter' {
   export default JsonReporter;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/logToConsole.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/logToConsole.js
 declare module 'metro/src/lib/logToConsole' {
   import type { Terminal } from 'metro-core';
   const $$EXPORT_DEFAULT_DECLARATION$$: (
@@ -1652,7 +1649,7 @@ declare module 'metro/src/lib/logToConsole' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/parseCustomResolverOptions.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/parseCustomResolverOptions.js
 declare module 'metro/src/lib/parseCustomResolverOptions' {
   import type { CustomResolverOptions } from 'metro-resolver/src/types';
   const $$EXPORT_DEFAULT_DECLARATION$$: (urlObj: {
@@ -1663,7 +1660,7 @@ declare module 'metro/src/lib/parseCustomResolverOptions' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/parseCustomTransformOptions.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/parseCustomTransformOptions.js
 declare module 'metro/src/lib/parseCustomTransformOptions' {
   import type { CustomTransformOptions } from 'metro-transform-worker';
   const $$EXPORT_DEFAULT_DECLARATION$$: (urlObj: {
@@ -1674,7 +1671,7 @@ declare module 'metro/src/lib/parseCustomTransformOptions' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/parseOptionsFromUrl.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/parseOptionsFromUrl.js
 declare module 'metro/src/lib/parseOptionsFromUrl' {
   import type { BundleOptions } from 'metro/src/shared/types.flow';
   const $$EXPORT_DEFAULT_DECLARATION$$: (
@@ -1684,7 +1681,7 @@ declare module 'metro/src/lib/parseOptionsFromUrl' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/RamBundleParser.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/RamBundleParser.js
 declare module 'metro/src/lib/RamBundleParser' {
   /**
    * Implementation of a RAM bundle parser in JS.
@@ -1708,14 +1705,14 @@ declare module 'metro/src/lib/RamBundleParser' {
   export default RamBundleParser;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/relativizeSourceMap.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/relativizeSourceMap.js
 declare module 'metro/src/lib/relativizeSourceMap' {
   import type { MixedSourceMap } from 'metro-source-map';
   function relativizeSourceMapInline(sourceMap: MixedSourceMap, sourcesRoot: string): void;
   export default relativizeSourceMapInline;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/reporting.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/reporting.js
 declare module 'metro/src/lib/reporting' {
   import type { Terminal } from 'metro-core';
   import type { HealthCheckResult, WatcherStatus } from 'metro-file-map';
@@ -1897,7 +1894,7 @@ declare module 'metro/src/lib/reporting' {
   };
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/splitBundleOptions.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/splitBundleOptions.js
 declare module 'metro/src/lib/splitBundleOptions' {
   import type { BundleOptions, SplitBundleOptions } from 'metro/src/shared/types.flow';
   /**
@@ -1907,7 +1904,7 @@ declare module 'metro/src/lib/splitBundleOptions' {
   export default splitBundleOptions;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/TerminalReporter.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/TerminalReporter.js
 declare module 'metro/src/lib/TerminalReporter' {
   import type { BundleDetails, ReportableEvent } from 'metro/src/lib/reporting';
   import type { Terminal } from 'metro-core';
@@ -1989,7 +1986,7 @@ declare module 'metro/src/lib/TerminalReporter' {
   export default TerminalReporter;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/lib/transformHelpers.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/transformHelpers.js
 declare module 'metro/src/lib/transformHelpers' {
   import type Bundler from 'metro/src/Bundler';
   import type {
@@ -2016,7 +2013,7 @@ declare module 'metro/src/lib/transformHelpers' {
   ): Promise<(from: string, dependency: TransformResultDependency) => BundlerResolution>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/ModuleGraph/worker/collectDependencies.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/ModuleGraph/worker/collectDependencies.js
 declare module 'metro/src/ModuleGraph/worker/collectDependencies' {
   import type { NodePath } from '@babel/traverse';
   import type {
@@ -2118,7 +2115,7 @@ declare module 'metro/src/ModuleGraph/worker/collectDependencies' {
   export default collectDependencies;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/ModuleGraph/worker/generateImportNames.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/ModuleGraph/worker/generateImportNames.js
 declare module 'metro/src/ModuleGraph/worker/generateImportNames' {
   import type * as _babel_types from '@babel/types';
   /**
@@ -2132,16 +2129,16 @@ declare module 'metro/src/ModuleGraph/worker/generateImportNames' {
   export default generateImportNames;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/ModuleGraph/worker/importLocationsPlugin.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/ModuleGraph/worker/importLocationsPlugin.js
 declare module 'metro/src/ModuleGraph/worker/importLocationsPlugin' {
   import type * as _babel_types from '@babel/types';
   import type { PluginObj } from '@babel/core';
-  type Types = typeof $$IMPORT_TYPEOF_1$$;
+  type Types = typeof _babel_types;
   export function importLocationsPlugin($$PARAM_0$$: { types: Types }): PluginObj;
   export function locToKey(loc: _babel_types.SourceLocation): string;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/ModuleGraph/worker/JsFileWrapping.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/ModuleGraph/worker/JsFileWrapping.js
 declare module 'metro/src/ModuleGraph/worker/JsFileWrapping' {
   import type * as _babel_types from '@babel/types';
   export const WRAP_NAME: '$$_REQUIRE';
@@ -2161,7 +2158,7 @@ declare module 'metro/src/ModuleGraph/worker/JsFileWrapping' {
   export function wrapPolyfill(fileAst: _babel_types.File): _babel_types.File;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/node-haste/DependencyGraph.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/DependencyGraph.js
 declare module 'metro/src/node-haste/DependencyGraph' {
   import type {
     BundlerResolution,
@@ -2221,8 +2218,7 @@ declare module 'metro/src/node-haste/DependencyGraph' {
         };
     _createModuleCache(): ModuleCache;
     getAllFiles(): string[];
-    getSha1(filename: string): string;
-    unstable_getOrComputeSha1(mixedPath: string): Promise<{
+    getOrComputeSha1(mixedPath: string): Promise<{
       content?: Buffer;
       sha1: string;
     }>;
@@ -2251,7 +2247,7 @@ declare module 'metro/src/node-haste/DependencyGraph' {
   export default DependencyGraph;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/node-haste/DependencyGraph/createFileMap.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/DependencyGraph/createFileMap.js
 declare module 'metro/src/node-haste/DependencyGraph/createFileMap' {
   import type { ConfigT } from 'metro-config/src/configTypes.flow';
   import MetroFileMap from 'metro-file-map';
@@ -2267,7 +2263,7 @@ declare module 'metro/src/node-haste/DependencyGraph/createFileMap' {
   export default createFileMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
 declare module 'metro/src/node-haste/DependencyGraph/ModuleResolution' {
   import type {
     BundlerResolution,
@@ -2372,7 +2368,7 @@ declare module 'metro/src/node-haste/DependencyGraph/ModuleResolution' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/node-haste/lib/AssetPaths.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/lib/AssetPaths.js
 declare module 'metro/src/node-haste/lib/AssetPaths' {
   export type AssetPath = {
     assetName: string;
@@ -2392,7 +2388,7 @@ declare module 'metro/src/node-haste/lib/AssetPaths' {
   ): null | undefined | AssetPath;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/node-haste/lib/parsePlatformFilePath.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/lib/parsePlatformFilePath.js
 declare module 'metro/src/node-haste/lib/parsePlatformFilePath' {
   type PlatformFilePathParts = {
     dirPath: string;
@@ -2411,7 +2407,7 @@ declare module 'metro/src/node-haste/lib/parsePlatformFilePath' {
   export default parsePlatformFilePath;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/node-haste/Module.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/Module.js
 declare module 'metro/src/node-haste/Module' {
   import type ModuleCache from 'metro/src/node-haste/ModuleCache';
   import type Package from 'metro/src/node-haste/Package';
@@ -2426,7 +2422,7 @@ declare module 'metro/src/node-haste/Module' {
   export default Module;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/node-haste/ModuleCache.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/ModuleCache.js
 declare module 'metro/src/node-haste/ModuleCache' {
   import Module from 'metro/src/node-haste/Module';
   import Package from 'metro/src/node-haste/Package';
@@ -2479,7 +2475,7 @@ declare module 'metro/src/node-haste/ModuleCache' {
   export default ModuleCache;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/node-haste/Package.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/Package.js
 declare module 'metro/src/node-haste/Package' {
   import type { PackageJson } from 'metro-resolver/src/types';
   class Package {
@@ -2493,7 +2489,7 @@ declare module 'metro/src/node-haste/Package' {
   export default Package;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/Server.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/Server.js
 declare module 'metro/src/Server' {
   import type { AssetData } from 'metro/src/Assets';
   import type { ExplodedSourceMap } from 'metro/src/DeltaBundler/Serializers/getExplodedSourceMap';
@@ -2695,7 +2691,7 @@ declare module 'metro/src/Server' {
   export default Server;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/Server/MultipartResponse.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/Server/MultipartResponse.js
 declare module 'metro/src/Server/MultipartResponse' {
   import type { IncomingMessage, ServerResponse } from 'http';
   type Data = string | Buffer | Uint8Array;
@@ -2720,7 +2716,7 @@ declare module 'metro/src/Server/MultipartResponse' {
   export default MultipartResponse;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/Server/symbolicate.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/Server/symbolicate.js
 declare module 'metro/src/Server/symbolicate' {
   import type { ExplodedSourceMap } from 'metro/src/DeltaBundler/Serializers/getExplodedSourceMap';
   import type { ConfigT } from 'metro-config/src/configTypes.flow';
@@ -2743,15 +2739,15 @@ declare module 'metro/src/Server/symbolicate' {
   export default symbolicate;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/shared/output/bundle.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/bundle.js
 declare module 'metro/src/shared/output/bundle' {
-  // See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/shared/output/bundle.js
+  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/bundle.js
 
   // NOTE(cedric): Metro uses this weird Flow syntax /*:: */ to override the exported types...
   export * from 'metro/src/shared/output/bundle.flow';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/shared/output/bundle.flow.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/bundle.flow.js
 declare module 'metro/src/shared/output/bundle.flow' {
   import type { OutputOptions, RequestOptions } from 'metro/src/shared/types.flow';
   import Server from 'metro/src/Server';
@@ -2767,7 +2763,7 @@ declare module 'metro/src/shared/output/bundle.flow' {
   export const formatName: 'bundle';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/shared/output/meta.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/meta.js
 declare module 'metro/src/shared/output/meta' {
   const $$EXPORT_DEFAULT_DECLARATION$$: (
     code: Buffer | string,
@@ -2776,7 +2772,7 @@ declare module 'metro/src/shared/output/meta' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/shared/output/RamBundle.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/RamBundle.js
 declare module 'metro/src/shared/output/RamBundle' {
   import type { RamBundleInfo } from 'metro/src/DeltaBundler/Serializers/getRamBundleInfo';
   import type { OutputOptions, RequestOptions } from 'metro/src/shared/types.flow';
@@ -2790,7 +2786,7 @@ declare module 'metro/src/shared/output/RamBundle' {
   export const formatName: 'bundle';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/shared/output/RamBundle/as-assets.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/RamBundle/as-assets.js
 declare module 'metro/src/shared/output/RamBundle/as-assets' {
   import type { RamBundleInfo } from 'metro/src/DeltaBundler/Serializers/getRamBundleInfo';
   import type { OutputOptions } from 'metro/src/shared/types.flow';
@@ -2809,7 +2805,7 @@ declare module 'metro/src/shared/output/RamBundle/as-assets' {
   export default saveAsAssets;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/shared/output/RamBundle/as-indexed-file.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/RamBundle/as-indexed-file.js
 declare module 'metro/src/shared/output/RamBundle/as-indexed-file' {
   import type { RamBundleInfo } from 'metro/src/DeltaBundler/Serializers/getRamBundleInfo';
   import type {
@@ -2834,7 +2830,7 @@ declare module 'metro/src/shared/output/RamBundle/as-indexed-file' {
   ): void;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/shared/output/RamBundle/buildSourcemapWithMetadata.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/RamBundle/buildSourcemapWithMetadata.js
 declare module 'metro/src/shared/output/RamBundle/buildSourcemapWithMetadata' {
   import type { ModuleGroups, ModuleTransportLike } from 'metro/src/shared/types.flow';
   import type { IndexMap } from 'metro-source-map';
@@ -2848,13 +2844,13 @@ declare module 'metro/src/shared/output/RamBundle/buildSourcemapWithMetadata' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/shared/output/RamBundle/magic-number.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/RamBundle/magic-number.js
 declare module 'metro/src/shared/output/RamBundle/magic-number' {
   const $$EXPORT_DEFAULT_DECLARATION$$: 0xfb0bd1e5;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/shared/output/RamBundle/util.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/RamBundle/util.js
 declare module 'metro/src/shared/output/RamBundle/util' {
   import type { ModuleGroups, ModuleTransportLike } from 'metro/src/shared/types.flow';
   import type { BasicSourceMap, IndexMap } from 'metro-source-map';
@@ -2881,7 +2877,7 @@ declare module 'metro/src/shared/output/RamBundle/util' {
   export function lineToLineSourceMap(source: string, filename?: string): BasicSourceMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/shared/output/RamBundle/write-sourcemap.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/RamBundle/write-sourcemap.js
 declare module 'metro/src/shared/output/RamBundle/write-sourcemap' {
   function writeSourcemap(
     fileName: string,
@@ -2891,12 +2887,12 @@ declare module 'metro/src/shared/output/RamBundle/write-sourcemap' {
   export default writeSourcemap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/shared/output/unbundle.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/unbundle.js
 declare module 'metro/src/shared/output/unbundle' {
   export { default } from 'metro/src/shared/output/RamBundle';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/shared/output/writeFile.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/writeFile.js
 declare module 'metro/src/shared/output/writeFile' {
   import fs from 'fs';
   const writeFile: typeof fs.promises.writeFile;
@@ -2908,7 +2904,7 @@ declare module 'metro/src/shared/types' {
   export * from 'metro/src/shared/types.flow';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.81.3/packages/metro/src/shared/types.flow.js
+// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/types.flow.js
 declare module 'metro/src/shared/types.flow' {
   import type {
     Options as DeltaBundlerOptions,


### PR DESCRIPTION
# Why

Stacked upon #35513 

React Native 0.79 bumps up Metro to `0.82.0`. This is the types bump for `0.81.3 -> 0.82.0`.

# How

- Regenerated the types from Flow code

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
