### PR TITLE
[docs] router - add warning for unexpected modal presentation limitations

### DIFF
--- a/docs/pages/router/advanced/modals.mdx
+++ b/docs/pages/router/advanced/modals.mdx
@@ -30,6 +30,8 @@ For most use cases, you can use the `Modal` component and customize it according
 
 A modal screen is a file created inside the **app** directory and is used as a route within the existing stack. It is used for complex interactions that need to be part of the navigation system, such as multi-step forms where you can link to a specific screen after the process completes.
 
+> **warning** Modals only present over a screen in the same stack. It won't work in separate or nested stacks.
+
 Below is an example of how a modal screen works on different platforms:
 
 <ContentSpotlight file="expo-router/modal.mp4" />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

As seen in expo/router#630 (and my own hours of struggling), it's not clear enough that modal presentation only works on screens within the same stack.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Please suggest changes to the wording as I don't expect it's perfectly within the style guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
