### PR TITLE
[audio][Android] Remove maxSdkVersion from MODIFY_AUDIO_SETTINGS permission

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Remove maxSdkVersion from MODIFY_AUDIO_SETTINGS permission ([#35541](https://github.com/expo/expo/pull/35541) by [@jakex7](https://github.com/jakex7))
+
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-audio/android/src/main/AndroidManifest.xml
+++ b/packages/expo-audio/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.RECORD_AUDIO" />
-  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" android:maxSdkVersion="30" />
+  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 </manifest>


### PR DESCRIPTION
# Why

Fixes #35345

On Android SDK 30 and above, the `MODIFY_AUDIO_SETTINGS` permission is always denied when `expo-audio` is installed. This happens because the library mistakenly defines `android:maxSdkVersion="30"`, even though the permission is still necessary.

# How

Removed `maxSdkVersion` from the library's manifest.

# Test Plan

1. Clone the following repository https://github.com/Foxeye-Rinx/mic-test-expo/tree/main or create a new app with `expo-audio` installed and prebuild android.
2. Run `./gradlew app:processDebugManifest`
3. Inspect the generated `AndroidManifest.xml` at `android/app/build/intermediates/merged_manifest/debug/processDebugMainManifest/AndroidManifest.xml`. It contains `maxSdkVersion` added
```    <uses-permission
        android:name="android.permission.MODIFY_AUDIO_SETTINGS"
        android:maxSdkVersion="30" />
```
And in blame `android/app/build/intermediates/manifest_merge_blame_file/debug/processDebugMainManifest/manifest-merger-blame-debug-report.txt` we can see that this line is being added by expo-audio manifest
```
13    <uses-permission
13-->/Users/jakubgrzywacz/Projects/expo-repro/mic-test-expo/android/app/src/main/AndroidManifest.xml:3:3-77
14        android:name="android.permission.MODIFY_AUDIO_SETTINGS"
14-->/Users/jakubgrzywacz/Projects/expo-repro/mic-test-expo/android/app/src/main/AndroidManifest.xml:3:20-75
15        android:maxSdkVersion="30" />
15-->[:expo-audio] /Users/jakubgrzywacz/Projects/expo-repro/mic-test-expo/node_modules/expo-audio/android/build/intermediates/merged_manifest/debug/processDebugManifest/AndroidManifest.xml:10:9-35
```

After this changes, it should no longer have `android:maxSdkVersion="30"`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
