### PR TITLE
[docs] Remove `searchLevel` attribute

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -41,7 +41,6 @@ export default function DocumentationPage({
   hideTOC,
   modificationDate,
   searchRank,
-  searchLevel,
   searchPosition,
 }: DocPageProps) {
   const [isMobileMenuVisible, setMobileMenuVisible] = useState(false);
@@ -145,11 +144,6 @@ export default function DocumentationPage({
           RoutesUtils.isPreviewPath(pathname) ||
           RoutesUtils.isArchivePath(pathname)) && <meta name="robots" content="noindex" />}
         {searchRank && <meta name="searchRank" content={String(searchRank)} />}
-        {searchLevel ? (
-          <meta name="searchLevel" content={String(searchLevel)} />
-        ) : (
-          <meta name="searchLevel" content={String(searchRank)} />
-        )}
         {searchPosition && <meta name="searchPosition" content={String(searchPosition)} />}
       </DocumentationHead>
       <div

--- a/docs/components/DocumentationPageWrapper.tsx
+++ b/docs/components/DocumentationPageWrapper.tsx
@@ -41,7 +41,6 @@ export function DocumentationPageWrapper(props: DocumentationElementsProps) {
               modificationDate={props.meta.modificationDate}
               platforms={props.meta.platforms}
               searchRank={props.meta.searchRank}
-              searchLevel={props.meta.searchLevel}
               searchPosition={props.meta.searchPosition}>
               {props.children}
             </DocumentationPage>

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -11,7 +11,6 @@ export type PageMetadata = {
   platforms?: string[];
   modificationDate?: string;
   searchRank?: number;
-  searchLevel?: number;
   searchPosition?: number;
 };
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #35521

Running tests with Algolia's Crawler, I've found that using the default `level: 90` value is sufficient. From the docs source, we need to only update/modify `pageRank` and `position` values.

Confirmed this with @Simek while debugging the crawler configuration.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove `searchLevel` attribute property. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
