### PR TITLE
[push] simplify TimeIntervalTrigger nextTriggerDate

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 💡 Others
 
+- simplify `nextTriggerDate` in `TimeIntervalTrigger` ([#35559](https://github.com/expo/expo/pull/35559) by [@vonovak](https://github.com/vonovak))
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))
 - [iOS] Swift conversion 6: refactor Record classes. ([#34413](https://github.com/expo/expo/pull/34413) by [@douglowder](https://github.com/douglowder))
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/triggers/NotificationTriggers.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/triggers/NotificationTriggers.kt
@@ -114,7 +114,7 @@ class TimeIntervalTrigger(
   override val channelId: String?,
   val timeInterval: Long,
   val isRepeating: Boolean,
-  private var triggerDate: Date = Date(Date().time + timeInterval * 1000)
+  private var triggerDate: Date = Date(System.currentTimeMillis() + timeInterval * 1000)
 ) : ChannelAwareTrigger(channelId), SchedulableNotificationTrigger {
   override fun toBundle() = bundleWithChannelId(
     "type" to "timeInterval",
@@ -125,10 +125,12 @@ class TimeIntervalTrigger(
   override fun nextTriggerDate(): Date? {
     val now = Date()
 
-    if (isRepeating) {
-      while (triggerDate.before(now)) {
-        triggerDate.time += timeInterval * 1000
-      }
+    if (isRepeating && triggerDate.before(now)) {
+      val intervalMillis = timeInterval * 1000
+      val elapsedMillis = now.time - triggerDate.time
+
+      val remainingMillis = intervalMillis - (elapsedMillis % intervalMillis)
+      triggerDate.time = now.time + remainingMillis
     }
 
     if (triggerDate.before(now)) {


### PR DESCRIPTION
# Why

Original motivation is this failing pipeline - https://github.com/expo/expo/actions/runs/13921909569/job/38956950268

the problem with `testTimeIntervalTrigger` is that the  2 seconds could "overflow" into the next minute, making the test flaky

# How

- refactored `testTimeIntervalTrigger` to work independent of current time
- Changed the initial trigger date calculation to use `System.currentTimeMillis()` instead of `Date().time` - same behavior
-  calculates the nextTriggerDate using modulo, avoiding loop
- Added a test case to verify that it works

# Test Plan

- green CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)