### PR TITLE
[notifications] change jest preset

### DIFF
--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -35,7 +35,11 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/notifications/",
   "jest": {
-    "preset": "expo-module-scripts/ios"
+    "projects": [
+      {
+        "preset": "jest-expo/ios"
+      }
+    ]
   },
   "dependencies": {
     "@expo/image-utils": "^0.6.0",

--- a/packages/expo-notifications/src/__tests__/__snapshots__/index-test.ts.snap.ios
+++ b/packages/expo-notifications/src/__tests__/__snapshots__/index-test.ts.snap.ios
@@ -82,6 +82,7 @@ exports[`Notifications exports 1`] = `
     "UNKNOWN": 0,
   },
   "DEFAULT_ACTION_IDENTIFIER": "expo.modules.notifications.actions.DEFAULT",
+  "EventSubscription": undefined,
   "IosAlertStyle": {
     "0": "NONE",
     "1": "BANNER",
@@ -111,6 +112,8 @@ exports[`Notifications exports 1`] = `
     "PROVISIONAL": 3,
   },
   "NotificationTimeoutError": [Function],
+  "PermissionExpiration": undefined,
+  "PermissionResponse": undefined,
   "PermissionStatus": {
     "DENIED": "denied",
     "GRANTED": "granted",

--- a/packages/expo-notifications/src/utils/__tests__/updateDevicePushTokenAsync-test.ts
+++ b/packages/expo-notifications/src/utils/__tests__/updateDevicePushTokenAsync-test.ts
@@ -32,6 +32,10 @@ describe('given valid registration info', () => {
     global.fetch = jest.fn();
   });
 
+  beforeEach(() => {
+    global.fetch.mockClear();
+  });
+
   afterAll(() => {
     global.fetch = originalFetch;
   });


### PR DESCRIPTION
# Why

- "expo-module-scripts/ios" is deprecated 

# How

migrated according to https://github.com/expo/expo/tree/main/packages/jest-expo#mixing-runners and fixed test failures

# Test Plan

- green CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
