### PR TITLE
[docs] Remove search attributes from specific docs

### DIFF
--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -2,8 +2,6 @@
 title: Run EAS Build locally with local flag
 sidebar_title: Run EAS Build locally
 description: Learn how to use EAS Build locally on your machine or a custom infrastructure using the --local flag.
-searchRank: 80
-searchPosition: 1
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -2,8 +2,6 @@
 title: Create a production build locally
 sidebar_title: Production
 description: Learn how to create a production build for your Expo app locally.
-searchRank: 75
-searchPosition: 10
 ---
 
 import { GoogleAppStoreIcon } from '@expo/styleguide-icons/custom/AndroidIcon';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up https://github.com/expo/expo/pull/35521

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove `searchRank` and `searchPosition` metadata fields from EAS Build locally and Local production app docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
