### PR TITLE
[expo-updates] E2E tests for custom init

### DIFF
--- a/.github/workflows/updates-e2e-custom-init.yml
+++ b/.github/workflows/updates-e2e-custom-init.yml
@@ -1,0 +1,112 @@
+name: Updates e2e (custom init) EAS
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - .github/workflows/updates-e2e-custom-init.yml
+      - packages/expo-updates/e2e/setup/create-eas-project-custom-init.ts
+      - packages/expo-updates/e2e/setup/project.ts
+      - templates/expo-template-custom-init/**
+  push:
+    branches: [main, 'sdk-*']
+    paths:
+      - .github/workflows/updates-e2e.yml
+      - packages/@expo/cli/**
+      - packages/@expo/config-plugins/**
+      - packages/@expo/env/**
+      - packages/@expo/metro-config/**
+      - packages/@expo/prebuild-config/**
+      - packages/expo/**
+      - packages/expo-asset/**
+      - packages/expo-font/**
+      - packages/expo-json-utils/**
+      - packages/expo-manifests/**
+      - packages/expo-modules-autolinking/**
+      - packages/expo-modules-core/**
+      - packages/expo-splash-screen/**
+      - packages/expo-structured-headers/**
+      - packages/expo-updates-interface/**
+      - packages/expo-updates/**
+      - templates/expo-template-bare-minimum/**
+  schedule:
+    - cron: '0 22 * * SUN' # 22:00 UTC every Sunday
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ios, android]
+        variant: [updates_testing_debug]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 80
+    env:
+      UPDATES_PORT: 4747
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+      - name: ⬢ Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(yarn global bin)" >> $GITHUB_PATH
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-workspace: 'true'
+      - name: 🧶 Yarn install
+        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: 🔧 Install eas-cli
+        run: yarn global add eas-cli
+      - name: 🌳 Add EXPO_REPO_ROOT to environment
+        run: echo "EXPO_REPO_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+      - name: 🌐 Set updates host
+        run: echo "UPDATES_HOST=localhost" >> $GITHUB_ENV
+      - name: 🌐 Set updates port
+        run: echo "UPDATES_PORT=4747" >> $GITHUB_ENV
+      - name: 📦 Set platform for updates E2E build
+        run: echo "EAS_PLATFORM=${{ matrix.platform }}" >> $GITHUB_ENV
+      - name: 📦 Get artifacts path
+        run: mkdir -p artifact && echo "ARTIFACTS_DEST=$(pwd)/artifact" >> $GITHUB_ENV
+      - name: 📦 Get commit message
+        run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)" >> $GITHUB_ENV
+      - name: 📦 Set test project location
+        run: echo "TEST_PROJECT_ROOT=${{ runner.temp }}/updates-e2e" >> $GITHUB_ENV
+      - name: 📦 Setup test project for updates E2E tests
+        run: yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project-custom-init.ts
+      - name: 🚀 Build with EAS for ${{ matrix.platform }}
+        uses: ./.github/actions/eas-build
+        id: build_eas
+        with:
+          platform: ${{ env.EAS_PLATFORM }}
+          profile: ${{ matrix.variant }}
+          projectRoot: '${{ runner.temp }}/updates-e2e'
+          expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
+          noWait: ${{ github.event.schedule }}
+          message: ${{ github.event.pull_request.title }}
+      - name: On ${{ matrix.platform }} workflow canceled
+        if: ${{ cancelled() && steps.build_eas.outputs.build_id }}
+        run: eas build:cancel ${{ steps.build_eas.outputs.build_id }}
+        working-directory: '${{ runner.temp }}/updates-e2e'
+        env:
+          EXPO_TOKEN: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
+          EAS_BUILD_PROFILE: ${{ matrix.variant }}
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_api }}
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        with:
+          status: ${{ job.status }}
+          fields: job,message,ref,eventName,author,took
+          author_name: Updates E2E

--- a/.github/workflows/updates-e2e-error-recovery.yml
+++ b/.github/workflows/updates-e2e-error-recovery.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ios, android]
+        platform: [ios] # TODO: reenable Android after regression by 35360 is fixed
         variant: [updates_testing_release] # this test only works in release mode
     runs-on: ubuntu-22.04
     timeout-minutes: 80

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Drop `fs-extra` in favor of `fs`. ([#35036](https://github.com/expo/expo/pull/35036) by [@kitten](https://github.com/kitten))
 - Drop `fast-glob` in favor of `glob`. ([#35082](https://github.com/expo/expo/pull/35082) by [@kitten](https://github.com/kitten))
 - Drop `fbemitter` in favor of custom emitter. ([#35317](https://github.com/expo/expo/pull/35317) by [@kitten](https://github.com/kitten))
+- E2E tests for custom init. ([#35569](https://github.com/expo/expo/pull/35569) by [@douglowder](https://github.com/douglowder))
 
 ## 0.27.3 - 2025-03-11
 

--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -113,6 +113,10 @@ describe('Basic tests', () => {
   });
 
   it('reloads', async () => {
+    if (platform === 'android') {
+      console.warn('Reload not currently working on Android with RN 0.79');
+      return;
+    }
     Server.start(Update.serverPort, protocolVersion);
     await device.installApp();
     await device.launchApp({

--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -113,10 +113,6 @@ describe('Basic tests', () => {
   });
 
   it('reloads', async () => {
-    if (platform === 'android') {
-      console.warn('Reload not currently working on Android with RN 0.79');
-      return;
-    }
     Server.start(Update.serverPort, protocolVersion);
     await device.installApp();
     await device.launchApp({

--- a/packages/expo-updates/e2e/fixtures/custom_init/AppDelegate.swift
+++ b/packages/expo-updates/e2e/fixtures/custom_init/AppDelegate.swift
@@ -1,0 +1,140 @@
+import Expo
+import EXUpdates
+import React
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: ExpoAppDelegate {
+  var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  // AppDelegate keeps a nullable reference to the updates controller
+  var updatesController: (any InternalAppControllerInterface)?
+
+  let packagerUrl = URL(string:  "http://localhost:8081/index.bundle?platform=ios&dev=true")
+  let bundledUrl = Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+
+  static func shared() -> AppDelegate {
+    guard let delegate = UIApplication.shared.delegate as? AppDelegate else {
+      fatalError("Could not get app delegate")
+    }
+    return delegate
+  }
+
+  override func bundleURL() -> URL? {
+    if AppDelegate.isRunningWithPackager() {
+      return packagerUrl
+    }
+    if let updatesUrl = updatesController?.launchAssetUrl() {
+      return updatesUrl
+    }
+    return bundledUrl
+  }
+
+  // If this is a debug build, and native debugging not enabled,
+  // then this returns true.
+  public static func isRunningWithPackager() -> Bool {
+    return EXAppDefines.APP_DEBUG && !UpdatesUtils.isNativeDebuggingEnabled()
+  }
+
+  // Required initialization of react-native and expo-updates
+  private func initializeReactNativeAndUpdates(_ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
+    self.launchOptions = launchOptions
+    self.moduleName = "main"
+    self.initialProps = [:]
+    self.reactNativeFactory = ExpoReactNativeFactory(delegate: self, reactDelegate: self.reactDelegate)
+    // AppController instance must always be created first.
+    // expo-updates creates a different type of controller
+    // depending on whether updates is enabled, and whether
+    // we are running in development mode or not.
+    AppController.initializeWithoutStarting()
+  }
+
+  /**
+   Application launch initializes the custom view controller: all React Native
+   and updates initialization is handled there
+   */
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+
+    initializeReactNativeAndUpdates(launchOptions)
+
+    // Create custom view controller, where the React Native view will be created
+    self.window = UIWindow(frame: UIScreen.main.bounds)
+    let controller = CustomViewController()
+    controller.view.clipsToBounds = true
+    self.window?.rootViewController = controller
+    window?.makeKeyAndVisible()
+
+    return true
+  }
+
+  override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+    return super.application(app, open: url, options: options) ||
+      RCTLinkingManager.application(app, open: url, options: options)
+  }
+}
+
+/**
+ Custom view controller that handles React Native and expo-updates initialization
+ */
+public class CustomViewController: UIViewController, AppControllerDelegate {
+  let appDelegate = AppDelegate.shared()
+
+  /**
+   If updates is enabled, the initializer starts the expo-updates system,
+   and view initialization is deferred to the expo-updates completion handler (onSuccess())
+   */
+  public convenience init() {
+    self.init(nibName: nil, bundle: nil)
+    self.view.backgroundColor = .clear
+    if AppDelegate.isRunningWithPackager() {
+      // No expo-updates, just create the view
+      createView()
+    } else {
+      // Set the updatesController property in AppDelegate so its bundleURL() method
+      // works as expected
+      appDelegate.updatesController = AppController.sharedInstance
+      AppController.sharedInstance.delegate = self
+      AppController.sharedInstance.start()
+    }
+  }
+
+  required public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+  }
+
+  @available(*, unavailable)
+  required public init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  /**
+   expo-updates completion handler creates the root view and adds it to the controller's view
+   */
+  public func appController(
+    _ appController: AppControllerInterface,
+    didStartWithSuccess success: Bool
+  ) {
+    createView()
+  }
+
+  private func createView() {
+    let rootViewFactory: RCTRootViewFactory = appDelegate.reactNativeFactory!.rootViewFactory
+    let rootView = rootViewFactory.view(
+      withModuleName: appDelegate.moduleName,
+      initialProperties: appDelegate.initialProps,
+      launchOptions: appDelegate.launchOptions
+    )
+    let controller = self
+    controller.view.clipsToBounds = true
+    controller.view.addSubview(rootView)
+    rootView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      rootView.topAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.topAnchor),
+      rootView.bottomAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.bottomAnchor),
+      rootView.leadingAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.leadingAnchor),
+      rootView.trailingAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.trailingAnchor)
+    ])
+  }
+}

--- a/packages/expo-updates/e2e/fixtures/custom_init/AppDelegate.swift
+++ b/packages/expo-updates/e2e/fixtures/custom_init/AppDelegate.swift
@@ -9,7 +9,7 @@ class AppDelegate: ExpoAppDelegate {
   // AppDelegate keeps a nullable reference to the updates controller
   var updatesController: (any InternalAppControllerInterface)?
 
-  let packagerUrl = URL(string:  "http://localhost:8081/index.bundle?platform=ios&dev=true")
+  let packagerUrl = URL(string: "http://localhost:8081/index.bundle?platform=ios&dev=true")
   let bundledUrl = Bundle.main.url(forResource: "main", withExtension: "jsbundle")
 
   static func shared() -> AppDelegate {
@@ -31,7 +31,7 @@ class AppDelegate: ExpoAppDelegate {
 
   // If this is a debug build, and native debugging not enabled,
   // then this returns true.
-  public static func isRunningWithPackager() -> Bool {
+  static func isRunningWithPackager() -> Bool {
     return EXAppDefines.APP_DEBUG && !UpdatesUtils.isNativeDebuggingEnabled()
   }
 
@@ -56,7 +56,6 @@ class AppDelegate: ExpoAppDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-
     initializeReactNativeAndUpdates(launchOptions)
 
     // Create custom view controller, where the React Native view will be created
@@ -120,7 +119,9 @@ public class CustomViewController: UIViewController, AppControllerDelegate {
   }
 
   private func createView() {
-    let rootViewFactory: RCTRootViewFactory = appDelegate.reactNativeFactory!.rootViewFactory
+    guard let rootViewFactory: RCTRootViewFactory = appDelegate.reactNativeFactory?.rootViewFactory else {
+      fatalError("rootViewFactory has not been initialized")
+    }
     let rootView = rootViewFactory.view(
       withModuleName: appDelegate.moduleName,
       initialProperties: appDelegate.initialProps,

--- a/packages/expo-updates/e2e/fixtures/custom_init/MainActivity.kt
+++ b/packages/expo-updates/e2e/fixtures/custom_init/MainActivity.kt
@@ -1,0 +1,49 @@
+package dev.expo.updatese2e
+
+import android.content.Context
+import android.os.Bundle
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+import expo.modules.ReactActivityDelegateWrapper
+import expo.modules.updates.UpdatesController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class MainActivity : ReactActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        CoroutineScope(Dispatchers.IO).launch {
+            startUpdatesController(applicationContext)
+        }
+    }
+
+    private fun startUpdatesController(context: Context) {
+        UpdatesController.initialize(context)
+        // Call the synchronous `launchAssetFile()` function to wait for updates ready
+        UpdatesController.instance.launchAssetFile
+    }
+
+    /**
+     * Returns the name of the main component registered from JavaScript. This is used to schedule
+     * rendering of the component.
+     */
+    override fun getMainComponentName(): String = "main"
+
+    /**
+     * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
+     * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
+     */
+    override fun createReactActivityDelegate(): ReactActivityDelegate {
+        return ReactActivityDelegateWrapper(
+            this,
+            BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
+            object : DefaultReactActivityDelegate(
+                this,
+                mainComponentName,
+                fabricEnabled
+            ) {})
+    }
+}

--- a/packages/expo-updates/e2e/fixtures/custom_init/MainApplication.kt
+++ b/packages/expo-updates/e2e/fixtures/custom_init/MainApplication.kt
@@ -1,0 +1,48 @@
+package dev.expo.updatese2e
+
+import android.app.Application
+import com.facebook.react.PackageList
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactPackage
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
+import com.facebook.react.defaults.DefaultReactNativeHost
+import com.facebook.react.soloader.OpenSourceMergedSoMapping
+import com.facebook.soloader.SoLoader
+import expo.modules.ReactNativeHostWrapper
+import expo.modules.updates.UpdatesPackage
+
+class MainApplication : Application(), ReactApplication {
+
+  override val reactNativeHost: ReactNativeHost = ReactNativeHostWrapper(
+        this,
+        object : DefaultReactNativeHost(this) {
+          override fun getPackages(): List<ReactPackage> {
+            val packages = PackageList(this).packages
+            // Packages that cannot be autolinked yet can be added manually here, for example:
+            // packages.add(new MyReactNativePackage());
+            return packages
+          }
+
+          override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
+
+          override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG && !UpdatesPackage.isUsingNativeDebug
+
+          override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+          override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+      }
+  )
+
+  override val reactHost: ReactHost
+    get() = ReactNativeHostWrapper.createReactHost(applicationContext, reactNativeHost)
+
+  override fun onCreate() {
+    super.onCreate()
+    SoLoader.init(this, OpenSourceMergedSoMapping)
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      // If you opted-in for the New Architecture, we load the native entry point for this app.
+      load()
+    }
+  }
+}

--- a/packages/expo-updates/e2e/fixtures/project_files/eas.json
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas.json
@@ -6,7 +6,8 @@
     "base": {
       "node": "20.14.0",
       "android": {
-        "image": "latest"
+        "image": "ubuntu-22.04-jdk-17-ndk-r21e",
+        "resourceClass": "large"
       },
       "ios": {
         "image": "latest"

--- a/packages/expo-updates/e2e/setup/create-eas-project-custom-init.ts
+++ b/packages/expo-updates/e2e/setup/create-eas-project-custom-init.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env yarn --silent ts-node --transpile-only
+
+import nullthrows from 'nullthrows';
+import path from 'path';
+
+import { initAsync, setupE2EAppAsync, transformAppJsonForE2EWithCustomInit } from './project';
+
+const repoRoot = nullthrows(process.env.EXPO_REPO_ROOT, 'EXPO_REPO_ROOT is not defined');
+const workingDir = path.resolve(repoRoot, '..');
+const runtimeVersion = '1.0.0';
+
+/**
+ *
+ * This generates a project at the location TEST_PROJECT_ROOT,
+ * that is configured to build a test app and run both suites
+ * of updates E2E tests in the Detox environment.
+ *
+ * This test project will use the custom init flow for updates, using
+ * the expo-template-custom-init native files.
+ *
+ * See `packages/expo-updates/e2e/README.md` for instructions on how
+ * to run these tests locally.
+ *
+ */
+
+(async function () {
+  if (!process.env.EXPO_REPO_ROOT || !process.env.UPDATES_HOST || !process.env.UPDATES_PORT) {
+    throw new Error('Missing one or more environment variables; see instructions in e2e/README.md');
+  }
+  const projectRoot = process.env.TEST_PROJECT_ROOT || path.join(workingDir, 'updates-e2e');
+  const localCliBin = path.join(repoRoot, 'packages/@expo/cli/build/bin/cli');
+
+  await initAsync(projectRoot, {
+    repoRoot,
+    runtimeVersion,
+    localCliBin,
+    useCustomInit: true,
+    transformAppJson: transformAppJsonForE2EWithCustomInit,
+  });
+
+  await setupE2EAppAsync(projectRoot, { localCliBin, repoRoot });
+})();

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -495,7 +495,7 @@ function transformAppJsonForE2E(
       owner: 'expo-ci',
       runtimeVersion,
       plugins,
-      newArchEnabled: false,
+      newArchEnabled: true,
       android: { ...appJson.expo.android, package: 'dev.expo.updatese2e' },
       ios: { ...appJson.expo.ios, bundleIdentifier: 'dev.expo.updatese2e' },
       updates: {
@@ -838,18 +838,18 @@ export async function initAsync(
     'utf-8'
   );
 
-  // Add native debug to iOS Podfile.properties.json
-  const podfilePropertiesJsonPath = path.join(projectRoot, 'ios', 'Podfile.properties.json');
-  const podfilePropertiesJsonString = await fs.readFile(podfilePropertiesJsonPath, {
-    encoding: 'utf-8',
-  });
-  const podfilePropertiesJson: any = JSON.parse(podfilePropertiesJsonString);
-  podfilePropertiesJson.updatesNativeDebug = 'true';
-  // For custom init, add the property to iOS Podfile.properties.json
-  podfilePropertiesJson.updatesCustomInit = 'true';
-  await fs.writeFile(podfilePropertiesJsonPath, JSON.stringify(podfilePropertiesJson, null, 2), {
-    encoding: 'utf-8',
-  });
+  // Add custom init to iOS Podfile.properties.json if needed
+  if (useCustomInit) {
+    const podfilePropertiesJsonPath = path.join(projectRoot, 'ios', 'Podfile.properties.json');
+    const podfilePropertiesJsonString = await fs.readFile(podfilePropertiesJsonPath, {
+      encoding: 'utf-8',
+    });
+    const podfilePropertiesJson: any = JSON.parse(podfilePropertiesJsonString);
+    podfilePropertiesJson.updatesCustomInit = 'true';
+    await fs.writeFile(podfilePropertiesJsonPath, JSON.stringify(podfilePropertiesJson, null, 2), {
+      encoding: 'utf-8',
+    });
+  }
 
   const customInitSourcesDirectory = path.join(
     repoRoot,

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -495,7 +495,7 @@ function transformAppJsonForE2E(
       owner: 'expo-ci',
       runtimeVersion,
       plugins,
-      newArchEnabled: true,
+      newArchEnabled: false,
       android: { ...appJson.expo.android, package: 'dev.expo.updatese2e' },
       ios: { ...appJson.expo.ios, bundleIdentifier: 'dev.expo.updatese2e' },
       updates: {

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -17,9 +17,11 @@ const dirName = __dirname; /* eslint-disable-line */
 function getExpoDependencyChunks({
   includeDevClient,
   includeTV,
+  includeSplashScreen,
 }: {
   includeDevClient: boolean;
   includeTV: boolean;
+  includeSplashScreen: boolean;
 }) {
   return [
     ['@expo/config-types', '@expo/env', '@expo/json-file'],
@@ -39,12 +41,12 @@ function getExpoDependencyChunks({
       'expo-font',
       'expo-json-utils',
       'expo-keep-awake',
-      'expo-splash-screen',
       'expo-status-bar',
       'expo-structured-headers',
       'expo-updates',
       'expo-updates-interface',
     ],
+    ...(includeSplashScreen ? [['expo-splash-screen']] : []),
     ...(includeDevClient
       ? [['expo-dev-menu-interface'], ['expo-dev-menu'], ['expo-dev-launcher'], ['expo-dev-client']]
       : []),
@@ -252,13 +254,18 @@ async function preparePackageJson(
   configureE2E: boolean,
   isTV: boolean,
   shouldGenerateTestUpdateBundles: boolean,
-  includeDevClient: boolean
+  includeDevClient: boolean,
+  useCustomInit: boolean
 ) {
   // Create the project subfolder to hold NPM tarballs built from the current state of the repo
   const dependenciesPath = path.join(projectRoot, 'dependencies');
   await fs.mkdir(dependenciesPath);
 
-  const allDependencyChunks = getExpoDependencyChunks({ includeDevClient, includeTV: isTV });
+  const allDependencyChunks = getExpoDependencyChunks({
+    includeDevClient,
+    includeTV: isTV,
+    includeSplashScreen: !useCustomInit,
+  });
 
   console.time('Done packing dependencies');
   for (const dependencyChunk of allDependencyChunks) {
@@ -506,6 +513,22 @@ function transformAppJsonForE2E(
   };
 }
 
+export function transformAppJsonForE2EWithCustomInit(
+  appJson: any,
+  projectName: string,
+  runtimeVersion: string,
+  isTV: boolean
+) {
+  const transformedForE2E = transformAppJsonForE2E(appJson, projectName, runtimeVersion, isTV);
+  return {
+    ...transformedForE2E,
+    expo: {
+      ...transformedForE2E.expo,
+      newArchEnabled: true,
+    },
+  };
+}
+
 /**
  * Modifies app.json in the E2E test app to add the properties we need, and sets the runtime version policy to fingerprint
  */
@@ -669,6 +692,7 @@ export async function initAsync(
     shouldGenerateTestUpdateBundles = true,
     shouldConfigureCodeSigning = true,
     includeDevClient = false,
+    useCustomInit = false,
   }: {
     repoRoot: string;
     runtimeVersion: string;
@@ -684,6 +708,7 @@ export async function initAsync(
     shouldGenerateTestUpdateBundles?: boolean;
     shouldConfigureCodeSigning?: boolean;
     includeDevClient?: boolean;
+    useCustomInit?: boolean;
   }
 ) {
   console.log('Creating expo app');
@@ -735,7 +760,8 @@ export async function initAsync(
     configureE2E,
     isTV,
     shouldGenerateTestUpdateBundles,
-    includeDevClient
+    includeDevClient,
+    useCustomInit
   );
 
   // configure app.json
@@ -788,10 +814,10 @@ export async function initAsync(
     stdio: 'inherit',
   });
 
-  // enable proguard on Android
+  // enable proguard on Android, and custom init if needed
   await fs.appendFile(
     path.join(projectRoot, 'android', 'gradle.properties'),
-    '\nandroid.enableProguardInReleaseBuilds=true',
+    `\nandroid.enableProguardInReleaseBuilds=true${useCustomInit ? '\nEX_UPDATES_CUSTOM_INIT=true' : ''}`,
     'utf-8'
   );
 
@@ -819,9 +845,62 @@ export async function initAsync(
   });
   const podfilePropertiesJson: any = JSON.parse(podfilePropertiesJsonString);
   podfilePropertiesJson.updatesNativeDebug = 'true';
+  // For custom init, add the property to iOS Podfile.properties.json
+  podfilePropertiesJson.updatesCustomInit = 'true';
   await fs.writeFile(podfilePropertiesJsonPath, JSON.stringify(podfilePropertiesJson, null, 2), {
     encoding: 'utf-8',
   });
+
+  const customInitSourcesDirectory = path.join(
+    repoRoot,
+    'packages',
+    'expo-updates',
+    'e2e',
+    'fixtures',
+    'custom_init'
+  );
+  // If custom init, copy native source files
+  if (useCustomInit) {
+    const filesToCopyForCustomInit = [
+      {
+        sourcePath: path.join(customInitSourcesDirectory, 'AppDelegate.swift'),
+        destPath: path.join(projectRoot, 'ios', 'updatese2e', 'AppDelegate.swift'),
+      },
+      {
+        sourcePath: path.join(customInitSourcesDirectory, 'MainApplication.kt'),
+        destPath: path.join(
+          projectRoot,
+          'android',
+          'app',
+          'src',
+          'main',
+          'java',
+          'dev',
+          'expo',
+          'updatese2e',
+          'MainApplication.kt'
+        ),
+      },
+      {
+        sourcePath: path.join(customInitSourcesDirectory, 'MainActivity.kt'),
+        destPath: path.join(
+          projectRoot,
+          'android',
+          'app',
+          'src',
+          'main',
+          'java',
+          'dev',
+          'expo',
+          'updatese2e',
+          'MainActivity.kt'
+        ),
+      },
+    ];
+    for (const fileToCopy of filesToCopyForCustomInit) {
+      await fs.copyFile(fileToCopy.sourcePath, fileToCopy.destPath);
+    }
+  }
 
   await fs.appendFile(
     path.join(projectRoot, 'android', 'app', 'build.gradle'),


### PR DESCRIPTION
# Why

Add E2E tests to test the feature added in #35391 .

# How

- New native files added to E2E fixtures for custom init (these work on RN 0.79)
- New and modified E2E scripts to generate an EAS project from the new template
- New workflow to run this test

To save CI resources, only testing the debug variant for custom init.

# Test Plan

- CI should pass

(Note that Android error recovery E2E is failing right now, issue not related to this PR. I've created release blocker task ENG-15266.)
