### PR TITLE
feat(cli): fix --device flag with multiple booted devices present

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add fallback resolution strategy for dependencies and optional peer dependencies of `expo` and `expo-router` to prevent broken resolution for isolated dependencies and hoisting issues. ([#34286](https://github.com/expo/expo/pull/34286) by [@kitten](https://github.com/kitten))
 - Preserve proxy leases on webcontainers ([#34831](https://github.com/expo/expo/pull/34831) by [@kitten](https://github.com))
 - Add support for `isESMImport` in fast resolver and React Server resolution. ([#35520](https://github.com/expo/expo/pull/35520) by [@byCedric](https://github.com/byCedric))
+- Fix --device flag with multiple booted devices present. ([#35570](https://github.com/expo/expo/pull/35570) by [@cbargren](https://github.com/cbargren))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/ios/launchApp.ts
+++ b/packages/@expo/cli/src/run/ios/launchApp.ts
@@ -45,13 +45,13 @@ export async function launchAppAsync(
 
   XcodeBuild.logPrettyItem(chalk`{bold Installing} on ${props.device.name}`);
 
-  const device = await AppleDeviceManager.resolveAsync({ device: props.device });
-  await device.installAppAsync(binaryPath);
+  const deviceManager = await AppleDeviceManager.resolveAsync({ device: props.device });
+  await deviceManager.installAppAsync(binaryPath);
 
-  XcodeBuild.logPrettyItem(chalk`{bold Opening} on ${device.name} {dim (${appId})}`);
+  XcodeBuild.logPrettyItem(chalk`{bold Opening} on ${deviceManager.name} {dim (${appId})}`);
 
   if (props.shouldStartBundler) {
-    await SimulatorLogStreamer.getStreamer(device.device, {
+    await SimulatorLogStreamer.getStreamer(deviceManager.device, {
       appId,
     }).attachAsync();
   }
@@ -61,7 +61,7 @@ export async function launchAppAsync(
     {
       applicationId: appId,
     },
-    { device }
+    { device: deviceManager.device }
   );
 }
 


### PR DESCRIPTION
This fixes an issue where if you have multiple iOS simulator targets running and specify which device for expo to install/launch the app on, it will install on the correct device, but attempt to launch it on the first available device that xcrun detects instead of the specified target.

# Why

The --device flag should work even if you have multiple simulators running.

# How

I ran into this issue when I was working with our expo-based app trying to test a feature on both an iPhone and iPad simulator. It would install on the iPad, but run on the iPhone (or fail the build and exit the bundler if the app wasn't yet installed on the iPhone). I dug through the `run` code to find out if I was doing something wrong and found what seems to be that a `DeviceManager` is being passed around where a `Device` is expected.

# Test Plan

1. Fire up 2 different simulators with xcode or via xcrun
```sh
xcrun simctl boot "iPhone 15 Pro"
xcrun simctl boot "iPad Pro 13-inch (M4)"
```
2. Fetch the list of the booted devices, copying the name of the second one in the list
```sh
xcrun simctl list | egrep '(Booted)'
```
3. Add a --device flag to `apps/bare-expo/scripts/start-simulator.sh:37` indicating the second device in the list from the previous step
```sh
    npx expo run:ios --port "${port}" --device "iPad Pro 13-inch (M4)"
```
4. Run the `bare-expo` ios app
```sh
cd apps/bare-expo
yarn ios
```


Without the associated change, following these steps will fail with the following error:

```
› Opening on iPad Pro 13-inch (M4) (dev.expo.Payments)
CommandError: No development build (dev.expo.Payments) for this project is installed. Please make and install a development build on the device first.
Learn more: https://docs.expo.dev/development/build/
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
