### PR TITLE
[jest-expo] Update module mocks

### DIFF
--- a/apps/expo-go/src/api/__tests__/AuthSessions-test.js
+++ b/apps/expo-go/src/api/__tests__/AuthSessions-test.js
@@ -7,11 +7,7 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   removeItem: jest.fn(() => new Promise((resolve) => resolve(null))),
 }));
 
-jest.mock('@react-native-community/netinfo', () => ({
-  addEventListener: jest.fn(),
-  fetch: jest.fn(() => new Promise((resolve) => resolve(null))),
-  removeEventListener: jest.fn(),
-}));
+jest.mock('@react-native-community/netinfo');
 
 describe('User Authentication Flow', () => {
   let Store;

--- a/packages/expo-location/build/LocationEventEmitter.web.d.ts
+++ b/packages/expo-location/build/LocationEventEmitter.web.d.ts
@@ -1,2 +1,2 @@
-export declare const LocationEventEmitter: import("expo-modules-core/types").EventEmitter<Record<never, never>>;
+export declare const LocationEventEmitter: import("expo").EventEmitterType<Record<never, never>>;
 //# sourceMappingURL=LocationEventEmitter.web.d.ts.map

--- a/packages/expo-location/build/LocationEventEmitter.web.d.ts.map
+++ b/packages/expo-location/build/LocationEventEmitter.web.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"LocationEventEmitter.web.d.ts","sourceRoot":"","sources":["../src/LocationEventEmitter.web.ts"],"names":[],"mappings":"AAEA,eAAO,MAAM,oBAAoB,sEAAqB,CAAC"}
+{"version":3,"file":"LocationEventEmitter.web.d.ts","sourceRoot":"","sources":["../src/LocationEventEmitter.web.ts"],"names":[],"mappings":"AAEA,eAAO,MAAM,oBAAoB,uDAAqB,CAAC"}

--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/notifications/",
   "jest": {
-    "preset": "expo-module-scripts"
+    "preset": "expo-module-scripts/ios"
   },
   "dependencies": {
     "@expo/image-utils": "^0.6.0",

--- a/packages/expo-notifications/src/__tests__/DevicePushTokenAutoRegistration-test.ts
+++ b/packages/expo-notifications/src/__tests__/DevicePushTokenAutoRegistration-test.ts
@@ -33,8 +33,8 @@ describe('__handlePersistedRegistrationInfoAsync', () => {
     await DevicePushTokenAutoRegistration.__handlePersistedRegistrationInfoAsync(
       JSON.stringify(DISABLED_REGISTRATION_FIXTURE)
     );
-    expect(getDevicePushTokenAsync).not.toBeCalled();
-    expect(updateDevicePushTokenAsync).not.toBeCalled();
+    expect(getDevicePushTokenAsync).not.toHaveBeenCalled();
+    expect(updateDevicePushTokenAsync).not.toHaveBeenCalled();
   });
 
   it(`does try to update registration if it's enabled`, async () => {
@@ -48,7 +48,7 @@ describe('__handlePersistedRegistrationInfoAsync', () => {
     await DevicePushTokenAutoRegistration.__handlePersistedRegistrationInfoAsync(
       JSON.stringify(ENABLED_REGISTRATION_FIXTURE)
     );
-    expect(updateDevicePushTokenAsync).toBeCalledWith(
+    expect(updateDevicePushTokenAsync).toHaveBeenCalledWith(
       expect.anything(),
       mockPendingDevicePushToken
     );

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Drop `fbemitter` in favor of internal logic. ([#35318](https://github.com/expo/expo/pull/35319) by [@kitten](https://github.com/kitten)
+- Update mocks to for esm exports. ([#35574](https://github.com/expo/expo/pull/35574) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -171,7 +171,7 @@ jest.doMock('react-native/Libraries/BatchedBridge/NativeModules', () => ({
 }));
 
 jest.doMock('react-native/Libraries/LogBox/LogBox', () => ({
-  __esModule: true, // Marks this as an ES module mock
+  __esModule: true,
   default: {
     ignoreLogs: (patterns) => {
       // Do nothing.

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -165,20 +165,26 @@ jest.mock('@react-native/assets-registry/registry', () => ({
   })),
 }));
 
-jest.doMock('react-native/Libraries/BatchedBridge/NativeModules', () => mockNativeModules);
+jest.doMock('react-native/Libraries/BatchedBridge/NativeModules', () => ({
+  __esModule: true,
+  default: mockNativeModules,
+}));
 
 jest.doMock('react-native/Libraries/LogBox/LogBox', () => ({
-  ignoreLogs: (patterns) => {
-    // Do nothing.
-  },
-  ignoreAllLogs: (value) => {
-    // Do nothing.
-  },
-  install: () => {
-    // Do nothing.
-  },
-  uninstall: () => {
-    // Do nothing.
+  __esModule: true, // Marks this as an ES module mock
+  default: {
+    ignoreLogs: (patterns) => {
+      // Do nothing.
+    },
+    ignoreAllLogs: (value) => {
+      // Do nothing.
+    },
+    install: () => {
+      // Do nothing.
+    },
+    uninstall: () => {
+      // Do nothing.
+    },
   },
 }));
 


### PR DESCRIPTION
# Why
A lot of modules in RN were changed from commonjs to esm exports. We need to adjust our mocks so they have the `default` property.

# How
Update our `doMock` calls.

# Test Plan
Clean run of `et cp -a`
