### PR TITLE
[docs] improve platform tags text

### DIFF
--- a/docs/ui/components/PagePlatformTags/index.tsx
+++ b/docs/ui/components/PagePlatformTags/index.tsx
@@ -13,10 +13,11 @@ export function PagePlatformTags({ platforms }: Props) {
         .sort((a, b) => a.localeCompare(b))
         .map(platform => {
           if (platform.includes('*')) {
+            const text = platform.replace('*', ' - device only');
             return (
-              <Tooltip.Root key={platform}>
+              <Tooltip.Root key={text}>
                 <Tooltip.Trigger className="cursor-default">
-                  <PlatformTag platform={platform} className="rounded-full px-2.5 py-1.5" />
+                  <PlatformTag platform={text} className="rounded-full px-2.5 py-1.5" />
                 </Tooltip.Trigger>
                 <Tooltip.Content side="bottom">
                   {platform.startsWith('android') && (

--- a/docs/ui/components/PagePlatformTags/index.tsx
+++ b/docs/ui/components/PagePlatformTags/index.tsx
@@ -1,6 +1,4 @@
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
-import { FOOTNOTE } from '~/ui/components/Text';
-import * as Tooltip from '~/ui/components/Tooltip';
 
 type Props = {
   platforms: string[];
@@ -8,33 +6,12 @@ type Props = {
 
 export function PagePlatformTags({ platforms }: Props) {
   return (
-    <div className="mt-3 inline-flex flex-wrap gap-1">
+    <div className="mt-3 inline-flex flex-wrap">
       {platforms
         .sort((a, b) => a.localeCompare(b))
         .map(platform => {
-          if (platform.includes('*')) {
-            const text = platform.replace('*', ' (device only)');
-            return (
-              <Tooltip.Root key={text}>
-                <Tooltip.Trigger className="cursor-default">
-                  <PlatformTag platform={text} className="rounded-full px-2.5 py-1.5" />
-                </Tooltip.Trigger>
-                <Tooltip.Content side="bottom">
-                  {platform.startsWith('android') && (
-                    <FOOTNOTE>Android Emulator not supported</FOOTNOTE>
-                  )}
-                  {platform.startsWith('ios') && <FOOTNOTE>iOS Simulator not supported</FOOTNOTE>}
-                </Tooltip.Content>
-              </Tooltip.Root>
-            );
-          }
-          return (
-            <PlatformTag
-              platform={platform}
-              key={platform}
-              className="rounded-full px-2.5 py-1.5"
-            />
-          );
+          const text = platform.includes('*') ? platform.replace('*', ' (device only)') : platform;
+          return <PlatformTag platform={text} key={text} className="rounded-full px-2.5 py-1.5" />;
         })}
     </div>
   );

--- a/docs/ui/components/PagePlatformTags/index.tsx
+++ b/docs/ui/components/PagePlatformTags/index.tsx
@@ -13,7 +13,7 @@ export function PagePlatformTags({ platforms }: Props) {
         .sort((a, b) => a.localeCompare(b))
         .map(platform => {
           if (platform.includes('*')) {
-            const text = platform.replace('*', ' - device only');
+            const text = platform.replace('*', ' (device only)');
             return (
               <Tooltip.Root key={text}>
                 <Tooltip.Trigger className="cursor-default">

--- a/docs/ui/components/PagePlatformTags/index.tsx
+++ b/docs/ui/components/PagePlatformTags/index.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export function PagePlatformTags({ platforms }: Props) {
   return (
-    <div className="mt-3 inline-flex flex-wrap">
+    <div className="mt-3 inline-flex flex-wrap gap-1">
       {platforms
         .sort((a, b) => a.localeCompare(b))
         .map(platform => {


### PR DESCRIPTION
# Why

The "not supported on emulator / simulator" info is in a tooltip, meaning it's hard to find and inaccessible on mobile.

<img width="465" alt="Screenshot 2025-03-19 at 13 02 41" src="https://github.com/user-attachments/assets/46d52392-41d2-49a2-9ff1-b3077ae3547f" />


# How

Added the `(device only)` in the tag itself so it's always visible.

Removed the tooltip as it's not showing the same information as the label.

# Test Plan

Verified locally on https://docs.expo.dev/versions/latest/sdk/camera/

<img width="512" alt="Screenshot 2025-03-19 at 15 13 04" src="https://github.com/user-attachments/assets/afeb95d6-c372-4b45-bd1d-a93e21f1a1eb" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
