### PR TITLE
fix(cli): use port with `expo run ios --port` when running in headless mode

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add fallback resolution strategy for dependencies and optional peer dependencies of `expo` and `expo-router` to prevent broken resolution for isolated dependencies and hoisting issues. ([#34286](https://github.com/expo/expo/pull/34286) by [@kitten](https://github.com/kitten))
 - Preserve proxy leases on webcontainers ([#34831](https://github.com/expo/expo/pull/34831) by [@kitten](https://github.com))
 - Add support for `isESMImport` in fast resolver and React Server resolution. ([#35520](https://github.com/expo/expo/pull/35520) by [@byCedric](https://github.com/byCedric))
+- Use explicit user-provided port for `expo run ios --port` when running in headless mode.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Add fallback resolution strategy for dependencies and optional peer dependencies of `expo` and `expo-router` to prevent broken resolution for isolated dependencies and hoisting issues. ([#34286](https://github.com/expo/expo/pull/34286) by [@kitten](https://github.com/kitten))
 - Preserve proxy leases on webcontainers ([#34831](https://github.com/expo/expo/pull/34831) by [@kitten](https://github.com))
 - Add support for `isESMImport` in fast resolver and React Server resolution. ([#35520](https://github.com/expo/expo/pull/35520) by [@byCedric](https://github.com/byCedric))
-- Use explicit user-provided port for `expo run ios --port` when running in headless mode.
+- Use explicit user-provided port for `expo run ios --port` when running in headless mode. ([#35582](https://github.com/expo/expo/pull/35582) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/resolveBundlerProps.ts
+++ b/packages/@expo/cli/src/run/resolveBundlerProps.ts
@@ -34,8 +34,8 @@ export async function resolveBundlerPropsAsync(
   // Skip bundling if the port is null -- meaning skip the bundler if the port is already running the app.
   options.bundler = !!port;
   if (!port) {
-    // any random number
-    port = 8081;
+    // Use explicit user-provided port, or the default port
+    port = options.port ?? 8081;
   }
   Log.debug(`Resolved port: ${port}, start dev server: ${options.bundler}`);
 


### PR DESCRIPTION
# Why

Fixes #35542

# How

- Use explicitly user-provided port when running in headless mode
- When not provided, fallback to default port

# Test Plan

- `bun create expo ./test-app`
- `cd ./test-app`
- `bun expo install expo-dev-client`
- Split into two terminals and run these commands
  1. `bun expo start --port 8888`
  2. `bun expo run ios --port 8888`
- Should work fine

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
