### PR TITLE
fix(AudioModule.kt): isPrepared is a requirement for record()

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - [Android] Remove maxSdkVersion from MODIFY_AUDIO_SETTINGS permission ([#35541](https://github.com/expo/expo/pull/35541) by [@jakex7](https://github.com/jakex7))
 
+- [Android] Recording was not working when prepared due to wrong precondition check ([#35591](https://github.com/expo/expo/pull/35591) by [@pennersr](https://github.com/pennersr))
+
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -332,7 +332,7 @@ class AudioModule : Module() {
 
       Function("record") { ref: AudioRecorder ->
         checkRecordingPermission()
-        if (!ref.isPrepared) {
+        if (ref.isPrepared) {
           ref.record()
         }
       }


### PR DESCRIPTION
# Why

For recording, the documented flow is:

``` js
   await audioRecorder.prepareToRecordAsync();
    audioRecorder.record();
 ```

So, the `!isPrepared` check is clearly wrong.

# How

The change is obvious.

# Test Plan

Obvious change -- can be manually code reviewed.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
