### PR TITLE
[sqlite] fix build warnings

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Removed deprecated CR-SQLite integration. ([#35097](https://github.com/expo/expo/pull/35097) by [@kudo](https://github.com/kudo))
 - Remove prebuilt worker on Web. ([#35311](https://github.com/expo/expo/pull/35311) by [@kudo](https://github.com/kudo))
 - [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
+- Fixed build warnings. ([#35610](https://github.com/expo/expo/pull/35610) by [@kudo](https://github.com/kudo))
 
 ## 15.1.2 - 2025-02-05
 

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt
@@ -17,8 +17,12 @@ internal class NativeDatabase(val databasePath: String, val openOptions: OpenDat
     return other is NativeDatabase && this.ref == other.ref
   }
 
-  override fun deallocate() {
-    super.deallocate()
+  override fun hashCode(): Int {
+    return ref.hashCode()
+  }
+
+  override fun sharedObjectDidRelease() {
+    super.sharedObjectDidRelease()
     val shouldClose = refCount.decrementAndGet() <= 0
     if (shouldClose) {
       this.ref.close()

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabaseBinding.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabaseBinding.kt
@@ -8,7 +8,7 @@ import java.io.Closeable
 
 private typealias UpdateListener = (databaseName: String, tableName: String, operationType: Int, rowID: Long) -> Unit
 
-@Suppress("KotlinJniMissingFunction")
+@Suppress("KotlinJniMissingFunction", "FunctionName")
 @DoNotStrip
 internal class NativeDatabaseBinding : Closeable {
   @DoNotStrip
@@ -35,6 +35,7 @@ internal class NativeDatabaseBinding : Closeable {
   /**
    * Disable data change notifications
    */
+  @Suppress("unused")
   fun disableUpdateHook() {
     mUpdateListener = null
     sqlite3_update_hook(false)

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeSession.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeSession.kt
@@ -13,4 +13,8 @@ internal class NativeSession : SharedRef<NativeSessionBinding>(NativeSessionBind
   override fun equals(other: Any?): Boolean {
     return other is NativeSession && this.ref == other.ref
   }
+
+  override fun hashCode(): Int {
+    return ref.hashCode()
+  }
 }

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeSessionBinding.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeSessionBinding.kt
@@ -6,7 +6,7 @@ import com.facebook.jni.HybridData
 import expo.modules.core.interfaces.DoNotStrip
 import java.io.Closeable
 
-@Suppress("KotlinJniMissingFunction")
+@Suppress("KotlinJniMissingFunction", "FunctionName")
 @DoNotStrip
 internal class NativeSessionBinding : Closeable {
   @DoNotStrip

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatement.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatement.kt
@@ -7,12 +7,16 @@ import expo.modules.kotlin.sharedobjects.SharedRef
 internal class NativeStatement : SharedRef<NativeStatementBinding>(NativeStatementBinding()) {
   var isFinalized = false
 
-  override fun deallocate() {
-    super.deallocate()
+  override fun sharedObjectDidRelease() {
+    super.sharedObjectDidRelease()
     this.ref.close()
   }
 
   override fun equals(other: Any?): Boolean {
     return other is NativeStatement && this.ref == other.ref
+  }
+
+  override fun hashCode(): Int {
+    return ref.hashCode()
   }
 }

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatementBinding.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatementBinding.kt
@@ -9,7 +9,7 @@ import java.io.Closeable
 internal typealias SQLiteColumnNames = ArrayList<String>
 internal typealias SQLiteColumnValues = ArrayList<Any>
 
-@Suppress("KotlinJniMissingFunction")
+@Suppress("KotlinJniMissingFunction", "FunctionName")
 @DoNotStrip
 internal class NativeStatementBinding : Closeable {
   @DoNotStrip

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
@@ -3,8 +3,8 @@
 package expo.modules.sqlite
 
 import android.content.Context
-import android.net.Uri
 import androidx.core.net.toFile
+import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
@@ -62,7 +62,7 @@ class SQLiteModule : Module() {
       if (dbFile.exists() && !forceOverwrite) {
         return@AsyncFunction
       }
-      val assetFile = Uri.parse(assetDatabasePath).toFile()
+      val assetFile = assetDatabasePath.toUri().toFile()
       if (!assetFile.isFile) {
         throw OpenDatabaseException(assetDatabasePath)
       }
@@ -309,7 +309,7 @@ class SQLiteModule : Module() {
     }
     try {
       val parsedPath =
-        Uri.parse(databasePath).path ?: throw IOException("Couldn't parse Uri - $databasePath")
+        databasePath.toUri().path ?: throw IOException("Couldn't parse Uri - $databasePath")
       val path = File(parsedPath)
       val parentPath =
         path.parentFile ?: throw IOException("Parent directory is null for path '$path'.")

--- a/packages/expo-sqlite/ios/NativeDatabase.swift
+++ b/packages/expo-sqlite/ios/NativeDatabase.swift
@@ -2,16 +2,17 @@
 
 import ExpoModulesCore
 
-final class NativeDatabase: SharedRef<OpaquePointer?>, Equatable, Hashable {
+final class NativeDatabase: SharedObject, Equatable, Hashable {
+  var pointer: OpaquePointer?
   let databasePath: String
   let openOptions: OpenDatabaseOptions
   var isClosed = false
   var extraPointer: OpaquePointer?
 
   init(_ pointer: OpaquePointer?, databasePath: String, openOptions: OpenDatabaseOptions) {
+    self.pointer = pointer
     self.databasePath = databasePath
     self.openOptions = openOptions
-    super.init(pointer)
   }
 
   // MARK: - Equatable


### PR DESCRIPTION
# Why

fix build warning for expo-sqlite

# How

- fix warnings
- `NativeDatabase` on ios can actually use `SharedObject` and we can then fix `SharedObject.pointer` being deprecated warning
- replace deprecated `SharedRef.deallocate` to `SharedRef.sharedObjectDidRelease` on android

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
