### PR TITLE
[android][camera] Don't throw when setting ratio

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [Android] Fix flash. ([#34893](https://github.com/expo/expo/pull/34893) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Attempts to address crash that occurs more frequently on iPads. ([#34915](https://github.com/expo/expo/pull/34915) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Control barcode scanner on session queue. ([#35107](https://github.com/expo/expo/pull/35107) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Don't throw when setting the aspect ratio and instead fallback safely.
+- [Android] Don't throw when setting the aspect ratio and instead fallback safely. ([#35614](https://github.com/expo/expo/pull/35614) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [Android] Fix flash. ([#34893](https://github.com/expo/expo/pull/34893) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Attempts to address crash that occurs more frequently on iPads. ([#34915](https://github.com/expo/expo/pull/34915) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Control barcode scanner on session queue. ([#35107](https://github.com/expo/expo/pull/35107) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Don't throw when setting the aspect ratio and instead fallback safely.
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/records/CameraRecords.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/records/CameraRecords.kt
@@ -28,7 +28,7 @@ enum class CameraRatio(val value: String) : Enumerable {
   fun mapToStrategy() = when (this) {
     FOUR_THREE -> AspectRatioStrategy.RATIO_4_3_FALLBACK_AUTO_STRATEGY
     SIXTEEN_NINE -> AspectRatioStrategy.RATIO_16_9_FALLBACK_AUTO_STRATEGY
-    else -> AspectRatioStrategy.FALLBACK_RULE_AUTO
+    else -> AspectRatioStrategy.RATIO_4_3_FALLBACK_AUTO_STRATEGY
   }
 }
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/records/CameraRecords.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/records/CameraRecords.kt
@@ -28,7 +28,7 @@ enum class CameraRatio(val value: String) : Enumerable {
   fun mapToStrategy() = when (this) {
     FOUR_THREE -> AspectRatioStrategy.RATIO_4_3_FALLBACK_AUTO_STRATEGY
     SIXTEEN_NINE -> AspectRatioStrategy.RATIO_16_9_FALLBACK_AUTO_STRATEGY
-    else -> throw CameraExceptions.UnsupportedAspectRatioException(this.value)
+    else -> AspectRatioStrategy.FALLBACK_RULE_AUTO
   }
 }
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/records/CameraRecords.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/records/CameraRecords.kt
@@ -5,7 +5,6 @@ import androidx.camera.core.ImageCapture
 import androidx.camera.core.resolutionselector.AspectRatioStrategy
 import androidx.camera.video.Quality
 import com.google.mlkit.vision.barcode.common.Barcode
-import expo.modules.camera.CameraExceptions
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable


### PR DESCRIPTION
# Why
Closes #35608
The docs describe the correct behaviour of setting the aspect ratio https://docs.expo.dev/versions/latest/sdk/camera/#ratio

# How
Instead of throwing we should fallback to the default of 4:3 and allow cameraX to select the closest ratio available to that

# Test Plan
bare-expo

