### PR TITLE
[changelog] Add note about individual package updates after SDK release in root changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 This is the log of notable changes to the Expo client that are developer-facing.
 Package-specific changes not released in any SDK will be added here just before the release. Until then, you can find them in changelogs of the individual packages (see [packages](./packages) directory).
 
+Note: Individual packages that remain compatible with older SDK versions may receive updates and even new features after that SDK’s initial release. These updates will not retroactively be added to the SDK’s changelog section here. Please refer to the changelogs of individual packages for the most accurate and up-to-date information.
+
 ## Unpublished
 
 ### 📚 3rd party library updates


### PR DESCRIPTION
# Why

While using Expo SDK 51, I needed to resolve READ_MEDIA_* permission issues on Android. I checked the root changelog but couldn’t find any mention of expo-image-picker removing READ_MEDIA_IMAGES and READ_MEDIA_VIDEO permissions under the SDK 51 section.

This caused confusion, even though the latest version of expo-image-picker compatible with SDK 51 (v15.1.0) had addressed the issue.

A note was added to the top of the changelog to clarify that package-level updates may introduce changes or new features after an SDK’s release, and such updates are not retroactively reflected in the SDK changelog.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
