### PR TITLE
fix(docs): typo in documentation for splash screen

### DIFF
--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -116,13 +116,12 @@ To test your new splash screen, build your app for [internal distribution](/tuto
           "ios": {
             "backgroundColor": "#ffffff",
             "image": "./assets/images/splash-icon.png",
-            "resizeMode": "cover",
+            "resizeMode": "cover"
           },
           "android": {
             "backgroundColor": "#0c7cff",
             "image": "./assets/images/splash-android-icon.png",
-            "imageWidth": 150,
-            }
+            "imageWidth": 150
           }
         }
       ]


### PR DESCRIPTION
# Why
There is a typo in current public docs in splash screen section with extra curly brace and trailing comma which this PR removes.
<img width="732" alt="image" src="https://github.com/user-attachments/assets/43a70842-91ce-4994-9191-1b71a3dd6fb1" />


# Test Plan
Tested changes on localhost:
<img width="1392" alt="image" src="https://github.com/user-attachments/assets/992176cd-8bc8-43c8-96b1-857c39265c86" />


# Checklist
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
