### PR TITLE
chore(apps/expo-go): add Expo Go export validation in workflow

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - .github/workflows/home.yml
       - apps/expo-go/**
+      - react-native-lab/**
       - yarn.lock
   push:
     branches: [main, 'sdk-*']
     paths:
       - .github/workflows/home.yml
       - apps/expo-go/**
+      - react-native-lab/**
       - yarn.lock
 
 concurrency:

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -26,27 +26,42 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
+
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
           yarn-workspace: 'true'
+
       - name: 🧶 Yarn install
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
+
+      - name: 🧶 Yarn install (react-native-lab)
+        run: yarn install --frozen-lockfile
+        working-directory: react-native-lab/react-native
+
       - name: 🛠 Compile Home sources
         run: yarn tsc
         working-directory: apps/expo-go
+
       - name: 🧪 Run Home tests
         run: yarn jest --maxWorkers 1
         working-directory: apps/expo-go
+
       - name: 🚨 Lint Home app
         run: yarn lint --max-warnings 0
         working-directory: apps/expo-go
+
+      - name: 👷 Build Home app
+        run: yarn expo export
+        working-directory: apps/expo-go
+  
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))


### PR DESCRIPTION
# Why

This PR adds actually bundling the Expo Go app to CI, which helps us validate if it still can be built. E.g. changing `react-native-lab/react-native` or upgrading React Native might affect this.

# How

- Added `react-native-lab/react-native` installation step
- Added `apps/expo-go` export step

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
