### PR TITLE
chore(apps/test-suite): enable `gradle` caching for Android builds

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -167,6 +167,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+          cache: 'gradle'
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: ♻️ Restore caches


### PR DESCRIPTION
# Why

TBD

# How

TBD

# Test Plan

See CI

- `android-build` without an existing Gradle cache: https://github.com/expo/expo/actions/runs/13990630334/job/39173578238?pr=35626#step:5:32
- `android-build` with a populated Gradle cache: https://github.com/expo/expo/actions/runs/13990630334/job/39175671237?pr=35626#step:5:34

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
