### PR TITLE
[android][audio] Fix muting

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -12,8 +12,8 @@
 
 - [Android] Remove maxSdkVersion from MODIFY_AUDIO_SETTINGS permission ([#35541](https://github.com/expo/expo/pull/35541) by [@jakex7](https://github.com/jakex7))
 - Use the same prop name for "muted" on all platforms. Fix playing in background on iOS.([#35600](https://github.com/expo/expo/pull/35600) by [@alanjhughes](https://github.com/alanjhughes))
-
 - [Android] Recording was not working when prepared due to wrong precondition check ([#35591](https://github.com/expo/expo/pull/35591) by [@pennersr](https://github.com/pennersr))
+- [Android] Correctly handle muting and volume. ([#35631](https://github.com/expo/expo/pull/35631) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -46,6 +46,8 @@ class AudioPlayer(
   val player = ref
   var preservesPitch = false
   var isPaused = false
+  var isMuted = false
+  var previousVolume = 1f
 
   private var playerScope = CoroutineScope(Dispatchers.Default)
   private var samplingEnabled = false
@@ -62,6 +64,18 @@ class AudioPlayer(
     addPlayerListeners()
     source?.let {
       setMediaSource(source)
+    }
+  }
+
+  fun setVolume(volume: Float?) = appContext?.mainQueue?.launch {
+    val boundedVolume = volume?.coerceIn(0f, 1f) ?: 1f
+    if (isMuted) {
+      if (boundedVolume > 0f) {
+        previousVolume = boundedVolume
+      }
+      player.volume = 0f
+    } else {
+      player.volume = if (boundedVolume > 0) boundedVolume else previousVolume
     }
   }
 


### PR DESCRIPTION
# Why
Correctly handles the volume on android. Determining if the audio is muted should not be done through `isDeviceMuted` on the `ExoPlayer` instance. This refers to the devices global sound setting. It should instead be determined on the the volume of the player.

# How
Update `muted` to use `volume == 0f`. Because users can write to the `muted` property this leads to a complications with the `volume` property. Both are now controlling the same underlying property so we need to store the muted state on the player instance as well as the last non 0 volume to determine what we should be setting the volume to at any given time. 

# Test Plan
Bare-expo. Muting and unmuting works as expected and unmuting restores the volume to the previous level it was at.

