### PR TITLE
[CI] Move to RNTV 0.79 for TV compile test

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -375,7 +375,7 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@~0.78.0-0',
+        'react-native': 'npm:react-native-tvos@0.79.0-0rc2',
         '@react-native-tvos/config-tv': '^0.1.1',
       },
       expo: {


### PR DESCRIPTION
# Why

RNTV now has a 0.79 prerelease available, so we can reenable TV compile CI on main.

# How

Updated the RNTV version in CI scripts.

# Test Plan

CI should pass
