### PR TITLE
[template-default] fix `ExternalLink` link type issue

### DIFF
--- a/templates/expo-template-default/components/ExternalLink.tsx
+++ b/templates/expo-template-default/components/ExternalLink.tsx
@@ -1,11 +1,8 @@
-import { Link } from 'expo-router';
+import { Link, type LinkProps } from 'expo-router';
 import { openBrowserAsync } from 'expo-web-browser';
-import { type ComponentProps } from 'react';
 import { Platform } from 'react-native';
 
-type Props = Omit<ComponentProps<typeof Link>, 'href'> & { href: string };
-
-export function ExternalLink({ href, ...rest }: Props) {
+export function ExternalLink({ href, ...rest }: LinkProps) {
   return (
     <Link
       target="_blank"
@@ -16,7 +13,7 @@ export function ExternalLink({ href, ...rest }: Props) {
           // Prevent the default behavior of linking to the default browser on native.
           event.preventDefault();
           // Open the link in an in-app browser.
-          await openBrowserAsync(href);
+          await openBrowserAsync(href.toString());
         }
       }}
     />


### PR DESCRIPTION
# Why

Spotted types error while setting up a test project using default template and latest versions of dependencies.

![Screenshot 2025-03-23 at 12 16 18](https://github.com/user-attachments/assets/f134a4ab-29aa-4c98-a0d5-62b4cc21a0d2)

# How

Refactor `ExternalLink` to use `LinkProps` type directly from the router. IIRC this was a workaround for previous issues with router link typings, which seems to be addressed now.

# Test Plan

Running `yarn tsc` in the template directory does not return any errors.

Template app is bundling and working as expected.