### PR TITLE
Remove redundant </key> in docs for BackgroundFetch

### DIFF
--- a/docs/pages/versions/unversioned/sdk/background-fetch.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.mdx
@@ -39,10 +39,9 @@ If you're not using Continuous Native Generation ([CNG](/workflow/continuous-nat
 
 ```xml ios/project-name/Supporting/Expo.plist
 <key>UIBackgroundModes</key>
-  <array>
-    <string>fetch</string>
-  </array>
-</key>
+<array>
+  <string>fetch</string>
+</array>
 ```
 
 </Collapsible>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
While going through docs of [expo-background-fetch](https://docs.expo.dev/versions/latest/sdk/background-fetch/), saw that in the code suggestion, there's an extra `</key>` which isn't necessary.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
