### PR TITLE
[ios] [expo-ui] Add swipeActions functionality to native List

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Adds `DateTimePicker` component. ([#34883](https://github.com/expo/expo/pull/34883) by [@alanjhughes](https://github.com/alanjhughes))
 - Add CircularProgress and LinearProgress component. ([#34907](https://github.com/expo/expo/pull/34907) by [@janicduplessis](https://github.com/janicduplessis))
 - Add Gauge component ([#35032](https://github.com/expo/expo/pull/35032) by [@jakex7](https://github.com/jakex7))
+- Add `ListItem` component. ([#35655](https://github.com/expo/expo/pull/35655) by [@patrikholcak](https://github.com/patrikholcak))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-ui/components/ListItem/index.tsx
+++ b/packages/expo-ui/components/ListItem/index.tsx
@@ -1,0 +1,124 @@
+import { requireNativeView } from 'expo';
+import { Children, Fragment, isValidElement, ReactElement, ReactNode, useMemo } from 'react';
+import { NativeSyntheticEvent } from 'react-native';
+
+import { Button, ButtonProps, NativeButtonProps, transformButtonProps } from '../Button';
+
+type SwipeActionNativeEvent = NativeSyntheticEvent<{ id: string }>;
+type EventHandlerMap = Map<string, (event: SwipeActionNativeEvent) => void>;
+type NativeSwipeActionProps = { id: string; props: NativeButtonProps };
+type SwipeActionElement = ReactElement<ButtonProps>;
+
+type SwipeAction = SwipeActionElement | React.ReactElement<{ children: SwipeActionElement[] }>;
+
+export type ListItemProps = {
+  /**
+   * Actions which will appear when swiping from the leading edge
+   */
+  leadingActions?: SwipeAction;
+
+  /**
+   * Whether to activate the first action when user overshoots swipe from leading edge
+   * @default true
+   */
+  allowsFullSwipeLeading?: boolean;
+
+  /**
+   * Actions which will appear when swiping from the trailing edge
+   */
+  trailingActions?: SwipeAction;
+
+  /**
+   * Whether to activate the first action when user overshoots swipe from trailing edge
+   * @default true
+   */
+  allowsFullSwipeTrailing?: boolean;
+
+  /**
+   * Whether to hide trailing edge actions when list edit mode is active
+   * @default true
+   */
+  hideTrailingActionsInEditMode?: boolean;
+
+  children: React.ReactNode;
+};
+
+type ListItemNativeProps = Omit<ListItemProps, 'leadingActions' | 'trailingActions'> & {
+  leadingActions?: NativeSwipeActionProps[];
+  trailingActions?: NativeSwipeActionProps[];
+  onActionPressed: (event: SwipeActionNativeEvent) => void;
+};
+
+const ListItemNativeView: React.ComponentType<ListItemNativeProps> = requireNativeView(
+  'ExpoUI',
+  'ListItemView'
+);
+
+/**
+ * Provides a way to add swipe actions to List items
+ *
+ * @param {ListItemProps} props - The properties passed to the item.
+ * @returns {JSX.Element} The rendered native component.
+ * @platform ios
+ */
+export function ListItem({ leadingActions, trailingActions, children, ...props }: ListItemProps) {
+  const eventHandlersMap = new Map<string, (event: NativeSyntheticEvent<any>) => void>();
+
+  const processedLeadingActions = useMemo(
+    () => transformSwipeActions(leadingActions, eventHandlersMap),
+    [leadingActions]
+  );
+  const processedTrailingActions = useMemo(
+    () => transformSwipeActions(trailingActions, eventHandlersMap),
+    [trailingActions]
+  );
+
+  return (
+    <ListItemNativeView
+      {...props}
+      leadingActions={processedLeadingActions}
+      trailingActions={processedTrailingActions}
+      onActionPressed={(ev) => eventHandlersMap.get(ev.nativeEvent.id)?.call(undefined, ev)}>
+      {children}
+    </ListItemNativeView>
+  );
+}
+
+function isButtonElement(element: ReactElement<any>): element is SwipeActionElement {
+  return element.type === Button;
+}
+
+function processSwipeAction(
+  child: ReactNode,
+  eventHandlersMap: EventHandlerMap
+): NativeSwipeActionProps | null {
+  const isValidChild = isValidElement(child);
+  if (!isValidChild || !isButtonElement(child)) {
+    console.warn('Unsupported button type in ListItem ', isValidChild ? child?.type : child);
+    return null;
+  }
+
+  const uuid = expo.uuidv4();
+
+  if (child.props.onPress) eventHandlersMap.set(uuid, child.props.onPress);
+
+  return {
+    id: uuid,
+    props: transformButtonProps(child.props),
+  };
+}
+
+function getChildren(node?: SwipeAction) {
+  if (isValidElement(node) && node.type === Fragment) return Children.toArray(node.props.children);
+
+  return Children.toArray(node);
+}
+
+export function transformSwipeActions(
+  children: SwipeAction | undefined,
+  eventHandlersMap: EventHandlerMap
+): NativeSwipeActionProps[] {
+  return getChildren(children)
+    .map((child) => processSwipeAction(child, eventHandlersMap))
+    .filter((el): el is NativeSwipeActionProps => el !== null);
+}

--- a/packages/expo-ui/ios/ExpoUIModule.swift
+++ b/packages/expo-ui/ios/ExpoUIModule.swift
@@ -20,5 +20,6 @@ public class ExpoUIModule: Module {
     View(TextInputView.self)
     View(ProgressView.self)
     View(GaugeView.self)
+    View(ListItemView.self)
   }
 }

--- a/packages/expo-ui/ios/ListItem.swift
+++ b/packages/expo-ui/ios/ListItem.swift
@@ -1,0 +1,65 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+import SwiftUI
+
+internal class SwipeAction: Record, Identifiable {
+  required init() { }
+  @Field var id: String
+  @Field var props: ButtonProps
+}
+
+class ListItemViewProps: ExpoSwiftUI.ViewProps {
+  @Field var leadingActions: [SwipeAction]
+  @Field var allowsFullSwipeLeading = true
+
+  @Field var trailingActions: [SwipeAction]
+  @Field var allowsFullSwipeTrailing = true
+  @Field var hideTrailingActionsInEditMode = true
+
+  var onActionPressed = EventDispatcher()
+}
+
+struct ActionButtons: View {
+  let fromArray: [SwipeAction]?
+  let handleButtonPress: (_ id: String) -> Void
+
+  var body: some View {
+    ForEach(fromArray ?? []) { elem in
+      elem.props.onButtonPressed.onEventSent = { _ in
+        handleButtonPress(elem.id)
+      }
+
+      return ExpoUI.Button().environmentObject(elem.props)
+    }
+  }
+}
+
+struct ListItemView: ExpoSwiftUI.View {
+  @Environment(\.editMode) private var editMode
+  @EnvironmentObject var props: ListItemViewProps
+
+  var body: some View {
+    UnwrappedChildren { child, isHostingView in
+      child
+        .if(!isHostingView) {
+          $0
+            .offset(
+              x: UIDevice.current.userInterfaceIdiom == .pad
+              ? IPAD_OFFSET : IPHONE_OFFSET)
+        }
+    }
+    .swipeActions(edge: .leading, allowsFullSwipe: props.allowsFullSwipeLeading) {
+      ActionButtons(fromArray: props.leadingActions) { id in
+        props.onActionPressed.callAsFunction(["id": id])
+      }
+    }
+    .swipeActions(edge: .trailing, allowsFullSwipe: props.allowsFullSwipeTrailing) {
+      if (editMode?.wrappedValue == .inactive || !props.hideTrailingActionsInEditMode) {
+          ActionButtons(fromArray: props.trailingActions) { id in
+            props.onActionPressed.callAsFunction(["id": id])
+          }
+      }
+    }
+  }
+}

--- a/packages/expo-ui/ios/ListItem.swift
+++ b/packages/expo-ui/ios/ListItem.swift
@@ -55,10 +55,10 @@ struct ListItemView: ExpoSwiftUI.View {
       }
     }
     .swipeActions(edge: .trailing, allowsFullSwipe: props.allowsFullSwipeTrailing) {
-      if (editMode?.wrappedValue == .inactive || !props.hideTrailingActionsInEditMode) {
-          ActionButtons(fromArray: props.trailingActions) { id in
-            props.onActionPressed(["id": id])
-          }
+      if editMode?.wrappedValue == .inactive || !props.hideTrailingActionsInEditMode {
+        ActionButtons(fromArray: props.trailingActions) { id in
+          props.onActionPressed(["id": id])
+        }
       }
     }
   }

--- a/packages/expo-ui/ios/ListItem.swift
+++ b/packages/expo-ui/ios/ListItem.swift
@@ -51,13 +51,13 @@ struct ListItemView: ExpoSwiftUI.View {
     }
     .swipeActions(edge: .leading, allowsFullSwipe: props.allowsFullSwipeLeading) {
       ActionButtons(fromArray: props.leadingActions) { id in
-        props.onActionPressed.callAsFunction(["id": id])
+        props.onActionPressed(["id": id])
       }
     }
     .swipeActions(edge: .trailing, allowsFullSwipe: props.allowsFullSwipeTrailing) {
       if (editMode?.wrappedValue == .inactive || !props.hideTrailingActionsInEditMode) {
           ActionButtons(fromArray: props.trailingActions) { id in
-            props.onActionPressed.callAsFunction(["id": id])
+            props.onActionPressed(["id": id])
           }
       }
     }


### PR DESCRIPTION
# Why

The PR #35222 implements most of the native list functionality but is missing swipe actions api. I figured the best way to implement this would be to create optional `<ListItem />` component which would provide the actions to the list row.

# How

Adding a component which can wrap the list items and provide more functionality. This component could implement more functionality in the future, but for now it only implements swipe actions.

I think you can technically attach `swipeActions` to whole `Section`s in SwiftUI, and this shouldn’t prevent you from doing just that (although maybe it’s badly named for this case).

# Test Plan

1. Checkout ~#35222~ #35750 (this PR does not work without changes in that PR)
1. Merge changes from that PR changes into this
1. Update <kbd>expo/apps/native-component-list/src/screens/UI/ListScreen.tsx</kbd> by adding the following code
   https://github.com/expo/expo/blob/4a57b2c4db7d7e00a44e831b8bdfc9cf5635add0/apps/native-component-list/src/screens/UI/ListScreen.tsx#L106
   ```tsx
   <ListItem
     leadingActions={
       <>
         <Button onPress={() => alert('Leading action 1 pressed')}>
           Leading Action 1
         </Button>
         <Button>Leading Action 2</Button>
       </>
     }
     trailingActions={<Button>Trailing Action</Button>}
   >
     <Label title="Custom Swipe actions" systemImage="arrow.left.arrow.right" />
   </ListItem>
   ```

https://github.com/user-attachments/assets/f11f6d1e-3a4d-4142-9aa8-cae8e479971b

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
