### PR TITLE
[expo] re-export bin for autolinking and fingerprint

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [apple] Add EXAppDelegateWrapper import to Expo.h ([#35172](https://github.com/expo/expo/pull/35172) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Improve devtools plugins transport performance. ([#35581](https://github.com/expo/expo/pull/35581) by [@kudo](https://github.com/kudo))
 - Improve warning for incompatible devtools plugins. ([#35587](https://github.com/expo/expo/pull/35587) by [@kudo](https://github.com/kudo))
+- Re-export bin for `expo-modules-autolinking` and `fingerprint`. ([#35660](https://github.com/expo/expo/pull/35660) by [@kudo](https://github.com/kudo))
 
 ## 52.0.39 - 2025-03-14
 

--- a/packages/expo/bin/autolinking
+++ b/packages/expo/bin/autolinking
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('expo-modules-autolinking/bin/expo-modules-autolinking');

--- a/packages/expo/bin/fingerprint
+++ b/packages/expo/bin/fingerprint
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('@expo/fingerprint/bin/cli');

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -10,7 +10,11 @@
     "*.fx.web.tsx",
     "./src/winter/*.ts"
   ],
-  "bin": "bin/cli",
+  "bin": {
+    "expo": "bin/cli",
+    "expo-modules-autolinking": "bin/autolinking",
+    "fingerprint": "bin/fingerprint"
+  },
   "files": [
     "android",
     "bin",


### PR DESCRIPTION
# Why

re-export bin for autolinking and fingerprint, so that people can run `npx expo-modules-autolinking` and `npx fingerprint` in pnpm isolated mode
close ENG-14908

# How

re-export bin for autolinking and fingerprint

# Test Plan

prepare a blank project with pnpm isolated mode
```
$ cd packages/expo && npm pack --pack-destination ../..
$ pnpm add /path/to/expo/expo/expo-52.0.11.tgz
$ npx expo
$ npx expo-modues-autolinking
$ npx fingerprint
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
