### PR TITLE
[templates] use npx expo-modules-autolinking

### DIFF
--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -27,10 +27,8 @@ abstract_target 'BareExpoMain' do
   use_frameworks! :linkage => ENV['USE_FRAMEWORKS'].to_sym if ENV['USE_FRAMEWORKS']
 
   config_command = [
-    'node',
-    '--no-warnings',
-    '--eval',
-    'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
+    'npx',
+    'expo-modules-autolinking',
     'react-native-config',
     '--json',
     '--platform',

--- a/apps/bare-expo/macos/Podfile
+++ b/apps/bare-expo/macos/Podfile
@@ -8,10 +8,8 @@ prepare_react_native_project!
 target 'BareExpo-macOS' do
   platform :macos, '11.0'
   config_command = [
-    'node',
-    '--no-warnings',
-    '--eval',
-    'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
+    'npx',
+    'expo-modules-autolinking',
     'react-native-config',
     '--json',
     '--platform',

--- a/apps/expo-go/android/settings.gradle
+++ b/apps/expo-go/android/settings.gradle
@@ -13,10 +13,8 @@ plugins { id("com.facebook.react.settings") }
 
 extensions.configure(com.facebook.react.ReactSettingsExtension) { ex ->
   def command = [
-    'node',
-    '--no-warnings',
-    '--eval',
-    'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
+    'npx',
+    'expo-modules-autolinking',
     'react-native-config',
     '--json',
     '--platform',

--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -68,10 +68,8 @@ target 'Expo Go' do
   use_pods! 'vendored/unversioned/**/*.podspec.json'
 
   config_command = [
-    'node',
-    '--no-warnings',
-    '--eval',
-    'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
+    'npx',
+    'expo-modules-autolinking',
     'react-native-config',
     '--json',
     '--platform',

--- a/apps/native-tests/ios/Podfile
+++ b/apps/native-tests/ios/Podfile
@@ -21,10 +21,8 @@ target 'NativeTests' do
   pod 'ExpoModulesTestCore', :path => "../../../packages/expo-modules-test-core/ios"
 
   config_command = [
-    'node',
-    '--no-warnings',
-    '--eval',
-    'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
+    'npx',
+    'expo-modules-autolinking',
     'react-native-config',
     '--json',
     '--platform',

--- a/apps/paper-tester/android/settings.gradle
+++ b/apps/paper-tester/android/settings.gradle
@@ -5,10 +5,8 @@ plugins { id("com.facebook.react.settings") }
 
 extensions.configure(com.facebook.react.ReactSettingsExtension) { ex ->
     def command = [
-      'node',
-      '--no-warnings',
-      '--eval',
-      'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
+      'npx',
+      'expo-modules-autolinking',
       'react-native-config',
       '--json',
       '--platform',

--- a/apps/paper-tester/ios/Podfile
+++ b/apps/paper-tester/ios/Podfile
@@ -17,10 +17,8 @@ target 'papertester' do
   use_expo_modules!
 
   config_command = [
-    'node',
-    '--no-warnings',
-    '--eval',
-    'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
+    'npx',
+    'expo-modules-autolinking',
     'react-native-config',
     '--json',
     '--platform',

--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Only add `UISupportedInterfaceOrientations~ipad` if tablet support is also enabled. ([#32361](https://github.com/expo/expo/pull/32361) by [@EvanBacon](https://github.com/EvanBacon))
 - Removed creating the bridging header from the defaults plugin and added it to the template instead. ([#33539](https://github.com/expo/expo/pull/33539) by [@tsapeta](https://github.com/tsapeta))
 - Throw more descriptive error when string resource tag value is empty. ([#34212](https://github.com/expo/expo/pull/34212) by [@wschurman](https://github.com/wschurman))
+- Update test snapshot for template changes. ([#35661](https://github.com/expo/expo/pull/35661) by [@kudo](https://github.com/kudo))
 
 ## 9.0.17 - 2025-03-11
 

--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -176,10 +176,8 @@ target 'HelloWorld' do
     config_command = ['node', '-e', "process.argv=['', '', 'config'];require('@react-native-community/cli').run()"];
   else
     config_command = [
-      'node',
-      '--no-warnings',
-      '--eval',
-      'require(require.resolve(\\'expo-modules-autolinking\\', { paths: [require.resolve(\\'expo/package.json\\')] }))(process.argv.slice(1))',
+      'npx',
+      'expo-modules-autolinking',
       'react-native-config',
       '--json',
       '--platform',

--- a/templates/expo-template-bare-minimum/android/settings.gradle
+++ b/templates/expo-template-bare-minimum/android/settings.gradle
@@ -8,10 +8,8 @@ extensions.configure(com.facebook.react.ReactSettingsExtension) { ex ->
     ex.autolinkLibrariesFromCommand()
   } else {
     def command = [
-      'node',
-      '--no-warnings',
-      '--eval',
-      'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
+      'npx',
+      'expo-modules-autolinking',
       'react-native-config',
       '--json',
       '--platform',

--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -20,10 +20,8 @@ target 'HelloWorld' do
     config_command = ['node', '-e', "process.argv=['', '', 'config'];require('@react-native-community/cli').run()"];
   else
     config_command = [
-      'node',
-      '--no-warnings',
-      '--eval',
-      'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
+      'npx',
+      'expo-modules-autolinking',
       'react-native-config',
       '--json',
       '--platform',


### PR DESCRIPTION
# Why

based on #35660, we can use `npx expo-modules-autolinking` directly

# How

use `npx expo-modules-autolinking` in all templates

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
