### PR TITLE
[autolinking][Android] Link prebuilt projects

### DIFF
--- a/apps/bare-expo/modules/benchmarking/android/build.gradle
+++ b/apps/bare-expo/modules/benchmarking/android/build.gradle
@@ -6,6 +6,10 @@ plugins {
 group = 'host.exp.exponent'
 version = '1.0.0'
 
+expoModule {
+  canBePublished false
+}
+
 android {
   namespace "expo.modules.benchmark"
   defaultConfig {

--- a/packages/expo-dev-client/android/build.gradle
+++ b/packages/expo-dev-client/android/build.gradle
@@ -3,6 +3,10 @@ plugins {
   id 'expo-module-gradle-plugin'
 }
 
+expoModule {
+  canBePublished false
+}
+
 android {
   namespace "expo.modules.devclient"
   defaultConfig {

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -5,8 +5,8 @@ plugins {
   id 'expo-module-gradle-plugin'
 }
 
-def getRNVersion = {
-  return project.extensions.getByType(ExpoModuleExtension).reactNativeVersion
+expoModule {
+  canBePublished false
 }
 
 android {

--- a/packages/expo-dev-menu-interface/android/build.gradle
+++ b/packages/expo-dev-menu-interface/android/build.gradle
@@ -6,6 +6,10 @@ plugins {
 group = 'host.exp.exponent'
 version = '1.9.2'
 
+expoModule {
+  canBePublished false
+}
+
 android {
   namespace "expo.interfaces.devmenu"
   defaultConfig {

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -6,6 +6,10 @@ plugins {
 group = 'host.exp.exponent'
 version = '6.0.12'
 
+expoModule {
+  canBePublished false
+}
+
 android {
   namespace "expo.modules.devmenu"
   defaultConfig {

--- a/packages/expo-eas-client/android/build.gradle
+++ b/packages/expo-eas-client/android/build.gradle
@@ -6,6 +6,10 @@ plugins {
 group = 'host.exp.exponent'
 version = '0.13.1'
 
+expoModule {
+  canBePublished false
+}
+
 android {
   namespace "expo.modules.easclient"
   defaultConfig {

--- a/packages/expo-json-utils/android/build.gradle
+++ b/packages/expo-json-utils/android/build.gradle
@@ -6,6 +6,10 @@ plugins {
 group = 'host.exp.exponent'
 version = '0.14.0'
 
+expoModule {
+  canBePublished false
+}
+
 android {
   namespace "expo.modules.jsonutils"
   defaultConfig {

--- a/packages/expo-manifests/android/build.gradle
+++ b/packages/expo-manifests/android/build.gradle
@@ -6,6 +6,10 @@ plugins {
 group = 'host.exp.exponent'
 version = '0.15.4'
 
+expoModule {
+  canBePublished false
+}
+
 android {
   namespace "expo.modules.manifests"
   defaultConfig {

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
@@ -26,13 +26,22 @@ open class ExpoAutolinkingPlugin : Plugin<Project> {
     project.logger.quiet("")
     project.logger.quiet("Using expo modules")
 
-    project.withSubprojects(config.allProjects) { subproject ->
+    val (projects, prebuiltProjects) = config.allProjects.partition { project -> project.publication == null }
+
+    project.withSubprojects(projects) { subproject ->
       // Ensures that dependencies are resolved before the project is evaluated.
       project.evaluationDependsOn(subproject.path)
       // Adds the subproject as a dependency to the current project (expo package).
       project.dependencies.add("api", subproject)
 
       project.logger.quiet("  - ${subproject.name.withColor(Colors.GREEN)} (${subproject.version})")
+    }
+
+    prebuiltProjects.forEach { prebuiltProject ->
+      val publication = requireNotNull(prebuiltProject.publication)
+      project.dependencies.add("api", "${publication.groupId}:${publication.artifactId}:${publication.version}")
+
+      project.logger.quiet("  - ${"[\uD83D\uDCE6]".withColor(Colors.YELLOW)} ${prebuiltProject.name.withColor(Colors.GREEN)} (${publication.version})")
     }
 
     project.logger.quiet("")

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
@@ -89,7 +89,11 @@ class SettingsManager(
    * Links all projects, plugins and aar projects.
    */
   private fun link() = with(config) {
-    allProjects.forEach(settings::linkProject)
+    allProjects.forEach { project ->
+      if (project.publication == null) {
+        settings.linkProject(project)
+      }
+    }
     allPlugins.forEach(settings::linkPlugin)
     allAarProjects.forEach(settings::linkAarProject)
   }

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -60,6 +60,10 @@ def isNewArchitectureEnabled = findProperty("newArchEnabled") == "true"
 
 def shouldTurnWarningsIntoErrors = findProperty("EXPO_TURN_WARNINGS_INTO_ERRORS") == "true"
 
+expoModule {
+  canBePublished false
+}
+
 android {
   if (rootProject.hasProperty("ndkPath")) {
     ndkPath rootProject.ext.ndkPath

--- a/packages/expo-modules-test-core/android/build.gradle
+++ b/packages/expo-modules-test-core/android/build.gradle
@@ -6,6 +6,10 @@ plugins {
 group = 'org.unimodules'
 version = '0.19.0'
 
+expoModule {
+  canBePublished false
+}
+
 android {
   namespace "org.unimodules.test.core"
   defaultConfig {

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -5,6 +5,10 @@ plugins {
   id 'expo-module-gradle-plugin'
 }
 
+expoModule {
+  canBePublished false
+}
+
 String toPlatformIndependentPath(File path) {
   def result = path.toString()
   if (Os.isFamily(Os.FAMILY_WINDOWS)) {

--- a/packages/expo-structured-headers/android/build.gradle
+++ b/packages/expo-structured-headers/android/build.gradle
@@ -6,6 +6,10 @@ plugins {
 group = 'host.exp.exponent'
 version = '4.0.0'
 
+expoModule {
+  canBePublished false
+}
+
 android {
   namespace "expo.modules.structuredheaders"
   defaultConfig {

--- a/packages/expo-updates-interface/android/build.gradle
+++ b/packages/expo-updates-interface/android/build.gradle
@@ -6,6 +6,10 @@ plugins {
 group = 'host.exp.exponent'
 version = '1.0.0'
 
+expoModule {
+  canBePublished false
+}
+
 android {
   namespace "expo.modules.updatesinterface"
   defaultConfig {


### PR DESCRIPTION
# Why

Links prebuilt projects if available. 

# How

Add logic to determine if the package was prebuilt or not. Right now, we don't support any options to customize it. It's the first pass on that integration. However, I was able to run some tests to see how much we would gain by using prebuilt versions of our packages.

![Screenshot 2025-03-24 at 12 53 52](https://github.com/user-attachments/assets/a5447656-6c74-453f-a8d8-9f7e31873db3)

By pre-building most of our packages, you can expect at least ~40% improvement in massive projects like bare-expo. The predicted gain will be slightly higher because the first test was run with a partial cache. 

I've also added an indicator to tell whether the consumed project was prebuilt. 
 
<img width="376" alt="Screenshot 2025-03-24 at 12 54 27" src="https://github.com/user-attachments/assets/fe9d8223-a198-442d-ab5e-9bb44c6efa18" />

# Test Plan

- bare-expo ✅ 