### PR TITLE
[notifications] correctly serialize null trigger

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- correctly serialize `null` trigger on iOS ([#35672](https://github.com/expo/expo/pull/35672) by [@vonovak](https://github.com/vonovak))
 - restore `useLastNotificationResponse` return value behavior ([#35504](https://github.com/expo/expo/pull/35504) by [@vonovak](https://github.com/vonovak))
 - fix ios textInput action missing title ([#34866](https://github.com/expo/expo/pull/34866) by [@vonovak](https://github.com/vonovak))
 - [ios] Fixed incorrect `EXNotifications-Swift.h` import. ([#34987](https://github.com/expo/expo/pull/34987) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationSerializer.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationSerializer.m
@@ -38,7 +38,7 @@ static NSString * const EXNotificationResponseDefaultActionIdentifier = @"expo.m
   NSMutableDictionary *serializedRequest = [NSMutableDictionary dictionary];
   serializedRequest[@"identifier"] = request.identifier;
   serializedRequest[@"content"] = [self serializedNotificationContent:request];
-  serializedRequest[@"trigger"] = [self serializedNotificationTrigger:request];
+  serializedRequest[@"trigger"] = request.trigger ? [self serializedNotificationTrigger:request] : [NSNull null];
   return serializedRequest;
 }
 


### PR DESCRIPTION
previously, `null` trigger (used to present a notification immediately) would be serialized as `type: "unknown"`. 

This fixes it to be serialized as `null`.

Android counterpart [here](https://github.com/expo/expo/blob/15371b19458f2a23db1f9177dec5c5786ce12fd7/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java#L63)

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

tested locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
