### PR TITLE
[core][Android] Add `getExpoDependency`

### DIFF
--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/configuration/ExpoAutolinkingConfig.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/configuration/ExpoAutolinkingConfig.kt
@@ -1,8 +1,11 @@
 package expo.modules.plugin.configuration
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 @Serializable
 data class ExpoAutolinkingConfig(
@@ -92,7 +95,18 @@ data class GradleProject(
   val sourceDir: String,
   val publication: Publication? = null,
   val aarProjects: List<GradleAarProject> = emptyList(),
-  val modules: List<String> = emptyList()
+  val modules: List<String> = emptyList(),
+  @Transient val configuration: GradleProjectConfiguration = GradleProjectConfiguration()
+) {
+  /**
+   * Returns whether the publication was defined and should be used.
+   */
+  val shouldUsePublication: Boolean
+    get() = publication != null && configuration.shouldUsePublication
+}
+
+data class GradleProjectConfiguration(
+  var shouldUsePublication: Boolean = false
 )
 
 /**

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
@@ -26,7 +26,9 @@ open class ExpoAutolinkingPlugin : Plugin<Project> {
     project.logger.quiet("")
     project.logger.quiet("Using expo modules")
 
-    val (projects, prebuiltProjects) = config.allProjects.partition { project -> project.publication == null }
+    val (prebuiltProjects, projects) = config.allProjects.partition { project ->
+      project.shouldUsePublication
+    }
 
     project.withSubprojects(projects) { subproject ->
       // Ensures that dependencies are resolved before the project is evaluated.

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
@@ -45,7 +45,15 @@ class SettingsManager(
       env.commandLine(command)
     }.standardOutput.asText.get()
 
-    ExpoAutolinkingConfig.decodeFromString(result)
+    val decodedConfig = ExpoAutolinkingConfig.decodeFromString(result)
+
+    decodedConfig.allProjects.forEach { project ->
+      if (project.publication != null) {
+        project.configuration.shouldUsePublication = true
+      }
+    }
+
+    return@lazy decodedConfig
   }
 
   fun useExpoModules() {
@@ -90,7 +98,7 @@ class SettingsManager(
    */
   private fun link() = with(config) {
     allProjects.forEach { project ->
-      if (project.publication == null) {
+      if (!project.shouldUsePublication) {
         settings.linkProject(project)
       }
     }

--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -43,6 +43,15 @@ dependencies {
 java {
   sourceCompatibility = JavaVersion.VERSION_11
   targetCompatibility = JavaVersion.VERSION_11
+
+  sourceSets {
+    val path = if (isExpoAutolinkingSettingsPluginAvailable) {
+      "withAutolinkingPlugin"
+    } else {
+      "withoutAutolinkingPlugin"
+    }
+    getByName("main").java.srcDirs("src/${path}/kotlin")
+  }
 }
 
 tasks.withType<KotlinCompile> {

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/AutolinkingIntegration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/AutolinkingIntegration.kt
@@ -1,0 +1,7 @@
+package expo.modules.plugin
+
+import org.gradle.api.Project
+
+interface AutolinkingIntegration {
+  fun getExpoDependency(project: Project, name: String): Any
+}

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -34,7 +34,7 @@ internal fun Project.applyKotlin(kotlinVersion: String, kspVersion: String) {
 }
 
 internal fun Project.applyDefaultDependencies() {
-  val modulesCore = project.project(":expo-modules-core")
+  val modulesCore = rootProject.project(":expo-modules-core")
   if (project != modulesCore) {
     project.dependencies.add("implementation", project.project(":expo-modules-core"))
   }

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
@@ -1,5 +1,7 @@
 package expo.modules.plugin.gradle
 
+import expo.modules.plugin.AutolinkingIntegration
+import expo.modules.plugin.AutolinkingIntegrationImpl
 import org.gradle.api.Project
 import java.io.File
 import java.util.Properties
@@ -15,6 +17,10 @@ open class ExpoModuleExtension(val project: Project) {
     project.gradle.extensions.getByType(ExpoGradleHelperExtension::class.java)
   }
 
+  private val autolinking: AutolinkingIntegration by lazy {
+    AutolinkingIntegrationImpl()
+  }
+
   val reactNativeDir: File
     get() = gradleHelper.getReactNativeDir(project)
 
@@ -26,6 +32,10 @@ open class ExpoModuleExtension(val project: Project) {
 
   fun safeExtGet(name: String, default: Any): Any {
     return project.rootProject.extra.safeGet<Any>(name) ?: default
+  }
+
+  fun getExpoDependency(name: String): Any {
+    return autolinking.getExpoDependency(project, name)
   }
 
   var canBePublished: Boolean = true

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/withAutolinkingPlugin/kotlin/expo/modules/plugin/AutolinkingIntegrationImpl.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/withAutolinkingPlugin/kotlin/expo/modules/plugin/AutolinkingIntegrationImpl.kt
@@ -1,0 +1,29 @@
+package expo.modules.plugin
+
+import expo.modules.plugin.configuration.ExpoAutolinkingConfig
+import org.gradle.api.Project
+
+class AutolinkingIntegrationImpl : AutolinkingIntegration {
+  override fun getExpoDependency(project: Project, name: String): Any {
+    val config = getConfig(project)
+    val dependency = config.allProjects.find { it.name == name }
+
+    if (dependency == null) {
+      throw IllegalStateException("Couldn't find project with name $name in `expo-autolinking-settings` configuration.")
+    }
+
+    if (dependency.shouldUsePublication) {
+      val publication = requireNotNull(dependency.publication)
+      return "${publication.groupId}:${publication.artifactId}:${publication.version}"
+    }
+
+    return project.rootProject.findProject(":$name")
+      ?: throw IllegalStateException("Couldn't find project with name $name.")
+  }
+
+  private fun getConfig(project: Project): ExpoAutolinkingConfig {
+    val gradleExtension = project.gradle.extensions.findByType(ExpoGradleExtension::class.java)
+      ?: throw IllegalStateException("`ExpoGradleExtension` not found. Please, make sure that `useExpoModules` was called in `settings.gradle`.")
+    return gradleExtension.config
+  }
+}

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/withoutAutolinkingPlugin/kotlin/expo/modules/plugin/AutolinkingIntegrationImpl.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/withoutAutolinkingPlugin/kotlin/expo/modules/plugin/AutolinkingIntegrationImpl.kt
@@ -1,0 +1,10 @@
+package expo.modules.plugin
+
+import org.gradle.api.Project
+
+class AutolinkingIntegrationImpl : AutolinkingIntegration {
+  override fun getExpoDependency(project: Project, name: String): Any {
+    return project.rootProject.findProject(":$name")
+      ?: throw IllegalStateException("Couldn't find project with name $name.")
+  }
+}


### PR DESCRIPTION
# Why

Adds `getExpoDependency` function which can handle prebuilt projects and those which are build from sources. 

# How

Integrate autolinking and expo module gradle plugin.

# Test Plan

- bare-expo ✅ 