### PR TITLE
[github] Fix macos build workflow

### DIFF
--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -69,6 +69,7 @@ jobs:
         working-directory: apps/bare-expo/macos
       - name: 🏗️ Build macOS project
         run: |
+          set -o pipefail
           xcodebuild -workspace macos/BareExpo-macOS.xcworkspace -scheme ExpoMacOS-macOS -sdk macosx -derivedDataPath "macos/build" | xcpretty
         working-directory: apps/bare-expo
         timeout-minutes: 55


### PR DESCRIPTION
# Why

I noticed that the macOS workflow was succeeding even when it shouldn't
Follow up PR will fix the actual compile errors

# How

Set pipefail 

# Test Plan

CI should fail

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
