### PR TITLE
fix(docs): typo in tailwind installation guide

### DIFF
--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -48,7 +48,7 @@ Install `tailwindcss` and its required peer dependencies. Then, the run initiali
 <Terminal
   cmd={[
     '# Install Tailwind and its peer dependencies',
-    '$ npx expo add tailwindcss@3 postcss autoprefixer -- --dev',
+    '$ npx expo add tailwindcss@3 postcss autoprefixer --dev',
     '',
     '# Create a Tailwind config file',
     '$ npx tailwindcss init -p',
@@ -134,7 +134,7 @@ Install `tailwindcss` and its required peer dependencies:
 <Terminal
   cmd={[
     '# Install Tailwind and its peer dependencies',
-    '$ npx expo add tailwindcss @tailwindcss/postcss postcss -- --dev',
+    '$ npx expo add tailwindcss @tailwindcss/postcss postcss --dev',
   ]}
 />
 


### PR DESCRIPTION
# Why

Currently the documentation for the Tailwind configuration describes a step to install the packages as dev dependencies. The extra `--` in the `npx expo add` is not actually correct

Output of that command
```
❯ npx expo add tailwindcss @tailwindcss/postcss postcss -- --dev
› Installing 3 other packages using npm
> npm install --save --dev tailwindcss @tailwindcss/postcss postcss
npm warn config dev Please use --include=dev instead.
```
it is not doing `npm install --save-dev` After removing the extra '--' in the npx expo command the output looks like this
```
❯ npx expo add tailwindcss @tailwindcss/postcss postcss --dev
› Installing 3 other packages using npm
> npm install --save-dev tailwindcss @tailwindcss/postcss postcss
```

![Screenshot 2025-03-24 at 8 14 17 PM](https://github.com/user-attachments/assets/e69bc265-4bed-46ee-91a9-4d338254ec50)

# Test Plan
Tested on localhost docs build for both v3 and v4 versions of tailwind 
![Screenshot 2025-03-24 at 8 27 34 PM](https://github.com/user-attachments/assets/eb7549e0-48bc-4feb-9bb5-6b3dbf3417af)
![Screenshot 2025-03-24 at 8 27 39 PM](https://github.com/user-attachments/assets/dc1be9da-4c41-466d-9e75-e7241d809b3d)






# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
