### PR TITLE
[docs] Updates iOS build resources

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -248,12 +248,6 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 iOS builder VMs run on Mac mini hosts in an isolated environment. Every build gets its own fresh macOS VM. For more information, see [iOS-specific resource classes](/eas/json/#resourceclass-2).
 
-- Hardware:
-
-  - M1 3.2GHz 8-Core, 16 GB RAM
-  - M2 3.9GHz 8-Core, 24 GB RAM
-  - M2 Pro 3.9GHz 12-Core, 32 GB RAM
-
 - Build resources:
 
   <BuildResourceList platform="ios" />

--- a/docs/ui/components/utils/infrastructure.tsx
+++ b/docs/ui/components/utils/infrastructure.tsx
@@ -34,17 +34,8 @@ const AndroidResourceClassToSpec: Record<(typeof ResourceClasses.android)[number
 };
 
 const IosResourceClassToSpec: Record<(typeof ResourceClasses.ios)[number], JSX.Element> = {
-  medium: <>3 vCPUs, 8 GB RAM</>,
-  large: (
-    <>
-      <markdownComponents.ul>
-        <markdownComponents.li>6 vCPUs, 22 GB RAM if running on an M2 Mac</markdownComponents.li>
-        <markdownComponents.li>
-          5 vCPUs, 12 GB RAM if running on an M2 Pro Mac
-        </markdownComponents.li>
-      </markdownComponents.ul>
-    </>
-  ),
+  medium: <>5 efficiency cores, 20 GiB RAM, 110 GB SSD</>,
+  large: <>10 efficiency cores, 40 GiB RAM, 110 GB SSD</>,
 };
 
 function ResourceClassSpecLink({


### PR DESCRIPTION
# Why

We now have M4 Pro Mac Minis, so im updating the resource documentation to reflect the new workers.

Since we no longer have M2 and M2 Pro chip computers, I removed the section defining hardware.

# Test Plan

Make sure the changes read well and that they are accurate. This text appears on: /build-reference/infrastructure/#ios-build-server-configurations

<img width="836" alt="Screenshot 2025-03-24 at 8 22 56 PM" src="https://github.com/user-attachments/assets/76368537-9659-44aa-b010-81995a08657e" />

