### PR TITLE
[docs] corrected path on reference links

### DIFF
--- a/docs/pages/router/basics/common-navigation-patterns.mdx
+++ b/docs/pages/router/basics/common-navigation-patterns.mdx
@@ -78,7 +78,7 @@ You can also nest tabs inside of an outer stack navigator. That is often more us
 <BoxLink
   title="Nested navigators"
   description="Learn more about how to use nested navigators in your Expo Router app."
-  href="/router/advanced/nested-navigators/"
+  href="/router/advanced/nesting-navigators/"
   Icon={DocsLogo}
 />
 
@@ -199,7 +199,7 @@ This will cause **app/(logged-in)/\_layout.tsx** to re-render again. This time, 
 <BoxLink
   title="Expo Router Authentication Guide"
   description="Follow an in-depth example of implementing authentication using protected routes."
-  href="/router/advanced/auhentication/"
+  href="/router/advanced/authentication/"
   Icon={DocsLogo}
 />
 
@@ -228,6 +228,6 @@ export default function Layout() {
 <BoxLink
   title="Modals in Expo Router"
   description="Learn multiple patterns for displaying modals in Expo Router, including using a modal inside of a layout file."
-  href="/advanced/modals/"
+  href="/router/advanced/modals/"
   Icon={DocsLogo}
 />


### PR DESCRIPTION
### Summary
Fixed reference links to related sections on docs

### Link to the related docs page

https://docs.expo.dev/router/basics/common-navigation-patterns/

### Anything else?

No response