### PR TITLE
[notifications] fix missing trigger type in docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -536,6 +536,7 @@ await Notifications.scheduleNotificationAsync({
     sound: 'mySoundFile.wav', // Provide ONLY the base filename
   },
   trigger: {
+    type: SchedulableTriggerInputTypes.TIME_INTERVAL,
     seconds: 2,
     channelId: 'new_emails',
   },
@@ -567,6 +568,7 @@ await Notifications.scheduleNotificationAsync({
     sound: 'email_sound.wav', // <- for Android below 8.0
   },
   trigger: {
+    type: SchedulableTriggerInputTypes.TIME_INTERVAL,
     seconds: 2,
     channelId: 'new_emails', // <- for Android 8.0+, see definition above
   },

--- a/docs/pages/versions/v52.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/notifications.mdx
@@ -543,6 +543,7 @@ await Notifications.scheduleNotificationAsync({
     sound: 'mySoundFile.wav', // Provide ONLY the base filename
   },
   trigger: {
+    type: SchedulableTriggerInputTypes.TIME_INTERVAL,
     seconds: 2,
     channelId: 'new_emails',
   },
@@ -574,6 +575,7 @@ await Notifications.scheduleNotificationAsync({
     sound: 'email_sound.wav', // <- for Android below 8.0
   },
   trigger: {
+    type: SchedulableTriggerInputTypes.TIME_INTERVAL,
     seconds: 2,
     channelId: 'new_emails', // <- for Android 8.0+, see definition above
   },


### PR DESCRIPTION
# Why

Added missing `type` property in notification trigger examples in the documentation. 

# How

Updated the code examples in the notifications documentation to include the required `type: SchedulableTriggerInputTypes.TIME_INTERVAL` property in the trigger object for both unversioned and v52.0.0 documentation.

# Test Plan



# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)