### PR TITLE
[docs] Update --save-dev command references

### DIFF
--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -39,10 +39,10 @@ Install `jest-expo` and other required dev dependencies in your project. Run the
 
 <Terminal
   cmd={[
-    '$ npx expo install jest-expo jest @types/jest -- --save-dev',
+    '$ npx expo install jest-expo jest @types/jest --save-dev',
     '',
     '# For Bun and Yarn',
-    '$ npx expo install jest-expo jest @types/jest -- --dev',
+    '$ npx expo install jest-expo jest @types/jest --dev',
   ]}
 />
 
@@ -52,10 +52,10 @@ Install `jest-expo` and other required dev dependencies in your project. Run the
 
 <Terminal
   cmd={[
-    '$ npx expo install jest-expo jest @types/jest "--" --save-dev',
+    '$ npx expo install jest-expo jest @types/jest --save-dev',
     '',
     '# For bun and yarn',
-    '$ npx expo install jest-expo jest @types/jest "--" --dev',
+    '$ npx expo install jest-expo jest @types/jest --dev',
   ]}
 />
 
@@ -141,10 +141,10 @@ To install it, run the following command:
 
 <Terminal
   cmd={[
-    '$ npx expo install @testing-library/react-native -- --save-dev',
+    '$ npx expo install @testing-library/react-native --save-dev',
     '',
     '# For Bun and Yarn',
-    '$ npx expo install @testing-library/react-native -- --dev',
+    '$ npx expo install @testing-library/react-native --dev',
   ]}
 />
 
@@ -154,10 +154,10 @@ To install it, run the following command:
 
 <Terminal
   cmd={[
-    '$ npx expo install @testing-library/react-native "--" --save-dev',
+    '$ npx expo install @testing-library/react-native --save-dev',
     '',
     '# For Bun and Yarn',
-    '$ npx expo install @testing-library/react-native "--" --dev',
+    '$ npx expo install @testing-library/react-native --dev',
   ]}
 />
 

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -37,27 +37,13 @@ Install `jest-expo` and other required dev dependencies in your project. Run the
 
 <Tab label="macOS/Linux">
 
-<Terminal
-  cmd={[
-    '$ npx expo install jest-expo jest @types/jest --save-dev',
-    '',
-    '# For Bun and Yarn',
-    '$ npx expo install jest-expo jest @types/jest --dev',
-  ]}
-/>
+<Terminal cmd={['$ npx expo install jest-expo jest @types/jest --dev']} />
 
 </Tab>
 
 <Tab label="Windows">
 
-<Terminal
-  cmd={[
-    '$ npx expo install jest-expo jest @types/jest --save-dev',
-    '',
-    '# For bun and yarn',
-    '$ npx expo install jest-expo jest @types/jest --dev',
-  ]}
-/>
+<Terminal cmd={['$ npx expo install jest-expo jest @types/jest "--" --dev']} />
 
 </Tab>
 
@@ -139,27 +125,13 @@ To install it, run the following command:
 
 <Tab label="macOS/Linux">
 
-<Terminal
-  cmd={[
-    '$ npx expo install @testing-library/react-native --save-dev',
-    '',
-    '# For Bun and Yarn',
-    '$ npx expo install @testing-library/react-native --dev',
-  ]}
-/>
+<Terminal cmd={['$ npx expo install @testing-library/react-native --dev']} />
 
 </Tab>
 
 <Tab label="Windows">
 
-<Terminal
-  cmd={[
-    '$ npx expo install @testing-library/react-native --save-dev',
-    '',
-    '# For Bun and Yarn',
-    '$ npx expo install @testing-library/react-native --dev',
-  ]}
-/>
+<Terminal cmd={['$ npx expo install @testing-library/react-native "--" --dev']} />
 
 </Tab>
 

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -48,7 +48,7 @@ Install `tailwindcss` and its required peer dependencies. Then, the run initiali
 <Terminal
   cmd={[
     '# Install Tailwind and its peer dependencies',
-    '$ npx expo add tailwindcss@3 postcss autoprefixer --dev',
+    '$ npx expo install tailwindcss@3 postcss autoprefixer --dev',
     '',
     '# Create a Tailwind config file',
     '$ npx tailwindcss init -p',
@@ -134,7 +134,7 @@ Install `tailwindcss` and its required peer dependencies:
 <Terminal
   cmd={[
     '# Install Tailwind and its peer dependencies',
-    '$ npx expo add tailwindcss @tailwindcss/postcss postcss --dev',
+    '$ npx expo install tailwindcss @tailwindcss/postcss postcss --dev',
   ]}
 />
 

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -52,27 +52,13 @@ To install required `devDependencies` such as `typescript` and `@types/react` in
 
 <Tab label="macOS/Linux">
 
-<Terminal
-  cmd={[
-    '$ npx expo install typescript @types/react --save-dev',
-    '',
-    '# For Bun and Yarn',
-    '$ npx expo install typescript @types/react --dev',
-  ]}
-/>
+<Terminal cmd={['$ npx expo install typescript @types/react --dev']} />
 
 </Tab>
 
 <Tab label="Windows">
 
-<Terminal
-  cmd={[
-    '$ npx expo install typescript @types/react --save-dev',
-    '',
-    '# For Bun and Yarn',
-    '$ npx expo install typescript @types/react --dev',
-  ]}
-/>
+<Terminal cmd={['$ npx expo install typescript @types/react "--" --dev']} />
 
 </Tab>
 
@@ -202,27 +188,13 @@ Additional setup is required to use TypeScript for configuration files such as *
 
 <Tab label="macOS/Linux">
 
-<Terminal
-  cmd={[
-    '$ npx expo install ts-node --save-dev',
-    '',
-    '# For Bun and Yarn',
-    '$ npx expo install ts-node --dev',
-  ]}
-/>
+<Terminal cmd={['$ npx expo install ts-node --dev']} />
 
 </Tab>
 
 <Tab label="Windows">
 
-<Terminal
-  cmd={[
-    '$ npx expo install ts-node --save-dev',
-    '',
-    '# For Bun and Yarn',
-    '$ npx expo install ts-node --dev',
-  ]}
-/>
+<Terminal cmd={['$ npx expo install ts-node "--" --dev']} />
 
 </Tab>
 

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -54,10 +54,10 @@ To install required `devDependencies` such as `typescript` and `@types/react` in
 
 <Terminal
   cmd={[
-    '$ npx expo install typescript @types/react  -- --save-dev',
+    '$ npx expo install typescript @types/react --save-dev',
     '',
     '# For Bun and Yarn',
-    '$ npx expo install typescript @types/react -- --dev',
+    '$ npx expo install typescript @types/react --dev',
   ]}
 />
 
@@ -67,10 +67,10 @@ To install required `devDependencies` such as `typescript` and `@types/react` in
 
 <Terminal
   cmd={[
-    '$ npx expo install typescript @types/react "--" --save-dev',
+    '$ npx expo install typescript @types/react --save-dev',
     '',
     '# For Bun and Yarn',
-    '$ npx expo install typescript @types/react "--" --dev',
+    '$ npx expo install typescript @types/react --dev',
   ]}
 />
 
@@ -204,10 +204,10 @@ Additional setup is required to use TypeScript for configuration files such as *
 
 <Terminal
   cmd={[
-    '$ npx expo install ts-node -- --save-dev',
+    '$ npx expo install ts-node --save-dev',
     '',
     '# For Bun and Yarn',
-    '$ npx expo install ts-node -- --dev',
+    '$ npx expo install ts-node --dev',
   ]}
 />
 
@@ -217,10 +217,10 @@ Additional setup is required to use TypeScript for configuration files such as *
 
 <Terminal
   cmd={[
-    '$ npx expo install ts-node "--" --save-dev',
+    '$ npx expo install ts-node --save-dev',
     '',
     '# For Bun and Yarn',
-    '$ npx expo install ts-node "--" --dev',
+    '$ npx expo install ts-node --dev',
   ]}
 />
 

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -35,10 +35,10 @@ Install ESLint, and [`eslint-config-expo`](https://github.com/expo/expo/tree/mai
 
 <Terminal
   cmd={[
-    '$ npx expo install eslint@8 eslint-config-expo -- --save-dev',
+    '$ npx expo install eslint@8 eslint-config-expo --save-dev',
     '',
     '# For Bun and Yarn',
-    '$ npx expo install eslint@8 eslint-config-expo -- --dev',
+    '$ npx expo install eslint@8 eslint-config-expo --dev',
   ]}
 />
 
@@ -48,10 +48,10 @@ Install ESLint, and [`eslint-config-expo`](https://github.com/expo/expo/tree/mai
 
 <Terminal
   cmd={[
-    '$ npx expo install eslint@8 eslint-config-expo "--" --save-dev',
+    '$ npx expo install eslint@8 eslint-config-expo --save-dev',
     '',
     '# For Bun and Yarn',
-    '$ npx expo install eslint@8 eslint-config-expo "--" --dev',
+    '$ npx expo install eslint@8 eslint-config-expo --dev',
   ]}
 />
 
@@ -165,10 +165,10 @@ To install Prettier in your project:
 
 <Terminal
   cmd={[
-    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier -- --save-dev',
+    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier --save-dev',
     '',
     '# For Bun and Yarn',
-    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier -- --dev',
+    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier --dev',
   ]}
 />
 
@@ -178,10 +178,10 @@ To install Prettier in your project:
 
 <Terminal
   cmd={[
-    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier "--" --save-dev',
+    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier --save-dev',
     '',
     '# For Bun and Yarn',
-    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier "--" --dev',
+    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier --dev',
   ]}
 />
 
@@ -246,10 +246,10 @@ Remove the `eslint-config-universe` library and install the `eslint-config-expo`
 
 <Terminal
   cmd={[
-    '$ npx expo install eslint-config-expo -- --save-dev',
+    '$ npx expo install eslint-config-expo --save-dev',
     '',
     '# For Bun and Yarn',
-    '$ npx expo install eslint-config-expo -- --dev',
+    '$ npx expo install eslint-config-expo --dev',
   ]}
 />
 
@@ -259,10 +259,10 @@ Remove the `eslint-config-universe` library and install the `eslint-config-expo`
 
 <Terminal
   cmd={[
-    '$ npx expo install eslint-config-expo "--" --save-dev',
+    '$ npx expo install eslint-config-expo --save-dev',
     '',
     '# For Bun and Yarn',
-    '$ npx expo install eslint-config-expo "--" --dev',
+    '$ npx expo install eslint-config-expo --dev',
   ]}
 />
 

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -33,27 +33,13 @@ Install ESLint, and [`eslint-config-expo`](https://github.com/expo/expo/tree/mai
 
 <Tab label="macOS/Linux">
 
-<Terminal
-  cmd={[
-    '$ npx expo install eslint@8 eslint-config-expo --save-dev',
-    '',
-    '# For Bun and Yarn',
-    '$ npx expo install eslint@8 eslint-config-expo --dev',
-  ]}
-/>
+<Terminal cmd={['$ npx expo install eslint@8 eslint-config-expo --dev']} />
 
 </Tab>
 
 <Tab label="Windows">
 
-<Terminal
-  cmd={[
-    '$ npx expo install eslint@8 eslint-config-expo --save-dev',
-    '',
-    '# For Bun and Yarn',
-    '$ npx expo install eslint@8 eslint-config-expo --dev',
-  ]}
-/>
+<Terminal cmd={['$ npx expo install eslint@8 eslint-config-expo "--" --dev']} />
 
 </Tab>
 
@@ -164,12 +150,7 @@ To install Prettier in your project:
 <Tab label="macOS/Linux">
 
 <Terminal
-  cmd={[
-    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier --save-dev',
-    '',
-    '# For Bun and Yarn',
-    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier --dev',
-  ]}
+  cmd={['$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier --dev']}
 />
 
 </Tab>
@@ -177,12 +158,7 @@ To install Prettier in your project:
 <Tab label="Windows">
 
 <Terminal
-  cmd={[
-    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier --save-dev',
-    '',
-    '# For Bun and Yarn',
-    '$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier --dev',
-  ]}
+  cmd={['$ npx expo install prettier eslint-config-prettier eslint-plugin-prettier "--" --dev']}
 />
 
 </Tab>
@@ -244,27 +220,13 @@ Remove the `eslint-config-universe` library and install the `eslint-config-expo`
 
 <Tab label="macOS/Linux">
 
-<Terminal
-  cmd={[
-    '$ npx expo install eslint-config-expo --save-dev',
-    '',
-    '# For Bun and Yarn',
-    '$ npx expo install eslint-config-expo --dev',
-  ]}
-/>
+<Terminal cmd={['$ npx expo install eslint-config-expo --dev']} />
 
 </Tab>
 
 <Tab label="Windows">
 
-<Terminal
-  cmd={[
-    '$ npx expo install eslint-config-expo --save-dev',
-    '',
-    '# For Bun and Yarn',
-    '$ npx expo install eslint-config-expo --dev',
-  ]}
-/>
+<Terminal cmd={['$ npx expo install eslint-config-expo "--" --dev']} />
 
 </Tab>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up #35681 to replace `-- --save-dev` & `-- --dev` command references to `--dev` when installing a devDepdenency in an Expo project.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update references `-- --save-dev`  & `-- --dev` command references to `--save-dev`.
- Update the `npx expo add` command reference in the Tailwind CSS guide to `npx expo install` for consistency.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

To test that extra "--" is not required or `--save-dev` can be replaced by `--dev` in case of npm/pnpm 

- Create a new project: `pnpm create expo-app`
- Inside the newly created project directory, install a dev dependency: `npx expo install @testing-library/react-native --dev`

Here's a test from a project created with Yarn v1:
![CleanShot 2025-03-25 at 17 01 38](https://github.com/user-attachments/assets/225d8bde-09bf-41b6-90f1-ab8b12118854)

Another test from a project created using pnpm:

![CleanShot 2025-03-25 at 17 11 04](https://github.com/user-attachments/assets/6cdf8d5f-e956-4185-ab88-4fc5843e4cbe)


For doc changes in this PR, please proofread the diff.

## Preview

![CleanShot 2025-03-25 at 17 15 02@2x](https://github.com/user-attachments/assets/72a9bf68-7ae3-40cd-b21c-870a1fa95412)
![CleanShot 2025-03-25 at 17 14 59@2x](https://github.com/user-attachments/assets/be9d4a2f-9083-48b2-92ea-7605441c68db)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
