### PR TITLE
Update core-concepts.mdx

### DIFF
--- a/docs/pages/router/basics/core-concepts.mdx
+++ b/docs/pages/router/basics/core-concepts.mdx
@@ -47,7 +47,7 @@ Let's apply these foundational rules of Expo Router to quickly identify key elem
 <FileTree
   files={[
     ['app/index.tsx'],
-    ['app/about.tsx'],
+    ['app/home.tsx'],
     ['app/\_layout.tsx'],
     ['app/profile/friends.tsx'],
     ['components/TextField.tsx'],


### PR DESCRIPTION
# Why
Looking through the expo router documentation and noticed a route being described that did not exist in the directory.
Documentation describes a '/home' route while this does not exist in the app directory. Instead there was a '/about' route that is not described. I assume these have been swapped by accident.
Page where error was found: [Expo Router Docs](https://docs.expo.dev/router/basics/core-concepts/)

This quick fix should clear up in any confusion

# How

Simply swapped out '/about' with '/home'

# Test Plan
Nothing to test

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
