### PR TITLE
[docs] Specify gradle.properties values for EAS credentials

### DIFF
--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -61,11 +61,13 @@ Open **android/gradle.properties** file and add the following gradle variables a
 
 These variables contain information about your upload key:
 
-```groovy android/gradle.properties
-MYAPP_UPLOAD_STORE_FILE=my-upload-key.keystore
-MYAPP_UPLOAD_KEY_ALIAS=my-key-alias
-MYAPP_UPLOAD_STORE_PASSWORD=*****
-MYAPP_UPLOAD_KEY_PASSWORD=*****
+```ruby android/gradle.properties
+# If you've downloaded the credentials from `eas credentials` command, see comments below for each value.
+
+MYAPP_UPLOAD_STORE_FILE=my-upload-key.keystore     # Path to the "keystore.jks" file
+MYAPP_UPLOAD_KEY_ALIAS=my-key-alias                # Value of the `keystore.keyAlias` field in the credentials.json file
+MYAPP_UPLOAD_STORE_PASSWORD=*****                  # Value of the `keystore.password` field in the credentials.json file
+MYAPP_UPLOAD_KEY_PASSWORD=*****                    # Value of the `keystore.keyPassword` field in the credentials.json file
 ```
 
 > **warning** If you commit the **android** directory to a version control system like Git, don't commit the above information. Instead, create a **~/.gradle/gradle.properties** file on your computer and add the above variables to this file.

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -4,7 +4,7 @@ sidebar_title: Production
 description: Learn how to create a production build for your Expo app locally.
 ---
 
-import { GoogleAppStoreIcon } from '@expo/styleguide-icons/custom/AndroidIcon';
+import { GoogleAppStoreIcon } from '@expo/styleguide-icons/custom/GoogleAppStoreIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -65,9 +65,9 @@ These variables contain information about your upload key:
 # If you've downloaded the credentials from `eas credentials` command, see comments below for each value.
 
 MYAPP_UPLOAD_STORE_FILE=my-upload-key.keystore     # Path to the "keystore.jks" file
-MYAPP_UPLOAD_KEY_ALIAS=my-key-alias                # Value of the `keystore.keyAlias` field in the credentials.json file
-MYAPP_UPLOAD_STORE_PASSWORD=*****                  # Value of the `keystore.password` field in the credentials.json file
-MYAPP_UPLOAD_KEY_PASSWORD=*****                    # Value of the `keystore.keyPassword` field in the credentials.json file
+MYAPP_UPLOAD_KEY_ALIAS=my-key-alias                # Replace with value of the `keystore.keyAlias` field in the credentials.json file
+MYAPP_UPLOAD_STORE_PASSWORD=*****                  # Replace with value of the `keystore.password` field in the credentials.json file
+MYAPP_UPLOAD_KEY_PASSWORD=*****                    # Replace with value of the `keystore.keyPassword` field in the credentials.json file
 ```
 
 > **warning** If you commit the **android** directory to a version control system like Git, don't commit the above information. Instead, create a **~/.gradle/gradle.properties** file on your computer and add the above variables to this file.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes ENG-15295

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update code block to specify how values from `credentials.json` map to the properties in `android/gradle.properties`. This will help avoid confusion when Android credentials have been generated using EAS.
Also, fix the code syntax highlight language by updating it to ruby and the icon path for BoxLink.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-03-25 at 20 53 48](https://github.com/user-attachments/assets/20a1ab1f-8134-4c45-9554-6a8f711b0cdf)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
