### PR TITLE
[ios][location][permissions] fix ios permission flow

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed issue with some permission request flows resolving too soon on iOS.
 - [iOS] Remove restarting all services when CLLocationManager reports an error ([#35478](https://github.com/expo/expo/pull/35478) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Add missing ProGuard rule to fix task consumer failed ([#34098](https://github.com/expo/expo/pull/34098) by [@cornejobarraza](https://github.com/cornejobarraza))
 - [iOS] `startLocationUpdatesAsync` should not require background permissions ([#33617](https://github.com/expo/expo/pull/33617) by [@andrejpavlovic](https://github.com/andrejpavlovic)

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed issue with some permission request flows resolving too soon on iOS.
+- [iOS] Fixed issue with some permission request flows resolving too soon on iOS. ([#35693](https://github.com/expo/expo/pull/35693) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Remove restarting all services when CLLocationManager reports an error ([#35478](https://github.com/expo/expo/pull/35478) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Add missing ProGuard rule to fix task consumer failed ([#34098](https://github.com/expo/expo/pull/34098) by [@cornejobarraza](https://github.com/cornejobarraza))
 - [iOS] `startLocationUpdatesAsync` should not require background permissions ([#33617](https://github.com/expo/expo/pull/33617) by [@andrejpavlovic](https://github.com/andrejpavlovic)

--- a/packages/expo-location/ios/Requesters/EXBackgroundLocationPermissionRequester.m
+++ b/packages/expo-location/ios/Requesters/EXBackgroundLocationPermissionRequester.m
@@ -10,6 +10,7 @@ static SEL alwaysAuthorizationSelector;
 @interface EXBackgroundLocationPermissionRequester ()
 
 @property (nonatomic, assign) bool wasAsked;
+@property (nonatomic, assign) bool isWaitingForTimeout;
 
 @end
 
@@ -19,6 +20,7 @@ static SEL alwaysAuthorizationSelector;
 {
   if (self = [super init]) {
     _wasAsked = false;
+    _isWaitingForTimeout = false;
   }
   return self;
 }
@@ -37,10 +39,28 @@ static SEL alwaysAuthorizationSelector;
 {
   if ([EXBaseLocationRequester isConfiguredForAlwaysAuthorization] && [self.locationManager respondsToSelector:alwaysAuthorizationSelector]) {
     _wasAsked = true;
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleAppBecomingActive)
-                                                 name:UIApplicationDidBecomeActiveNotification
-                                               object:nil];
+    CLAuthorizationStatus status = [self.locationManager authorizationStatus];
+    
+    if (status == kCLAuthorizationStatusAuthorizedWhenInUse) {
+      // We already have a foreground permission granted:
+      // When asking for background location, we might or might not have asked for foreground permission
+      // before we get here. An issue here is if the user has a temporary permission ("Allow once") - which
+      // results in the status being "kCLAuthorizationStatusAuthorizedWhenInUse" - without us knowing.
+      // We need to handle this special case which is not possible to detect through the API.
+      // What we do is that we'll wait 1.5 seconds on an UIApplicationWillResignActiveNotification
+      // notification (which will be emitted almost directly if the permission dialog is displayed). If the permission
+      // dialog is not displayed we'll timeout and can resolve the waiting promise with an updated denied status.
+      [[NSNotificationCenter defaultCenter] addObserver:self
+                                               selector:@selector(handleAppBecomingInactive)
+                                                   name:UIApplicationWillResignActiveNotification
+                                                 object:nil];
+      
+      // Setup timeout - if no permission dialog was displayed we can just stop listening and deny
+      // the request
+      [self setupAppInactivateTimeout];
+    }
+    
+    // Request permissions
     ((void (*)(id, SEL))objc_msgSend)(self.locationManager, alwaysAuthorizationSelector);
   } else {
     self.reject(@"ERR_LOCATION_INFO_PLIST", @"One of the `NSLocation*UsageDescription` keys must be present in Info.plist to be able to use geolocation.", nil);
@@ -50,9 +70,6 @@ static SEL alwaysAuthorizationSelector;
   }
 }
 
-// If user selects "Keep Only While Using" option, the `locationManagerDidChangeAuthorization` won't be called.
-// So we don't know when we should resolve promise.
-// Hovewer, we can check for `UIApplicationDidBecomeActiveNotification` event which is called when permissions modal disappears.
 - (void)handleAppBecomingActive
 {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
@@ -61,6 +78,47 @@ static SEL alwaysAuthorizationSelector;
     self.resolve = nil;
     self.reject = nil;
   }
+}
+
+- (void)handleAppBecomingInactive
+{
+  // Let's wait until the app becomes inactive - this happens when OS displays the
+  // permission dialog - then we can cancel the timeout handler.
+
+  _isWaitingForTimeout = false;
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+  
+  // When the app is inactive it means that a permission dialog is showing and we should ask to be
+  // notified when the dialog is closed:
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(handleAppBecomingActive)
+                                               name:UIApplicationDidBecomeActiveNotification
+                                             object:nil];
+}
+
+- (void)setupAppInactivateTimeout
+{
+  _isWaitingForTimeout = true;
+  
+  // Obtain a reference to the current queue
+  dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
+
+  // Calculate the time for the delay
+  dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.5 * NSEC_PER_SEC));
+
+  EX_WEAKIFY(self);
+  
+  // Schedule the block to be executed after the delay
+  dispatch_after(delayTime, currentQueue, ^{
+    EX_ENSURE_STRONGIFY(self)
+    // Check if we are still waiting - ie. we haven't seen a permission dialog
+    if (self.isWaitingForTimeout && self.resolve) {
+      self.isWaitingForTimeout = false;
+      self.resolve([self getPermissions]);
+      self.resolve = nil;
+      self.reject = nil;
+    }
+  });
 }
 
 - (NSDictionary *)parsePermissions:(CLAuthorizationStatus)systemStatus

--- a/packages/expo-location/ios/Requesters/EXBaseLocationRequester.h
+++ b/packages/expo-location/ios/Requesters/EXBaseLocationRequester.h
@@ -3,8 +3,9 @@
 #import <CoreLocation/CLLocationManager.h>
 
 #import <ExpoModulesCore/EXPermissionsInterface.h>
+#import <CoreLocation/CLLocationManagerDelegate.h>
 
-@interface EXBaseLocationRequester : NSObject<EXPermissionsRequester>
+@interface EXBaseLocationRequester : NSObject<EXPermissionsRequester, CLLocationManagerDelegate>
 
 @property (nonatomic, strong) CLLocationManager *locationManager;
 @property (nonatomic, strong) EXPromiseResolveBlock resolve;
@@ -15,7 +16,5 @@
 
 - (void)requestLocationPermissions;
 - (NSDictionary *)parsePermissions:(CLAuthorizationStatus)systemStatus;
-
-- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status;
 
 @end


### PR DESCRIPTION
# Why 

The iOS permission flow is a bit flawed as described in #33911 where asking for background permission in the same session as where you asked for foreground permissions results in the promise resolving too early with a permission denied result.

This was caused by the semi-complex way that iOS location permissions work from iOS 13+.

Closes #33911

# How

This PR proposes a fix that refactors how location permissions are requested on iOS:

- Refactored permission flow to include handling multiple permutations of the flow.
  - Removed deprecated delegate method `- (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status`
  - Simplified handling the first delegate callback that we're not interested in (see http://stackoverflow.com/questions/30106341/swift-locationmanager-didchangeauthorizationstatus-always-called/30107511#30107511) by storing the initial state when starting a flow and comparing against this value instead of a static value that wasn't correct for some of the flows.
  - Added special handling for temporary foreground permissions by using active/inactive lifecycle events to detect wether a permission dialog was displayed or not.

# Test Plan

Test the following scenarios in BareExpo -> APIs -> Location

(before each test, make sure to clear any location permissions and restart the app)
    
  _rfp_ = requestForegroundPermissionsAsync, fp: Expected foreground permission
  _rbp_ = requestBackgroundPermissionsAsync, bg: Expected background permission
    
 - _rfp_ -> "Allow once", then _rbp_ -> no dialog = (fp: granted (temporary), bg: denied after 1.5 seconds)
 - _rfp_ -> "Allow while using App", then _rbp_ -> "Keep only while using" = (fp: granted, bg: denied)
 - _rfp_ -> "Allow while using App", then _rbp_ -> "Change to always allow" = (fp: granted, bg: granted)
 - _rfp_ -> "Don't allow", then _rbp_ -> no dialog = (fp: denied, bg: denied)
 - _rbp_ -> "Allow once", no more dialog = (fp: granted (temporary), bg: denied)
 - _rbp_ -> "Allow while using App", no more dialog = (fp: granted, bg: granted (provisional))
 - _rbp_ -> "Don't allow" = (fp: denied, bg: denied)

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
