### PR TITLE
Upgrades React Native to 0.79.0-rc.3

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -17,6 +17,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -85,6 +86,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactAppDependencyProvider
@@ -117,6 +119,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactAppDependencyProvider
@@ -153,6 +156,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactAppDependencyProvider
@@ -184,6 +188,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactAppDependencyProvider
@@ -210,6 +215,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -239,6 +245,7 @@ PODS:
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactAppDependencyProvider
@@ -263,6 +270,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -287,6 +295,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -314,6 +323,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -339,6 +349,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactAppDependencyProvider
@@ -364,6 +375,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -489,6 +501,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -515,6 +528,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -550,6 +564,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -614,6 +629,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -644,6 +660,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -653,12 +670,12 @@ PODS:
   - EXUpdatesInterface (1.0.0):
     - ExpoModulesCore
   - fast_float (6.1.4)
-  - FBLazyVector (0.79.0-rc.2)
+  - FBLazyVector (0.79.0-rc.3)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.79.0-rc.2):
-    - hermes-engine/Pre-built (= 0.79.0-rc.2)
-  - hermes-engine/Pre-built (0.79.0-rc.2)
+  - hermes-engine (0.79.0-rc.3):
+    - hermes-engine/Pre-built (= 0.79.0-rc.3)
+  - hermes-engine/Pre-built (0.79.0-rc.3)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -695,6 +712,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -735,33 +753,33 @@ PODS:
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.79.0-rc.2)
-  - RCTRequired (0.79.0-rc.2)
-  - RCTTypeSafety (0.79.0-rc.2):
-    - FBLazyVector (= 0.79.0-rc.2)
-    - RCTRequired (= 0.79.0-rc.2)
-    - React-Core (= 0.79.0-rc.2)
+  - RCTDeprecation (0.79.0-rc.3)
+  - RCTRequired (0.79.0-rc.3)
+  - RCTTypeSafety (0.79.0-rc.3):
+    - FBLazyVector (= 0.79.0-rc.3)
+    - RCTRequired (= 0.79.0-rc.3)
+    - React-Core (= 0.79.0-rc.3)
   - ReachabilitySwift (5.2.4)
-  - React (0.79.0-rc.2):
-    - React-Core (= 0.79.0-rc.2)
-    - React-Core/DevSupport (= 0.79.0-rc.2)
-    - React-Core/RCTWebSocket (= 0.79.0-rc.2)
-    - React-RCTActionSheet (= 0.79.0-rc.2)
-    - React-RCTAnimation (= 0.79.0-rc.2)
-    - React-RCTBlob (= 0.79.0-rc.2)
-    - React-RCTImage (= 0.79.0-rc.2)
-    - React-RCTLinking (= 0.79.0-rc.2)
-    - React-RCTNetwork (= 0.79.0-rc.2)
-    - React-RCTSettings (= 0.79.0-rc.2)
-    - React-RCTText (= 0.79.0-rc.2)
-    - React-RCTVibration (= 0.79.0-rc.2)
-  - React-callinvoker (0.79.0-rc.2)
-  - React-Core (0.79.0-rc.2):
+  - React (0.79.0-rc.3):
+    - React-Core (= 0.79.0-rc.3)
+    - React-Core/DevSupport (= 0.79.0-rc.3)
+    - React-Core/RCTWebSocket (= 0.79.0-rc.3)
+    - React-RCTActionSheet (= 0.79.0-rc.3)
+    - React-RCTAnimation (= 0.79.0-rc.3)
+    - React-RCTBlob (= 0.79.0-rc.3)
+    - React-RCTImage (= 0.79.0-rc.3)
+    - React-RCTLinking (= 0.79.0-rc.3)
+    - React-RCTNetwork (= 0.79.0-rc.3)
+    - React-RCTSettings (= 0.79.0-rc.3)
+    - React-RCTText (= 0.79.0-rc.3)
+    - React-RCTVibration (= 0.79.0-rc.3)
+  - React-callinvoker (0.79.0-rc.3)
+  - React-Core (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.79.0-rc.2)
+    - React-Core/Default (= 0.79.0-rc.3)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -774,61 +792,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.79.0-rc.2):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/Default (0.79.0-rc.2):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/DevSupport (0.79.0-rc.2):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.79.0-rc.2)
-    - React-Core/RCTWebSocket (= 0.79.0-rc.2)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.79.0-rc.2):
+  - React-Core/CoreModulesHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -846,7 +810,43 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.79.0-rc.2):
+  - React-Core/Default (0.79.0-rc.3):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/DevSupport (0.79.0-rc.3):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.79.0-rc.3)
+    - React-Core/RCTWebSocket (= 0.79.0-rc.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -864,7 +864,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.79.0-rc.2):
+  - React-Core/RCTAnimationHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -882,7 +882,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.79.0-rc.2):
+  - React-Core/RCTBlobHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -900,7 +900,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.79.0-rc.2):
+  - React-Core/RCTImageHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -918,7 +918,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.79.0-rc.2):
+  - React-Core/RCTLinkingHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -936,7 +936,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.79.0-rc.2):
+  - React-Core/RCTNetworkHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -954,7 +954,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.79.0-rc.2):
+  - React-Core/RCTSettingsHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -972,7 +972,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.79.0-rc.2):
+  - React-Core/RCTTextHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -990,12 +990,12 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.79.0-rc.2):
+  - React-Core/RCTVibrationHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.79.0-rc.2)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -1008,23 +1008,41 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-CoreModules (0.79.0-rc.2):
+  - React-Core/RCTWebSocket (0.79.0-rc.3):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.79.0-rc.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-CoreModules (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - RCT-Folly (= 2024.11.18.00)
-    - RCTTypeSafety (= 0.79.0-rc.2)
-    - React-Core/CoreModulesHeaders (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+    - RCTTypeSafety (= 0.79.0-rc.3)
+    - React-Core/CoreModulesHeaders (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.79.0-rc.2)
+    - React-RCTImage (= 0.79.0-rc.3)
     - ReactCommon
     - SocketRocket (= 0.7.1)
-  - React-cxxreact (0.79.0-rc.2):
+  - React-cxxreact (0.79.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float (= 6.1.4)
@@ -1032,17 +1050,17 @@ PODS:
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-rc.2)
-    - React-debug (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+    - React-callinvoker (= 0.79.0-rc.3)
+    - React-debug (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
-    - React-logger (= 0.79.0-rc.2)
-    - React-perflogger (= 0.79.0-rc.2)
-    - React-runtimeexecutor (= 0.79.0-rc.2)
-    - React-timing (= 0.79.0-rc.2)
-  - React-debug (0.79.0-rc.2)
-  - React-defaultsnativemodule (0.79.0-rc.2):
+    - React-logger (= 0.79.0-rc.3)
+    - React-perflogger (= 0.79.0-rc.3)
+    - React-runtimeexecutor (= 0.79.0-rc.3)
+    - React-timing (= 0.79.0-rc.3)
+  - React-debug (0.79.0-rc.3)
+  - React-defaultsnativemodule (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - React-domnativemodule
@@ -1053,7 +1071,7 @@ PODS:
     - React-jsiexecutor
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
-  - React-domnativemodule (0.79.0-rc.2):
+  - React-domnativemodule (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - React-Fabric
@@ -1065,7 +1083,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric (0.79.0-rc.2):
+  - React-Fabric (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1077,22 +1095,22 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.79.0-rc.2)
-    - React-Fabric/attributedstring (= 0.79.0-rc.2)
-    - React-Fabric/componentregistry (= 0.79.0-rc.2)
-    - React-Fabric/componentregistrynative (= 0.79.0-rc.2)
-    - React-Fabric/components (= 0.79.0-rc.2)
-    - React-Fabric/consistency (= 0.79.0-rc.2)
-    - React-Fabric/core (= 0.79.0-rc.2)
-    - React-Fabric/dom (= 0.79.0-rc.2)
-    - React-Fabric/imagemanager (= 0.79.0-rc.2)
-    - React-Fabric/leakchecker (= 0.79.0-rc.2)
-    - React-Fabric/mounting (= 0.79.0-rc.2)
-    - React-Fabric/observers (= 0.79.0-rc.2)
-    - React-Fabric/scheduler (= 0.79.0-rc.2)
-    - React-Fabric/telemetry (= 0.79.0-rc.2)
-    - React-Fabric/templateprocessor (= 0.79.0-rc.2)
-    - React-Fabric/uimanager (= 0.79.0-rc.2)
+    - React-Fabric/animations (= 0.79.0-rc.3)
+    - React-Fabric/attributedstring (= 0.79.0-rc.3)
+    - React-Fabric/componentregistry (= 0.79.0-rc.3)
+    - React-Fabric/componentregistrynative (= 0.79.0-rc.3)
+    - React-Fabric/components (= 0.79.0-rc.3)
+    - React-Fabric/consistency (= 0.79.0-rc.3)
+    - React-Fabric/core (= 0.79.0-rc.3)
+    - React-Fabric/dom (= 0.79.0-rc.3)
+    - React-Fabric/imagemanager (= 0.79.0-rc.3)
+    - React-Fabric/leakchecker (= 0.79.0-rc.3)
+    - React-Fabric/mounting (= 0.79.0-rc.3)
+    - React-Fabric/observers (= 0.79.0-rc.3)
+    - React-Fabric/scheduler (= 0.79.0-rc.3)
+    - React-Fabric/telemetry (= 0.79.0-rc.3)
+    - React-Fabric/templateprocessor (= 0.79.0-rc.3)
+    - React-Fabric/uimanager (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1103,29 +1121,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.79.0-rc.2):
+  - React-Fabric/animations (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1147,7 +1143,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.79.0-rc.2):
+  - React-Fabric/attributedstring (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1169,7 +1165,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.79.0-rc.2):
+  - React-Fabric/componentregistry (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1191,33 +1187,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.79.0-rc.2)
-    - React-Fabric/components/root (= 0.79.0-rc.2)
-    - React-Fabric/components/scrollview (= 0.79.0-rc.2)
-    - React-Fabric/components/view (= 0.79.0-rc.2)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.79.0-rc.2):
+  - React-Fabric/componentregistrynative (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1239,7 +1209,33 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.79.0-rc.2):
+  - React-Fabric/components (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.79.0-rc.3)
+    - React-Fabric/components/root (= 0.79.0-rc.3)
+    - React-Fabric/components/scrollview (= 0.79.0-rc.3)
+    - React-Fabric/components/view (= 0.79.0-rc.3)
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/legacyviewmanagerinterop (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1261,7 +1257,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/scrollview (0.79.0-rc.2):
+  - React-Fabric/components/root (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1283,7 +1279,29 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.79.0-rc.2):
+  - React-Fabric/components/scrollview (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1307,7 +1325,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/consistency (0.79.0-rc.2):
+  - React-Fabric/consistency (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1329,7 +1347,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/core (0.79.0-rc.2):
+  - React-Fabric/core (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1351,7 +1369,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/dom (0.79.0-rc.2):
+  - React-Fabric/dom (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1373,7 +1391,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.79.0-rc.2):
+  - React-Fabric/imagemanager (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1395,7 +1413,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.79.0-rc.2):
+  - React-Fabric/leakchecker (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1417,7 +1435,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.79.0-rc.2):
+  - React-Fabric/mounting (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1439,7 +1457,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers (0.79.0-rc.2):
+  - React-Fabric/observers (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1451,7 +1469,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.79.0-rc.2)
+    - React-Fabric/observers/events (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1462,7 +1480,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers/events (0.79.0-rc.2):
+  - React-Fabric/observers/events (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1484,7 +1502,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.79.0-rc.2):
+  - React-Fabric/scheduler (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1508,7 +1526,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.79.0-rc.2):
+  - React-Fabric/telemetry (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1530,7 +1548,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.79.0-rc.2):
+  - React-Fabric/templateprocessor (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1552,7 +1570,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.79.0-rc.2):
+  - React-Fabric/uimanager (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1564,30 +1582,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.79.0-rc.2)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager/consistency (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1599,7 +1594,30 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricComponents (0.79.0-rc.2):
+  - React-Fabric/uimanager/consistency (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-FabricComponents (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1612,8 +1630,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.79.0-rc.2)
-    - React-FabricComponents/textlayoutmanager (= 0.79.0-rc.2)
+    - React-FabricComponents/components (= 0.79.0-rc.3)
+    - React-FabricComponents/textlayoutmanager (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1625,7 +1643,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components (0.79.0-rc.2):
+  - React-FabricComponents/components (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1638,15 +1656,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.79.0-rc.2)
-    - React-FabricComponents/components/iostextinput (= 0.79.0-rc.2)
-    - React-FabricComponents/components/modal (= 0.79.0-rc.2)
-    - React-FabricComponents/components/rncore (= 0.79.0-rc.2)
-    - React-FabricComponents/components/safeareaview (= 0.79.0-rc.2)
-    - React-FabricComponents/components/scrollview (= 0.79.0-rc.2)
-    - React-FabricComponents/components/text (= 0.79.0-rc.2)
-    - React-FabricComponents/components/textinput (= 0.79.0-rc.2)
-    - React-FabricComponents/components/unimplementedview (= 0.79.0-rc.2)
+    - React-FabricComponents/components/inputaccessory (= 0.79.0-rc.3)
+    - React-FabricComponents/components/iostextinput (= 0.79.0-rc.3)
+    - React-FabricComponents/components/modal (= 0.79.0-rc.3)
+    - React-FabricComponents/components/rncore (= 0.79.0-rc.3)
+    - React-FabricComponents/components/safeareaview (= 0.79.0-rc.3)
+    - React-FabricComponents/components/scrollview (= 0.79.0-rc.3)
+    - React-FabricComponents/components/text (= 0.79.0-rc.3)
+    - React-FabricComponents/components/textinput (= 0.79.0-rc.3)
+    - React-FabricComponents/components/unimplementedview (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1658,55 +1676,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/modal (0.79.0-rc.2):
+  - React-FabricComponents/components/inputaccessory (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1730,7 +1700,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/rncore (0.79.0-rc.2):
+  - React-FabricComponents/components/iostextinput (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1754,7 +1724,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.79.0-rc.2):
+  - React-FabricComponents/components/modal (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1778,7 +1748,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/scrollview (0.79.0-rc.2):
+  - React-FabricComponents/components/rncore (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1802,7 +1772,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/text (0.79.0-rc.2):
+  - React-FabricComponents/components/safeareaview (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1826,7 +1796,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/textinput (0.79.0-rc.2):
+  - React-FabricComponents/components/scrollview (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1850,7 +1820,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.79.0-rc.2):
+  - React-FabricComponents/components/text (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1874,7 +1844,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.79.0-rc.2):
+  - React-FabricComponents/components/textinput (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1898,30 +1868,78 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricImage (0.79.0-rc.2):
+  - React-FabricComponents/components/unimplementedview (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired (= 0.79.0-rc.2)
-    - RCTTypeSafety (= 0.79.0-rc.2)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricImage (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired (= 0.79.0-rc.3)
+    - RCTTypeSafety (= 0.79.0-rc.3)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-hermes
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.79.0-rc.2)
+    - React-jsiexecutor (= 0.79.0-rc.3)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.79.0-rc.2):
+  - React-featureflags (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
-  - React-featureflagsnativemodule (0.79.0-rc.2):
+  - React-featureflagsnativemodule (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - React-featureflags
@@ -1930,7 +1948,7 @@ PODS:
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - React-graphics (0.79.0-rc.2):
+  - React-graphics (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1941,21 +1959,21 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-utils
-  - React-hermes (0.79.0-rc.2):
+  - React-hermes (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact (= 0.79.0-rc.2)
+    - React-cxxreact (= 0.79.0-rc.3)
     - React-jsi
-    - React-jsiexecutor (= 0.79.0-rc.2)
+    - React-jsiexecutor (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
-    - React-perflogger (= 0.79.0-rc.2)
+    - React-perflogger (= 0.79.0-rc.3)
     - React-runtimeexecutor
-  - React-idlecallbacksnativemodule (0.79.0-rc.2):
+  - React-idlecallbacksnativemodule (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly
@@ -1965,7 +1983,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
-  - React-ImageManager (0.79.0-rc.2):
+  - React-ImageManager (0.79.0-rc.3):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -1974,7 +1992,7 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jserrorhandler (0.79.0-rc.2):
+  - React-jserrorhandler (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -1983,7 +2001,7 @@ PODS:
     - React-featureflags
     - React-jsi
     - ReactCommon/turbomodule/bridging
-  - React-jsi (0.79.0-rc.2):
+  - React-jsi (0.79.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float (= 6.1.4)
@@ -1991,19 +2009,19 @@ PODS:
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-  - React-jsiexecutor (0.79.0-rc.2):
+  - React-jsiexecutor (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
-    - React-perflogger (= 0.79.0-rc.2)
-  - React-jsinspector (0.79.0-rc.2):
+    - React-perflogger (= 0.79.0-rc.3)
+  - React-jsinspector (0.79.0-rc.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2011,29 +2029,29 @@ PODS:
     - React-featureflags
     - React-jsi
     - React-jsinspectortracing
-    - React-perflogger (= 0.79.0-rc.2)
-    - React-runtimeexecutor (= 0.79.0-rc.2)
-  - React-jsinspectortracing (0.79.0-rc.2):
+    - React-perflogger (= 0.79.0-rc.3)
+    - React-runtimeexecutor (= 0.79.0-rc.3)
+  - React-jsinspectortracing (0.79.0-rc.3):
     - RCT-Folly
     - React-oscompat
-  - React-jsitooling (0.79.0-rc.2):
+  - React-jsitooling (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
-  - React-jsitracing (0.79.0-rc.2):
+  - React-jsitracing (0.79.0-rc.3):
     - React-jsi
-  - React-logger (0.79.0-rc.2):
+  - React-logger (0.79.0-rc.3):
     - glog
-  - React-Mapbuffer (0.79.0-rc.2):
+  - React-Mapbuffer (0.79.0-rc.3):
     - glog
     - React-debug
-  - React-microtasksnativemodule (0.79.0-rc.2):
+  - React-microtasksnativemodule (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - React-hermes
@@ -2061,6 +2079,7 @@ PODS:
     - react-native-pager-view/common (= 6.5.1)
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2084,6 +2103,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2109,6 +2129,7 @@ PODS:
     - react-native-safe-area-context/fabric (= 5.2.0)
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2132,6 +2153,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2156,6 +2178,7 @@ PODS:
     - react-native-safe-area-context/common
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2182,6 +2205,7 @@ PODS:
     - react-native-slider/common (= 4.5.5)
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2205,6 +2229,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2228,6 +2253,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2251,13 +2277,14 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-NativeModulesApple (0.79.0-rc.2):
+  - React-NativeModulesApple (0.79.0-rc.3):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -2270,20 +2297,20 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-oscompat (0.79.0-rc.2)
-  - React-perflogger (0.79.0-rc.2):
+  - React-oscompat (0.79.0-rc.3)
+  - React-perflogger (0.79.0-rc.3):
     - DoubleConversion
     - RCT-Folly (= 2024.11.18.00)
-  - React-performancetimeline (0.79.0-rc.2):
+  - React-performancetimeline (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - React-cxxreact
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
-  - React-RCTActionSheet (0.79.0-rc.2):
-    - React-Core/RCTActionSheetHeaders (= 0.79.0-rc.2)
-  - React-RCTAnimation (0.79.0-rc.2):
+  - React-RCTActionSheet (0.79.0-rc.3):
+    - React-Core/RCTActionSheetHeaders (= 0.79.0-rc.3)
+  - React-RCTAnimation (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTAnimationHeaders
@@ -2291,7 +2318,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTAppDelegate (0.79.0-rc.2):
+  - React-RCTAppDelegate (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - RCTRequired
@@ -2317,7 +2344,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon
-  - React-RCTBlob (0.79.0-rc.2):
+  - React-RCTBlob (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -2331,7 +2358,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.79.0-rc.2):
+  - React-RCTFabric (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -2357,7 +2384,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTFBReactNativeSpec (0.79.0-rc.2):
+  - React-RCTFBReactNativeSpec (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - RCTRequired
@@ -2368,7 +2395,7 @@ PODS:
     - React-jsiexecutor
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTImage (0.79.0-rc.2):
+  - React-RCTImage (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTImageHeaders
@@ -2377,14 +2404,14 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.79.0-rc.2):
-    - React-Core/RCTLinkingHeaders (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+  - React-RCTLinking (0.79.0-rc.3):
+    - React-Core/RCTLinkingHeaders (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.79.0-rc.2)
-  - React-RCTNetwork (0.79.0-rc.2):
+    - ReactCommon/turbomodule/core (= 0.79.0-rc.3)
+  - React-RCTNetwork (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTNetworkHeaders
@@ -2392,7 +2419,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTRuntime (0.79.0-rc.2):
+  - React-RCTRuntime (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -2405,7 +2432,7 @@ PODS:
     - React-RuntimeApple
     - React-RuntimeCore
     - React-RuntimeHermes
-  - React-RCTSettings (0.79.0-rc.2):
+  - React-RCTSettings (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTSettingsHeaders
@@ -2413,28 +2440,28 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTText (0.79.0-rc.2):
-    - React-Core/RCTTextHeaders (= 0.79.0-rc.2)
+  - React-RCTText (0.79.0-rc.3):
+    - React-Core/RCTTextHeaders (= 0.79.0-rc.3)
     - Yoga
-  - React-RCTVibration (0.79.0-rc.2):
+  - React-RCTVibration (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-rendererconsistency (0.79.0-rc.2)
-  - React-renderercss (0.79.0-rc.2):
+  - React-rendererconsistency (0.79.0-rc.3)
+  - React-renderercss (0.79.0-rc.3):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.79.0-rc.2):
+  - React-rendererdebug (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - RCT-Folly (= 2024.11.18.00)
     - React-debug
-  - React-rncore (0.79.0-rc.2)
-  - React-RuntimeApple (0.79.0-rc.2):
+  - React-rncore (0.79.0-rc.3)
+  - React-RuntimeApple (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
     - React-callinvoker
@@ -2456,7 +2483,7 @@ PODS:
     - React-RuntimeHermes
     - React-runtimescheduler
     - React-utils
-  - React-RuntimeCore (0.79.0-rc.2):
+  - React-RuntimeCore (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -2473,9 +2500,9 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.79.0-rc.2):
-    - React-jsi (= 0.79.0-rc.2)
-  - React-RuntimeHermes (0.79.0-rc.2):
+  - React-runtimeexecutor (0.79.0-rc.3):
+    - React-jsi (= 0.79.0-rc.3)
+  - React-RuntimeHermes (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
     - React-featureflags
@@ -2487,7 +2514,7 @@ PODS:
     - React-jsitracing
     - React-RuntimeCore
     - React-utils
-  - React-runtimescheduler (0.79.0-rc.2):
+  - React-runtimescheduler (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -2504,17 +2531,17 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - React-utils
-  - React-timing (0.79.0-rc.2)
-  - React-utils (0.79.0-rc.2):
+  - React-timing (0.79.0-rc.3)
+  - React-utils (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - React-debug
     - React-hermes
-    - React-jsi (= 0.79.0-rc.2)
-  - ReactAppDependencyProvider (0.79.0-rc.2):
+    - React-jsi (= 0.79.0-rc.3)
+  - ReactAppDependencyProvider (0.79.0-rc.3):
     - ReactCodegen
-  - ReactCodegen (0.79.0-rc.2):
+  - ReactCodegen (0.79.0-rc.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2536,49 +2563,49 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - ReactCommon (0.79.0-rc.2):
-    - ReactCommon/turbomodule (= 0.79.0-rc.2)
-  - ReactCommon/turbomodule (0.79.0-rc.2):
+  - ReactCommon (0.79.0-rc.3):
+    - ReactCommon/turbomodule (= 0.79.0-rc.3)
+  - ReactCommon/turbomodule (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-rc.2)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
-    - React-logger (= 0.79.0-rc.2)
-    - React-perflogger (= 0.79.0-rc.2)
-    - ReactCommon/turbomodule/bridging (= 0.79.0-rc.2)
-    - ReactCommon/turbomodule/core (= 0.79.0-rc.2)
-  - ReactCommon/turbomodule/bridging (0.79.0-rc.2):
+    - React-callinvoker (= 0.79.0-rc.3)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
+    - React-logger (= 0.79.0-rc.3)
+    - React-perflogger (= 0.79.0-rc.3)
+    - ReactCommon/turbomodule/bridging (= 0.79.0-rc.3)
+    - ReactCommon/turbomodule/core (= 0.79.0-rc.3)
+  - ReactCommon/turbomodule/bridging (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-rc.2)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
-    - React-logger (= 0.79.0-rc.2)
-    - React-perflogger (= 0.79.0-rc.2)
-  - ReactCommon/turbomodule/core (0.79.0-rc.2):
+    - React-callinvoker (= 0.79.0-rc.3)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
+    - React-logger (= 0.79.0-rc.3)
+    - React-perflogger (= 0.79.0-rc.3)
+  - ReactCommon/turbomodule/core (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-rc.2)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-debug (= 0.79.0-rc.2)
-    - React-featureflags (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
-    - React-logger (= 0.79.0-rc.2)
-    - React-perflogger (= 0.79.0-rc.2)
-    - React-utils (= 0.79.0-rc.2)
+    - React-callinvoker (= 0.79.0-rc.3)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-debug (= 0.79.0-rc.3)
+    - React-featureflags (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
+    - React-logger (= 0.79.0-rc.3)
+    - React-perflogger (= 0.79.0-rc.3)
+    - React-utils (= 0.79.0-rc.3)
   - RNCAsyncStorage (1.23.1):
     - DoubleConversion
     - glog
@@ -2596,6 +2623,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2619,6 +2647,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2642,6 +2671,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2665,6 +2695,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2688,6 +2719,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2711,6 +2743,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2734,6 +2767,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2759,6 +2793,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2783,6 +2818,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2806,6 +2842,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2830,6 +2867,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2854,6 +2892,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFabric
     - React-RCTImage
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2879,6 +2918,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFabric
     - React-RCTImage
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2902,6 +2942,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2926,6 +2967,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -3553,7 +3595,7 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  BenchmarkingModule: 46453c95f802da3d8f202b87d7ec7bc8aba96a96
+  BenchmarkingModule: a97859cac8efb2f5411b2052e61841b349813a4a
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EASClient: 720af5473430a688e792ffa91f33d11fe72fcb89
@@ -3566,8 +3608,8 @@ SPEC CHECKSUMS:
   EXNotifications: 3b6c5a91673a5fe7eae005c1fa79889f645111aa
   Expo: 24ec4e242d7cb4bc0095beeb984ac1006a8782e1
   expo-dev-client: 8c99b4979086a27f19e773e96ef10219102a5c4f
-  expo-dev-launcher: d50e10c4023bdcba441b67b55e9d534b237fc7f4
-  expo-dev-menu: 0e4920d6ea02a784390d7bfa750e7049acb192e8
+  expo-dev-launcher: 958c0d27cd819c8b3ed69e1ec3accc43b7357a02
+  expo-dev-menu: ef0c84491ce3f037c25a6617662726f561801e67
   expo-dev-menu-interface: 4baf2f8b3b79ce37cf4b900e4b3ba6df3384f0a1
   ExpoAppleAuthentication: 218e275c9bf19963247a198c450ce3852e6a9342
   ExpoAsset: 6e707be0cb7e792faa06e42d8ebc85600921af89
@@ -3605,12 +3647,12 @@ SPEC CHECKSUMS:
   ExpoMaps: b84e936b1c90ec650f8b6e9f1979f7479c3a28f6
   ExpoMediaLibrary: 778e8fd37b0172f8a7984c0ab1b3a1f91a837eef
   ExpoMeshGradient: 10206dfd6045700677d876bf58a27f065f4b9f70
-  ExpoModulesCore: 0e2e6ca33190d0d2689f9496a24bdb5f05d383c1
+  ExpoModulesCore: f31cdbb91d3c027f51369ca53b2d94e1267aeeb2
   ExpoModulesTestCore: c81e21fd6ff61a212f3053d172aa163ad0db4d49
   ExpoNetwork: f07b371f7e143812980075fda6768702c154a0a0
   ExpoPrint: 3f9f5a5a19dbda5b30963d5bf078918f024aa29d
   ExpoScreenCapture: 14768e6fe66412d678862858f5c2e0241b7f84b7
-  ExpoScreenOrientation: b2d1d7649b2bc82fd58bdf3ca6daf1f219ea45a2
+  ExpoScreenOrientation: 026387432f290e1d06e29984678fa0ca063bec1d
   ExpoSecureStore: 06c3192d58ed167f619af3d53797c055f5ada785
   ExpoSensors: 55eef9972309aa8ec26bf5922040453e4c5cf7df
   ExpoSharing: 39a198e64bf522948fe60e270e49a0c7757912c1
@@ -3628,107 +3670,107 @@ SPEC CHECKSUMS:
   ExpoWebBrowser: f08aaf1c8a02af8a768d83793186cb6d2c69f529
   EXStructuredHeaders: 09c70347b282e3d2507e25fb4c747b1b885f87f6
   EXTaskManager: 8e915e1120894daead363cf31ff85cd4d182cd89
-  EXUpdates: d971052c208ce093230b2df7aea55ca5ecd407ee
+  EXUpdates: 8ac12f8608f0de89311d016e087648c6342953f1
   EXUpdatesInterface: 1dcebac98ac5dad4289e6ff2bd5616822e894397
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
-  FBLazyVector: 73f927157a20d4c20c419d3ea42197c28e895fc3
+  FBLazyVector: a13cdda7bbe886d533908636117037b198014387
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 35fc9a910fa91f0e71d953aa76cf0629a2f8643c
+  hermes-engine: 222573b97e0c0023ee02f5a8480d6aa3080ceb3f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: d63feeef23e936c6722546ecebb0a6ee470d9a3c
+  lottie-react-native: 78b9ae436cd15e08e56a750449c3ca3759406720
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
   RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
-  RCTDeprecation: 57c8eb30be38b17267f7947496586e8c56655000
-  RCTRequired: 0a0a46bc2ee03107636ea3e3ecd17fcf96ecb973
-  RCTTypeSafety: e01703b8ae90a9e4f832d192b6426e2be278e2cd
+  RCTDeprecation: 2fa7e5950e440764f4a7c2731840d35b5e464383
+  RCTRequired: e46164234affa609618ee854dc3f1648ef270d3c
+  RCTTypeSafety: 0d5a0cf9e39231a471f38d74415845761b339273
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: e004cb14e60cebfcf2bc8c33ffac89ef88a8889d
-  React-callinvoker: 6f8b5686eeab81591262e71369c04830bef3cc47
-  React-Core: 7ecda373ee452d8239d7bd74bc7348409a511f80
-  React-CoreModules: 1dadfd981eab73a91e52be159ac272f07406e1c6
-  React-cxxreact: dfd36141a363e36768ab164f710591bd8b2de8f5
-  React-debug: 40b4e98b1e6abd7b2b07158d065eb0e653c8e6be
-  React-defaultsnativemodule: d47fe1f071cd3e28feeefe79c74f1c72938ec14c
-  React-domnativemodule: 3c037c30f7dcedcc7cb2115a4856e26dc7fd427a
-  React-Fabric: b69bf84ed89753f1004cd4dca58453142768e94e
-  React-FabricComponents: a5d5656033380fe70a54c9755f26695e61a55c02
-  React-FabricImage: af0c8d13671eab38adb9399b987d6a1c94b829db
-  React-featureflags: 6076c7a9ed2039e0d4a874dca4fcb1e83d81fe13
-  React-featureflagsnativemodule: 84e926d230eb9f3cc347f496ac25fd882d86cdb0
-  React-graphics: cf422929daf9aace64422744b293dada6021a0bc
-  React-hermes: 8a37df7f343cf690636248a625a005b524c20935
-  React-idlecallbacksnativemodule: 839db78afe2e9f5805ad59b34da80e570bcaab32
-  React-ImageManager: aa393db52bf534a35a0bab615c773059e272d009
-  React-jserrorhandler: 3daba80788b61ba30a606c3e46ac33e5780dd88c
-  React-jsi: 88646f87400f9733a40affa590c017b79bc0a6b4
-  React-jsiexecutor: 9406e8aacb1e5eba4632d894af232de7f6d6046f
-  React-jsinspector: 02c0f15ac34f56656ceed9f6337a52d31f1df169
-  React-jsinspectortracing: cecb1569bc769b2fd9bbd5995c086f9a30a085ed
-  React-jsitooling: 598b5e82d7eb0677bf0d6fd2083d788be8589ff8
-  React-jsitracing: 67d7707c7912c2f59fefe325339d1879aebde323
-  React-logger: ae25d57a8548a6ef7a15ea3f647e192cb420e464
-  React-Mapbuffer: 1d2b097474d043c73f1b3bca045f08eb8886eba2
-  React-microtasksnativemodule: dddd71a2a01726d7ed8e2732787a03c7e1fefe7f
+  React: f860d6b597a59819f52cd18de431320c658774b5
+  React-callinvoker: 47a4bbcb912ff682f5f57b437204237305b1f03e
+  React-Core: b89018209a1692fa31fdda082525fda2ec885e02
+  React-CoreModules: 6718956d9537656367a9a31a01d84c2f1c201244
+  React-cxxreact: c7c3450683f60b41fdbb7ec02f9347e94279069a
+  React-debug: 354c1023f0feec2c484c35edc2d9614abc7e1e47
+  React-defaultsnativemodule: d376de286c4dfb3e2970f2b4ce6698ce1862a8f8
+  React-domnativemodule: eadf20cdc91872b99ad8dc72611ac473dc6b4a1c
+  React-Fabric: 39e5f9d5e7ee74a07de91748e785975be29547b5
+  React-FabricComponents: 739c83e170a19d6e8f90c9f1295a530c9888460c
+  React-FabricImage: 1d621b5273ffcb9c2fb0c756f231b35fa08752b0
+  React-featureflags: e8b460883a5562ce85c934f248655a81d5e09f21
+  React-featureflagsnativemodule: 275dbfb2cdcbf14ba52743eb2eccef16950f438a
+  React-graphics: e0ab76bd9ef6db26237ae69aff66c3a8224519f1
+  React-hermes: 4eafcbe1e9e558fae5ae3e1addf130fb8d1f6647
+  React-idlecallbacksnativemodule: dd2e62d7ab928dcd761e180b473f340b4d31c522
+  React-ImageManager: 8f604c44f6da53c199ea76febba49c427343ab7d
+  React-jserrorhandler: b987989ea5fa952be6926a4cc086867b956787c7
+  React-jsi: d0211699cbb8e9b7397ece49890536713d2ccc9a
+  React-jsiexecutor: 3be18538fd9ac380f25d8fd72b30b2882aa189e8
+  React-jsinspector: 7fdc505319d3e87622c02867df8e476ca3975863
+  React-jsinspectortracing: b8e229eed818878b5e65d8faaed60e2f49915b6b
+  React-jsitooling: db92692002692ba568d29a02b5b2c6bdce2c4323
+  React-jsitracing: eca84150c74c598ecabc790415f0c7a6257802d0
+  React-logger: 0de8a4004273f62f6296d0c3b8c120c2245eaf81
+  React-Mapbuffer: b4708d8976588eeda6dacfa14742b1f2056e5bb6
+  React-microtasksnativemodule: 9d28b4b9272b52dffabcd2d48a934a8d8177f1e6
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
-  react-native-pager-view: 0d7e01587e0abaaeee392683675959ecef40c12e
-  react-native-safe-area-context: 3ea8a97b7bda6f2c3a202a5ec9ae6406f58c24a4
+  react-native-pager-view: a1b4f854df102a127b38fa49ff9d25af20a3c550
+  react-native-safe-area-context: fb22a3043ce75c3145da87a74254a2ec527267b0
   react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
-  react-native-slider: a27e2643e000c73867e21495d6ac5d027c408ec8
-  react-native-view-shot: 8a62a3f06485a1f5e5fa7fab6cacfd43d2cced53
-  react-native-webview: 2fc69e028efee4085ef064d735dbde1f4ced8279
-  React-NativeModulesApple: 08302164cb4c4a3ecf26d04c794750c8da76ee26
-  React-oscompat: 38090361205b8f47117134b291a4a928c50e0def
-  React-perflogger: 809ab1f94e7293ae6439ab770f67d92df729b37f
-  React-performancetimeline: a7419f23796a8c2879edc830a6cc1666607f263d
-  React-RCTActionSheet: 8bde2412a4fa37e4cb87d6ab739483a9f2f95638
-  React-RCTAnimation: 55ca7cc5572ab20b80e7c89832b8b88338c68afd
-  React-RCTAppDelegate: 8bde0e7827dcceeee2cc23e520f25dca37ede115
-  React-RCTBlob: eac258b7de2209e123cfe0bb1f93ac2468486c0b
-  React-RCTFabric: a0ffaf9df5a9d5819b063f52280c297c9a2ccc6f
-  React-RCTFBReactNativeSpec: f722a2add697e78c809d4a68baaeb1ee0266980a
-  React-RCTImage: df7970e2943ce7895aec1edf97cfbe9769e5431f
-  React-RCTLinking: c6fe4d4831706bb7d0ec736b4615cff8b3dfa7b4
-  React-RCTNetwork: 1bbeb395f3aefc647d65b47a045fd244a8001034
-  React-RCTRuntime: 38986df612b538aa056b9e2ff0a8e3fc8a078a88
-  React-RCTSettings: 994c927ae049a24571cfb1c5fb85068548f0f03e
-  React-RCTText: 10ba61380dde029c205b05fdb09296f3575734d7
-  React-RCTVibration: 7825602652fd01ff658752e4b8c043ae25ae45fe
-  React-rendererconsistency: 3709930705daedba53af997342cc4f01d4e56795
-  React-renderercss: 6393d95573a4b924bd185727eaa07ada9de80f1a
-  React-rendererdebug: ac3604cf7e7e5eb708503b288e22865fd7660097
-  React-rncore: 33ac9ffecdd38a4b81f9348309d63b4d045d4814
-  React-RuntimeApple: 8bc11af9d8649066c3b0e515ea5a261507f281fb
-  React-RuntimeCore: f154b9bf28cdd3c6bd14aeb4275f9d069cccc82b
-  React-runtimeexecutor: a9656dde5693fea60fbe4483748be5115aa9b6e1
-  React-RuntimeHermes: 3a431c82b79911c0f5f16f5a0049b942e165da5f
-  React-runtimescheduler: 8420ce60e320f30b3b0ceb26c3c61d4936bf7ccd
-  React-timing: 26311cc6420b9af8e1e9bd53dfaa1b025ec270b1
-  React-utils: de08a59446d8782c10502e6a4a5f7cc40a7c7090
-  ReactAppDependencyProvider: 17afd7407f6899a032c40bf3900b9a645809dff3
-  ReactCodegen: 9a1449a4332a97ef05f41bf1516566801d1d1698
-  ReactCommon: 9f144a83e0f8d980f6083b3935eb6d423454eede
-  RNCAsyncStorage: bf32d338adfc41224c0b182a7ccd3c67c8b96a83
-  RNCMaskedView: d89065f41812f079eb0d9a5924353c175591de94
-  RNCPicker: cd6f3505c76c78a5efad97b5baf1cbaf3adf7ea8
-  RNDateTimePicker: 1ed5c52b06c6ec39a829e7ba4f4efe7f8a91a64d
-  RNFlashList: f1a63d27d13903c8c44d67e0501486ab7a451091
-  RNGestureHandler: 54481e63bf74e3aebd744c2ce715d57ab2d63b75
-  RNReanimated: 321287dce49bf1f96bb453985219b5af1f20bd0e
-  RNScreens: 9ce01d366c096aa6bab28ca5546c1ec6effa5419
-  RNSVG: a9d7676ad21a91f78a6bb5c56e975575b7e2f714
+  react-native-slider: c57011b1447edac8ddcc4d61cbd54172f378b7a0
+  react-native-view-shot: 105375eceab012a37db548637dd6fca795af977a
+  react-native-webview: 4203df130be3d3f03e0437cfe3f8ad5076044a56
+  React-NativeModulesApple: a5ed6f425abed68a61415527cf902b22eb661b32
+  React-oscompat: 481559f37d95c98fa39fa84674171a5f6646a932
+  React-perflogger: bfa66d1709c975ed0bf7aa886882414a7497f7d6
+  React-performancetimeline: 64af0e7dd7a682213bd0e7e1cbdfff731cd17901
+  React-RCTActionSheet: 48ce30c88e7aa83a3153f2785f58eb18985e4b7c
+  React-RCTAnimation: 13d78666184cdd284b0237bd7830a7c849a38a82
+  React-RCTAppDelegate: baccce68e95160d1ba9086be2ee395690fc225f2
+  React-RCTBlob: 13f05f3a783777856957478b2f58dd73ac86fd4b
+  React-RCTFabric: 78e3f673ae73e70e7229036e800803656becfa31
+  React-RCTFBReactNativeSpec: 6ab3a57d15ddc12abb97696dea30b6594d4c4d1c
+  React-RCTImage: 5c96e5f762fd945b5438b26770456b93ac9cefe3
+  React-RCTLinking: 4ed5e0842227fd5036404aa04994e0720e556caa
+  React-RCTNetwork: 5fbbe5bc152936e28d3f66d6c0d16dd7fc43a430
+  React-RCTRuntime: 9b5bf6f87e24393f1de2a3d70b2e840f90282a5a
+  React-RCTSettings: 0c5d7460873ef191b51ab614cc5f9dc0706c34aa
+  React-RCTText: b3026406d7ff8c95b64437ba48d7ba35a0a7fcd6
+  React-RCTVibration: 64da0c913099e3f4f6c556322cb398a83be2b7fc
+  React-rendererconsistency: a4d8b222d165650a4bff33cf50033e1adf9a87a3
+  React-renderercss: 768ef55fa1720e0131a979e0228ed8955a40f7a7
+  React-rendererdebug: 520d105541cf2946ed3505a8aa83df6b17647544
+  React-rncore: 27f409047489a44511ad49e64fbc00b798455cbc
+  React-RuntimeApple: 25352c0b749482ac743bb5670e7d629fdf9caaae
+  React-RuntimeCore: 86dc1275e9d58d77985dc4167ff6a2931d2e44f8
+  React-runtimeexecutor: 1f7b57e78d4721d2e9c98d094d6f480c93da3f25
+  React-RuntimeHermes: a8e3287c412ed138475dada3374cca6a5e9df450
+  React-runtimescheduler: 1a328781b0d0d8a47a62c58a307e09b96b8938bc
+  React-timing: 1b7c77ff812ae55c820636333909f4bfe948eb06
+  React-utils: e38a4ca98a4148b50bc470346e05ea5a3935eb46
+  ReactAppDependencyProvider: 556c91ab2e8cf1389f8c07cbcadb04134923ead4
+  ReactCodegen: daea2a288fc631ab7785e2008974e214c701b0fe
+  ReactCommon: 0b6cc8bfc9e59b9c652f83325881f271501e9b0e
+  RNCAsyncStorage: 3070bd18200c569f2ce2d1f43ac3bbf6d956d19b
+  RNCMaskedView: 3e8d6bf9764b519d077986413882959eafceffbc
+  RNCPicker: 04b02770d871072243f4a95fa2523b9c3398a2f5
+  RNDateTimePicker: dad505d754e617e94a6a465925e5b9b321358c14
+  RNFlashList: 180edc34e4f015749b56c7674bc0f54a40d3deff
+  RNGestureHandler: ccf4105b125002bd88e39d2a1f2b7e6001bcdf34
+  RNReanimated: fc1e35380ba37c5f28b83414be9850e4091efa76
+  RNScreens: e02f237d99e332f2d75092c7d7ba065110bcf1af
+  RNSVG: ee32efbed652c5151fd3f98bed13c68af285bc38
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   UMAppLoader: bda51f73f8599e336a778b23e0956130d1e244d5
-  Yoga: d15788383b33ea88af96bc7c12354810089527f4
+  Yoga: 99c3ff1f0452d13c8774222903cef8dda229d5ce
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 567bb58fe91a07874d34e36dc2ed989b409d33cd

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -59,7 +59,7 @@
     "native-component-list": "*",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "react-native": "0.79.0-rc.2",
+    "react-native": "0.79.0-rc.3",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-pager-view": "6.5.1",
     "react-native-reanimated": "3.17.1",

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -21,7 +21,7 @@
       },
       "ios": {
         "cache": {
-          "key": "sdk53-0.79.0-rc.2",
+          "key": "sdk53-0.79.0-rc.3",
           "customPaths": ["../expo-go/ios/Pods"]
         },
         "image": "macos-sonoma-14.6-xcode-16.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -147,6 +147,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -173,6 +174,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -208,6 +210,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -268,6 +271,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -298,6 +302,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -307,7 +312,7 @@ PODS:
   - EXUpdatesInterface (1.0.0):
     - ExpoModulesCore
   - fast_float (6.1.4)
-  - FBLazyVector (0.79.0-rc.2)
+  - FBLazyVector (0.79.0-rc.3)
   - FirebaseAnalytics (11.4.0):
     - FirebaseAnalytics/AdIdSupport (= 11.4.0)
     - FirebaseCore (~> 11.0)
@@ -430,17 +435,17 @@ PODS:
   - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - hermes-engine (0.79.0-rc.2):
-    - hermes-engine/cdp (= 0.79.0-rc.2)
-    - hermes-engine/Hermes (= 0.79.0-rc.2)
-    - hermes-engine/inspector (= 0.79.0-rc.2)
-    - hermes-engine/inspector_chrome (= 0.79.0-rc.2)
-    - hermes-engine/Public (= 0.79.0-rc.2)
-  - hermes-engine/cdp (0.79.0-rc.2)
-  - hermes-engine/Hermes (0.79.0-rc.2)
-  - hermes-engine/inspector (0.79.0-rc.2)
-  - hermes-engine/inspector_chrome (0.79.0-rc.2)
-  - hermes-engine/Public (0.79.0-rc.2)
+  - hermes-engine (0.79.0-rc.3):
+    - hermes-engine/cdp (= 0.79.0-rc.3)
+    - hermes-engine/Hermes (= 0.79.0-rc.3)
+    - hermes-engine/inspector (= 0.79.0-rc.3)
+    - hermes-engine/inspector_chrome (= 0.79.0-rc.3)
+    - hermes-engine/Public (= 0.79.0-rc.3)
+  - hermes-engine/cdp (0.79.0-rc.3)
+  - hermes-engine/Hermes (0.79.0-rc.3)
+  - hermes-engine/inspector (0.79.0-rc.3)
+  - hermes-engine/inspector_chrome (0.79.0-rc.3)
+  - hermes-engine/Public (0.79.0-rc.3)
   - JKBigInteger (0.0.6)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
@@ -478,6 +483,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -514,33 +520,33 @@ PODS:
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.79.0-rc.2)
-  - RCTRequired (0.79.0-rc.2)
-  - RCTTypeSafety (0.79.0-rc.2):
-    - FBLazyVector (= 0.79.0-rc.2)
-    - RCTRequired (= 0.79.0-rc.2)
-    - React-Core (= 0.79.0-rc.2)
+  - RCTDeprecation (0.79.0-rc.3)
+  - RCTRequired (0.79.0-rc.3)
+  - RCTTypeSafety (0.79.0-rc.3):
+    - FBLazyVector (= 0.79.0-rc.3)
+    - RCTRequired (= 0.79.0-rc.3)
+    - React-Core (= 0.79.0-rc.3)
   - ReachabilitySwift (5.2.4)
-  - React (0.79.0-rc.2):
-    - React-Core (= 0.79.0-rc.2)
-    - React-Core/DevSupport (= 0.79.0-rc.2)
-    - React-Core/RCTWebSocket (= 0.79.0-rc.2)
-    - React-RCTActionSheet (= 0.79.0-rc.2)
-    - React-RCTAnimation (= 0.79.0-rc.2)
-    - React-RCTBlob (= 0.79.0-rc.2)
-    - React-RCTImage (= 0.79.0-rc.2)
-    - React-RCTLinking (= 0.79.0-rc.2)
-    - React-RCTNetwork (= 0.79.0-rc.2)
-    - React-RCTSettings (= 0.79.0-rc.2)
-    - React-RCTText (= 0.79.0-rc.2)
-    - React-RCTVibration (= 0.79.0-rc.2)
-  - React-callinvoker (0.79.0-rc.2)
-  - React-Core (0.79.0-rc.2):
+  - React (0.79.0-rc.3):
+    - React-Core (= 0.79.0-rc.3)
+    - React-Core/DevSupport (= 0.79.0-rc.3)
+    - React-Core/RCTWebSocket (= 0.79.0-rc.3)
+    - React-RCTActionSheet (= 0.79.0-rc.3)
+    - React-RCTAnimation (= 0.79.0-rc.3)
+    - React-RCTBlob (= 0.79.0-rc.3)
+    - React-RCTImage (= 0.79.0-rc.3)
+    - React-RCTLinking (= 0.79.0-rc.3)
+    - React-RCTNetwork (= 0.79.0-rc.3)
+    - React-RCTSettings (= 0.79.0-rc.3)
+    - React-RCTText (= 0.79.0-rc.3)
+    - React-RCTVibration (= 0.79.0-rc.3)
+  - React-callinvoker (0.79.0-rc.3)
+  - React-Core (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.79.0-rc.2)
+    - React-Core/Default (= 0.79.0-rc.3)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -553,61 +559,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.79.0-rc.2):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/Default (0.79.0-rc.2):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/DevSupport (0.79.0-rc.2):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.79.0-rc.2)
-    - React-Core/RCTWebSocket (= 0.79.0-rc.2)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.79.0-rc.2):
+  - React-Core/CoreModulesHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -625,7 +577,43 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.79.0-rc.2):
+  - React-Core/Default (0.79.0-rc.3):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/DevSupport (0.79.0-rc.3):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.79.0-rc.3)
+    - React-Core/RCTWebSocket (= 0.79.0-rc.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -643,7 +631,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.79.0-rc.2):
+  - React-Core/RCTAnimationHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -661,7 +649,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.79.0-rc.2):
+  - React-Core/RCTBlobHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -679,7 +667,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.79.0-rc.2):
+  - React-Core/RCTImageHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -697,7 +685,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.79.0-rc.2):
+  - React-Core/RCTLinkingHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -715,7 +703,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.79.0-rc.2):
+  - React-Core/RCTNetworkHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -733,7 +721,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.79.0-rc.2):
+  - React-Core/RCTSettingsHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -751,7 +739,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.79.0-rc.2):
+  - React-Core/RCTTextHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -769,12 +757,12 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.79.0-rc.2):
+  - React-Core/RCTVibrationHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.79.0-rc.2)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -787,23 +775,41 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-CoreModules (0.79.0-rc.2):
+  - React-Core/RCTWebSocket (0.79.0-rc.3):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.79.0-rc.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-CoreModules (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - RCT-Folly (= 2024.11.18.00)
-    - RCTTypeSafety (= 0.79.0-rc.2)
-    - React-Core/CoreModulesHeaders (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+    - RCTTypeSafety (= 0.79.0-rc.3)
+    - React-Core/CoreModulesHeaders (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.79.0-rc.2)
+    - React-RCTImage (= 0.79.0-rc.3)
     - ReactCommon
     - SocketRocket (= 0.7.1)
-  - React-cxxreact (0.79.0-rc.2):
+  - React-cxxreact (0.79.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float (= 6.1.4)
@@ -811,17 +817,17 @@ PODS:
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-rc.2)
-    - React-debug (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+    - React-callinvoker (= 0.79.0-rc.3)
+    - React-debug (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
-    - React-logger (= 0.79.0-rc.2)
-    - React-perflogger (= 0.79.0-rc.2)
-    - React-runtimeexecutor (= 0.79.0-rc.2)
-    - React-timing (= 0.79.0-rc.2)
-  - React-debug (0.79.0-rc.2)
-  - React-defaultsnativemodule (0.79.0-rc.2):
+    - React-logger (= 0.79.0-rc.3)
+    - React-perflogger (= 0.79.0-rc.3)
+    - React-runtimeexecutor (= 0.79.0-rc.3)
+    - React-timing (= 0.79.0-rc.3)
+  - React-debug (0.79.0-rc.3)
+  - React-defaultsnativemodule (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - React-domnativemodule
@@ -832,7 +838,7 @@ PODS:
     - React-jsiexecutor
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
-  - React-domnativemodule (0.79.0-rc.2):
+  - React-domnativemodule (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - React-Fabric
@@ -844,7 +850,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric (0.79.0-rc.2):
+  - React-Fabric (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -856,22 +862,22 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.79.0-rc.2)
-    - React-Fabric/attributedstring (= 0.79.0-rc.2)
-    - React-Fabric/componentregistry (= 0.79.0-rc.2)
-    - React-Fabric/componentregistrynative (= 0.79.0-rc.2)
-    - React-Fabric/components (= 0.79.0-rc.2)
-    - React-Fabric/consistency (= 0.79.0-rc.2)
-    - React-Fabric/core (= 0.79.0-rc.2)
-    - React-Fabric/dom (= 0.79.0-rc.2)
-    - React-Fabric/imagemanager (= 0.79.0-rc.2)
-    - React-Fabric/leakchecker (= 0.79.0-rc.2)
-    - React-Fabric/mounting (= 0.79.0-rc.2)
-    - React-Fabric/observers (= 0.79.0-rc.2)
-    - React-Fabric/scheduler (= 0.79.0-rc.2)
-    - React-Fabric/telemetry (= 0.79.0-rc.2)
-    - React-Fabric/templateprocessor (= 0.79.0-rc.2)
-    - React-Fabric/uimanager (= 0.79.0-rc.2)
+    - React-Fabric/animations (= 0.79.0-rc.3)
+    - React-Fabric/attributedstring (= 0.79.0-rc.3)
+    - React-Fabric/componentregistry (= 0.79.0-rc.3)
+    - React-Fabric/componentregistrynative (= 0.79.0-rc.3)
+    - React-Fabric/components (= 0.79.0-rc.3)
+    - React-Fabric/consistency (= 0.79.0-rc.3)
+    - React-Fabric/core (= 0.79.0-rc.3)
+    - React-Fabric/dom (= 0.79.0-rc.3)
+    - React-Fabric/imagemanager (= 0.79.0-rc.3)
+    - React-Fabric/leakchecker (= 0.79.0-rc.3)
+    - React-Fabric/mounting (= 0.79.0-rc.3)
+    - React-Fabric/observers (= 0.79.0-rc.3)
+    - React-Fabric/scheduler (= 0.79.0-rc.3)
+    - React-Fabric/telemetry (= 0.79.0-rc.3)
+    - React-Fabric/templateprocessor (= 0.79.0-rc.3)
+    - React-Fabric/uimanager (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -882,29 +888,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.79.0-rc.2):
+  - React-Fabric/animations (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -926,7 +910,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.79.0-rc.2):
+  - React-Fabric/attributedstring (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -948,7 +932,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.79.0-rc.2):
+  - React-Fabric/componentregistry (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -970,33 +954,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.79.0-rc.2)
-    - React-Fabric/components/root (= 0.79.0-rc.2)
-    - React-Fabric/components/scrollview (= 0.79.0-rc.2)
-    - React-Fabric/components/view (= 0.79.0-rc.2)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.79.0-rc.2):
+  - React-Fabric/componentregistrynative (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1018,7 +976,33 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.79.0-rc.2):
+  - React-Fabric/components (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.79.0-rc.3)
+    - React-Fabric/components/root (= 0.79.0-rc.3)
+    - React-Fabric/components/scrollview (= 0.79.0-rc.3)
+    - React-Fabric/components/view (= 0.79.0-rc.3)
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/legacyviewmanagerinterop (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1040,7 +1024,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/scrollview (0.79.0-rc.2):
+  - React-Fabric/components/root (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1062,7 +1046,29 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.79.0-rc.2):
+  - React-Fabric/components/scrollview (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1086,7 +1092,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/consistency (0.79.0-rc.2):
+  - React-Fabric/consistency (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1108,7 +1114,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/core (0.79.0-rc.2):
+  - React-Fabric/core (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1130,7 +1136,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/dom (0.79.0-rc.2):
+  - React-Fabric/dom (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1152,7 +1158,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.79.0-rc.2):
+  - React-Fabric/imagemanager (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1174,7 +1180,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.79.0-rc.2):
+  - React-Fabric/leakchecker (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1196,7 +1202,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.79.0-rc.2):
+  - React-Fabric/mounting (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1218,7 +1224,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers (0.79.0-rc.2):
+  - React-Fabric/observers (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1230,7 +1236,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.79.0-rc.2)
+    - React-Fabric/observers/events (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1241,7 +1247,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers/events (0.79.0-rc.2):
+  - React-Fabric/observers/events (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1263,7 +1269,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.79.0-rc.2):
+  - React-Fabric/scheduler (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1287,7 +1293,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.79.0-rc.2):
+  - React-Fabric/telemetry (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1309,7 +1315,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.79.0-rc.2):
+  - React-Fabric/templateprocessor (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1331,7 +1337,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.79.0-rc.2):
+  - React-Fabric/uimanager (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1343,30 +1349,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.79.0-rc.2)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager/consistency (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1378,7 +1361,30 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricComponents (0.79.0-rc.2):
+  - React-Fabric/uimanager/consistency (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-FabricComponents (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1391,8 +1397,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.79.0-rc.2)
-    - React-FabricComponents/textlayoutmanager (= 0.79.0-rc.2)
+    - React-FabricComponents/components (= 0.79.0-rc.3)
+    - React-FabricComponents/textlayoutmanager (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1404,7 +1410,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components (0.79.0-rc.2):
+  - React-FabricComponents/components (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1417,15 +1423,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.79.0-rc.2)
-    - React-FabricComponents/components/iostextinput (= 0.79.0-rc.2)
-    - React-FabricComponents/components/modal (= 0.79.0-rc.2)
-    - React-FabricComponents/components/rncore (= 0.79.0-rc.2)
-    - React-FabricComponents/components/safeareaview (= 0.79.0-rc.2)
-    - React-FabricComponents/components/scrollview (= 0.79.0-rc.2)
-    - React-FabricComponents/components/text (= 0.79.0-rc.2)
-    - React-FabricComponents/components/textinput (= 0.79.0-rc.2)
-    - React-FabricComponents/components/unimplementedview (= 0.79.0-rc.2)
+    - React-FabricComponents/components/inputaccessory (= 0.79.0-rc.3)
+    - React-FabricComponents/components/iostextinput (= 0.79.0-rc.3)
+    - React-FabricComponents/components/modal (= 0.79.0-rc.3)
+    - React-FabricComponents/components/rncore (= 0.79.0-rc.3)
+    - React-FabricComponents/components/safeareaview (= 0.79.0-rc.3)
+    - React-FabricComponents/components/scrollview (= 0.79.0-rc.3)
+    - React-FabricComponents/components/text (= 0.79.0-rc.3)
+    - React-FabricComponents/components/textinput (= 0.79.0-rc.3)
+    - React-FabricComponents/components/unimplementedview (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1437,55 +1443,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/modal (0.79.0-rc.2):
+  - React-FabricComponents/components/inputaccessory (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1509,7 +1467,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/rncore (0.79.0-rc.2):
+  - React-FabricComponents/components/iostextinput (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1533,7 +1491,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.79.0-rc.2):
+  - React-FabricComponents/components/modal (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1557,7 +1515,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/scrollview (0.79.0-rc.2):
+  - React-FabricComponents/components/rncore (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1581,7 +1539,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/text (0.79.0-rc.2):
+  - React-FabricComponents/components/safeareaview (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1605,7 +1563,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/textinput (0.79.0-rc.2):
+  - React-FabricComponents/components/scrollview (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1629,7 +1587,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.79.0-rc.2):
+  - React-FabricComponents/components/text (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1653,7 +1611,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.79.0-rc.2):
+  - React-FabricComponents/components/textinput (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1677,30 +1635,78 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricImage (0.79.0-rc.2):
+  - React-FabricComponents/components/unimplementedview (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired (= 0.79.0-rc.2)
-    - RCTTypeSafety (= 0.79.0-rc.2)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricImage (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired (= 0.79.0-rc.3)
+    - RCTTypeSafety (= 0.79.0-rc.3)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-hermes
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.79.0-rc.2)
+    - React-jsiexecutor (= 0.79.0-rc.3)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.79.0-rc.2):
+  - React-featureflags (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
-  - React-featureflagsnativemodule (0.79.0-rc.2):
+  - React-featureflagsnativemodule (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - React-featureflags
@@ -1709,7 +1715,7 @@ PODS:
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - React-graphics (0.79.0-rc.2):
+  - React-graphics (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1720,21 +1726,21 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-utils
-  - React-hermes (0.79.0-rc.2):
+  - React-hermes (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact (= 0.79.0-rc.2)
+    - React-cxxreact (= 0.79.0-rc.3)
     - React-jsi
-    - React-jsiexecutor (= 0.79.0-rc.2)
+    - React-jsiexecutor (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
-    - React-perflogger (= 0.79.0-rc.2)
+    - React-perflogger (= 0.79.0-rc.3)
     - React-runtimeexecutor
-  - React-idlecallbacksnativemodule (0.79.0-rc.2):
+  - React-idlecallbacksnativemodule (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly
@@ -1744,7 +1750,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
-  - React-ImageManager (0.79.0-rc.2):
+  - React-ImageManager (0.79.0-rc.3):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -1753,12 +1759,12 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jsc (0.79.0-rc.2):
-    - React-jsc/Fabric (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
-  - React-jsc/Fabric (0.79.0-rc.2):
-    - React-jsi (= 0.79.0-rc.2)
-  - React-jserrorhandler (0.79.0-rc.2):
+  - React-jsc (0.79.0-rc.3):
+    - React-jsc/Fabric (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
+  - React-jsc/Fabric (0.79.0-rc.3):
+    - React-jsi (= 0.79.0-rc.3)
+  - React-jserrorhandler (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -1767,7 +1773,7 @@ PODS:
     - React-featureflags
     - React-jsi
     - ReactCommon/turbomodule/bridging
-  - React-jsi (0.79.0-rc.2):
+  - React-jsi (0.79.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float (= 6.1.4)
@@ -1775,19 +1781,19 @@ PODS:
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-  - React-jsiexecutor (0.79.0-rc.2):
+  - React-jsiexecutor (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
-    - React-perflogger (= 0.79.0-rc.2)
-  - React-jsinspector (0.79.0-rc.2):
+    - React-perflogger (= 0.79.0-rc.3)
+  - React-jsinspector (0.79.0-rc.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1795,29 +1801,29 @@ PODS:
     - React-featureflags
     - React-jsi
     - React-jsinspectortracing
-    - React-perflogger (= 0.79.0-rc.2)
-    - React-runtimeexecutor (= 0.79.0-rc.2)
-  - React-jsinspectortracing (0.79.0-rc.2):
+    - React-perflogger (= 0.79.0-rc.3)
+    - React-runtimeexecutor (= 0.79.0-rc.3)
+  - React-jsinspectortracing (0.79.0-rc.3):
     - RCT-Folly
     - React-oscompat
-  - React-jsitooling (0.79.0-rc.2):
+  - React-jsitooling (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
-  - React-jsitracing (0.79.0-rc.2):
+  - React-jsitracing (0.79.0-rc.3):
     - React-jsi
-  - React-logger (0.79.0-rc.2):
+  - React-logger (0.79.0-rc.3):
     - glog
-  - React-Mapbuffer (0.79.0-rc.2):
+  - React-Mapbuffer (0.79.0-rc.3):
     - glog
     - React-debug
-  - React-microtasksnativemodule (0.79.0-rc.2):
+  - React-microtasksnativemodule (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - React-hermes
@@ -1847,6 +1853,7 @@ PODS:
     - react-native-pager-view/common (= 6.5.1)
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -1870,6 +1877,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -1895,6 +1903,7 @@ PODS:
     - react-native-safe-area-context/fabric (= 5.2.0)
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -1918,6 +1927,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -1942,6 +1952,7 @@ PODS:
     - react-native-safe-area-context/common
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -1969,6 +1980,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -1993,6 +2005,7 @@ PODS:
     - react-native-slider/common (= 4.5.5)
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2016,6 +2029,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2039,6 +2053,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2062,13 +2077,14 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-NativeModulesApple (0.79.0-rc.2):
+  - React-NativeModulesApple (0.79.0-rc.3):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -2081,20 +2097,20 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-oscompat (0.79.0-rc.2)
-  - React-perflogger (0.79.0-rc.2):
+  - React-oscompat (0.79.0-rc.3)
+  - React-perflogger (0.79.0-rc.3):
     - DoubleConversion
     - RCT-Folly (= 2024.11.18.00)
-  - React-performancetimeline (0.79.0-rc.2):
+  - React-performancetimeline (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - React-cxxreact
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
-  - React-RCTActionSheet (0.79.0-rc.2):
-    - React-Core/RCTActionSheetHeaders (= 0.79.0-rc.2)
-  - React-RCTAnimation (0.79.0-rc.2):
+  - React-RCTActionSheet (0.79.0-rc.3):
+    - React-Core/RCTActionSheetHeaders (= 0.79.0-rc.3)
+  - React-RCTAnimation (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTAnimationHeaders
@@ -2102,7 +2118,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTAppDelegate (0.79.0-rc.2):
+  - React-RCTAppDelegate (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - RCTRequired
@@ -2128,7 +2144,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon
-  - React-RCTBlob (0.79.0-rc.2):
+  - React-RCTBlob (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -2142,7 +2158,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.79.0-rc.2):
+  - React-RCTFabric (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -2168,7 +2184,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTFBReactNativeSpec (0.79.0-rc.2):
+  - React-RCTFBReactNativeSpec (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - RCTRequired
@@ -2179,7 +2195,7 @@ PODS:
     - React-jsiexecutor
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTImage (0.79.0-rc.2):
+  - React-RCTImage (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTImageHeaders
@@ -2188,14 +2204,14 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.79.0-rc.2):
-    - React-Core/RCTLinkingHeaders (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+  - React-RCTLinking (0.79.0-rc.3):
+    - React-Core/RCTLinkingHeaders (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.79.0-rc.2)
-  - React-RCTNetwork (0.79.0-rc.2):
+    - ReactCommon/turbomodule/core (= 0.79.0-rc.3)
+  - React-RCTNetwork (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTNetworkHeaders
@@ -2203,7 +2219,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTRuntime (0.79.0-rc.2):
+  - React-RCTRuntime (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -2216,7 +2232,7 @@ PODS:
     - React-RuntimeApple
     - React-RuntimeCore
     - React-RuntimeHermes
-  - React-RCTSettings (0.79.0-rc.2):
+  - React-RCTSettings (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTSettingsHeaders
@@ -2224,28 +2240,28 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTText (0.79.0-rc.2):
-    - React-Core/RCTTextHeaders (= 0.79.0-rc.2)
+  - React-RCTText (0.79.0-rc.3):
+    - React-Core/RCTTextHeaders (= 0.79.0-rc.3)
     - Yoga
-  - React-RCTVibration (0.79.0-rc.2):
+  - React-RCTVibration (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-rendererconsistency (0.79.0-rc.2)
-  - React-renderercss (0.79.0-rc.2):
+  - React-rendererconsistency (0.79.0-rc.3)
+  - React-renderercss (0.79.0-rc.3):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.79.0-rc.2):
+  - React-rendererdebug (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - RCT-Folly (= 2024.11.18.00)
     - React-debug
-  - React-rncore (0.79.0-rc.2)
-  - React-RuntimeApple (0.79.0-rc.2):
+  - React-rncore (0.79.0-rc.3)
+  - React-RuntimeApple (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
     - React-callinvoker
@@ -2267,7 +2283,7 @@ PODS:
     - React-RuntimeHermes
     - React-runtimescheduler
     - React-utils
-  - React-RuntimeCore (0.79.0-rc.2):
+  - React-RuntimeCore (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -2284,9 +2300,9 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.79.0-rc.2):
-    - React-jsi (= 0.79.0-rc.2)
-  - React-RuntimeHermes (0.79.0-rc.2):
+  - React-runtimeexecutor (0.79.0-rc.3):
+    - React-jsi (= 0.79.0-rc.3)
+  - React-RuntimeHermes (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
     - React-featureflags
@@ -2298,7 +2314,7 @@ PODS:
     - React-jsitracing
     - React-RuntimeCore
     - React-utils
-  - React-runtimescheduler (0.79.0-rc.2):
+  - React-runtimescheduler (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -2315,17 +2331,17 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - React-utils
-  - React-timing (0.79.0-rc.2)
-  - React-utils (0.79.0-rc.2):
+  - React-timing (0.79.0-rc.3)
+  - React-utils (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - React-debug
     - React-hermes
-    - React-jsi (= 0.79.0-rc.2)
-  - ReactAppDependencyProvider (0.79.0-rc.2):
+    - React-jsi (= 0.79.0-rc.3)
+  - ReactAppDependencyProvider (0.79.0-rc.3):
     - ReactCodegen
-  - ReactCodegen (0.79.0-rc.2):
+  - ReactCodegen (0.79.0-rc.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2347,49 +2363,49 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - ReactCommon (0.79.0-rc.2):
-    - ReactCommon/turbomodule (= 0.79.0-rc.2)
-  - ReactCommon/turbomodule (0.79.0-rc.2):
+  - ReactCommon (0.79.0-rc.3):
+    - ReactCommon/turbomodule (= 0.79.0-rc.3)
+  - ReactCommon/turbomodule (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-rc.2)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
-    - React-logger (= 0.79.0-rc.2)
-    - React-perflogger (= 0.79.0-rc.2)
-    - ReactCommon/turbomodule/bridging (= 0.79.0-rc.2)
-    - ReactCommon/turbomodule/core (= 0.79.0-rc.2)
-  - ReactCommon/turbomodule/bridging (0.79.0-rc.2):
+    - React-callinvoker (= 0.79.0-rc.3)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
+    - React-logger (= 0.79.0-rc.3)
+    - React-perflogger (= 0.79.0-rc.3)
+    - ReactCommon/turbomodule/bridging (= 0.79.0-rc.3)
+    - ReactCommon/turbomodule/core (= 0.79.0-rc.3)
+  - ReactCommon/turbomodule/bridging (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-rc.2)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
-    - React-logger (= 0.79.0-rc.2)
-    - React-perflogger (= 0.79.0-rc.2)
-  - ReactCommon/turbomodule/core (0.79.0-rc.2):
+    - React-callinvoker (= 0.79.0-rc.3)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
+    - React-logger (= 0.79.0-rc.3)
+    - React-perflogger (= 0.79.0-rc.3)
+  - ReactCommon/turbomodule/core (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-rc.2)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-debug (= 0.79.0-rc.2)
-    - React-featureflags (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
-    - React-logger (= 0.79.0-rc.2)
-    - React-perflogger (= 0.79.0-rc.2)
-    - React-utils (= 0.79.0-rc.2)
+    - React-callinvoker (= 0.79.0-rc.3)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-debug (= 0.79.0-rc.3)
+    - React-featureflags (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
+    - React-logger (= 0.79.0-rc.3)
+    - React-perflogger (= 0.79.0-rc.3)
+    - React-utils (= 0.79.0-rc.3)
   - RNCAsyncStorage (1.23.1):
     - DoubleConversion
     - glog
@@ -2407,6 +2423,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2430,6 +2447,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2453,6 +2471,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2476,6 +2495,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2499,6 +2519,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2522,6 +2543,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2545,6 +2567,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2570,6 +2593,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2594,6 +2618,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2617,6 +2642,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2641,6 +2667,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2665,6 +2692,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFabric
     - React-RCTImage
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2690,6 +2718,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFabric
     - React-RCTImage
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2713,6 +2742,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2737,6 +2767,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -3401,12 +3432,12 @@ SPEC CHECKSUMS:
   ExpoMailComposer: 63589e1cbfa08220b2e650eecac0457be61ddd69
   ExpoMediaLibrary: 778e8fd37b0172f8a7984c0ab1b3a1f91a837eef
   ExpoMeshGradient: 10206dfd6045700677d876bf58a27f065f4b9f70
-  ExpoModulesCore: 0e2e6ca33190d0d2689f9496a24bdb5f05d383c1
+  ExpoModulesCore: f31cdbb91d3c027f51369ca53b2d94e1267aeeb2
   ExpoModulesTestCore: c81e21fd6ff61a212f3053d172aa163ad0db4d49
   ExpoNetwork: f07b371f7e143812980075fda6768702c154a0a0
   ExpoPrint: 3f9f5a5a19dbda5b30963d5bf078918f024aa29d
   ExpoScreenCapture: 14768e6fe66412d678862858f5c2e0241b7f84b7
-  ExpoScreenOrientation: b2d1d7649b2bc82fd58bdf3ca6daf1f219ea45a2
+  ExpoScreenOrientation: 026387432f290e1d06e29984678fa0ca063bec1d
   ExpoSecureStore: 06c3192d58ed167f619af3d53797c055f5ada785
   ExpoSensors: 55eef9972309aa8ec26bf5922040453e4c5cf7df
   ExpoSharing: 39a198e64bf522948fe60e270e49a0c7757912c1
@@ -3422,10 +3453,10 @@ SPEC CHECKSUMS:
   ExpoWebBrowser: f08aaf1c8a02af8a768d83793186cb6d2c69f529
   EXStructuredHeaders: 09c70347b282e3d2507e25fb4c747b1b885f87f6
   EXTaskManager: 8e915e1120894daead363cf31ff85cd4d182cd89
-  EXUpdates: c52f9139eaaf52b10da337b71cff06f6c2f6b3ba
+  EXUpdates: bce95a953418f8262e1fd5bec69923757343b741
   EXUpdatesInterface: 1dcebac98ac5dad4289e6ff2bd5616822e894397
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
-  FBLazyVector: 73f927157a20d4c20c419d3ea42197c28e895fc3
+  FBLazyVector: a13cdda7bbe886d533908636117037b198014387
   FirebaseAnalytics: 3feef9ae8733c567866342a1000691baaa7cad49
   FirebaseCore: 8542de610f35f86196ba26cdb2544565a5157c8e
   FirebaseCoreExtension: f1bc67a4702931a7caa097d8e4ac0a1b0d16720e
@@ -3441,13 +3472,13 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 80ea184ed6bf44139f383a8b0e248ba3ec1cc8c9
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 58ec89be8c7d19c80732931910702446ae8137fd
+  hermes-engine: c75c0305485bcf52f89bd0a3aa41876d6e21e539
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: d63feeef23e936c6722546ecebb0a6ee470d9a3c
+  lottie-react-native: 78b9ae436cd15e08e56a750449c3ca3759406720
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
@@ -3455,87 +3486,87 @@ SPEC CHECKSUMS:
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
   RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
-  RCTDeprecation: 57c8eb30be38b17267f7947496586e8c56655000
-  RCTRequired: 0a0a46bc2ee03107636ea3e3ecd17fcf96ecb973
-  RCTTypeSafety: e01703b8ae90a9e4f832d192b6426e2be278e2cd
+  RCTDeprecation: 2fa7e5950e440764f4a7c2731840d35b5e464383
+  RCTRequired: e46164234affa609618ee854dc3f1648ef270d3c
+  RCTTypeSafety: 0d5a0cf9e39231a471f38d74415845761b339273
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: e004cb14e60cebfcf2bc8c33ffac89ef88a8889d
-  React-callinvoker: 6f8b5686eeab81591262e71369c04830bef3cc47
-  React-Core: 044be050c322359373889fed8b1b8b77c0fafc52
-  React-CoreModules: 1dadfd981eab73a91e52be159ac272f07406e1c6
-  React-cxxreact: dfd36141a363e36768ab164f710591bd8b2de8f5
-  React-debug: 40b4e98b1e6abd7b2b07158d065eb0e653c8e6be
-  React-defaultsnativemodule: d47fe1f071cd3e28feeefe79c74f1c72938ec14c
-  React-domnativemodule: 3c037c30f7dcedcc7cb2115a4856e26dc7fd427a
-  React-Fabric: b69bf84ed89753f1004cd4dca58453142768e94e
-  React-FabricComponents: a5d5656033380fe70a54c9755f26695e61a55c02
-  React-FabricImage: af0c8d13671eab38adb9399b987d6a1c94b829db
-  React-featureflags: 6076c7a9ed2039e0d4a874dca4fcb1e83d81fe13
-  React-featureflagsnativemodule: 84e926d230eb9f3cc347f496ac25fd882d86cdb0
-  React-graphics: cf422929daf9aace64422744b293dada6021a0bc
-  React-hermes: 8a37df7f343cf690636248a625a005b524c20935
-  React-idlecallbacksnativemodule: 839db78afe2e9f5805ad59b34da80e570bcaab32
-  React-ImageManager: aa393db52bf534a35a0bab615c773059e272d009
-  React-jsc: f75c1aee593c03ce4e8ba57a08f8bb83beb14d18
-  React-jserrorhandler: 3daba80788b61ba30a606c3e46ac33e5780dd88c
-  React-jsi: 88646f87400f9733a40affa590c017b79bc0a6b4
-  React-jsiexecutor: 9406e8aacb1e5eba4632d894af232de7f6d6046f
-  React-jsinspector: 02c0f15ac34f56656ceed9f6337a52d31f1df169
-  React-jsinspectortracing: cecb1569bc769b2fd9bbd5995c086f9a30a085ed
-  React-jsitooling: 598b5e82d7eb0677bf0d6fd2083d788be8589ff8
-  React-jsitracing: 67d7707c7912c2f59fefe325339d1879aebde323
-  React-logger: ae25d57a8548a6ef7a15ea3f647e192cb420e464
-  React-Mapbuffer: 1d2b097474d043c73f1b3bca045f08eb8886eba2
-  React-microtasksnativemodule: dddd71a2a01726d7ed8e2732787a03c7e1fefe7f
+  React: f860d6b597a59819f52cd18de431320c658774b5
+  React-callinvoker: 47a4bbcb912ff682f5f57b437204237305b1f03e
+  React-Core: a1d2ff3f5522f86554c71116da08cb101f5d6b9b
+  React-CoreModules: 6718956d9537656367a9a31a01d84c2f1c201244
+  React-cxxreact: c7c3450683f60b41fdbb7ec02f9347e94279069a
+  React-debug: 354c1023f0feec2c484c35edc2d9614abc7e1e47
+  React-defaultsnativemodule: d376de286c4dfb3e2970f2b4ce6698ce1862a8f8
+  React-domnativemodule: eadf20cdc91872b99ad8dc72611ac473dc6b4a1c
+  React-Fabric: 39e5f9d5e7ee74a07de91748e785975be29547b5
+  React-FabricComponents: 739c83e170a19d6e8f90c9f1295a530c9888460c
+  React-FabricImage: 1d621b5273ffcb9c2fb0c756f231b35fa08752b0
+  React-featureflags: e8b460883a5562ce85c934f248655a81d5e09f21
+  React-featureflagsnativemodule: 275dbfb2cdcbf14ba52743eb2eccef16950f438a
+  React-graphics: e0ab76bd9ef6db26237ae69aff66c3a8224519f1
+  React-hermes: 4eafcbe1e9e558fae5ae3e1addf130fb8d1f6647
+  React-idlecallbacksnativemodule: dd2e62d7ab928dcd761e180b473f340b4d31c522
+  React-ImageManager: 8f604c44f6da53c199ea76febba49c427343ab7d
+  React-jsc: 32f492e890c5edb0e4b5690ccb0b4826f9ddeeef
+  React-jserrorhandler: b987989ea5fa952be6926a4cc086867b956787c7
+  React-jsi: d0211699cbb8e9b7397ece49890536713d2ccc9a
+  React-jsiexecutor: 3be18538fd9ac380f25d8fd72b30b2882aa189e8
+  React-jsinspector: 7fdc505319d3e87622c02867df8e476ca3975863
+  React-jsinspectortracing: b8e229eed818878b5e65d8faaed60e2f49915b6b
+  React-jsitooling: db92692002692ba568d29a02b5b2c6bdce2c4323
+  React-jsitracing: eca84150c74c598ecabc790415f0c7a6257802d0
+  React-logger: 0de8a4004273f62f6296d0c3b8c120c2245eaf81
+  React-Mapbuffer: b4708d8976588eeda6dacfa14742b1f2056e5bb6
+  React-microtasksnativemodule: 9d28b4b9272b52dffabcd2d48a934a8d8177f1e6
   react-native-maps: 2e6e9896195781327ee15b33e3e84bf73c08207a
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
-  react-native-pager-view: 0d7e01587e0abaaeee392683675959ecef40c12e
-  react-native-safe-area-context: 3ea8a97b7bda6f2c3a202a5ec9ae6406f58c24a4
+  react-native-pager-view: a1b4f854df102a127b38fa49ff9d25af20a3c550
+  react-native-safe-area-context: fb22a3043ce75c3145da87a74254a2ec527267b0
   react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
-  react-native-skia: e8fdd0fc4fcc70197aebb6a8dde933d0ef98d950
-  react-native-slider: a27e2643e000c73867e21495d6ac5d027c408ec8
-  react-native-view-shot: 8a62a3f06485a1f5e5fa7fab6cacfd43d2cced53
-  react-native-webview: 8673de48c48ad46a0be179cd59856085bd0f1290
-  React-NativeModulesApple: 08302164cb4c4a3ecf26d04c794750c8da76ee26
-  React-oscompat: 38090361205b8f47117134b291a4a928c50e0def
-  React-perflogger: 809ab1f94e7293ae6439ab770f67d92df729b37f
-  React-performancetimeline: a7419f23796a8c2879edc830a6cc1666607f263d
-  React-RCTActionSheet: 8bde2412a4fa37e4cb87d6ab739483a9f2f95638
-  React-RCTAnimation: 55ca7cc5572ab20b80e7c89832b8b88338c68afd
-  React-RCTAppDelegate: 8bde0e7827dcceeee2cc23e520f25dca37ede115
-  React-RCTBlob: eac258b7de2209e123cfe0bb1f93ac2468486c0b
-  React-RCTFabric: a0ffaf9df5a9d5819b063f52280c297c9a2ccc6f
-  React-RCTFBReactNativeSpec: f722a2add697e78c809d4a68baaeb1ee0266980a
-  React-RCTImage: df7970e2943ce7895aec1edf97cfbe9769e5431f
-  React-RCTLinking: c6fe4d4831706bb7d0ec736b4615cff8b3dfa7b4
-  React-RCTNetwork: 1bbeb395f3aefc647d65b47a045fd244a8001034
-  React-RCTRuntime: 38986df612b538aa056b9e2ff0a8e3fc8a078a88
-  React-RCTSettings: 994c927ae049a24571cfb1c5fb85068548f0f03e
-  React-RCTText: 10ba61380dde029c205b05fdb09296f3575734d7
-  React-RCTVibration: 7825602652fd01ff658752e4b8c043ae25ae45fe
-  React-rendererconsistency: 3709930705daedba53af997342cc4f01d4e56795
-  React-renderercss: 6393d95573a4b924bd185727eaa07ada9de80f1a
-  React-rendererdebug: ac3604cf7e7e5eb708503b288e22865fd7660097
-  React-rncore: 33ac9ffecdd38a4b81f9348309d63b4d045d4814
-  React-RuntimeApple: 8bc11af9d8649066c3b0e515ea5a261507f281fb
-  React-RuntimeCore: f154b9bf28cdd3c6bd14aeb4275f9d069cccc82b
-  React-runtimeexecutor: a9656dde5693fea60fbe4483748be5115aa9b6e1
-  React-RuntimeHermes: 3a431c82b79911c0f5f16f5a0049b942e165da5f
-  React-runtimescheduler: 8420ce60e320f30b3b0ceb26c3c61d4936bf7ccd
-  React-timing: 26311cc6420b9af8e1e9bd53dfaa1b025ec270b1
-  React-utils: de08a59446d8782c10502e6a4a5f7cc40a7c7090
-  ReactAppDependencyProvider: 17afd7407f6899a032c40bf3900b9a645809dff3
-  ReactCodegen: c4d9ff009d8a0aaf628c7bf9aa3bde2c1963583f
-  ReactCommon: 9f144a83e0f8d980f6083b3935eb6d423454eede
-  RNCAsyncStorage: bf32d338adfc41224c0b182a7ccd3c67c8b96a83
-  RNCMaskedView: d89065f41812f079eb0d9a5924353c175591de94
-  RNCPicker: cd6f3505c76c78a5efad97b5baf1cbaf3adf7ea8
-  RNDateTimePicker: 1ed5c52b06c6ec39a829e7ba4f4efe7f8a91a64d
-  RNFlashList: f1a63d27d13903c8c44d67e0501486ab7a451091
-  RNGestureHandler: 54481e63bf74e3aebd744c2ce715d57ab2d63b75
-  RNReanimated: 321287dce49bf1f96bb453985219b5af1f20bd0e
-  RNScreens: 9ce01d366c096aa6bab28ca5546c1ec6effa5419
-  RNSVG: a9d7676ad21a91f78a6bb5c56e975575b7e2f714
+  react-native-skia: 76d98b23c05d77c39346bc094183d314bd7bdf5b
+  react-native-slider: c57011b1447edac8ddcc4d61cbd54172f378b7a0
+  react-native-view-shot: 105375eceab012a37db548637dd6fca795af977a
+  react-native-webview: d3a6bde17001bc9cded1b2219b6cc2e60f27b74d
+  React-NativeModulesApple: a5ed6f425abed68a61415527cf902b22eb661b32
+  React-oscompat: 481559f37d95c98fa39fa84674171a5f6646a932
+  React-perflogger: bfa66d1709c975ed0bf7aa886882414a7497f7d6
+  React-performancetimeline: 64af0e7dd7a682213bd0e7e1cbdfff731cd17901
+  React-RCTActionSheet: 48ce30c88e7aa83a3153f2785f58eb18985e4b7c
+  React-RCTAnimation: 13d78666184cdd284b0237bd7830a7c849a38a82
+  React-RCTAppDelegate: baccce68e95160d1ba9086be2ee395690fc225f2
+  React-RCTBlob: 13f05f3a783777856957478b2f58dd73ac86fd4b
+  React-RCTFabric: 78e3f673ae73e70e7229036e800803656becfa31
+  React-RCTFBReactNativeSpec: 6ab3a57d15ddc12abb97696dea30b6594d4c4d1c
+  React-RCTImage: 5c96e5f762fd945b5438b26770456b93ac9cefe3
+  React-RCTLinking: 4ed5e0842227fd5036404aa04994e0720e556caa
+  React-RCTNetwork: 5fbbe5bc152936e28d3f66d6c0d16dd7fc43a430
+  React-RCTRuntime: 9b5bf6f87e24393f1de2a3d70b2e840f90282a5a
+  React-RCTSettings: 0c5d7460873ef191b51ab614cc5f9dc0706c34aa
+  React-RCTText: b3026406d7ff8c95b64437ba48d7ba35a0a7fcd6
+  React-RCTVibration: 64da0c913099e3f4f6c556322cb398a83be2b7fc
+  React-rendererconsistency: a4d8b222d165650a4bff33cf50033e1adf9a87a3
+  React-renderercss: 768ef55fa1720e0131a979e0228ed8955a40f7a7
+  React-rendererdebug: 520d105541cf2946ed3505a8aa83df6b17647544
+  React-rncore: 27f409047489a44511ad49e64fbc00b798455cbc
+  React-RuntimeApple: 25352c0b749482ac743bb5670e7d629fdf9caaae
+  React-RuntimeCore: 86dc1275e9d58d77985dc4167ff6a2931d2e44f8
+  React-runtimeexecutor: 1f7b57e78d4721d2e9c98d094d6f480c93da3f25
+  React-RuntimeHermes: a8e3287c412ed138475dada3374cca6a5e9df450
+  React-runtimescheduler: 1a328781b0d0d8a47a62c58a307e09b96b8938bc
+  React-timing: 1b7c77ff812ae55c820636333909f4bfe948eb06
+  React-utils: e38a4ca98a4148b50bc470346e05ea5a3935eb46
+  ReactAppDependencyProvider: 556c91ab2e8cf1389f8c07cbcadb04134923ead4
+  ReactCodegen: d7f8d9c10a451391b891994ff1c3ce04e67503c7
+  ReactCommon: 0b6cc8bfc9e59b9c652f83325881f271501e9b0e
+  RNCAsyncStorage: 3070bd18200c569f2ce2d1f43ac3bbf6d956d19b
+  RNCMaskedView: 3e8d6bf9764b519d077986413882959eafceffbc
+  RNCPicker: 04b02770d871072243f4a95fa2523b9c3398a2f5
+  RNDateTimePicker: dad505d754e617e94a6a465925e5b9b321358c14
+  RNFlashList: 180edc34e4f015749b56c7674bc0f54a40d3deff
+  RNGestureHandler: ccf4105b125002bd88e39d2a1f2b7e6001bcdf34
+  RNReanimated: fc1e35380ba37c5f28b83414be9850e4091efa76
+  RNScreens: e02f237d99e332f2d75092c7d7ba065110bcf1af
+  RNSVG: ee32efbed652c5151fd3f98bed13c68af285bc38
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
@@ -3551,7 +3582,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: c24f990b03a68a7f6fe704b15dd487e7bb6b603e
   StripeUICore: f2d514e900c37436dc5427fdf2c29d68ab1c2935
   UMAppLoader: bda51f73f8599e336a778b23e0956130d1e244d5
-  Yoga: d15788383b33ea88af96bc7c12354810089527f4
+  Yoga: 99c3ff1f0452d13c8774222903cef8dda229d5ce
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 7bf572a9e490bdde01cd39bf74a0ef2638865a2d

--- a/apps/expo-go/metro.config.js
+++ b/apps/expo-go/metro.config.js
@@ -54,6 +54,22 @@ function withReactNativeLabPackages(config) {
   config.serializer.getPolyfills = () =>
     require(require.resolve('@react-native/js-polyfills', { paths: [reactNativeLabsPath] }))();
 
+  // Ensure the initialize code is being loaded from react-native-lab
+  const getMainModules = config.serializer.getModulesRunBeforeMainModule;
+  config.serializer.getModulesRunBeforeMainModule = () => {
+    // This module import should be loaded from `react-native-lab`
+    const initializeCore = 'react-native/Libraries/Core/InitializeCore.js';
+    const initializeCorePath = require.resolve(initializeCore, { paths: [reactNativeLabsPath] });
+    // Ensure the old initialize core path is replaced with the react-native-lab version
+    return getMainModules().map((filePath) => {
+      if (filePath.endsWith(initializeCore)) {
+        return initializeCorePath;
+      }
+
+      return filePath;
+    });
+  };
+
   // The import matcher that matches any of the list packages, e.g. `<packageName>` or `<packageName>/nested/file`
   const importMatcher = new RegExp(`^(?:(${linkedPackages.join('|')}))(?:(/|$))`);
 

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -67,7 +67,7 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "19.0.0",
-    "react-native": "0.79.0-rc.2",
+    "react-native": "0.79.0-rc.3",
     "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-infinite-scroll-view": "^0.4.5",

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -9,6 +9,6 @@
     "expo": "~52.0.0",
     "expo-clipboard": "~7.0.0",
     "react": "19.0.0",
-    "react-native": "0.79.0-rc.2"
+    "react-native": "0.79.0-rc.3"
   }
 }

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -137,7 +137,7 @@
     "processing-js": "^1.6.6",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "react-native": "0.79.0-rc.2",
+    "react-native": "0.79.0-rc.3",
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-maps": "1.18.0",

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -18,7 +18,7 @@
     "native-component-list": "*",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "react-native": "0.79.0-rc.2"
+    "react-native": "0.79.0-rc.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/apps/paper-tester/ios/Podfile.lock
+++ b/apps/paper-tester/ios/Podfile.lock
@@ -44,8 +44,10 @@ PODS:
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
+    - ReactAppDependencyProvider
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
@@ -75,8 +77,10 @@ PODS:
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
+    - ReactAppDependencyProvider
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
@@ -105,8 +109,10 @@ PODS:
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
+    - ReactAppDependencyProvider
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
@@ -130,6 +136,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -159,6 +166,7 @@ PODS:
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactAppDependencyProvider
@@ -183,6 +191,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -207,6 +216,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -231,6 +241,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -280,6 +291,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -314,6 +326,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -323,12 +336,12 @@ PODS:
   - EXUpdatesInterface (1.0.0):
     - ExpoModulesCore
   - fast_float (6.1.4)
-  - FBLazyVector (0.79.0-rc.2)
+  - FBLazyVector (0.79.0-rc.3)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.79.0-rc.2):
-    - hermes-engine/Pre-built (= 0.79.0-rc.2)
-  - hermes-engine/Pre-built (0.79.0-rc.2)
+  - hermes-engine (0.79.0-rc.3):
+    - hermes-engine/Pre-built (= 0.79.0-rc.3)
+  - hermes-engine/Pre-built (0.79.0-rc.3)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -353,33 +366,33 @@ PODS:
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.79.0-rc.2)
-  - RCTRequired (0.79.0-rc.2)
-  - RCTTypeSafety (0.79.0-rc.2):
-    - FBLazyVector (= 0.79.0-rc.2)
-    - RCTRequired (= 0.79.0-rc.2)
-    - React-Core (= 0.79.0-rc.2)
+  - RCTDeprecation (0.79.0-rc.3)
+  - RCTRequired (0.79.0-rc.3)
+  - RCTTypeSafety (0.79.0-rc.3):
+    - FBLazyVector (= 0.79.0-rc.3)
+    - RCTRequired (= 0.79.0-rc.3)
+    - React-Core (= 0.79.0-rc.3)
   - ReachabilitySwift (5.2.4)
-  - React (0.79.0-rc.2):
-    - React-Core (= 0.79.0-rc.2)
-    - React-Core/DevSupport (= 0.79.0-rc.2)
-    - React-Core/RCTWebSocket (= 0.79.0-rc.2)
-    - React-RCTActionSheet (= 0.79.0-rc.2)
-    - React-RCTAnimation (= 0.79.0-rc.2)
-    - React-RCTBlob (= 0.79.0-rc.2)
-    - React-RCTImage (= 0.79.0-rc.2)
-    - React-RCTLinking (= 0.79.0-rc.2)
-    - React-RCTNetwork (= 0.79.0-rc.2)
-    - React-RCTSettings (= 0.79.0-rc.2)
-    - React-RCTText (= 0.79.0-rc.2)
-    - React-RCTVibration (= 0.79.0-rc.2)
-  - React-callinvoker (0.79.0-rc.2)
-  - React-Core (0.79.0-rc.2):
+  - React (0.79.0-rc.3):
+    - React-Core (= 0.79.0-rc.3)
+    - React-Core/DevSupport (= 0.79.0-rc.3)
+    - React-Core/RCTWebSocket (= 0.79.0-rc.3)
+    - React-RCTActionSheet (= 0.79.0-rc.3)
+    - React-RCTAnimation (= 0.79.0-rc.3)
+    - React-RCTBlob (= 0.79.0-rc.3)
+    - React-RCTImage (= 0.79.0-rc.3)
+    - React-RCTLinking (= 0.79.0-rc.3)
+    - React-RCTNetwork (= 0.79.0-rc.3)
+    - React-RCTSettings (= 0.79.0-rc.3)
+    - React-RCTText (= 0.79.0-rc.3)
+    - React-RCTVibration (= 0.79.0-rc.3)
+  - React-callinvoker (0.79.0-rc.3)
+  - React-Core (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.79.0-rc.2)
+    - React-Core/Default (= 0.79.0-rc.3)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -392,61 +405,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.79.0-rc.2):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/Default (0.79.0-rc.2):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/DevSupport (0.79.0-rc.2):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.79.0-rc.2)
-    - React-Core/RCTWebSocket (= 0.79.0-rc.2)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.79.0-rc.2):
+  - React-Core/CoreModulesHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -464,7 +423,43 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.79.0-rc.2):
+  - React-Core/Default (0.79.0-rc.3):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/DevSupport (0.79.0-rc.3):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.79.0-rc.3)
+    - React-Core/RCTWebSocket (= 0.79.0-rc.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -482,7 +477,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.79.0-rc.2):
+  - React-Core/RCTAnimationHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -500,7 +495,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.79.0-rc.2):
+  - React-Core/RCTBlobHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -518,7 +513,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.79.0-rc.2):
+  - React-Core/RCTImageHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -536,7 +531,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.79.0-rc.2):
+  - React-Core/RCTLinkingHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -554,7 +549,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.79.0-rc.2):
+  - React-Core/RCTNetworkHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -572,7 +567,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.79.0-rc.2):
+  - React-Core/RCTSettingsHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -590,7 +585,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.79.0-rc.2):
+  - React-Core/RCTTextHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -608,12 +603,12 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.79.0-rc.2):
+  - React-Core/RCTVibrationHeaders (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.79.0-rc.2)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -626,23 +621,41 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-CoreModules (0.79.0-rc.2):
+  - React-Core/RCTWebSocket (0.79.0-rc.3):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.79.0-rc.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-CoreModules (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - RCT-Folly (= 2024.11.18.00)
-    - RCTTypeSafety (= 0.79.0-rc.2)
-    - React-Core/CoreModulesHeaders (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+    - RCTTypeSafety (= 0.79.0-rc.3)
+    - React-Core/CoreModulesHeaders (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.79.0-rc.2)
+    - React-RCTImage (= 0.79.0-rc.3)
     - ReactCommon
     - SocketRocket (= 0.7.1)
-  - React-cxxreact (0.79.0-rc.2):
+  - React-cxxreact (0.79.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float (= 6.1.4)
@@ -650,17 +663,17 @@ PODS:
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-rc.2)
-    - React-debug (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+    - React-callinvoker (= 0.79.0-rc.3)
+    - React-debug (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
-    - React-logger (= 0.79.0-rc.2)
-    - React-perflogger (= 0.79.0-rc.2)
-    - React-runtimeexecutor (= 0.79.0-rc.2)
-    - React-timing (= 0.79.0-rc.2)
-  - React-debug (0.79.0-rc.2)
-  - React-defaultsnativemodule (0.79.0-rc.2):
+    - React-logger (= 0.79.0-rc.3)
+    - React-perflogger (= 0.79.0-rc.3)
+    - React-runtimeexecutor (= 0.79.0-rc.3)
+    - React-timing (= 0.79.0-rc.3)
+  - React-debug (0.79.0-rc.3)
+  - React-defaultsnativemodule (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - React-domnativemodule
@@ -671,7 +684,7 @@ PODS:
     - React-jsiexecutor
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
-  - React-domnativemodule (0.79.0-rc.2):
+  - React-domnativemodule (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - React-Fabric
@@ -683,7 +696,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric (0.79.0-rc.2):
+  - React-Fabric (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -695,22 +708,22 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.79.0-rc.2)
-    - React-Fabric/attributedstring (= 0.79.0-rc.2)
-    - React-Fabric/componentregistry (= 0.79.0-rc.2)
-    - React-Fabric/componentregistrynative (= 0.79.0-rc.2)
-    - React-Fabric/components (= 0.79.0-rc.2)
-    - React-Fabric/consistency (= 0.79.0-rc.2)
-    - React-Fabric/core (= 0.79.0-rc.2)
-    - React-Fabric/dom (= 0.79.0-rc.2)
-    - React-Fabric/imagemanager (= 0.79.0-rc.2)
-    - React-Fabric/leakchecker (= 0.79.0-rc.2)
-    - React-Fabric/mounting (= 0.79.0-rc.2)
-    - React-Fabric/observers (= 0.79.0-rc.2)
-    - React-Fabric/scheduler (= 0.79.0-rc.2)
-    - React-Fabric/telemetry (= 0.79.0-rc.2)
-    - React-Fabric/templateprocessor (= 0.79.0-rc.2)
-    - React-Fabric/uimanager (= 0.79.0-rc.2)
+    - React-Fabric/animations (= 0.79.0-rc.3)
+    - React-Fabric/attributedstring (= 0.79.0-rc.3)
+    - React-Fabric/componentregistry (= 0.79.0-rc.3)
+    - React-Fabric/componentregistrynative (= 0.79.0-rc.3)
+    - React-Fabric/components (= 0.79.0-rc.3)
+    - React-Fabric/consistency (= 0.79.0-rc.3)
+    - React-Fabric/core (= 0.79.0-rc.3)
+    - React-Fabric/dom (= 0.79.0-rc.3)
+    - React-Fabric/imagemanager (= 0.79.0-rc.3)
+    - React-Fabric/leakchecker (= 0.79.0-rc.3)
+    - React-Fabric/mounting (= 0.79.0-rc.3)
+    - React-Fabric/observers (= 0.79.0-rc.3)
+    - React-Fabric/scheduler (= 0.79.0-rc.3)
+    - React-Fabric/telemetry (= 0.79.0-rc.3)
+    - React-Fabric/templateprocessor (= 0.79.0-rc.3)
+    - React-Fabric/uimanager (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -721,29 +734,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.79.0-rc.2):
+  - React-Fabric/animations (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -765,7 +756,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.79.0-rc.2):
+  - React-Fabric/attributedstring (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -787,7 +778,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.79.0-rc.2):
+  - React-Fabric/componentregistry (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -809,33 +800,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.79.0-rc.2)
-    - React-Fabric/components/root (= 0.79.0-rc.2)
-    - React-Fabric/components/scrollview (= 0.79.0-rc.2)
-    - React-Fabric/components/view (= 0.79.0-rc.2)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.79.0-rc.2):
+  - React-Fabric/componentregistrynative (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -857,7 +822,33 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.79.0-rc.2):
+  - React-Fabric/components (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.79.0-rc.3)
+    - React-Fabric/components/root (= 0.79.0-rc.3)
+    - React-Fabric/components/scrollview (= 0.79.0-rc.3)
+    - React-Fabric/components/view (= 0.79.0-rc.3)
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/legacyviewmanagerinterop (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -879,7 +870,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/scrollview (0.79.0-rc.2):
+  - React-Fabric/components/root (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -901,7 +892,29 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.79.0-rc.2):
+  - React-Fabric/components/scrollview (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -925,7 +938,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/consistency (0.79.0-rc.2):
+  - React-Fabric/consistency (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -947,7 +960,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/core (0.79.0-rc.2):
+  - React-Fabric/core (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -969,7 +982,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/dom (0.79.0-rc.2):
+  - React-Fabric/dom (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -991,7 +1004,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.79.0-rc.2):
+  - React-Fabric/imagemanager (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1013,7 +1026,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.79.0-rc.2):
+  - React-Fabric/leakchecker (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1035,7 +1048,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.79.0-rc.2):
+  - React-Fabric/mounting (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1057,7 +1070,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers (0.79.0-rc.2):
+  - React-Fabric/observers (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1069,7 +1082,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.79.0-rc.2)
+    - React-Fabric/observers/events (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1080,7 +1093,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers/events (0.79.0-rc.2):
+  - React-Fabric/observers/events (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1102,7 +1115,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.79.0-rc.2):
+  - React-Fabric/scheduler (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1126,7 +1139,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.79.0-rc.2):
+  - React-Fabric/telemetry (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1148,7 +1161,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.79.0-rc.2):
+  - React-Fabric/templateprocessor (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1170,7 +1183,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.79.0-rc.2):
+  - React-Fabric/uimanager (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1182,30 +1195,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.79.0-rc.2)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager/consistency (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1217,7 +1207,30 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricComponents (0.79.0-rc.2):
+  - React-Fabric/uimanager/consistency (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-FabricComponents (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1230,8 +1243,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.79.0-rc.2)
-    - React-FabricComponents/textlayoutmanager (= 0.79.0-rc.2)
+    - React-FabricComponents/components (= 0.79.0-rc.3)
+    - React-FabricComponents/textlayoutmanager (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1243,7 +1256,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components (0.79.0-rc.2):
+  - React-FabricComponents/components (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1256,15 +1269,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.79.0-rc.2)
-    - React-FabricComponents/components/iostextinput (= 0.79.0-rc.2)
-    - React-FabricComponents/components/modal (= 0.79.0-rc.2)
-    - React-FabricComponents/components/rncore (= 0.79.0-rc.2)
-    - React-FabricComponents/components/safeareaview (= 0.79.0-rc.2)
-    - React-FabricComponents/components/scrollview (= 0.79.0-rc.2)
-    - React-FabricComponents/components/text (= 0.79.0-rc.2)
-    - React-FabricComponents/components/textinput (= 0.79.0-rc.2)
-    - React-FabricComponents/components/unimplementedview (= 0.79.0-rc.2)
+    - React-FabricComponents/components/inputaccessory (= 0.79.0-rc.3)
+    - React-FabricComponents/components/iostextinput (= 0.79.0-rc.3)
+    - React-FabricComponents/components/modal (= 0.79.0-rc.3)
+    - React-FabricComponents/components/rncore (= 0.79.0-rc.3)
+    - React-FabricComponents/components/safeareaview (= 0.79.0-rc.3)
+    - React-FabricComponents/components/scrollview (= 0.79.0-rc.3)
+    - React-FabricComponents/components/text (= 0.79.0-rc.3)
+    - React-FabricComponents/components/textinput (= 0.79.0-rc.3)
+    - React-FabricComponents/components/unimplementedview (= 0.79.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1276,55 +1289,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.79.0-rc.2):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/modal (0.79.0-rc.2):
+  - React-FabricComponents/components/inputaccessory (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1348,7 +1313,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/rncore (0.79.0-rc.2):
+  - React-FabricComponents/components/iostextinput (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1372,7 +1337,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.79.0-rc.2):
+  - React-FabricComponents/components/modal (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1396,7 +1361,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/scrollview (0.79.0-rc.2):
+  - React-FabricComponents/components/rncore (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1420,7 +1385,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/text (0.79.0-rc.2):
+  - React-FabricComponents/components/safeareaview (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1444,7 +1409,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/textinput (0.79.0-rc.2):
+  - React-FabricComponents/components/scrollview (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1468,7 +1433,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.79.0-rc.2):
+  - React-FabricComponents/components/text (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1492,7 +1457,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.79.0-rc.2):
+  - React-FabricComponents/components/textinput (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1516,30 +1481,78 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricImage (0.79.0-rc.2):
+  - React-FabricComponents/components/unimplementedview (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired (= 0.79.0-rc.2)
-    - RCTTypeSafety (= 0.79.0-rc.2)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricImage (0.79.0-rc.3):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired (= 0.79.0-rc.3)
+    - RCTTypeSafety (= 0.79.0-rc.3)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-hermes
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.79.0-rc.2)
+    - React-jsiexecutor (= 0.79.0-rc.3)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.79.0-rc.2):
+  - React-featureflags (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
-  - React-featureflagsnativemodule (0.79.0-rc.2):
+  - React-featureflagsnativemodule (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - React-featureflags
@@ -1548,7 +1561,7 @@ PODS:
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - React-graphics (0.79.0-rc.2):
+  - React-graphics (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1559,21 +1572,21 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-utils
-  - React-hermes (0.79.0-rc.2):
+  - React-hermes (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact (= 0.79.0-rc.2)
+    - React-cxxreact (= 0.79.0-rc.3)
     - React-jsi
-    - React-jsiexecutor (= 0.79.0-rc.2)
+    - React-jsiexecutor (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
-    - React-perflogger (= 0.79.0-rc.2)
+    - React-perflogger (= 0.79.0-rc.3)
     - React-runtimeexecutor
-  - React-idlecallbacksnativemodule (0.79.0-rc.2):
+  - React-idlecallbacksnativemodule (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly
@@ -1583,7 +1596,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
-  - React-ImageManager (0.79.0-rc.2):
+  - React-ImageManager (0.79.0-rc.3):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -1592,7 +1605,7 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jserrorhandler (0.79.0-rc.2):
+  - React-jserrorhandler (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -1601,7 +1614,7 @@ PODS:
     - React-featureflags
     - React-jsi
     - ReactCommon/turbomodule/bridging
-  - React-jsi (0.79.0-rc.2):
+  - React-jsi (0.79.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float (= 6.1.4)
@@ -1609,19 +1622,19 @@ PODS:
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-  - React-jsiexecutor (0.79.0-rc.2):
+  - React-jsiexecutor (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
-    - React-perflogger (= 0.79.0-rc.2)
-  - React-jsinspector (0.79.0-rc.2):
+    - React-perflogger (= 0.79.0-rc.3)
+  - React-jsinspector (0.79.0-rc.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1629,29 +1642,29 @@ PODS:
     - React-featureflags
     - React-jsi
     - React-jsinspectortracing
-    - React-perflogger (= 0.79.0-rc.2)
-    - React-runtimeexecutor (= 0.79.0-rc.2)
-  - React-jsinspectortracing (0.79.0-rc.2):
+    - React-perflogger (= 0.79.0-rc.3)
+    - React-runtimeexecutor (= 0.79.0-rc.3)
+  - React-jsinspectortracing (0.79.0-rc.3):
     - RCT-Folly
     - React-oscompat
-  - React-jsitooling (0.79.0-rc.2):
+  - React-jsitooling (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-jsinspector
     - React-jsinspectortracing
-  - React-jsitracing (0.79.0-rc.2):
+  - React-jsitracing (0.79.0-rc.3):
     - React-jsi
-  - React-logger (0.79.0-rc.2):
+  - React-logger (0.79.0-rc.3):
     - glog
-  - React-Mapbuffer (0.79.0-rc.2):
+  - React-Mapbuffer (0.79.0-rc.3):
     - glog
     - React-debug
-  - React-microtasksnativemodule (0.79.0-rc.2):
+  - React-microtasksnativemodule (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - React-hermes
@@ -1659,7 +1672,7 @@ PODS:
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - React-NativeModulesApple (0.79.0-rc.2):
+  - React-NativeModulesApple (0.79.0-rc.3):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -1672,20 +1685,20 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-oscompat (0.79.0-rc.2)
-  - React-perflogger (0.79.0-rc.2):
+  - React-oscompat (0.79.0-rc.3)
+  - React-perflogger (0.79.0-rc.3):
     - DoubleConversion
     - RCT-Folly (= 2024.11.18.00)
-  - React-performancetimeline (0.79.0-rc.2):
+  - React-performancetimeline (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - React-cxxreact
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
-  - React-RCTActionSheet (0.79.0-rc.2):
-    - React-Core/RCTActionSheetHeaders (= 0.79.0-rc.2)
-  - React-RCTAnimation (0.79.0-rc.2):
+  - React-RCTActionSheet (0.79.0-rc.3):
+    - React-Core/RCTActionSheetHeaders (= 0.79.0-rc.3)
+  - React-RCTAnimation (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTAnimationHeaders
@@ -1693,7 +1706,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTAppDelegate (0.79.0-rc.2):
+  - React-RCTAppDelegate (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - RCTRequired
@@ -1719,7 +1732,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon
-  - React-RCTBlob (0.79.0-rc.2):
+  - React-RCTBlob (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1733,7 +1746,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.79.0-rc.2):
+  - React-RCTFabric (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -1759,7 +1772,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTFBReactNativeSpec (0.79.0-rc.2):
+  - React-RCTFBReactNativeSpec (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly
     - RCTRequired
@@ -1770,7 +1783,7 @@ PODS:
     - React-jsiexecutor
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTImage (0.79.0-rc.2):
+  - React-RCTImage (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTImageHeaders
@@ -1779,14 +1792,14 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.79.0-rc.2):
-    - React-Core/RCTLinkingHeaders (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
+  - React-RCTLinking (0.79.0-rc.3):
+    - React-Core/RCTLinkingHeaders (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.79.0-rc.2)
-  - React-RCTNetwork (0.79.0-rc.2):
+    - ReactCommon/turbomodule/core (= 0.79.0-rc.3)
+  - React-RCTNetwork (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTNetworkHeaders
@@ -1794,7 +1807,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTRuntime (0.79.0-rc.2):
+  - React-RCTRuntime (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -1807,7 +1820,7 @@ PODS:
     - React-RuntimeApple
     - React-RuntimeCore
     - React-RuntimeHermes
-  - React-RCTSettings (0.79.0-rc.2):
+  - React-RCTSettings (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTSettingsHeaders
@@ -1815,28 +1828,28 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTText (0.79.0-rc.2):
-    - React-Core/RCTTextHeaders (= 0.79.0-rc.2)
+  - React-RCTText (0.79.0-rc.3):
+    - React-Core/RCTTextHeaders (= 0.79.0-rc.3)
     - Yoga
-  - React-RCTVibration (0.79.0-rc.2):
+  - React-RCTVibration (0.79.0-rc.3):
     - RCT-Folly (= 2024.11.18.00)
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-rendererconsistency (0.79.0-rc.2)
-  - React-renderercss (0.79.0-rc.2):
+  - React-rendererconsistency (0.79.0-rc.3)
+  - React-renderercss (0.79.0-rc.3):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.79.0-rc.2):
+  - React-rendererdebug (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - RCT-Folly (= 2024.11.18.00)
     - React-debug
-  - React-rncore (0.79.0-rc.2)
-  - React-RuntimeApple (0.79.0-rc.2):
+  - React-rncore (0.79.0-rc.3)
+  - React-RuntimeApple (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
     - React-callinvoker
@@ -1858,7 +1871,7 @@ PODS:
     - React-RuntimeHermes
     - React-runtimescheduler
     - React-utils
-  - React-RuntimeCore (0.79.0-rc.2):
+  - React-RuntimeCore (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -1875,9 +1888,9 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.79.0-rc.2):
-    - React-jsi (= 0.79.0-rc.2)
-  - React-RuntimeHermes (0.79.0-rc.2):
+  - React-runtimeexecutor (0.79.0-rc.3):
+    - React-jsi (= 0.79.0-rc.3)
+  - React-RuntimeHermes (0.79.0-rc.3):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
     - React-featureflags
@@ -1889,7 +1902,7 @@ PODS:
     - React-jsitracing
     - React-RuntimeCore
     - React-utils
-  - React-runtimescheduler (0.79.0-rc.2):
+  - React-runtimescheduler (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -1906,17 +1919,17 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - React-utils
-  - React-timing (0.79.0-rc.2)
-  - React-utils (0.79.0-rc.2):
+  - React-timing (0.79.0-rc.3)
+  - React-utils (0.79.0-rc.3):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - React-debug
     - React-hermes
-    - React-jsi (= 0.79.0-rc.2)
-  - ReactAppDependencyProvider (0.79.0-rc.2):
+    - React-jsi (= 0.79.0-rc.3)
+  - ReactAppDependencyProvider (0.79.0-rc.3):
     - ReactCodegen
-  - ReactCodegen (0.79.0-rc.2):
+  - ReactCodegen (0.79.0-rc.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1938,49 +1951,49 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - ReactCommon (0.79.0-rc.2):
-    - ReactCommon/turbomodule (= 0.79.0-rc.2)
-  - ReactCommon/turbomodule (0.79.0-rc.2):
+  - ReactCommon (0.79.0-rc.3):
+    - ReactCommon/turbomodule (= 0.79.0-rc.3)
+  - ReactCommon/turbomodule (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-rc.2)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
-    - React-logger (= 0.79.0-rc.2)
-    - React-perflogger (= 0.79.0-rc.2)
-    - ReactCommon/turbomodule/bridging (= 0.79.0-rc.2)
-    - ReactCommon/turbomodule/core (= 0.79.0-rc.2)
-  - ReactCommon/turbomodule/bridging (0.79.0-rc.2):
+    - React-callinvoker (= 0.79.0-rc.3)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
+    - React-logger (= 0.79.0-rc.3)
+    - React-perflogger (= 0.79.0-rc.3)
+    - ReactCommon/turbomodule/bridging (= 0.79.0-rc.3)
+    - ReactCommon/turbomodule/core (= 0.79.0-rc.3)
+  - ReactCommon/turbomodule/bridging (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-rc.2)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
-    - React-logger (= 0.79.0-rc.2)
-    - React-perflogger (= 0.79.0-rc.2)
-  - ReactCommon/turbomodule/core (0.79.0-rc.2):
+    - React-callinvoker (= 0.79.0-rc.3)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
+    - React-logger (= 0.79.0-rc.3)
+    - React-perflogger (= 0.79.0-rc.3)
+  - ReactCommon/turbomodule/core (0.79.0-rc.3):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.79.0-rc.2)
-    - React-cxxreact (= 0.79.0-rc.2)
-    - React-debug (= 0.79.0-rc.2)
-    - React-featureflags (= 0.79.0-rc.2)
-    - React-jsi (= 0.79.0-rc.2)
-    - React-logger (= 0.79.0-rc.2)
-    - React-perflogger (= 0.79.0-rc.2)
-    - React-utils (= 0.79.0-rc.2)
+    - React-callinvoker (= 0.79.0-rc.3)
+    - React-cxxreact (= 0.79.0-rc.3)
+    - React-debug (= 0.79.0-rc.3)
+    - React-featureflags (= 0.79.0-rc.3)
+    - React-jsi (= 0.79.0-rc.3)
+    - React-logger (= 0.79.0-rc.3)
+    - React-perflogger (= 0.79.0-rc.3)
+    - React-utils (= 0.79.0-rc.3)
   - SDWebImage (5.19.7):
     - SDWebImage/Core (= 5.19.7)
   - SDWebImage/Core (5.19.7)
@@ -2306,8 +2319,8 @@ SPEC CHECKSUMS:
   EXManifests: f30a0c5d3d6cad8db9c01bab579e0aa0df5d3cb2
   Expo: 24ec4e242d7cb4bc0095beeb984ac1006a8782e1
   expo-dev-client: 8c99b4979086a27f19e773e96ef10219102a5c4f
-  expo-dev-launcher: c44b371e716dc42d8ce74a60cdaa2b7858a2f35a
-  expo-dev-menu: 4d23c42a26733a55bd26509ff4f9362815061c87
+  expo-dev-launcher: 7b1172e0103f74cfb242f27deb2e5c83aa37836e
+  expo-dev-menu: b5156ba51a752969f91e089e85d7e1a4002ed7d8
   expo-dev-menu-interface: 4baf2f8b3b79ce37cf4b900e4b3ba6df3384f0a1
   ExpoAppleAuthentication: 218e275c9bf19963247a198c450ce3852e6a9342
   ExpoAsset: 6e707be0cb7e792faa06e42d8ebc85600921af89
@@ -2318,87 +2331,87 @@ SPEC CHECKSUMS:
   ExpoImage: 89f672e47b391a749b56fecb3e2a8d6d68b9b379
   ExpoKeepAwake: 5a84230d022094b50d2ef369fdcae76d0ea44913
   ExpoLinearGradient: 7ca3b1d1625a1ab85c129abce4a3cdc78a9500a3
-  ExpoModulesCore: 42bfec8f0219de8b25890ee751a9e599b5d50234
+  ExpoModulesCore: ee9093339160a9f3b2a9bff460fc9ddacbb7219b
   ExpoSplashScreen: 47a5c337586329223b70b5ef777d34c1f9edf412
   ExpoVideo: 85750319df61d76237b5952fca5a9f39504c6b9b
   EXStructuredHeaders: 09c70347b282e3d2507e25fb4c747b1b885f87f6
-  EXUpdates: d0768cf029ae340a4c2fa7f586a45df7d7aeb6da
+  EXUpdates: 2f0ece04a4e624547cd9124a522fb7349633db5c
   EXUpdatesInterface: 1dcebac98ac5dad4289e6ff2bd5616822e894397
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
-  FBLazyVector: 73f927157a20d4c20c419d3ea42197c28e895fc3
+  FBLazyVector: a13cdda7bbe886d533908636117037b198014387
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 35fc9a910fa91f0e71d953aa76cf0629a2f8643c
+  hermes-engine: 222573b97e0c0023ee02f5a8480d6aa3080ceb3f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
-  RCTDeprecation: 57c8eb30be38b17267f7947496586e8c56655000
-  RCTRequired: 0a0a46bc2ee03107636ea3e3ecd17fcf96ecb973
-  RCTTypeSafety: e01703b8ae90a9e4f832d192b6426e2be278e2cd
+  RCTDeprecation: 2fa7e5950e440764f4a7c2731840d35b5e464383
+  RCTRequired: e46164234affa609618ee854dc3f1648ef270d3c
+  RCTTypeSafety: 0d5a0cf9e39231a471f38d74415845761b339273
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: e004cb14e60cebfcf2bc8c33ffac89ef88a8889d
-  React-callinvoker: 6f8b5686eeab81591262e71369c04830bef3cc47
-  React-Core: 7ecda373ee452d8239d7bd74bc7348409a511f80
-  React-CoreModules: 1dadfd981eab73a91e52be159ac272f07406e1c6
-  React-cxxreact: dfd36141a363e36768ab164f710591bd8b2de8f5
-  React-debug: 40b4e98b1e6abd7b2b07158d065eb0e653c8e6be
-  React-defaultsnativemodule: d47fe1f071cd3e28feeefe79c74f1c72938ec14c
-  React-domnativemodule: 3c037c30f7dcedcc7cb2115a4856e26dc7fd427a
-  React-Fabric: b69bf84ed89753f1004cd4dca58453142768e94e
-  React-FabricComponents: a5d5656033380fe70a54c9755f26695e61a55c02
-  React-FabricImage: af0c8d13671eab38adb9399b987d6a1c94b829db
-  React-featureflags: 6076c7a9ed2039e0d4a874dca4fcb1e83d81fe13
-  React-featureflagsnativemodule: 84e926d230eb9f3cc347f496ac25fd882d86cdb0
-  React-graphics: cf422929daf9aace64422744b293dada6021a0bc
-  React-hermes: 8a37df7f343cf690636248a625a005b524c20935
-  React-idlecallbacksnativemodule: 839db78afe2e9f5805ad59b34da80e570bcaab32
-  React-ImageManager: aa393db52bf534a35a0bab615c773059e272d009
-  React-jserrorhandler: 3daba80788b61ba30a606c3e46ac33e5780dd88c
-  React-jsi: 88646f87400f9733a40affa590c017b79bc0a6b4
-  React-jsiexecutor: 9406e8aacb1e5eba4632d894af232de7f6d6046f
-  React-jsinspector: 02c0f15ac34f56656ceed9f6337a52d31f1df169
-  React-jsinspectortracing: cecb1569bc769b2fd9bbd5995c086f9a30a085ed
-  React-jsitooling: 598b5e82d7eb0677bf0d6fd2083d788be8589ff8
-  React-jsitracing: 67d7707c7912c2f59fefe325339d1879aebde323
-  React-logger: ae25d57a8548a6ef7a15ea3f647e192cb420e464
-  React-Mapbuffer: 1d2b097474d043c73f1b3bca045f08eb8886eba2
-  React-microtasksnativemodule: dddd71a2a01726d7ed8e2732787a03c7e1fefe7f
-  React-NativeModulesApple: 08302164cb4c4a3ecf26d04c794750c8da76ee26
-  React-oscompat: 38090361205b8f47117134b291a4a928c50e0def
-  React-perflogger: 809ab1f94e7293ae6439ab770f67d92df729b37f
-  React-performancetimeline: a7419f23796a8c2879edc830a6cc1666607f263d
-  React-RCTActionSheet: 8bde2412a4fa37e4cb87d6ab739483a9f2f95638
-  React-RCTAnimation: 55ca7cc5572ab20b80e7c89832b8b88338c68afd
-  React-RCTAppDelegate: d99b2a13ab1890054b1c1bfa3e16fab40716b433
-  React-RCTBlob: eac258b7de2209e123cfe0bb1f93ac2468486c0b
-  React-RCTFabric: db179fd3ef5ef6d854ae7cd539c5d8f1613dd089
-  React-RCTFBReactNativeSpec: 8bf88c7a98256caf81214127465a3dd74772ac1a
-  React-RCTImage: df7970e2943ce7895aec1edf97cfbe9769e5431f
-  React-RCTLinking: c6fe4d4831706bb7d0ec736b4615cff8b3dfa7b4
-  React-RCTNetwork: 1bbeb395f3aefc647d65b47a045fd244a8001034
-  React-RCTRuntime: 16553ec024fe34b3eedad8adcba7ee09fd3b38e6
-  React-RCTSettings: 994c927ae049a24571cfb1c5fb85068548f0f03e
-  React-RCTText: 10ba61380dde029c205b05fdb09296f3575734d7
-  React-RCTVibration: 7825602652fd01ff658752e4b8c043ae25ae45fe
-  React-rendererconsistency: 3709930705daedba53af997342cc4f01d4e56795
-  React-renderercss: 6393d95573a4b924bd185727eaa07ada9de80f1a
-  React-rendererdebug: ac3604cf7e7e5eb708503b288e22865fd7660097
-  React-rncore: 33ac9ffecdd38a4b81f9348309d63b4d045d4814
-  React-RuntimeApple: 8bc11af9d8649066c3b0e515ea5a261507f281fb
-  React-RuntimeCore: f154b9bf28cdd3c6bd14aeb4275f9d069cccc82b
-  React-runtimeexecutor: a9656dde5693fea60fbe4483748be5115aa9b6e1
-  React-RuntimeHermes: 3a431c82b79911c0f5f16f5a0049b942e165da5f
-  React-runtimescheduler: 8420ce60e320f30b3b0ceb26c3c61d4936bf7ccd
-  React-timing: 26311cc6420b9af8e1e9bd53dfaa1b025ec270b1
-  React-utils: de08a59446d8782c10502e6a4a5f7cc40a7c7090
-  ReactAppDependencyProvider: 17afd7407f6899a032c40bf3900b9a645809dff3
-  ReactCodegen: c72f0c5d35d9173ae2f25cd47ab50cbe718da90f
-  ReactCommon: 9f144a83e0f8d980f6083b3935eb6d423454eede
+  React: f860d6b597a59819f52cd18de431320c658774b5
+  React-callinvoker: 47a4bbcb912ff682f5f57b437204237305b1f03e
+  React-Core: b89018209a1692fa31fdda082525fda2ec885e02
+  React-CoreModules: 6718956d9537656367a9a31a01d84c2f1c201244
+  React-cxxreact: c7c3450683f60b41fdbb7ec02f9347e94279069a
+  React-debug: 354c1023f0feec2c484c35edc2d9614abc7e1e47
+  React-defaultsnativemodule: d376de286c4dfb3e2970f2b4ce6698ce1862a8f8
+  React-domnativemodule: eadf20cdc91872b99ad8dc72611ac473dc6b4a1c
+  React-Fabric: 39e5f9d5e7ee74a07de91748e785975be29547b5
+  React-FabricComponents: 739c83e170a19d6e8f90c9f1295a530c9888460c
+  React-FabricImage: 1d621b5273ffcb9c2fb0c756f231b35fa08752b0
+  React-featureflags: e8b460883a5562ce85c934f248655a81d5e09f21
+  React-featureflagsnativemodule: 275dbfb2cdcbf14ba52743eb2eccef16950f438a
+  React-graphics: e0ab76bd9ef6db26237ae69aff66c3a8224519f1
+  React-hermes: 4eafcbe1e9e558fae5ae3e1addf130fb8d1f6647
+  React-idlecallbacksnativemodule: dd2e62d7ab928dcd761e180b473f340b4d31c522
+  React-ImageManager: 8f604c44f6da53c199ea76febba49c427343ab7d
+  React-jserrorhandler: b987989ea5fa952be6926a4cc086867b956787c7
+  React-jsi: d0211699cbb8e9b7397ece49890536713d2ccc9a
+  React-jsiexecutor: 3be18538fd9ac380f25d8fd72b30b2882aa189e8
+  React-jsinspector: 7fdc505319d3e87622c02867df8e476ca3975863
+  React-jsinspectortracing: b8e229eed818878b5e65d8faaed60e2f49915b6b
+  React-jsitooling: db92692002692ba568d29a02b5b2c6bdce2c4323
+  React-jsitracing: eca84150c74c598ecabc790415f0c7a6257802d0
+  React-logger: 0de8a4004273f62f6296d0c3b8c120c2245eaf81
+  React-Mapbuffer: b4708d8976588eeda6dacfa14742b1f2056e5bb6
+  React-microtasksnativemodule: 9d28b4b9272b52dffabcd2d48a934a8d8177f1e6
+  React-NativeModulesApple: a5ed6f425abed68a61415527cf902b22eb661b32
+  React-oscompat: 481559f37d95c98fa39fa84674171a5f6646a932
+  React-perflogger: bfa66d1709c975ed0bf7aa886882414a7497f7d6
+  React-performancetimeline: 64af0e7dd7a682213bd0e7e1cbdfff731cd17901
+  React-RCTActionSheet: 48ce30c88e7aa83a3153f2785f58eb18985e4b7c
+  React-RCTAnimation: 13d78666184cdd284b0237bd7830a7c849a38a82
+  React-RCTAppDelegate: eff7c933a1c4e8b248c03dd5d78683da621ffa83
+  React-RCTBlob: 13f05f3a783777856957478b2f58dd73ac86fd4b
+  React-RCTFabric: 9e8738cff3d8018458ff8e67858e8c4a9d3e42a4
+  React-RCTFBReactNativeSpec: 103e99d2e6cb48af2e70925ec974b5f8bf8598ac
+  React-RCTImage: 5c96e5f762fd945b5438b26770456b93ac9cefe3
+  React-RCTLinking: 4ed5e0842227fd5036404aa04994e0720e556caa
+  React-RCTNetwork: 5fbbe5bc152936e28d3f66d6c0d16dd7fc43a430
+  React-RCTRuntime: 2519dd7215757366d6b5652266778e31f9919fb2
+  React-RCTSettings: 0c5d7460873ef191b51ab614cc5f9dc0706c34aa
+  React-RCTText: b3026406d7ff8c95b64437ba48d7ba35a0a7fcd6
+  React-RCTVibration: 64da0c913099e3f4f6c556322cb398a83be2b7fc
+  React-rendererconsistency: a4d8b222d165650a4bff33cf50033e1adf9a87a3
+  React-renderercss: 768ef55fa1720e0131a979e0228ed8955a40f7a7
+  React-rendererdebug: 520d105541cf2946ed3505a8aa83df6b17647544
+  React-rncore: 27f409047489a44511ad49e64fbc00b798455cbc
+  React-RuntimeApple: 25352c0b749482ac743bb5670e7d629fdf9caaae
+  React-RuntimeCore: 86dc1275e9d58d77985dc4167ff6a2931d2e44f8
+  React-runtimeexecutor: 1f7b57e78d4721d2e9c98d094d6f480c93da3f25
+  React-RuntimeHermes: a8e3287c412ed138475dada3374cca6a5e9df450
+  React-runtimescheduler: 1a328781b0d0d8a47a62c58a307e09b96b8938bc
+  React-timing: 1b7c77ff812ae55c820636333909f4bfe948eb06
+  React-utils: e38a4ca98a4148b50bc470346e05ea5a3935eb46
+  ReactAppDependencyProvider: 556c91ab2e8cf1389f8c07cbcadb04134923ead4
+  ReactCodegen: 0972ef43e68680314fe0fe053e3bd21937a2904b
+  ReactCommon: 0b6cc8bfc9e59b9c652f83325881f271501e9b0e
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: d15788383b33ea88af96bc7c12354810089527f4
+  Yoga: 99c3ff1f0452d13c8774222903cef8dda229d5ce
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 0dc2e90d9ec86faf0bb296e40ffef712f807f396

--- a/apps/paper-tester/package.json
+++ b/apps/paper-tester/package.json
@@ -22,7 +22,7 @@
     "expo-video": "~2.0.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "react-native": "0.79.0-rc.2",
+    "react-native": "0.79.0-rc.3",
     "react-native-web": "~0.19.13"
   },
   "devDependencies": {

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -30,7 +30,7 @@
     "expo-speech": "~13.0.0",
     "expo-sqlite": "~15.0.0",
     "react": "19.0.0",
-    "react-native": "0.79.0-rc.2",
+    "react-native": "0.79.0-rc.3",
     "react-native-safe-area-context": "5.2.0",
     "react-native-screens": "4.9.0",
     "react-native-webview": "13.13.0"

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -15,7 +15,7 @@
     "expo-router": "^4.0.0",
     "expo-splash-screen": "~0.29.13",
     "react": "19.0.0",
-    "react-native": "0.79.0-rc.2",
+    "react-native": "0.79.0-rc.3",
     "react-native-safe-area-context": "5.2.0",
     "react-native-screens": "4.9.0"
   },

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -50,7 +50,7 @@
     "jasmine-core": "^2.4.1",
     "lodash": "^4.17.19",
     "react": "19.0.0",
-    "react-native": "0.79.0-rc.2",
+    "react-native": "0.79.0-rc.3",
     "react-native-gesture-handler": "~2.24.0",
     "sinon": "^7.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     ]
   },
   "resolutions": {
-    "react-native": "0.79.0-rc.2",
+    "react-native": "0.79.0-rc.3",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "@react-navigation/bottom-tabs": "^7.2.0",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -56,7 +56,7 @@
     "@expo/spawn-async": "^1.7.2",
     "@expo/ws-tunnel": "^1.0.1",
     "@expo/xcpretty": "^4.3.0",
-    "@react-native/dev-middleware": "0.79.0-rc.2",
+    "@react-native/dev-middleware":"0.79.0-rc.3",
     "@urql/core": "^5.0.6",
     "@urql/exchange-retry": "^1.3.0",
     "accepts": "^1.3.8",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -56,7 +56,7 @@
     "@expo/spawn-async": "^1.7.2",
     "@expo/ws-tunnel": "^1.0.1",
     "@expo/xcpretty": "^4.3.0",
-    "@react-native/dev-middleware":"0.79.0-rc.3",
+    "@react-native/dev-middleware": "0.79.0-rc.3",
     "@urql/core": "^5.0.6",
     "@urql/exchange-retry": "^1.3.0",
     "accepts": "^1.3.8",

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -42,7 +42,7 @@
     "@expo/config-types": "^52.0.0",
     "@expo/image-utils": "^0.6.0",
     "@expo/json-file": "^9.0.0",
-    "@react-native/normalize-colors": "0.79.0-rc.2",
+    "@react-native/normalize-colors": "0.79.0-rc.3",
     "debug": "^4.3.1",
     "resolve-from": "^5.0.0",
     "semver": "^7.6.0",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -55,7 +55,7 @@
     "@babel/plugin-transform-parameters": "^7.24.7",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
-    "@react-native/babel-preset": "0.79.0-rc.2",
+    "@react-native/babel-preset": "0.79.0-rc.3",
     "babel-plugin-react-native-web": "~0.19.13",
     "babel-plugin-transform-flow-enums": "^0.0.2",
     "babel-plugin-syntax-hermes-parser": "^0.25.1",

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -50,7 +50,7 @@
     "graphql": "^16.0.1",
     "graphql-request": "^3.6.1",
     "react": "19.0.0",
-    "react-native": "0.79.0-rc.2",
+    "react-native": "0.79.0-rc.3",
     "react-query": "^3.34.16",
     "url": "^0.11.0"
   },

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -59,7 +59,7 @@
     "expo-module-scripts": "^4.0.0",
     "fuse.js": "^6.4.6",
     "react": "19.0.0",
-    "react-native": "0.79.0-rc.2",
+    "react-native": "0.79.0-rc.3",
     "url": "^0.11.0",
     "use-subscription": "^1.8.0"
   },

--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/navigation-bar",
   "dependencies": {
-    "@react-native/normalize-colors": "0.79.0-rc.2",
+    "@react-native/normalize-colors": "0.79.0-rc.3",
     "debug": "^4.3.2",
     "react-native-is-edge-to-edge": "^1.1.6"
   },

--- a/packages/expo-system-ui/package.json
+++ b/packages/expo-system-ui/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/system-ui",
   "dependencies": {
-    "@react-native/normalize-colors": "0.79.0-rc.2",
+    "@react-native/normalize-colors": "0.79.0-rc.3",
     "debug": "^4.3.2"
   },
   "jest": {

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -91,7 +91,7 @@
     "expo-module-scripts": "^4.0.2",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "react-native": "0.79.0-rc.2",
+    "react-native": "0.79.0-rc.3",
     "ws": "^8.18.0"
   },
   "peerDependencies": {

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -14,7 +14,7 @@
     "expo": "canary",
     "expo-status-bar": "~2.0.0",
     "react": "19.0.0",
-    "react-native": "0.79.0-rc.2"
+    "react-native": "0.79.0-rc.3"
   },
   "overrides": {
     "react": "19.0.0"

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -14,7 +14,7 @@
     "expo": "canary",
     "expo-status-bar": "~2.0.0",
     "react": "19.0.0",
-    "react-native": "0.79.0-rc.2"
+    "react-native": "0.79.0-rc.3"
   },
   "overrides": {
     "react": "19.0.0"

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -14,7 +14,7 @@
     "expo": "canary",
     "expo-status-bar": "~2.0.0",
     "react": "19.0.0",
-    "react-native": "0.79.0-rc.2"
+    "react-native": "0.79.0-rc.3"
   },
   "overrides": {
     "react": "19.0.0"

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -33,7 +33,7 @@
     "expo-web-browser": "~14.0.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "react-native": "0.79.0-rc.2",
+    "react-native": "0.79.0-rc.3",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-reanimated": "~3.17.1",
     "react-native-safe-area-context": "5.2.0",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "expo-web-browser": "~14.0.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "react-native": "0.79.0-rc.2",
+    "react-native": "0.79.0-rc.3",
     "react-native-reanimated": "~3.17.1",
     "react-native-safe-area-context": "~5.2.0",
     "react-native-screens": "~4.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3033,23 +3033,23 @@
   resolved "https://registry.yarnpkg.com/@react-native-segmented-control/segmented-control/-/segmented-control-2.5.4.tgz#c0097491c3ec7c7c34397d72c44501d615354dcd"
   integrity sha512-M8c+NORkGZzKUXB+yT6pq6+wWZUZK9HhVtuMz8Y5Co4tnOSJ86KhhJsM3RI1rPuUvmyzGc0jeJpkB3ul8X1XNw==
 
-"@react-native/assets-registry@0.79.0-rc.2":
-  version "0.79.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.79.0-rc.2.tgz#ecdf9f06bb3a55db40c7a6db2195676e1c40f258"
-  integrity sha512-cPliUc9YDDZuWNUN1EYCIKX4rkmVrQorLyKlwh+64NWe7uZPOoIIMttQveR5OutDBNP3bJvwL3NuXdlpBPEUZQ==
+"@react-native/assets-registry@0.79.0-rc.3":
+  version "0.79.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.79.0-rc.3.tgz#d61ea040db758429b1f12d790c4119e1c76d51b3"
+  integrity sha512-hSfBllF2Xs/gWrh0adduXR6Jgqt16dTycq5UDXQ3sVI4FiiF5ljV3Q6xFJovNJm+JTAAdeKOtLRNhi0tXXwS/g==
 
-"@react-native/babel-plugin-codegen@0.79.0-rc.2":
-  version "0.79.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.79.0-rc.2.tgz#c7339f2614ea8d73d51782eac74ffeb4aaeb3a96"
-  integrity sha512-ZYB9NP8Sg9OTn0zPp1yiGpP5/TZkYmu5RfflVpKST4vSsrdEpbL+p6++UY+OiBYl/0Na3ZHm0IUsMVvCMpFyWA==
+"@react-native/babel-plugin-codegen@0.79.0-rc.3":
+  version "0.79.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.79.0-rc.3.tgz#41e069430361c4219a9207f9d0527040cb526af4"
+  integrity sha512-FGL8ZcZBivW3Xict1YI2WdxEOBTL0e1uBwubhu6ElJbHWfIS/vDCCu05SAYjXG1+YMd1nDneiLwY1J7KOzfqRg==
   dependencies:
     "@babel/traverse" "^7.25.3"
-    "@react-native/codegen" "0.79.0-rc.2"
+    "@react-native/codegen" "0.79.0-rc.3"
 
-"@react-native/babel-preset@0.79.0-rc.2":
-  version "0.79.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.79.0-rc.2.tgz#49a41fac9180e766c439122bdad8414e89697047"
-  integrity sha512-Rtl3o4BucSo5+4IrVrC10D6TCJOFeGeclWS7PtC1nlvtRoGf1GzW4hIt5GO2rAPeY1nzVbEHvWiBHL3+2JePvA==
+"@react-native/babel-preset@0.79.0-rc.3":
+  version "0.79.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.79.0-rc.3.tgz#e2b9b76085433329eb5caa3310e3a0b13f2750e0"
+  integrity sha512-3HYMrj5sDFCPILQchhFobmUhkf63Ap6S6Qq43DUP47zwT+925vJ8cmoTLkU0/ZutX12DV/i+G6IUYz5hECMMsg==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/plugin-proposal-export-default-from" "^7.24.7"
@@ -3092,15 +3092,15 @@
     "@babel/plugin-transform-typescript" "^7.25.2"
     "@babel/plugin-transform-unicode-regex" "^7.24.7"
     "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.79.0-rc.2"
+    "@react-native/babel-plugin-codegen" "0.79.0-rc.3"
     babel-plugin-syntax-hermes-parser "0.25.1"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
 
-"@react-native/codegen@0.79.0-rc.2":
-  version "0.79.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.79.0-rc.2.tgz#4cc0fd5d7ed671de3342072ee62eb34190fcfe6b"
-  integrity sha512-z+x5I6hiIJrkfVH589cYE/qPBhnAifKxDNd9QxXhMtI6dfSSZHyjbVCSyVpC2Yz7FMV7oDsDs2/lYyVIL5bQsw==
+"@react-native/codegen@0.79.0-rc.3":
+  version "0.79.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.79.0-rc.3.tgz#848d732c5d6d83795f6b236b0bb30021b3179506"
+  integrity sha512-OdwNQRbsa/sA1ldPXPbv3bvi5AXywhh/4rWL2ZU9T/cdewIDvP7mp1nN1QyrO2I9QbIHtrYwRjmlA/JIkon5gw==
   dependencies:
     glob "^7.1.1"
     hermes-parser "0.25.1"
@@ -3108,12 +3108,12 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/community-cli-plugin@0.79.0-rc.2":
-  version "0.79.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.0-rc.2.tgz#ea3f8c25e1c24c4782718bd3ad20dabcd43485c9"
-  integrity sha512-8uB3+RyPAjnkx15BFrOpZoAi88f3+JN5uaG1VQbluBk2Qak+W//y1vn0jJRF5GGYsMNw3MfdUIc/kAlksxagsA==
+"@react-native/community-cli-plugin@0.79.0-rc.3":
+  version "0.79.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.0-rc.3.tgz#a13892cfe06311f5f5a6781e37f8569bdeb48b08"
+  integrity sha512-GOIIiM3b/iYU/hAbHJ5bmh81vcPDIGK2uto9YuE+bs4CGo4n8/X9hRIjl5pxhKc5dNnYqy9p+0Qw1ukiBn/dyg==
   dependencies:
-    "@react-native/dev-middleware" "0.79.0-rc.2"
+    "@react-native/dev-middleware" "0.79.0-rc.3"
     chalk "^4.0.0"
     debug "^2.2.0"
     invariant "^2.2.4"
@@ -3122,18 +3122,18 @@
     metro-core "^0.82.0"
     semver "^7.1.3"
 
-"@react-native/debugger-frontend@0.79.0-rc.2":
-  version "0.79.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.79.0-rc.2.tgz#478274f9ebc7ee40f7f97a55c46d325c9c1b15e5"
-  integrity sha512-L78QtrOxUtAs3Qu4T78+HegZdwSr/xIQ7HURtcfixcbCs4EIhX3C/35OqGPeq9wdaBe8ctYtAoI2x2QAx6wEDA==
+"@react-native/debugger-frontend@0.79.0-rc.3":
+  version "0.79.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.79.0-rc.3.tgz#6a02d6327a0c8b3872eb4b79f29aee7d1d88e16b"
+  integrity sha512-dGU7OfT9FsRPGsX3xTy+uOSFVOr0yl8w+vdWaBbstNZ15B74x6xCP72OblxGcJ2w2DsRUXu/VYLPJYyXtcYg+Q==
 
-"@react-native/dev-middleware@0.79.0-rc.2":
-  version "0.79.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.79.0-rc.2.tgz#7dea963171c545f8cf9011767afcda23c2140e8d"
-  integrity sha512-ugu92UBJv1M4XcAJDDq5P0TpLfQuvGRcz99ERJgmXfxGZzIchr4FrjVJPa2MxMKcYB5QuGD1Lmy1McwAOxWgLg==
+"@react-native/dev-middleware@0.79.0-rc.3":
+  version "0.79.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.79.0-rc.3.tgz#4fb5990bfd6f13d54283ebcd1c0a31cd9133147f"
+  integrity sha512-pgtbFg35X/zZUsWnT830loSZC20Q2Zk9+XlwDLU0hFzaWGQ259KhPghK8vMvt65rR01A/dxC7S+IfTrrG3mMdg==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.79.0-rc.2"
+    "@react-native/debugger-frontend" "0.79.0-rc.3"
     chrome-launcher "^0.15.2"
     chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
@@ -3144,30 +3144,30 @@
     serve-static "^1.16.2"
     ws "^6.2.3"
 
-"@react-native/gradle-plugin@0.79.0-rc.2":
-  version "0.79.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.79.0-rc.2.tgz#a6c66ae860517ee5a9d7f3c6c46ceb18154aac31"
-  integrity sha512-YUR24HYK3rMAIlcCilPGS3SXSRJP4921YV+uRXy/HHhptMeRZ7lMq789P/v3tWAZQhtoPltBbso+MxmAFMwLmA==
+"@react-native/gradle-plugin@0.79.0-rc.3":
+  version "0.79.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.79.0-rc.3.tgz#76c2919ceac87c466714f1d628340a2e3579b242"
+  integrity sha512-v83pLZa9qky0YJ2k35JOQffVRw0piekHn6kkyoe/BjawUnGdGlNYyGYj1WLTmEXoIxjdHt4cXOBWdE7VZMuszw==
 
-"@react-native/js-polyfills@0.79.0-rc.2":
-  version "0.79.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.79.0-rc.2.tgz#a4ee47a9414ff9cc50ce4d8dc636d853e81edf10"
-  integrity sha512-fIJ+Gnoc/yeBn7LN/8Y57+m6a8c0K3GC8cmo3EKrd1Fdj/bo60l8x5C1qtREvmEWTMQilu1rVfJH7GqKX9jLhQ==
+"@react-native/js-polyfills@0.79.0-rc.3":
+  version "0.79.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.79.0-rc.3.tgz#98d7b6dfb6013868574c8dda48c1dacebe593663"
+  integrity sha512-J38tfZQPsoYYdjZWGZkH0YjHrik64RGfP0mnMYMXG075pVyAjss/pGx6x+5L8vBANzRFKduHvUFjforDG3paBg==
 
-"@react-native/normalize-colors@0.79.0-rc.2":
-  version "0.79.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.79.0-rc.2.tgz#6b2f769cd4f418ae24e46531a53badd6d4edfd2d"
-  integrity sha512-kOIxgpulY+h3Vepg+YI2SU1nhQTuvqPOWFcKu0Jdj7MQPsb0Zk32qz4kEtXjSQY/SwwmPXwJ7H3gr8GH4LAEsw==
+"@react-native/normalize-colors@0.79.0-rc.3":
+  version "0.79.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.79.0-rc.3.tgz#04c33fbe56ed14a8cbd15c1716c5016c10a60880"
+  integrity sha512-Q+ayUASculzYjeNIh6ga8ObvY/4hazax3IJdDdZJ1nk+xb2RFvsZSnRgMXZYRCp3XoVypXLYOgC4u9UOx6VuRw==
 
 "@react-native/normalize-colors@^0.74.1":
   version "0.74.88"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.74.88.tgz#46f4c7270c8e6853281d7dd966e0eb362068e41a"
   integrity sha512-He5oTwPBxvXrxJ91dZzpxR7P+VYmc9IkJfhuH8zUiU50ckrt+xWNjtVugPdUv4LuVjmZ36Vk2EX8bl1gVn2dVA==
 
-"@react-native/virtualized-lists@0.79.0-rc.2":
-  version "0.79.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.79.0-rc.2.tgz#0d75827e8354635d908a00ba466501ce2619d8e7"
-  integrity sha512-MEcGevwwBrZWSdBaUP4tRcG4ROgvePElduVga5lHNqRgRlIvaJfHOOCb/bmP1nXm0+u5d8IJd+f+dE3qNLsQtg==
+"@react-native/virtualized-lists@0.79.0-rc.3":
+  version "0.79.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.79.0-rc.3.tgz#c5f60dd2c729238107937d25fddc5a137e307b6c"
+  integrity sha512-dJ36xxTHupTj7FdkX0LENUMvX8FOfDzHyom1fQQULNnGznmAEoFF8yyZHUlWyUCYQ0YziWJG3PmU7QQ++y4aJw==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -13189,19 +13189,19 @@ react-native-webview@13.13.0:
     escape-string-regexp "^4.0.0"
     invariant "2.2.4"
 
-react-native@0.79.0-rc.2:
-  version "0.79.0-rc.2"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.79.0-rc.2.tgz#e195b9b1a9f687820e979529a1b247e3c089069e"
-  integrity sha512-EycpxPXwa+wJOicK2iYybCs8ozTbjzKjB0t7/vjl+X2VmStD9xpRiz3hwyqeiJG/dbld+XBu4Ib2NIjRdGFVaA==
+react-native@0.79.0-rc.3:
+  version "0.79.0-rc.3"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.79.0-rc.3.tgz#d1bce6a99609fa21e50282d1efc9b0da244ad4f4"
+  integrity sha512-0R7DiTh0ygITmYXt6tGa+g5rxBu4fbVK4jD7Noz0xnhlBdzEHui/MWPlGqeaaw7l8PetY2MnMSFdGLWo02OITg==
   dependencies:
     "@jest/create-cache-key-function" "^29.7.0"
-    "@react-native/assets-registry" "0.79.0-rc.2"
-    "@react-native/codegen" "0.79.0-rc.2"
-    "@react-native/community-cli-plugin" "0.79.0-rc.2"
-    "@react-native/gradle-plugin" "0.79.0-rc.2"
-    "@react-native/js-polyfills" "0.79.0-rc.2"
-    "@react-native/normalize-colors" "0.79.0-rc.2"
-    "@react-native/virtualized-lists" "0.79.0-rc.2"
+    "@react-native/assets-registry" "0.79.0-rc.3"
+    "@react-native/codegen" "0.79.0-rc.3"
+    "@react-native/community-cli-plugin" "0.79.0-rc.3"
+    "@react-native/gradle-plugin" "0.79.0-rc.3"
+    "@react-native/js-polyfills" "0.79.0-rc.3"
+    "@react-native/normalize-colors" "0.79.0-rc.3"
+    "@react-native/virtualized-lists" "0.79.0-rc.3"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"


### PR DESCRIPTION
# Why
Follow up of #35561 for the react-native 0.79 upgrade

# How
update package versions
- react-native 0.79.0.rc.2 -> 0.79.0.rc.3

# Test Plan
- bare-expo ios ✅ / android ✅
- expo-go ios ✅ / android ✅
- paper-tester ios ❌ / android ✅