### PR TITLE
Update @shopify/react-native-skia to version v2.0.0-next.2

### DIFF
--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1956,7 +1956,7 @@ PODS:
     - Yoga
   - react-native-segmented-control (2.5.7):
     - React-Core
-  - react-native-skia (1.12.0):
+  - react-native-skia (v2.0.0-next.2):
     - DoubleConversion
     - glog
     - hermes-engine

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1956,7 +1956,7 @@ PODS:
     - Yoga
   - react-native-segmented-control (2.5.7):
     - React-Core
-  - react-native-skia (1.5.0):
+  - react-native-skia (1.12.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3515,13 +3515,13 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: 9d28b4b9272b52dffabcd2d48a934a8d8177f1e6
   react-native-maps: 2e6e9896195781327ee15b33e3e84bf73c08207a
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
-  react-native-pager-view: b7f8cf921e19063a3528ee2aeae945bb42104dbd
-  react-native-safe-area-context: 55dbcf556a51092ddf163b29febbc07dc7f14ebb
-  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
-  react-native-skia: 76d98b23c05d77c39346bc094183d314bd7bdf5b
-  react-native-slider: c4c1a975352113af59b59dc783abc111618ec37a
-  react-native-view-shot: 41c5c50c809f1fd61f91c99400b2222c9b80d13f
-  react-native-webview: cde150463e7caa49b316b0ed1871e7ef8193bef4
+  react-native-pager-view: a1b4f854df102a127b38fa49ff9d25af20a3c550
+  react-native-safe-area-context: fb22a3043ce75c3145da87a74254a2ec527267b0
+  react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
+  react-native-skia: cb39d585f5f2a666c77c698ee438cdd82f2cc494
+  react-native-slider: c57011b1447edac8ddcc4d61cbd54172f378b7a0
+  react-native-view-shot: 105375eceab012a37db548637dd6fca795af977a
+  react-native-webview: d3a6bde17001bc9cded1b2219b6cc2e60f27b74d
   React-NativeModulesApple: a5ed6f425abed68a61415527cf902b22eb661b32
   React-oscompat: 481559f37d95c98fa39fa84674171a5f6646a932
   React-perflogger: bfa66d1709c975ed0bf7aa886882414a7497f7d6

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -1956,7 +1956,7 @@ PODS:
     - Yoga
   - react-native-segmented-control (2.5.7):
     - React-Core
-  - react-native-skia (v2.0.0-next.2):
+  - react-native-skia (2.0.0-next.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3515,13 +3515,13 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: 9d28b4b9272b52dffabcd2d48a934a8d8177f1e6
   react-native-maps: 2e6e9896195781327ee15b33e3e84bf73c08207a
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
-  react-native-pager-view: a1b4f854df102a127b38fa49ff9d25af20a3c550
-  react-native-safe-area-context: fb22a3043ce75c3145da87a74254a2ec527267b0
-  react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
+  react-native-pager-view: b7f8cf921e19063a3528ee2aeae945bb42104dbd
+  react-native-safe-area-context: 55dbcf556a51092ddf163b29febbc07dc7f14ebb
+  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
   react-native-skia: cb39d585f5f2a666c77c698ee438cdd82f2cc494
-  react-native-slider: c57011b1447edac8ddcc4d61cbd54172f378b7a0
-  react-native-view-shot: 105375eceab012a37db548637dd6fca795af977a
-  react-native-webview: d3a6bde17001bc9cded1b2219b6cc2e60f27b74d
+  react-native-slider: c4c1a975352113af59b59dc783abc111618ec37a
+  react-native-view-shot: 41c5c50c809f1fd61f91c99400b2222c9b80d13f
+  react-native-webview: cde150463e7caa49b316b0ed1871e7ef8193bef4
   React-NativeModulesApple: a5ed6f425abed68a61415527cf902b22eb661b32
   React-oscompat: 481559f37d95c98fa39fa84674171a5f6646a932
   React-perflogger: bfa66d1709c975ed0bf7aa886882414a7497f7d6

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -39,7 +39,7 @@
     "@react-navigation/native": "^7.0.17",
     "@react-navigation/stack": "^7.1.1",
     "@shopify/flash-list": "1.7.6",
-    "@shopify/react-native-skia": "1.5.0",
+    "@shopify/react-native-skia": "v2.0.0-next.1",
     "@stripe/stripe-react-native": "0.43.0",
     "date-fns": "^2.28.0",
     "dedent": "^0.7.0",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -39,7 +39,7 @@
     "@react-navigation/native": "^7.0.17",
     "@react-navigation/stack": "^7.1.1",
     "@shopify/flash-list": "1.7.6",
-    "@shopify/react-native-skia": "v2.0.0-next.1",
+    "@shopify/react-native-skia": "v2.0.0-next.2",
     "@stripe/stripe-react-native": "0.43.0",
     "date-fns": "^2.28.0",
     "dedent": "^0.7.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -51,7 +51,7 @@
     "@react-navigation/native": "^7.0.17",
     "@react-navigation/stack": "^7.1.1",
     "@shopify/flash-list": "1.7.6",
-    "@shopify/react-native-skia": "1.5.0",
+    "@shopify/react-native-skia": "v2.0.0-next.1",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.9",
     "expo": "~52.0.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -51,7 +51,7 @@
     "@react-navigation/native": "^7.0.17",
     "@react-navigation/stack": "^7.1.1",
     "@shopify/flash-list": "1.7.6",
-    "@shopify/react-native-skia": "v2.0.0-next.1",
+    "@shopify/react-native-skia": "v2.0.0-next.2",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.9",
     "expo": "~52.0.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -101,7 +101,7 @@
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~5.0.0",
   "unimodules-image-loader-interface": "~6.1.0",
-  "@shopify/react-native-skia": "1.5.0",
+  "@shopify/react-native-skia": "v2.0.0-next.1",
   "@shopify/flash-list": "1.7.6",
   "@sentry/react-native": "~6.3.0"
 }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -101,7 +101,7 @@
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~5.0.0",
   "unimodules-image-loader-interface": "~6.1.0",
-  "@shopify/react-native-skia": "v2.0.0-next.1",
+  "@shopify/react-native-skia": "v2.0.0-next.2",
   "@shopify/flash-list": "1.7.6",
   "@sentry/react-native": "~6.3.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,12 +3265,12 @@
     recyclerlistview "4.2.3"
     tslib "2.8.1"
 
-"@shopify/react-native-skia@v2.0.0-next.1":
-  version "2.0.0-next.1"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-2.0.0-next.1.tgz#57bafef20feea5269b3d087c4a6712f0b1684f9a"
-  integrity sha512-g4qTueyZlSrsUXQeatzPoLT28ncTUV96T90N0xbkbskQL0LyRt7LyzJhJleL/cRNMcYIrN5ndYtbIkpz1N7o2A==
+"@shopify/react-native-skia@v2.0.0-next.2":
+  version "2.0.0-next.2"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-2.0.0-next.2.tgz#4e749d268f18d548f89e912f9e47bc99e6b815e2"
+  integrity sha512-Ht62iLPqTd8ufctR85Jkvpb+KtVn+DGIdtzXOj+PsCY6NubxWtoOVINr2H2dzjroMFJ+WZyyJ6fEoyuHe0ObRg==
   dependencies:
-    canvaskit-wasm "0.39.1"
+    canvaskit-wasm "0.40.0"
     react-reconciler "0.31.0"
 
 "@sinclair/typebox@^0.27.8":
@@ -5665,10 +5665,10 @@ caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001688:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz#f2d15e3aaf8e18f76b2b8c1481abde063b8104c8"
   integrity sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==
 
-canvaskit-wasm@0.39.1:
-  version "0.39.1"
-  resolved "https://registry.yarnpkg.com/canvaskit-wasm/-/canvaskit-wasm-0.39.1.tgz#c3c8f3962cbabbedf246f7bcf90e859013c7eae9"
-  integrity sha512-Gy3lCmhUdKq+8bvDrs9t8+qf7RvcjuQn+we7vTVVyqgOVO1UVfHpsnBxkTZw+R4ApEJ3D5fKySl9TU11hmjl/A==
+canvaskit-wasm@0.40.0:
+  version "0.40.0"
+  resolved "https://registry.yarnpkg.com/canvaskit-wasm/-/canvaskit-wasm-0.40.0.tgz#61a77657259fddfc0025ad1c3f57ac8d4d5850ff"
+  integrity sha512-Od2o+ZmoEw9PBdN/yCGvzfu0WVqlufBPEWNG452wY7E9aT8RBE+ChpZF526doOlg7zumO4iCS+RAeht4P0Gbpw==
   dependencies:
     "@webgpu/types" "0.1.21"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,13 +3265,13 @@
     recyclerlistview "4.2.3"
     tslib "2.8.1"
 
-"@shopify/react-native-skia@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-1.5.0.tgz#2c771bb7b6ad49b4b1c1cfb3ed47c06c22203f87"
-  integrity sha512-YNcw7cbksiMJ3d8uxh14LFRztUhjQFphFV/GCm8cSO4SxFc4niqnvsGklXNv68DLESMdn5hQnfYpa0oJqaW20w==
+"@shopify/react-native-skia@v2.0.0-next.1":
+  version "2.0.0-next.1"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-2.0.0-next.1.tgz#57bafef20feea5269b3d087c4a6712f0b1684f9a"
+  integrity sha512-g4qTueyZlSrsUXQeatzPoLT28ncTUV96T90N0xbkbskQL0LyRt7LyzJhJleL/cRNMcYIrN5ndYtbIkpz1N7o2A==
   dependencies:
     canvaskit-wasm "0.39.1"
-    react-reconciler "0.27.0"
+    react-reconciler "0.31.0"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -10788,7 +10788,7 @@ longest@^1.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
   integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -13243,13 +13243,12 @@ react-query@^3.34.16:
     broadcast-channel "^3.4.1"
     match-sorter "^6.0.2"
 
-react-reconciler@0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.27.0.tgz#360124fdf2d76447c7491ee5f0e04503ed9acf5b"
-  integrity sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==
+react-reconciler@0.31.0:
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.31.0.tgz#6b7390fe8fab59210daf523d7400943973de1458"
+  integrity sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==
   dependencies:
-    loose-envify "^1.1.0"
-    scheduler "^0.21.0"
+    scheduler "^0.25.0"
 
 react-redux@^7.2.0:
   version "7.2.6"
@@ -13873,13 +13872,6 @@ scheduler@0.25.0, scheduler@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.25.0.tgz#336cd9768e8cceebf52d3c80e3dcf5de23e7e015"
   integrity sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==
-
-scheduler@^0.21.0:
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.21.0.tgz#6fd2532ff5a6d877b6edb12f00d8ab7e8f308820"
-  integrity sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==
-  dependencies:
-    loose-envify "^1.1.0"
 
 schema-utils@^4.0.1:
   version "4.2.0"


### PR DESCRIPTION
# Why

This commit updates @shopify/react-native-skia from 1.5.0 -> v2.0.0-next.2

Closes ENG-15319

# How

- Updated package.json in expo-go + ncl
- Updated bundledNativeModules.json
- Updated yarn.lock
- Updated podfile.lock for expo-go

(BareExpo isn't built with RNSkia)

# Test Plan

Run Expo Go locally:
- [X] Tested on Expo Go iOS
- [X] Tested on Expo Go Android

# Notes:

~I found an [issue](https://github.com/Shopify/react-native-skia/issues/2974) in their repo about not being compatible with React 19 and RN 0.78 yet (which causes it to crash on Expo Go on main even before updating). This is fixed in a next [release](https://github.com/Shopify/react-native-skia/releases/tag/v2.0.0-next.1) in RNSkia - but it requires Android SDK 26 and might not be backwards compatible with RN < 0.78 when released.  Seems to be OK for ExpoGo (except for the min SDK restriction?) - is this ok for us to upgrade to?~

New RNSKIA version 2.0.0-next.2 reverted the minSdk change.