### PR TITLE
[create-expo-module] Fix typo in instructions

### DIFF
--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -472,7 +472,7 @@ function printFurtherLocalInstructions(slug: string, name: string) {
   console.log();
   console.log(`You can now import this module inside your application.`);
   console.log(`For example, you can add this line to your App.js or App.tsx file:`);
-  console.log(`${chalk.gray.italic(`import ${name} './modules/${slug}';`)}`);
+  console.log(`${chalk.gray.italic(`import ${name} from './modules/${slug}';`)}`);
   console.log();
   console.log(`Learn more on Expo Modules APIs: ${chalk.blue.bold(DOCS_URL)}`);
   console.log(


### PR DESCRIPTION
# Why

Fixes incorrect import message:
```
import HealthkitModule './modules/healthkit';
```

Becomes:
```
import HealthkitModule from './modules/healthkit';
```