### PR TITLE
[docs] add corepack eas.json field to docs

### DIFF
--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -95,6 +95,13 @@ export default [
     description: ['Version of Node.js used for build.'],
   },
   {
+    name: 'corepack',
+    type: 'boolean',
+    description: [
+      'If set to `true`, [corepack](https://nodejs.org/api/corepack.html) will be enabled at the begining of build process. Defaults to `false`.',
+    ],
+  },
+  {
     name: 'yarn',
     type: 'string',
     description: ['Version of Yarn used for build.'],
@@ -107,7 +114,9 @@ export default [
   {
     name: 'bun',
     type: 'string',
-    description: ['Version of Bun used for build. You can also use a specific version. Learn [how to configure the exact version in eas.json](/guides/using-bun/#customize-bun-version-on-eas).'],
+    description: [
+      'Version of Bun used for build. You can also use a specific version. Learn [how to configure the exact version in eas.json](/guides/using-bun/#customize-bun-version-on-eas).',
+    ],
   },
   {
     name: 'expoCli',
@@ -166,7 +175,7 @@ export default [
     description: [
       'Custom workflow file name that will be used to run this build. You can also specify this property on platform level for platform-specific workflows. [Learn more](/custom-builds/get-started/).',
       '',
-      'Example: `"config": "production.yml"` will use workflow from `.eas/build/production.yml`.'
+      'Example: `"config": "production.yml"` will use workflow from `.eas/build/production.yml`.',
     ],
   },
   {
@@ -175,5 +184,5 @@ export default [
     description: [
       'The environment used to apply environment variables for the build process. [Learn more](/eas/environment-variables).',
     ],
-  }
+  },
 ];


### PR DESCRIPTION
# Why

Add the `corepack` field in `eas.json` to docs

# How

Add the `corepack` field in `eas.json` to docs

# Test Plan

Preview
