### PR TITLE
Add packageManager to top level package.json

### DIFF
--- a/.github/workflows/create-expo-app.yml
+++ b/.github/workflows/create-expo-app.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - .github/workflows/create-expo-app.yml
       - packages/create-expo/**
+      - package.json
       - yarn.lock
   pull_request:
     paths:

--- a/package.json
+++ b/package.json
@@ -42,5 +42,6 @@
   },
   "volta": {
     "node": "22.14.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,5 @@
   },
   "volta": {
     "node": "22.14.0"
-  },
-  "packageManager": "yarn@1.22.22"
+  }
 }


### PR DESCRIPTION
# Why

For developers using `corepack`, it is helpful to have a specification for the expected package manager already in place.

# How

Since our scripts expect `yarn` to be the package manager, I added this to the top level `package.json`.

# Test Plan

CI should pass. It appears that this change breaks the create-expo-app workflow for Node 22. Investigating.
