### PR TITLE
[docs] Fix vale warnings and update HeadingCase rule

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -261,3 +261,4 @@ exceptions:
   - How can I implement a custom
   - Drizzle ORM
   - architecture?
+  - index.tsx files

--- a/docs/pages/build-reference/easignore.mdx
+++ b/docs/pages/build-reference/easignore.mdx
@@ -53,7 +53,7 @@ You've successfully configured your **.easignore** file.
 
 ## Adding files to your project upload with .easignore
 
-In addition to ignoring additional files beyond what is in your gitignore file, you can also use the **.easignore** file to include files with your EAS Build upload that are not committed to source control. This is useful if you have custom scripts that generate temporary files needed for your build process just prior to build. To upload a file not in source control to EAS Build, add it to the **.easignore** file with a `!` prefix, along with the rest of your **.gitignore ** contents. The `!` prefixed file should be last, so it takes precedence over any prior rules that would ignore it.
+In addition to ignoring additional files beyond what is in your gitignore file, you can also use the **.easignore** file to include files with your EAS Build upload that are not committed to source control. This is useful if you have custom scripts that generate temporary files needed for your build process just before the build. To upload a file not in source control to EAS Build, add it to the **.easignore** file with a `!` prefix, along with the rest of your **.gitignore ** contents. The `!` prefixed file should be last, so it takes precedence over any prior rules that would ignore it.
 
 ```bash .easignore
 # Copy everything from your .gitignore file here

--- a/docs/pages/router/basics/layout.mdx
+++ b/docs/pages/router/basics/layout.mdx
@@ -6,7 +6,7 @@ sidebar_title: Layout
 
 import { FileTree } from '~/ui/components/FileTree';
 
-Each directory within the **app** directory (including **app** itself) can define a layout in the form of a **\_layout.tsx** file inside that directory. This file defines how all the pages within that directory are arranged. This is where you would define a stack navigator, tab navigator, drawer navigator, or any other layout that you want to use for the pages in that directory. The layout file exports a default component that is rendered prior to whatever page you are navigating to within that directory.
+Each directory within the **app** directory (including **app** itself) can define a layout in the form of a **\_layout.tsx** file inside that directory. This file defines how all the pages within that directory are arranged. This is where you would define a stack navigator, tab navigator, drawer navigator, or any other layout that you want to use for the pages in that directory. The layout file exports a default component that is rendered before whatever page you are navigating to within that directory.
 
 Let's look at a few common layout scenarios.
 

--- a/docs/pages/router/basics/navigation.mdx
+++ b/docs/pages/router/basics/navigation.mdx
@@ -218,7 +218,7 @@ With app links and universal links, you can also link to your app with an `https
 
 ## Initial routes
 
-When opening a deep link to a page in your app, you will likely want back navigation to work as if the user navigated to the page from your home page. To do this, you can specify an `initialRouteName` configuration, which defines the page in a layout that should be loaded prior to the deep linked page.
+When opening a deep link to a page in your app, you will likely want back navigation to work as if the user navigated to the page from your home page. To do this, you can specify an `initialRouteName` configuration, which defines the page in a layout that should be loaded before the deep linked page.
 
 Consider the following file structure:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix Vale warnings and update HeadingCase rule to include a new exception.

![CleanShot 2025-03-26 at 23 08 14](https://github.com/user-attachments/assets/51e96571-20de-45f3-8fb9-2b41a084987d)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run vale`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
