### PR TITLE
[create-expo] Support aliasing and deprecating examples

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Support GitHub shorthand for templates ([#33383](https://github.com/expo/expo/pull/33383) by [@satya164](https://github.com/satya164))
+- Add support for aliasing and deprecating examples.
 
 ### 🐛 Bug fixes
 

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Support GitHub shorthand for templates ([#33383](https://github.com/expo/expo/pull/33383) by [@satya164](https://github.com/satya164))
-- Add support for aliasing and deprecating examples.
+- Add support for aliasing and deprecating examples. ([#35717](https://github.com/expo/expo/pull/35717) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes
 

--- a/packages/create-expo/src/Examples.ts
+++ b/packages/create-expo/src/Examples.ts
@@ -29,6 +29,23 @@ export type GithubContent = {
   type: 'file' | 'dir';
 };
 
+export type ExamplesMetadata = {
+  aliases: {
+    [key: string]:
+      | string
+      | {
+          destination: string;
+          message?: string;
+        };
+  };
+  deprecated: {
+    [key: string]: {
+      outdatedExampleHref: string;
+      message?: string;
+    };
+  };
+};
+
 /** List all existing examples directory from https://github.com/expo/examples. */
 async function listExamplesAsync() {
   const response = await fetch('https://api.github.com/repos/expo/examples/contents');
@@ -38,6 +55,17 @@ async function listExamplesAsync() {
 
   const data = (await response.json()) as GithubContent[];
   return data.filter((item) => item.type === 'dir' && !item.name.startsWith('.'));
+}
+
+/** Fetch the metadata for the examples from https://github.com/expo/examples. This includes aliases and deprecated examples. */
+export async function fetchMetadataAsync() {
+  const response = await fetch(`https://raw.githubusercontent.com/expo/examples/master/meta.json`);
+
+  if (!response.ok) {
+    throw new Error(`Unexpected GitHub API response: ${response.status} - ${response.statusText}`);
+  }
+
+  return (await response.json()) as ExamplesMetadata;
 }
 
 /** Determine if an example exists, using only its name */

--- a/packages/create-expo/src/__tests__/Examples.test.ts
+++ b/packages/create-expo/src/__tests__/Examples.test.ts
@@ -4,6 +4,7 @@ import prompts from 'prompts';
 
 import {
   ensureExampleExists,
+  fetchMetadataAsync,
   GithubContent,
   promptExamplesAsync,
   sanitizeScriptsAsync,
@@ -43,6 +44,39 @@ describe(ensureExampleExists, () => {
       /unexpected GitHub API response/i
     );
 
+    scope.done();
+  });
+});
+
+describe(fetchMetadataAsync, () => {
+  const mockMetadata = {
+    aliases: {
+      test: {
+        destination: 'test-1',
+      },
+    },
+    deprecated: {
+      test: {
+        outdatedExampleHref: 'test-2',
+      },
+    },
+  };
+
+  it('returns the metadata', async () => {
+    const scope = nock('https://raw.githubusercontent.com/')
+      .get('/expo/examples/master/meta.json')
+      .reply(200, mockMetadata);
+    const metadata = await fetchMetadataAsync();
+    expect(metadata).toBeDefined();
+    expect(metadata).toEqual(mockMetadata);
+    scope.done();
+  });
+
+  it('throws when the metadata is not found', async () => {
+    const scope = nock('https://raw.githubusercontent.com/')
+      .get('/expo/examples/master/meta.json')
+      .reply(404);
+    await expect(() => fetchMetadataAsync()).rejects.toThrow(/unexpected GitHub API response/i);
     scope.done();
   });
 });

--- a/packages/create-expo/src/cli.ts
+++ b/packages/create-expo/src/cli.ts
@@ -93,6 +93,7 @@ async function run() {
       event: AnalyticsEventTypes.CREATE_EXPO_APP,
       properties: { phase: AnalyticsEventPhases.SUCCESS },
     });
+
     // Flush all events.
     await flushAsync();
   } catch (error: any) {

--- a/packages/create-expo/src/createAsync.ts
+++ b/packages/create-expo/src/createAsync.ts
@@ -156,9 +156,7 @@ async function createExampleAsync(inputPath: string, props: Options): Promise<vo
     resolvedExample = props.example;
   }
 
-  await ensureExampleExists(resolvedExample);
-
-  /** Handle remapping aliases and throwing for deprecated examples. */
+  // Handle remapping aliases and throwing for deprecated examples.
   const metadata = await fetchMetadataAsync();
 
   if (metadata.aliases[resolvedExample]) {
@@ -168,10 +166,18 @@ async function createExampleAsync(inputPath: string, props: Options): Promise<vo
       chalk`{gray The {cyan ${resolvedExample}} example has been renamed to {cyan ${destination}}.}`
     );
 
+    // Optional message to show when an example is aliased, in case additional context is required
+    if (typeof alias === 'object' && alias.message) {
+      console.log(chalk`{gray ${alias.message}}`);
+    }
+
     resolvedExample = destination;
   } else if (metadata.deprecated[resolvedExample]) {
     throw new Error(getDeprecatedExampleErrorMessage(resolvedExample, metadata));
   }
+
+  // Ensure the example exists after performing remapping and deprecation checks.
+  await ensureExampleExists(resolvedExample);
 
   // Log the status after aliases and deprecated examples are handled.
   console.log(chalk`Creating an Expo project using the {cyan ${resolvedExample}} example.\n`);
@@ -284,7 +290,7 @@ function getDeprecatedExampleErrorMessage(example: string, metadata: ExamplesMet
   }
 
   if (outdatedExampleHref) {
-    output += `\n\n You can also refer to the outdated example code in examples git repository history, if it is useful: ${outdatedExampleHref}`;
+    output += `\n\nYou can also refer to the outdated example code in examples git repository history, if it is useful: ${outdatedExampleHref}`;
   }
 
   return output;


### PR DESCRIPTION
# Why

We have a bunch of examples in https://github.com/expo/examples that we'd like to remove, rename, or merge. Adding this functionality allows us to keep the repo more organized and easy to browse, without breaking any existing documentation (or at least, not without a useful error message).

# How

- I added [**meta.json**](https://github.com/expo/examples/blob/master/meta.json) to https://github.com/expo/examples
- We fetch that from `create-expo` and use it to determine whether to remap to another example (alias) or throw a meaningful error (deprecation)

## Alias

```
create-expod -e with-tab-navigation
The with-tab-navigation example has been renamed to with-react-navigation.
Creating an Expo project using the with-react-navigation example.

? What is your app named? › my-app
```

You can just alias it and the message above will be displayed, or you can add a `message` too in order to provide more context:

```
The with-tab-navigation example has been renamed to with-react-navigation.
This example has been replaced with a more complete navigation example, which also includes tabs.
Creating an Expo project using the with-react-navigation example.

? What is your app named? › my-app
```

## Deprecation

```
create-expod -e with-formik
Error: with-formik is no longer available. Formik is a plain-JavaScript library that does not require any specific configuration related to React Native or Expo. Follow the Formik documentation: https://formik.org/

You can also refer to the outdated example code in examples git repository history, if it is useful: https://github.com/expo/examples/tree/7a5145833837b9e3c72ebe381c06925b7fc5daf6/with-formik
```

Note: in this case, we can optionally provide `message` (the "Formik is a plain-JavaScript library" part), and an `outdatedExampleHref` (the https://github.com/expo/examples/tree/7a5145833837b9e3c72ebe381c06925b7fc5daf6/with-formik link), so we can guide people in the right direction.

# Test Plan

Ran it locally, verified it all looks good. 

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
