### PR TITLE
[go][android][1/n] Roll out edge-to-edge -  Enable edge-to-edge for all Expo Go projects

### DIFF
--- a/apps/expo-go/android/app/build.gradle
+++ b/apps/expo-go/android/app/build.gradle
@@ -202,6 +202,10 @@ dependencies {
   // Our dependencies
   implementation ('androidx.appcompat:appcompat:1.6.1')
 
+  // Our dependencies for toggling edge-to-edge support
+  implementation 'androidx.activity:activity:1.10.1'
+  implementation 'androidx.activity:activity-ktx:1.10.1'
+
   // Our dependencies from ExpoView
   // DON'T ADD ANYTHING HERE THAT ISN'T IN EXPOVIEW. ONLY COPY THINGS FROM EXPOVIEW TO HERE.
   compileOnly 'org.glassfish:javax.annotation:3.1.1'

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/LauncherActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/LauncherActivity.kt
@@ -8,11 +8,11 @@ import android.content.pm.PackageManager
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ProcessLifecycleOwner
-import androidx.lifecycle.get
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.kernel.Kernel
 import host.exp.expoview.BuildConfig
@@ -27,6 +27,7 @@ class LauncherActivity : AppCompatActivity() {
   lateinit var kernel: Kernel
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
     super.onCreate(savedInstanceState)
     if (BuildConfig.DEBUG) {
       // Need WRITE_EXTERNAL_STORAGE for method tracing

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ErrorActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ErrorActivity.kt
@@ -7,6 +7,9 @@ import javax.inject.Inject
 import android.os.Bundle
 import host.exp.exponent.di.NativeModuleDepsProvider
 import android.content.Intent
+import android.graphics.Color
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
@@ -31,6 +34,11 @@ class ErrorActivity() : FragmentActivity() {
   lateinit var kernel: Kernel
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    // The error screen doesn't change with theme changes, so we set the status bar to dark mode
+    // to align the status bar color with the color of the text of the screen.
+    enableEdgeToEdge(
+      SystemBarStyle.dark(Color.TRANSPARENT)
+    )
     super.onCreate(savedInstanceState)
     binding = ErrorActivityNewBinding.inflate(layoutInflater)
     val view = binding.root

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -7,6 +7,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -16,6 +17,7 @@ import android.view.animation.AccelerateInterpolator
 import android.view.animation.AlphaAnimation
 import android.view.animation.Animation
 import android.widget.RemoteViews
+import androidx.activity.enableEdgeToEdge
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
@@ -139,6 +141,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
    *
    */
   override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
     super.onCreate(savedInstanceState)
 
     isLoadExperienceAllowedToRun = true
@@ -250,6 +253,12 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
         )
       }
     }
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    // Will update the navigation bar colors if the system theme has changed. This is only relevant for the three button navigation bar.
+    enableEdgeToEdge()
+    super.onConfigurationChanged(newConfig)
   }
 
   private fun soLoaderInit() {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
@@ -2,8 +2,10 @@
 package host.exp.exponent.experience
 
 import android.content.Intent
+import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Debug
+import androidx.activity.enableEdgeToEdge
 import com.facebook.react.runtime.ReactSurfaceView
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
@@ -48,6 +50,7 @@ open class HomeActivity : BaseExperienceActivity() {
 
   //region Activity Lifecycle
   override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
     super.onCreate(savedInstanceState)
     NativeModuleDepsProvider.instance.inject(HomeActivity::class.java, this)
 
@@ -111,6 +114,12 @@ open class HomeActivity : BaseExperienceActivity() {
   override fun onError(intent: Intent) {
     intent.putExtra(ErrorActivity.IS_HOME_KEY, true)
     kernel.setHasError()
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    // Will update the navigation bar colors if the system theme has changed. This is only relevant for the three button navigation bar.
+    enableEdgeToEdge()
+    super.onConfigurationChanged(newConfig)
   }
 
   companion object : ModulesProvider {


### PR DESCRIPTION
# Why

ENG-15058
Starting with SDK 53 we want all Expo Go projects to use egde-to-edge

# How

Enabled the edge-to-edge using the `enableEdgeToEdge` function for expo-go activities. 
This works only for projects, which aren't using the `<StatusBar/>` component, as including it breaks the edge-to-edge (work in progress) 

# Test Plan

Tested in Expo Go on Android. Only on a single screen, as I couldn't get NCL to work.
| App using edge-to-edge (the status bar tint was added manually, by default it's transparent) | Error Activity in edge-to-edge |
| :---:   | :---: | 
| ![edge-to-edge-app](https://github.com/user-attachments/assets/929b9b2c-1f3a-4709-b354-27029ab64e90) | ![edge-to-edge-error](https://github.com/user-attachments/assets/46d1c797-2568-44e7-8196-d7c941ff353b)  




