### PR TITLE
[go] fix build error

### DIFF
--- a/apps/expo-go/ios/Client/Menu/EXDevMenuDelegateProtocol.h
+++ b/apps/expo-go/ios/Client/Menu/EXDevMenuDelegateProtocol.h
@@ -1,7 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <React/RCTBridge.h>
-#import <React-RCTAppDelegate/RCTAppDelegate.h>
+#import <Expo/RCTAppDelegateUmbrella.h>
 
 @class EXDevMenuManager;
 

--- a/apps/expo-go/ios/Client/Menu/EXDevMenuViewController.mm
+++ b/apps/expo-go/ios/Client/Menu/EXDevMenuViewController.mm
@@ -1,7 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <React/RCTRootView.h>
-#import <React-RCTAppDelegate/RCTAppDelegate.h>
+#import <Expo/RCTAppDelegateUmbrella.h>
 #import <ExpoModulesCore/EXDefines.h>
 
 #import "EXDevMenuViewController.h"

--- a/apps/expo-go/ios/Exponent-Bridging-Header.h
+++ b/apps/expo-go/ios/Exponent-Bridging-Header.h
@@ -4,6 +4,8 @@
 
 #import <ExpoModulesCore/ExpoModulesCore.h>
 #import <ExpoModulesCore-Swift.h>
+#import <Expo/RCTAppDelegateUmbrella.h>
+#import <Expo/EXReactNativeFactoryDelegate.h>
 #import <Expo-Swift.h>
 #import <EXUpdatesInterface-Swift.h>
 #import <EXUpdates-Swift.h>

--- a/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.h
+++ b/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.h
@@ -1,7 +1,7 @@
 
 #import <UIKit/UIKit.h>
+#import <Expo/RCTAppDelegateUmbrella.h>
 #import <React/RCTBridgeDelegate.h>
-#import <React-RCTAppDelegate/RCTAppDelegate.h>
 #import <React/RCTReloadCommand.h>
 
 #import "EXAppFetcher.h"

--- a/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoAppInstance.h
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoAppInstance.h
@@ -1,16 +1,6 @@
 #import "EXVersionManagerObjC.h"
 
-#if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
-#import <React-RCTAppDelegate/RCTAppDelegate.h>
-#elif __has_include(<React_RCTAppDelegate/RCTAppDelegate.h>)
-// for importing the header from framework, the dash will be transformed to underscore
-#import <React_RCTAppDelegate/RCTAppDelegate.h>
-#endif
-
-#if __has_include(<ReactAppDependencyProvider/RCTAppDependencyProvider.h>)
-#import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>
-#endif
-
+#import <Expo/RCTAppDelegateUmbrella.h>
 #import <React/RCTJavaScriptLoader.h>
 
 @class RCTHost;

--- a/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoAppInstance.mm
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoAppInstance.mm
@@ -3,6 +3,9 @@
 #import <ReactCommon/RCTTurboModuleManager.h>
 #import <ReactCommon/RCTHost.h>
 
+#if __has_include(<ReactAppDependencyProvider/RCTAppDependencyProvider.h>)
+#import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>
+#endif
 
 @implementation ExpoAppInstance
 

--- a/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoGoReactNativeFactory.h
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoGoReactNativeFactory.h
@@ -1,10 +1,4 @@
-#if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
-#import <React-RCTAppDelegate/RCTAppDelegate.h>
-#elif __has_include(<React_RCTAppDelegate/RCTAppDelegate.h>)
-// for importing the header from framework, the dash will be transformed to underscore
-#import <React_RCTAppDelegate/RCTAppDelegate.h>
-#endif
-
+#import <Expo/RCTAppDelegateUmbrella.h>
 
 @interface ExpoGoReactNativeFactory : RCTReactNativeFactory
 


### PR DESCRIPTION
# Why

expo-go build error: https://expo.dev/accounts/expo-ci/projects/unversioned-expo-go/builds/1526f5ed-61c5-4131-9fb9-9de321c23576
regression from #35679

# How

fix imports

# Test Plan

expo-go ci passed

# Checklist

- n/a I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
