### PR TITLE
update react-native-view-shot to 4.0.3

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2256,7 +2256,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-view-shot (4.0.2):
+  - react-native-view-shot (4.0.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3742,7 +3742,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 55dbcf556a51092ddf163b29febbc07dc7f14ebb
   react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
   react-native-slider: c4c1a975352113af59b59dc783abc111618ec37a
-  react-native-view-shot: 105375eceab012a37db548637dd6fca795af977a
+  react-native-view-shot: 41c5c50c809f1fd61f91c99400b2222c9b80d13f
   react-native-webview: 4203df130be3d3f03e0437cfe3f8ad5076044a56
   React-NativeModulesApple: a5ed6f425abed68a61415527cf902b22eb661b32
   React-oscompat: 481559f37d95c98fa39fa84674171a5f6646a932

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -66,7 +66,7 @@
     "react-native-safe-area-context": "5.3.0",
     "react-native-screens": "4.9.0",
     "react-native-svg": "15.11.2",
-    "react-native-view-shot": "4.0.2",
+    "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.13.0",
     "test-suite": "*"
   },

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2056,7 +2056,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-view-shot (4.0.2):
+  - react-native-view-shot (4.0.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3545,7 +3545,7 @@ SPEC CHECKSUMS:
   react-native-segmented-control: fde795d4d9c95ebc97cd37a034eb0a7a922f1ec5
   react-native-skia: 76d98b23c05d77c39346bc094183d314bd7bdf5b
   react-native-slider: c4c1a975352113af59b59dc783abc111618ec37a
-  react-native-view-shot: 105375eceab012a37db548637dd6fca795af977a
+  react-native-view-shot: 41c5c50c809f1fd61f91c99400b2222c9b80d13f
   react-native-webview: d3a6bde17001bc9cded1b2219b6cc2e60f27b74d
   React-NativeModulesApple: a5ed6f425abed68a61415527cf902b22eb661b32
   React-oscompat: 481559f37d95c98fa39fa84674171a5f6646a932

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3406,9 +3406,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/googlemaps/google-maps-ios-utils.git
 
 SPEC CHECKSUMS:
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
+  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EASClient: 720af5473430a688e792ffa91f33d11fe72fcb89
   EXApplication: e1ad9c950c98b2b134578092c948b10b403f3ea7
   EXAV: 9773c9799767c9925547b05e41a26a0240bb8ef2
@@ -3486,13 +3486,13 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: e75e348953352a000331eb77caf01e424248e176
   FirebaseSessions: 655ff17f3cc1a635cbdc2d69b953878001f9e25b
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   Google-Maps-iOS-Utils: cfe6a0239c7ca634b7e001ad059a6707143dc8dc
   GoogleAppMeasurement: 987769c4ca6b968f2479fbcc9fe3ce34af454b8e
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 80ea184ed6bf44139f383a8b0e248ba3ec1cc8c9
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: b582c44eb901463ed655200759977d79b91ab8bd
+  hermes-engine: b2efca291af9785edd0128611dbc1b1fb4020a6a
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f

--- a/apps/expo-go/modules/README.md
+++ b/apps/expo-go/modules/README.md
@@ -1,0 +1,5 @@
+### Updating vendored modules
+
+Anything in `modules` in Expo Go means we vendor it and apply some Expo-Go-specific patches located in `tools/src/vendoring/config`.
+
+To update a module here, run (example) `et uvm  react-native-view-shot -c "4.0.3"`. This will update the module to the specified version and apply the patches.

--- a/apps/expo-go/modules/react-native-view-shot/ios/RNViewShot.mm
+++ b/apps/expo-go/modules/react-native-view-shot/ios/RNViewShot.mm
@@ -45,7 +45,7 @@ RCT_EXPORT_METHOD(releaseCapture:(nonnull NSString *)uri)
   }
 }
 
-RCT_EXPORT_METHOD(captureRef:(NSNumber *)target
+RCT_EXPORT_METHOD(captureRef:(nonnull NSNumber *)target
                   withOptions:(NSDictionary *)options
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)

--- a/apps/expo-go/modules/react-native-view-shot/package.json
+++ b/apps/expo-go/modules/react-native-view-shot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-view-shot",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Capture a React Native view to an image",
   "main": "src/index.js",
   "types": "src/index.d.ts",
@@ -39,5 +39,5 @@
       "javaPackageName": "fr.greweb.reactnativeviewshot"
     }
   },
-  "stableVersion": "4.0.1"
+  "stableVersion": "4.0.2"
 }

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -79,7 +79,7 @@
     "react-native-safe-area-context": "5.3.0",
     "react-native-screens": "4.9.0",
     "react-native-svg": "15.11.2",
-    "react-native-view-shot": "4.0.2",
+    "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.13.0",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -147,7 +147,7 @@
     "react-native-safe-area-context": "5.3.0",
     "react-native-screens": "4.9.0",
     "react-native-svg": "15.11.2",
-    "react-native-view-shot": "4.0.2",
+    "react-native-view-shot": "4.0.3",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.13.0",
     "regl": "^1.3.0",

--- a/apps/native-component-list/src/screens/ViewShotScreen.tsx
+++ b/apps/native-component-list/src/screens/ViewShotScreen.tsx
@@ -1,8 +1,9 @@
+import { Image, ImageErrorEventData } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as MediaLibrary from 'expo-media-library';
 import { Platform } from 'expo-modules-core';
 import { useRef, useState } from 'react';
-import { Dimensions, Image, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Dimensions, ScrollView, StyleSheet, Text, View, Alert } from 'react-native';
 import { captureRef as takeSnapshotAsync, captureScreen } from 'react-native-view-shot';
 
 import Button from '../components/Button';
@@ -62,12 +63,19 @@ export default function ViewShotScreen() {
     }
   };
 
-  const imageSource = { uri: image };
+  const onError = ({ error }: ImageErrorEventData) => {
+    Alert.alert('Failed to load snapshot ', error);
+  };
+
   return (
     <ScrollView contentContainerStyle={{ alignItems: 'center' }}>
       <View style={styles.snapshotContainer} collapsable={false} ref={view}>
         <LinearGradient colors={gradientColors} style={styles.gradient} start={[0, 0]} end={[0, 1]}>
-          <Image style={styles.snapshot} source={imageSource} />
+          <Image
+            style={styles.snapshot}
+            source={{ uri: image }}
+            onError={image ? onError : undefined}
+          />
           <Text style={styles.text}>Snapshot will show above</Text>
         </LinearGradient>
       </View>
@@ -85,6 +93,7 @@ export default function ViewShotScreen() {
           borderWidth: 10,
         }}
         source={{ uri: screenUri }}
+        onError={screenUri ? onError : undefined}
       />
       <Button
         style={styles.button}

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -96,7 +96,7 @@
   "react-native-screens": "~4.9.1",
   "react-native-safe-area-context": "5.3.0",
   "react-native-svg": "15.11.2",
-  "react-native-view-shot": "4.0.2",
+  "react-native-view-shot": "4.0.3",
   "react-native-webview": "13.13.2",
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13155,10 +13155,10 @@ react-native-svg@15.11.2:
     css-tree "^1.1.3"
     warn-once "0.1.1"
 
-react-native-view-shot@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-4.0.2.tgz#18949ff2a3083a231d055e9f53ce705ccb9d821c"
-  integrity sha512-niAiQmiYe+vHtfgkcZ1WhJhTL0NzNB2REERnP6eIqro9EQcV/JqLo2rzdordn+kHJEp095/2ioLrCg3d+k3Mng==
+react-native-view-shot@4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-4.0.3.tgz#9b98388fcc5228073cb66ac98ca339eda35767ac"
+  integrity sha512-USNjYmED7C0me02c1DxKA0074Hw+y/nxo+xJKlffMvfUWWzL5ELh/TJA/pTnVqFurIrzthZDPtDM7aBFJuhrHQ==
   dependencies:
     html2canvas "^1.4.1"
 


### PR DESCRIPTION
# Why

resolves https://linear.app/expo/issue/ENG-15312

# How

updated the package

Changed RN core Image for expo-image because using core image doesn't display the view shot image on iOS, giving this log in the console

```
Task orphaned for request <NSMutableURLRequest: 0x60000037bda0> { URL: file:///Users/.../Library/Developer/CoreSimulator/Devices/.../data/Containers/Data/Application/.../tmp/ReactNative/67E8F539-E6A5-46A7-A2BF-B145644879EF.jpg
```

# Test Plan

- bare expo
- expo go

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
