### PR TITLE
[core][Android] Add `expoPublish` task

### DIFF
--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -7,12 +7,14 @@ import expo.modules.plugin.android.PublicationInfo
 import expo.modules.plugin.android.applyLinterOptions
 import expo.modules.plugin.android.applyPublishingVariant
 import expo.modules.plugin.android.applySDKVersions
+import expo.modules.plugin.android.createExpoPublishTask
 import expo.modules.plugin.android.createExpoPublishToMavenLocalTask
 import expo.modules.plugin.android.createReleasePublication
 import expo.modules.plugin.gradle.ExpoModuleExtension
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.internal.extensions.core.extra
+import java.net.URI
 
 internal fun Project.applyDefaultPlugins() {
   if (!plugins.hasPlugin("com.android.library")) {
@@ -76,6 +78,22 @@ internal fun Project.applyPublishing(expoModulesExtension: ExpoModuleExtension) 
       .createReleasePublication(publicationInfo)
 
     createExpoPublishToMavenLocalTask(publicationInfo)
+
+    val publicationToken = rootProject.findProperty("EXPO_GITHUB_PUBLISH_TOKEN") as? String
+    if (!publicationToken.isNullOrEmpty()) {
+      publishingExtension().repositories.maven { mavenRepo ->
+        mavenRepo.name = "GitHubPackages"
+        mavenRepo.url = URI("https://maven.pkg.github.com/expo/expo")
+
+        mavenRepo.credentials { pc ->
+          pc.username = "expo"
+          pc.password = publicationToken
+        }
+      }
+      createExpoPublishTask(publicationInfo)
+    } else {
+      createExpoPublishTask(IllegalStateException("EXPO_GITHUB_PUBLISH_TOKEN is not defined"))
+    }
   }
 }
 


### PR DESCRIPTION
# Why

Adds the `expoPublish` task that publishes packages to the Maven repository hosted on GitHub. This task will not work without the GitHub published token.

# How

Introduces a task similar to `expoPublishToMavenLocal`, which was added previously. This new task updates `expo-modules.core.json` and publishes the package to the `https://maven.pkg.github.com/expo/expo`.

I've also added some metadata about the package. They're not required, but it's nice to have them.

# Test Plan

- https://github.com/expo/expo/packages/2449166 ✅ 