### PR TITLE
fix(expo-go): use correct `react-native-lab` rewrites for Expo fast resolver

### DIFF
--- a/apps/expo-go/metro.config.js
+++ b/apps/expo-go/metro.config.js
@@ -80,7 +80,13 @@ function withReactNativeLabPackages(config) {
     }
 
     return context.resolveRequest(
-      { ...context, originModulePath: reactNativeLabsPath },
+      {
+        ...context,
+        originModulePath: reactNativeLabsPath,
+        // Also list the react-native-lab node modules folder for Expo's fast resolver
+        // But only do it for the packages that are "linked" from react-native-lab
+        nodeModulesPaths: [reactNativeLabsPath, ...context.nodeModulesPaths],
+      },
       moduleImport,
       platform
     );


### PR DESCRIPTION
# Why

The custom resolver we have for Expo Go does not work with the Expo Fast Resolver. Turns out that Jest's resolver is more strict when it comes to node modules directories, and does not recursively try all parent `<dir>/node_modules` folders.

# How

- Added `nodeModulesPaths` for `react-native-labs`.

# Test Plan

- `cd ./apps/expo-go`
- `EXPO_USE_FAST_RESOLVER=1 yarn start`
- Expo Go should work fine

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
