### PR TITLE
[android][audio] Fix `replace` when useAudioPlayer is not given a source

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Use the same prop name for "muted" on all platforms. Fix playing in background on iOS.([#35600](https://github.com/expo/expo/pull/35600) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Recording was not working when prepared due to wrong precondition check ([#35591](https://github.com/expo/expo/pull/35591) by [@pennersr](https://github.com/pennersr))
 - [Android] Correctly handle muting and volume. ([#35631](https://github.com/expo/expo/pull/35631) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fix replacing item when `useAudioPlayer` is passed an empty source.
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Use the same prop name for "muted" on all platforms. Fix playing in background on iOS.([#35600](https://github.com/expo/expo/pull/35600) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Recording was not working when prepared due to wrong precondition check ([#35591](https://github.com/expo/expo/pull/35591) by [@pennersr](https://github.com/pennersr))
 - [Android] Correctly handle muting and volume. ([#35631](https://github.com/expo/expo/pull/35631) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fix replacing item when `useAudioPlayer` is passed an empty source.
+- [Android] Fix replacing item when `useAudioPlayer` is passed an empty source. ([#35749](https://github.com/expo/expo/pull/35749) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -262,7 +262,7 @@ class AudioModule : Module() {
             val mediaSource = createMediaItem(source)
             val wasPlaying = ref.player.isPlaying
             mediaSource?.let {
-              ref.player.replaceMediaItem(0, it.mediaItem)
+              ref.setMediaSource(it)
               if (wasPlaying) {
                 ref.player.play()
               }

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -79,7 +79,7 @@ class AudioPlayer(
     }
   }
 
-  private fun setMediaSource(source: MediaSource) {
+  fun setMediaSource(source: MediaSource) {
     player.setMediaSource(source)
     player.prepare()
     startUpdating()


### PR DESCRIPTION
# Why
Closes #35670 
When `useAudioPlayer` is not passed a source initially, the `replace` method will silently fail because it tries to replace the first item in the playlist and there isn't one. 

# How
Because we don't currently support queues of items, we can just call `setMediaSource` again to replace everything in the playlist

# Test Plan
bare-expo and the provided repro.
