### PR TITLE
[sqlite] add backup and session api stubs for libsql

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Remove prebuilt worker on Web. ([#35311](https://github.com/expo/expo/pull/35311) by [@kudo](https://github.com/kudo))
 - [iOS] Fix warnings which will become errors in Swift 6. ([#35288](https://github.com/expo/expo/pull/35288) by [@behenate](https://github.com/behenate))
 - Fixed build warnings. ([#35610](https://github.com/expo/expo/pull/35610) by [@kudo](https://github.com/kudo))
+- Added backup and session API stubs to LibSQL implementations. ([#35755](https://github.com/expo/expo/pull/35755) by [@kudo](https://github.com/kudo))
 
 ### 📚 3rd party library updates
 

--- a/packages/expo-sqlite/android/src/main/cpp/libsql/NativeDatabaseBinding.cpp
+++ b/packages/expo-sqlite/android/src/main/cpp/libsql/NativeDatabaseBinding.cpp
@@ -41,6 +41,7 @@ void NativeDatabaseBinding::registerNatives() {
                        NativeDatabaseBinding::sqlite3_deserialize),
       makeNativeMethod("sqlite3_update_hook",
                        NativeDatabaseBinding::sqlite3_update_hook),
+      makeNativeMethod("sqlite3_backup", NativeDatabaseBinding::sqlite3_backup),
       makeNativeMethod("libsql_open_remote",
                        NativeDatabaseBinding::libsql_open_remote),
       makeNativeMethod("libsql_open", NativeDatabaseBinding::libsql_open),
@@ -128,6 +129,17 @@ int NativeDatabaseBinding::sqlite3_deserialize(
 
 void NativeDatabaseBinding::sqlite3_update_hook(bool enabled) {
   jni::throwNewJavaException(UnsupportedOperationException::create().get());
+}
+
+// static
+int NativeDatabaseBinding::sqlite3_backup(
+    jni::alias_ref<jni::JClass> clazz,
+    jni::alias_ref<NativeDatabaseBinding::jhybridobject> destDatabase,
+    const std::string &destDatabaseName,
+    jni::alias_ref<NativeDatabaseBinding::jhybridobject> sourceDatabase,
+    const std::string &sourceDatabaseName) {
+  jni::throwNewJavaException(UnsupportedOperationException::create().get());
+  return -1;
 }
 
 int NativeDatabaseBinding::libsql_open_remote(const std::string &url,

--- a/packages/expo-sqlite/android/src/main/cpp/libsql/NativeDatabaseBinding.h
+++ b/packages/expo-sqlite/android/src/main/cpp/libsql/NativeDatabaseBinding.h
@@ -39,6 +39,13 @@ public:
                           jni::alias_ref<jni::JArrayByte> serializedData);
   void sqlite3_update_hook(bool enabled);
 
+  static int sqlite3_backup(
+      jni::alias_ref<jni::JClass> clazz,
+      jni::alias_ref<NativeDatabaseBinding::jhybridobject> destDatabase,
+      const std::string &destDatabaseName,
+      jni::alias_ref<NativeDatabaseBinding::jhybridobject> sourceDatabase,
+      const std::string &sourceDatabaseName);
+
   int libsql_open_remote(const std::string &url, const std::string &authToken);
   int libsql_open(const std::string &dbPath, const std::string &url,
                   const std::string &authToken);

--- a/packages/expo-sqlite/android/src/main/cpp/libsql/NativeSessionBinding.cpp
+++ b/packages/expo-sqlite/android/src/main/cpp/libsql/NativeSessionBinding.cpp
@@ -1,0 +1,84 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#include "NativeSessionBinding.h"
+
+#include "Exceptions.h"
+
+namespace expo {
+
+void NativeSessionBinding::registerNatives() {
+  registerHybrid({
+      makeNativeMethod("initHybrid", NativeSessionBinding::initHybrid),
+      makeNativeMethod("sqlite3session_create",
+                       NativeSessionBinding::sqlite3session_create),
+      makeNativeMethod("sqlite3session_attach",
+                       NativeSessionBinding::sqlite3session_attach),
+      makeNativeMethod("sqlite3session_enable",
+                       NativeSessionBinding::sqlite3session_enable),
+      makeNativeMethod("sqlite3session_delete",
+                       NativeSessionBinding::sqlite3session_delete),
+      makeNativeMethod("sqlite3session_changeset",
+                       NativeSessionBinding::sqlite3session_changeset),
+      makeNativeMethod("sqlite3session_changeset_inverted",
+                       NativeSessionBinding::sqlite3session_changeset_inverted),
+      makeNativeMethod("sqlite3changeset_apply",
+                       NativeSessionBinding::sqlite3changeset_apply),
+      makeNativeMethod("sqlite3changeset_invert",
+                       NativeSessionBinding::sqlite3changeset_invert),
+  });
+}
+
+// static
+jni::local_ref<NativeSessionBinding::jhybriddata>
+NativeSessionBinding::initHybrid(jni::alias_ref<jhybridobject> jThis) {
+  return makeCxxInstance(jThis);
+}
+
+int NativeSessionBinding::sqlite3session_create(
+    jni::alias_ref<NativeDatabaseBinding::javaobject> db,
+    const std::string &dbName) {
+  jni::throwNewJavaException(UnsupportedOperationException::create().get());
+  return -1;
+}
+
+int NativeSessionBinding::sqlite3session_attach(
+    jni::alias_ref<jni::JString> tableName) {
+  jni::throwNewJavaException(UnsupportedOperationException::create().get());
+  return -1;
+}
+
+int NativeSessionBinding::sqlite3session_enable(bool enabled) {
+  jni::throwNewJavaException(UnsupportedOperationException::create().get());
+  return -1;
+}
+
+void NativeSessionBinding::sqlite3session_delete() {
+  jni::throwNewJavaException(UnsupportedOperationException::create().get());
+}
+
+jni::local_ref<jni::JArrayByte>
+NativeSessionBinding::sqlite3session_changeset() {
+  jni::throwNewJavaException(UnsupportedOperationException::create().get());
+  return nullptr;
+}
+
+jni::local_ref<jni::JArrayByte>
+NativeSessionBinding::sqlite3session_changeset_inverted() {
+  jni::throwNewJavaException(UnsupportedOperationException::create().get());
+  return nullptr;
+}
+
+int NativeSessionBinding::sqlite3changeset_apply(
+    jni::alias_ref<NativeDatabaseBinding::javaobject> db,
+    jni::alias_ref<jni::JArrayByte> changeset) {
+  jni::throwNewJavaException(UnsupportedOperationException::create().get());
+  return -1;
+}
+
+jni::local_ref<jni::JArrayByte> NativeSessionBinding::sqlite3changeset_invert(
+    jni::alias_ref<jni::JArrayByte> changeset) {
+  jni::throwNewJavaException(UnsupportedOperationException::create().get());
+  return nullptr;
+}
+
+} // namespace expo

--- a/packages/expo-sqlite/android/src/main/cpp/libsql/NativeSessionBinding.h
+++ b/packages/expo-sqlite/android/src/main/cpp/libsql/NativeSessionBinding.h
@@ -1,0 +1,49 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <string>
+
+#include "NativeDatabaseBinding.h"
+
+namespace jni = facebook::jni;
+
+namespace expo {
+
+class NativeSessionBinding : public jni::HybridClass<NativeSessionBinding> {
+public:
+  static constexpr auto kJavaDescriptor =
+      "Lexpo/modules/sqlite/NativeSessionBinding;";
+
+  static void registerNatives();
+
+  // sqlite3session bindings
+  int sqlite3session_create(
+      jni::alias_ref<NativeDatabaseBinding::javaobject> db,
+      const std::string &dbName);
+  int sqlite3session_attach(jni::alias_ref<jni::JString> tableName);
+  int sqlite3session_enable(bool enabled);
+  void sqlite3session_delete();
+  jni::local_ref<jni::JArrayByte> sqlite3session_changeset();
+  jni::local_ref<jni::JArrayByte> sqlite3session_changeset_inverted();
+  int sqlite3changeset_apply(
+      jni::alias_ref<NativeDatabaseBinding::javaobject> db,
+      jni::alias_ref<jni::JArrayByte> changeset);
+  jni::local_ref<jni::JArrayByte>
+  sqlite3changeset_invert(jni::alias_ref<jni::JArrayByte> changeset);
+
+private:
+  explicit NativeSessionBinding(
+      jni::alias_ref<NativeSessionBinding::jhybridobject> jThis) {}
+
+private:
+  static jni::local_ref<jhybriddata>
+  initHybrid(jni::alias_ref<jhybridobject> jThis);
+
+private:
+  friend HybridBase;
+  friend NativeDatabaseBinding;
+};
+
+} // namespace expo

--- a/packages/expo-sqlite/android/src/main/cpp/libsql/SQLite3Main.cpp
+++ b/packages/expo-sqlite/android/src/main/cpp/libsql/SQLite3Main.cpp
@@ -3,11 +3,13 @@
 #include <fbjni/fbjni.h>
 
 #include "NativeDatabaseBinding.h"
+#include "NativeSessionBinding.h"
 #include "NativeStatementBinding.h"
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
   return facebook::jni::initialize(vm, [] {
     expo::NativeDatabaseBinding::registerNatives();
+    expo::NativeSessionBinding::registerNatives();
     expo::NativeStatementBinding::registerNatives();
   });
 }

--- a/packages/expo-sqlite/ios/SQLiteModuleLibSQL.swift
+++ b/packages/expo-sqlite/ios/SQLiteModuleLibSQL.swift
@@ -74,6 +74,15 @@ public final class SQLiteModule: Module {
       try ensureDatabasePathExists(path: databasePath)
     }
 
+    AsyncFunction("backupDatabaseAsync") { (_: NativeDatabase, _: String, _: NativeDatabase, _: String) in
+      throw UnsupportedOperationException()
+    }
+    Function("backupDatabaseSync") { (_: NativeDatabase, _: String, _: NativeDatabase, _: String) in
+      throw UnsupportedOperationException()
+    }
+
+    // MARK: - NativeDatabase
+
     // swiftlint:disable:next closure_body_length
     Class(NativeDatabase.self) {
       // swiftlint:disable:next closure_body_length
@@ -178,6 +187,13 @@ public final class SQLiteModule: Module {
         try prepareStatement(database: database, statement: statement, source: source)
       }
 
+      AsyncFunction("createSessionAsync") { (_: NativeDatabase, _: NativeSession, _: String) in
+        throw UnsupportedOperationException()
+      }
+      Function("createSessionSync") { (_: NativeDatabase, _: NativeSession, _: String) in
+        throw UnsupportedOperationException()
+      }
+
       AsyncFunction("syncLibSQL") { (database: NativeDatabase) in
         var errMsg: UnsafePointer<CChar>?
         if libsql_sync(database.pointer, &errMsg) != 0 {
@@ -186,6 +202,8 @@ public final class SQLiteModule: Module {
         }
       }
     }
+
+    // MARK: - NativeStatement
 
     // swiftlint:disable:next closure_body_length
     Class(NativeStatement.self) {
@@ -237,6 +255,64 @@ public final class SQLiteModule: Module {
       }
       Function("finalizeSync") { (statement: NativeStatement, database: NativeDatabase) in
         try finalize(statement: statement, database: database)
+      }
+    }
+
+    // MARK: - NativeSession
+
+    // swiftlint:disable:next closure_body_length
+    Class(NativeSession.self) {
+      Constructor {
+        return NativeSession()
+      }
+
+      AsyncFunction("attachAsync") { (_: NativeSession, _: NativeDatabase, _: String?) in
+        throw UnsupportedOperationException()
+      }
+      Function("attachSync") { (_: NativeSession, _: NativeDatabase, _: String?) in
+        throw UnsupportedOperationException()
+      }
+
+      AsyncFunction("enableAsync") { (_: NativeSession, _: NativeDatabase, _: Bool) in
+        throw UnsupportedOperationException()
+      }
+      Function("enableSync") { (_: NativeSession, _: NativeDatabase, _: Bool) in
+        throw UnsupportedOperationException()
+      }
+
+      AsyncFunction("closeAsync") { (_: NativeSession, _: NativeDatabase) in
+        throw UnsupportedOperationException()
+      }
+      Function("closeSync") { (_: NativeSession, _: NativeDatabase) in
+        throw UnsupportedOperationException()
+      }
+
+      AsyncFunction("createChangesetAsync") { (_: NativeSession, _: NativeDatabase) -> Data in
+        throw UnsupportedOperationException()
+      }
+      Function("createChangesetSync") { (_: NativeSession, _: NativeDatabase) -> Data in
+        throw UnsupportedOperationException()
+      }
+
+      AsyncFunction("createInvertedChangesetAsync") { (_: NativeSession, _: NativeDatabase) -> Data in
+        throw UnsupportedOperationException()
+      }
+      Function("createInvertedChangesetSync") { (_: NativeSession, _: NativeDatabase) -> Data in
+        throw UnsupportedOperationException()
+      }
+
+      AsyncFunction("applyChangesetAsync") { (_: NativeSession, _: NativeDatabase, _: Data) in
+        throw UnsupportedOperationException()
+      }
+      Function("applyChangesetSync") { (_: NativeSession, _: NativeDatabase, _: Data) in
+        throw UnsupportedOperationException()
+      }
+
+      AsyncFunction("invertChangesetAsync") { (_: NativeSession, _: NativeDatabase, _: Data) -> Data in
+        throw UnsupportedOperationException()
+      }
+      Function("invertChangesetSync") { (_: NativeSession, _: NativeDatabase, _: Data) -> Data in
+        throw UnsupportedOperationException()
       }
     }
   }


### PR DESCRIPTION
# Why

from #35459 and #35604, i didn't add corresponding api to libsql implementations. that might break libsql integration

# How

added api stubs to libsql implementations

# Test Plan

- ci passed
- use bare-expo to test the [libsql example](https://github.com/expo/examples/blob/master/with-libsql/App.tsx)

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
