### PR TITLE
[autolinking][Android] Handle `buildFromSource` field

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -31,6 +31,11 @@
         "flags": {
           "inhibit_warnings": false
         }
+      },
+      "android": {
+        "buildFromSource": [
+          ".*"
+        ]
       }
     }
   },

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/configuration/ExpoAutolinkingConfig.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/configuration/ExpoAutolinkingConfig.kt
@@ -9,7 +9,8 @@ import kotlinx.serialization.modules.SerializersModule
 data class ExpoAutolinkingConfig(
   val modules: List<ExpoModule> = emptyList(),
   val extraDependencies: List<MavenRepo> = emptyList(),
-  val coreFeatures: List<String> = emptyList()
+  val coreFeatures: List<String> = emptyList(),
+  val configuration: Configuration = Configuration()
 ) {
   /**
    * Returns all gradle projects from all modules.
@@ -52,6 +53,15 @@ data class ExpoAutolinkingConfig(
     fun decodeFromString(input: String): ExpoAutolinkingConfig {
       return jsonDecoder.decodeFromString(input)
     }
+  }
+}
+
+@Serializable
+data class Configuration(
+  val buildFromSource: List<String> = emptyList<String>()
+) {
+  val buildFromSourceRegex by lazy {
+    buildFromSource.map { it.toRegex() }
   }
 }
 

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
@@ -68,7 +68,11 @@ class SettingsManager(
   private fun configurePublication(config: ExpoAutolinkingConfig) {
     config.allProjects.forEach { project ->
       if (project.publication != null) {
-        project.configuration.shouldUsePublication = evaluateShouldUsePublicationScript(project)
+        val forceBuildFromSource = config.configuration.buildFromSourceRegex.any {
+          it.matches(project.name)
+        }
+
+        project.configuration.shouldUsePublication = !forceBuildFromSource && evaluateShouldUsePublicationScript(project)
       }
     }
   }


### PR DESCRIPTION
# Why

Follow up to the https://github.com/expo/expo/pull/35737.

# How

Handles `android.buildFromSource` field in the android part of the autolinking.

# Test Plan

- bare-expo ✅ 