### PR TITLE
[cli] Remove rawBody handling on /symbolicate endpoint

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Remove `rawBody` handling on `/symbolicate` endpoint. Clients MUST send the header `'Content-Type': 'application/json'`. ([#35757](https://github.com/expo/expo/pull/35757) by [@huntie](https://github.com/huntie))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -18,9 +18,6 @@ export function createMetroMiddleware(metroConfig: Pick<MetroConfig, 'projectRoo
     // Support opening stack frames from clients directly in the editor
     .use('/open-stack-frame', rawBodyMiddleware)
     .use('/open-stack-frame', metroOpenStackFrameMiddleware)
-    // Support the symbolication endpoint of Metro
-    // See: https://github.com/facebook/metro/blob/a792d85ffde3c21c3fbf64ac9404ab0afe5ff957/packages/metro/src/Server.js#L1266
-    .use('/symbolicate', rawBodyMiddleware)
     // Support status check to detect if the packager needs to be started from the native side
     .use('/status', createMetroStatusMiddleware(metroConfig));
 


### PR DESCRIPTION
# Why

This removes a longstanding hack that covered for a lack of JSON body parsing in Metro's `/symbolicate` endpoint. We're now resolving this in https://github.com/facebook/metro/pull/1475 — meaning this can be removed from Expo CLI.

Related PRs:

- https://github.com/react-native-community/cli/pull/2637
- https://github.com/facebook/react-native/pull/49042

# How

Delete interception of `/symbolicate` in Expo CLI middleware stack.

# Test Plan

- Link local `metro` into a local checkout of Expo via `yarn link`.
- `cd apps/bare-expo`
- `yarn ios`
- Open app, modified to throw an error on launch.

[Incoming]

> [!Important]
> We'll wait for the relevant release of Metro to land on `main` first. See @byCedric's comment below.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
