### PR TITLE
[keep-awake][android] Remove deactivation warning.

### DIFF
--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 💡 Others
 
+- [android] Remove deactivation warning. ([#35760](https://github.com/expo/expo/pull/35760) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
 
 ## 14.0.3 - 2025-02-19

--- a/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakeExceptions.kt
+++ b/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakeExceptions.kt
@@ -5,8 +5,5 @@ import expo.modules.kotlin.exception.CodedException
 internal class ActivateKeepAwakeException :
   CodedException("Unable to activate keep awake")
 
-internal class DeactivateKeepAwakeException :
-  CodedException("Unable to deactivate keep awake. However, it probably is deactivated already")
-
 internal class MissingModuleException(moduleName: String) :
   CodedException("Module '$moduleName' not found. Are you sure all modules are linked correctly?")

--- a/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakeModule.kt
+++ b/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakeModule.kt
@@ -16,7 +16,7 @@ class KeepAwakeModule : Module() {
 
     AsyncFunction("activate") { tag: String, promise: Promise ->
       try {
-        keepAwakeManager.activate(tag) { promise.resolve(true) }
+        keepAwakeManager.activate(tag) { promise.resolve() }
       } catch (ex: CurrentActivityNotFoundException) {
         promise.reject(ActivateKeepAwakeException())
       }
@@ -24,10 +24,8 @@ class KeepAwakeModule : Module() {
 
     AsyncFunction("deactivate") { tag: String, promise: Promise ->
       try {
-        keepAwakeManager.deactivate(tag) { promise.resolve(true) }
-      } catch (ex: CurrentActivityNotFoundException) {
-        promise.reject(DeactivateKeepAwakeException())
-      }
+        keepAwakeManager.deactivate(tag) { promise.resolve() }
+      } catch { promise.resolve() }
     }
 
     AsyncFunction<Boolean>("isActivated") {

--- a/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakeModule.kt
+++ b/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakeModule.kt
@@ -25,7 +25,9 @@ class KeepAwakeModule : Module() {
     AsyncFunction("deactivate") { tag: String, promise: Promise ->
       try {
         keepAwakeManager.deactivate(tag) { promise.resolve() }
-      } catch { promise.resolve() }
+      } catch (e: Exception) {
+        promise.resolve()
+      }
     }
 
     AsyncFunction<Boolean>("isActivated") {


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/35665#issuecomment-2755901954

# How

Aligned iOS and Android – I agree we can safely ignore deactivation errors. Also the promise returned value is not used anywhere and not reported in types.

# Test Plan

Tested if bare-expo still compiles.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
