### PR TITLE
[fix] allow `$schema` as top-level key in app.json

### DIFF
--- a/packages/@expo/config/CHANGELOG.md
+++ b/packages/@expo/config/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Allow `$schema` in `app.json` ([#35770](https://github.com/expo/expo/pull/35770) by [@typeofweb](https://github.com/typeofweb))
+
 ### 💡 Others
 
 ## 10.0.11 - 2025-03-11

--- a/packages/@expo/config/src/Config.ts
+++ b/packages/@expo/config/src/Config.ts
@@ -39,7 +39,7 @@ function reduceExpoObject(config?: any): SplitConfigs {
   if (!config) return config === undefined ? null : config;
 
   if (config.expo && !hasWarnedAboutRootConfig) {
-    const keys = Object.keys(config).filter((key) => key !== 'expo');
+    const keys = Object.keys(config).filter((key) => key !== 'expo' && key !== '$schema');
     if (keys.length) {
       hasWarnedAboutRootConfig = true;
       const ansiYellow = (str: string) => `\u001B[33m${str}\u001B[0m`;


### PR DESCRIPTION
# Why

Adding `$schema` field in the app.json file is extremely useful to validate and autocomplete properties:

```json
"$schema": "https://json.schemastore.org/expo-52.0.0.json",
```

Currently, doing so results in a warning, and it may feel counterintuitive as if the developer was doing something incorrectly.

# How

Allow `$schema` along with `metro`.

# Test Plan

…

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
