### PR TITLE
[docs] corrected path on internal link

### DIFF
--- a/docs/pages/router/basics/core-concepts.mdx
+++ b/docs/pages/router/basics/core-concepts.mdx
@@ -22,7 +22,7 @@ All pages have a URL path that matches the file's location in the **app** direct
 
 ### 3. First index.tsx is the initial route
 
-With Expo Router, you do not define an initial route or first screen in code. Rather, when you open your app, Expo Router will look for the first **index.tsx** file matching the `/` URL. This could be an **app/index.tsx** file, but it doesn't have to be. If the user should start by default in a deeper part of your navigation tree, you can use a [route group](/router/notation/parentheses) (a directory where the name is surrounded in parenthesis), and that will not count as part of the URL. If you want your first screen to be a group of tabs, you might put all of the tab pages inside the **app/(tabs)** directory and define the default tab as **index.tsx**. With this arrangement, the `/` URL will take the user directly to **app/(tabs)/index.tsx** file.
+With Expo Router, you do not define an initial route or first screen in code. Rather, when you open your app, Expo Router will look for the first **index.tsx** file matching the `/` URL. This could be an **app/index.tsx** file, but it doesn't have to be. If the user should start by default in a deeper part of your navigation tree, you can use a [route group](/router/basics/notation/#parentheses) (a directory where the name is surrounded in parenthesis), and that will not count as part of the URL. If you want your first screen to be a group of tabs, you might put all of the tab pages inside the **app/(tabs)** directory and define the default tab as **index.tsx**. With this arrangement, the `/` URL will take the user directly to **app/(tabs)/index.tsx** file.
 
 ### 4. Root \_layout.tsx replaces App.jsx/tsx
 


### PR DESCRIPTION
# Why

A 404 Not Found error was discovered due to incorrect internal links in the documentation.

# How

I updated the internal links to point to the correct absolute paths. I ran the docs locally in development mode and confirmed that updated link `/router/basics/notation/#parentheses` now respond correctly.

# Test Plan

<img width="762" alt="image" src="https://github.com/user-attachments/assets/8ccd0afa-4047-4919-a658-13232a12071d" />

# Checklist
- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
