### PR TITLE
Updated `react-native-screens` from `4.9.2` to `4.10.0`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2894,7 +2894,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (4.9.2):
+  - RNScreens (4.10.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2918,9 +2918,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.9.2)
+    - RNScreens/common (= 4.10.0)
     - Yoga
-  - RNScreens/common (4.9.2):
+  - RNScreens/common (4.10.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3782,7 +3782,7 @@ SPEC CHECKSUMS:
   RNFlashList: 30b68f572400383347ce7df3777985af0d089624
   RNGestureHandler: ccf4105b125002bd88e39d2a1f2b7e6001bcdf34
   RNReanimated: fc1e35380ba37c5f28b83414be9850e4091efa76
-  RNScreens: 7298b3526f6aca5cd6f215f7ff48381568943769
+  RNScreens: c5c07a86e4088ce92f0d3854082250dfa9c61f75
   RNSVG: ee32efbed652c5151fd3f98bed13c68af285bc38
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -64,7 +64,7 @@
     "react-native-pager-view": "6.5.1",
     "react-native-reanimated": "3.17.1",
     "react-native-safe-area-context": "5.3.0",
-    "react-native-screens": "4.9.2",
+    "react-native-screens": "4.10.0",
     "react-native-svg": "15.11.2",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.13.5",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2694,7 +2694,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (4.9.2):
+  - RNScreens (4.10.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2718,9 +2718,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.9.2)
+    - RNScreens/common (= 4.10.0)
     - Yoga
-  - RNScreens/common (4.9.2):
+  - RNScreens/common (4.10.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -3492,7 +3492,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 80ea184ed6bf44139f383a8b0e248ba3ec1cc8c9
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: c75c0305485bcf52f89bd0a3aa41876d6e21e539
+  hermes-engine: 197827f1ec648b53dcdc503d7a1b3a7644f9b4cb
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
@@ -3585,7 +3585,7 @@ SPEC CHECKSUMS:
   RNFlashList: 30b68f572400383347ce7df3777985af0d089624
   RNGestureHandler: ccf4105b125002bd88e39d2a1f2b7e6001bcdf34
   RNReanimated: fc1e35380ba37c5f28b83414be9850e4091efa76
-  RNScreens: 7298b3526f6aca5cd6f215f7ff48381568943769
+  RNScreens: c5c07a86e4088ce92f0d3854082250dfa9c61f75
   RNSVG: ee32efbed652c5151fd3f98bed13c68af285bc38
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -77,7 +77,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "3.17.1",
     "react-native-safe-area-context": "5.3.0",
-    "react-native-screens": "4.9.2",
+    "react-native-screens": "4.10.0",
     "react-native-svg": "15.11.2",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.13.5",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -145,7 +145,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "3.17.1",
     "react-native-safe-area-context": "5.3.0",
-    "react-native-screens": "4.9.2",
+    "react-native-screens": "4.10.0",
     "react-native-svg": "15.11.2",
     "react-native-view-shot": "4.0.3",
     "react-native-web": "~0.19.13",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -32,7 +32,7 @@
     "react": "19.0.0",
     "react-native": "0.79.0-rc.3",
     "react-native-safe-area-context": "5.3.0",
-    "react-native-screens": "4.9.2",
+    "react-native-screens": "4.10.0",
     "react-native-webview": "13.13.5"
   },
   "devDependencies": {

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -17,7 +17,7 @@
     "react": "19.0.0",
     "react-native": "0.79.0-rc.3",
     "react-native-safe-area-context": "5.3.0",
-    "react-native-screens": "4.9.2"
+    "react-native-screens": "4.10.0"
   },
   "devDependencies": {
     "babel-preset-expo": "~12.0.0"

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -93,7 +93,7 @@
   "react-native-maps": "1.18.0",
   "react-native-pager-view": "6.5.1",
   "react-native-reanimated": "~3.17.1",
-  "react-native-screens": "~4.9.2",
+  "react-native-screens": "~4.10.0",
   "react-native-safe-area-context": "5.3.0",
   "react-native-svg": "15.11.2",
   "react-native-view-shot": "4.0.3",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -37,7 +37,7 @@
     "react-native-gesture-handler": "~2.24.0",
     "react-native-reanimated": "~3.17.1",
     "react-native-safe-area-context": "5.3.0",
-    "react-native-screens": "~4.9.2",
+    "react-native-screens": "~4.10.0",
     "react-native-web": "~0.19.13",
     "react-native-webview": "~13.13.2"
   },

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -30,7 +30,7 @@
     "react-native": "0.79.0-rc.3",
     "react-native-reanimated": "~3.17.1",
     "react-native-safe-area-context": "~5.3.0",
-    "react-native-screens": "~4.9.2",
+    "react-native-screens": "~4.10.0",
     "react-native-web": "~0.19.13"
   },
   "overrides": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13133,10 +13133,10 @@ react-native-safe-area-context@5.3.0:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.3.0.tgz#272e6786a58aafe3362fde4d3233713b66158179"
   integrity sha512-glV9bwuozTjf/JDBIBm+ITnukHNaUT3nucgdeADwjtHsfEN3RL5UO6nq99vvdWv5j/O9yCZBvFncM1BBQ+UvpQ==
 
-react-native-screens@4.9.2:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.9.2.tgz#40bb8a405997414e1258b51175662880f8588397"
-  integrity sha512-87gR7XRIirACYxtYltEl1BbUo5r0W4AFPckUDDzATAN6LIUZ2PC3bX6UAFeoEBEqBbfaemRZTWSYHl6MCZFSgw==
+react-native-screens@4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.10.0.tgz#40634aead590c6b7034ded6a9f92465d1d611906"
+  integrity sha512-Tw21NGuXm3PbiUGtZd0AnXirUixaAbPXDjNR0baBH7/WJDaDTTELLcQ7QRXuqAWbmr/EVCrKj1348ei1KFIr8A==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
# Why

Resolves ENG-15325

# How

Updated `react-native-screens` from `4.9.2` to `4.10.0`

# Test Plan

Bare Expo

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).