### PR TITLE
[docs] add compact mode for SidebarHeader

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -239,7 +239,7 @@ not appear on the screen.
           class="select-none mt-1"
         >
           <svg
-            class="translate-z icon-xs text-icon-secondary"
+            class="translate-z shrink-0 icon-xs text-icon-secondary"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -1128,7 +1128,7 @@ properties.
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -1331,7 +1331,7 @@ This should come from the user field of an
           class="select-none mt-1"
         >
           <svg
-            class="translate-z icon-xs text-icon-default"
+            class="translate-z shrink-0 icon-xs text-icon-default"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -1376,7 +1376,7 @@ This should come from the user field of an
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -1529,7 +1529,7 @@ value depending on the state of the credential.
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -1768,7 +1768,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -2065,7 +2065,7 @@ the user, since this remains the same for apps released by the same developer.
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -2350,7 +2350,7 @@ from using
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -2604,7 +2604,7 @@ sign-out operation.
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -2784,7 +2784,7 @@ which contains all of the pertinent user and credential information.
           class="select-none mt-1"
         >
           <svg
-            class="translate-z icon-xs text-icon-secondary"
+            class="translate-z shrink-0 icon-xs text-icon-secondary"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -3711,7 +3711,7 @@ may be
           class="select-none mt-1"
         >
           <svg
-            class="translate-z icon-xs text-icon-secondary"
+            class="translate-z shrink-0 icon-xs text-icon-secondary"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -3897,7 +3897,7 @@ You must include the ID string of the user whose credentials you'd like to refre
           class="select-none mt-1"
         >
           <svg
-            class="translate-z icon-xs text-icon-secondary"
+            class="translate-z shrink-0 icon-xs text-icon-secondary"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -4224,7 +4224,7 @@ None of these options are required.
           class="select-none mt-1"
         >
           <svg
-            class="translate-z icon-xs text-icon-secondary"
+            class="translate-z shrink-0 icon-xs text-icon-secondary"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -4571,7 +4571,7 @@ You must include the ID string of the user to sign out.
           class="select-none mt-1"
         >
           <svg
-            class="translate-z icon-xs text-icon-secondary"
+            class="translate-z shrink-0 icon-xs text-icon-secondary"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -5610,7 +5610,7 @@ After calling this function, the listener will no longer receive any events from
           class="select-none mt-1"
         >
           <svg
-            class="translate-z icon-xs text-icon-secondary"
+            class="translate-z shrink-0 icon-xs text-icon-secondary"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -6299,7 +6299,7 @@ for more details.
           class="select-none mt-1"
         >
           <svg
-            class="translate-z icon-xs text-icon-default"
+            class="translate-z shrink-0 icon-xs text-icon-default"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -6340,7 +6340,7 @@ You will still need to handle null values for any fields you request.
           class="select-none mt-1"
         >
           <svg
-            class="translate-z icon-xs text-icon-secondary"
+            class="translate-z shrink-0 icon-xs text-icon-secondary"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -6580,7 +6580,7 @@ for more details.
           class="select-none mt-1"
         >
           <svg
-            class="translate-z icon-xs text-icon-secondary"
+            class="translate-z shrink-0 icon-xs text-icon-secondary"
             fill="currentColor"
             role="img"
             viewBox="0 0 24 24"
@@ -6947,7 +6947,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -7231,7 +7231,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -7338,7 +7338,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="select-none mt-1"
             >
               <svg
-                class="translate-z icon-xs text-icon-default"
+                class="translate-z shrink-0 icon-xs text-icon-default"
                 fill="currentColor"
                 role="img"
                 viewBox="0 0 24 24"
@@ -7443,7 +7443,7 @@ a start date that is more than seven days in the past returns only the available
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -7586,7 +7586,7 @@ available on this device.
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -7802,7 +7802,7 @@ provided with a single argument that is
           class="flex flex-row items-center gap-2"
         >
           <svg
-            class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+            class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
             fill="none"
             role="img"
             stroke="currentColor"
@@ -7875,7 +7875,7 @@ provided with a single argument that is
               class="select-none mt-1"
             >
               <svg
-                class="translate-z icon-xs text-icon-default"
+                class="translate-z shrink-0 icon-xs text-icon-default"
                 fill="currentColor"
                 role="img"
                 viewBox="0 0 24 24"
@@ -8235,7 +8235,7 @@ On iOS, the
         class="flex flex-row items-center gap-2"
       >
         <svg
-          class="translate-z icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
+          class="translate-z shrink-0 icon-sm relative -mt-0.5 inline-block text-icon-tertiary"
           fill="none"
           role="img"
           stroke="currentColor"

--- a/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
+++ b/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
@@ -87,7 +87,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
           data-text="true"
         >
           <svg
-            class="translate-z icon-sm text-icon-secondary"
+            class="translate-z shrink-0 icon-sm text-icon-secondary"
             fill="none"
             role="img"
             stroke="currentColor"

--- a/docs/package.json
+++ b/docs/package.json
@@ -26,10 +26,10 @@
   },
   "packageManager": "yarn@4.7.0",
   "dependencies": {
-    "@expo/styleguide": "^9.0.5",
+    "@expo/styleguide": "^9.1.0",
     "@expo/styleguide-base": "^2.0.3",
-    "@expo/styleguide-icons": "^2.1.3",
-    "@expo/styleguide-search-ui": "^2.3.1",
+    "@expo/styleguide-icons": "^2.2.0",
+    "@expo/styleguide-search-ui": "^2.3.2",
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/mdx": "^3.1.0",
     "@mdx-js/react": "^3.1.0",

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="ml-1.5 mr-2 mt-[5px] self-baseline"
           >
             <svg
-              class="translate-z icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
+              class="translate-z shrink-0 icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -231,7 +231,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="ml-1.5 mr-2 mt-[5px] self-baseline"
           >
             <svg
-              class="translate-z icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
+              class="translate-z shrink-0 icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -307,7 +307,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="ml-1.5 mr-2 mt-[5px] self-baseline"
           >
             <svg
-              class="translate-z icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
+              class="translate-z shrink-0 icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
               fill="none"
               role="img"
               viewBox="0 0 24 24"
@@ -467,7 +467,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="ml-1.5 mr-2 mt-[5px] self-baseline"
             >
               <svg
-                class="translate-z icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
+                class="translate-z shrink-0 icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
                 fill="none"
                 role="img"
                 viewBox="0 0 24 24"
@@ -799,7 +799,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="ml-1.5 mr-2 mt-[5px] self-baseline"
           >
             <svg
-              class="translate-z icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
+              class="translate-z shrink-0 icon-sm text-icon-default -rotate-90 transition-transform duration-200 [details[open]>summary_&]:rotate-0"
               fill="none"
               role="img"
               viewBox="0 0 24 24"

--- a/docs/ui/components/Sidebar/SidebarHead.tsx
+++ b/docs/ui/components/Sidebar/SidebarHead.tsx
@@ -17,6 +17,8 @@ type SidebarHeadProps = {
 };
 
 export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
+  const isPreviewVisible = shouldShowFeaturePreviewLink();
+
   if (sidebarActiveGroup === 'archive') {
     return (
       <div className="flex flex-col gap-0.5 border-b border-default bg-default p-1.5">
@@ -38,7 +40,12 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
           'short:pb-3'
         )}>
         <Search />
-        <div className={mergeClasses('contents', 'short:grid short:grid-cols-5 short:gap-1')}>
+        <div
+          className={mergeClasses(
+            'contents',
+            'short:grid short:grid-cols-5 short:gap-1',
+            isPreviewVisible && 'short:grid-cols-6'
+          )}>
           <SidebarSingleEntry
             href="/"
             title="Home"
@@ -69,7 +76,7 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
             Icon={GraduationHat02DuotoneIcon}
             isActive={sidebarActiveGroup === 'learn'}
           />
-          {shouldShowFeaturePreviewLink() && (
+          {isPreviewVisible && (
             <SidebarSingleEntry
               href="/feature-preview/"
               title="Feature Preview"

--- a/docs/ui/components/Sidebar/SidebarHead.tsx
+++ b/docs/ui/components/Sidebar/SidebarHead.tsx
@@ -1,4 +1,4 @@
-import { DocsLogo, LinkBase } from '@expo/styleguide';
+import { DocsLogo, LinkBase, mergeClasses } from '@expo/styleguide';
 import { PlanEnterpriseIcon } from '@expo/styleguide-icons/custom/PlanEnterpriseIcon';
 import { BookOpen02DuotoneIcon } from '@expo/styleguide-icons/duotone/BookOpen02DuotoneIcon';
 import { GraduationHat02DuotoneIcon } from '@expo/styleguide-icons/duotone/GraduationHat02DuotoneIcon';
@@ -32,46 +32,52 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
 
   return (
     <>
-      <div className="flex flex-col gap-0.5 border-b border-default bg-default p-4">
+      <div
+        className={mergeClasses(
+          'flex flex-col gap-0.5 border-b border-default bg-default p-4',
+          'short:pb-3'
+        )}>
         <Search />
-        <SidebarSingleEntry
-          href="/"
-          title="Home"
-          Icon={Home02DuotoneIcon}
-          isActive={sidebarActiveGroup === 'home'}
-        />
-        <SidebarSingleEntry
-          href="/guides/overview/"
-          title="Guides"
-          Icon={BookOpen02DuotoneIcon}
-          isActive={sidebarActiveGroup === 'general'}
-        />
-        <SidebarSingleEntry
-          href="/eas/"
-          title="EAS"
-          Icon={PlanEnterpriseIcon}
-          isActive={sidebarActiveGroup === 'eas'}
-        />
-        <SidebarSingleEntry
-          href="/versions/latest/"
-          title="Reference"
-          Icon={DocsLogo}
-          isActive={sidebarActiveGroup === 'reference'}
-        />
-        <SidebarSingleEntry
-          href="/tutorial/overview/"
-          title="Learn"
-          Icon={GraduationHat02DuotoneIcon}
-          isActive={sidebarActiveGroup === 'learn'}
-        />
-        {shouldShowFeaturePreviewLink() && (
+        <div className={mergeClasses('contents', 'short:grid short:grid-cols-5 short:gap-1')}>
           <SidebarSingleEntry
-            href="/feature-preview/"
-            title="Feature Preview"
-            Icon={Stars02DuotoneIcon}
-            isActive={sidebarActiveGroup === 'featurePreview' || sidebarActiveGroup === 'preview'}
+            href="/"
+            title="Home"
+            Icon={Home02DuotoneIcon}
+            isActive={sidebarActiveGroup === 'home'}
           />
-        )}
+          <SidebarSingleEntry
+            href="/guides/overview/"
+            title="Guides"
+            Icon={BookOpen02DuotoneIcon}
+            isActive={sidebarActiveGroup === 'general'}
+          />
+          <SidebarSingleEntry
+            href="/eas/"
+            title="EAS"
+            Icon={PlanEnterpriseIcon}
+            isActive={sidebarActiveGroup === 'eas'}
+          />
+          <SidebarSingleEntry
+            href="/versions/latest/"
+            title="Reference"
+            Icon={DocsLogo}
+            isActive={sidebarActiveGroup === 'reference'}
+          />
+          <SidebarSingleEntry
+            href="/tutorial/overview/"
+            title="Learn"
+            Icon={GraduationHat02DuotoneIcon}
+            isActive={sidebarActiveGroup === 'learn'}
+          />
+          {shouldShowFeaturePreviewLink() && (
+            <SidebarSingleEntry
+              href="/feature-preview/"
+              title="Feature Preview"
+              Icon={Stars02DuotoneIcon}
+              isActive={sidebarActiveGroup === 'featurePreview' || sidebarActiveGroup === 'preview'}
+            />
+          )}
+        </div>
       </div>
       <ApiVersionSelect />
     </>

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -1,8 +1,8 @@
-import { mergeClasses } from '@expo/styleguide';
+import { LinkBase, mergeClasses } from '@expo/styleguide';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons/outline/ArrowUpRightIcon';
 import type { ComponentType, HTMLAttributes } from 'react';
 
-import { A } from '../Text';
+import * as Tooltip from '~/ui/components/Tooltip';
 
 type SidebarSingleEntryProps = {
   href: string;
@@ -24,25 +24,34 @@ export const SidebarSingleEntry = ({
   shouldLeakReferrer,
 }: SidebarSingleEntryProps) => {
   return (
-    <A
-      href={href}
-      className={mergeClasses(
-        'flex min-h-[32px] items-center gap-3 rounded-md px-2 py-1 text-sm !leading-[100%] text-secondary !opacity-100',
-        'hocus:bg-element',
-        'focus-visible:relative focus-visible:z-10',
-        secondary && 'text-xs',
-        isActive && 'bg-palette-blue3 font-medium text-link hocus:bg-palette-blue4 hocus:text-link'
-      )}
-      shouldLeakReferrer={shouldLeakReferrer}
-      isStyled>
-      <Icon
-        className={mergeClasses(
-          secondary ? 'icon-xs' : 'icon-sm',
-          isActive ? 'text-palette-blue11' : 'text-icon-tertiary'
-        )}
-      />
-      {title}
-      {isExternal && <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary" />}
-    </A>
+    <Tooltip.Root delayDuration={500} disableHoverableContent>
+      <Tooltip.Trigger asChild>
+        <LinkBase
+          href={href}
+          className={mergeClasses(
+            'flex min-h-[32px] items-center gap-3 rounded-md px-2 py-1 text-sm !leading-[100%] text-secondary',
+            'hocus:bg-element',
+            'focus-visible:relative focus-visible:z-10',
+            'short:justify-center short:bg-subtle',
+            secondary && 'text-xs',
+            isActive &&
+              '!bg-palette-blue3 font-medium text-link hocus:!bg-palette-blue4 hocus:text-link'
+          )}
+          {...(shouldLeakReferrer && { target: '_blank', referrerPolicy: 'origin' })}>
+          <Icon
+            className={mergeClasses(
+              'shrink-0',
+              secondary ? 'icon-xs' : 'icon-sm',
+              isActive ? 'text-palette-blue11' : 'text-icon-tertiary'
+            )}
+          />
+          <span className="short:hidden">{title}</span>
+          {isExternal && <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary" />}
+        </LinkBase>
+      </Tooltip.Trigger>
+      <Tooltip.Content side="bottom" className="z-50 hidden short:flex">
+        <span className="text-2xs text-secondary">{title}</span>
+      </Tooltip.Content>
+    </Tooltip.Root>
   );
 };

--- a/docs/ui/components/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
+++ b/docs/ui/components/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`TableOfContents correctly matches snapshot 1`] = `
       data-text="true"
     >
       <svg
-        class="text-icon-default translate-z icon-sm"
+        class="text-icon-default translate-z shrink-0 icon-sm"
         fill="none"
         role="img"
         stroke="currentColor"
@@ -39,7 +39,7 @@ exports[`TableOfContents correctly matches snapshot 1`] = `
         >
           <svg
             aria-label="Scroll to top"
-            class="translate-z icon-sm text-icon-secondary"
+            class="translate-z shrink-0 icon-sm text-icon-secondary"
             fill="none"
             role="img"
             stroke="currentColor"

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -505,23 +505,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/styleguide-icons@npm:^2.1.3":
-  version: 2.1.3
-  resolution: "@expo/styleguide-icons@npm:2.1.3"
+"@expo/styleguide-icons@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@expo/styleguide-icons@npm:2.2.0"
   dependencies:
     tailwind-merge: "npm:^2.5.4"
   peerDependencies:
     react: ">= 16"
-  checksum: 10c0/72eb1987b35aee6f50ed83135d4df35b6d58c752a1e317be354fdf2a7cd6cbe4c60d858c4acaf94863128588ae42f99955e5f5db9dc8261cecd674423298e6a4
+  checksum: 10c0/058085af3264149e1f842e003df3813f377f2b88b3b36b97d0e08c9f00bb76fc2a2b4274861a4bff88c1cf0277f556ecc3eb5b2a8953b8af0eb0bcbfaab94ce7
   languageName: node
   linkType: hard
 
-"@expo/styleguide-search-ui@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "@expo/styleguide-search-ui@npm:2.3.1"
+"@expo/styleguide-search-ui@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "@expo/styleguide-search-ui@npm:2.3.2"
   dependencies:
-    "@expo/styleguide": "npm:^9.0.5"
-    "@expo/styleguide-icons": "npm:^2.1.3"
+    "@expo/styleguide": "npm:^9.1.0"
+    "@expo/styleguide-icons": "npm:^2.2.0"
     "@sanity/client": "npm:^6.28.3"
     "@sanity/image-url": "npm:^1.1.0"
     cmdk: "npm:^0.2.1"
@@ -529,20 +529,20 @@ __metadata:
   peerDependencies:
     next: ">= 13"
     react: ">= 16"
-  checksum: 10c0/961caa6804d127ceb4c6edda43ca56d67ce915ae644ab25ef516c151f02c1815dcc257f6a2cff99ba39add6b255873cd4e9451248269349c9da74ef6b62a6cb3
+  checksum: 10c0/59571f247c37831a7bc5693dc17d83ae7e7ab3d07608400d4bf6ae407a99654fd50392bbe9534d0b2c72baf688945f9ac87c5856fdf1fccd79c6786d32913e88
   languageName: node
   linkType: hard
 
-"@expo/styleguide@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "@expo/styleguide@npm:9.0.5"
+"@expo/styleguide@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@expo/styleguide@npm:9.1.0"
   dependencies:
     "@expo/styleguide-base": "npm:^2.0.3"
     tailwind-merge: "npm:^2.5.4"
   peerDependencies:
     next: ">= 13"
     react: ">= 16"
-  checksum: 10c0/be3a5735d30a5a0d28f560f85dbc37bd36fb4197ee6ef0a7916718b649ee8f346128203a88cb9a601e8b43c60b080e5073a8f2df34ae7cc478592a541a2dacac
+  checksum: 10c0/8696b7c0d94377595da0902d9b06b7ecce5b11841a885cdc70aea061531ea2cda25c6da368c615012a6eb7b5d44057f2a4cd7ac0c7a62a0c77936bbcaee9910a
   languageName: node
   linkType: hard
 
@@ -5660,10 +5660,10 @@ __metadata:
   dependencies:
     "@apidevtools/json-schema-ref-parser": "npm:^11.7.3"
     "@expo/spawn-async": "npm:^1.7.2"
-    "@expo/styleguide": "npm:^9.0.5"
+    "@expo/styleguide": "npm:^9.1.0"
     "@expo/styleguide-base": "npm:^2.0.3"
-    "@expo/styleguide-icons": "npm:^2.1.3"
-    "@expo/styleguide-search-ui": "npm:^2.3.1"
+    "@expo/styleguide-icons": "npm:^2.2.0"
+    "@expo/styleguide-search-ui": "npm:^2.3.2"
     "@mdx-js/loader": "npm:^3.1.0"
     "@mdx-js/mdx": "npm:^3.1.0"
     "@mdx-js/react": "npm:^3.1.0"


### PR DESCRIPTION
# Why

It was reported that in certain situations, when user sticks to tiled window layout with small app windows the scrollable part of sidebar is become too small.

# How

Utilize new helper media query (from updated styleguide packages) which allow us to apply changes on shorter in height viewport windows, which will collapse the static part of sidebar (the Header) into row display with labels moved out into tooltips.

As a follow up, I will try to utilize the top bar section label (like we do currently for Archive) to further clarify for users in the compart header mode in which section of docs they are.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

https://github.com/user-attachments/assets/fe069e63-62eb-4636-a747-f961ab1b73c0

