### PR TITLE
[autolinking][Android] Introduce `useExpoVersionCatalog` and `reactNativeGradlePlugin`

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -173,15 +173,15 @@ dependencies {
 
     if (isGifEnabled) {
         // For animated gif support
-        implementation("com.facebook.fresco:animated-gif:${libs.versions.fresco.get()}")
+        implementation("com.facebook.fresco:animated-gif:${expoLibs.versions.fresco.get()}")
     }
 
     if (isWebpEnabled) {
         // For webp support
-        implementation("com.facebook.fresco:webpsupport:${libs.versions.fresco.get()}")
+        implementation("com.facebook.fresco:webpsupport:${expoLibs.versions.fresco.get()}")
         if (isWebpAnimatedEnabled) {
             // Animated webp support
-            implementation("com.facebook.fresco:animated-webp:${libs.versions.fresco.get()}")
+            implementation("com.facebook.fresco:animated-webp:${expoLibs.versions.fresco.get()}")
         }
     }
 

--- a/apps/bare-expo/android/settings.gradle
+++ b/apps/bare-expo/android/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
   def reactNativeGradlePlugin = new File(
     providers.exec {
       workingDir(rootDir)
-      commandLine("node", "--print", "require.resolve('@react-native/gradle-plugin/package.json')")
+      commandLine("node", "--print", "require.resolve('@react-native/gradle-plugin/package.json', { paths: [require.resolve('react-native/package.json')] })")
     }.standardOutput.asText.get().trim()
   ).getParentFile().absolutePath
   includeBuild(reactNativeGradlePlugin)

--- a/apps/bare-expo/android/settings.gradle
+++ b/apps/bare-expo/android/settings.gradle
@@ -1,5 +1,11 @@
 pluginManagement {
-  includeBuild(new File(["node", "--print", "require.resolve('@react-native/gradle-plugin/package.json')"].execute(null, rootDir).text.trim()).getParentFile().toString())
+  def reactNativeGradlePlugin = new File(
+    providers.exec {
+      workingDir(rootDir)
+      commandLine("node", "--print", "require.resolve('@react-native/gradle-plugin/package.json')")
+    }.standardOutput.asText.get().trim()
+  ).getParentFile().absolutePath
+  includeBuild(reactNativeGradlePlugin)
 
   def expoPluginsPath = new File(
     providers.exec {
@@ -10,6 +16,7 @@ pluginManagement {
   ).absolutePath
   includeBuild(expoPluginsPath)
 }
+
 plugins {
   id("com.facebook.react.settings")
   id("expo-autolinking-settings")
@@ -22,43 +29,10 @@ expoAutolinking.useExpoModules()
 
 rootProject.name = 'BareExpo'
 
-def reactNativePackage = providers.exec {
-  workingDir(rootDir)
-  commandLine("node", "--print", "require.resolve('react-native/package.json')")
-}.standardOutput.asText.get().trim()
-
-dependencyResolutionManagement {
-  versionCatalogs {
-    libs {
-      from(files(new File(reactNativePackage, "../gradle/libs.versions.toml")))
-      if (hasProperty('android.buildToolsVersion')) {
-        version("buildTools", findProperty('android.buildToolsVersion'))
-      }
-      if (hasProperty('android.minSdkVersion')) {
-        version("minSdk", findProperty('android.minSdkVersion'))
-      }
-      if (hasProperty('android.compileSdkVersion')) {
-        version("compileSdk", findProperty('android.compileSdkVersion'))
-      }
-      if (hasProperty('android.targetSdkVersion')) {
-        version("targetSdk", findProperty('android.targetSdkVersion'))
-      }
-      if (hasProperty('android.kotlinVersion')) {
-        version("kotlin", findProperty('android.kotlinVersion'))
-      }
-    }
-  }
-}
+expoAutolinking.useExpoVersionCatalog()
 
 include(":expo-modules-test-core")
 project(":expo-modules-test-core").projectDir = new File("../../../packages/expo-modules-test-core/android")
 
 include ':app'
-includeBuild(
-  file(
-    providers.exec {
-      workingDir(rootDir)
-      commandLine("node", "--print", "require.resolve('@react-native/gradle-plugin/package.json')")
-    }.standardOutput.asText.get().trim()
-  ).getParentFile()
-)
+includeBuild(expoAutolinking.reactNativeGradlePlugin)

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Added `coreFeatures` field. ([#34015](https://github.com/expo/expo/pull/34015) by [@lukmccall](https://github.com/lukmccall))
 - Add macOS support. ([#35065](https://github.com/expo/expo/pull/35065) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [Android] Added `expoAutolinking.useExpoVersionCatalog` and `expoAutolinking.reactNativeGradlePlugin`.
+- [Android] Added `expoAutolinking.useExpoVersionCatalog` and `expoAutolinking.reactNativeGradlePlugin`. ([#35789](https://github.com/expo/expo/pull/35789) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Added `coreFeatures` field. ([#34015](https://github.com/expo/expo/pull/34015) by [@lukmccall](https://github.com/lukmccall))
 - Add macOS support. ([#35065](https://github.com/expo/expo/pull/35065) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Android] Added `expoAutolinking.useExpoVersionCatalog` and `expoAutolinking.reactNativeGradlePlugin`.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsExtension.kt
@@ -1,8 +1,18 @@
 package expo.modules.plugin
 
+import org.gradle.api.Action
 import org.gradle.api.initialization.Settings
+import org.gradle.api.initialization.dsl.VersionCatalogBuilder
+import org.gradle.api.model.ObjectFactory
+import java.io.File
+import javax.inject.Inject
 
-open class ExpoAutolinkingSettingsExtension(val settings: Settings) {
+open class ExpoAutolinkingSettingsExtension(
+  val settings: Settings,
+  @Inject val objects: ObjectFactory
+) {
+
+
   /**
    * Command that should be provided to `react-native` to resolve the configuration.
    */
@@ -28,6 +38,30 @@ open class ExpoAutolinkingSettingsExtension(val settings: Settings) {
   var exclude: List<String>? = null
 
   /**
+   * The file pointing to the React Native Gradle plugin.
+   */
+  val reactNativeGradlePlugin: File by lazy {
+    File(
+      settings.providers.exec { env ->
+        env.workingDir(settings.rootDir)
+        env.commandLine("node", "--print", "require.resolve('@react-native/gradle-plugin/package.json')")
+      }.standardOutput.asText.get().trim(),
+    ).parentFile
+  }
+
+  /**
+   * The file pointing to the React Native root directory.
+   */
+  val reactNative: File by lazy {
+    File(
+      settings.providers.exec { env ->
+        env.workingDir(settings.rootDir)
+        env.commandLine("node", "--print", "require.resolve('react-native/package.json')")
+      }.standardOutput.asText.get().trim(),
+    ).parentFile
+  }
+
+  /**
    * Uses Expo modules autolinking.
    */
   fun useExpoModules() {
@@ -37,5 +71,61 @@ open class ExpoAutolinkingSettingsExtension(val settings: Settings) {
       ignorePaths,
       exclude
     ).useExpoModules()
+  }
+
+  fun useExpoVersionCatalog() {
+    useExpoVersionCatalog(
+      reactNativeVersionCatalog = null,
+      override = null
+    )
+  }
+
+  fun useExpoVersionCatalog(
+    override: Action<in VersionCatalogBuilder>
+  ) {
+    useExpoVersionCatalog(
+      reactNativeVersionCatalog = null,
+      override = override
+    )
+  }
+
+  fun useExpoVersionCatalog(
+    reactNativeVersionCatalog: String?,
+    override: Action<in VersionCatalogBuilder>?
+  ) {
+    val baseFile = if (reactNativeVersionCatalog != null) {
+      File(reactNativeVersionCatalog)
+    } else {
+      File(
+        reactNative,
+        "gradle/libs.versions.toml"
+      )
+    }
+
+    val catalogFile = objects.fileCollection().from(baseFile)
+
+    val properties = listOf(
+      "android.buildToolsVersion" to "buildTools",
+      "android.minSdkVersion" to "minSdk",
+      "android.compileSdkVersion" to "compileSdk",
+      "android.targetSdkVersion" to "targetSdk",
+      "android.kotlinVersion" to "kotlin"
+    )
+
+    settings.dependencyResolutionManagement {
+      it.versionCatalogs { spec ->
+        spec.create("expoLibs") { catalog ->
+          catalog.from(catalogFile)
+          properties.forEach { (propertyName, name) ->
+            val property = settings.providers.gradleProperty(propertyName)
+            if (property.isPresent) {
+              catalog.version(name, property.get())
+            }
+          }
+
+          override?.execute(catalog)
+        }
+      }
+    }
   }
 }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsExtension.kt
@@ -42,7 +42,7 @@ open class ExpoAutolinkingSettingsExtension(
     File(
       settings.providers.exec { env ->
         env.workingDir(settings.rootDir)
-        env.commandLine("node", "--print", "require.resolve('@react-native/gradle-plugin/package.json')")
+        env.commandLine("node", "--print", "require.resolve('@react-native/gradle-plugin/package.json', { paths: [require.resolve('react-native/package.json')] })")
       }.standardOutput.asText.get().trim(),
     ).parentFile
   }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsExtension.kt
@@ -11,8 +11,6 @@ open class ExpoAutolinkingSettingsExtension(
   val settings: Settings,
   @Inject val objects: ObjectFactory
 ) {
-
-
   /**
    * Command that should be provided to `react-native` to resolve the configuration.
    */


### PR DESCRIPTION
# Why

Adds `expoAutolinking.useExpoVersionCatalog` and `expoAutolinking.reactNativeGradlePlugin`.

# How

I've started updating our bare template and I've decided to clean the `setting.gradle` file to reduce configuration.

# Test Plan

- bare-expo ✅ 