### PR TITLE
Add note about unstable_enablePackageExports in monorepo docs

### DIFF
--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -92,6 +92,9 @@ config.resolver.nodeModulesPaths = [
   path.resolve(monorepoRoot, 'node_modules'),
 ];
 
+// If you are using named package exports, make sure to turn on unstable_enablePackageExports
+// config.resolver.unstable_enablePackageExports = true;
+
 module.exports = config;
 ```
 


### PR DESCRIPTION
# Why

I found it helpful to add a note about using `unstable_enablePackageExports` when working with monorepo packages which use package exports.

# Test Plan

Docs only change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
