### PR TITLE
[docs] Fix theme selection on touch events

### DIFF
--- a/docs/ui/components/Select.tsx
+++ b/docs/ui/components/Select.tsx
@@ -80,11 +80,15 @@ export function Select({
       </SelectPrimitive.Trigger>
       <SelectPrimitive.Portal>
         <SelectPrimitive.Content
-          ref={ref =>
+          ref={ref => {
             ref?.addEventListener('touchend', event => {
-              event.preventDefault();
-            })
-          }
+              const target = event.target as HTMLElement;
+              const isSelectItem = target.closest('[role="option"]');
+              if (!isSelectItem) {
+                event.preventDefault();
+              }
+            });
+          }}
           // z-[605] to be above the dialogs (601)
           className={mergeClasses(
             'relative z-[605] max-w-[87.5vw] overflow-hidden rounded-md border border-default bg-overlay shadow-md',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, on mobile views, the theme selector does not allow switching to a different theme when using a touch event:


https://github.com/user-attachments/assets/e292e9b5-fdfe-4741-ba54-d5f01c5dab5e



# How

<!--
How did you build this feature or fix this bug and why?
-->

Previously, the component was unconditionally calling `event.preventDefault()` on all touch events, which prevented the selection of themes on mobile devices.  The updated implementation maintains the original behavior for non-interactive areas of the dropdown while allowing selections to work as expected.

- Modified the touch event handling in the Select component to conditionally apply `preventDefault()` only when necessary.
- The event listener now checks if a touch is occurring on a selectable option (`[role="option"]`).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

## Preview


https://github.com/user-attachments/assets/d58569d4-caa0-4f50-9595-df5a2b21d733


https://github.com/user-attachments/assets/d6afb1ba-df45-4161-b267-e9d148c51f3d



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
