### PR TITLE
[docs] Improve Terminal component mobile usability in Prerequisites component

### DIFF
--- a/docs/ui/components/Prerequisites/Requirement.tsx
+++ b/docs/ui/components/Prerequisites/Requirement.tsx
@@ -10,7 +10,7 @@ export function Requirement({ title, number, children }: RequirementProps) {
   return (
     <div className={mergeClasses('flex gap-1.5 border-t border-default p-5')}>
       <p className="mb-2 text-right font-medium">{number}.</p>
-      <div className="flex-1">
+      <div className="flex-1 overflow-hidden">
         <p className="mb-2 font-medium">{title}</p>
         <div className={mergeClasses('last:[&>*]:!mb-0 [&_p]:ml-0 [&_pre>pre]:mt-0')}>
           {children}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15238

![CleanShot 2025-03-31 at 18 02 11@2x](https://github.com/user-attachments/assets/30837c24-0e79-4579-bb62-0fc1a1ed6b9a)


# How

<!--
How did you build this feature or fix this bug and why?
-->

- Added overflow-hidden to the content container in `Requirement` component so that the text and contents of a requirement do not overflow on mobile views.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

The changes have been reviewed by running the docs app locally. All lint checks and tests are passing.

## Preview

![CleanShot 2025-03-31 at 18 03 26@2x](https://github.com/user-attachments/assets/d8538f7f-47ae-4199-bf14-7ff055e19552)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
