### PR TITLE
[docs] remove no longer wanted Radix Select workaround

### DIFF
--- a/docs/ui/components/Select.tsx
+++ b/docs/ui/components/Select.tsx
@@ -80,11 +80,6 @@ export function Select({
       </SelectPrimitive.Trigger>
       <SelectPrimitive.Portal>
         <SelectPrimitive.Content
-          ref={ref =>
-            ref?.addEventListener('touchend', event => {
-              event.preventDefault();
-            })
-          }
           // z-[605] to be above the dialogs (601)
           className={mergeClasses(
             'relative z-[605] max-w-[87.5vw] overflow-hidden rounded-md border border-default bg-overlay shadow-md',


### PR DESCRIPTION
# Why

Supersedes:
* https://github.com/expo/expo/pull/35793

# How

Remove the workaround we have in code for bug in previous Radix Select version, which after update broke the item selection on mobile, see:
* https://github.com/radix-ui/primitives/issues/1658

# Test Plan

The changes have been tested by running docs app locally, and visiting it on my real mobile device connected to the same local network.

# Preview

https://github.com/user-attachments/assets/6dbd71e6-e5e2-4852-a618-aaa4e570a79d
