### PR TITLE
[docs] clarify where Node install is required when using bun

### DIFF
--- a/docs/pages/guides/using-bun.mdx
+++ b/docs/pages/guides/using-bun.mdx
@@ -9,6 +9,8 @@ import { Terminal } from '~/ui/components/Snippet';
 
 ## Prerequisites
 
+> While Bun replaces Node.js for most uses in your project, at this time, a [Node.js LTS version](https://nodejs.org/) is still required to be installed for the `bun create expo` and `bun expo prebuild` commands, as those commands use `npm pack` to download project templates.
+
 To create a new app using Bun, [install Bun on your local machine](https://bun.sh/docs/installation#installing).
 
 ## Start a new Expo project with Bun

--- a/docs/pages/guides/using-bun.mdx
+++ b/docs/pages/guides/using-bun.mdx
@@ -9,7 +9,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 ## Prerequisites
 
-> While Bun replaces Node.js for most uses in your project, at this time, a [Node.js LTS version](https://nodejs.org/) is still required to be installed for the `bun create expo` and `bun expo prebuild` commands, as those commands use `npm pack` to download project templates.
+> **Note:** While Bun replaces Node.js for most use cases in your project, at this time, a [Node.js LTS version](https://nodejs.org/) is still required to be installed for the `bun create expo` and `bun expo prebuild` commands. These commands use `npm pack` to download project templates.
 
 To create a new app using Bun, [install Bun on your local machine](https://bun.sh/docs/installation#installing).
 


### PR DESCRIPTION
# Why
As noted in #31682, despite Bun being a drop-in replacement for Node.js, some commands don't work with _only_ bun installed. 

I'm opening an internal issue to see what our long-term options are. I don't expect it's a quick fix to change the uses of `npm pack` to make everything work only with Bun, so a note is warranted. 

# How

Added a note in the prerequisites to clarify the situation

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
