### PR TITLE
[web][video] Add support for loading subtitle tracks from external source

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [Android][iOS] Add caching functionality. ([#31781](https://github.com/expo/expo/pull/31781) by [@behenate](https://github.com/behenate))
 - Add `onFirstFrameRender` event to the `VideoView`. ([#35346](https://github.com/expo/expo/pull/35346) by [@behenate](https://github.com/behenate))
 - Add `useExoShutter` property to the `VideoView`. ([#35366](https://github.com/expo/expo/pull/35366) by [@behenate](https://github.com/behenate))
+- [Web] Add support for loading subtitle tracks from external source. ([#35808](https://github.com/expo/expo/pull/35808) by [@Fausto95](https://github.com/Fausto95))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-video/src/VideoPlayer.types.ts
+++ b/packages/expo-video/src/VideoPlayer.types.ts
@@ -162,6 +162,7 @@ export declare class VideoPlayer extends SharedObject<VideoPlayerEvents> {
    * @default null
    * @platform android
    * @platform ios
+   * @platform web
    */
   subtitleTrack: SubtitleTrack | null;
 
@@ -170,6 +171,7 @@ export declare class VideoPlayer extends SharedObject<VideoPlayerEvents> {
    *
    * @platform android
    * @platform ios
+   * @platform web
    */
   readonly availableSubtitleTracks: SubtitleTrack[];
 
@@ -482,6 +484,12 @@ export type SubtitleTrack = {
    * Label of the subtitle track in the language of the device.
    */
   label: string;
+
+  /**
+   * URI to the subtitle file (WebVTT, SRT, etc.).
+   * If not provided, subtitles will be extracted from the video container.
+   */
+  uri?: string;
 };
 
 /**

--- a/packages/expo-video/src/VideoView.web.tsx
+++ b/packages/expo-video/src/VideoView.web.tsx
@@ -163,6 +163,35 @@ export const VideoView = forwardRef((props: { player?: VideoPlayer } & VideoView
     }
   }
 
+  function renderSubtitleTracks() {
+    if (
+      !props.player?.availableSubtitleTracks ||
+      props.player.availableSubtitleTracks.length === 0
+    ) {
+      return null;
+    }
+
+    return props.player.availableSubtitleTracks.map((track) => {
+      const trackSrc = track.uri || '';
+
+      if (!trackSrc) {
+        return null;
+      }
+
+      return (
+        <track
+          key={track.id}
+          id={track.id}
+          kind="subtitles"
+          src={trackSrc}
+          srcLang={track.language}
+          label={track.label}
+          default={props.player?.subtitleTrack?.id === track.id}
+        />
+      );
+    });
+  }
+
   useEffect(() => {
     if (videoRef.current) {
       props.player?.mountVideoView(videoRef.current);
@@ -205,8 +234,9 @@ export const VideoView = forwardRef((props: { player?: VideoPlayer } & VideoView
         }
       }}
       disablePictureInPicture={!props.allowsPictureInPicture}
-      src={getSourceUri(props.player?.src) ?? ''}
-    />
+      src={getSourceUri(props.player?.src) ?? ''}>
+      {renderSubtitleTracks()}
+    </video>
   );
 });
 

--- a/packages/expo-video/src/VideoView.web.tsx
+++ b/packages/expo-video/src/VideoView.web.tsx
@@ -163,33 +163,22 @@ export const VideoView = forwardRef((props: { player?: VideoPlayer } & VideoView
     }
   }
 
-  function renderSubtitleTracks() {
-    if (
-      !props.player?.availableSubtitleTracks ||
-      props.player.availableSubtitleTracks.length === 0
-    ) {
+  function renderSubtitleTrack() {
+    if (!props.player?.subtitleTrack) {
       return null;
     }
 
-    return props.player.availableSubtitleTracks.map((track) => {
-      const trackSrc = track.uri || '';
-
-      if (!trackSrc) {
-        return null;
-      }
-
-      return (
-        <track
-          key={track.id}
-          id={track.id}
-          kind="subtitles"
-          src={trackSrc}
-          srcLang={track.language}
-          label={track.label}
-          default={props.player?.subtitleTrack?.id === track.id}
-        />
-      );
-    });
+    return (
+      <track
+        key={props.player.subtitleTrack.id}
+        id={props.player.subtitleTrack.id}
+        kind="subtitles"
+        src={props.player.subtitleTrack.uri}
+        srcLang={props.player.subtitleTrack.language}
+        label={props.player.subtitleTrack.label}
+        default
+      />
+    );
   }
 
   useEffect(() => {
@@ -235,7 +224,7 @@ export const VideoView = forwardRef((props: { player?: VideoPlayer } & VideoView
       }}
       disablePictureInPicture={!props.allowsPictureInPicture}
       src={getSourceUri(props.player?.src) ?? ''}>
-      {renderSubtitleTracks()}
+      {renderSubtitleTrack()}
     </video>
   );
 });


### PR DESCRIPTION
# Why

[Feature request](https://expo.canny.io/feature-requests/p/expo-video-web-support-for-subtitle-tracks-1)

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds support for loading subtitle tracks from external source by mapping over the list of `availableSubtitleTracks` from the `player` and rendering them inside the `video` tag.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I actually couldn't find a way to test this, because all of the current video sources do not have subtitles, how should I do it?

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
