### PR TITLE
[updates] Migrate `IUpdatesController` to use coroutines

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -26,11 +26,18 @@ import expo.modules.updates.procedures.StartupProcedure
 import expo.modules.updates.selectionpolicy.SelectionPolicyFactory
 import expo.modules.updates.statemachine.UpdatesStateMachine
 import expo.modules.updates.statemachine.UpdatesStateValue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.io.File
 import java.lang.ref.WeakReference
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -52,8 +59,10 @@ class EnabledUpdatesController(
     updatesConfiguration.getRuntimeVersion()
   )
   private val stateMachine = UpdatesStateMachine(logger, eventManager, UpdatesStateValue.entries.toSet())
-  private val databaseHolder = DatabaseHolder(UpdatesDatabase.getInstance(context))
   private val controllerScope = CoroutineScope(Dispatchers.IO)
+  private val databaseHolder = DatabaseHolder(UpdatesDatabase.getInstance(context, Dispatchers.IO))
+  private val startupFinishedDeferred = CompletableDeferred<Unit>()
+  private val startupFinishedMutex = Mutex()
 
   private fun purgeUpdatesLogsOlderThanOneDay() {
     UpdatesLogReader(context.filesDir).purgeLogEntries {
@@ -70,9 +79,15 @@ class EnabledUpdatesController(
 
   @Synchronized
   private fun onStartupProcedureFinished() {
+    controllerScope.launch {
+      startupFinishedMutex.withLock {
+        if (!startupFinishedDeferred.isCompleted) {
+          startupFinishedDeferred.complete(Unit)
+        }
+      }
+    }
     isStartupFinished = true
     startupEndTimeMillis = System.currentTimeMillis()
-    (this@EnabledUpdatesController as java.lang.Object).notify()
   }
 
   private val startupProcedure = StartupProcedure(
@@ -103,18 +118,14 @@ class EnabledUpdatesController(
   private val localAssetFiles
     get() = startupProcedure.localAssetFiles
 
-  @get:Synchronized
   override val launchAssetFile: String?
     get() {
-      while (!isStartupFinished) {
-        try {
-          (this as java.lang.Object).wait()
-        } catch (e: InterruptedException) {
-          logger.error("Interrupted while waiting for launch asset file", e, UpdatesErrorCode.InitializationError)
-        }
+      runBlocking {
+        startupFinishedDeferred.await()
       }
       return startupProcedure.launchAssetFile
     }
+
   override val bundleAssetName: String?
     get() = startupProcedure.bundleAssetName
 
@@ -187,41 +198,41 @@ class EnabledUpdatesController(
     )
   }
 
-  override fun relaunchReactApplicationForModule(callback: IUpdatesController.ModuleCallback<Unit>) {
+  override suspend fun relaunchReactApplicationForModule() = suspendCancellableCoroutine { continuation ->
     val canRelaunch = launchedUpdate != null
     if (!canRelaunch) {
-      callback.onFailure(object : CodedException("ERR_UPDATES_RELOAD", "Cannot relaunch without a launched update.", null) {})
+      continuation.resumeWithException(object : CodedException("ERR_UPDATES_RELOAD", "Cannot relaunch without a launched update.", null) {})
     } else {
       relaunchReactApplication(
         shouldRunReaper = true,
         object : LauncherCallback {
           override fun onFailure(e: Exception) {
-            callback.onFailure(e.toCodedException())
+            continuation.resumeWithException(e.toCodedException())
           }
 
           override fun onSuccess() {
-            callback.onSuccess(Unit)
+            continuation.resume(Unit)
           }
         }
       )
     }
   }
 
-  override fun checkForUpdate(callback: IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult>) {
+  override suspend fun checkForUpdate() = suspendCancellableCoroutine { continuation ->
     val procedure = CheckForUpdateProcedure(context, updatesConfiguration, databaseHolder, logger, fileDownloader, selectionPolicy, launchedUpdate) {
-      callback.onSuccess(it)
+      continuation.resume(it)
     }
     stateMachine.queueExecution(procedure)
   }
 
-  override fun fetchUpdate(callback: IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult>) {
+  override suspend fun fetchUpdate() = suspendCancellableCoroutine { continuation ->
     val procedure = FetchUpdateProcedure(context, updatesConfiguration, logger, databaseHolder, updatesDirectory, fileDownloader, selectionPolicy, launchedUpdate) {
-      callback.onSuccess(it)
+      continuation.resume(it)
     }
     stateMachine.queueExecution(procedure)
   }
 
-  override fun getExtraParams(callback: IUpdatesController.ModuleCallback<Bundle>) {
+  override suspend fun getExtraParams() = suspendCancellableCoroutine { continuation ->
     controllerScope.launch {
       try {
         val result = ManifestMetadata.getExtraParams(
@@ -239,17 +250,17 @@ class EnabledUpdatesController(
             }
           }
         }
-        callback.onSuccess(resultMap)
+        continuation.resume(resultMap)
       } catch (e: Exception) {
         databaseHolder.releaseDatabase()
-        callback.onFailure(e.toCodedException())
+        continuation.resumeWithException(e.toCodedException())
       }
     }
   }
 
-  override fun setExtraParam(key: String, value: String?, callback: IUpdatesController.ModuleCallback<Unit>) {
+  override suspend fun setExtraParam(key: String, value: String?) = suspendCancellableCoroutine { continuation ->
     controllerScope.launch {
-      try {
+      runCatching {
         ManifestMetadata.setExtraParam(
           databaseHolder.database,
           updatesConfiguration,
@@ -257,10 +268,10 @@ class EnabledUpdatesController(
           value
         )
         databaseHolder.releaseDatabase()
-        callback.onSuccess(Unit)
-      } catch (e: Exception) {
+        continuation.resume(Unit)
+      }.onFailure { e ->
         databaseHolder.releaseDatabase()
-        callback.onFailure(e.toCodedException())
+        continuation.resumeWithException(e.toCodedException())
       }
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
@@ -3,7 +3,6 @@ package expo.modules.updates
 import android.os.Bundle
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
-import expo.modules.kotlin.exception.CodedException
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.events.IUpdatesEventManager
@@ -62,11 +61,6 @@ interface IUpdatesController {
    * the application's lifecycle.
    */
   fun start()
-
-  interface ModuleCallback<T> {
-    fun onSuccess(result: T)
-    fun onFailure(exception: CodedException)
-  }
 
   data class UpdatesModuleConstants(
     val launchedUpdate: UpdateEntity?,
@@ -130,8 +124,6 @@ interface IUpdatesController {
   }
   fun getConstantsForModule(): UpdatesModuleConstants
 
-  fun relaunchReactApplicationForModule(callback: ModuleCallback<Unit>)
-
   sealed class CheckForUpdateResult(private val status: Status) {
     private enum class Status {
       NO_UPDATE_AVAILABLE,
@@ -145,7 +137,6 @@ interface IUpdatesController {
     class RollBackToEmbedded(val commitTime: Date) : CheckForUpdateResult(Status.ROLL_BACK_TO_EMBEDDED)
     class ErrorResult(val error: Exception) : CheckForUpdateResult(Status.ERROR)
   }
-  fun checkForUpdate(callback: ModuleCallback<CheckForUpdateResult>)
 
   sealed class FetchUpdateResult(private val status: Status) {
     private enum class Status {
@@ -160,11 +151,16 @@ interface IUpdatesController {
     class RollBackToEmbedded : FetchUpdateResult(Status.ROLL_BACK_TO_EMBEDDED)
     class ErrorResult(val error: Exception) : FetchUpdateResult(Status.ERROR)
   }
-  fun fetchUpdate(callback: ModuleCallback<FetchUpdateResult>)
 
-  fun getExtraParams(callback: ModuleCallback<Bundle>)
+  suspend fun relaunchReactApplicationForModule()
 
-  fun setExtraParam(key: String, value: String?, callback: ModuleCallback<Unit>)
+  suspend fun checkForUpdate(): CheckForUpdateResult
+
+  suspend fun fetchUpdate(): FetchUpdateResult
+
+  suspend fun getExtraParams(): Bundle
+
+  suspend fun setExtraParam(key: String, value: String?)
 
   fun setUpdateURLAndRequestHeadersOverride(configOverride: UpdatesConfigurationOverride?)
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -29,9 +29,12 @@ import expo.modules.updates.selectionpolicy.SelectionPolicyFactory
 import expo.modules.updates.statemachine.UpdatesStateContext
 import expo.modules.updatesinterface.UpdatesInterface
 import expo.modules.updatesinterface.UpdatesInterfaceCallbacks
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.json.JSONObject
 import java.io.File
 import java.lang.ref.WeakReference
+import kotlin.coroutines.resume
 
 /**
  * Main entry point to expo-updates in development builds with expo-dev-client. Similar to EnabledUpdatesController
@@ -59,7 +62,7 @@ class UpdatesDevLauncherController(
   private var previousUpdatesConfiguration: UpdatesConfiguration? = null
   private var updatesConfiguration: UpdatesConfiguration? = initialUpdatesConfiguration
 
-  private val databaseHolder = DatabaseHolder(UpdatesDatabase.getInstance(context))
+  private val databaseHolder = DatabaseHolder(UpdatesDatabase.getInstance(context, Dispatchers.IO))
 
   private var mSelectionPolicy: SelectionPolicy? = null
   private var defaultSelectionPolicy: SelectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy(
@@ -67,12 +70,15 @@ class UpdatesDevLauncherController(
   )
   private val selectionPolicy: SelectionPolicy
     get() = mSelectionPolicy ?: defaultSelectionPolicy
+
   private fun setNextSelectionPolicy(selectionPolicy: SelectionPolicy?) {
     mSelectionPolicy = selectionPolicy
   }
+
   private fun resetSelectionPolicyToDefault() {
     mSelectionPolicy = null
   }
+
   private fun setDefaultSelectionPolicy(selectionPolicy: SelectionPolicy) {
     defaultSelectionPolicy = selectionPolicy
   }
@@ -193,7 +199,8 @@ class UpdatesDevLauncherController(
           )
         }
 
-        val update = updateResponse.manifestUpdateResponsePart?.update ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
+        val update = updateResponse.manifestUpdateResponsePart?.update
+          ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
         return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = callback.onManifestLoaded(update.manifest.getRawJson()))
       }
     })
@@ -220,9 +227,11 @@ class UpdatesDevLauncherController(
       UpdatesConfigurationValidationResult.INVALID_NOT_ENABLED -> {
         throw Exception("Failed to load update: UpdatesConfiguration object is not enabled")
       }
+
       UpdatesConfigurationValidationResult.INVALID_MISSING_URL -> {
         throw Exception("Failed to load update: UpdatesConfiguration object must include a valid update URL")
       }
+
       UpdatesConfigurationValidationResult.INVALID_MISSING_RUNTIME_VERSION -> {
         throw Exception("Failed to load update: UpdatesConfiguration object must include a valid runtime version")
       }
@@ -335,35 +344,28 @@ class UpdatesDevLauncherController(
     )
   }
 
-  override fun relaunchReactApplicationForModule(
-    callback: IUpdatesController.ModuleCallback<Unit>
-  ) {
+  override suspend fun relaunchReactApplicationForModule() = suspendCancellableCoroutine { continuation ->
     this.updatesInterfaceCallbacks?.get()?.onRequestRelaunch()
-    callback.onSuccess(Unit)
+    continuation.resume(Unit)
   }
 
-  override fun checkForUpdate(
-    callback: IUpdatesController.ModuleCallback<IUpdatesController.CheckForUpdateResult>
-  ) {
-    callback.onFailure(NotAvailableInDevClientException("Updates.checkForUpdateAsync() is not supported in development builds."))
+  override suspend fun checkForUpdate(): IUpdatesController.CheckForUpdateResult {
+    throw NotAvailableInDevClientException("Updates.checkForUpdateAsync() is not supported in development builds.")
   }
 
-  override fun fetchUpdate(
-    callback: IUpdatesController.ModuleCallback<IUpdatesController.FetchUpdateResult>
-  ) {
-    callback.onFailure(NotAvailableInDevClientException("Updates.fetchUpdateAsync() is not supported in development builds."))
+  override suspend fun fetchUpdate(): IUpdatesController.FetchUpdateResult {
+    throw NotAvailableInDevClientException("Updates.fetchUpdateAsync() is not supported in development builds.")
   }
 
-  override fun getExtraParams(callback: IUpdatesController.ModuleCallback<Bundle>) {
-    callback.onFailure(NotAvailableInDevClientException("Updates.getExtraParamsAsync() is not supported in development builds."))
+  override suspend fun getExtraParams(): Bundle {
+    throw NotAvailableInDevClientException("Updates.getExtraParamsAsync() is not supported in development builds.")
   }
 
-  override fun setExtraParam(
+  override suspend fun setExtraParam(
     key: String,
-    value: String?,
-    callback: IUpdatesController.ModuleCallback<Unit>
+    value: String?
   ) {
-    callback.onFailure(NotAvailableInDevClientException("Updates.setExtraParamAsync() is not supported in development builds."))
+    throw NotAvailableInDevClientException("Updates.setExtraParamAsync() is not supported in development builds.")
   }
 
   override fun setUpdateURLAndRequestHeadersOverride(configOverride: UpdatesConfigurationOverride?) {


### PR DESCRIPTION
# Why
Currently, we rely a lot on callbacks in updates. Reducing them will be a multi step process. This PR starts with the `IUpdatesController` interface.

# How
Convert the functions related to checking and fetching updates to suspend functions. I've also removed the use of `wait` and `notify` in favour of `CompletableDeferred`. Note, there is an upstream issue that is currently causing a failure in `ErrorRecovery.kt`. I've addressed it [here](https://github.com/facebook/react-native/pull/50400) but it won't be in RC4.

# Test Plan
Running bare-expo in release mode and CI
