### PR TITLE
[docs] height breakpoint tweak, Tailwind config cleanup, styleguide bumps

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -26,10 +26,10 @@
   },
   "packageManager": "yarn@4.7.0",
   "dependencies": {
-    "@expo/styleguide": "^9.1.0",
+    "@expo/styleguide": "^9.1.2",
     "@expo/styleguide-base": "^2.0.3",
     "@expo/styleguide-icons": "^2.2.0",
-    "@expo/styleguide-search-ui": "^2.3.2",
+    "@expo/styleguide-search-ui": "^2.3.4",
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/mdx": "^3.1.0",
     "@mdx-js/react": "^3.1.0",

--- a/docs/tailwind.config.cjs
+++ b/docs/tailwind.config.cjs
@@ -1,6 +1,5 @@
 const expoTheme = require('@expo/styleguide/tailwind');
 const merge = require('lodash/merge');
-const plugin = require('tailwindcss/plugin');
 
 function getExpoTheme(extend = {}, plugins = []) {
   const customizedTheme = Object.assign({}, expoTheme);
@@ -20,56 +19,44 @@ module.exports = {
     './node_modules/@expo/styleguide/dist/**/*.{js,ts,jsx,tsx}',
     './node_modules/@expo/styleguide-search-ui/dist/**/*.{js,ts,jsx,tsx}',
   ],
-  ...getExpoTheme(
-    {
-      backgroundColor: {
-        'launch-party-red': '#D22323',
-        'launch-party-blue': '#006CFF',
-        'launch-party-yellow': '#F3AD0D',
-      },
-      borderColor: {
-        'palette-orange3.5': 'hsl(from var(--orange-4) h calc(s - 5) calc(l + 5));',
-      },
-      backgroundImage: () => ({
-        'cell-quickstart-pattern': "url('/static/images/home/QuickStartPattern.svg')",
-        'cell-tutorial-pattern': "url('/static/images/home/TutorialPattern.svg')",
-        'launch-party-banner': "url('/static/images/launch-party-banner-bg.svg')",
-        'launch-party-banner-mobile': "url('/static/images/launch-party-banner-bg.svg') 200px",
-      }),
-      keyframes: {
-        wave: {
-          '0%, 100%': {
-            transform: 'rotate(0deg)',
-          },
-          '50%': {
-            transform: 'rotate(20deg)',
-          },
+  ...getExpoTheme({
+    backgroundColor: {
+      'launch-party-red': '#D22323',
+      'launch-party-blue': '#006CFF',
+      'launch-party-yellow': '#F3AD0D',
+    },
+    borderColor: {
+      'palette-orange3.5': 'hsl(from var(--orange-4) h calc(s - 5) calc(l + 5));',
+    },
+    backgroundImage: () => ({
+      'cell-quickstart-pattern': "url('/static/images/home/QuickStartPattern.svg')",
+      'cell-tutorial-pattern': "url('/static/images/home/TutorialPattern.svg')",
+      'launch-party-banner': "url('/static/images/launch-party-banner-bg.svg')",
+      'launch-party-banner-mobile': "url('/static/images/launch-party-banner-bg.svg') 200px",
+    }),
+    keyframes: {
+      wave: {
+        '0%, 100%': {
+          transform: 'rotate(0deg)',
         },
-        slideUpAndFadeIn: {
-          '0%': {
-            opacity: 0,
-            transform: 'translateY(16px)',
-          },
-          '100%': {
-            opacity: 1,
-            transform: 'translateY(0)',
-          },
+        '50%': {
+          transform: 'rotate(20deg)',
         },
       },
-      animation: {
-        slideUpAndFadeIn: 'slideUpAndFadeIn 0.25s ease-out',
-        wave: 'wave 0.25s ease-in-out 4',
+      slideUpAndFadeIn: {
+        '0%': {
+          opacity: 0,
+          transform: 'translateY(16px)',
+        },
+        '100%': {
+          opacity: 1,
+          transform: 'translateY(0)',
+        },
       },
     },
-    [
-      plugin(function ({ addUtilities }) {
-        addUtilities({
-          '.asset-shadow': {
-            filter:
-              'drop-shadow(0 3px 8px rgba(0, 0, 0, 0.12)) drop-shadow(0 2px 6px rgba(0, 0, 0, 0.07))',
-          },
-        });
-      }),
-    ]
-  ),
+    animation: {
+      slideUpAndFadeIn: 'slideUpAndFadeIn 0.25s ease-out',
+      wave: 'wave 0.25s ease-in-out 4',
+    },
+  }),
 };

--- a/docs/ui/components/Sidebar/SidebarHead.tsx
+++ b/docs/ui/components/Sidebar/SidebarHead.tsx
@@ -37,14 +37,14 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
       <div
         className={mergeClasses(
           'flex flex-col gap-0.5 border-b border-default bg-default p-4',
-          'short:pb-3'
+          'compact-height:pb-3'
         )}>
         <Search />
         <div
           className={mergeClasses(
             'contents',
-            'short:grid short:grid-cols-5 short:gap-1',
-            isPreviewVisible && 'short:grid-cols-6'
+            'compact-height:grid compact-height:grid-cols-5 compact-height:gap-1',
+            isPreviewVisible && 'compact-height:grid-cols-6'
           )}>
           <SidebarSingleEntry
             href="/"

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -32,7 +32,7 @@ export const SidebarSingleEntry = ({
             'flex min-h-[32px] items-center gap-3 rounded-md px-2 py-1 text-sm !leading-[100%] text-secondary',
             'hocus:bg-element',
             'focus-visible:relative focus-visible:z-10',
-            'short:justify-center short:bg-subtle',
+            'compact-height:justify-center compact-height:bg-subtle',
             secondary && 'text-xs',
             isActive &&
               '!bg-palette-blue3 font-medium text-link hocus:!bg-palette-blue4 hocus:text-link'
@@ -45,11 +45,11 @@ export const SidebarSingleEntry = ({
               isActive ? 'text-palette-blue11' : 'text-icon-tertiary'
             )}
           />
-          <span className="short:hidden">{title}</span>
+          <span className="compact-height:hidden">{title}</span>
           {isExternal && <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary" />}
         </LinkBase>
       </Tooltip.Trigger>
-      <Tooltip.Content side="bottom" className="z-50 hidden short:flex">
+      <Tooltip.Content side="bottom" className="z-50 hidden compact-height:flex">
         <span className="text-2xs text-secondary">{title}</span>
       </Tooltip.Content>
     </Tooltip.Root>

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -516,11 +516,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/styleguide-search-ui@npm:^2.3.2":
-  version: 2.3.2
-  resolution: "@expo/styleguide-search-ui@npm:2.3.2"
+"@expo/styleguide-search-ui@npm:^2.3.4":
+  version: 2.3.4
+  resolution: "@expo/styleguide-search-ui@npm:2.3.4"
   dependencies:
-    "@expo/styleguide": "npm:^9.1.0"
+    "@expo/styleguide": "npm:^9.1.2"
     "@expo/styleguide-icons": "npm:^2.2.0"
     "@sanity/client": "npm:^6.28.3"
     "@sanity/image-url": "npm:^1.1.0"
@@ -529,20 +529,20 @@ __metadata:
   peerDependencies:
     next: ">= 13"
     react: ">= 16"
-  checksum: 10c0/59571f247c37831a7bc5693dc17d83ae7e7ab3d07608400d4bf6ae407a99654fd50392bbe9534d0b2c72baf688945f9ac87c5856fdf1fccd79c6786d32913e88
+  checksum: 10c0/a435b89a12e2c19f39164cb510cc06be82f0fb80930db05abc36a162877b28ee0dace1225ccce7ed4fff69ac9ac5a5fbe95590b45c89e9ecf698698dd5fe742f
   languageName: node
   linkType: hard
 
-"@expo/styleguide@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "@expo/styleguide@npm:9.1.0"
+"@expo/styleguide@npm:^9.1.2":
+  version: 9.1.2
+  resolution: "@expo/styleguide@npm:9.1.2"
   dependencies:
     "@expo/styleguide-base": "npm:^2.0.3"
     tailwind-merge: "npm:^2.5.4"
   peerDependencies:
     next: ">= 13"
     react: ">= 16"
-  checksum: 10c0/8696b7c0d94377595da0902d9b06b7ecce5b11841a885cdc70aea061531ea2cda25c6da368c615012a6eb7b5d44057f2a4cd7ac0c7a62a0c77936bbcaee9910a
+  checksum: 10c0/003936dbf97ff5af74adc802726295267ac003c44140ba3b8a1ff3fbcfed09f48cf1d6ba74d8491a9867c90b2245b61bb655e2e9527092340f808e3e302534b5
   languageName: node
   linkType: hard
 
@@ -5660,10 +5660,10 @@ __metadata:
   dependencies:
     "@apidevtools/json-schema-ref-parser": "npm:^11.7.3"
     "@expo/spawn-async": "npm:^1.7.2"
-    "@expo/styleguide": "npm:^9.1.0"
+    "@expo/styleguide": "npm:^9.1.2"
     "@expo/styleguide-base": "npm:^2.0.3"
     "@expo/styleguide-icons": "npm:^2.2.0"
-    "@expo/styleguide-search-ui": "npm:^2.3.2"
+    "@expo/styleguide-search-ui": "npm:^2.3.4"
     "@mdx-js/loader": "npm:^3.1.0"
     "@mdx-js/mdx": "npm:^3.1.0"
     "@mdx-js/react": "npm:^3.1.0"


### PR DESCRIPTION
# Why

Spotted that previous way to define height-related breakpoint have some unwanted side-effects.

# How

Switch to defining variant approach based on plugin API (in the vendored package), cleanup existing Tailwind customizations, bump Styleguide packages.

# Test Plan

The changes have been reviewed by running docs app locally, and confirmed that height break still works as expected, and it does not conflict with other, viewport width base scopes.

# Preview

![Screenshot 2025-04-01 at 11 42 43](https://github.com/user-attachments/assets/4ca320de-05b9-4da9-b47a-a8fd1307535f)
