### PR TITLE
[ios][xcode] fix xcode 16.3 compile errors

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [ios] Fixed build errors in XCode 16.3
+- [ios] Fixed build errors in XCode 16.3 ([#35811](https://github.com/expo/expo/pull/35811) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Fixed `task ':expo-dev-menu:generateDebugLintModel' uses this output of task ':expo-dev-menu:copyAssets' without declaring an explicit or implicit dependency`. ([#34688](https://github.com/expo/expo/pull/34688) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Add `ReactAppDependencyProvider` as a dependency when running React Native 0.77. ([#35092](https://github.com/expo/expo/pull/35092) by [@alanjhughes](https://github.com/alanjhughes))
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fixed build errors in XCode 16.3
 - [Android] Fixed `task ':expo-dev-menu:generateDebugLintModel' uses this output of task ':expo-dev-menu:copyAssets' without declaring an explicit or implicit dependency`. ([#34688](https://github.com/expo/expo/pull/34688) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Add `ReactAppDependencyProvider` as a dependency when running React Native 0.77. ([#35092](https://github.com/expo/expo/pull/35092) by [@alanjhughes](https://github.com/alanjhughes))
 

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -63,7 +63,11 @@ class DevMenuViewController: UIViewController {
   // MARK: private
 
   private func initialProps() -> [String: Any] {
-    let isSimulator = TARGET_IPHONE_SIMULATOR > 0
+#if targetEnvironment(simulator)
+    let isSimulator = true
+#else
+    let isSimulator = false
+#endif
 
     return [
       "showOnboardingView": manager.shouldShowOnboarding(),

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [ios] Fixed build errors in XCode 16.3
+- [ios] Fixed build errors in XCode 16.3 ([#35811](https://github.com/expo/expo/pull/35811) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fixed build errors in XCode 16.3
+
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-device/ios/UIDevice.swift
+++ b/packages/expo-device/ios/UIDevice.swift
@@ -183,7 +183,11 @@ public extension UIDevice {
 
   // Credit: https://github.com/developerinsider/isJailBroken/blob/master/IsJailBroken/Extension/UIDevice%2BJailBroken.swift
   var isSimulator: Bool {
-    return TARGET_OS_SIMULATOR != 0
+#if targetEnvironment(simulator)
+    return true
+#else
+    return false
+#endif
   }
 
   var isJailbroken: Bool {

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fixed build errors in XCode 16.3
 - stb_image PNG: Checks for invalid DEFLATE codes. ([#35184](https://github.com/expo/expo/pull/35184) by [@manoj23](https://github.com/manoj23))
 
 ### 💡 Others

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [ios] Fixed build errors in XCode 16.3
+- [ios] Fixed build errors in XCode 16.3 ([#35811](https://github.com/expo/expo/pull/35811) by [@chrfalch](https://github.com/chrfalch))
 - stb_image PNG: Checks for invalid DEFLATE codes. ([#35184](https://github.com/expo/expo/pull/35184) by [@manoj23](https://github.com/manoj23))
 
 ### 💡 Others

--- a/packages/expo-gl/common/EXGLNativeContext.h
+++ b/packages/expo-gl/common/EXGLNativeContext.h
@@ -128,7 +128,7 @@ class EXGLContext {
   std::atomic_uint nextObjectId = 1;
 
   bool supportsWebGL2 = false;
-  std::set<const std::string> supportedExtensions;
+  std::set<std::string> supportedExtensions;
 
   // function that calls flush on GL thread - on Android it is passed by JNI
   std::function<void(void)> flushOnGLThread = [&] {};


### PR DESCRIPTION
# Why 

Closes ENG-15363

https://developer.apple.com/documentation/xcode-release-notes/xcode-16_3-release-notes

Some changes makes BareExpo/Expo-go fail to build:

- libc++ no longer supports std::allocator<const T>
- The base template for std::char_traits has been removed.

In addition TARGET_OS_SIMULATOR is not available in Swift anymore.

# How

This commit fixes the issues related to the above by changing the use of `TARGET_OS_SIMULATOR` in swift code to `#if targetEnvironment(simulator)` instead.

In addition the error with `std::allocator<const T>` is fixed in EXGLNativeContext.h where we `used a std::set<const std::string>`.

# Test Plan

Tested by building both BareExpo and ExpoGo on iOS with new Xcode 16.3

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
