### PR TITLE
[docs] Update existing React Native projects installation instruction for `expo-dev-client`

### DIFF
--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -74,9 +74,9 @@ For detailed, step-by-step instructions, see our [EAS Tutorial](/tutorial/eas/in
 
 <Terminal cmd={['$ npx expo install expo-dev-client']} />
 
-<Collapsible summary="Are you using this library in a bare React Native app?">
+<Collapsible summary="Are you using this library in a existing (bare) React Native app?">
 
-Apps that don't use [Continuous Native Generation](/workflow/continuous-native-generation/) need to follow instructions from [Install `expo-dev-client` in bare React Native](/bare/install-dev-builds-in-bare/).
+Apps that don't use [Continuous Native Generation](/workflow/continuous-native-generation/) or are created with `npx react-native`, require further configuration after installing this library. See steps 1 and 2 from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
 
 </Collapsible>
 

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -74,9 +74,9 @@ For detailed, step-by-step instructions, see our [EAS Tutorial](/tutorial/eas/in
 
 <Terminal cmd={['$ npx expo install expo-dev-client']} />
 
-<Collapsible summary="Are you using this library in a existing (bare) React Native app?">
+<Collapsible summary="Are you using this library in a existing (bare) React Native apps?">
 
-Apps that don't use [Continuous Native Generation](/workflow/continuous-native-generation/) or are created with `npx react-native`, require further configuration after installing this library. See steps 1 and 2 from [Install `expo-dev-client` in an existing React Native project](/bare/install-dev-builds-in-bare/).
+Apps that don't use [Continuous Native Generation](/workflow/continuous-native-generation/) or are created with `npx react-native`, require further configuration after installing this library. See steps 1 and 2 from [Install `expo-dev-client` in an existing React Native app](/bare/install-dev-builds-in-bare/).
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on [feedback](https://github.com/expo/expo/pull/34163#discussion_r2021877067) from @brentvatne.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the existing (bare) React Native app collapsible to include the steps required to install `expo-dev-client` library.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

All changes have been tested by running docs app locally.

## Preview

![CleanShot 2025-04-01 at 17 39 27@2x](https://github.com/user-attachments/assets/bef434d6-c195-4149-839a-6778c349af03)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
