### PR TITLE
[sqlite] add reference counting for database closing functions.

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fixed build error for conflict `libc++_shared.so` on Android. ([#35298](https://github.com/expo/expo/pull/35298) by [@kudo](https://github.com/kudo))
 - Fixed `syncLibSQL` return type. ([#35804](https://github.com/expo/expo/pull/35804) by [@kudo](https://github.com/kudo))
+- Added reference counting for database closing functions. ([#35818](https://github.com/expo/expo/pull/35818) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt
@@ -9,8 +9,12 @@ internal class NativeDatabase(val databasePath: String, val openOptions: OpenDat
   var isClosed = false
   private val refCount = AtomicInteger(1)
 
-  internal fun addRef() {
-    refCount.incrementAndGet()
+  internal fun addRef(): Int {
+    return refCount.incrementAndGet()
+  }
+
+  internal fun release(): Int {
+    return refCount.decrementAndGet()
   }
 
   override fun equals(other: Any?): Boolean {
@@ -23,9 +27,6 @@ internal class NativeDatabase(val databasePath: String, val openOptions: OpenDat
 
   override fun sharedObjectDidRelease() {
     super.sharedObjectDidRelease()
-    val shouldClose = refCount.decrementAndGet() <= 0
-    if (shouldClose) {
-      this.ref.close()
-    }
+    this.ref.close()
   }
 }

--- a/packages/expo-sqlite/ios/AtomicInteger.swift
+++ b/packages/expo-sqlite/ios/AtomicInteger.swift
@@ -1,0 +1,44 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+internal final class AtomicInteger {
+  private let lock = DispatchSemaphore(value: 1)
+  private var value: Int
+
+  init(_ value: Int = 0) {
+    self.value = value
+  }
+
+  func increment() -> Int {
+    lock.wait()
+    defer {
+      lock.signal()
+    }
+    value += 1
+    return value
+  }
+
+  func decrement() -> Int {
+    lock.wait()
+    defer {
+      lock.signal()
+    }
+    value -= 1
+    return value
+  }
+
+  func get() -> Int {
+    lock.wait()
+    defer {
+      lock.signal()
+    }
+    return value
+  }
+
+  func set(_ newValue: Int) {
+    lock.wait()
+    defer {
+      lock.signal()
+    }
+    value = newValue
+  }
+}

--- a/packages/expo-sqlite/ios/NativeDatabase.swift
+++ b/packages/expo-sqlite/ios/NativeDatabase.swift
@@ -8,11 +8,22 @@ final class NativeDatabase: SharedObject, Equatable, Hashable {
   let openOptions: OpenDatabaseOptions
   var isClosed = false
   var extraPointer: OpaquePointer?
+  private var refCount = AtomicInteger(1)
 
   init(_ pointer: OpaquePointer?, databasePath: String, openOptions: OpenDatabaseOptions) {
     self.pointer = pointer
     self.databasePath = databasePath
     self.openOptions = openOptions
+  }
+
+  @discardableResult
+  func addRef() -> Int {
+    return refCount.increment()
+  }
+
+  @discardableResult
+  func release() -> Int {
+    return refCount.decrement()
   }
 
   // MARK: - Equatable


### PR DESCRIPTION
# Why

fixes #33677
close ENG-14586

# How

added reference counting to NativeDatabase

# Test Plan

- ci passed
- test repro from https://github.com/jameswilddev/expo-repro/blob/d16059415b4e3e342e9e936c5d4d4e83981cc310/App.js#L18

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
