### PR TITLE
[docs] Sidebar: improve deprecation visual marking, add few flags

### DIFF
--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -1,5 +1,7 @@
 import { LinkBase, mergeClasses } from '@expo/styleguide';
+import { AlertTriangleIcon } from '@expo/styleguide-icons/outline/AlertTriangleIcon';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons/outline/ArrowUpRightIcon';
+import { AlertTriangleSolidIcon } from '@expo/styleguide-icons/solid/AlertTriangleSolidIcon';
 import { useRouter } from 'next/compat/router';
 import { useEffect, useRef, type PropsWithChildren } from 'react';
 
@@ -67,6 +69,12 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
         )}
       />
       {children}
+      {info.isDeprecated && !isSelected && (
+        <AlertTriangleIcon className="icon-xs ml-1.5 !text-icon-warning" />
+      )}
+      {info.isDeprecated && isSelected && (
+        <AlertTriangleSolidIcon className="icon-xs ml-1.5 !text-icon-warning" />
+      )}
       {info.isNew && (
         <div
           className={mergeClasses(


### PR DESCRIPTION
# Why

Spotted that marking for deprecated packages in reference sidebar are not that obvious to spot.

# How

Add alert/warn icon to the deprecated pages sidebar entries.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and test are passing.

# Preview

![Screenshot 2025-04-01 at 16 48 03](https://github.com/user-attachments/assets/3922d529-21d1-4e92-9cff-91959214680a)
![Screenshot 2025-04-01 at 16 47 46](https://github.com/user-attachments/assets/4fdbaabb-c4d5-48de-b1cc-63b756b62b46)
![Screenshot 2025-04-01 at 16 40 27](https://github.com/user-attachments/assets/e54c2bee-f66c-4a9d-b918-f806042b2a92)

