### PR TITLE
[Android][core] Use `compileOnly` to depend on the `e-m-c`

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 - On Android, remove dependency on `smart-location-lib`. ([#33609](https://github.com/expo/expo/pull/33609) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Added missing dependency.
+- [Android] Added missing dependency. ([#35822](https://github.com/expo/expo/pull/35822) by [@lukmccall](https://github.com/lukmccall))
 
 ## 18.0.9 - 2025-03-31
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - On Android, remove dependency on `smart-location-lib`. ([#33609](https://github.com/expo/expo/pull/33609) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Added missing dependency.
 
 ## 18.0.9 - 2025-03-31
 

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -17,4 +17,5 @@ android {
 
 dependencies {
   api 'com.google.android.gms:play-services-location:21.0.1'
+  implementation 'androidx.annotation:annotation:1.7.1'
 }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -48,6 +48,7 @@
 - [Android] Remove `BarCodeScannerInterface`. ([#34966](https://github.com/expo/expo/pull/34966) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Make ExpoComposeView builder function optional. ([#34907](https://github.com/expo/expo/pull/34907) by [@janicduplessis](https://github.com/janicduplessis))
 - Refactored `RCTReactNativeFactory` integration. ([#35679](https://github.com/expo/expo/pull/35679) by [@kudo](https://github.com/kudo))
+- [Android] Used `compileOnly` to depend on the `expo-modules-core` when applying default dependencies.
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -48,7 +48,7 @@
 - [Android] Remove `BarCodeScannerInterface`. ([#34966](https://github.com/expo/expo/pull/34966) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Make ExpoComposeView builder function optional. ([#34907](https://github.com/expo/expo/pull/34907) by [@janicduplessis](https://github.com/janicduplessis))
 - Refactored `RCTReactNativeFactory` integration. ([#35679](https://github.com/expo/expo/pull/35679) by [@kudo](https://github.com/kudo))
-- [Android] Used `compileOnly` to depend on the `expo-modules-core` when applying default dependencies.
+- [Android] Used `compileOnly` to depend on the `expo-modules-core` when applying default dependencies. ([#35822](https://github.com/expo/expo/pull/35822) by [@lukmccall](https://github.com/lukmccall))
 
 ### ⚠️ Notices
 

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -38,7 +38,10 @@ internal fun Project.applyKotlin(kotlinVersion: String, kspVersion: String) {
 internal fun Project.applyDefaultDependencies() {
   val modulesCore = rootProject.project(":expo-modules-core")
   if (project != modulesCore) {
-    project.dependencies.add("compileOnly", project.project(":expo-modules-core"))
+    project.dependencies.add("compileOnly", modulesCore)
+
+    project.dependencies.add("testImplementation", modulesCore)
+    project.dependencies.add("androidTestImplementation", modulesCore)
   }
 }
 

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -38,7 +38,7 @@ internal fun Project.applyKotlin(kotlinVersion: String, kspVersion: String) {
 internal fun Project.applyDefaultDependencies() {
   val modulesCore = rootProject.project(":expo-modules-core")
   if (project != modulesCore) {
-    project.dependencies.add("implementation", project.project(":expo-modules-core"))
+    project.dependencies.add("compileOnly", project.project(":expo-modules-core"))
   }
 }
 


### PR DESCRIPTION
# Why

Uses `compileOnly` to depend on the `e-m-c`.

# How
According to https://blog.gradle.org/introducing-compile-only-dependencies, `e-m-c` should be consumed using `compileOnly`. It falls into the following use case:
```
Dependencies whose API is required at compile time but whose implementation is to be provided by a consuming library, application or runtime environment
```
Currently, it doesn't matter since we haven't precompiled anything. However, once we do, it will make a significant difference. When you use `compileOnly` for a library, that library is not included in the `pom` file. This approach helps prevent version mismatches.

# Test Plan

- bare-expo ✅ 
- some unit tests might fail. I'll fix them as it goes 