### PR TITLE
[docs] change grouping, and page names, in unversioned reference docs

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -637,7 +637,15 @@ const versionsReference = VERSIONS.reduce(
       }),
       makeSection(
         'Expo SDK',
-        shiftEntryToFront(pagesFromDir(`versions/${version}/sdk`), entry => entry.name === 'Expo'),
+        shiftEntryToFront(
+          pagesFromDir(`versions/${version}/sdk`).filter(entry => !entry.inExpoGo),
+          entry => entry.name === 'Expo'
+        ),
+        { expanded: true }
+      ),
+      makeSection(
+        'Included in Expo Go',
+        pagesFromDir(`versions/${version}/sdk`).filter(entry => entry.inExpoGo),
         { expanded: true }
       ),
       makeSection('Technical specs', [
@@ -694,6 +702,9 @@ export default {
 // --- MDX methods ---
 
 function makeSection(name, children = [], props = {}) {
+  if (children.length === 0) {
+    return null;
+  }
   return make('section', { name, expanded: false, ...props }, children);
 }
 
@@ -728,6 +739,7 @@ function makePage(file) {
     href: url,
     isNew: data.isNew ?? undefined,
     isDeprecated: data.isDeprecated ?? undefined,
+    inExpoGo: data.inExpoGo ?? undefined,
   };
   // TODO(cedric): refactor sidebarTitle into metadata
   if (data.sidebar_title) {

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -644,8 +644,11 @@ const versionsReference = VERSIONS.reduce(
         { expanded: true }
       ),
       makeSection(
-        'Included in Expo Go',
-        pagesFromDir(`versions/${version}/sdk`).filter(entry => entry.inExpoGo),
+        'Third-party libraries',
+        shiftEntryToFront(
+          pagesFromDir(`versions/${version}/sdk`).filter(entry => entry.inExpoGo),
+          entry => entry.name === 'Overview'
+        ),
         { expanded: true }
       ),
       makeSection('Technical specs', [

--- a/docs/pages/versions/unversioned/sdk/async-storage.mdx
+++ b/docs/pages/versions/unversioned/sdk/async-storage.mdx
@@ -1,9 +1,10 @@
 ---
-title: AsyncStorage
+title: '@react-native-async-storage/async-storage'
 description: A library that provides an asynchronous, unencrypted, persistent, key-value storage API.
 sourceCodeUrl: 'https://github.com/react-native-async-storage/async-storage'
 packageName: '@react-native-async-storage/async-storage'
 platforms: ['android', 'ios', 'tvos', 'macos', 'web']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/async-storage.mdx
+++ b/docs/pages/versions/unversioned/sdk/async-storage.mdx
@@ -7,14 +7,22 @@ platforms: ['android', 'ios', 'tvos', 'macos', 'web']
 inExpoGo: true
 ---
 
-import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
-An asynchronous, unencrypted, persistent, key-value storage API.
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
+
+Async Storage is asynchronous, unencrypted, persistent, key-value storage solution.
 
 ## Installation
 
 <APIInstallSection href="https://react-native-async-storage.github.io/async-storage/docs/install#android--ios" />
 
-## Usage
+## Learn more
 
-See [Async Storage's documentation](https://react-native-async-storage.github.io/async-storage/docs/usage) for usage instructions.
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://react-native-async-storage.github.io/async-storage/docs/usage"
+/>

--- a/docs/pages/versions/unversioned/sdk/captureRef.mdx
+++ b/docs/pages/versions/unversioned/sdk/captureRef.mdx
@@ -7,9 +7,10 @@ platforms: ['android', 'ios']
 inExpoGo: true
 ---
 
-import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/set-up-your-environment/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 Given a view, `captureRef` will essentially screenshot that view and return an image for you. This is very useful for things like signature pads, where the user draws something, and then you want to save an image from it.
 
@@ -18,37 +19,6 @@ If you're interested in taking snapshots from the GLView, we recommend you use [
 ## Installation
 
 <APIInstallSection href="https://github.com/gre/react-native-view-shot" />
-
-## API
-
-```js
-import { captureRef } from 'react-native-view-shot';
-```
-
-### `captureRef(view, options)`
-
-Snapshots the given view.
-
-#### Arguments
-
-- **view (_number|ReactElement_)** -- The `ref` or `reactTag` (also known as node handle) for the view to snapshot.
-- **options (_object_)** --
-
-  An optional map of optional options
-
-  - **format (_string_)** -- `"png" | "jpg" | "webm"`, defaults to `"png"`, `"webm"` supported only on Android.
-  - **quality (_number_)** -- Number between 0 and 1 where 0 is worst quality and 1 is best, defaults to `1`
-  - **result (_string_)** -- The type for the resulting image.
-    \- `'tmpfile'` -- (default) Return a temporary file uri.
-    \- `'base64'` -- base64 encoded image.
-    \- `'data-uri'` -- base64 encoded image with data-uri prefix.
-  - **height (_number_)** -- Height of result in pixels
-  - **width (_number_)** -- Width of result in pixels
-  - **snapshotContentContainer (_bool_)** -- if true and when view is a ScrollView, the "content container" height will be evaluated instead of the container height
-
-#### Returns
-
-An image of the format specified in the options parameter.
 
 ## Note on pixel values
 
@@ -70,3 +40,12 @@ const result = await captureRef(this.imageContainer, {
   format: 'png',
 });
 ```
+
+## Learn more
+
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://github.com/gre/react-native-view-shot"
+/>

--- a/docs/pages/versions/unversioned/sdk/captureRef.mdx
+++ b/docs/pages/versions/unversioned/sdk/captureRef.mdx
@@ -1,9 +1,10 @@
 ---
-title: captureRef
+title: react-native-view-shot
 description: A library that allows you to capture a React Native view and save it as an image.
 sourceCodeUrl: 'https://github.com/gre/react-native-view-shot'
-packageName: 'react-native-view-shot'
+packageName: react-native-view-shot
 platforms: ['android', 'ios']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/date-time-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/date-time-picker.mdx
@@ -7,7 +7,10 @@ platforms: ['android', 'ios']
 inExpoGo: true
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 A component that provides access to the system UI for date and time selection.
@@ -18,6 +21,11 @@ A component that provides access to the system UI for date and time selection.
 
 <APIInstallSection href="https://github.com/react-native-datetimepicker/datetimepicker#getting-started" />
 
-## Usage
+## Learn more
 
-See full documentation at [`react-native-community/react-native-datetimepicker`](https://github.com/react-native-community/react-native-datetimepicker).
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://github.com/react-native-datetimepicker/datetimepicker"
+/>

--- a/docs/pages/versions/unversioned/sdk/date-time-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/date-time-picker.mdx
@@ -1,9 +1,10 @@
 ---
-title: DateTimePicker
+title: '@react-native-community/datetimepicker'
 description: A component that provides access to the system UI for date and time selection.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-datetimepicker'
 packageName: '@react-native-community/datetimepicker'
 platforms: ['android', 'ios']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/flash-list.mdx
+++ b/docs/pages/versions/unversioned/sdk/flash-list.mdx
@@ -1,9 +1,10 @@
 ---
-title: FlashList
+title: '@shopify/flash-list'
 description: A React Native component that provides a fast and performant way to render lists.
 sourceCodeUrl: 'https://github.com/shopify/flash-list'
 packageName: '@shopify/flash-list'
 platforms: ['android', 'ios', 'tvos', 'web']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/flash-list.mdx
+++ b/docs/pages/versions/unversioned/sdk/flash-list.mdx
@@ -7,9 +7,10 @@ platforms: ['android', 'ios', 'tvos', 'web']
 inExpoGo: true
 ---
 
-import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/set-up-your-environment/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 `@shopify/flash-list` is a "Fast and performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
 
@@ -17,6 +18,11 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 <APIInstallSection href="https://shopify.github.io/flash-list/docs/" />
 
-## Usage
+## Learn more
 
-See full documentation at [https://shopify.github.io/flash-list/](https://shopify.github.io/flash-list/).
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://shopify.github.io/flash-list/"
+/>

--- a/docs/pages/versions/unversioned/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/unversioned/sdk/gesture-handler.mdx
@@ -1,10 +1,10 @@
 ---
-title: React Native Gesture Handler
-sidebar_title: GestureHandler
+title: react-native-gesture-handler
 description: A library that provides an API for handling complex gestures.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-gesture-handler'
-packageName: 'react-native-gesture-handler'
+packageName: react-native-gesture-handler
 platforms: ['android', 'ios', 'web']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/unversioned/sdk/gesture-handler.mdx
@@ -7,7 +7,10 @@ platforms: ['android', 'ios', 'web']
 inExpoGo: true
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 `react-native-gesture-handler` is a library for handling complex gestures. From it's README:
 
@@ -17,6 +20,11 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 <APIInstallSection href="https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation" />
 
-## Usage
+## Learn more
 
-Read the [`react-native-gesture-handler` documentation](https://docs.swmansion.com/react-native-gesture-handler/) for more information on the API and usage.
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://docs.swmansion.com/react-native-gesture-handler/"
+/>

--- a/docs/pages/versions/unversioned/sdk/lottie.mdx
+++ b/docs/pages/versions/unversioned/sdk/lottie.mdx
@@ -7,10 +7,11 @@ platforms: ['android', 'ios', 'tvos', 'web']
 inExpoGo: true
 ---
 
-import { APIInstallSection } from '~/components/plugins/InstallSection';
-import { SnackInline } from '~/ui/components/Snippet';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/set-up-your-environment/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { SnackInline } from '~/ui/components/Snippet';
 
 [Lottie](https://airbnb.io/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
 
@@ -21,7 +22,7 @@ import { SnackInline } from '~/ui/components/Snippet';
   href="https://github.com/lottie-react-native/lottie-react-native#installing"
 />
 
-## Usage
+## Example
 
 <SnackInline
   label="Lottie"
@@ -83,10 +84,11 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-## API
+## Learn more
 
-```js
-import LottieView from 'lottie-react-native';
-```
-
-Refer to the [lottie-react-native repository](https://github.com/lottie-react-native/lottie-react-native#usage) for more detailed documentation.
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://airbnb.io/lottie/#/react-native"
+/>

--- a/docs/pages/versions/unversioned/sdk/lottie.mdx
+++ b/docs/pages/versions/unversioned/sdk/lottie.mdx
@@ -1,9 +1,10 @@
 ---
-title: Lottie
+title: lottie-react-native
 description: A library that allows rendering After Effects animations.
 sourceCodeUrl: 'https://github.com/lottie-react-native/lottie-react-native'
-packageName: 'lottie-react-native'
+packageName: lottie-react-native
 platforms: ['android', 'ios', 'tvos', 'web']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -1,10 +1,10 @@
 ---
-title: React Native Maps
-sidebar_title: MapView (react-native-maps)
+title: react-native-maps
 description: A library that provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 sourceCodeUrl: 'https://github.com/react-native-maps/react-native-maps'
-packageName: 'react-native-maps'
+packageName: react-native-maps
 platforms: ['android', 'ios']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -12,8 +12,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
-
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 
 No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploy-app-with-google-maps).

--- a/docs/pages/versions/unversioned/sdk/masked-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/masked-view.mdx
@@ -1,9 +1,10 @@
 ---
-title: MaskedView
+title: '@react-native-masked-view/masked-view'
 description: A library that provides a masked view.
 sourceCodeUrl: 'https://github.com/react-native-masked-view/masked-view'
 packageName: '@react-native-masked-view/masked-view'
 platforms: ['android', 'ios', 'tvos']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/masked-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/masked-view.mdx
@@ -7,7 +7,10 @@ platforms: ['android', 'ios', 'tvos']
 inExpoGo: true
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 `@react-native-masked-view/masked-view` provides a masked view that only displays the pixels that overlap with the view rendered in its mask element.
 
@@ -19,6 +22,11 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 <APIInstallSection href="https://github.com/react-native-masked-view/masked-view#getting-started" />
 
-## Usage
+## Learn more
 
-See full documentation at [`react-native-masked-view/masked-view`](https://github.com/react-native-masked-view/masked-view).
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://github.com/react-native-masked-view/masked-view"
+/>

--- a/docs/pages/versions/unversioned/sdk/netinfo.mdx
+++ b/docs/pages/versions/unversioned/sdk/netinfo.mdx
@@ -1,9 +1,10 @@
 ---
-title: NetInfo
+title: '@react-native-community/netinfo'
 description: A cross-platform API that provides access to network information.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-netinfo'
 packageName: '@react-native-community/netinfo'
 platforms: ['android', 'ios', 'tvos', 'web']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/netinfo.mdx
+++ b/docs/pages/versions/unversioned/sdk/netinfo.mdx
@@ -7,7 +7,10 @@ platforms: ['android', 'ios', 'tvos', 'web']
 inExpoGo: true
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 `@react-native-community/netinfo` allows you to get information about connection type and connection quality.
 
@@ -48,8 +51,6 @@ unsubscribe();
 
 To access the `ssid` property (available under `state.details.ssid`), there are a few additional configuration steps:
 
-### Android and iOS
-
 - Request location permissions with [`Location.requestForegroundPermissionsAsync()`](location.mdx#locationrequestforegroundpermissionsasync) or [`Location.requestBackgroundPermissionsAsync()`](location.mdx#locationrequestbackgroundpermissionsasync).
 
 ### iOS only
@@ -67,4 +68,11 @@ To access the `ssid` property (available under `state.details.ssid`), there are 
 - Check the **Access Wi-Fi Information** box in your app's App Identifier, [which can be found here](https://developer.apple.com/account/resources/identifiers/list).
 - Rebuild your app with [`eas build --platform ios`](/build/setup/#4-run-a-build) or [`npx expo run:ios`](/more/expo-cli/#compiling).
 
-For more information on API and usage, see [`react-native-netinfo` documentation](https://github.com/react-native-community/react-native-netinfo#react-native-communitynetinfo).
+## Learn more
+
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://github.com/react-native-netinfo/react-native-netinfo"
+/>

--- a/docs/pages/versions/unversioned/sdk/picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/picker.mdx
@@ -7,11 +7,10 @@ platforms: ['android', 'ios', 'macos', 'web']
 inExpoGo: true
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-
-{/* todo: add video */}
-
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+import { BoxLink } from '~/ui/components/BoxLink';
 
 A component that provides access to the system UI for picking between several options.
 
@@ -19,6 +18,11 @@ A component that provides access to the system UI for picking between several op
 
 <APIInstallSection href="https://github.com/react-native-picker/picker#getting-started" />
 
-## Usage
+## Learn more
 
-See complete documentation at [`react-native-picker/picker`](https://github.com/react-native-picker/picker).
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://github.com/react-native-picker/picker"
+/>

--- a/docs/pages/versions/unversioned/sdk/picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/picker.mdx
@@ -1,10 +1,10 @@
 ---
-title: React Native Picker
-sidebar_title: Picker
+title: '@react-native-picker/picker'
 description: A cross-platform component that provides access to the system UI for picking between several options.
 sourceCodeUrl: 'https://github.com/react-native-picker/picker'
 packageName: '@react-native-picker/picker'
 platforms: ['android', 'ios', 'macos', 'web']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -7,10 +7,11 @@ platforms: ['android', 'ios', 'tvos', 'web']
 inExpoGo: true
 ---
 
-import { APIInstallSection } from '~/components/plugins/InstallSection';
-import { SnackInline } from '~/ui/components/Snippet';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { SnackInline } from '~/ui/components/Snippet';
 
 [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/) provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
@@ -26,7 +27,7 @@ No additional configuration is required. [Reanimated Babel plugin](https://docs.
 
 ## Usage
 
-The following example shows how to use the `react-native-reanimated` library to create a simple animation. For more information on the API and its usage, see [`react-native-reanimated` documentation](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
+The following example shows how to use the `react-native-reanimated` library to create a simple animation.
 
 <SnackInline label="Using react-native-reanimated" dependencies={['react-native-reanimated']}>
 
@@ -83,3 +84,12 @@ const styles = StyleSheet.create({
 ```
 
 </SnackInline>
+
+## Learn more
+
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation"
+/>

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -1,10 +1,10 @@
 ---
-title: React Native Reanimated
-sidebar_title: Reanimated
+title: react-native-reanimated
 description: A library that provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-reanimated'
-packageName: 'react-native-reanimated'
+packageName: react-native-reanimated
 platforms: ['android', 'ios', 'tvos', 'web']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -1,10 +1,10 @@
 ---
-title: React Native Safe Area Context
-sidebar_title: SafeAreaContext
+title: react-native-safe-area-context
 description: A library with a flexible API for accessing the device's safe area inset information.
 sourceCodeUrl: 'https://github.com/th3rdwave/react-native-safe-area-context'
-packageName: 'react-native-safe-area-context'
+packageName: react-native-safe-area-context
 platforms: ['android', 'ios', 'web', 'tvos']
+inExpoGo: true
 ---
 
 import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRightIcon';

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -14,8 +14,6 @@ import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
 import { CALLOUT } from '~/ui/components/Text';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
-
 `react-native-safe-area-context` provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
 
 ## Installation

--- a/docs/pages/versions/unversioned/sdk/screens.mdx
+++ b/docs/pages/versions/unversioned/sdk/screens.mdx
@@ -1,9 +1,10 @@
 ---
-title: Screens
+title: react-native-screens
 description: A library that provides native primitives to represent screens instead of plain React Native View components for better operating system behavior and screen optimizations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-screens'
-packageName: 'react-native-screens'
+packageName: react-native-screens
 platforms: ['android', 'ios', 'tvos', 'web']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/screens.mdx
+++ b/docs/pages/versions/unversioned/sdk/screens.mdx
@@ -1,24 +1,28 @@
 ---
 title: react-native-screens
-description: A library that provides native primitives to represent screens instead of plain React Native View components for better operating system behavior and screen optimizations.
+description: A library that provides native primitives to represent screens for better operating system behavior and screen optimizations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-screens'
 packageName: react-native-screens
 platforms: ['android', 'ios', 'tvos', 'web']
 inExpoGo: true
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 `react-native-screens` provides native primitives to represent screens instead of plain `<View>` components To better take advantage of operating system behavior and optimizations around screens. This capability is used by library authors and is unlikely to be used directly by most app developers. It also provides the native components needed for React Navigation's [`createNativeStackNavigator`](https://reactnavigation.org/docs/native-stack-navigator).
-
-> **Note**: See [`react-native-screens` issue tracker](https://github.com/software-mansion/react-native-screens/issues) if you encounter any problems.
 
 ## Installation
 
 <APIInstallSection href="https://github.com/software-mansion/react-native-screens#installation" />
 
-## API
+## Learn more
 
-The complete API reference and documentation are available in the [`react-native-screens` README](https://github.com/software-mansion/react-native-screens).
-
-To use the native stack navigator if you are using React Navigation, see [`createNativeStackNavigator` documentation](https://reactnavigation.org/docs/native-stack-navigator).
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://docs.swmansion.com/react-native-screens/"
+/>

--- a/docs/pages/versions/unversioned/sdk/skia.mdx
+++ b/docs/pages/versions/unversioned/sdk/skia.mdx
@@ -7,9 +7,10 @@ platforms: ['android', 'ios', 'web']
 inExpoGo: true
 ---
 
-import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 `@shopify/react-native-skia` brings the Skia Graphics Library to React Native. Skia serves as the graphics engine for Google Chrome and Chrome OS, Android, Flutter, Mozilla Firefox and Firefox OS, and many other products.
 
@@ -17,8 +18,15 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 <APIInstallSection href="https://shopify.github.io/react-native-skia/docs/getting-started/installation/" />
 
-> **Additional setup required for web**: If you want to use Skia on web, you will need to follow [web installation instructions](https://shopify.github.io/react-native-skia/docs/getting-started/web/#expo) to load CanvasKit.
+### Web
 
-## Usage
+If you want to use Skia on web, you will need to follow [web installation instructions](https://shopify.github.io/react-native-skia/docs/getting-started/web/#expo) to load CanvasKit.
 
-See [`@shopify/react-native-skia` documentation](https://shopify.github.io/react-native-skia/) for usage instructions.
+## Learn more
+
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://shopify.github.io/react-native-skia/"
+/>

--- a/docs/pages/versions/unversioned/sdk/skia.mdx
+++ b/docs/pages/versions/unversioned/sdk/skia.mdx
@@ -1,9 +1,10 @@
 ---
-title: Skia
+title: '@shopify/react-native-skia'
 description: A React Native library for creating graphics using Skia.
 sourceCodeUrl: 'https://github.com/shopify/react-native-skia'
 packageName: '@shopify/react-native-skia'
 platforms: ['android', 'ios', 'web']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -1,9 +1,10 @@
 ---
-title: Stripe
+title: '@stripe/stripe-react-native'
 description: A library that provides access to native APIs for integrating Stripe payments.
 sourceCodeUrl: 'https://github.com/stripe/stripe-react-native'
 packageName: '@stripe/stripe-react-native'
 platforms: ['android', 'ios']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/svg.mdx
+++ b/docs/pages/versions/unversioned/sdk/svg.mdx
@@ -7,10 +7,12 @@ platforms: ['android', 'ios', 'macos', 'web', 'tvos']
 inExpoGo: true
 ---
 
-import { APIInstallSection } from '~/components/plugins/InstallSection';
-import { SnackInline } from '~/ui/components/Snippet';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { SnackInline } from '~/ui/components/Snippet';
+import { MONOSPACE } from '~/ui/components/text';
 
 `react-native-svg` allows you to use SVGs in your app, with support for interactivity and animation.
 
@@ -24,7 +26,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 import * as Svg from 'react-native-svg';
 ```
 
-### `Svg`
+### <MONOSPACE>Svg</MONOSPACE>
 
 A set of drawing primitives such as `Circle`, `Rect`, `Path`,
 `ClipPath`, and `Polygon`. It supports most SVG elements and properties.
@@ -47,11 +49,20 @@ export default function SvgComponent(props) {
 
 </SnackInline>
 
-### Pro tips
+### Tips
 
 Here are some helpful links that will get you moving fast!
 
 - Looking for SVGs? Try the [noun project](https://thenounproject.com/).
 - Create or modify your own SVGs for free using [Figma](https://www.figma.com/).
 - Optimize your SVG with [SVGOMG](https://jakearchibald.github.io/svgomg/). This will make the code smaller and easier to work with. Be sure not to remove the `viewbox` for best results on Android.
-- Convert your SVG to an Expo component in the browser using [React SVGR](https://react-svgr.com/playground/?native=true&typescript=true).
+- Convert your SVG to an Expo component in the browser using [SVGR](https://react-svgr.com/playground/?native=true&typescript=true).
+
+## Learn more
+
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://github.com/software-mansion/react-native-svg"
+/>

--- a/docs/pages/versions/unversioned/sdk/svg.mdx
+++ b/docs/pages/versions/unversioned/sdk/svg.mdx
@@ -12,7 +12,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { SnackInline } from '~/ui/components/Snippet';
-import { MONOSPACE } from '~/ui/components/text';
+import { MONOSPACE } from '~/ui/components/Text';
 
 `react-native-svg` allows you to use SVGs in your app, with support for interactivity and animation.
 

--- a/docs/pages/versions/unversioned/sdk/svg.mdx
+++ b/docs/pages/versions/unversioned/sdk/svg.mdx
@@ -1,10 +1,10 @@
 ---
-title: React Native SVG
-sidebar_title: Svg
+title: react-native-svg
 description: A library that allows using SVGs in your app.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-svg'
-packageName: 'react-native-svg'
+packageName: react-native-svg
 platforms: ['android', 'ios', 'macos', 'web', 'tvos']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/third-party-overview.mdx
+++ b/docs/pages/versions/unversioned/sdk/third-party-overview.mdx
@@ -1,0 +1,31 @@
+---
+title: Third-party libraries supported in Expo Go
+sidebar_title: Overview
+description: A set of third-party libraries which support for is included by default in Expo Go environment.
+inExpoGo: true
+hideTOC: true
+---
+
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
+The Expo Go sandbox enables you to quickly experiment with building native Android and iOS apps. It supports a curated list of third-party libraries that are community-driven, provide well-tested solutions, and can streamline the development process or enhance app functionality.
+
+The difference between libraries listed in this section, and any other third-party library is that the support for former is built-in in Expo Go environment. You may use any library of your choice with development builds.
+
+## Learn more
+
+<BoxLink
+  title="Using other third-party libraries"
+  description="Learn how to use other third-party npm libraries in your project."
+  Icon={BookOpen02Icon}
+  href="/workflow/using-libraries/#third-party-libraries"
+/>
+
+<BoxLink
+  title="Introduction to development builds"
+  description="Learn why use development builds, and how to get started."
+  Icon={BookOpen02Icon}
+  href="/develop/development-builds/introduction/"
+/>

--- a/docs/pages/versions/unversioned/sdk/third-party-overview.mdx
+++ b/docs/pages/versions/unversioned/sdk/third-party-overview.mdx
@@ -10,7 +10,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 
-The Expo Go sandbox enables you to quickly experiment with building native Android and iOS apps. It supports a curated list of third-party libraries that are community-driven, provide well-tested solutions, and can streamline the development process or enhance app functionality.
+The Expo Go sandbox enables you to quickly experiment with building native Android and iOS apps. It supports a curated list of third-party libraries that are community-driven, provide APIs for common app functionalities, and are tested with each Expo SDK release.
 
 The difference between libraries listed in this section, and any other third-party library is that the support for former is built-in in Expo Go environment. You may use any library of your choice with development builds.
 

--- a/docs/pages/versions/unversioned/sdk/view-pager.mdx
+++ b/docs/pages/versions/unversioned/sdk/view-pager.mdx
@@ -7,10 +7,11 @@ platforms: ['android', 'ios']
 inExpoGo: true
 ---
 
-import { APIInstallSection } from '~/components/plugins/InstallSection';
-import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 `react-native-pager-view` exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
@@ -19,10 +20,6 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 ## Installation
 
 <APIInstallSection href="https://github.com/callstack/react-native-pager-view#linking" />
-
-## Usage
-
-See full documentation at [callstack/react-native-pager-view](https://github.com/callstack/react-native-pager-view).
 
 ## Example
 
@@ -59,3 +56,12 @@ const styles = StyleSheet.create({
   },
 });
 ```
+
+## Learn more
+
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://github.com/callstack/react-native-pager-view"
+/>

--- a/docs/pages/versions/unversioned/sdk/view-pager.mdx
+++ b/docs/pages/versions/unversioned/sdk/view-pager.mdx
@@ -1,9 +1,10 @@
 ---
-title: ViewPager
+title: react-native-pager-view
 description: A component library that provides a carousel-like view to swipe through pages of content.
 sourceCodeUrl: 'https://github.com/callstack/react-native-pager-view'
-packageName: 'react-native-pager-view'
+packageName: react-native-pager-view
 platforms: ['android', 'ios']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/unversioned/sdk/webview.mdx
+++ b/docs/pages/versions/unversioned/sdk/webview.mdx
@@ -7,7 +7,10 @@ platforms: ['android', 'ios']
 inExpoGo: true
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
 import { SnackInline } from '~/ui/components/Snippet';
 
 `react-native-webview` provides a `WebView` component that renders web content in a native view.
@@ -17,8 +20,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 <APIInstallSection href="https://github.com/react-native-webview/react-native-webview/blob/master/docs/Getting-Started.md#react-native-webview-getting-started-guide" />
 
 ## Usage
-
-You should refer to the [`react-native-webview` documentation](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. The following example (courtesy of that repository) is a quick way to get up and running!
 
 <SnackInline label="Basic Webview usage" dependencies={["react-native-webview", "expo-constants"]}>
 
@@ -47,7 +48,7 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-Minimal example with inline HTML:
+### With inline HTML
 
 <SnackInline label="Webview inline HTML" dependencies={["react-native-webview", "expo-constants"]}>
 
@@ -75,3 +76,12 @@ const styles = StyleSheet.create({
 ```
 
 </SnackInline>
+
+## Learn more
+
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md"
+/>

--- a/docs/pages/versions/unversioned/sdk/webview.mdx
+++ b/docs/pages/versions/unversioned/sdk/webview.mdx
@@ -1,10 +1,10 @@
 ---
-title: React Native WebView
-sidebar_title: WebView
+title: react-native-webview
 description: A library that provides a WebView component.
 sourceCodeUrl: 'https://github.com/react-native-webview/react-native-webview'
-packageName: 'react-native-webview'
+packageName: react-native-webview
 platforms: ['android', 'ios']
+inExpoGo: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/scripts/generate-llms/utils.js
+++ b/docs/scripts/generate-llms/utils.js
@@ -45,7 +45,7 @@ function processGroup(group) {
 }
 
 export function processSection(node) {
-  if (node.type !== 'section') {
+  if (!node || node.type !== 'section') {
     return null;
   }
 

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -46,6 +46,7 @@ export type NavigationRoute = {
   weight?: number;
   isNew?: boolean;
   isDeprecated?: boolean;
+  inExpoGo?: boolean;
   children?: NavigationRouteWithSection[];
 };
 

--- a/docs/ui/components/Sidebar/Sidebar.tsx
+++ b/docs/ui/components/Sidebar/Sidebar.tsx
@@ -28,6 +28,10 @@ export const Sidebar = ({ routes = [] }: SidebarProps) => {
         )}
       />
       {routes.map(route => {
+        if (!route) {
+          return null;
+        }
+
         const Component = renderTypes[route.type];
         return !!Component && <Component key={`${route.type}-${route.name}`} route={route} />;
       })}


### PR DESCRIPTION
# Why

A concept of new pages arrangement and naming in the reference part of the docs. 

Opening this one as a draft, to signify experimental nature of the changed, and to get a bit more feedback around.

# How

This changes applies only to the `unversioned` docs, and adds a new dedicated "Third party libraries" packages group, for lightweight package for 3rd-party libraries that are included in Expo Go default libraries bundle.

In addition to new section, those pages will now use the pnm package name as a title, to make it more obvious, which packages we take about, in comparison to the custom call-names we used so far.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

![Screenshot 2025-04-07 at 15 48 19](https://github.com/user-attachments/assets/7a2be848-cef9-469a-9f36-a3e91175998f)

![Screenshot 2025-04-07 at 15 48 52](https://github.com/user-attachments/assets/a8968426-812d-47fd-b60b-2803cbdc97af)


