### PR TITLE
fix @react-navigation/drawer package version in expo-router package.json

### DIFF
--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -95,7 +95,7 @@
     }
   },
   "devDependencies": {
-    "@react-navigation/drawer": "^7.2.q",
+    "@react-navigation/drawer": "^7.2.1",
     "@testing-library/jest-native": "^5.4.2",
     "@testing-library/react": "^15.0.7",
     "@testing-library/react-native": "^13.1.0",


### PR DESCRIPTION
# Why

npm install errors out on the "q", so I've replaced it with a 1 which matches the version of the package from the peerDependencies block.

# How

unblocks NPM install

# Test Plan

Run npm install, it should pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
