### PR TITLE
[android][updates] Refactor procedures and remove older api usage

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
@@ -14,6 +14,10 @@ import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.EmbeddedManifestUtils
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import expo.modules.updates.statemachine.UpdatesStateEvent
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.json.JSONObject
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 class CheckForUpdateProcedure(
   private val context: Context,
@@ -37,144 +41,161 @@ class CheckForUpdateProcedure(
       launchedUpdate,
       embeddedUpdate
     )
-    databaseHolder.releaseDatabase()
+
+    try {
+      val updateResponse = downloadRemoteUpdate(extraHeaders)
+      processUpdatesResponse(updateResponse, procedureContext, embeddedUpdate)
+    } catch (e: Exception) {
+      procedureContext.processStateEvent(UpdatesStateEvent.CheckError(e.localizedMessageWithCauseLocalizedMessage()))
+      callback(IUpdatesController.CheckForUpdateResult.ErrorResult(e))
+      procedureContext.onComplete()
+    } finally {
+      databaseHolder.releaseDatabase()
+    }
+  }
+
+  private suspend fun downloadRemoteUpdate(extraHeaders: JSONObject) = suspendCancellableCoroutine { continuation ->
     fileDownloader.downloadRemoteUpdate(
       extraHeaders,
       object : FileDownloader.RemoteUpdateDownloadCallback {
         override fun onFailure(e: Exception) {
-          procedureContext.processStateEvent(UpdatesStateEvent.CheckError(e.localizedMessageWithCauseLocalizedMessage()))
-          callback(IUpdatesController.CheckForUpdateResult.ErrorResult(e))
-          procedureContext.onComplete()
+          if (continuation.isActive) {
+            continuation.resumeWithException(e)
+          }
         }
 
         override fun onSuccess(updateResponse: UpdateResponse) {
-          val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
-          val update = updateResponse.manifestUpdateResponsePart?.update
-
-          if (updateDirective != null) {
-            when (updateDirective) {
-              is UpdateDirective.NoUpdateAvailableUpdateDirective -> {
-                procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-                callback(
-                  IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
-                    LoaderTask.RemoteCheckResultNotAvailableReason.NO_UPDATE_AVAILABLE_ON_SERVER
-                  )
-                )
-                procedureContext.onComplete()
-                return
-              }
-
-              is UpdateDirective.RollBackToEmbeddedUpdateDirective -> {
-                if (!updatesConfiguration.hasEmbeddedUpdate) {
-                  procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-                  callback(
-                    IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
-                      LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED
-                    )
-                  )
-                  procedureContext.onComplete()
-                  return
-                }
-
-                if (embeddedUpdate == null) {
-                  procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-                  callback(
-                    IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
-                      LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED
-                    )
-                  )
-                  procedureContext.onComplete()
-                  return
-                }
-
-                if (!selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
-                    updateDirective,
-                    embeddedUpdate,
-                    launchedUpdate,
-                    updateResponse.responseHeaderData?.manifestFilters
-                  )
-                ) {
-                  procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-                  callback(
-                    IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
-                      LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_REJECTED_BY_SELECTION_POLICY
-                    )
-                  )
-                  procedureContext.onComplete()
-                  return
-                }
-
-                procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteWithRollback(updateDirective.commitTime))
-                callback(IUpdatesController.CheckForUpdateResult.RollBackToEmbedded(updateDirective.commitTime))
-                procedureContext.onComplete()
-                return
-              }
-            }
-          }
-
-          if (update == null) {
-            procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-            callback(
-              IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
-                LoaderTask.RemoteCheckResultNotAvailableReason.NO_UPDATE_AVAILABLE_ON_SERVER
-              )
-            )
-            procedureContext.onComplete()
-            return
-          }
-
-          if (launchedUpdate == null) {
-            // this shouldn't ever happen, but if we don't have anything to compare
-            // the new manifest to, let the user know an update is available
-            procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteWithUpdate(update.manifest.getRawJson()))
-            callback(IUpdatesController.CheckForUpdateResult.UpdateAvailable(update))
-            procedureContext.onComplete()
-            return
-          }
-
-          var shouldLaunch = false
-          var failedPreviously = false
-          if (selectionPolicy.shouldLoadNewUpdate(
-              update.updateEntity,
-              launchedUpdate,
-              updateResponse.responseHeaderData?.manifestFilters
-            )
-          ) {
-            // If "update" has failed to launch previously, then
-            // "launchedUpdate" will be an earlier update, and the test above
-            // will return true (incorrectly).
-            // We check to see if the new update is already in the DB, and if so,
-            // only allow the update if it has had no launch failures.
-            shouldLaunch = true
-            update.updateEntity?.let { updateEntity ->
-              val storedUpdateEntity = databaseHolder.database.updateDao().loadUpdateWithId(
-                updateEntity.id
-              )
-              databaseHolder.releaseDatabase()
-              storedUpdateEntity?.let {
-                shouldLaunch = it.failedLaunchCount == 0
-                updatesLogger.info("Stored update found: ID = ${updateEntity.id}, failureCount = ${it.failedLaunchCount}")
-                failedPreviously = !shouldLaunch
-              }
-            }
-          }
-          if (shouldLaunch) {
-            procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteWithUpdate(update.manifest.getRawJson()))
-            callback(IUpdatesController.CheckForUpdateResult.UpdateAvailable(update))
-            procedureContext.onComplete()
-            return
-          } else {
-            val reason = when (failedPreviously) {
-              true -> LoaderTask.RemoteCheckResultNotAvailableReason.UPDATE_PREVIOUSLY_FAILED
-              else -> LoaderTask.RemoteCheckResultNotAvailableReason.UPDATE_REJECTED_BY_SELECTION_POLICY
-            }
-            procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
-            callback(IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(reason))
-            procedureContext.onComplete()
-            return
+          if (continuation.isActive) {
+            continuation.resume(updateResponse)
           }
         }
       }
     )
+  }
+
+  private fun processUpdatesResponse(updateResponse: UpdateResponse, procedureContext: ProcedureContext, embeddedUpdate: UpdateEntity?) {
+    val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
+    val update = updateResponse.manifestUpdateResponsePart?.update
+
+    updateDirective?.let { directive ->
+      when (directive) {
+        is UpdateDirective.NoUpdateAvailableUpdateDirective -> {
+          procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+          callback(
+            IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+              LoaderTask.RemoteCheckResultNotAvailableReason.NO_UPDATE_AVAILABLE_ON_SERVER
+            )
+          )
+          procedureContext.onComplete()
+          return
+        }
+
+        is UpdateDirective.RollBackToEmbeddedUpdateDirective -> {
+          if (!updatesConfiguration.hasEmbeddedUpdate) {
+            procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+            callback(
+              IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+                LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED
+              )
+            )
+            procedureContext.onComplete()
+            return
+          }
+
+          if (embeddedUpdate == null) {
+            procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+            callback(
+              IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+                LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_NO_EMBEDDED
+              )
+            )
+            procedureContext.onComplete()
+            return
+          }
+
+          if (!selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
+              directive,
+              embeddedUpdate,
+              launchedUpdate,
+              updateResponse.responseHeaderData?.manifestFilters
+            )
+          ) {
+            procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+            callback(
+              IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+                LoaderTask.RemoteCheckResultNotAvailableReason.ROLLBACK_REJECTED_BY_SELECTION_POLICY
+              )
+            )
+            procedureContext.onComplete()
+            return
+          }
+
+          procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteWithRollback(directive.commitTime))
+          callback(IUpdatesController.CheckForUpdateResult.RollBackToEmbedded(directive.commitTime))
+          procedureContext.onComplete()
+          return
+        }
+      }
+    }
+
+    if (update == null) {
+      procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+      callback(
+        IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(
+          LoaderTask.RemoteCheckResultNotAvailableReason.NO_UPDATE_AVAILABLE_ON_SERVER
+        )
+      )
+      procedureContext.onComplete()
+      return
+    }
+
+    if (launchedUpdate == null) {
+      // this shouldn't ever happen, but if we don't have anything to compare
+      // the new manifest to, let the user know an update is available
+      procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteWithUpdate(update.manifest.getRawJson()))
+      callback(IUpdatesController.CheckForUpdateResult.UpdateAvailable(update))
+      procedureContext.onComplete()
+      return
+    }
+
+    var shouldLaunch = false
+    var failedPreviously = false
+    if (selectionPolicy.shouldLoadNewUpdate(
+        update.updateEntity,
+        launchedUpdate,
+        updateResponse.responseHeaderData?.manifestFilters
+      )
+    ) {
+      // If "update" has failed to launch previously, then
+      // "launchedUpdate" will be an earlier update, and the test above
+      // will return true (incorrectly).
+      // We check to see if the new update is already in the DB, and if so,
+      // only allow the update if it has had no launch failures.
+      shouldLaunch = true
+      update.updateEntity?.let { updateEntity ->
+        val storedUpdateEntity = databaseHolder.database.updateDao().loadUpdateWithId(
+          updateEntity.id
+        )
+        storedUpdateEntity?.let {
+          shouldLaunch = it.failedLaunchCount == 0
+          updatesLogger.info("Stored update found: ID = ${updateEntity.id}, failureCount = ${it.failedLaunchCount}")
+          failedPreviously = !shouldLaunch
+        }
+      }
+    }
+
+    if (shouldLaunch) {
+      procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteWithUpdate(update.manifest.getRawJson()))
+      callback(IUpdatesController.CheckForUpdateResult.UpdateAvailable(update))
+      procedureContext.onComplete()
+    } else {
+      val reason = when (failedPreviously) {
+        true -> LoaderTask.RemoteCheckResultNotAvailableReason.UPDATE_PREVIOUSLY_FAILED
+        else -> LoaderTask.RemoteCheckResultNotAvailableReason.UPDATE_REJECTED_BY_SELECTION_POLICY
+      }
+      procedureContext.processStateEvent(UpdatesStateEvent.CheckCompleteUnavailable())
+      callback(IUpdatesController.CheckForUpdateResult.NoUpdateAvailable(reason))
+      procedureContext.onComplete()
+    }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import expo.modules.updates.IUpdatesController
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.DatabaseHolder
+import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.loader.FileDownloader
@@ -14,7 +15,10 @@ import expo.modules.updates.loader.UpdateResponse
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import expo.modules.updates.statemachine.UpdatesStateEvent
+import kotlinx.coroutines.suspendCancellableCoroutine
 import java.io.File
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 class FetchUpdateProcedure(
   private val context: Context,
@@ -33,88 +37,102 @@ class FetchUpdateProcedure(
     procedureContext.processStateEvent(UpdatesStateEvent.Download())
 
     val database = databaseHolder.database
-    RemoteLoader(
-      context,
-      updatesConfiguration,
-      logger,
-      database,
-      fileDownloader,
-      updatesDirectory,
-      launchedUpdate
-    )
-      .start(
-        object : Loader.LoaderCallback {
-          override fun onFailure(e: Exception) {
-            databaseHolder.releaseDatabase()
-            procedureContext.processStateEvent(
-              UpdatesStateEvent.DownloadError("Failed to download new update: ${e.message}")
-            )
-            callback(IUpdatesController.FetchUpdateResult.ErrorResult(e))
-            procedureContext.onComplete()
-          }
+    try {
+      val loaderResult = startRemoteLoader(database)
+      processSuccessLoaderResult(loaderResult, procedureContext)
+    } catch (e: Exception) {
+      logger.error("Failed to download new update", e)
+      procedureContext.processStateEvent(
+        UpdatesStateEvent.DownloadError("Failed to download new update: ${e.message}")
+      )
+      callback(IUpdatesController.FetchUpdateResult.ErrorResult(e))
+    } finally {
+      databaseHolder.releaseDatabase()
+      procedureContext.onComplete()
+    }
+  }
 
-          override fun onAssetLoaded(
-            asset: AssetEntity,
-            successfulAssetCount: Int,
-            failedAssetCount: Int,
-            totalAssetCount: Int
-          ) {
-          }
+  private suspend fun startRemoteLoader(database: UpdatesDatabase): Loader.LoaderResult =
+    suspendCancellableCoroutine { continuation ->
+      RemoteLoader(
+        context,
+        updatesConfiguration,
+        logger,
+        database,
+        fileDownloader,
+        updatesDirectory,
+        launchedUpdate
+      )
+        .start(
+          object : Loader.LoaderCallback {
+            override fun onFailure(e: Exception) {
+              if (continuation.isActive) {
+                continuation.resumeWithException(e)
+              }
+            }
 
-          override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
-            val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
-            if (updateDirective != null) {
+            override fun onAssetLoaded(
+              asset: AssetEntity,
+              successfulAssetCount: Int,
+              failedAssetCount: Int,
+              totalAssetCount: Int
+            ) = Unit
+
+            override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
+              val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
+              if (updateDirective != null) {
+                return Loader.OnUpdateResponseLoadedResult(
+                  shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
+                    is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
+                    is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
+                  }
+                )
+              }
+
+              val update = updateResponse.manifestUpdateResponsePart?.update
+                ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
+
               return Loader.OnUpdateResponseLoadedResult(
-                shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
-                  is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
-                  is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
-                }
+                shouldDownloadManifestIfPresentInResponse = selectionPolicy.shouldLoadNewUpdate(
+                  update.updateEntity,
+                  launchedUpdate,
+                  updateResponse.responseHeaderData?.manifestFilters
+                )
               )
             }
 
-            val update = updateResponse.manifestUpdateResponsePart?.update
-              ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
-
-            return Loader.OnUpdateResponseLoadedResult(
-              shouldDownloadManifestIfPresentInResponse = selectionPolicy.shouldLoadNewUpdate(
-                update.updateEntity,
-                launchedUpdate,
-                updateResponse.responseHeaderData?.manifestFilters
-              )
-            )
-          }
-
-          override fun onSuccess(loaderResult: Loader.LoaderResult) {
-            RemoteLoader.processSuccessLoaderResult(
-              context,
-              updatesConfiguration,
-              logger,
-              database,
-              selectionPolicy,
-              updatesDirectory,
-              launchedUpdate,
-              loaderResult
-            ) { availableUpdate, didRollBackToEmbedded ->
-              databaseHolder.releaseDatabase()
-
-              if (didRollBackToEmbedded) {
-                procedureContext.processStateEvent(UpdatesStateEvent.DownloadCompleteWithRollback())
-                callback(IUpdatesController.FetchUpdateResult.RollBackToEmbedded())
-                procedureContext.onComplete()
-              } else {
-                if (availableUpdate == null) {
-                  procedureContext.processStateEvent(UpdatesStateEvent.DownloadComplete())
-                  callback(IUpdatesController.FetchUpdateResult.Failure())
-                  procedureContext.onComplete()
-                } else {
-                  procedureContext.processStateEvent(UpdatesStateEvent.DownloadCompleteWithUpdate(availableUpdate.manifest))
-                  callback(IUpdatesController.FetchUpdateResult.Success(availableUpdate))
-                  procedureContext.onComplete()
-                }
+            override fun onSuccess(loaderResult: Loader.LoaderResult) {
+              if (continuation.isActive) {
+                continuation.resume(loaderResult)
               }
             }
           }
+        )
+    }
+
+  private fun processSuccessLoaderResult(loaderResult: Loader.LoaderResult, procedureContext: ProcedureContext) {
+    RemoteLoader.processSuccessLoaderResult(
+      context,
+      updatesConfiguration,
+      logger,
+      databaseHolder.database,
+      selectionPolicy,
+      updatesDirectory,
+      launchedUpdate,
+      loaderResult
+    ) { availableUpdate, didRollBackToEmbedded ->
+      if (didRollBackToEmbedded) {
+        procedureContext.processStateEvent(UpdatesStateEvent.DownloadCompleteWithRollback())
+        callback(IUpdatesController.FetchUpdateResult.RollBackToEmbedded())
+      } else {
+        if (availableUpdate == null) {
+          procedureContext.processStateEvent(UpdatesStateEvent.DownloadComplete())
+          callback(IUpdatesController.FetchUpdateResult.Failure())
+        } else {
+          procedureContext.processStateEvent(UpdatesStateEvent.DownloadCompleteWithUpdate(availableUpdate.manifest))
+          callback(IUpdatesController.FetchUpdateResult.Success(availableUpdate))
         }
-      )
+      }
+    }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RecreateReactContextProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RecreateReactContextProcedure.kt
@@ -2,17 +2,20 @@ package expo.modules.updates.procedures
 
 import android.app.Activity
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
 import com.facebook.react.ReactApplication
 import expo.modules.updates.launcher.Launcher
 import expo.modules.updates.statemachine.UpdatesStateEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.lang.ref.WeakReference
 
 class RecreateReactContextProcedure(
   private val context: Context,
   private val weakActivity: WeakReference<Activity>?,
-  private val callback: Launcher.LauncherCallback
+  private val callback: Launcher.LauncherCallback,
+  private val procedureScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 ) : StateMachineProcedure() {
   override val loggerTimerLabel = "timer-recreate-react-context"
 
@@ -24,8 +27,10 @@ class RecreateReactContextProcedure(
 
     procedureContext.processStateEvent(UpdatesStateEvent.Restart())
     callback.onSuccess()
-    Handler(Looper.getMainLooper()).post {
-      reactApplication.restart(weakActivity?.get(), "Restart from RecreateReactContextProcedure")
+    procedureScope.launch {
+      withContext(Dispatchers.Main) {
+        reactApplication.restart(weakActivity?.get(), "Restart from RecreateReactContextProcedure")
+      }
     }
     procedureContext.resetStateAfterRestart()
     procedureContext.onComplete()


### PR DESCRIPTION
# Why
The state procedures were using older apis like `Handler`, these have been removed. Also, the `run` function tended to be large due to large anonymous classes, I've tried to break this up in an attempt to make the code paths easier to follow. I've also modified the `UpdatesModule` `AsyncFunction`s to use the `Coroutine` builder

# How
Split the run function into separate steps.  Fetching, checking for updates etc followed by processing the result. 

# Test Plan
Bare-expo in release, CI

