### PR TITLE
[image-picker][iOS] Use preferred representation mode to support heic

### DIFF
--- a/apps/native-component-list/src/screens/ImagePicker/ImagePickerScreen.tsx
+++ b/apps/native-component-list/src/screens/ImagePicker/ImagePickerScreen.tsx
@@ -188,6 +188,25 @@ const LAUNCH_PICKER_PARAMETERS: FunctionParameter[] = [
           },
         ],
       },
+      {
+        name: 'preferredAssetRepresentationMode',
+        type: 'enum',
+        platforms: ['ios'],
+        values: [
+          {
+            name: 'UIImagePickerPreferredAssetRepresentationMode.Automatic',
+            value: ImagePicker.UIImagePickerPreferredAssetRepresentationMode.Automatic,
+          },
+          {
+            name: 'UIImagePickerPreferredAssetRepresentationMode.Current',
+            value: ImagePicker.UIImagePickerPreferredAssetRepresentationMode.Current,
+          },
+          {
+            name: 'UIImagePickerPreferredAssetRepresentationMode.Compatible',
+            value: ImagePicker.UIImagePickerPreferredAssetRepresentationMode.Compatible,
+          },
+        ],
+      },
     ],
   },
 ];

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix `getPendingResultAsync` incorrect return type ([#35791](https://github.com/expo/expo/pull/35791) by [@sorenfrederiksen](https://github.com/sorenfrederiksen))
+- [iOS] Use preferred representation mode to support heic ([#35840](https://github.com/expo/expo/pull/35840) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/ios/ImageUtils.swift
+++ b/packages/expo-image-picker/ios/ImageUtils.swift
@@ -108,6 +108,8 @@ internal struct ImageUtils {
         initialMetadata: nil
       )
       return (gifData, ".gif")
+    case UTType.heic.identifier:
+      return (rawData, ".heic")
     default:
       if options.quality >= 1.0 {
         return (rawData, ".jpg")

--- a/packages/expo-image-picker/ios/NSItemProvider+Async.swift
+++ b/packages/expo-image-picker/ios/NSItemProvider+Async.swift
@@ -16,7 +16,7 @@ internal extension NSItemProvider {
 
   func loadImageDataRepresentation() async throws -> Data {
     return try await withCheckedThrowingContinuation { continuation in
-      let preferredTypeIdentifier = self.registeredTypeIdentifiers().first ?? UTType.image.identifier
+      let preferredTypeIdentifier = self.registeredTypeIdentifiers().compactMap { UTType($0) }.first { $0.conforms(to: .image) }?.identifier ?? UTType.image.identifier
       loadDataRepresentation(forTypeIdentifier: preferredTypeIdentifier) { data, error in
         if let data {
           continuation.resume(returning: data)

--- a/packages/expo-image-picker/ios/NSItemProvider+Async.swift
+++ b/packages/expo-image-picker/ios/NSItemProvider+Async.swift
@@ -16,7 +16,10 @@ internal extension NSItemProvider {
 
   func loadImageDataRepresentation() async throws -> Data {
     return try await withCheckedThrowingContinuation { continuation in
-      let preferredTypeIdentifier = self.registeredTypeIdentifiers().compactMap { UTType($0) }.first { $0.conforms(to: .image) }?.identifier ?? UTType.image.identifier
+      let preferredTypeIdentifier = self.registeredTypeIdentifiers()
+        .compactMap { UTType($0) }
+        .first { $0.conforms(to: .image) }?
+        .identifier ?? UTType.image.identifier
       loadDataRepresentation(forTypeIdentifier: preferredTypeIdentifier) { data, error in
         if let data {
           continuation.resume(returning: data)

--- a/packages/expo-image-picker/ios/NSItemProvider+Async.swift
+++ b/packages/expo-image-picker/ios/NSItemProvider+Async.swift
@@ -16,7 +16,8 @@ internal extension NSItemProvider {
 
   func loadImageDataRepresentation() async throws -> Data {
     return try await withCheckedThrowingContinuation { continuation in
-      loadDataRepresentation(forTypeIdentifier: UTType.image.identifier) { data, error in
+      let preferredTypeIdentifier = self.registeredTypeIdentifiers().first ?? UTType.image.identifier
+      loadDataRepresentation(forTypeIdentifier: preferredTypeIdentifier) { data, error in
         if let data {
           continuation.resume(returning: data)
         } else {


### PR DESCRIPTION
# Why

Fixes #35714
Currently, even when `preferredAssetRepresentationMode` is set to `UIImagePickerPreferredAssetRepresentationMode.Current` the user selects a `HEIC` file, the image-picker returns a `JPEG`

# How

`PHPicker` provides the selected image in multiple representation types. For example
<img width="304" alt="image" src="https://github.com/user-attachments/assets/d16e6dc4-585c-4941-a388-7f5e4e23246b" />

However, we always load the data representation for `UTType.image` type identifier, which prioritize `public.jpeg` over `public.heic`. Instead, we should select the asset's first registered type identifier that conforms to `UTType.image`, as this is the preferred format.

> [!NOTE]
> `registeredTypeIdentifiers` Returns the array of type identifiers for the item provider, in the same order they were registered.


# Test Plan

Bare Expo: 

https://github.com/user-attachments/assets/f3d129a6-3e26-4a85-a5db-affb859ad4f2

# Checklist


- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
