### PR TITLE
[expo-go] Fix home not surviving backgrounding.

### DIFF
--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -38,11 +38,12 @@ class AppDelegate: ExpoAppDelegate {
   }
 
   private func setUpUserInterfaceForApplication(_ application: UIApplication, withLaunchOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
-    ExpoKit.sharedInstance().registerRootViewControllerClass(EXRootViewController.self)
-    ExpoKit.sharedInstance().prepare(launchOptions: launchOptions)
     if self.window != nil {
       return
     }
+    ExpoKit.sharedInstance().registerRootViewControllerClass(EXRootViewController.self)
+    ExpoKit.sharedInstance().prepare(launchOptions: launchOptions)
+
     let window = UIWindow(frame: UIScreen.main.bounds)
     self.window = window
     window.backgroundColor = UIColor.white

--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -42,7 +42,7 @@ class AppDelegate: ExpoAppDelegate {
     ExpoKit.sharedInstance().prepare(launchOptions: launchOptions)
 
     let window = UIWindow(frame: UIScreen.main.bounds)
-    if(self.window != nil) {
+    if self.window != nil {
       return
     }
     self.window = window

--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -42,6 +42,9 @@ class AppDelegate: ExpoAppDelegate {
     ExpoKit.sharedInstance().prepare(launchOptions: launchOptions)
 
     let window = UIWindow(frame: UIScreen.main.bounds)
+    if(self.window != nil) {
+      return
+    }
     self.window = window
     window.backgroundColor = UIColor.white
     rootViewController = (ExpoKit.sharedInstance().rootViewController() as! EXRootViewController)

--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -40,11 +40,10 @@ class AppDelegate: ExpoAppDelegate {
   private func setUpUserInterfaceForApplication(_ application: UIApplication, withLaunchOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
     ExpoKit.sharedInstance().registerRootViewControllerClass(EXRootViewController.self)
     ExpoKit.sharedInstance().prepare(launchOptions: launchOptions)
-
-    let window = UIWindow(frame: UIScreen.main.bounds)
     if self.window != nil {
       return
     }
+    let window = UIWindow(frame: UIScreen.main.bounds)
     self.window = window
     window.backgroundColor = UIColor.white
     rootViewController = (ExpoKit.sharedInstance().rootViewController() as! EXRootViewController)


### PR DESCRIPTION
# Why

Expo Go stopped working after backgrounding and foregrounding the app again with error:
```
Manually adding the rootViewController's view to the view hierarchy is no longer supported. Please allow UIWindow to add the rootViewController's view to the view hierarchy itself.
```

# Test Plan

Tested this fixes things on a physical device. Not 100% confident this has no unintended consequences, but seems safe enough to land – hopefully we can find any problems during QA

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
