### PR TITLE
[symbols][Android] Fix platform misconfiguration in the `expo-modules.config`

### DIFF
--- a/packages/expo-symbols/CHANGELOG.md
+++ b/packages/expo-symbols/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix platform misconfiguration in the `expo-modules.config`.
+
 ### 💡 Others
 
 - [apple] Migrate remaining `expo-module.config.json` to unified platform syntax. ([#34445](https://github.com/expo/expo/pull/34445) by [@reichhartd](https://github.com/reichhartd))

--- a/packages/expo-symbols/CHANGELOG.md
+++ b/packages/expo-symbols/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix platform misconfiguration in the `expo-modules.config`.
+- [Android] Fix platform misconfiguration in the `expo-modules.config`. ([#35849](https://github.com/expo/expo/pull/35849) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-symbols/expo-module.config.json
+++ b/packages/expo-symbols/expo-module.config.json
@@ -1,5 +1,5 @@
 {
-  "platforms": ["apple", "android"],
+  "platforms": ["apple"],
   "apple": {
     "modules": ["SymbolModule"]
   },


### PR DESCRIPTION
# Why

Fixes platform misconfiguration in the `expo-modules.config`

