### PR TITLE
[core][Android] Add empty publish task when publishing was disabled

### DIFF
--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -7,6 +7,8 @@ import expo.modules.plugin.android.PublicationInfo
 import expo.modules.plugin.android.applyLinterOptions
 import expo.modules.plugin.android.applyPublishingVariant
 import expo.modules.plugin.android.applySDKVersions
+import expo.modules.plugin.android.createEmptyExpoPublishTask
+import expo.modules.plugin.android.createEmptyExpoPublishToMavenLocalTask
 import expo.modules.plugin.android.createExpoPublishTask
 import expo.modules.plugin.android.createExpoPublishToMavenLocalTask
 import expo.modules.plugin.android.createReleasePublication
@@ -65,6 +67,8 @@ internal fun Project.applyDefaultAndroidSdkVersions() {
  */
 internal fun Project.applyPublishing(expoModulesExtension: ExpoModuleExtension) {
   if (!expoModulesExtension.canBePublished) {
+    createEmptyExpoPublishTask()
+    createEmptyExpoPublishToMavenLocalTask()
     return
   }
 

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
@@ -101,6 +101,20 @@ internal fun Project.createExpoPublishTask(publicationInfo: PublicationInfo): Ta
   return taskProvider
 }
 
+internal fun Project.createEmptyExpoPublishTask(): TaskProvider<Task> {
+  val taskProvider = tasks.register("expoPublish") { task ->
+    task.doLast {
+      logger.warn("Publishing is not configured for this project!")
+    }
+  }
+  taskProvider.configure { task ->
+    task.group = "publishing"
+    task.description = "Publishes the library to the GitHub Packages repository"
+  }
+
+  return taskProvider
+}
+
 internal fun Project.createExpoPublishTask(error: Throwable): TaskProvider<Task> {
   val taskProvider = tasks.register("expoPublish") { task ->
     task.doLast {
@@ -110,6 +124,20 @@ internal fun Project.createExpoPublishTask(error: Throwable): TaskProvider<Task>
   taskProvider.configure { task ->
     task.group = "publishing"
     task.description = "Publishes the library to the GitHub Packages repository"
+  }
+
+  return taskProvider
+}
+
+internal fun Project.createEmptyExpoPublishToMavenLocalTask(): TaskProvider<Task> {
+  val taskProvider = tasks.register("expoPublishToMavenLocal") { task ->
+    task.doLast {
+      logger.warn("Publishing is not configured for this project!")
+    }
+  }
+  taskProvider.configure { task ->
+    task.group = "publishing"
+    task.description = "Publishes the library to the local Maven repository"
   }
 
   return taskProvider


### PR DESCRIPTION
# Why

Adds empty publish task when publishing was disabled. 
We can add empty publish tasks to simplify our internal tooling even if the publishing was turned off for a specific package. By doing that, we don't have to check if before running the Gradle command.
