### PR TITLE
[ui][iOS] Allow undefined props on ExpoSwiftUIView

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Android] Add Constant API ([#35157](https://github.com/expo/expo/pull/35157) by [@jakex7](https://github.com/jakex7))
 - [iOS] Add Constant API ([#35199](https://github.com/expo/expo/pull/35199) by [@jakex7](https://github.com/jakex7))
 - [Android] Added support for custom queues for async functions. ([#35838](https://github.com/expo/expo/pull/35838) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Allow undefined props on ExpoSwiftUIView ([#35852](https://github.com/expo/expo/pull/35852) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinitionDefaultProps.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinitionDefaultProps.swift
@@ -1,0 +1,17 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+/**
+ An empty class that conforms to ExpoSwiftUI.ViewProps.
+ */
+public class ExpoSwiftUIDefaultProps: ExpoSwiftUI.ViewProps {}
+
+/**
+ Fallback to ExpoSwiftUIDefaultProps when Props are not declared.
+ */
+public extension ExpoSwiftUIView where Props == ExpoSwiftUIDefaultProps {
+  var props: ExpoSwiftUIDefaultProps {
+    ExpoSwiftUIDefaultProps()
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinitionDefaultProps.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinitionDefaultProps.swift
@@ -10,7 +10,7 @@ public class ExpoSwiftUIDefaultProps: ExpoSwiftUI.ViewProps {}
 /**
  Fallback to ExpoSwiftUIDefaultProps when Props are not declared.
  */
-public extension ExpoSwiftUIView where Props == ExpoSwiftUIDefaultProps {
+public extension ExpoSwiftUIView {
   var props: ExpoSwiftUIDefaultProps {
     ExpoSwiftUIDefaultProps()
   }


### PR DESCRIPTION
# Why

When creating a simple component that doesn’t require any props, we still need to define an empty class conforming to `ExpoSwiftUI.ViewProps` and include an `EnvironmentObject` within the struct. For example:

```swift
class SpacerProps: ExpoSwiftUI.ViewProps {}

struct SpacerView: ExpoSwiftUI.View {
  @EnvironmentObject var props: SpacerProps
  var body: some View {
    Spacer()
  }
}
```

# How

Adds `ExpoSwiftUIView` extension with default props, which is an empty class that conforms to `ExpoSwiftUI.ViewProps`.

Now, the same struct can simply be:

```swift
struct SpacerView: ExpoSwiftUI.View {
  var body: some View {
    Spacer()
  }
}
```

# Test Plan

Bare Expo, all expo-ui components should continue to work and new component with above snippet should compile without errors. 

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
