### PR TITLE
[task-manager][Android] Fix `namespace` contains a capital letter

### DIFF
--- a/packages/expo-task-manager/android/build.gradle
+++ b/packages/expo-task-manager/android/build.gradle
@@ -7,7 +7,7 @@ group = 'host.exp.exponent'
 version = '13.0.0'
 
 android {
-  namespace "expo.modules.taskManager"
+  namespace "expo.modules.taskmanager"
   defaultConfig {
     versionCode 23
     versionName "13.0.0"


### PR DESCRIPTION
# Why

Fixes `namespace` contains a capital letter.

# How

It's turn out that Github returns `422 Unprocessable Entity` when trying to upload artifact with capital letters.

# Test Plan

- https://github.com/orgs/expo/packages ✅ 
