### PR TITLE
[et] Publish Android artifacts when publishing canary

### DIFF
--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -42,6 +42,7 @@ jobs:
         run: ./bin/expotools publish-packages --canary ${{ github.event_name != 'workflow_dispatch' && '--dry' || '' }}
         env:
           FORCE_COLOR: '2'
+          EXPO_GITHUB_PUBLISH_TOKEN: ${{ secrets.EXPO_GITHUB_PUBLISH_TOKEN }}
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -25,6 +25,11 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
+      - name: 🔨 Use JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -47,7 +47,6 @@ jobs:
         run: ./bin/expotools publish-packages --canary ${{ github.event_name != 'workflow_dispatch' && '--dry' || '' }}
         env:
           FORCE_COLOR: '2'
-          EXPO_GITHUB_PUBLISH_TOKEN: ${{ secrets.EXPO_GITHUB_PUBLISH_TOKEN }}
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && github.event_name == 'schedule'

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/ProjectExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/ProjectExtension.kt
@@ -3,6 +3,7 @@ package expo.modules.plugin.gradle
 import expo.modules.plugin.configuration.GradleAarProject
 import expo.modules.plugin.configuration.GradlePlugin
 import expo.modules.plugin.configuration.MavenRepo
+import expo.modules.plugin.configuration.Publication
 import org.gradle.api.Project
 import java.io.File
 import java.net.URI
@@ -18,6 +19,19 @@ internal fun Project.applyAarProject(aarProject: GradleAarProject) {
 
 internal fun Project.linkBuildDependence(plugin: GradlePlugin) {
   buildscript.dependencies.add("classpath", "${plugin.group}:${plugin.id}")
+}
+
+internal fun Project.linkLocalMavenRepository(path: String, publications: List<Publication>) {
+  repositories.mavenLocal { maven ->
+    val repositoryFile = file(path).absolutePath
+    maven.url = URI.create("file://$repositoryFile")
+
+    maven.content { content ->
+      publications.forEach { publication ->
+        content.includeVersion(publication.groupId, publication.artifactId, publication.version)
+      }
+    }
+  }
 }
 
 internal fun Project.linkMavenRepository(mavenRepo: MavenRepo) {

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -87,6 +87,8 @@ internal fun Project.applyPublishing(expoModulesExtension: ExpoModuleExtension) 
     createExpoPublishToMavenLocalTask(publicationInfo)
 
     val publicationToken = rootProject.findProperty("EXPO_GITHUB_PUBLISH_TOKEN") as? String
+      ?: System.getenv("EXPO_GITHUB_PUBLISH_TOKEN")
+
     if (!publicationToken.isNullOrEmpty()) {
       publishingExtension().repositories.maven { mavenRepo ->
         mavenRepo.name = "GitHubPackages"

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -86,23 +86,14 @@ internal fun Project.applyPublishing(expoModulesExtension: ExpoModuleExtension) 
 
     createExpoPublishToMavenLocalTask(publicationInfo)
 
-    val publicationToken = rootProject.findProperty("EXPO_GITHUB_PUBLISH_TOKEN") as? String
-      ?: System.getenv("EXPO_GITHUB_PUBLISH_TOKEN")
-
-    if (!publicationToken.isNullOrEmpty()) {
-      publishingExtension().repositories.maven { mavenRepo ->
-        mavenRepo.name = "GitHubPackages"
-        mavenRepo.url = URI("https://maven.pkg.github.com/expo/expo")
-
-        mavenRepo.credentials { pc ->
-          pc.username = "expo"
-          pc.password = publicationToken
-        }
-      }
-      createExpoPublishTask(publicationInfo)
-    } else {
-      createExpoPublishTask(IllegalStateException("EXPO_GITHUB_PUBLISH_TOKEN is not defined"))
+    val npmLocalRepositoryRelativePath = "local-maven-repo"
+    val npmLocalRepository = URI("file://${project.projectDir.parentFile}/${npmLocalRepositoryRelativePath}")
+    publishingExtension().repositories.mavenLocal { mavenRepo ->
+      mavenRepo.name = "NPMPackage"
+      mavenRepo.url = npmLocalRepository
     }
+
+    createExpoPublishTask(publicationInfo, npmLocalRepositoryRelativePath)
   }
 }
 

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
@@ -19,6 +19,7 @@ import org.gradle.api.component.SoftwareComponent
 import org.gradle.api.publish.PublicationContainer
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.TaskProvider
+import java.net.URI
 import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.toPath
@@ -84,10 +85,10 @@ internal fun PublicationContainer.createReleasePublication(publicationInfo: Publ
   }
 }
 
-internal fun Project.createExpoPublishTask(publicationInfo: PublicationInfo): TaskProvider<Task> {
+internal fun Project.createExpoPublishTask(publicationInfo: PublicationInfo, pathToRepository: String): TaskProvider<Task> {
   val taskProvider = tasks.register("expoPublish") { task ->
     task.doLast {
-      expoPublishBody(publicationInfo, isLocal = false)
+      expoPublishBody(publicationInfo, pathToRepository = pathToRepository)
     }
   }
   taskProvider.configure { task ->
@@ -115,20 +116,6 @@ internal fun Project.createEmptyExpoPublishTask(): TaskProvider<Task> {
   return taskProvider
 }
 
-internal fun Project.createExpoPublishTask(error: Throwable): TaskProvider<Task> {
-  val taskProvider = tasks.register("expoPublish") { task ->
-    task.doLast {
-      logger.error("Failed to publish the library to the GitHub Packages repository: ${error.message}", error)
-    }
-  }
-  taskProvider.configure { task ->
-    task.group = "publishing"
-    task.description = "Publishes the library to the GitHub Packages repository"
-  }
-
-  return taskProvider
-}
-
 internal fun Project.createEmptyExpoPublishToMavenLocalTask(): TaskProvider<Task> {
   val taskProvider = tasks.register("expoPublishToMavenLocal") { task ->
     task.doLast {
@@ -146,7 +133,7 @@ internal fun Project.createEmptyExpoPublishToMavenLocalTask(): TaskProvider<Task
 internal fun Project.createExpoPublishToMavenLocalTask(publicationInfo: PublicationInfo): TaskProvider<Task> {
   val taskProvider = tasks.register("expoPublishToMavenLocal") { task ->
     task.doLast {
-      expoPublishBody(publicationInfo, isLocal = true)
+      expoPublishBody(publicationInfo)
     }
   }
   taskProvider.configure { task ->
@@ -160,8 +147,8 @@ internal fun Project.createExpoPublishToMavenLocalTask(publicationInfo: Publicat
   return taskProvider
 }
 
-private fun Project.expoPublishBody(publicationInfo: PublicationInfo, isLocal: Boolean) {
-  if (isLocal) {
+private fun Project.expoPublishBody(publicationInfo: PublicationInfo, pathToRepository: String? = null) {
+  if (pathToRepository == null) {
     val mavenLocal = publishingExtension().repositories.mavenLocal()
     val mavenLocalPath = mavenLocal.url.toPath()
     val publicationPath = publicationInfo.resolvePath(mavenLocalPath)
@@ -181,7 +168,7 @@ private fun Project.expoPublishBody(publicationInfo: PublicationInfo, isLocal: B
   }
 
   val jsonElement = json.parseToJsonElement(expoModuleConfig.readText()).jsonObject
-  val newJsonElement = modifyModuleConfig(projectName = name, jsonElement, publicationInfo, isLocal)
+  val newJsonElement = modifyModuleConfig(projectName = name, jsonElement, publicationInfo, pathToRepository)
 
   val newJsonString = json.encodeToString(JsonObject.serializer(), newJsonElement)
 
@@ -195,16 +182,12 @@ private fun Project.expoPublishBody(publicationInfo: PublicationInfo, isLocal: B
   }.result.get()
 }
 
-private fun modifyModuleConfig(projectName: String, currentConfig: JsonObject, publicationInfo: PublicationInfo, isLocal: Boolean): JsonObject {
+private fun modifyModuleConfig(projectName: String, currentConfig: JsonObject, publicationInfo: PublicationInfo, pathToRepository: String?): JsonObject {
   val publicationObject = JsonObject(mapOf(
     "groupId" to publicationInfo.groupId.toJsonElement(),
     "artifactId" to publicationInfo.artifactId.toJsonElement(),
     "version" to publicationInfo.version.toJsonElement(),
-    "repository" to if (isLocal) {
-      "mavenLocal"
-    } else {
-      "https://maven.pkg.github.com/expo/expo"
-    }.toJsonElement(),
+    "repository" to (pathToRepository ?: "mavenLocal").toJsonElement(),
   ))
 
   val androidObject = currentConfig.getOrDefault("android", JsonObject(emptyMap())).jsonObject.mutate {

--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -75,6 +75,12 @@ export type ExpoModuleConfig = {
   };
   android?: {
     subdirectory?: string;
+    name?: string;
+    publication?: any;
+    projects?: {
+      name?: string;
+      publication?: any;
+    }[];
   };
 };
 
@@ -84,13 +90,13 @@ export type ExpoModuleConfig = {
 export class Package {
   path: string;
   packageJson: PackageJson;
-  expoModuleConfig: ExpoModuleConfig;
+  expoModuleConfig?: ExpoModuleConfig;
   packageView?: Npm.PackageViewType | null;
 
   constructor(rootPath: string, packageJson?: PackageJson) {
     this.path = rootPath;
     this.packageJson = packageJson || require(path.join(rootPath, 'package.json'));
-    this.expoModuleConfig = readExpoModuleConfigJson(rootPath);
+    this.expoModuleConfig = readExpoModuleConfigJson(this.expoModulesConfigPath);
   }
 
   get hasPlugin(): boolean {
@@ -190,6 +196,10 @@ export class Package {
 
   get changelogPath(): string {
     return path.join(this.path, 'CHANGELOG.md');
+  }
+
+  get expoModulesConfigPath(): string {
+    return path.join(this.path, 'expo-module.config.json');
   }
 
   isExpoModule() {
@@ -389,12 +399,9 @@ export async function getListOfPackagesAsync(): Promise<Package[]> {
   return cachedPackages;
 }
 
-function readExpoModuleConfigJson(dir: string) {
-  const expoModuleConfigJsonPath = path.join(dir, 'expo-module.config.json');
-  const expoModuleConfigJsonExists = fs.existsSync(expoModuleConfigJsonPath);
-  const unimoduleJsonPath = path.join(dir, 'unimodule.json');
+function readExpoModuleConfigJson(expoModuleConfigJsonPath: string) {
   try {
-    return require(expoModuleConfigJsonExists ? expoModuleConfigJsonPath : unimoduleJsonPath);
+    return require(expoModuleConfigJsonPath);
   } catch {
     return null;
   }

--- a/tools/src/publish-packages/tasks/publishAndroidPackages.ts
+++ b/tools/src/publish-packages/tasks/publishAndroidPackages.ts
@@ -1,0 +1,141 @@
+import spawnAsync from '@expo/spawn-async';
+import { green } from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
+
+import { EXPO_DIR } from '../../Constants';
+import logger from '../../Logger';
+import { ExpoModuleConfig, Package } from '../../Packages';
+import { Task } from '../../TasksRunner';
+import type { CommandOptions, Parcel } from '../types';
+import { updateAndroidProjects } from './updateAndroidProjects';
+
+const EXCLUDE = ['expo-module-template-local', 'expo-module-template'];
+
+export const publishAndroidArtifacts = new Task(
+  {
+    name: 'publishAndroidArtifacts',
+    dependsOn: [updateAndroidProjects],
+    filesToStage: ['packages/**/expo-module.config.json'],
+  },
+  async (parcels: Parcel[], options: CommandOptions) => {
+    const packages = parcels.map((parcels) => parcels.pkg);
+
+    // Collect all packages that have Android artifacts to publish.
+    const androidPackages = packages.filter((pkg) => {
+      const moduleConfig = pkg.expoModuleConfig;
+      if (!moduleConfig) {
+        return false;
+      }
+      if (!moduleConfig.platforms.includes('android')) {
+        return false;
+      }
+      if (EXCLUDE.includes(pkg.packageName)) {
+        return false;
+      }
+      return true;
+    });
+
+    if (androidPackages.length === 0) {
+      logger.log('\n🤖 No Android artifacts to publish.');
+      return;
+    }
+
+    logger.info('\n🤖 Publishing Android artifacts...');
+
+    logger.log('  ', 'Removing existing publications...');
+    // Remove existing publications from expo-module.config.json
+    await Promise.all(androidPackages.map((pkg) => removeExistingPublications(pkg)));
+
+    const batch = logger.batch();
+    batch.log('  ', 'Collecting publication Gradle tasks...');
+    // Collect all Gradle tasks to publish Android artifacts.
+    // We need to use `expoPublishToMavenLocal` for dry run.
+    // Otherwise, we use `expoPublish`.
+    const gradleTasks = androidPackages.flatMap((pkg) => {
+      const publicationCommands = getPublicationCommands(
+        pkg.packageName,
+        pkg.expoModuleConfig!,
+        options
+      );
+
+      if (publicationCommands.length === 1) {
+        const publicationCommand = publicationCommands[0];
+        batch.log('  ', '  ', `${green(pkg.packageName)}: ${publicationCommand}`);
+      } else {
+        batch.log('  ', '  ', `${green(pkg.packageName)}:`);
+        for (const command of publicationCommands) {
+          batch.log('  ', '  ', '  ', `${command}`);
+        }
+      }
+
+      return publicationCommands;
+    });
+    batch.flush();
+
+    logger.log('  ', 'Publishing Android artifacts...');
+    // Run Gradle tasks in one batch to speed up the process.
+    await spawnAsync('./gradlew', gradleTasks, {
+      cwd: path.join(EXPO_DIR, 'apps/bare-expo/android'),
+      stdio: 'inherit',
+    });
+    logger.success('  ', 'Done!');
+  }
+);
+
+function getPublicationCommands(
+  packageName: string,
+  moduleConfig: ExpoModuleConfig,
+  options: CommandOptions
+): string[] {
+  const androidProjectsName = new Set<string>();
+  androidProjectsName.add(moduleConfig.android?.name ?? convertPackageToProjectName(packageName));
+
+  for (const subproject of moduleConfig.android?.projects ?? []) {
+    const subprojectName = subproject.name;
+    if (subprojectName) {
+      androidProjectsName.add(subprojectName);
+    }
+  }
+
+  const gradleTask = options.dry ? 'expoPublishToMavenLocal' : 'expoPublish';
+
+  return [...androidProjectsName].map((projectName) => `:${projectName}:${gradleTask}`);
+}
+
+async function removeExistingPublications(pkg: Package) {
+  let needToUpdate = false;
+
+  if (pkg.expoModuleConfig?.android?.publication) {
+    needToUpdate = true;
+    delete pkg.expoModuleConfig?.android?.publication;
+  }
+
+  pkg.expoModuleConfig?.android?.projects?.forEach((project) => {
+    if (project.publication) {
+      needToUpdate = true;
+      delete project.publication;
+    }
+  });
+
+  if (!needToUpdate) {
+    return;
+  }
+
+  const stringifyConfig = JSON.stringify(pkg.expoModuleConfig, null, 2);
+
+  await fs.writeFile(pkg.expoModulesConfigPath, stringifyConfig, 'utf-8');
+  return spawnAsync('yarn', ['prettier', '--write', pkg.expoModulesConfigPath], {
+    cwd: pkg.path,
+  });
+}
+
+/**
+ * Converts the package name to Android's project name.
+ *   `/` path will transform as `-`
+ *
+ * Example: `@expo/example` + `android/build.gradle` → `expo-example`
+ */
+function convertPackageToProjectName(packageName: string): string {
+  return packageName.replace(/^@/g, '').replace(/\W+/g, '-');
+}

--- a/tools/src/publish-packages/tasks/publishAndroidPackages.ts
+++ b/tools/src/publish-packages/tasks/publishAndroidPackages.ts
@@ -50,14 +50,8 @@ export const publishAndroidArtifacts = new Task(
     const batch = logger.batch();
     batch.log('  ', 'Collecting publication Gradle tasks...');
     // Collect all Gradle tasks to publish Android artifacts.
-    // We need to use `expoPublishToMavenLocal` for dry run.
-    // Otherwise, we use `expoPublish`.
     const gradleTasks = androidPackages.flatMap((pkg) => {
-      const publicationCommands = getPublicationCommands(
-        pkg.packageName,
-        pkg.expoModuleConfig!,
-        options
-      );
+      const publicationCommands = getPublicationCommands(pkg.packageName, pkg.expoModuleConfig!);
 
       if (publicationCommands.length === 1) {
         const publicationCommand = publicationCommands[0];
@@ -83,11 +77,7 @@ export const publishAndroidArtifacts = new Task(
   }
 );
 
-function getPublicationCommands(
-  packageName: string,
-  moduleConfig: ExpoModuleConfig,
-  options: CommandOptions
-): string[] {
+function getPublicationCommands(packageName: string, moduleConfig: ExpoModuleConfig): string[] {
   const androidProjectsName = new Set<string>();
   androidProjectsName.add(moduleConfig.android?.name ?? convertPackageToProjectName(packageName));
 
@@ -98,9 +88,7 @@ function getPublicationCommands(
     }
   }
 
-  const gradleTask = options.dry ? 'expoPublishToMavenLocal' : 'expoPublish';
-
-  return [...androidProjectsName].map((projectName) => `:${projectName}:${gradleTask}`);
+  return [...androidProjectsName].map((projectName) => `:${projectName}:expoPublish`);
 }
 
 async function removeExistingPublications(pkg: Package) {

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -6,6 +6,7 @@ import { checkEnvironmentTask } from './checkEnvironmentTask';
 import { checkPackageAccess } from './checkPackageAccess';
 import { loadRequestedParcels } from './loadRequestedParcels';
 import { packPackageToTarball } from './packPackageToTarball';
+import { publishAndroidArtifacts } from './publishAndroidPackages';
 import { publishPackages } from './publishPackages';
 import { updateBundledNativeModulesFile } from './updateBundledNativeModulesFile';
 import { updateModuleTemplate } from './updateModuleTemplate';
@@ -24,6 +25,7 @@ import { Task } from '../../TasksRunner';
 import { runWithSpinner } from '../../Utils';
 import { resolveReleaseTypeAndVersion } from '../helpers';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
+import { updateAndroidProjects } from './updateAndroidProjects';
 
 const { cyan, green } = chalk;
 
@@ -167,6 +169,8 @@ export const publishCanaryPipeline = new Task<TaskArgs>(
       updateBundledNativeModulesFile,
       updateModuleTemplate,
       updateWorkspaceProjects,
+      updateAndroidProjects,
+      publishAndroidArtifacts,
       packPackageToTarball,
       publishPackages,
       publishCanaryProjectTemplates,


### PR DESCRIPTION
# Why

Publishes Android artifacts when publishing canary.

# How

It's an initial integration between `et` and bare-expo for publishing Android artifacts. There are still some rough edges to address. It was added to start testing the whole flow somehow.

Think to address:
- error when publishing the same version twice 
- restoring from backpack 
- which project should be used to publish the android

# Test Plan

- https://github.com/orgs/expo/packages ✅ 
- running `et publish-packages --canary` ✅ 
