### PR TITLE
Update ios-development-build-for-simulators.mdx

### DIFF
--- a/docs/pages/tutorial/eas/ios-development-build-for-simulators.mdx
+++ b/docs/pages/tutorial/eas/ios-development-build-for-simulators.mdx
@@ -46,12 +46,11 @@ For a development build, it's necessary to have the `developmentClient` and `dis
 ```json eas.json
 {
   "ios-simulator": {
-      /* @info The <CODE>extends</CODE> keyword inherits properties from the <CODE>development</CODE> profile. */
-      "extends": "development",
-      /* @end */
-      "ios": {
-        "simulator": true
-      }
+    /* @info The <CODE>extends</CODE> keyword inherits properties from the <CODE>development</CODE> profile. */
+    "extends": "development",
+    /* @end */
+    "ios": {
+      "simulator": true
     }
   }
 }


### PR DESCRIPTION
a small fix. The code snippet has a wrong closing bracket for a section "Create a simulator build profile in eas.json"

# Why

I tried to copy the snippet from a documentation and isn't working


# How

only adjust for documentation (remove the bracket and fix code ident)

