### PR TITLE
[notifications] event emitter should not influence notification presentation

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- event emitter should not influence notification presentation ([#35858](https://github.com/expo/expo/pull/35858) by [@vonovak](https://github.com/vonovak))
 - correctly serialize `null` trigger on iOS ([#35672](https://github.com/expo/expo/pull/35672) by [@vonovak](https://github.com/vonovak))
 - restore `useLastNotificationResponse` return value behavior ([#35504](https://github.com/expo/expo/pull/35504) by [@vonovak](https://github.com/vonovak))
 - fix ios textInput action missing title ([#34866](https://github.com/expo/expo/pull/34866) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Emitter/EmitterModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Emitter/EmitterModule.swift
@@ -53,7 +53,6 @@ public class EmitterModule: Module, NotificationDelegate {
     // TODO: convert serialization to Records
     let serializedNotification = EXNotificationSerializer.serializedNotification(notification)
     self.sendEvent(onDidReceiveNotification, serializedNotification as [String: Any])
-    completionHandler([])
-    return true
+    return false
   }
 }

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Handler/HandlerModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Handler/HandlerModule.swift
@@ -28,7 +28,7 @@ public class HandlerModule: Module, NotificationDelegate, SingleNotificationHand
         promise.reject("ERR_NOTIFICATION_HANDLED", "Failed to handle notification \(identifier) because it has already been handled")
         return
       }
-      if task.handleResponse(behavior) {
+      if task.processNotificationWithBehavior(behavior) {
         promise.resolve(nil)
       } else {
         promise.reject("ERR_NOTIFICATION_RESPONSE_TIMEOUT", "Notification has already been handled. Most probably the request has timed out.")

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Handler/SingleNotificationHandlerTask.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Handler/SingleNotificationHandlerTask.swift
@@ -44,7 +44,7 @@ public class SingleNotificationHandlerTask {
     finish()
   }
 
-  public func handleResponse(_ behavior: [String: Bool]) -> Bool {
+  public func processNotificationWithBehavior(_ behavior: [String: Bool]) -> Bool {
     if let completionHandler = completionHandler {
       let options = presentationOptions(behavior)
       completionHandler(options)

--- a/packages/expo-notifications/ios/EXNotifications/PushToken/PushTokenModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/PushToken/PushTokenModule.swift
@@ -24,7 +24,7 @@ public class PushTokenModule: Module, NotificationDelegate {
 
     AsyncFunction("getDevicePushTokenAsync") { (promise: Promise) in
       if promiseNotYetResolved != nil {
-        promise.reject("E_AWAIT_PROMISE", "Another async call to this method is in progress. Await the first Promise.")
+        promise.reject("E_AWAIT_PROMISE", "Another async call to getDevicePushTokenAsync() is in progress. Await the first Promise.")
         return
       }
       promiseNotYetResolved = promise


### PR DESCRIPTION
# Why

This PR removes the `completionHandler([])` call and changes the return value to `false` in the `EmitterModule` - this module should emit events to JS, not decide whether a notification should be presented

# How

- In `EmitterModule.swift`, changed the return value from `true` to `false` and removed the `completionHandler([])` call to ensure that notifications presentation is decided by `SingleNotificationHandlerTask`, not `EmitterModule`
- renamed `handleResponse` to `processNotificationWithBehavior` because that's what it's called on Android and because `handleResponse` can be easily confused for dealing with responding to a notification action

# Test Plan

1. Test receiving push notifications on iOS and verify they are presented correctly


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)