### PR TITLE
[docs][modules] Improve guide to using third party ios frameworks

### DIFF
--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -8,6 +8,7 @@ import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
@@ -162,7 +163,7 @@ dependencies {
 
 <Collapsible summary={<>Are you trying to use an <CODE>.xcframework</CODE> or <CODE>.framework</CODE> dependency?</>}>
 
-On iOS, you can also use dependencies bundled as a framework by using the `vendored_framework` config option.
+On iOS, you can also use dependencies bundled as a framework by using the `vendored_frameworks` config option.
 
 ```diff ios/ExpoRadialChart.podspec
     s.static_framework = true
@@ -170,6 +171,30 @@ On iOS, you can also use dependencies bundled as a framework by using the `vendo
 +   s.vendored_frameworks = 'Frameworks/MyFramework.framework'
     # Swift/Objective-C compatibility
 ```
+
+> **info** **Note**: The file pattern used to specify the path to the framework is relative to the podspec file,
+> and doesn't support traversing the parent directory (`..`), meaning you need to place the framework inside the **ios** directory
+> (or a subdirectory of **ios**).
+
+Once the framework is added, make sure that the `source_files` option file pattern doesn't match any files inside the framework.
+One easy way to achive this is to move your ios source swift files (that is `ExpoRadialChartView.swift` and `ExpoRadialChartModule.swift`)
+into a **src** directory seperate from where you placed your framework(s) and update the `source_files` option to only match the **src** directory:
+
+```diff ios/ExpoRadialChart.podspec
+- s.source_files = '**/*.{h,m,mm,swift,hpp,cpp}'
++ s.source_files = 'src/**/*.{h,m,mm,swift,hpp,cpp}'
+```
+
+Your **ios** folder should end up with a file structure similar to this:
+
+<FileTree
+  files={[
+    'Frameworks/MyFramework.framework',
+    'src/ExpoRadialChartView.swift',
+    'src/ExpoRadialChartModule.swift',
+    'ExpoRadialChart.podspec',
+  ]}
+/>
 
 </Collapsible>
 

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -176,16 +176,14 @@ On iOS, you can also use dependencies bundled as a framework by using the `vendo
 > and doesn't support traversing the parent directory (`..`), meaning you need to place the framework inside the **ios** directory
 > (or a subdirectory of **ios**).
 
-Once the framework is added, make sure that the `source_files` option file pattern doesn't match any files inside the framework.
-One easy way to achieve this is to move your ios source swift files (that is `ExpoRadialChartView.swift` and `ExpoRadialChartModule.swift`)
-into a **src** directory separate from where you placed your framework(s) and update the `source_files` option to only match the **src** directory:
+Once the framework is added, make sure that the `source_files` option file pattern doesn't match any files inside the framework. One way to achieve this is to move your iOS source Swift files (that is `ExpoRadialChartView.swift` and `ExpoRadialChartModule.swift`) into a **src** directory separate from where you placed your framework(s) and update the `source_files` option to only match the **src** directory:
 
 ```diff ios/ExpoRadialChart.podspec
 - s.source_files = '**/*.{h,m,mm,swift,hpp,cpp}'
 + s.source_files = 'src/**/*.{h,m,mm,swift,hpp,cpp}'
 ```
 
-Your **ios** folder should end up with a file structure similar to this:
+Your **ios** directory should end up with a file structure similar to this:
 
 <FileTree
   files={[

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -177,8 +177,8 @@ On iOS, you can also use dependencies bundled as a framework by using the `vendo
 > (or a subdirectory of **ios**).
 
 Once the framework is added, make sure that the `source_files` option file pattern doesn't match any files inside the framework.
-One easy way to achive this is to move your ios source swift files (that is `ExpoRadialChartView.swift` and `ExpoRadialChartModule.swift`)
-into a **src** directory seperate from where you placed your framework(s) and update the `source_files` option to only match the **src** directory:
+One easy way to achieve this is to move your ios source swift files (that is `ExpoRadialChartView.swift` and `ExpoRadialChartModule.swift`)
+into a **src** directory separate from where you placed your framework(s) and update the `source_files` option to only match the **src** directory:
 
 ```diff ios/ExpoRadialChart.podspec
 - s.source_files = '**/*.{h,m,mm,swift,hpp,cpp}'


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Using the current documentation will cause your iOS build to fail. The default `source_files` glob pattern will match the header files inside the .`(xc)framework` which causes import statements for those header files to be added to the umbrella header file of the module. This eventually leads to a build error, since the header files aren't available in the consuming project, causing an error similar to:

```shell
❌  (/some/path/ModulesRepro/ios/DerivedData/ModulesRepro/Build/Products/Debug-iphonesimulator/MyModule/MyModule-umbrella.h:13:9)

  11 | #endif
  12 |
> 13 | #import "MyFramework.h"
     |         ^ 'MyFramework.h' file not found
  14 | #import "MyFramework.h"
  15 |
  16 | FOUNDATION_EXPORT double MyModuleVersionNumber;
```

Notice how multiple import statements are added when using an xcframework (one for each platform that the xcframework supports).

Podspecs also support an option called [exclude_files](https://guides.cocoapods.org/syntax/podspec.html#exclude_files), but it's impact on other options than `source_files` is not immediately clear. It's described as `A list of file patterns that should be excluded from the other file patterns.` which implies that it will affect all options that use file patterns (not just `source_files`). Therefore, I decided to split the frameworks and source files into separate folders instead.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Reproduction

- Set up a new app using a development build
- Follow https://docs.expo.dev/modules/get-started/#add-a-new-module-to-an-existing-application to add a module to the app
- Add an iOS (xc)framework using the current documentation https://docs.expo.dev/modules/third-party-library/#add-native-dependencies
- Build and run the ios app and watch the error occur.
- Implement the changes according to the new documentation and the app should now build successfully.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
