### PR TITLE
[expo-notifications][iOS] Swift conversion 10: refactor for Expo Go

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [iOS] Swift conversion 7: Handler and Emitter. ([#35564](https://github.com/expo/expo/pull/35564) by [@douglowder](https://github.com/douglowder))
 - [iOS] Swift conversion 8: Background module. ([#35695](https://github.com/expo/expo/pull/35695) by [@douglowder](https://github.com/douglowder))
 - [iOS] Swift conversion 9: Permissions module. ([#35719](https://github.com/expo/expo/pull/35719) by [@douglowder](https://github.com/douglowder))
+- [iOS] Swift conversion 10: Refactor for Expo Go. ([#35862](https://github.com/expo/expo/pull/35862) by [@douglowder](https://github.com/douglowder))
 
 ## 0.29.14 - 2025-03-11
 

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/CategoriesModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/CategoriesModule.swift
@@ -10,7 +10,7 @@ open class CategoriesModule: Module {
 
     AsyncFunction("getNotificationCategoriesAsync") {
       let categories = await UNUserNotificationCenter.current().notificationCategories()
-      return filterAndSerializeCategories(Array(categories))
+      return filterAndSerializeCategories(categories)
     }
 
     AsyncFunction("setNotificationCategoryAsync") { (identifier: String, actions: [CategoryActionRecord], options: CategoryOptionsRecord?) in
@@ -22,7 +22,7 @@ open class CategoriesModule: Module {
     }
   }
 
-  open func filterAndSerializeCategories(_ categories: [UNNotificationCategory]) -> [CategoryRecord] {
+  open func filterAndSerializeCategories(_ categories: Set<UNNotificationCategory>) -> [CategoryRecord] {
     return categories.map { CategoryRecord($0) }
   }
 

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/CategoriesModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/CategoriesModule.swift
@@ -21,7 +21,10 @@ open class CategoriesModule: Module {
     }
   }
 
-  public func getNotificationCategories(completion: @escaping (_ categoryRecords: [CategoryRecord]) -> Void, filter: @escaping (_ category: UNNotificationCategory) -> Bool) {
+  public func getNotificationCategories(
+    completion: @escaping (_ categoryRecords: [CategoryRecord]) -> Void,
+    filter: @escaping (_ category: UNNotificationCategory) -> Bool
+  ) {
     UNUserNotificationCenter.current().getNotificationCategories { categories in
       let existingCategories = categories
         .filter(filter)
@@ -35,7 +38,7 @@ open class CategoriesModule: Module {
   open func getNotificationCategoriesAsync(promise: Promise) {
     getNotificationCategories { categoryRecords in
       promise.resolve(categoryRecords)
-    } filter: { category in
+    } filter: { _ in
       true
     }
   }

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/CategoriesModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/CategoriesModule.swift
@@ -10,22 +10,14 @@ open class CategoriesModule: Module {
 
     AsyncFunction("getNotificationCategoriesAsync") {
       let categories = await UNUserNotificationCenter.current().notificationCategories()
-      let existingCategories = categories.map { category in
-        return CategoryRecord(category)
-      }
-      return existingCategories
-    }
-      let categories = await UNUserNotificationCenter.current().notificationCategories()
-      promise.resolve(filterAndSerializeCategories(Array(categories)))
+      return filterAndSerializeCategories(Array(categories))
     }
 
-  AsyncFunction("setNotificationCategoryAsync") { (identifier: String, actions: [CategoryActionRecord], options: CategoryOptionsRecord?) in
-     return await setNotificationCategoryAsync(identifier: identifier, actions: actions, options: options)
-    }
-      setNotificationCategoryAsync(identifier: identifier, actions: actions, options: options, promise: promise)
+    AsyncFunction("setNotificationCategoryAsync") { (identifier: String, actions: [CategoryActionRecord], options: CategoryOptionsRecord?) in
+      return await setNotificationCategoryAsync(identifier: identifier, actions: actions, options: options)
     }
 
-    AsyncFunction("deleteNotificationCategoryAsync") { (identifier: String, promise: Promise) in
+    AsyncFunction("deleteNotificationCategoryAsync") { (identifier: String, _: Promise) in
       return await deleteNotificationCategoryAsync(identifier: identifier)
     }
   }
@@ -34,19 +26,22 @@ open class CategoriesModule: Module {
     return categories.map { CategoryRecord($0) }
   }
 
-  
-  func setNotificationCategoryAsync(identifier: String, actions: [CategoryActionRecord], options: CategoryOptionsRecord?) async -> CategoryRecord {
+  open func setNotificationCategoryAsync(identifier: String, actions: [CategoryActionRecord], options: CategoryOptionsRecord?) async -> CategoryRecord {
     let categoryRecord = CategoryRecord(identifier, actions: actions, options: options)
     let newNotificationCategory = categoryRecord.toUNNotificationCategory()
-    let oldcategories = await UNUserNotificationCenter.current().notificationCategories()
-    let newCategories = Set(oldcategories.filter { oldCategory in
-      return oldCategory.identifier != newNotificationCategory.identifier
-    }.union([newNotificationCategory]))
+    let oldCategories = await UNUserNotificationCenter.current().notificationCategories()
+    let newCategories = Set(
+      oldCategories
+        .filter { oldCategory in
+          return oldCategory.identifier != newNotificationCategory.identifier
+        }
+        .union([newNotificationCategory])
+    )
     UNUserNotificationCenter.current().setNotificationCategories(newCategories)
     return CategoryRecord(newNotificationCategory)
   }
 
-open func deleteNotificationCategoryAsync(identifier: String) async -> Bool {
+  open func deleteNotificationCategoryAsync(identifier: String) async -> Bool {
     let oldCategories = await UNUserNotificationCenter.current().notificationCategories()
     let didDelete = oldCategories.contains { oldCategory in
       return oldCategory.identifier == identifier

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/CategoriesModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/CategoriesModule.swift
@@ -9,7 +9,8 @@ open class CategoriesModule: Module {
     Name("ExpoNotificationCategoriesModule")
 
     AsyncFunction("getNotificationCategoriesAsync") { (promise: Promise) in
-      getNotificationCategoriesAsync(promise: promise)
+      let categories = await UNUserNotificationCenter.current().notificationCategories()
+      promise.resolve(filterAndSerializeCategories(Array(categories)))
     }
 
     AsyncFunction("setNotificationCategoryAsync") { (identifier: String, actions: [CategoryActionRecord], options: CategoryOptionsRecord?, promise: Promise) in
@@ -21,26 +22,8 @@ open class CategoriesModule: Module {
     }
   }
 
-  public func getNotificationCategories(
-    completion: @escaping (_ categoryRecords: [CategoryRecord]) -> Void,
-    filter: @escaping (_ category: UNNotificationCategory) -> Bool
-  ) {
-    UNUserNotificationCenter.current().getNotificationCategories { categories in
-      let existingCategories = categories
-        .filter(filter)
-        .map { category in
-          return CategoryRecord(category)
-        }
-      completion(existingCategories)
-    }
-  }
-
-  open func getNotificationCategoriesAsync(promise: Promise) {
-    getNotificationCategories { categoryRecords in
-      promise.resolve(categoryRecords)
-    } filter: { _ in
-      true
-    }
+  open func filterAndSerializeCategories(_ categories: [UNNotificationCategory]) -> [CategoryRecord] {
+    return categories.map { CategoryRecord($0) }
   }
 
   open func setNotificationCategoryAsync(identifier: String, actions: [CategoryActionRecord], options: CategoryOptionsRecord?, promise: Promise) {

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/CategoriesModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/CategoriesModule.swift
@@ -17,7 +17,7 @@ open class CategoriesModule: Module {
       return await setNotificationCategoryAsync(identifier: identifier, actions: actions, options: options)
     }
 
-    AsyncFunction("deleteNotificationCategoryAsync") { (identifier: String, _: Promise) in
+    AsyncFunction("deleteNotificationCategoryAsync") { (identifier: String) in
       return await deleteNotificationCategoryAsync(identifier: identifier)
     }
   }

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Emitter/EmitterModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Emitter/EmitterModule.swift
@@ -8,7 +8,7 @@ let onDidReceiveNotification = "onDidReceiveNotification"
 let onDidReceiveNotificationResponse = "onDidReceiveNotificationResponse"
 let onDidClearNotificationResponse = "onDidClearNotificationResponse"
 
-public class EmitterModule: Module, NotificationDelegate {
+open class EmitterModule: Module, NotificationDelegate {
   public func definition() -> ModuleDefinition {
     Name("ExpoNotificationsEmitter")
 
@@ -40,19 +40,25 @@ public class EmitterModule: Module, NotificationDelegate {
     return true
   }
 
-  public func didReceive(_ response: UNNotificationResponse, completionHandler: @escaping () -> Void) -> Bool {
+  open func didReceive(_ response: UNNotificationResponse, completionHandler: @escaping () -> Void) -> Bool {
     NotificationCenterManager.shared.lastResponse = response
-    // TODO: convert serialization to Records
-    let serializedResponse = EXNotificationSerializer.serializedNotificationResponse(response)
-    self.sendEvent(onDidReceiveNotificationResponse, serializedResponse as [String: Any])
+    self.sendEvent(onDidReceiveNotificationResponse, serializedResponse(response))
     completionHandler()
     return true
   }
 
-  public func willPresent(_ notification: UNNotification, completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) -> Bool {
-    // TODO: convert serialization to Records
-    let serializedNotification = EXNotificationSerializer.serializedNotification(notification)
-    self.sendEvent(onDidReceiveNotification, serializedNotification as [String: Any])
+  open func willPresent(_ notification: UNNotification, completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) -> Bool {
+    self.sendEvent(onDidReceiveNotification, serializedNotification(notification))
     return false
+  }
+
+  open func serializedNotification(_ notification: UNNotification) -> [String: Any] {
+    // TODO: convert serialization to Records
+    return EXNotificationSerializer.serializedNotification(notification)
+  }
+
+  open func serializedResponse(_ response: UNNotificationResponse) -> [String: Any] {
+    // TODO: convert serialization to Records
+    return EXNotificationSerializer.serializedNotificationResponse(response)
   }
 }

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Emitter/EmitterModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Emitter/EmitterModule.swift
@@ -22,16 +22,15 @@ open class EmitterModule: Module, NotificationDelegate {
       NotificationCenterManager.shared.removeDelegate(self)
     }
 
-    AsyncFunction("getLastNotificationResponseAsync") {(promise: Promise) in
+    AsyncFunction("getLastNotificationResponseAsync") {() -> [String: Any]? in
       if let lastResponse: UNNotificationResponse = NotificationCenterManager.shared.lastResponse {
-        promise.resolve(EXNotificationSerializer.serializedNotificationResponse(lastResponse))
+        return EXNotificationSerializer.serializedNotificationResponse(lastResponse)
       }
-      promise.resolve(nil)
+      return nil
     }
 
-    AsyncFunction("clearLastNotificationResponseAsync") {(promise: Promise) in
+    AsyncFunction("clearLastNotificationResponseAsync") {
       NotificationCenterManager.shared.lastResponse = nil
-      promise.resolve(nil)
     }
   }
 

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Handler/HandlerModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Handler/HandlerModule.swift
@@ -7,7 +7,7 @@ import MachO
 let onHandleNotification = "onHandleNotification"
 let onHandleNotificationTimeout = "onHandleNotificationTimeout"
 
-public class HandlerModule: Module, NotificationDelegate, SingleNotificationHandlerTaskDelegate {
+open class HandlerModule: Module, NotificationDelegate, SingleNotificationHandlerTaskDelegate {
   var tasksMap: [String: SingleNotificationHandlerTask] = [:]
 
   public func definition() -> ModuleDefinition {
@@ -38,7 +38,7 @@ public class HandlerModule: Module, NotificationDelegate, SingleNotificationHand
 
   // MARK: - NotificationDelegate
 
-  public func willPresent(_ notification: UNNotification, completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) -> Bool {
+  open func willPresent(_ notification: UNNotification, completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) -> Bool {
     let task = SingleNotificationHandlerTask(notification: notification, completionHandler: completionHandler, delegate: self)
     tasksMap[task.identifier] = task
     task.start()

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Presenting/PresentationModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Presenting/PresentationModule.swift
@@ -18,16 +18,13 @@ open class PresentationModule: Module, NotificationDelegate {
       NotificationCenterManager.shared.removeDelegate(self)
     }
 
-  AsyncFunction("presentNotificationAsync") { (identifier: String, notificationSpec: [String: Any]) in
+    AsyncFunction("presentNotificationAsync") { (identifier: String, notificationSpec: [String: Any]) in
       try await presentNotificationAsync(identifier: identifier, notificationSpec: notificationSpec)
     }
-      presentNotificationAsync(identifier: identifier, notificationSpec: notificationSpec, promise: promise)
-    }
 
-    AsyncFunction("getPresentedNotificationsAsync") { (promise: Promise) in
-      UNUserNotificationCenter.current().getDeliveredNotifications { notifications in
-        promise.resolve(self.serializeNotifications(notifications))
-      }
+    AsyncFunction("getPresentedNotificationsAsync") {
+      let notifications = await UNUserNotificationCenter.current().deliveredNotifications()
+      return self.serializeNotifications(notifications)
     }
 
     AsyncFunction("dismissNotificationAsync") { (identifier: String) in

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Presenting/PresentationModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Presenting/PresentationModule.swift
@@ -4,7 +4,7 @@ import ExpoModulesCore
 import UIKit
 import MachO
 
-public class PresentationModule: Module, NotificationDelegate {
+open class PresentationModule: Module, NotificationDelegate {
   var presentedNotifications: Set<String> = []
 
   public func definition() -> ModuleDefinition {
@@ -19,33 +19,7 @@ public class PresentationModule: Module, NotificationDelegate {
     }
 
     AsyncFunction("presentNotificationAsync") { (identifier: String, notificationSpec: [String: Any], promise: Promise) in
-      do {
-        guard let appContext = appContext else {
-          let error = NSError(domain: "ExpoNotificationPresenter", code: 0, userInfo: nil)
-          promise.reject("ERR_NOTIF_PRESENT", error.localizedDescription)
-          return
-        }
-        let requestContentRecord = try NotificationRequestContentRecord(from: notificationSpec, appContext: appContext)
-        let content = requestContentRecord.toUNMutableNotificationContent()
-        var request: UNNotificationRequest?
-        try EXUtilities.catchException {
-          request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
-        }
-        guard let request = request else {
-          promise.reject("ERR_NOTIF_PRESENT", "Notification could not be presented")
-          return
-        }
-        presentedNotifications.insert(identifier)
-        UNUserNotificationCenter.current().add(request) { error in
-          if let error {
-            promise.reject("ERR_NOTIF_PRESENT", error.localizedDescription)
-          } else {
-            promise.resolve()
-          }
-        }
-      } catch {
-        promise.reject("ERR_NOTIF_PRESENT", error.localizedDescription)
-      }
+      presentNotificationAsync(identifier: identifier, notificationSpec: notificationSpec, promise: promise)
     }
     .runOnQueue(.main)
 
@@ -56,15 +30,15 @@ public class PresentationModule: Module, NotificationDelegate {
     }
 
     AsyncFunction("dismissNotificationAsync") { (identifier: String) in
-      UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [identifier])
+      removeDeliveredNotifications(identifier: identifier)
     }
 
     AsyncFunction("dismissAllNotificationsAsync") {
-      UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+      removeAllDeliveredNotifications()
     }
   }
 
-  public func willPresent(_ notification: UNNotification, completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) -> Bool {
+  open func willPresent(_ notification: UNNotification, completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) -> Bool {
     let identifier = notification.request.identifier
     if presentedNotifications.contains(identifier) {
       presentedNotifications.remove(identifier)
@@ -74,10 +48,48 @@ public class PresentationModule: Module, NotificationDelegate {
     return false
   }
 
-  func serializeNotifications(_ notifications: [UNNotification]) -> [[AnyHashable: Any]] {
+  open func serializeNotifications(_ notifications: [UNNotification]) -> [[String: Any]] {
     return notifications.map { notification in
       // TODO: convert serialization to Records
       return EXNotificationSerializer.serializedNotification(notification)
+    }
+  }
+
+  open func removeDeliveredNotifications(identifier: String) {
+    UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [identifier])
+  }
+
+  open func removeAllDeliveredNotifications() {
+    UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+  }
+
+  open func presentNotificationAsync(identifier: String, notificationSpec: [String: Any], promise: Promise) {
+    do {
+      guard let appContext = appContext else {
+        let error = NSError(domain: "ExpoNotificationPresenter", code: 0, userInfo: nil)
+        promise.reject("ERR_NOTIF_PRESENT", error.localizedDescription)
+        return
+      }
+      let requestContentRecord = try NotificationRequestContentRecord(from: notificationSpec, appContext: appContext)
+      let content = requestContentRecord.toUNMutableNotificationContent()
+      var request: UNNotificationRequest?
+      try EXUtilities.catchException {
+        request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
+      }
+      guard let request = request else {
+        promise.reject("ERR_NOTIF_PRESENT", "Notification could not be presented")
+        return
+      }
+      presentedNotifications.insert(identifier)
+      UNUserNotificationCenter.current().add(request) { error in
+        if let error {
+          promise.reject("ERR_NOTIF_PRESENT", error.localizedDescription)
+        } else {
+          promise.resolve()
+        }
+      }
+    } catch {
+      promise.reject("ERR_NOTIF_PRESENT", error.localizedDescription)
     }
   }
 }

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Presenting/PresentationModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Presenting/PresentationModule.swift
@@ -32,7 +32,7 @@ open class PresentationModule: Module, NotificationDelegate {
     }
 
     AsyncFunction("dismissAllNotificationsAsync") {
-      removeAllDeliveredNotifications()
+      await removeAllDeliveredNotifications()
     }
   }
 
@@ -57,7 +57,7 @@ open class PresentationModule: Module, NotificationDelegate {
     UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [identifier])
   }
 
-  open func removeAllDeliveredNotifications() {
+  open func removeAllDeliveredNotifications() async {
     UNUserNotificationCenter.current().removeAllDeliveredNotifications()
   }
 

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Records.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Records.swift
@@ -4,11 +4,11 @@ import ExpoModulesCore
 
 // MARK: - NotificationBuilder record definitions
 
-protocol TriggerRecord: Record {
+public protocol TriggerRecord: Record {
   func toUNNotificationTrigger() throws -> UNNotificationTrigger?
 }
 
-struct CalendarTriggerRecord: TriggerRecord {
+public struct CalendarTriggerRecord: TriggerRecord {
   @Field
   var year: Int?
   @Field
@@ -47,6 +47,8 @@ struct CalendarTriggerRecord: TriggerRecord {
     "weekdayOrdinal": .weekdayOrdinal
   ]
 
+  public init() {}
+
   func dateComponentsFrom(_ calendarTrigger: CalendarTriggerRecord) -> DateComponents {
     var dateComponents = DateComponents()
     // TODO: Verify that DoW matches JS getDay()
@@ -63,7 +65,7 @@ struct CalendarTriggerRecord: TriggerRecord {
     return dateComponents
   }
 
-  func toUNNotificationTrigger() throws -> UNNotificationTrigger? {
+  public func toUNNotificationTrigger() throws -> UNNotificationTrigger? {
     var trigger: UNNotificationTrigger?
     try EXUtilities.catchException {
       let dateComponents: DateComponents = dateComponentsFrom(self)
@@ -74,13 +76,15 @@ struct CalendarTriggerRecord: TriggerRecord {
   }
 }
 
-struct TimeIntervalTriggerRecord: TriggerRecord {
+public struct TimeIntervalTriggerRecord: TriggerRecord {
   @Field
   var seconds: TimeInterval
   @Field
   var repeats: Bool
 
-  func toUNNotificationTrigger() throws -> UNNotificationTrigger? {
+  public init() {}
+
+  public func toUNNotificationTrigger() throws -> UNNotificationTrigger? {
     var trigger: UNNotificationTrigger?
     try EXUtilities.catchException {
       trigger = UNTimeIntervalNotificationTrigger(timeInterval: self.seconds, repeats: self.repeats)
@@ -89,11 +93,13 @@ struct TimeIntervalTriggerRecord: TriggerRecord {
   }
 }
 
-struct DateTriggerRecord: TriggerRecord {
+public struct DateTriggerRecord: TriggerRecord {
   @Field
   var timestamp: TimeInterval
 
-  func toUNNotificationTrigger() throws -> UNNotificationTrigger? {
+  public init() {}
+
+  public func toUNNotificationTrigger() throws -> UNNotificationTrigger? {
     let timestamp: Int = Int(self.timestamp / 1000)
     let date: Date = Date(timeIntervalSince1970: TimeInterval(timestamp))
     var trigger: UNNotificationTrigger?
@@ -104,13 +110,15 @@ struct DateTriggerRecord: TriggerRecord {
   }
 }
 
-struct DailyTriggerRecord: TriggerRecord {
+public struct DailyTriggerRecord: TriggerRecord {
   @Field
   var hour: Int
   @Field
   var minute: Int
 
-  func toUNNotificationTrigger() throws -> UNNotificationTrigger? {
+  public init() {}
+
+  public func toUNNotificationTrigger() throws -> UNNotificationTrigger? {
     let dateComponents: DateComponents = DateComponents(hour: self.hour, minute: self.minute)
     var trigger: UNNotificationTrigger?
     try EXUtilities.catchException {
@@ -120,7 +128,7 @@ struct DailyTriggerRecord: TriggerRecord {
   }
 }
 
-struct WeeklyTriggerRecord: TriggerRecord {
+public struct WeeklyTriggerRecord: TriggerRecord {
   @Field
   var weekday: Int
   @Field
@@ -128,7 +136,9 @@ struct WeeklyTriggerRecord: TriggerRecord {
   @Field
   var minute: Int
 
-  func toUNNotificationTrigger() throws -> UNNotificationTrigger? {
+  public init() {}
+
+  public func toUNNotificationTrigger() throws -> UNNotificationTrigger? {
     let dateComponents: DateComponents = DateComponents(hour: self.hour, minute: self.minute, weekday: self.weekday)
     var trigger: UNNotificationTrigger?
     try EXUtilities.catchException {
@@ -137,7 +147,7 @@ struct WeeklyTriggerRecord: TriggerRecord {
     return trigger  }
 }
 
-struct MonthlyTriggerRecord: TriggerRecord {
+public struct MonthlyTriggerRecord: TriggerRecord {
   @Field
   var day: Int
   @Field
@@ -145,7 +155,9 @@ struct MonthlyTriggerRecord: TriggerRecord {
   @Field
   var minute: Int
 
-  func toUNNotificationTrigger() throws -> UNNotificationTrigger? {
+  public init() {}
+
+  public func toUNNotificationTrigger() throws -> UNNotificationTrigger? {
     let dateComponents: DateComponents = DateComponents(day: self.day, hour: self.hour, minute: self.minute)
     var trigger: UNNotificationTrigger?
     try EXUtilities.catchException {
@@ -155,7 +167,7 @@ struct MonthlyTriggerRecord: TriggerRecord {
   }
 }
 
-struct YearlyTriggerRecord: TriggerRecord {
+public struct YearlyTriggerRecord: TriggerRecord {
   @Field
   var month: Int
   @Field
@@ -165,7 +177,9 @@ struct YearlyTriggerRecord: TriggerRecord {
   @Field
   var minute: Int
 
-  func toUNNotificationTrigger() throws -> UNNotificationTrigger? {
+  public init() {}
+
+  public func toUNNotificationTrigger() throws -> UNNotificationTrigger? {
     let dateComponents: DateComponents = DateComponents(
       month: self.month,
       day: self.day,
@@ -225,8 +239,8 @@ struct CategoryActionOptionsRecord: Record {
   }
 }
 
-struct CategoryActionRecord: Record {
-  init() {}
+public struct CategoryActionRecord: Record {
+  public init() {}
 
   @Field
   var identifier: String?
@@ -270,8 +284,8 @@ struct CategoryActionRecord: Record {
   }
 }
 
-struct CategoryOptionsRecord: Record {
-  init() {}
+public struct CategoryOptionsRecord: Record {
+  public init() {}
 
   // allowAnnouncement deprecated in iOS 15 and later
   /*
@@ -329,17 +343,17 @@ struct CategoryOptionsRecord: Record {
   }
 }
 
-struct CategoryRecord: Record {
-  init() {}
+public struct CategoryRecord: Record {
+  public init() {}
 
   @Field
-  var identifier: String
+  public var identifier: String
   @Field
   var actions: [CategoryActionRecord]?
   @Field
   var options: CategoryOptionsRecord?
 
-  init(_ category: UNNotificationCategory) {
+  public init(_ category: UNNotificationCategory) {
     self.identifier = category.identifier
     self.actions = category.actions.map { action in
       return CategoryActionRecord(action)
@@ -347,7 +361,7 @@ struct CategoryRecord: Record {
     self.options = CategoryOptionsRecord(category)
   }
 
-  init(_ identifier: String, actions: [CategoryActionRecord], options: CategoryOptionsRecord?) {
+  public init(_ identifier: String, actions: [CategoryActionRecord], options: CategoryOptionsRecord?) {
     self.identifier = identifier
     self.actions = actions
     self.options = options

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/SchedulerModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/SchedulerModule.swift
@@ -25,7 +25,9 @@ open class SchedulerModule: Module {
     Name("ExpoNotificationScheduler")
 
     AsyncFunction("getAllScheduledNotificationsAsync") { (promise: Promise) in
-      UNUserNotificationCenter.current().getPendingNotificationRequests { (requests: [UNNotificationRequest]) in
+AsyncFunction("getAllScheduledNotificationsAsync") { 
+     let request = await UNUserNotificationCenter.current().pendingNotificationRequests()
+     return serializedNotificationRequests(requests)
         promise.resolve(self.serializedNotificationRequests(requests))
       }
     }

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/SchedulerModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/SchedulerModule.swift
@@ -24,14 +24,10 @@ open class SchedulerModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoNotificationScheduler")
 
-    AsyncFunction("getAllScheduledNotificationsAsync") { (promise: Promise) in
-AsyncFunction("getAllScheduledNotificationsAsync") { 
-     let request = await UNUserNotificationCenter.current().pendingNotificationRequests()
-     return serializedNotificationRequests(requests)
-        promise.resolve(self.serializedNotificationRequests(requests))
-      }
+    AsyncFunction("getAllScheduledNotificationsAsync") {
+      let requests = await UNUserNotificationCenter.current().pendingNotificationRequests()
+      return serializedNotificationRequests(requests)
     }
-    .runOnQueue(.main)
 
     AsyncFunction("cancelScheduledNotificationAsync") { (identifier: String) in
       cancelScheduledNotification(identifier)

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/SchedulerModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Scheduling/SchedulerModule.swift
@@ -20,27 +20,23 @@ let calendarNotificationTriggerComponentsKey = "value"
 let calendarNotificationTriggerTimezoneKey = "timezone"
 // swiftlint:enable identifier_name
 
-public class SchedulerModule: Module {
+open class SchedulerModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoNotificationScheduler")
 
     AsyncFunction("getAllScheduledNotificationsAsync") { (promise: Promise) in
       UNUserNotificationCenter.current().getPendingNotificationRequests { (requests: [UNNotificationRequest]) in
-        var serializedRequests: [Any] = []
-        requests.forEach {request in
-          serializedRequests.append(EXNotificationSerializer.serializedNotificationRequest(request))
-        }
-        promise.resolve(serializedRequests)
+        promise.resolve(self.serializedNotificationRequests(requests))
       }
     }
     .runOnQueue(.main)
 
     AsyncFunction("cancelScheduledNotificationAsync") { (identifier: String) in
-      UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
+      cancelScheduledNotification(identifier)
     }
 
     AsyncFunction("cancelAllScheduledNotificationsAsync") { () in
-      UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+      cancelAllScheduledNotifications()
     }
 
     AsyncFunction("scheduleNotificationAsync") { (identifier: String, notificationSpec: [String: Any], triggerSpec: [String: Any]?, promise: Promise) in
@@ -125,15 +121,13 @@ public class SchedulerModule: Module {
     }
   }
 
-  func serializeNotificationRequests(_ requests: [UNNotificationRequest]) -> [Any] {
-    var serializedRequests: [[AnyHashable: Any]] = []
-    requests.forEach {request in
-      serializedRequests.append(EXNotificationSerializer .serializedNotificationRequest(request))
+  open func serializedNotificationRequests(_ requests: [UNNotificationRequest]) -> [[String: Any]] {
+    return requests.map {
+      EXNotificationSerializer.serializedNotificationRequest($0)
     }
-    return serializedRequests
   }
 
-  func buildNotificationRequest(
+  open func buildNotificationRequest(
     identifier: String,
     contentInput: [String: Any],
     triggerInput: [String: Any]?
@@ -147,5 +141,13 @@ public class SchedulerModule: Module {
       content: requestContentRecord.toUNMutableNotificationContent(),
       trigger: triggerFromParams(triggerInput, appContext: appContext)
     )
+  }
+
+  open func cancelScheduledNotification(_ identifier: String) {
+    UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
+  }
+
+  open func cancelAllScheduledNotifications() {
+    UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
   }
 }

--- a/packages/expo-notifications/ios/EXNotifications/ServerRegistration/ServerRegistrationModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/ServerRegistration/ServerRegistrationModule.swift
@@ -4,7 +4,7 @@ import ExpoModulesCore
 import UIKit
 import MachO
 
-public class ServerRegistrationModule: Module {
+open class ServerRegistrationModule: Module {
   public func definition() -> ModuleDefinition {
     Name("NotificationsServerRegistrationModule")
 
@@ -54,15 +54,15 @@ public class ServerRegistrationModule: Module {
   }
 
   private func getLegacyInstallationIdFromUserDefaults() -> String? {
-    return UserDefaults.standard.string(forKey: kEXDeviceInstallationUUIDLegacyKey)
+    return UserDefaults.standard.string(forKey: ServerRegistrationModule.kEXDeviceInstallationUUIDLegacyKey)
   }
 
   private func removeLegacyInstallationIdFromUserDefaults() {
-    UserDefaults.standard.removeObject(forKey: kEXDeviceInstallationUUIDLegacyKey)
+    UserDefaults.standard.removeObject(forKey: ServerRegistrationModule.kEXDeviceInstallationUUIDLegacyKey)
   }
 
   private func installationIdSearchQueryMerging(_ dictionaryToMerge: [AnyHashable: Any]) -> CFDictionary {
-    return keychainSearchQueryFor(key: kEXDeviceInstallationUUIDKey, dictionaryToMerge: dictionaryToMerge)
+    return keychainSearchQueryFor(key: ServerRegistrationModule.kEXDeviceInstallationUUIDKey, dictionaryToMerge: dictionaryToMerge)
   }
 
   private func installationIdSearchQuery() -> CFDictionary {
@@ -93,8 +93,8 @@ public class ServerRegistrationModule: Module {
     return try storeStringWithQueries(search: registrationSearchQuery(), set: registrationSetQuery(registrationInfo))
   }
 
-  private func registrationSearchQueryMerging(_ dictionaryToMerge: [AnyHashable: Any]) -> CFDictionary {
-    return keychainSearchQueryFor(key: kEXRegistrationInfoKey, dictionaryToMerge: dictionaryToMerge)
+  open func registrationSearchQueryMerging(_ dictionaryToMerge: [AnyHashable: Any]) -> CFDictionary {
+    return keychainSearchQueryFor(key: ServerRegistrationModule.kEXRegistrationInfoKey, dictionaryToMerge: dictionaryToMerge)
   }
 
   private func registrationSearchQuery() -> CFDictionary {
@@ -117,7 +117,7 @@ public class ServerRegistrationModule: Module {
 
   // MARK: - Generic keychain methods
 
-  private func keychainSearchQueryFor(key: String, dictionaryToMerge: [AnyHashable: Any]) -> CFDictionary {
+  public func keychainSearchQueryFor(key: String, dictionaryToMerge: [AnyHashable: Any]) -> CFDictionary {
     let encodedKey: Data = dataFromString(key)
     let bundleIdentifier = Bundle.main.bundleIdentifier ?? ""
     var query: [AnyHashable: Any] = [
@@ -172,8 +172,8 @@ public class ServerRegistrationModule: Module {
     return input.data(using: fastEncoding)!
   }
 
-  private let kEXDeviceInstallationUUIDKey = "EXDeviceInstallationUUIDKey"
-  private let kEXDeviceInstallationUUIDLegacyKey = "EXDeviceInstallationUUIDKey"
-  private let kEXRegistrationInfoKey = "EXNotificationRegistrationInfoKey"
+  public static let kEXDeviceInstallationUUIDKey = "EXDeviceInstallationUUIDKey"
+  public static let kEXDeviceInstallationUUIDLegacyKey = "EXDeviceInstallationUUIDKey"
+  public static let kEXRegistrationInfoKey = "EXNotificationRegistrationInfoKey"
   private let CFTrue = true as CFBoolean
 }


### PR DESCRIPTION
# Why

To support their use in Expo Go with different app scopes, some of the iOS modules need to be modified.

# How

- Made some modules open classes so they can be subclassed
- Extracted the implementations of some module functions into open methods that can be overridden
- Made some of the new record types public

# Test Plan

- CI should pass
- Should be no functional changes

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
