### PR TITLE
feat(cli): Remove **NOBRIDGE** tag from logs.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### 💡 Others
 
+- Remove ridiculous **NOBRIDGE** tag from logs.
 - Upgrade readiness status of React Server Components. ([#35467](https://github.com/expo/expo/pull/35467) by [@EvanBacon](https://github.com/EvanBacon))
 - Add tests for `Worker` and `require.unstable_resolveWorker()`. ([#34938](https://github.com/expo/expo/pull/34938) by [@EvanBacon](https://github.com/EvanBacon))
 - Replace cacache in fetch cache with lighter implementation. ([#34983](https://github.com/expo/expo/pull/34983) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 ### 💡 Others
 
-- Remove ridiculous **NOBRIDGE** tag from logs.
+- Remove ridiculous **NOBRIDGE** tag from logs. ([#35868](https://github.com/expo/expo/pull/35868) by [@EvanBacon](https://github.com/EvanBacon))
 - Upgrade readiness status of React Server Components. ([#35467](https://github.com/expo/expo/pull/35467) by [@EvanBacon](https://github.com/EvanBacon))
 - Add tests for `Worker` and `require.unstable_resolveWorker()`. ([#34938](https://github.com/expo/expo/pull/34938) by [@EvanBacon](https://github.com/EvanBacon))
 - Replace cacache in fetch cache with lighter implementation. ([#34983](https://github.com/expo/expo/pull/34983) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
+++ b/packages/@expo/cli/src/start/server/serverLogLikeMetro.ts
@@ -64,10 +64,9 @@ export function logLikeMetro(
       data[data.length - 1] = lastItem.trimEnd();
     }
 
-    const modePrefix = chalk.bold`${platform}`;
+    const modePrefix = platform === '' ? '' : chalk.bold`${platform} `;
     originalLogFunction(
       modePrefix +
-        ' ' +
         color.bold(` ${logFunction.toUpperCase()} `) +
         ''.padEnd(groupStack.length * 2, ' '),
       ...data


### PR DESCRIPTION
# Why

- Get rid of the ridiculous **NOBRIDGE** log that shows all over the terminal when you console log in a native app. Split out of https://github.com/expo/expo/pull/35866
- I left in the non-new architecture version though. Open to removing it too.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Use the RSC logger we built for Metro SSR to print custom logs.

## Before

<img width="208" alt="Screenshot 2025-04-02 at 6 48 05 PM" src="https://github.com/user-attachments/assets/dd8e69a3-a316-41dd-a55d-0a5d62d9698e" />

## After

<img width="151" alt="Screenshot 2025-04-02 at 6 47 47 PM" src="https://github.com/user-attachments/assets/282dc50f-8891-4841-a3ee-8f98c965470e" />

