### PR TITLE
[github] Remove `fail_on_error` from Vale GH action

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -52,7 +52,7 @@ jobs:
           NODE_ENV: production
         run: yarn lint --max-warnings 0
       - name: 💬 Lint Docs website content
-        uses: errata-ai/vale-action@v2.1.1
+        uses: errata-ai/vale-action@reviewdog
         with:
           version: 3.9.6
           reporter: github-pr-check

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -52,12 +52,12 @@ jobs:
           NODE_ENV: production
         run: yarn lint --max-warnings 0
       - name: 💬 Lint Docs website content
-        uses: errata-ai/vale-action@reviewdog
+        uses: errata-ai/vale-action@v2.1.1
         with:
+          version: 3.9.6
           reporter: github-pr-check
           files: 'docs/pages'
           vale_flags: '--config=./docs/.vale.ini'
-          fail_on_error: true
       - name: 🏗️ Build Docs website
         run: yarn export-preview
         timeout-minutes: 20

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,7 +55,7 @@ jobs:
           NODE_ENV: production
         run: yarn lint --max-warnings 0
       - name: 💬 Lint Docs website content
-        uses: errata-ai/vale-action@v2.1.1
+        uses: errata-ai/vale-action@reviewdog
         with:
           version: 3.9.6
           reporter: github-pr-check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,12 +55,12 @@ jobs:
           NODE_ENV: production
         run: yarn lint --max-warnings 0
       - name: 💬 Lint Docs website content
-        uses: errata-ai/vale-action@reviewdog
+        uses: errata-ai/vale-action@v2.1.1
         with:
+          version: 3.9.6
           reporter: github-pr-check
           files: 'docs/pages'
           vale_flags: '--config=./docs/.vale.ini'
-          fail_on_error: true
       - name: 🏗️ Build Docs website for deploy
         working-directory: docs
         run: yarn export


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Remove `fail_on_error` since it is causing PRs and main branch to randomly fail where there are changes but no warnings or errors from Vale.

Some similar issues: https://github.com/errata-ai/vale-action/issues/141, https://github.com/errata-ai/vale-action/issues/106

Also, set the Vale version to 3.9.6, which is what we use locally.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove `fail_on_error` from GH action flow for `docs-pr.yml` and `docs.yml`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
