### PR TITLE
[ncl] Fix nested screens navigation

### DIFF
--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -8,6 +8,7 @@ import { TabBackground } from '../components/TabBackground';
 import TabIcon from '../components/TabIcon';
 import getStackNavWithConfig from '../navigation/StackConfig';
 import { AudioScreens } from '../screens/Audio/AudioScreen';
+import { CalendarsScreens } from '../screens/CalendarsScreen';
 import { ContactsScreens } from '../screens/Contacts/ContactsScreen';
 import ExpoApis from '../screens/ExpoApisScreen';
 import { ModulesCoreScreens } from '../screens/ModulesCore/ModulesCoreScreen';
@@ -184,12 +185,6 @@ export const ScreensList: ScreenConfig[] = [
       return optionalRequire(() => require('../screens/ErrorScreen'));
     },
     name: 'Errors',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/EventsScreen'));
-    },
-    name: 'Events',
   },
   {
     getComponent() {
@@ -427,6 +422,7 @@ export const Screens: ScreenConfig[] = [
   ...ModulesCoreScreens,
   ...AudioScreens,
   ...ContactsScreens,
+  ...CalendarsScreens,
 ];
 
 export const screenApiItems: ScreenApiItem[] = ScreensList.map(({ name, route }) => ({

--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -8,6 +8,7 @@ import { TabBackground } from '../components/TabBackground';
 import TabIcon from '../components/TabIcon';
 import getStackNavWithConfig from '../navigation/StackConfig';
 import { AudioScreens } from '../screens/Audio/AudioScreen';
+import { ContactsScreens } from '../screens/Contacts/ContactsScreen';
 import ExpoApis from '../screens/ExpoApisScreen';
 import { ModulesCoreScreens } from '../screens/ModulesCore/ModulesCoreScreen';
 import { type ScreenApiItem, type ScreenConfig } from '../types/ScreenConfig';
@@ -177,12 +178,6 @@ export const ScreensList: ScreenConfig[] = [
       return optionalRequire(() => require('../screens/Contacts/ContactsScreen'));
     },
     name: 'Contacts',
-  },
-  {
-    getComponent() {
-      return optionalRequire(() => require('../screens/Contacts/ContactDetailScreen'));
-    },
-    name: 'ContactDetail',
   },
   {
     getComponent() {
@@ -427,7 +422,12 @@ export const ScreensList: ScreenConfig[] = [
   },
 ];
 
-export const Screens: ScreenConfig[] = [...ScreensList, ...ModulesCoreScreens, ...AudioScreens];
+export const Screens: ScreenConfig[] = [
+  ...ScreensList,
+  ...ModulesCoreScreens,
+  ...AudioScreens,
+  ...ContactsScreens,
+];
 
 export const screenApiItems: ScreenApiItem[] = ScreensList.map(({ name, route }) => ({
   name,

--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -13,6 +13,7 @@ import ExpoComponents from '../screens/ExpoComponentsScreen';
 import { MapsScreens } from '../screens/ExpoMaps/MapsScreen';
 import { GLScreens } from '../screens/GL/GLScreen';
 import { ImageScreens } from '../screens/Image/ImageScreen';
+import { SVGScreens } from '../screens/SVG/SVGScreen';
 import { UIScreens } from '../screens/UI/UIScreen';
 import { VideoScreens } from '../screens/Video/VideoScreen';
 import { type ScreenApiItem, type ScreenConfig } from '../types/ScreenConfig';
@@ -195,12 +196,6 @@ const ScreensList: ScreenConfig[] = [
   },
   {
     getComponent() {
-      return optionalRequire(() => require('../screens/SVG/SVGExampleScreen'));
-    },
-    name: 'SVGExample',
-  },
-  {
-    getComponent() {
       return optionalRequire(() => require('../screens/LinearGradientScreen'));
     },
     name: 'LinearGradient',
@@ -302,6 +297,7 @@ export const Screens: ScreenConfig[] = [
   ...ImageScreens,
   ...VideoScreens,
   ...UIScreens,
+  ...SVGScreens,
   ...MapsScreens,
 ];
 

--- a/apps/native-component-list/src/screens/CalendarsScreen.tsx
+++ b/apps/native-component-list/src/screens/CalendarsScreen.tsx
@@ -8,6 +8,18 @@ import HeadingText from '../components/HeadingText';
 import ListButton from '../components/ListButton';
 import MonoText from '../components/MonoText';
 import Colors from '../constants/Colors';
+import { optionalRequire } from '../navigation/routeBuilder';
+
+export const CalendarsScreens = [
+  {
+    name: 'Events',
+    route: 'events',
+    options: {},
+    getComponent() {
+      return optionalRequire(() => require('./EventsScreen'));
+    },
+  },
+];
 
 type StackNavigation = StackNavigationProp<{
   Reminders: { calendar: any };

--- a/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
@@ -12,8 +12,20 @@ import HeaderContainerRight from '../../components/HeaderContainerRight';
 import HeaderIconButton from '../../components/HeaderIconButton';
 import MonoText from '../../components/MonoText';
 import { Colors } from '../../constants';
+import { optionalRequire } from '../../navigation/routeBuilder';
 import usePermissions from '../../utilities/usePermissions';
 import { useResolvedValue } from '../../utilities/useResolvedValue';
+
+export const ContactsScreens = [
+  {
+    name: 'ContactDetail',
+    route: 'contact/detail',
+    options: {},
+    getComponent() {
+      return optionalRequire(() => require('./ContactDetailScreen'));
+    },
+  },
+];
 
 type StackParams = {
   ContactDetail: { id: string };

--- a/apps/native-component-list/src/screens/SVG/SVGExampleScreen.tsx
+++ b/apps/native-component-list/src/screens/SVG/SVGExampleScreen.tsx
@@ -4,7 +4,7 @@ import { ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import examples from './examples';
 
-type Links = { SVGExample: { title?: string; key: string } };
+type Links = { SVGExample: { title?: string; key?: string } };
 
 type Props = StackScreenProps<Links, 'SVGExample'>;
 
@@ -25,7 +25,7 @@ export default function SVGExampleScreen(props: Props) {
   const renderNoExample = React.useCallback(() => <Text>No example found.</Text>, []);
 
   const renderContent = () => {
-    const example = examples[props.route.params.key];
+    const example = props.route.params.key && examples[props.route.params.key];
     if (!example) {
       return renderNoExample();
     }

--- a/apps/native-component-list/src/screens/SVG/SVGScreen.tsx
+++ b/apps/native-component-list/src/screens/SVG/SVGScreen.tsx
@@ -3,6 +3,18 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import { FlatList, PixelRatio, StyleSheet, Text, TouchableHighlight, View } from 'react-native';
 
 import examples from './examples';
+import { optionalRequire } from '../../navigation/routeBuilder';
+
+export const SVGScreens = [
+  {
+    name: 'SVGExample',
+    route: 'svg/example',
+    options: {},
+    getComponent() {
+      return optionalRequire(() => require('./SVGExampleScreen'));
+    },
+  },
+];
 
 type StackParams = {
   SVGExample: { title: string; key: string };


### PR DESCRIPTION
# Why  

Nested screens that require parameters should not be directly listed, as they cannot be opened independently.

# How  

Removed nested screens from the screen listing and implemented proper nested navigation.

# Test Plan

To open the `SVGExample` screen:
  1. Navigate to the `SVG` screen.
  2. Select an example to navigate to the `SVGExample` screen.
  
To open the `ContactDetails` screen:
  1. In the `ContactsScreen`, select a contact.
  2. This will navigate to the `ContactDetails` screen.

To open the `Events` screen:
  1. In the `CalendarsScreen`, select a calendar.
  2. This will navigate to the `Events` screen.