### PR TITLE
[notifications] log when category doesn't exist

### DIFF
--- a/apps/native-component-list/src/screens/NotificationScreen.tsx
+++ b/apps/native-component-list/src/screens/NotificationScreen.tsx
@@ -1,17 +1,19 @@
 import * as Device from 'expo-device';
+import { EventSubscription } from 'expo-modules-core';
 import * as Notifications from 'expo-notifications';
 import { getAllScheduledNotificationsAsync } from 'expo-notifications';
 import React from 'react';
-import { Alert, Text, ScrollView, View } from 'react-native';
+import { Alert, Text, ScrollView, View, Platform } from 'react-native';
 
 import registerForPushNotificationsAsync from '../api/registerForPushNotificationsAsync';
 import HeadingText from '../components/HeadingText';
 import ListButton from '../components/ListButton';
 import MonoText from '../components/MonoText';
 
-const BACKGROUND_TEST_INFO = `To test background notification handling:\n(1) Background the app.\n(2) Send a push notification from your terminal. The push token can be found in your logs, and the command to send a notification can be found at https://docs.expo.dev/push-notifications/sending-notifications/#http2-api. On iOS, you need to include "_contentAvailable": "true" in your payload.\n(3) After receiving the notification, check the "persisted data" presented in the notification-tester app`;
+const BACKGROUND_TEST_INFO = `[notification-tester app only]: To test background notification handling:\n(1) Background the app.\n(2) Send a push notification from your terminal. The push token can be found in your logs, and the command to send a notification can be found at https://docs.expo.dev/push-notifications/sending-notifications/#http2-api. On iOS, you need to include "_contentAvailable": "true" in your payload.\n(3) After receiving the notification, check the "persisted data" presented in the notification-tester app`;
 
 const remotePushSupported = Device.isDevice;
+
 export default class NotificationScreen extends React.Component<
   void,
   {
@@ -25,6 +27,54 @@ export default class NotificationScreen extends React.Component<
   constructor(props: void) {
     super(props);
     this.state = {};
+  }
+
+  private _onReceivedListener: EventSubscription | undefined;
+  private _onResponseReceivedListener: EventSubscription | undefined;
+
+  componentDidMount() {
+    if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
+      return;
+    }
+    // Using the same category as in `registerForPushNotificationsAsync`
+    Notifications.setNotificationCategoryAsync('welcome', [
+      {
+        buttonTitle: `Don't open app`,
+        identifier: 'first-button',
+        options: {
+          opensAppToForeground: false,
+        },
+      },
+      {
+        buttonTitle: 'Respond with text',
+        identifier: 'second-button-with-text',
+        textInput: {
+          submitButtonTitle: 'Submit button',
+          placeholder: 'Placeholder text',
+        },
+      },
+      {
+        buttonTitle: 'Open app',
+        identifier: 'third-button',
+        options: {
+          opensAppToForeground: true,
+        },
+      },
+    ])
+      .then((_category) => {})
+      .catch((error) => console.warn('Could not have set notification category', error));
+
+    this._onReceivedListener = Notifications.addNotificationReceivedListener(
+      this._handleReceivedNotification
+    );
+    this._onResponseReceivedListener = Notifications.addNotificationResponseReceivedListener(
+      this._handleNotificationResponseReceived
+    );
+  }
+
+  componentWillUnmount() {
+    this._onReceivedListener?.remove();
+    this._onResponseReceivedListener?.remove();
   }
 
   render() {
@@ -167,13 +217,13 @@ export default class NotificationScreen extends React.Component<
     );
   }
 
-  _handelReceivedNotification = (notification: Notifications.Notification) => {
+  _handleReceivedNotification = (notification: Notifications.Notification) => {
     this.setState({
       lastNotifications: notification,
     });
   };
 
-  _handelNotificationResponseReceived = (
+  _handleNotificationResponseReceived = (
     notificationResponse: Notifications.NotificationResponse
   ) => {
     console.log({ notificationResponse });

--- a/apps/notification-tester/src/Notifier.tsx
+++ b/apps/notification-tester/src/Notifier.tsx
@@ -78,7 +78,7 @@ export const Notifier = () => {
 
     const responseListener = addNotificationResponseReceivedListener((response) => {
       setResponse(response);
-      console.log(`${Platform.OS} saw response for ${JSON.stringify(response, null, 2)}`);
+      console.log(`${Platform.OS} saw response: ${JSON.stringify(response, null, 2)}`);
     });
 
     console.log(`${Platform.OS} added listeners`);

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/CategoriesModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/CategoriesModule.swift
@@ -30,13 +30,11 @@ open class CategoriesModule: Module {
     let categoryRecord = CategoryRecord(identifier, actions: actions, options: options)
     let newNotificationCategory = categoryRecord.toUNNotificationCategory()
     let oldCategories = await UNUserNotificationCenter.current().notificationCategories()
-    let newCategories = Set(
-      oldCategories
-        .filter { oldCategory in
-          return oldCategory.identifier != newNotificationCategory.identifier
-        }
-        .union([newNotificationCategory])
-    )
+    let newCategories = oldCategories
+      .filter { oldCategory in
+        return oldCategory.identifier != newNotificationCategory.identifier
+      }
+      .union([newNotificationCategory])
     UNUserNotificationCenter.current().setNotificationCategories(newCategories)
     return CategoryRecord(newNotificationCategory)
   }
@@ -47,9 +45,9 @@ open class CategoriesModule: Module {
       return oldCategory.identifier == identifier
     }
     if didDelete {
-      let newCategories = Set(oldCategories.filter { oldCategory in
+      let newCategories = oldCategories.filter { oldCategory in
         return oldCategory.identifier != identifier
-      })
+      }
       UNUserNotificationCenter.current().setNotificationCategories(newCategories)
     }
     return didDelete


### PR DESCRIPTION
# Why

following up on QA - it was reported notifications with action buttons don't work. They do work, but I broke the NCL screen when I introduced the notification tester app in https://github.com/expo/expo/pull/35347

# How

- added back some code that I previously removed
- while I was at it I improved the native code a tiny bit

# Test Plan

- used the notification tester app, as well as bare expo to verify the local notifications with buttons

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
