### PR TITLE
[task-manager] Fix manifest error

### DIFF
--- a/packages/expo-task-manager/android/src/main/AndroidManifest.xml
+++ b/packages/expo-task-manager/android/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
         <receiver
-            android:name=".TaskBroadcastReceiver"
+            android:name="expo.modules.taskManager.TaskBroadcastReceiver"
             android:exported="false">
             <intent-filter>
                 <action android:name="expo.modules.taskManager.TaskBroadcastReceiver.INTENT_ACTION" />
@@ -10,7 +10,7 @@
             </intent-filter>
         </receiver>
         <service
-            android:name=".TaskJobService"
+            android:name="expo.modules.taskManager.TaskJobService"
             android:enabled="true"
             android:exported="false"
             android:permission="android.permission.BIND_JOB_SERVICE" />


### PR DESCRIPTION
# Why
Fixes an issue in the expo-task-manager manifest where the receiver does not find the service or receiver classes. It should be resolved relative to the namespace in the `build.gradle` but that's not working. Maybe @lukmccall knows why? I've cleaned everything, reset caches etc. still getting the same error.

# How
Use an absolute path to the classes

# Test Plan
Bare-expo runs without issue.
