### PR TITLE
[docs] fix compact height sidebar mode regression

### DIFF
--- a/docs/ui/components/Sidebar/SidebarHead.tsx
+++ b/docs/ui/components/Sidebar/SidebarHead.tsx
@@ -51,30 +51,35 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
             title="Home"
             Icon={Home02DuotoneIcon}
             isActive={sidebarActiveGroup === 'home'}
+            allowCompactDisplay
           />
           <SidebarSingleEntry
             href="/guides/overview/"
             title="Guides"
             Icon={BookOpen02DuotoneIcon}
             isActive={sidebarActiveGroup === 'general'}
+            allowCompactDisplay
           />
           <SidebarSingleEntry
             href="/eas/"
             title="EAS"
             Icon={PlanEnterpriseIcon}
             isActive={sidebarActiveGroup === 'eas'}
+            allowCompactDisplay
           />
           <SidebarSingleEntry
             href="/versions/latest/"
             title="Reference"
             Icon={DocsLogo}
             isActive={sidebarActiveGroup === 'reference'}
+            allowCompactDisplay
           />
           <SidebarSingleEntry
             href="/tutorial/overview/"
             title="Learn"
             Icon={GraduationHat02DuotoneIcon}
             isActive={sidebarActiveGroup === 'learn'}
+            allowCompactDisplay
           />
           {isPreviewVisible && (
             <SidebarSingleEntry
@@ -82,6 +87,7 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
               title="Feature Preview"
               Icon={Stars02DuotoneIcon}
               isActive={sidebarActiveGroup === 'featurePreview' || sidebarActiveGroup === 'preview'}
+              allowCompactDisplay
             />
           )}
         </div>

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -12,6 +12,7 @@ type SidebarSingleEntryProps = {
   isExternal?: boolean;
   secondary?: boolean;
   shouldLeakReferrer?: boolean;
+  allowCompactDisplay?: boolean;
 };
 
 export const SidebarSingleEntry = ({
@@ -21,7 +22,8 @@ export const SidebarSingleEntry = ({
   isActive = false,
   isExternal = false,
   secondary = false,
-  shouldLeakReferrer,
+  shouldLeakReferrer = false,
+  allowCompactDisplay = false,
 }: SidebarSingleEntryProps) => {
   return (
     <Tooltip.Root delayDuration={500} disableHoverableContent>
@@ -32,7 +34,7 @@ export const SidebarSingleEntry = ({
             'flex min-h-[32px] items-center gap-3 rounded-md px-2 py-1 text-sm !leading-[100%] text-secondary',
             'hocus:bg-element',
             'focus-visible:relative focus-visible:z-10',
-            'compact-height:justify-center compact-height:bg-subtle',
+            allowCompactDisplay && 'compact-height:justify-center compact-height:bg-subtle',
             secondary && 'text-xs',
             isActive &&
               '!bg-palette-blue3 font-medium text-link hocus:!bg-palette-blue4 hocus:text-link'
@@ -45,11 +47,15 @@ export const SidebarSingleEntry = ({
               isActive ? 'text-palette-blue11' : 'text-icon-tertiary'
             )}
           />
-          <span className="compact-height:hidden">{title}</span>
+          <span className={mergeClasses(allowCompactDisplay && 'compact-height:hidden')}>
+            {title}
+          </span>
           {isExternal && <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary" />}
         </LinkBase>
       </Tooltip.Trigger>
-      <Tooltip.Content side="bottom" className="z-50 hidden compact-height:flex">
+      <Tooltip.Content
+        side="bottom"
+        className={mergeClasses('z-50 hidden', allowCompactDisplay && 'compact-height:flex')}>
         <span className="text-2xs text-secondary">{title}</span>
       </Tooltip.Content>
     </Tooltip.Root>


### PR DESCRIPTION
# Why

Jon has spotted a small regression with compact mode yesterday:

![Screenshot 2025-04-03 at 12 16 33](https://github.com/user-attachments/assets/c777c388-7655-4aae-a29e-d44c50ce6513)

# How

Make the ability to collapse `SidebarSingleEntry` elements configurable via prop, not the style applied by default, add ne flag to `SidebarHead` entries.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

![Screenshot 2025-04-03 at 12 16 16](https://github.com/user-attachments/assets/8eedbfac-0333-4041-a94d-e5babff23919)

