### PR TITLE
[maps][Android] fix updating cameraPosition prop

### DIFF
--- a/apps/native-component-list/src/screens/ExpoMaps/google/MapsStreetViewScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoMaps/google/MapsStreetViewScreen.tsx
@@ -5,12 +5,16 @@ import { Platform, View, StyleSheet } from 'react-native';
 
 const cameraCoordinates = [
   {
-    latitude: 40.9971,
-    longitude: 29.1007,
+    latitude: 50.0620543,
+    longitude: 19.9388222,
   },
   {
     latitude: 37.78825,
     longitude: -122.4324,
+  },
+  {
+    latitude: 50.0494075,
+    longitude: 19.9655114,
   },
 ];
 

--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] fix updating cameraPosition prop ([#35883](https://github.com/expo/expo/pull/35883) by [@jakex7](https://github.com/jakex7))
+
 ### 💡 Others
 
 - [Android] Started using expo modules gradle plugin. ([#34176](https://github.com/expo/expo/pull/34176) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
@@ -138,7 +138,7 @@ class GoogleMapsView(context: Context, appContext: AppContext) : ExpoComposeView
   @Composable
   private fun updateCameraState(): CameraPositionState {
     val cameraPosition = props.cameraPosition.value
-    cameraState = remember {
+    cameraState = remember(cameraPosition) {
       CameraPositionState(
         position = CameraPosition.fromLatLngZoom(
           cameraPosition.coordinates.toLatLng(),


### PR DESCRIPTION
# Why

Updating the `cameraPosition` prop on Google Maps had no effect.


# How

Use props as a key to `remember` to update the state correctly.
Additionally, I updated the StreetView examples, as the previous ones were no longer working.

# Test Plan

NCL -> ExpoMaps -> camera controls

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
