### PR TITLE
[template] fix IconSymbol and ExternalLink types

### DIFF
--- a/templates/expo-template-default/components/ExternalLink.tsx
+++ b/templates/expo-template-default/components/ExternalLink.tsx
@@ -1,8 +1,11 @@
-import { Link, type LinkProps } from 'expo-router';
+import { Href, Link } from 'expo-router';
 import { openBrowserAsync } from 'expo-web-browser';
+import { type ComponentProps } from 'react';
 import { Platform } from 'react-native';
 
-export function ExternalLink({ href, ...rest }: LinkProps) {
+type Props = Omit<ComponentProps<typeof Link>, 'href'> & { href: Href & string };
+
+export function ExternalLink({ href, ...rest }: Props) {
   return (
     <Link
       target="_blank"
@@ -13,7 +16,7 @@ export function ExternalLink({ href, ...rest }: LinkProps) {
           // Prevent the default behavior of linking to the default browser on native.
           event.preventDefault();
           // Open the link in an in-app browser.
-          await openBrowserAsync(href.toString());
+          await openBrowserAsync(href);
         }
       }}
     />

--- a/templates/expo-template-default/components/ui/IconSymbol.tsx
+++ b/templates/expo-template-default/components/ui/IconSymbol.tsx
@@ -3,7 +3,7 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { SymbolWeight, SymbolViewProps } from 'expo-symbols';
 import { ComponentProps } from 'react';
-import { OpaqueColorValue, StyleProp, ViewStyle } from 'react-native';
+import { OpaqueColorValue, StyleProp, TextStyle } from 'react-native';
 
 type IconMapping = Record<SymbolViewProps['name'], ComponentProps<typeof MaterialIcons>['name']>;
 type IconSymbolName = keyof typeof MAPPING;
@@ -34,7 +34,7 @@ export function IconSymbol({
   name: IconSymbolName;
   size?: number;
   color: string | OpaqueColorValue;
-  style?: StyleProp<ViewStyle>;
+  style?: StyleProp<TextStyle>;
   weight?: SymbolWeight;
 }) {
   return <MaterialIcons color={color} size={size} name={MAPPING[name]} style={style} />;

--- a/templates/expo-template-default/components/ui/IconSymbol.tsx
+++ b/templates/expo-template-default/components/ui/IconSymbol.tsx
@@ -3,7 +3,7 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { SymbolWeight, SymbolViewProps } from 'expo-symbols';
 import { ComponentProps } from 'react';
-import { OpaqueColorValue, StyleProp, TextStyle } from 'react-native';
+import { OpaqueColorValue, type StyleProp, type TextStyle } from 'react-native';
 
 type IconMapping = Record<SymbolViewProps['name'], ComponentProps<typeof MaterialIcons>['name']>;
 type IconSymbolName = keyof typeof MAPPING;


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/35777

# How

1. For the IconButton, we're allowed to use TextStyles or ViewStyles, so we were just typing the props incorrectly
2. For the external link, we're looking for Href that is a string (which is more correct than stringifying the href)

# Test Plan

```sh
bun install
npx expo start
bunx tsc
```
& ensure there are no ts errors

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
