### PR TITLE
test(cli): increase e2e process timeout for windows

### DIFF
--- a/packages/@expo/cli/e2e/utils/process.ts
+++ b/packages/@expo/cli/e2e/utils/process.ts
@@ -108,7 +108,7 @@ export async function waitForProcessOutput<T>(
 export async function waitForProcessReady<T>(
   child: ChildProcess,
   resolver: () => Promise<T>,
-  timeoutMs = 60_000
+  timeoutMs = 120_000
 ) {
   // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers
   let resolve: (value: T | PromiseLike<T>) => void;


### PR DESCRIPTION

# Why

We keep running into random `npx serve` timeouts, likely due to github actions not being slow.

https://github.com/expo/expo/actions/runs/14251329244/job/39945342370?pr=34558

# How

- Doubled process timeout from `60s` to `120s`

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
