### PR TITLE
chore(metro-runtime): drop unused log

### DIFF
--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 💡 Others
 
-- Remove unused log.
+- Remove unused log. ([#35894](https://github.com/expo/expo/pull/35894) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 4.0.1 - 2025-01-19
 

--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### 💡 Others
 
+- Remove unused log.
+
 ## 4.0.1 - 2025-01-19
 
 ### 🐛 Bug fixes

--- a/packages/@expo/metro-runtime/src/messageSocket.native.ts
+++ b/packages/@expo/metro-runtime/src/messageSocket.native.ts
@@ -22,10 +22,6 @@ createWebSocketConnection().onmessage = (message) => {
           if (data.params.platform && data.params.platform !== process.env.EXPO_OS) {
             return;
           }
-          console.log(
-            'HMR(Client): Reload received from server. Sending to listeners:',
-            globalThis.__EXPO_RSC_RELOAD_LISTENERS__?.length
-          );
           if (!globalThis.__EXPO_RSC_RELOAD_LISTENERS__) {
             // server function-only mode
           } else {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
