### PR TITLE
[docs] Update EAS Hosting "Worker Runtime" page with Node.js built-in module table

### DIFF
--- a/docs/pages/eas/hosting/reference/worker-runtime.mdx
+++ b/docs/pages/eas/hosting/reference/worker-runtime.mdx
@@ -22,48 +22,48 @@ Cloudflare is part of [Winter CG](https://wintercg.org/), is more similar to the
 
 This means, many Node.js APIs that you might be used to or some dependencies you utilize, aren't directly available in the EAS Hosting runtime. To ease this transition, as not all dependencies will have first-class support for Web APIs yet, Node.js compatibility modules exist and can be used in your API routes.
 
-| Node.js built-in module                                       | Supported | Implementation Notes |
-| ------------------------------------------------------------- | --------- | ----------- |
-| `node:assert` | <YesIcon />  | |
-| `node:async_hooks` | <YesIcon />  | |
-| `node:buffer` | <YesIcon />  | |
-| `node:crypto` | <YesIcon />  | Select deprecated algorithms are not available |
-| `node:console` | <AlertIcon />  | Provided as partially functional JS shims |
-| `node:constants` | <YesIcon />  | |
-| `node:diagnostics_channel` | <YesIcon />  | Select deprecated algorithms are not implemented |
-| `node:dns` | <YesIcon />  | `Resolver` is unimplemented, All DNS requests are sent to Cloudflare |
-| `node:dns/promises` | <YesIcon />  | All DNS requests are sent to Cloudflare |
-| `node:events` | <YesIcon />  | |
-| `node:fs` | <NoIcon />  | Provided as JS stubs, but workers have no file system |
-| `node:fs/promises` | <NoIcon />  | Provided as JS stubs, but workers have no file system |
-| `node:http` | <AlertIcon />  | Provided as partially functional JS shims based on `fetch` |
-| `node:https` | <AlertIcon />  | Provided as partially functional JS shims based on `fetch` |
-| `node:module` | <AlertIcon />  | `SourceMap` is unimplemented, Implemented partially with JS stubs |
-| `node:net` | <AlertIcon />  | `Server` and `BlockList` are unimplemented, sockets are partially supported |
-| `node:os` | <YesIcon />  | Provided as JS stubs |
-| `node:path` | <YesIcon /> | |
-| `node:path/posix` | <YesIcon /> | |
-| `node:path/win32` | <YesIcon /> | |
-| `node:process` | <YesIcon /> | Provided as JS stubs |
-| `node:punycode` | <NoIcon /> | |
-| `node:querystring` | <YesIcon /> | |
-| `node:readline` | <NoIcon /> | Provided as non-functional JS stubs |
-| `node:readline/promises` | <NoIcon /> | Provided as non-functional JS stubs |
-| `node:stream` | <YesIcon /> | |
-| `node:stream/consumers` | <YesIcon /> | |
-| `node:stream/promises` | <YesIcon /> | |
-| `node:stream/web` | <YesIcon /> | |
-| `node:string_decoder` | <YesIcon /> | |
-| `node:timers` | <YesIcon /> | |
-| `node:timers/promises` | <YesIcon /> | |
-| `node:tls` | <NoIcon /> | Provides JS stubs but is unimplemented |
-| `node:trace_events` | <AlertIcon /> | Provided as non-functional JS stubs |
-| `node:tty` | <YesIcon /> | Provided as JS shims redirecting output to the Console API |
-| `node:url` | <YesIcon /> | |
-| `node:util` | <YesIcon /> | |
-| `node:util/types` | <YesIcon /> | |
-| `node:worker_threads` | <NoIcon /> | Provided as non-functional JS stubs, but workers don't support threading |
-| `node:zlib` | <YesIcon /> | |
+| Node.js built-in module    | Supported     | Implementation Notes                                                        |
+| -------------------------- | ------------- | --------------------------------------------------------------------------- |
+| `node:assert`              | <YesIcon />   |                                                                             |
+| `node:async_hooks`         | <YesIcon />   |                                                                             |
+| `node:buffer`              | <YesIcon />   |                                                                             |
+| `node:crypto`              | <YesIcon />   | Select deprecated algorithms are not available                              |
+| `node:console`             | <AlertIcon /> | Provided as partially functional JS shims                                   |
+| `node:constants`           | <YesIcon />   |                                                                             |
+| `node:diagnostics_channel` | <YesIcon />   | Select deprecated algorithms are not implemented                            |
+| `node:dns`                 | <YesIcon />   | `Resolver` is unimplemented, All DNS requests are sent to Cloudflare        |
+| `node:dns/promises`        | <YesIcon />   | All DNS requests are sent to Cloudflare                                     |
+| `node:events`              | <YesIcon />   |                                                                             |
+| `node:fs`                  | <NoIcon />    | Provided as JS stubs, but workers have no file system                       |
+| `node:fs/promises`         | <NoIcon />    | Provided as JS stubs, but workers have no file system                       |
+| `node:http`                | <AlertIcon /> | Provided as partially functional JS shims based on `fetch`                  |
+| `node:https`               | <AlertIcon /> | Provided as partially functional JS shims based on `fetch`                  |
+| `node:module`              | <AlertIcon /> | `SourceMap` is unimplemented, Implemented partially with JS stubs           |
+| `node:net`                 | <AlertIcon /> | `Server` and `BlockList` are unimplemented, sockets are partially supported |
+| `node:os`                  | <YesIcon />   | Provided as JS stubs                                                        |
+| `node:path`                | <YesIcon />   |                                                                             |
+| `node:path/posix`          | <YesIcon />   |                                                                             |
+| `node:path/win32`          | <YesIcon />   |                                                                             |
+| `node:process`             | <YesIcon />   | Provided as JS stubs                                                        |
+| `node:punycode`            | <NoIcon />    |                                                                             |
+| `node:querystring`         | <YesIcon />   |                                                                             |
+| `node:readline`            | <NoIcon />    | Provided as non-functional JS stubs                                         |
+| `node:readline/promises`   | <NoIcon />    | Provided as non-functional JS stubs                                         |
+| `node:stream`              | <YesIcon />   |                                                                             |
+| `node:stream/consumers`    | <YesIcon />   |                                                                             |
+| `node:stream/promises`     | <YesIcon />   |                                                                             |
+| `node:stream/web`          | <YesIcon />   |                                                                             |
+| `node:string_decoder`      | <YesIcon />   |                                                                             |
+| `node:timers`              | <YesIcon />   |                                                                             |
+| `node:timers/promises`     | <YesIcon />   |                                                                             |
+| `node:tls`                 | <NoIcon />    | Provides JS stubs but is unimplemented                                      |
+| `node:trace_events`        | <AlertIcon /> | Provided as non-functional JS stubs                                         |
+| `node:tty`                 | <YesIcon />   | Provided as JS shims redirecting output to the Console API                  |
+| `node:url`                 | <YesIcon />   |                                                                             |
+| `node:util`                | <YesIcon />   |                                                                             |
+| `node:util/types`          | <YesIcon />   |                                                                             |
+| `node:worker_threads`      | <NoIcon />    | Provided as non-functional JS stubs, but workers don't support threading    |
+| `node:zlib`                | <YesIcon />   |                                                                             |
 
 These modules generally provide a lower-accuracy polyfill or approximation of their Node.js counterparts.
 For example, the `http` and `https` modules only provide thin Node.js compatibility wrappers around the `fetch` API and cannot be used to make arbitrary HTTP requests.
@@ -76,17 +76,17 @@ Any modules that aren't mentioned here are unavailable or unsupported, and your 
 
 ## Globals
 
-| JavaScript runtime globals                                    | Supported | Implementation Notes |
-| ------------------------------------------------------------- | --------- | ----------- |
-| `process` | <YesIcon />  | |
-| `process.env` | <YesIcon />  | Populated with EAS Hosting environment variables |
-| `process.stdout` | <YesIcon />  | Will redirect output to the Console API (`console.log`) for logging |
-| `process.stderr` | <YesIcon />  | Will redirect output to the Console API (`console.error`) for logging |
-| `setImmediate` | <YesIcon />  | |
-| `clearImmediate` | <YesIcon />  | |
-| `Buffer` | <YesIcon />  | Provided via `node:buffer` |
-| `global` | <YesIcon />  | Set to `globalThis` |
-| `WeakRef` | <YesIcon />  | Shim that resets references after each request |
-| `FinalizationRegistry` | <NoIcon />  | Garbage collection is not observable within workers |
-| `require` | <AlertIcon /> | External requires are supported but limited to deployed JS files and built-in modules. Node module resolution is unsupported. |
-| `require.cache` | <NoIcon /> | |
+| JavaScript runtime globals | Supported     | Implementation Notes                                                                                                          |
+| -------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `process`                  | <YesIcon />   |                                                                                                                               |
+| `process.env`              | <YesIcon />   | Populated with EAS Hosting environment variables                                                                              |
+| `process.stdout`           | <YesIcon />   | Will redirect output to the Console API (`console.log`) for logging                                                           |
+| `process.stderr`           | <YesIcon />   | Will redirect output to the Console API (`console.error`) for logging                                                         |
+| `setImmediate`             | <YesIcon />   |                                                                                                                               |
+| `clearImmediate`           | <YesIcon />   |                                                                                                                               |
+| `Buffer`                   | <YesIcon />   | Provided via `node:buffer`                                                                                                    |
+| `global`                   | <YesIcon />   | Set to `globalThis`                                                                                                           |
+| `WeakRef`                  | <YesIcon />   | Shim that resets references after each request                                                                                |
+| `FinalizationRegistry`     | <NoIcon />    | Garbage collection is not observable within workers                                                                           |
+| `require`                  | <AlertIcon /> | External requires are supported but limited to deployed JS files and built-in modules. Node module resolution is unsupported. |
+| `require.cache`            | <NoIcon />    |                                                                                                                               |

--- a/docs/pages/eas/hosting/reference/worker-runtime.mdx
+++ b/docs/pages/eas/hosting/reference/worker-runtime.mdx
@@ -66,11 +66,11 @@ This means, many Node.js APIs that you might be used to or some dependencies you
 These modules generally provide a lower-accuracy polyfill or approximation of their Node.js counterparts.
 For example, the `http` and `https` modules only provide thin Node.js compatibility wrappers around the `fetch` API and cannot be used to make arbitrary HTTP requests.
 
-Any of the listed Node.js modules can be used in API routes or dependencies of your API routes as usual and will use appropriate compatibility modules. However, some of these modules may not provide any practical functionality and only exist to shim APIs to prevent runtime crashes.
+Any of the above listed Node.js modules can be used in API routes or dependencies of your API routes as usual and will use appropriate compatibility modules. However, some of these modules may not provide any practical functionality and only exist to shim APIs to prevent runtime crashes.
 
 Any modules that aren't mentioned here are unavailable or unsupported, and your code and none of your dependencies should rely on them being provided.
 
-> More Node compatibility shims may be added in the future, but all Node APIs that are not documented in this non-exhaustive list are not expected to work.
+> More Node.js compatibility shims may be added in the future, but all Node.js APIs that are not documented in this non-exhaustive list are not expected to work.
 
 ## Globals
 

--- a/docs/pages/eas/hosting/reference/worker-runtime.mdx
+++ b/docs/pages/eas/hosting/reference/worker-runtime.mdx
@@ -20,7 +20,7 @@ Cloudflare is part of [Winter CG](https://wintercg.org/), is more similar to the
 
 This means, many Node.js APIs that you might be used to or some dependencies you utilize, aren't directly available in the EAS Hosting runtime. To ease this transition, as not all dependencies will have first-class support for Web APIs yet, Node.js compatibility modules exist and can be used in your API routes.
 
-| Node.js built-in module    | Supported     | Implementation Notes                                                        |
+| Node.js built-in module    | Supported     | Implementation notes                                                        |
 | -------------------------- | ------------- | --------------------------------------------------------------------------- |
 | `node:assert`              | <YesIcon />   |                                                                             |
 | `node:async_hooks`         | <YesIcon />   |                                                                             |
@@ -29,14 +29,14 @@ This means, many Node.js APIs that you might be used to or some dependencies you
 | `node:console`             | <AlertIcon /> | Provided as partially functional JS shims                                   |
 | `node:constants`           | <YesIcon />   |                                                                             |
 | `node:diagnostics_channel` | <YesIcon />   | Select deprecated algorithms are not implemented                            |
-| `node:dns`                 | <YesIcon />   | `Resolver` is unimplemented, All DNS requests are sent to Cloudflare        |
+| `node:dns`                 | <YesIcon />   | `Resolver` is unimplemented, all DNS requests are sent to Cloudflare        |
 | `node:dns/promises`        | <YesIcon />   | All DNS requests are sent to Cloudflare                                     |
 | `node:events`              | <YesIcon />   |                                                                             |
 | `node:fs`                  | <NoIcon />    | Provided as JS stubs, but workers have no file system                       |
 | `node:fs/promises`         | <NoIcon />    | Provided as JS stubs, but workers have no file system                       |
 | `node:http`                | <AlertIcon /> | Provided as partially functional JS shims based on `fetch`                  |
 | `node:https`               | <AlertIcon /> | Provided as partially functional JS shims based on `fetch`                  |
-| `node:module`              | <AlertIcon /> | `SourceMap` is unimplemented, Implemented partially with JS stubs           |
+| `node:module`              | <AlertIcon /> | `SourceMap` is unimplemented, implemented partially with JS stubs           |
 | `node:net`                 | <AlertIcon /> | `Server` and `BlockList` are unimplemented, sockets are partially supported |
 | `node:os`                  | <YesIcon />   | Provided as JS stubs                                                        |
 | `node:path`                | <YesIcon />   |                                                                             |
@@ -74,7 +74,7 @@ Any modules that aren't mentioned here are unavailable or unsupported, and your 
 
 ## Globals
 
-| JavaScript runtime globals | Supported     | Implementation Notes                                                                                                          |
+| JavaScript runtime globals | Supported     | Implementation notes                                                                                                          |
 | -------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `process`                  | <YesIcon />   |                                                                                                                               |
 | `process.env`              | <YesIcon />   | Populated with EAS Hosting environment variables                                                                              |

--- a/docs/pages/eas/hosting/reference/worker-runtime.mdx
+++ b/docs/pages/eas/hosting/reference/worker-runtime.mdx
@@ -85,6 +85,7 @@ Any modules that aren't mentioned here are unavailable or unsupported, and your 
 | `setImmediate`             | <YesIcon />   |                                                                                                                               |
 | `clearImmediate`           | <YesIcon />   |                                                                                                                               |
 | `Buffer`                   | <YesIcon />   | Provided via `node:buffer`                                                                                                    |
+| `EventEmitter`             | <YesIcon />   | Provided via `node:events`                                                                                                    |
 | `global`                   | <YesIcon />   | Set to `globalThis`                                                                                                           |
 | `WeakRef`                  | <YesIcon />   | Shim that resets references after each request                                                                                |
 | `FinalizationRegistry`     | <NoIcon />    | Garbage collection is not observable within workers                                                                           |

--- a/docs/pages/eas/hosting/reference/worker-runtime.mdx
+++ b/docs/pages/eas/hosting/reference/worker-runtime.mdx
@@ -4,6 +4,8 @@ title: EAS Hosting worker runtime
 description: Learn about EAS Hosting worker runtime and Node.js compatibility.
 ---
 
+import { YesIcon, NoIcon, AlertIcon } from '~/ui/components/DocIcons';
+
 ## Caching with API Routes
 
 EAS Hosting is built on [Cloudflare Workers](https://developers.cloudflare.com/workers/), a modern and powerful platform for serverless APIs that's been built for seamless scalability, high reliability, and exceptional performance globally.
@@ -20,50 +22,71 @@ Cloudflare is part of [Winter CG](https://wintercg.org/), is more similar to the
 
 This means, many Node.js APIs that you might be used to or some dependencies you utilize, aren't directly available in the EAS Hosting runtime. To ease this transition, as not all dependencies will have first-class support for Web APIs yet, Node.js compatibility modules exist and can be used in your API routes.
 
-### Node.js shim modules
+| Node.js built-in module                                       | Supported | Implementation Notes |
+| ------------------------------------------------------------- | --------- | ----------- |
+| `node:assert` | <YesIcon />  | |
+| `node:async_hooks` | <YesIcon />  | |
+| `node:buffer` | <YesIcon />  | |
+| `node:crypto` | <YesIcon />  | Select deprecated algorithms are not available |
+| `node:console` | <AlertIcon />  | Provided as partially functional JS shims |
+| `node:constants` | <YesIcon />  | |
+| `node:diagnostics_channel` | <YesIcon />  | Select deprecated algorithms are not implemented |
+| `node:dns` | <YesIcon />  | `Resolver` is unimplemented, All DNS requests are sent to Cloudflare |
+| `node:dns/promises` | <YesIcon />  | All DNS requests are sent to Cloudflare |
+| `node:events` | <YesIcon />  | |
+| `node:fs` | <NoIcon />  | Provided as JS stubs, but workers have no file system |
+| `node:fs/promises` | <NoIcon />  | Provided as JS stubs, but workers have no file system |
+| `node:http` | <AlertIcon />  | Provided as partially functional JS shims based on `fetch` |
+| `node:https` | <AlertIcon />  | Provided as partially functional JS shims based on `fetch` |
+| `node:module` | <AlertIcon />  | `SourceMap` is unimplemented, Implemented partially with JS stubs |
+| `node:net` | <AlertIcon />  | `Server` and `BlockList` are unimplemented, sockets are partially supported |
+| `node:os` | <YesIcon />  | Provided as JS stubs |
+| `node:path` | <YesIcon /> | |
+| `node:path/posix` | <YesIcon /> | |
+| `node:path/win32` | <YesIcon /> | |
+| `node:process` | <YesIcon /> | Provided as JS stubs |
+| `node:punycode` | <NoIcon /> | |
+| `node:querystring` | <YesIcon /> | |
+| `node:readline` | <NoIcon /> | Provided as non-functional JS stubs |
+| `node:readline/promises` | <NoIcon /> | Provided as non-functional JS stubs |
+| `node:stream` | <YesIcon /> | |
+| `node:stream/consumers` | <YesIcon /> | |
+| `node:stream/promises` | <YesIcon /> | |
+| `node:stream/web` | <YesIcon /> | |
+| `node:string_decoder` | <YesIcon /> | |
+| `node:timers` | <YesIcon /> | |
+| `node:timers/promises` | <YesIcon /> | |
+| `node:tls` | <NoIcon /> | Provides JS stubs but is unimplemented |
+| `node:trace_events` | <AlertIcon /> | Provided as non-functional JS stubs |
+| `node:tty` | <YesIcon /> | Provided as JS shims redirecting output to the Console API |
+| `node:url` | <YesIcon /> | |
+| `node:util` | <YesIcon /> | |
+| `node:util/types` | <YesIcon /> | |
+| `node:worker_threads` | <NoIcon /> | Provided as non-functional JS stubs, but workers don't support threading |
+| `node:zlib` | <YesIcon /> | |
 
-The list of compatibility modules for Node.js APIs natively supported by Cloudflare's runtime are:
+These modules generally provide a lower-accuracy polyfill or approximation of their Node.js counterparts.
+For example, the `http` and `https` modules only provide thin Node.js compatibility wrappers around the `fetch` API and cannot be used to make arbitrary HTTP requests.
 
-- `assert`
-- `async_hooks`
-- `buffer`
-- `crypto` (With some limitations and missing exports)
-- `diagnostics_channel`
-- `events`
-- `path`, `path/posix`, and `path/win32`
-- `process`
-- `querystring`
-- `stream`, `stream/consumers`, `stream/promises`, and `stream/web`
-- `string_decoder`
-- `url`
-- `util`
-- `zlib`
+Any of the listed Node.js modules can be used in API routes or dependencies of your API routes as usual and will use appropriate compatibility modules. However, some of these modules may not provide any practical functionality and only exist to shim APIs to prevent runtime crashes.
 
-Additionally, EAS Hosting provides JavaScript-level shims (or rather polyfills) for the following modules:
+Any modules that aren't mentioned here are unavailable or unsupported, and your code and none of your dependencies should rely on them being provided.
 
-- `http`
-- `https`
-- `tty`
-
-These modules generally provide a lower-accuracy polyfill of their Node.js counterparts. For example, the `http` and `https` modules only provide thin Node.js compatibility wrappers around the `fetch` API and cannot be used to make arbitrary HTTP requests.
-
-The following modules are mocked but won't provide any functionality:
-
-- `child_process`
-- `net`
-
-Any of the above Node.js modules can be used in API routes or dependencies of your API routes as usual and will use appropriate compatibility modules.
-
-Any modules that aren't mentioned here are unavailable, and your code and none of your dependencies should rely on them being provided.
-
-> More Node compatibility shims may be added in the future, but all Node APIs that are not documented in these non-exhaustive lists are expected to work.
+> More Node compatibility shims may be added in the future, but all Node APIs that are not documented in this non-exhaustive list are not expected to work.
 
 ## Globals
 
-- The `process` global is present with mock values set as appropriate to match Node.js
-- `process.env` is available and will be populated with your deployment's environment variables
-- `process.stdout` and `process.stderr` will convert the output written to them to `console.log` and `console.error` calls
-- `setImmediate` and `clearImmediate` are available as shims around `setTimeout` and `clearTimeout`
-- The `Buffer` and `EventEmitter` globals are available and set to their Node.js shims
-- `global` is available and set to `globalThis`
-- `require()` is available in CommonJS modules but `require.cache` is unavailable
+| JavaScript runtime globals                                    | Supported | Implementation Notes |
+| ------------------------------------------------------------- | --------- | ----------- |
+| `process` | <YesIcon />  | |
+| `process.env` | <YesIcon />  | Populated with EAS Hosting environment variables |
+| `process.stdout` | <YesIcon />  | Will redirect output to the Console API (`console.log`) for logging |
+| `process.stderr` | <YesIcon />  | Will redirect output to the Console API (`console.error`) for logging |
+| `setImmediate` | <YesIcon />  | |
+| `clearImmediate` | <YesIcon />  | |
+| `Buffer` | <YesIcon />  | Provided via `node:buffer` |
+| `global` | <YesIcon />  | Set to `globalThis` |
+| `WeakRef` | <YesIcon />  | Shim that resets references after each request |
+| `FinalizationRegistry` | <NoIcon />  | Garbage collection is not observable within workers |
+| `require` | <AlertIcon /> | External requires are supported but limited to deployed JS files and built-in modules. Node module resolution is unsupported. |
+| `require.cache` | <NoIcon /> | |

--- a/docs/pages/eas/hosting/reference/worker-runtime.mdx
+++ b/docs/pages/eas/hosting/reference/worker-runtime.mdx
@@ -16,7 +16,7 @@ For more information on how Workers work, see [Cloudflare Workers](https://devel
 
 ## Node.js compatibility
 
-Cloudflare is part of [Winter CG](https://wintercg.org/), is more similar to the JavaScript environments in browsers and service workers rather than in Node.js. Restrictions like these provide a leaner runtime than Node.js, which is still familiar. This common runtime is a minimal standard supported by many JavaScript runtime these days.
+Cloudflare is part of [Winter TC](https://wintertc.org/), is more similar to the JavaScript environments in browsers and service workers rather than in Node.js. Restrictions like these provide a leaner runtime than Node.js, which is still familiar. This common runtime is a minimal standard supported by many JavaScript runtime these days.
 
 This means, many Node.js APIs that you might be used to or some dependencies you utilize, aren't directly available in the EAS Hosting runtime. To ease this transition, as not all dependencies will have first-class support for Web APIs yet, Node.js compatibility modules exist and can be used in your API routes.
 

--- a/docs/pages/eas/hosting/reference/worker-runtime.mdx
+++ b/docs/pages/eas/hosting/reference/worker-runtime.mdx
@@ -6,8 +6,6 @@ description: Learn about EAS Hosting worker runtime and Node.js compatibility.
 
 import { YesIcon, NoIcon, AlertIcon } from '~/ui/components/DocIcons';
 
-## Caching with API Routes
-
 EAS Hosting is built on [Cloudflare Workers](https://developers.cloudflare.com/workers/), a modern and powerful platform for serverless APIs that's been built for seamless scalability, high reliability, and exceptional performance globally.
 
 The Cloudflare Workers runtime runs on the V8 JavaScript engine, the same powering JavaScript in Node.js and Chromium. However, its runtime has a few key differences from what you might be used to in traditional serverless Node.js deployments.

--- a/docs/pages/eas/hosting/reference/worker-runtime.mdx
+++ b/docs/pages/eas/hosting/reference/worker-runtime.mdx
@@ -20,48 +20,48 @@ Cloudflare is part of [Winter CG](https://wintercg.org/), is more similar to the
 
 This means, many Node.js APIs that you might be used to or some dependencies you utilize, aren't directly available in the EAS Hosting runtime. To ease this transition, as not all dependencies will have first-class support for Web APIs yet, Node.js compatibility modules exist and can be used in your API routes.
 
-| Node.js built-in module    | Supported     | Implementation notes                                                        |
-| -------------------------- | ------------- | --------------------------------------------------------------------------- |
-| `node:assert`              | <YesIcon />   |                                                                             |
-| `node:async_hooks`         | <YesIcon />   |                                                                             |
-| `node:buffer`              | <YesIcon />   |                                                                             |
-| `node:crypto`              | <YesIcon />   | Select deprecated algorithms are not available                              |
-| `node:console`             | <AlertIcon /> | Provided as partially functional JS shims                                   |
-| `node:constants`           | <YesIcon />   |                                                                             |
-| `node:diagnostics_channel` | <YesIcon />   | Select deprecated algorithms are not implemented                            |
-| `node:dns`                 | <YesIcon />   | `Resolver` is unimplemented, all DNS requests are sent to Cloudflare        |
-| `node:dns/promises`        | <YesIcon />   | All DNS requests are sent to Cloudflare                                     |
-| `node:events`              | <YesIcon />   |                                                                             |
-| `node:fs`                  | <NoIcon />    | Provided as JS stubs, but workers have no file system                       |
-| `node:fs/promises`         | <NoIcon />    | Provided as JS stubs, but workers have no file system                       |
-| `node:http`                | <AlertIcon /> | Provided as partially functional JS shims based on `fetch`                  |
-| `node:https`               | <AlertIcon /> | Provided as partially functional JS shims based on `fetch`                  |
-| `node:module`              | <AlertIcon /> | `SourceMap` is unimplemented, implemented partially with JS stubs           |
-| `node:net`                 | <AlertIcon /> | `Server` and `BlockList` are unimplemented, sockets are partially supported |
-| `node:os`                  | <YesIcon />   | Provided as JS stubs                                                        |
-| `node:path`                | <YesIcon />   |                                                                             |
-| `node:path/posix`          | <YesIcon />   |                                                                             |
-| `node:path/win32`          | <YesIcon />   |                                                                             |
-| `node:process`             | <YesIcon />   | Provided as JS stubs                                                        |
-| `node:punycode`            | <NoIcon />    |                                                                             |
-| `node:querystring`         | <YesIcon />   |                                                                             |
-| `node:readline`            | <NoIcon />    | Provided as non-functional JS stubs                                         |
-| `node:readline/promises`   | <NoIcon />    | Provided as non-functional JS stubs                                         |
-| `node:stream`              | <YesIcon />   |                                                                             |
-| `node:stream/consumers`    | <YesIcon />   |                                                                             |
-| `node:stream/promises`     | <YesIcon />   |                                                                             |
-| `node:stream/web`          | <YesIcon />   |                                                                             |
-| `node:string_decoder`      | <YesIcon />   |                                                                             |
-| `node:timers`              | <YesIcon />   |                                                                             |
-| `node:timers/promises`     | <YesIcon />   |                                                                             |
-| `node:tls`                 | <NoIcon />    | Provides JS stubs but is unimplemented                                      |
-| `node:trace_events`        | <AlertIcon /> | Provided as non-functional JS stubs                                         |
-| `node:tty`                 | <YesIcon />   | Provided as JS shims redirecting output to the Console API                  |
-| `node:url`                 | <YesIcon />   |                                                                             |
-| `node:util`                | <YesIcon />   |                                                                             |
-| `node:util/types`          | <YesIcon />   |                                                                             |
-| `node:worker_threads`      | <NoIcon />    | Provided as non-functional JS stubs, but workers don't support threading    |
-| `node:zlib`                | <YesIcon />   |                                                                             |
+| Node.js built-in module    | Supported     | Implementation notes                                                               |
+| -------------------------- | ------------- | ---------------------------------------------------------------------------------- |
+| `node:assert`              | <YesIcon />   |                                                                                    |
+| `node:async_hooks`         | <YesIcon />   |                                                                                    |
+| `node:buffer`              | <YesIcon />   |                                                                                    |
+| `node:crypto`              | <YesIcon />   | Select deprecated algorithms are not available                                     |
+| `node:console`             | <AlertIcon /> | Provided as partially functional JS shims                                          |
+| `node:constants`           | <YesIcon />   |                                                                                    |
+| `node:diagnostics_channel` | <YesIcon />   | Select deprecated algorithms are not implemented                                   |
+| `node:dns`                 | <YesIcon />   | `Resolver` is unimplemented, all DNS requests are sent to Cloudflare               |
+| `node:dns/promises`        | <YesIcon />   | All DNS requests are sent to Cloudflare                                            |
+| `node:events`              | <YesIcon />   |                                                                                    |
+| `node:fs`                  | <NoIcon />    | Provided as JS stubs, since workers have no file system                            |
+| `node:fs/promises`         | <NoIcon />    | Provided as JS stubs, since workers have no file system                            |
+| `node:http`                | <AlertIcon /> | Provided as partially functional JS shims based on `fetch`                         |
+| `node:https`               | <AlertIcon /> | Provided as partially functional JS shims based on `fetch`                         |
+| `node:module`              | <AlertIcon /> | `SourceMap` is unimplemented, partially supported otherwise                        |
+| `node:net`                 | <AlertIcon /> | `Server` and `BlockList` are unimplemented, client sockets are partially supported |
+| `node:os`                  | <YesIcon />   | Provided as JS stubs that provide mock values matching Node.js on Linux            |
+| `node:path`                | <YesIcon />   |                                                                                    |
+| `node:path/posix`          | <YesIcon />   |                                                                                    |
+| `node:path/win32`          | <YesIcon />   |                                                                                    |
+| `node:process`             | <YesIcon />   | Provided as JS stubs                                                               |
+| `node:punycode`            | <NoIcon />    |                                                                                    |
+| `node:querystring`         | <YesIcon />   |                                                                                    |
+| `node:readline`            | <NoIcon />    | Provided as non-functional JS stubs, since workers have no `stdin`                 |
+| `node:readline/promises`   | <NoIcon />    | Provided as non-functional JS stubs, since workers have no `stdin`                 |
+| `node:stream`              | <YesIcon />   |                                                                                    |
+| `node:stream/consumers`    | <YesIcon />   |                                                                                    |
+| `node:stream/promises`     | <YesIcon />   |                                                                                    |
+| `node:stream/web`          | <YesIcon />   |                                                                                    |
+| `node:string_decoder`      | <YesIcon />   |                                                                                    |
+| `node:timers`              | <YesIcon />   |                                                                                    |
+| `node:timers/promises`     | <YesIcon />   |                                                                                    |
+| `node:tls`                 | <NoIcon />    | Provides JS stubs but is unimplemented                                             |
+| `node:trace_events`        | <AlertIcon /> | Provided as non-functional JS stubs                                                |
+| `node:tty`                 | <YesIcon />   | Provided as JS shims redirecting output to the Console API                         |
+| `node:url`                 | <YesIcon />   |                                                                                    |
+| `node:util`                | <YesIcon />   |                                                                                    |
+| `node:util/types`          | <YesIcon />   |                                                                                    |
+| `node:worker_threads`      | <NoIcon />    | Provided as non-functional JS stubs, since workers don't support threading         |
+| `node:zlib`                | <YesIcon />   |                                                                                    |
 
 These modules generally provide a lower-accuracy polyfill or approximation of their Node.js counterparts.
 For example, the `http` and `https` modules only provide thin Node.js compatibility wrappers around the `fetch` API and cannot be used to make arbitrary HTTP requests.
@@ -82,8 +82,8 @@ Any modules that aren't mentioned here are unavailable or unsupported, and your 
 | `process.stderr`           | <YesIcon />   | Will redirect output to the Console API (`console.error`) for logging                                                         |
 | `setImmediate`             | <YesIcon />   |                                                                                                                               |
 | `clearImmediate`           | <YesIcon />   |                                                                                                                               |
-| `Buffer`                   | <YesIcon />   | Provided via `node:buffer`                                                                                                    |
-| `EventEmitter`             | <YesIcon />   | Provided via `node:events`                                                                                                    |
+| `Buffer`                   | <YesIcon />   | Set to `Buffer` from `node:buffer`                                                                                            |
+| `EventEmitter`             | <YesIcon />   | Set to `EventEmitter` from `node:events`                                                                                      |
 | `global`                   | <YesIcon />   | Set to `globalThis`                                                                                                           |
 | `WeakRef`                  | <YesIcon />   | Shim that resets references after each request                                                                                |
 | `FinalizationRegistry`     | <NoIcon />    | Garbage collection is not observable within workers                                                                           |

--- a/docs/ui/components/DocIcons/AlertIcon.tsx
+++ b/docs/ui/components/DocIcons/AlertIcon.tsx
@@ -1,0 +1,7 @@
+import { AlertCircleSolidIcon } from '@expo/styleguide-icons/solid/AlertCircleSolidIcon';
+
+import { IconBase, DocIconProps } from './IconBase';
+
+export const AlertIcon = ({ small }: DocIconProps) => (
+  <IconBase Icon={AlertCircleSolidIcon} className="text-icon-warning" small={small} />
+);

--- a/docs/ui/components/DocIcons/index.ts
+++ b/docs/ui/components/DocIcons/index.ts
@@ -2,3 +2,4 @@ export * from './YesIcon';
 export * from './NoIcon';
 export * from './PendingIcon';
 export * from './WarningIcon';
+export * from './AlertIcon';


### PR DESCRIPTION
# Why

Currently, this page feels a little hard to follow and needed some updates for several Node.js built-in modules. However, reading and updating bullet point lists for all Node.js modules is tougher than it needs to be, and a table would give us more space to elaborate on implementation notes.

Node.js built-in modules in `workerd` and EAS Hosting are not on a clear "yes/no" (supported/unsupported) spectrum. Instead, we need some space to elaborate how a module is supported, if it's missing some functionality, or if it's not fully implemented. We also need a way to express that some modules are neither clearly supported or unsupported i.e. show them as an "inbetween" state that warrants extra attention from users.

<details>
<summary>Preview Screenshot (does not reflect two latest commits)</summary>

![image](https://github.com/user-attachments/assets/042a1f3c-ff38-4143-96c3-f7eb98499fd5)

</details>

# How

- Add a new circle alert icon to be used alongside `YesIcon` and `NoIcon`
  - Note: It's not a perfect match in size, but close enough imho
- Replace lists of supported modules with a table
- Make sure that this table contains all Node.js built-in modules we account for
- Add implementation notes where appropriate and mark modules that aren't clearly supported or unsupported with the `AlertIcon` rather than a `YesIcon` or `NoIcon`
- Replace globals list with a table as well
- Rewrite notes after the updated content

The globals table is not comprehensive (as per WinterTC) but it contains globals that we're modifying ourselves, i.e. that don't function as users may expect them to.

# Test Plan

- Ran the docs locally and checked the layout