### PR TITLE
[notifications] UNTextInputNotificationAction wasn't provided with options

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,10 +8,11 @@
 
 ### 🐛 Bug fixes
 
-- event emitter should not influence notification presentation ([#35858](https://github.com/expo/expo/pull/35858) by [@vonovak](https://github.com/vonovak))
+- [post-swift-conversion] UNTextInputNotificationAction wasn't provided with options ([#35903](https://github.com/expo/expo/pull/35903) by [@vonovak](https://github.com/vonovak))
+- [post-swift-conversion] event emitter should not influence notification presentation ([#35858](https://github.com/expo/expo/pull/35858) by [@vonovak](https://github.com/vonovak))
 - correctly serialize `null` trigger on iOS ([#35672](https://github.com/expo/expo/pull/35672) by [@vonovak](https://github.com/vonovak))
 - restore `useLastNotificationResponse` return value behavior ([#35504](https://github.com/expo/expo/pull/35504) by [@vonovak](https://github.com/vonovak))
-- fix ios textInput action missing title ([#34866](https://github.com/expo/expo/pull/34866) by [@vonovak](https://github.com/vonovak))
+- [post-swift-conversion] fix ios textInput action missing title ([#34866](https://github.com/expo/expo/pull/34866) by [@vonovak](https://github.com/vonovak))
 - [ios] Fixed incorrect `EXNotifications-Swift.h` import. ([#34987](https://github.com/expo/expo/pull/34987) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] fix notification response listener emitting duplicate response events ([#34849](https://github.com/expo/expo/pull/34849) by [@xc2](https://github.com/xc2))
 

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Records.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Records.swift
@@ -212,10 +212,11 @@ struct CategoryTextInputActionRecord: Record {
     self.submitButtonTitle = textInputAction.textInputButtonTitle
   }
 
-  func toUNTextInputNotificationAction(identifier: String, title: String) -> UNTextInputNotificationAction {
+  func toUNTextInputNotificationAction(identifier: String, title: String, options: UNNotificationActionOptions) -> UNTextInputNotificationAction {
     return UNTextInputNotificationAction(
       identifier: identifier,
       title: title,
+      options: options,
       textInputButtonTitle: submitButtonTitle ?? "",
       textInputPlaceholder: placeholder ?? ""
     )
@@ -265,9 +266,7 @@ public struct CategoryActionRecord: Record {
       let buttonTitle = buttonTitle else {
       return nil
     }
-    if let textInput = textInput {
-      return textInput.toUNTextInputNotificationAction(identifier: identifier, title: buttonTitle)
-    }
+
     var notificationOptions: UNNotificationActionOptions = []
     if let optionsParams = options {
       if optionsParams.opensAppToForeground == true {
@@ -279,6 +278,9 @@ public struct CategoryActionRecord: Record {
       if optionsParams.isAuthenticationRequired == true {
         notificationOptions.insert(.authenticationRequired)
       }
+    }
+    if let textInput = textInput {
+      return textInput.toUNTextInputNotificationAction(identifier: identifier, title: buttonTitle, options: notificationOptions)
     }
     return UNNotificationAction(identifier: identifier, title: buttonTitle, options: notificationOptions)
   }
@@ -368,9 +370,9 @@ public struct CategoryRecord: Record {
   }
 
   func toUNNotificationCategory() -> UNNotificationCategory {
-    let intentIdentifiers: [String] = options?.intentIdentifiers as? [String] ?? []
-    let previewPlaceholder: String? = options?.previewPlaceholder as? String
-    let categorySummaryFormat: String? = options?.categorySummaryFormat as? String
+    let intentIdentifiers: [String] = options?.intentIdentifiers ?? []
+    let previewPlaceholder: String? = options?.previewPlaceholder
+    let categorySummaryFormat: String? = options?.categorySummaryFormat
     let actionsArray = actions?.compactMap { action in
       return action.toUNNotificationAction()
     } ?? []


### PR DESCRIPTION
# Why

This PR fixes an issue with text input notification actions on iOS, where notification action options were not being properly applied to text input actions. Previously, options like `opensAppToForeground`, `destructive`, and `authenticationRequired` were only being applied to regular notification actions but not to text input actions.

# How

Modified the `toUNTextInputNotificationAction` method in `CategoryTextInputActionRecord` to accept and use notification options. 


# Test Plan

```
          const textResponseButton = {
            identifier: 'textResponseButton',
            buttonTitle: 'Click to Respond with Text',
            options: {
              isDestructive: true,
              isAuthenticationRequired: true,
              opensAppToForeground: true,
            },
            textInput: { submitButtonTitle: 'Send', placeholder: 'Type Something' },
          };

          type CategoryParams = {
            identifier: string;
            actions: NotificationAction[];
            options?: NotificationCategoryOptions;
          };

          const testCategory2: CategoryParams = {
            identifier: 'testNotificationCategory4',
            actions: [textResponseButton],
            options: {
              customDismissAction: false,
              allowInCarPlay: false,
              showTitle: true,
              showSubtitle: true,
              allowAnnouncement: false,
              categorySummaryFormat: '',
              previewPlaceholder: 'exPreview',
              intentIdentifiers: [],
            },
          };

          const resultCategory = await Notifications.setNotificationCategoryAsync(
            testCategory2.identifier,
            testCategory2.actions,
            testCategory2.options
          );
          console.log(JSON.stringify(resultCategory, null, 2));
```

<details>
<summary>test output</summary>

before:

```
{
  "options": {
    "previewPlaceholder": "exPreview",
    "categorySummaryFormat": "",
    "customDismissAction": false,
    "showSubtitle": true,
    "allowInCarPlay": false,
    "showTitle": true,
    "intentIdentifiers": []
  },
  "actions": [
    {
      "buttonTitle": "Click to Respond with Text",
      "identifier": "textResponseButton",
      "textInput": {
        "title": "Click to Respond with Text",
        "placeholder": "Type Something",
        "submitButtonTitle": "Send"
      },
      "options": {
        "isAuthenticationRequired": false,
        "isDestructive": false,
        "opensAppToForeground": false
      }
    }
  ],
  "identifier": "testNotificationCategory4"
}
```


after:


```
{
  "identifier": "testNotificationCategory4",
  "options": {
    "categorySummaryFormat": "",
    "customDismissAction": false,
    "allowInCarPlay": false,
    "previewPlaceholder": "exPreview",
    "intentIdentifiers": [],
    "showSubtitle": true,
    "showTitle": true
  },
  "actions": [
    {
      "textInput": {
        "submitButtonTitle": "Send",
        "placeholder": "Type Something",
        "title": "Click to Respond with Text"
      },
      "identifier": "textResponseButton",
      "buttonTitle": "Click to Respond with Text",
      "options": {
        "isDestructive": true,
        "isAuthenticationRequired": true,
        "opensAppToForeground": true
      }
    }
  ]
}
```

</details>


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)