### PR TITLE
fix(cli): force react navigation to use import instead of require.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 🐛 Bug fixes
 
+- Force react-navigation to resolve to the same condition each time.
 - Silence missing favicon file error. ([#35357](https://github.com/expo/expo/pull/35357) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix importing `@radix-ui/colors` in CSS files. ([#35213](https://github.com/expo/expo/pull/35213) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure HMR updates use the same serializer pass as initial bundles. ([#35110](https://github.com/expo/expo/pull/35110) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -713,6 +713,13 @@ export function withExtendedResolver(
         ];
       }
 
+      // HACK:
+      if (moduleName.match(/^@react-navigation\//)) {
+        // Force to use the ESM versions of react-navigation to prevent Metro behavior where it changes the
+        // resolution based on if a module is `import`ing or `require`ing it.
+        context.unstable_conditionNames = ['import', 'require'];
+      }
+
       if (isServerEnvironment(context.customResolverOptions?.environment)) {
         // Adjust nodejs source extensions to sort mjs after js, including platform variants.
         if (nodejsSourceExtensions === null) {
@@ -836,6 +843,10 @@ export async function withMetroMultiPlatformAsync(
     }
     // @ts-expect-error: watchFolders is readonly
     config.watchFolders.push(path.join(require.resolve('metro-runtime/package.json'), '../..'));
+    // @ts-expect-error: watchFolders is readonly
+    config.watchFolders.push(
+      path.join(require.resolve('@expo/metro-config/package.json'), '../..')
+    );
     if (isReactCanaryEnabled) {
       // @ts-expect-error: watchFolders is readonly
       config.watchFolders.push(path.join(require.resolve('@expo/cli/package.json'), '..'));


### PR DESCRIPTION
# Why

The new metro package exports syntax chooses which condition to use based on if the module is imported using `import` or `require` which means you can import multiple copies of the same package. This can lead to issues where a node module has a React context that isn't shared. Many libraries will potentially have this issue it's not entirely clear what the best move is here, potentially locking an import condition per bundle based on the first instance (which would require tracking across async bundles in dev), warning, or forcing everyone not to use require anymore (which is seemingly what the plan was).

People still use `require` syntax as a way to strip unused modules in production because tree shaking isn't enabled by default. Tree shaking isn't enabled by default because `experimentalImportSupport` (ESM handling) has a number of bugs such as inability to support require cycles. We need `experimentalImportSupport` because Hermes + RN don't have built-in support for ESM. Point here is that it'll take a while before this import/require resolution is a sensible default, so we need a workaround in the meantime.

# Test Plan

- `npx expo` in an SDK 53 project works as expected.
- Using `EXPO_ATLAS=1 npx expo` shows that only one copy of React Navigation is pulled in.