### PR TITLE
[docs][expo-router] Fix examples on how to config expo-router redirects and rewrites in app.json

### DIFF
--- a/docs/pages/router/advanced/redirects.mdx
+++ b/docs/pages/router/advanced/redirects.mdx
@@ -52,10 +52,12 @@ Static redirects allow you to specify a redirect configuration in your [app conf
   "plugins": [
     [
       "expo-router",
-      "redirects": [{
-        "source": "/redirect/from/here",
-        "destination": "/to/this/route"
-      }]
+      {
+        "redirects": [{
+          "source": "/redirect/from/here",
+          "destination": "/to/this/route"
+        }]
+      }
     ]
   ]
 }
@@ -81,10 +83,12 @@ The `source` and `destination` routes can use the [dynamic route syntax](/develo
   "plugins": [
     [
       "expo-router",
-      "redirects": [{
-        "source": "/redirect/[slug]",
-        "destination": "/target/[slug]"
-      }]
+      {
+        "redirects": [{
+          "source": "/redirect/[slug]",
+          "destination": "/target/[slug]"
+        }]
+      }
     ]
   ]
 }
@@ -97,10 +101,12 @@ The variable names will be matched when performing the redirection, if available
   "plugins": [
     [
       "expo-router",
-      "redirects": [{
-        "source": "/redirect/[fruit]/[vegetable]/[meat]",
-        "destination": "/target/[vegetable]/[fruit]"
-      }]
+      {
+        "redirects": [{
+          "source": "/redirect/[fruit]/[vegetable]/[meat]",
+          "destination": "/target/[vegetable]/[fruit]"
+        }]
+      }
     ]
   ]
 }
@@ -117,11 +123,13 @@ To redirect only certain HTTP methods, provide the methods as a string inside an
   "plugins": [
     [
       "expo-router",
-      "redirects": [{
-        "source": "/redirect/[slug]",
-        "destination": "/target/[slug]"
-        "methods": ["POST"]
-      }]
+      {
+        "redirects": [{
+          "source": "/redirect/[slug]",
+          "destination": "/target/[slug]"
+          "methods": ["POST"]
+        }]
+      }
     ]
   ]
 }
@@ -136,10 +144,12 @@ Rewrites are only possible through static configuration. They are different from
   "plugins": [
     [
       "expo-router",
-      "rewrites": [{
-        "source": "/redirect/from/here",
-        "destination": "/to/this/route"
-      }]
+      {
+        "rewrites": [{
+          "source": "/redirect/from/here",
+          "destination": "/to/this/route"
+        }]
+      }
     ]
   ]
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The examples provided [here](https://github.com/expo/expo/blob/main/docs/pages/router/advanced/redirects.mdx) on how to setup expo-router redirects and rewrites are invalid code. This PR fixes the examples.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Adding the missing curling braces around the redirects/rewrites config, as the second element of the plugin config must be an object.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Copy/paste the fixed example inside the "app.json" file. The old code snippet produces a invalid config, the new produces a working valid config.
