### PR TITLE
docs: Improve Cognito documentation for social providers with Cognito

### DIFF
--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -608,6 +608,7 @@ export default function App() {
 - Leverages the Hosted UI in Cognito ([API documentation][c-cognito-api-docs])
 - Requests code after successfully authenticating, followed by exchanging code for the auth tokens (PKCE)
 - The `/token` endpoint requires a `code_verifier` parameter which you can retrieve from the request before calling `exchangeCodeAsync()`:
+
 ```tsx
 extraParams: {
   code_verifier: request.codeVerifier,

--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -608,12 +608,19 @@ export default function App() {
 - Leverages the Hosted UI in Cognito ([API documentation][c-cognito-api-docs])
 - Requests code after successfully authenticating, followed by exchanging code for the auth tokens (PKCE)
 - The `/token` endpoint requires a `code_verifier` parameter which you can retrieve from the request before calling `exchangeCodeAsync()`:
-
 ```tsx
 extraParams: {
   code_verifier: request.codeVerifier,
 }
 ```
+
+- To open a specific Social Provider such as Google you can supply the providers name with `identity_provider` parameter within extraParams for the signIn url.
+```tsx
+extraParams: {
+    identity_provider: "Google",
+}
+```
+- Valid providers are `Google`, `COGNITO`, `Facebook` `LoginWithAmazon`, `SignInWithApple`. These are case sensitive and must match Social Provider within Cognito. You can provide custom providers.
 
 {/* prettier-ignore */}
 ```tsx Cognito Auth Example

--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -616,11 +616,13 @@ extraParams: {
 ```
 
 - To open a specific social identity provider, such as Google, you can supply the provider's name with the `identity_provider` parameter within `extraParams` for the sign in URL.
+
 ```tsx
 extraParams: {
     identity_provider: "Google",
 }
 ```
+
 - Valid providers are `Google`, `COGNITO`, `Facebook` `LoginWithAmazon`, `SignInWithApple`. These are case sensitive and must match the social provider within Cognito. You can provide custom providers.
 
 {/* prettier-ignore */}

--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -615,13 +615,13 @@ extraParams: {
 }
 ```
 
-- To open a specific Social Provider such as Google you can supply the providers name with `identity_provider` parameter within extraParams for the signIn url.
+- To open a specific social identity provider, such as Google, you can supply the provider's name with the `identity_provider` parameter within `extraParams` for the sign in URL.
 ```tsx
 extraParams: {
     identity_provider: "Google",
 }
 ```
-- Valid providers are `Google`, `COGNITO`, `Facebook` `LoginWithAmazon`, `SignInWithApple`. These are case sensitive and must match Social Provider within Cognito. You can provide custom providers.
+- Valid providers are `Google`, `COGNITO`, `Facebook` `LoginWithAmazon`, `SignInWithApple`. These are case sensitive and must match the social provider within Cognito. You can provide custom providers.
 
 {/* prettier-ignore */}
 ```tsx Cognito Auth Example


### PR DESCRIPTION
# Why

The documentation for expo-auth-session with Cognito is lacking some additional capabilities supported by Cognito. In this case Cognito Web Hosted UI can be launched with a specific social provider such as Google. This information isn't clearly documented by AWS either, it is mentioned in logout that identity_platform isn't supported, implying it is support for login (which has been tested)

# How

I am using Cognito for managing my authentication of users, and have supported Google as a social provider. I wanted to take advantage of the expo ecosystem and therefore utilises expo-auth-session to handle this. Cognito creates users within the user pool and will handle the authenticaiton/management of tokens between Cognito & Google. Meaning in order for Cognito to be the source of truth authentication needs to be with Cognito's Google Provider. 

# Test Plan

Cognito Application as per documentation where signIn url is has Google defined for Identity Platform. On Sign In Cognito Hosted UI is opened but instantly redirects to Google Sign In, reducing a step for end users. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
