### PR TITLE
[docs] Raised min. Android version to 7+

### DIFF
--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -99,7 +99,7 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version | Xcode version |
 | ---------------- | --------------- | ------------------- | ----------- | ------------- |
-| 52.0.0           | 6+              | 35                  | 15.1+       | 16.0 +        |
+| 52.0.0           | 7+              | 35                  | 15.1+       | 16.0 +        |
 | 51.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
 | 50.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
 

--- a/docs/pages/versions/v52.0.0/index.mdx
+++ b/docs/pages/versions/v52.0.0/index.mdx
@@ -99,7 +99,7 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version | Xcode version |
 | ---------------- | --------------- | ------------------- | ----------- | ------------- |
-| 52.0.0           | 6+              | 35                  | 15.1+       | 16.0+         |
+| 52.0.0           | 7+              | 35                  | 15.1+       | 16.0+         |
 | 51.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
 | 50.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
 


### PR DESCRIPTION
# Why

Android min. version with Expo SDK 52 is 7+ instead of 6+ as currently described in: https://docs.expo.dev/versions/latest/#support-for-android-and-ios-versions

References:
- https://github.com/react-native-community/discussions-and-proposals/discussions/802#discussion-6938582 
- https://expo.dev/changelog/2024-11-12-sdk-52

# How

Changed 6+ to 7+ in the docs.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
