### PR TITLE
fix: search for podspec files in root directory during autolinking

### DIFF
--- a/packages/expo-modules-autolinking/src/platforms/apple.ts
+++ b/packages/expo-modules-autolinking/src/platforms/apple.ts
@@ -24,7 +24,7 @@ async function findPodspecFiles(revision: PackageRevision): Promise<string[]> {
     return configPodspecPaths;
   }
 
-  const podspecFiles = await glob('*/*.podspec', {
+  const podspecFiles = await glob('**/*.podspec', {
     cwd: revision.path,
     ignore: ['**/node_modules/**'],
   });


### PR DESCRIPTION
# Why

Currently, the Expo autolinking system only searches for podspec files in subdirectories using the pattern `*/*.podspec`, which means it won't find podspec files in the root directory of a module. This is problematic because many React Native modules place their podspec files in the root directory, following the traditional React Native module structure. This limitation prevents Expo from properly autolinking these modules, causing integration issues for developers using both Expo and React Native modules.

# How

I modified the findPodspecFiles function in `packages/expo-modules-autolinking/src/platforms/apple.ts` to search for podspec files in both the root directory and subdirectories. The change replaces the current glob pattern `*/*.podspec` with `**/*.podspec`, which will match podspec files in the root directory and all subdirectories.
This change maintains backward compatibility with existing Expo modules while adding support for React Native modules that follow the traditional structure with podspec files in the root directory.

# Test Plan

1. Creating a test module with a podspec file in the root directory
2. Running ·npx expo prebuild· to verify that the module is correctly autolinked
3. Checking the generated Podfile to confirm the pod is included
4. Running pod install to verify that the pod is correctly installed
5. Building the app to ensure everything works correctly

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
