### PR TITLE
[github][docs] Update Vale config and version to 3.11.1

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -54,10 +54,11 @@ jobs:
       - name: 💬 Lint Docs website content
         uses: errata-ai/vale-action@reviewdog
         with:
-          version: 3.9.6
+          version: 3.11.1
           reporter: github-pr-check
           files: 'docs/pages'
           vale_flags: '--config=./docs/.vale.ini'
+          fail_on_error: true
       - name: 🏗️ Build Docs website
         run: yarn export-preview
         timeout-minutes: 20

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,10 +57,11 @@ jobs:
       - name: 💬 Lint Docs website content
         uses: errata-ai/vale-action@reviewdog
         with:
-          version: 3.9.6
+          version: 3.11.1
           reporter: github-pr-check
           files: 'docs/pages'
           vale_flags: '--config=./docs/.vale.ini'
+          fail_on_error: true
       - name: 🏗️ Build Docs website for deploy
         working-directory: docs
         run: yarn export

--- a/docs/.vale/writing-styles/expo-docs/AppStores.yml
+++ b/docs/.vale/writing-styles/expo-docs/AppStores.yml
@@ -3,6 +3,7 @@ message: "Consider using '%s' instead of '%s'"
 link: 'https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#referencing-app-stores'
 level: warning
 ignorecase: false
+scope: ~text.frontmatter
 swap:
   App Stores: app stores
   app Stores: app stores

--- a/docs/.vale/writing-styles/expo-docs/Consistency.yml
+++ b/docs/.vale/writing-styles/expo-docs/Consistency.yml
@@ -3,6 +3,7 @@ message: "Consider using '%s' instead of '%s'"
 link: 'https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#follow-external-product-casing'
 level: error
 ignorecase: true
+scope: ~text.frontmatter
 swap:
   '\b & \b': and
   amazon appstore: Amazon Appstore

--- a/docs/package.json
+++ b/docs/package.json
@@ -87,7 +87,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/semver": "^7.7.0",
-    "@vvago/vale": "3.9.6",
+    "@vvago/vale": "3.11.1",
     "acorn": "^8.14.1",
     "autoprefixer": "^10.4.21",
     "axios": "^1.8.4",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3206,9 +3206,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vvago/vale@npm:3.9.6":
-  version: 3.9.6
-  resolution: "@vvago/vale@npm:3.9.6"
+"@vvago/vale@npm:3.11.1":
+  version: 3.11.1
+  resolution: "@vvago/vale@npm:3.11.1"
   dependencies:
     axios: "npm:^1.4.0"
     rimraf: "npm:^5.0.0"
@@ -3216,7 +3216,7 @@ __metadata:
     unzipper: "npm:^0.10.14"
   bin:
     vale: bin/vale
-  checksum: 10c0/2483f9b472c20e87c376f8b3b6c17b313cbaf223519bcc5120d96b54b3d5e91c1a44786f1dba637bfdce9a6e36604fdcc7c0e1a8baeeeb5ce4930cc62a2a9160
+  checksum: 10c0/3a2249cac3d97ea7cceeade5a8ca389246f25c1dc1fc5cb88e1dbe6771e9b0fbc41f76ac2bc32afe5e40647ca774aed5fcf5f3042714559cd402cd0c1e8165db
   languageName: node
   linkType: hard
 
@@ -5711,7 +5711,7 @@ __metadata:
     "@types/react": "npm:^18.3.12"
     "@types/react-dom": "npm:^18.3.1"
     "@types/semver": "npm:^7.7.0"
-    "@vvago/vale": "npm:3.9.6"
+    "@vvago/vale": "npm:3.11.1"
     acorn: "npm:^8.14.1"
     autoprefixer: "npm:^10.4.21"
     axios: "npm:^1.8.4"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #35870

Update Vale config to use version 3.11.1 so that `frontmatter` related warnings do not fail. For a reference on how these warnings look like, see the image below, in which the Consistency rule failed because of the defined tokens in multiple pages frontmatter.

![CleanShot 2025-04-06 at 23 14 06](https://github.com/user-attachments/assets/2954b4b6-f0f7-4373-a7a1-26a80fa45af7)

Frontmatter of a docs page is a special case, and by default, Vale's pre-defined rule for `text.frontmatter` looks for title case and throws them as errors. In Expo docs, we can ignore this new scope since we often use brands and/or feature names in a page's title which might be reported as title case by Vale.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Upgrade `vale` dev dependency to 3.11.1 so that running `yarn run lint-prose` can match the latest version.
- Ignore `text.frontmatter` scope in Consistency and App Stores rules.
- Add `fail_on_error: true` back in the GitHub Action config to throw an error when a rule with the severity of the error is reported in a PR.
- Bump Vale's version in GitHub Action config to 3.11.1 to match locally used version.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Vale's config changes for version 3.11.1 have been tested locally by running `yarn run lint-prose` command:

![CleanShot 2025-04-06 at 23 21 40](https://github.com/user-attachments/assets/11cb9c83-033a-459d-b455-b44faa305cce)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
