### PR TITLE
[image] fix svg image tinting on ios

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed SVG image tinting on iOS. ([#35927](https://github.com/expo/expo/pull/35927) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.1.0 — 2025-04-04

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -139,10 +139,8 @@ public final class ImageView: ExpoView {
     // It seems that `UIImageView` can't tint some vector graphics. If the `tintColor` prop is specified,
     // we tell the SVG coder to decode to a bitmap instead. This will become useless when we switch to SVGNative coder.
     if imageTintColor != nil {
-      var decodeOptions = context[.imageDecodeOptions] as? [SDImageCoderOption: Any] ?? [:]
-      decodeOptions[.decodeThumbnailPixelSize] = sdImageView.bounds.size
-      decodeOptions[.decodePreserveAspectRatio] = true
-      context[.imageDecodeOptions] = decodeOptions
+      context[.imagePreserveAspectRatio] = true
+      context[.imageThumbnailPixelSize] = sdImageView.bounds.size
     }
 
     // Some loaders (e.g. PhotoLibraryAssetLoader) may need to know the screen scale.


### PR DESCRIPTION
# Why

fix svg image tinting on ios

# How

the #35802 way to specify thumbnail size is not correct because they would be overwrote by the [code](https://github.com/SDWebImage/SDWebImage/blob/cac9a55a3ae92478a2c95042dcc8d9695d2129ca/SDWebImage/Core/SDImageCacheDefine.m#L62-L63). the correct way is to pass into context directly

# Test Plan

NCL + image tint test case

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
