### PR TITLE
[et][publish-packages] Clear `local-naven-repo` when publishing canary

### DIFF
--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -138,6 +138,8 @@ export const cleanWorkingTree = new Task<TaskArgs>(
             'packages/**/package.json',
             'packages/expo-module-template/$package.json',
             'packages/expo/bundledNativeModules.json',
+            'packages/**/expo-module.config.json',
+            'packages/**/build.gradle',
             'templates/*/package.json',
           ],
         });
@@ -146,7 +148,7 @@ export const cleanWorkingTree = new Task<TaskArgs>(
         await Git.cleanAsync({
           recursive: true,
           force: true,
-          paths: ['packages/**/*.tgz'],
+          paths: ['packages/**/*.tgz', 'packages/**/local-maven-repo/**'],
         });
       },
       'Cleaned up the working tree'


### PR DESCRIPTION
# Why

Clears `local-naven-repo` when publishing canary.

# How

Removes local naven repositories when publishing canary.

# Test Plan

- run `et publish-packages --canary --dry` ✅ 