### PR TITLE
[cli] fix react native devtools opening issue

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed React Native Devtools opening issue. ([#35935](https://github.com/expo/expo/pull/35935) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Add backup stack trace ([#35913](https://github.com/expo/expo/pull/35913) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
@@ -15,6 +15,8 @@ export interface MetroInspectorProxyApp {
   /** Information about the underlying CDP implementation, e.g. "React Native Bridgeless [C++ connection]" */
   title: string;
   /** The application ID that is currently running on the device, e.g. "dev.expo.bareexpo" */
+  appId: string;
+  /** The description of the runtime, e.g. "React Native Bridgeless [C++ connection]" */
   description: string;
   /** The CDP debugger type, which should always be "node" */
   type: 'node';
@@ -50,7 +52,7 @@ export async function openJsInspector(metroBaseUrl: string, app: MetroInspectorP
   }
 
   const url = new URL('/open-debugger', metroBaseUrl);
-  url.searchParams.set('appId', app.description);
+  url.searchParams.set('appId', app.appId);
   url.searchParams.set('device', app.reactNative.logicalDeviceId);
   url.searchParams.set('target', app.id);
 
@@ -82,7 +84,7 @@ export async function queryInspectorAppAsync(
   appId: string
 ): Promise<MetroInspectorProxyApp | null> {
   const apps = await queryAllInspectorAppsAsync(metroServerOrigin);
-  return apps.find((app) => app.description === appId) ?? null;
+  return apps.find((app) => app.appId === appId) ?? null;
 }
 
 export async function queryAllInspectorAppsAsync(
@@ -91,7 +93,7 @@ export async function queryAllInspectorAppsAsync(
   const resp = await fetch(`${metroServerOrigin}/json/list`);
   // The newest runtime will be at the end of the list,
   // reversing the result would save time from try-error.
-  const apps: MetroInspectorProxyApp[] = transformApps(await resp.json()).reverse();
+  const apps: MetroInspectorProxyApp[] = (await resp.json()).reverse();
   const results: MetroInspectorProxyApp[] = [];
   for (const app of apps) {
     // Only use targets with better reloading support
@@ -138,28 +140,6 @@ export async function promptInspectorAppAsync(apps: MetroInspectorProxyApp[]) {
   const value = await selectAsync(chalk`Debug target {dim (Hermes only)}`, choices);
 
   return choices.find((item) => item.value === value)?.app;
-}
-
-// The description of `React Native Experimental (Improved Chrome Reloads)` target is `don't use` from metro.
-// This function tries to transform the unmeaningful description to appId
-function transformApps(apps: MetroInspectorProxyApp[]): MetroInspectorProxyApp[] {
-  const deviceIdToAppId: Record<string, string> = {};
-
-  for (const app of apps) {
-    if (app.description !== "don't use") {
-      const deviceId = app.reactNative?.logicalDeviceId ?? app.id.split('-')[0];
-      const appId = app.description;
-      deviceIdToAppId[deviceId] = appId;
-    }
-  }
-
-  return apps.map((app) => {
-    if (app.description === "don't use") {
-      const deviceId = app.reactNative?.logicalDeviceId ?? app.id.split('-')[0];
-      app.description = deviceIdToAppId[deviceId] ?? app.description;
-    }
-    return app;
-  });
 }
 
 const HIDE_FROM_INSPECTOR_ENV = 'globalThis.__expo_hide_from_inspector__';

--- a/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/JsInspector-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/JsInspector-test.ts
@@ -16,7 +16,7 @@ describe(openJsInspector, () => {
 
     // The URL parameters that should be sent for the inspectable target
     const params = new URLSearchParams();
-    params.set('appId', app.description);
+    params.set('appId', app.appId);
     params.set('device', app.reactNative!.logicalDeviceId!);
     params.set('target', app.id);
 
@@ -73,7 +73,7 @@ describe(queryInspectorAppAsync, () => {
     const appId = 'io.expo.test.devclient';
     const result = await queryInspectorAppAsync('http://localhost:8081', appId);
 
-    expect(result?.description).toBe(appId);
+    expect(result?.appId).toBe(appId);
     expect(scope.isDone()).toBe(true);
   });
 });

--- a/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/fixtures/metroInspectorResponse.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/fixtures/metroInspectorResponse.ts
@@ -3,8 +3,9 @@ import type { MetroInspectorProxyApp } from '../../JsInspector';
 export const METRO_INSPECTOR_RESPONSE_FIXTURE: MetroInspectorProxyApp[] = [
   {
     id: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-3',
-    description: 'io.expo.test.devclient',
-    title: 'Hermes React Native',
+    appId: 'io.expo.test.devclient',
+    description: 'React Native Bridgeless [C++ connection]',
+    title: 'io.expo.test.devclient (sdk_gphone64_arm64)',
     devtoolsFrontendUrl:
       'chrome-devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=%5B%3A%3A%5D%3A8081%2Finspector%2Fdebug%3Fdevice%3D0%26page%3D3',
     type: 'node',
@@ -18,23 +19,10 @@ export const METRO_INSPECTOR_RESPONSE_FIXTURE: MetroInspectorProxyApp[] = [
     },
   },
   {
-    id: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX--1',
-    description: "don't use",
-    title: 'React Native Experimental (Improved Chrome Reloads)',
-    devtoolsFrontendUrl:
-      'chrome-devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=%5B%3A%3A%5D%3A8081%2Finspector%2Fdebug%3Fdevice%3D0%26page%3D-1',
-    type: 'node',
-    webSocketDebuggerUrl: 'ws://[::]:8081/inspector/debug?device=0&page=-1',
-    deviceName: 'iPhone 15 Pro',
-    reactNative: {
-      logicalDeviceId: 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-      capabilities: {},
-    },
-  },
-  {
     id: 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY-1',
-    description: 'io.expo.test.hermes',
-    title: 'Hermes React Native',
+    appId: 'io.expo.test.hermes',
+    description: 'React Native Bridgeless [C++ connection]',
+    title: 'io.expo.test.devclient (sdk_gphone64_arm64)',
     devtoolsFrontendUrl:
       'chrome-devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=%5B%3A%3A%5D%3A8081%2Finspector%2Fdebug%3Fdevice%3D1%26page%3D1',
     type: 'node',
@@ -45,20 +33,6 @@ export const METRO_INSPECTOR_RESPONSE_FIXTURE: MetroInspectorProxyApp[] = [
       capabilities: {
         nativePageReloads: true,
       },
-    },
-  },
-  {
-    id: 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY--1',
-    description: "don't use",
-    title: 'React Native Experimental (Improved Chrome Reloads)',
-    devtoolsFrontendUrl:
-      'chrome-devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=%5B%3A%3A%5D%3A8081%2Finspector%2Fdebug%3Fdevice%3D1%26page%3D-1',
-    type: 'node',
-    webSocketDebuggerUrl: 'ws://[::]:8081/inspector/debug?device=1&page=-1',
-    deviceName: 'iPhone 15 Pro',
-    reactNative: {
-      logicalDeviceId: 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY',
-      capabilities: {},
     },
   },
 ];


### PR DESCRIPTION
# Why

unstable to open react native devtools since react-native 0.79

# How

since https://github.com/facebook/react-native/commit/c430083fa0, the CDP targets don't use description for appId. they have a dedicated `appId` field. this pr replaces the code to use `appId` and also remove the original `don't use` transformation. CDP targets don't have the `don't use` target (`React Native Experimental (Improved Chrome Reloads)`) anymore. 

# Test Plan

- ci passed
- press `j` on NCL

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
