### PR TITLE
[notifications] reintroduce device test suite

### DIFF
--- a/apps/native-component-list/src/screens/NotificationScreen.tsx
+++ b/apps/native-component-list/src/screens/NotificationScreen.tsx
@@ -98,6 +98,13 @@ export default class NotificationScreen extends React.Component<
           onPress={this._unregisterForNotificationsAsync}
           title="Unregister for push notifications"
         />
+        <ListButton
+          onPress={async () => {
+            const token = await Notifications.getDevicePushTokenAsync();
+            Alert.alert('Push token received', JSON.stringify(token));
+          }}
+          title="Get push token after unregistering"
+        />
         <BackgroundNotificationHandlingSection />
         <HeadingText>Badge Number</HeadingText>
         <ListButton

--- a/apps/notification-tester/metro.config.js
+++ b/apps/notification-tester/metro.config.js
@@ -11,6 +11,7 @@ const config = getDefaultConfig(__dirname);
 config.watchFolders = [
   __dirname, // Allow Metro to resolve all files within this project
   path.join(workspaceRoot, 'apps/native-component-list'), // Allow Metro to resolve all files within NCL
+  path.join(workspaceRoot, 'apps/test-suite'), // Allow Metro to resolve notification test suite
   path.join(workspaceRoot, 'apps/common'), // Allow Metro to resolve common ThemeProvider
   path.join(workspaceRoot, 'packages'), // Allow Metro to resolve all workspace files of the monorepo
   path.join(workspaceRoot, 'node_modules'), // Allow Metro to resolve "shared" `node_modules` of the monorepo

--- a/apps/notification-tester/src/app/index.tsx
+++ b/apps/notification-tester/src/app/index.tsx
@@ -8,6 +8,7 @@ export default function IndexPage() {
   const router = useRouter();
   return (
     <ScrollView contentContainerStyle={{ rowGap: 10, padding: 10 }}>
+      <Button title="Run on-device tests" onPress={() => router.push('/run')} />
       <Button title="Go to notification utils" onPress={() => router.push('/utilities')} />
       <Button title="Go to test scenarios" onPress={() => router.push('/scenarios')} />
       <Notifier />

--- a/apps/notification-tester/src/app/run.tsx
+++ b/apps/notification-tester/src/app/run.tsx
@@ -1,0 +1,18 @@
+// @ts-expect-error
+import TestScreen from 'test-suite/screens/TestScreen';
+
+const NotificationTestScreen = require('test-suite/tests/Notifications');
+
+// these are expo-notifications tests that are meant to be run on device from the notification-tester app
+// they test both local and remote notifications
+
+// yes, this is a hack - but the cost is low and benefit is high
+export default class NotificationTesterScreen extends TestScreen {
+  componentDidMount() {
+    const selectedModules = [NotificationTestScreen];
+    // @ts-expect-error
+    this._runTests(selectedModules);
+    // @ts-expect-error
+    this._isMounted = true;
+  }
+}


### PR DESCRIPTION
# Why

This PR adds on-device tests for expo-notifications in the notification-tester app and improves the existing test suite.

# How

- Created a new `/run` route that runs the Notifications test suite
- Converted the Notifications test file from JavaScript to TypeScript
- Fixed and modernized tests to use the current notification API structure

# Test Plan

- Verified that all tests pass correctly on iOS and Android using the notification tester app


https://github.com/user-attachments/assets/205c1d61-4c4a-4bbe-8923-04aad8a8c510


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)