### PR TITLE
[et][publish packages] Publish Android artifacts

### DIFF
--- a/tools/src/publish-packages/tasks/publishAndroidPackages.ts
+++ b/tools/src/publish-packages/tasks/publishAndroidPackages.ts
@@ -16,7 +16,6 @@ export const publishAndroidArtifacts = new Task(
   {
     name: 'publishAndroidArtifacts',
     dependsOn: [updateAndroidProjects],
-    filesToStage: ['packages/**/expo-module.config.json'],
   },
   async (parcels: Parcel[], options: CommandOptions) => {
     const packages = parcels.map((parcels) => parcels.pkg);

--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -9,6 +9,7 @@ import { commitStagedChanges } from './commitStagedChanges';
 import { cutOffChangelogs } from './cutOffChangelogs';
 import { grantTeamAccessToPackages } from './grantTeamAccessToPackages';
 import { loadRequestedParcels } from './loadRequestedParcels';
+import { publishAndroidArtifacts } from './publishAndroidPackages';
 import { publishPackages } from './publishPackages';
 import { pushCommittedChanges } from './pushCommittedChanges';
 import { selectPackagesToPublish } from './selectPackagesToPublish';
@@ -18,12 +19,11 @@ import { updateIosProjects } from './updateIosProjects';
 import { updateModuleTemplate } from './updateModuleTemplate';
 import { updatePackageVersions } from './updatePackageVersions';
 import { updateWorkspaceProjects } from './updateWorkspaceProjects';
+import Git from '../../Git';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
-import { CommandOptions, Parcel, TaskArgs } from '../types';
 import { runWithSpinner } from '../../Utils';
-import Git from '../../Git';
-import { publishAndroidArtifacts } from './publishAndroidPackages';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
 
 const { cyan, yellow } = chalk;
 


### PR DESCRIPTION
# Why

Builds and publishes Android artifacts when running `et publish packages` 

# Test Plan

- run `et publish-packages -p --dry expo-gl -S` ✅ 
