### PR TITLE
[et][publish packages] Add option to skip publishing Android artifacts

### DIFF
--- a/tools/src/commands/PublishPackages.ts
+++ b/tools/src/commands/PublishPackages.ts
@@ -72,7 +72,11 @@ export default (program: Command) => {
       false
     )
     .option('-C, --canary', 'Whether to publish all packages as canary versions.', false)
-
+    .option(
+      '-A, --skip-android-artifacts',
+      'Whether to build and publish Android artifacts to the local NPM registry.',
+      false
+    )
     /* debug options */
     .option(
       '-S, --skip-repo-checks',

--- a/tools/src/publish-packages/tasks/publishAndroidPackages.ts
+++ b/tools/src/publish-packages/tasks/publishAndroidPackages.ts
@@ -19,6 +19,11 @@ export const publishAndroidArtifacts = new Task(
     filesToStage: ['packages/**/expo-module.config.json'],
   },
   async (parcels: Parcel[], options: CommandOptions) => {
+    if (options.skipAndroidArtifacts) {
+      logger.log('\n🤖 Skipping publishing Android artifacts.');
+      return;
+    }
+
     const packages = parcels.map((parcels) => parcels.pkg);
 
     // Collect all packages that have Android artifacts to publish.

--- a/tools/src/publish-packages/types.ts
+++ b/tools/src/publish-packages/types.ts
@@ -19,6 +19,7 @@ export type CommandOptions = {
   force: boolean;
   canary: boolean;
   deps: boolean;
+  skipAndroidArtifacts: boolean;
 
   /* exclusive options that affect what the command does */
   listUnpublished: boolean;


### PR DESCRIPTION
# Why

Adds option to skip publishing Android artifacts

# Test Plan

- run `et publish-packages -p --dry expo-gl -S --skip-android-artifacts` ✅ 