### PR TITLE
[notifications][Android] Ignore flaky tests

### DIFF
--- a/packages/expo-notifications/android/src/test/java/expo/modules/notifications/NotificationTriggerTest.kt
+++ b/packages/expo-notifications/android/src/test/java/expo/modules/notifications/NotificationTriggerTest.kt
@@ -15,6 +15,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -23,6 +24,7 @@ import java.util.Date
 import java.util.concurrent.TimeUnit
 import kotlin.math.abs
 
+@Ignore("Those test were ignore, because there using current time to calculate next trigger date which is flaky.")
 @SmallTest
 @RunWith(RobolectricTestRunner::class)
 class NotificationTriggerTest {


### PR DESCRIPTION
# Why

Ignores flaky tests.

# How

Tests in `NotificationTriggerTest` are using the current time for all checks, which is flaky. They need to be finished within the same second; otherwise, the checks will fail. 
For now, I've decided to ignore them. The logic should be changed to be easily testable, or we should remove them. It doesn't make sense to keep them in their current form.

# Test Plan

- unit test ✅ 
