### PR TITLE
fix(expo-router): unpack `asyncServerImport` wrapped modules correctly

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Unpack default exports correctly from server actions using `expo-router/_async-server-import` ([#35948](https://github.com/expo/expo/pull/35948) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 5.0.1-preview.0 — 2025-04-05

--- a/packages/expo-router/_async-server-import.js
+++ b/packages/expo-router/_async-server-import.js
@@ -7,12 +7,13 @@ export async function asyncServerImport(moduleId) {
 
   let mod = await import(/* @metro-ignore */ moduleId);
 
-  // Return the default export, or nested default export
-  if ('default' in mod && typeof mod.default === 'object' && mod.default) {
+  // Unwrap exported `{ default: <mod> }` objects, where `<mod>` is another default exported ESM module
+  if (
+    'default' in mod &&
+    typeof mod.default === 'object' &&
+    (mod.default.default !== undefined || mod.default.__esModule === true)
+  ) {
     mod = mod.default;
-    if ('default' in mod && typeof mod.default === 'object' && mod.default) {
-      mod = mod.default;
-    }
   }
 
   return mod;

--- a/packages/expo-router/_async-server-import.js
+++ b/packages/expo-router/_async-server-import.js
@@ -5,13 +5,15 @@ export async function asyncServerImport(moduleId) {
     return $$require_external(moduleId);
   }
 
-  const m = await import(/* @metro-ignore */ moduleId);
+  let mod = await import(/* @metro-ignore */ moduleId);
 
-  if ('default' in m && typeof m.default === 'object' && m.default) {
-    const def = m.default;
-    if ('default' in def && typeof def.default === 'object' && def.default) {
-      return def;
+  // Return the default export, or nested default export
+  if ('default' in mod && typeof mod.default === 'object' && mod.default) {
+    mod = mod.default;
+    if ('default' in mod && typeof mod.default === 'object' && mod.default) {
+      mod = mod.default;
     }
   }
-  return m;
+
+  return mod;
 }

--- a/packages/expo-router/_async-server-import.js
+++ b/packages/expo-router/_async-server-import.js
@@ -11,7 +11,7 @@ export async function asyncServerImport(moduleId) {
   if (
     'default' in mod &&
     typeof mod.default === 'object' &&
-    mod.default !== null &&
+    mod.default &&
     (mod.default.default !== undefined || mod.default.__esModule === true)
   ) {
     mod = mod.default;

--- a/packages/expo-router/_async-server-import.js
+++ b/packages/expo-router/_async-server-import.js
@@ -11,6 +11,7 @@ export async function asyncServerImport(moduleId) {
   if (
     'default' in mod &&
     typeof mod.default === 'object' &&
+    mod.default !== null &&
     (mod.default.default !== undefined || mod.default.__esModule === true)
   ) {
     mod = mod.default;


### PR DESCRIPTION
# Why

When dogfooding (`expo@53.0.0-preview.0` / `expo-router@5.0.1-preview.0`), my project ran into server issues related to actions. The unpacking of the default value is done incorrectly within `expo-router/_async-server-import` - this fixes and simplifies that a bit.

<img width="660" alt="image" src="https://github.com/user-attachments/assets/ee85047f-b0cf-4818-9c83-0c7426c08908" />

<img width="664" alt="image" src="https://github.com/user-attachments/assets/88e5b443-68ae-495a-a3c8-17cd4912dee2" />


# How

- Simplify unpacking the default value of a module through `expo-router/_async-server-import`

# Test Plan

- `bun create expo --template default@canary`
- Add a server function
- `eas deploy`
- Test the server function on EAS hosting

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
