### PR TITLE
[cli] fix react native devtools opening issue

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Hide BRIDGE tags in webview logs. ([#35920](https://github.com/expo/expo/pull/35920) by [@EvanBacon](https://github.com/EvanBacon))
-- Fixed React Native Devtools opening issue. ([#35935](https://github.com/expo/expo/pull/35935) by [@kudo](https://github.com/kudo))
+- Fixed React Native Devtools opening issue. ([#35935](https://github.com/expo/expo/pull/35935), [#35952](https://github.com/expo/expo/pull/35952) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
@@ -52,8 +52,6 @@ export async function openJsInspector(metroBaseUrl: string, app: MetroInspectorP
   }
 
   const url = new URL('/open-debugger', metroBaseUrl);
-  url.searchParams.set('appId', app.appId);
-  url.searchParams.set('device', app.reactNative.logicalDeviceId);
   url.searchParams.set('target', app.id);
 
   // Request to open the React Native DevTools, but limit it to 1s

--- a/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/JsInspector-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/JsInspector-test.ts
@@ -16,8 +16,6 @@ describe(openJsInspector, () => {
 
     // The URL parameters that should be sent for the inspectable target
     const params = new URLSearchParams();
-    params.set('appId', app.appId);
-    params.set('device', app.reactNative!.logicalDeviceId!);
     params.set('target', app.id);
 
     const scope = nock('http://localhost:8081').post(`/open-debugger?${params}`).reply(200);


### PR DESCRIPTION
# Why

unstable to open react native devtools since react-native 0.79

# How

we should also remove `appId` from `/open-debugger`. otherwise dev-middleware will fall into legacy mode: https://github.com/facebook/react-native/blob/91acacc21817be700cba1f82113cc581a98c0dcb/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js#L109-L111

# Test Plan

press `j` with NCL + bare-expo + expo-go

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
