### PR TITLE
[autolinking] fix e2e test timeout

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed E2E test timeout. ([#35953](https://github.com/expo/expo/pull/35953) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.1.0 — 2025-04-04

--- a/packages/expo-modules-autolinking/e2e/__tests__/monorepo-test.ts
+++ b/packages/expo-modules-autolinking/e2e/__tests__/monorepo-test.ts
@@ -20,6 +20,8 @@ const monorepoConfig = {
 const apps = ['ejected', 'managed', 'with-sentry'];
 const testCases = combinations('app', apps, 'platform', ['android', 'apple']);
 
+jest.setTimeout(5 * 60 * 1000);
+
 describe('monorepo', () => {
   let monorepoProject: string | undefined;
 
@@ -31,17 +33,14 @@ describe('monorepo', () => {
     return join(monorepoProject!, 'apps', app);
   }
 
-  beforeAll(
-    async () => {
-      const temp = join(tempDirectory(), 'monorepo');
-      console.log(`Cloning monorepo into: ${temp}`);
-      await GitDirectory.shallowCloneAsync(temp, monorepoConfig.source, monorepoConfig.ref);
-      console.log('Yarning');
-      yarnSync({ cwd: temp });
-      monorepoProject = temp;
-    },
-    5 * 60 * 1000
-  );
+  beforeAll(async () => {
+    const temp = join(tempDirectory(), 'monorepo');
+    console.log(`Cloning monorepo into: ${temp}`);
+    await GitDirectory.shallowCloneAsync(temp, monorepoConfig.source, monorepoConfig.ref);
+    console.log('Yarning');
+    yarnSync({ cwd: temp });
+    monorepoProject = temp;
+  });
 
   afterAll(async () => {
     if (monorepoProject) {


### PR DESCRIPTION
# Why

fixes `et cp expo-autolinking` failure
```
stderr >   ● Test suite failed to run
stderr >
stderr >     thrown: "Exceeded timeout of 5000 ms for a hook.
stderr >     Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
stderr >
stderr >       44 |   );
stderr >       45 |
stderr >     > 46 |   afterAll(async () => {
stderr >          |   ^
stderr >       47 |     if (monorepoProject) {
stderr >       48 |       console.log(`Removing: ${monorepoProject}`);
stderr >       49 |       await fs.promises.rm(monorepoProject, { recursive: true, force: true });
stderr >
stderr >       at afterAll (e2e/__tests__/monorepo-test.ts:46:3)
stderr >       at Object.describe (e2e/__tests__/monorepo-test.ts:23:1)
```

# How

set timeout for the whole test file

# Test Plan

- `et cp expo-modules-autolinking`
- ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
