### PR TITLE
[ios][expo-go] removed processing from UIBackgroundModes

### DIFF
--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -424,10 +424,10 @@ async function internalRemoveBackgroundPermissionsFromInfoPlistAsync(): Promise<
   delete parsedPlist.NSLocationAlwaysUsageDescription;
 
   logger.info(
-    `Removing location, audio and remonte-notfication from UIBackgroundModes from ios/Exponent/Supporting/Info.plist`
+    `Removing location, audio, background-task and remote-notfication from UIBackgroundModes from ios/Exponent/Supporting/Info.plist`
   );
   parsedPlist.UIBackgroundModes = parsedPlist.UIBackgroundModes.filter(
-    (i: string) => !['location', 'audio', 'remote-notification'].includes(i)
+    (i: string) => !['location', 'audio', 'remote-notification', 'processing'].includes(i)
   );
   await fs.writeFile(INFO_PLIST_PATH, plist.build(parsedPlist));
 }


### PR DESCRIPTION
# Why

When building expo we run an expo-tools script to remove UIBackgroundModes that shouldn't be included in Expo-Go.

~We~ I missed the new `expo-background-task` value `processing`, which caused an exception when validating with the AppStore:

```
The Info.plist key 'BGTaskSchedulerPermittedIdentifiers' must contain a list of identifiers used to submit and handle tasks when 'UIBackgroundModes' has a value of 'processing'.
```

# How

This commit fixes this by also removing the `processing` value from the UIBackgroundModes in the `et eas remove-background-permissions-from-info-plist` command.

# Test Plan

- Open the following file `apps/expo-go/ios/Exponent/Supporting/Info.plist`
- Run the `et eas remove-background-permissions-from-info-plist` command
- Observe that the values 'location', 'audio', 'remote-notification', 'processing' was removed from the `UIBackgroundModes` key.

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
