### PR TITLE
[notifications] fix data serialization

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [post-swift-conversion] fix data serialization ([#35975](https://github.com/expo/expo/pull/35975) by [@vonovak](https://github.com/vonovak))
 - simplify push token event management ([#35944](https://github.com/expo/expo/pull/35944) by [@vonovak](https://github.com/vonovak))
 - fix Android `NotificationContent` not containing JSON data object ([#35942](https://github.com/expo/expo/pull/35942) by [@vonovak](https://github.com/vonovak))
 - [post-swift-conversion] fix regressions in `CalendarTriggerRecord` ([#35937](https://github.com/expo/expo/pull/35937) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Records.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Records.swift
@@ -402,7 +402,7 @@ struct NotificationRequestContentRecord: Record {
   @Field
   var badge: Int?
   @Field
-  var userInfo: [String: Any]?
+  var data: [String: Any]?
   @Field
   var categoryIdentifier: String?
   @Field
@@ -492,7 +492,7 @@ struct NotificationRequestContentRecord: Record {
       content.badge = NSNumber.init(value: badge)
     }
 
-    if let userInfo = userInfo {
+    if let userInfo = data {
       content.userInfo = userInfo
     }
 


### PR DESCRIPTION
# Why

fixes a bug in the iOS implementation of notifications where the `data` field was incorrectly mapped to `userInfo` in the Swift code. It also enhances the notification tests to provide more comprehensive validation of notification content and triggers.

# How

- Fixed the field name in `NotificationRequestContentRecord` from `userInfo` to `data` to correctly match the expected property name
- Enhanced the notification tests to:
 

# Test Plan

- tests pass

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)