### PR TITLE
[sdk-53][typescript] upgraded expo-build-properties to ts 5.8

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Upgraded to Typescript 5.4
+
 ## 0.14.0 — 2025-04-04
 
 ### 🎉 New features

--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Upgraded to Typescript 5.4
+- Upgraded to Typescript 5.4 ([#35981](https://github.com/expo/expo/pull/35981) by [@chrfalch](https://github.com/chrfalch))
 
 ## 0.14.0 — 2025-04-04
 

--- a/packages/expo-build-properties/build/android.js
+++ b/packages/expo-build-properties/build/android.js
@@ -3,7 +3,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.withAndroidDayNightTheme = exports.withAndroidQueries = exports.withAndroidCleartextTraffic = exports.updateAndroidProguardRules = exports.withAndroidPurgeProguardRulesOnce = exports.withAndroidProguardRules = exports.withAndroidBuildProperties = void 0;
+exports.withAndroidDayNightTheme = exports.withAndroidQueries = exports.withAndroidCleartextTraffic = exports.withAndroidPurgeProguardRulesOnce = exports.withAndroidProguardRules = exports.withAndroidBuildProperties = void 0;
+exports.updateAndroidProguardRules = updateAndroidProguardRules;
 const config_plugins_1 = require("expo/config-plugins");
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
@@ -178,7 +179,6 @@ function updateAndroidProguardRules(contents, newProguardRules, updateMode) {
     }
     return newContents;
 }
-exports.updateAndroidProguardRules = updateAndroidProguardRules;
 const withAndroidCleartextTraffic = (config, props) => {
     return (0, config_plugins_1.withAndroidManifest)(config, (config) => {
         if (props.android?.usesCleartextTraffic == null) {

--- a/packages/expo-build-properties/build/androidQueryUtils.js
+++ b/packages/expo-build-properties/build/androidQueryUtils.js
@@ -1,6 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.renderQueryIntents = exports.renderQueryPackages = exports.renderQueryProviders = void 0;
+exports.renderQueryProviders = renderQueryProviders;
+exports.renderQueryPackages = renderQueryPackages;
+exports.renderQueryIntents = renderQueryIntents;
 function renderQueryProviders(data) {
     return (Array.isArray(data) ? data : [data]).filter(Boolean).map((datum) => ({
         $: {
@@ -8,7 +10,6 @@ function renderQueryProviders(data) {
         },
     }));
 }
-exports.renderQueryProviders = renderQueryProviders;
 function renderQueryPackages(data) {
     return (Array.isArray(data) ? data : [data]).filter(Boolean).map((datum) => ({
         $: {
@@ -16,7 +17,6 @@ function renderQueryPackages(data) {
         },
     }));
 }
-exports.renderQueryPackages = renderQueryPackages;
 function renderQueryIntents(queryIntents) {
     return (queryIntents?.map((intent) => {
         const { data, category, action } = intent;
@@ -39,4 +39,3 @@ function renderQueryIntents(queryIntents) {
         };
     }) ?? []);
 }
-exports.renderQueryIntents = renderQueryIntents;

--- a/packages/expo-build-properties/build/fileContentsUtils.js
+++ b/packages/expo-build-properties/build/fileContentsUtils.js
@@ -6,7 +6,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.purgeContents = exports.appendContents = void 0;
+exports.appendContents = appendContents;
+exports.purgeContents = purgeContents;
 const assert_1 = __importDefault(require("assert"));
 /**
  * Append new contents to src with generated section comments
@@ -28,7 +29,6 @@ function appendContents(src, contents, sectionOptions) {
         return `${src}\n${sectionedContents}`;
     }
 }
-exports.appendContents = appendContents;
 /**
  * Purge a generated section
  */
@@ -38,7 +38,6 @@ function purgeContents(src, sectionOptions) {
     const regex = new RegExp(`\\n${escapeRegExp(start)}\\n[\\s\\S]*\\n${escapeRegExp(end)}`, 'gm');
     return src.replace(regex, '');
 }
-exports.purgeContents = purgeContents;
 /**
  * Create comments for generated section
  */

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.validateConfig = void 0;
+exports.validateConfig = validateConfig;
 const ajv_1 = __importDefault(require("ajv"));
 const semver_1 = __importDefault(require("semver"));
 /**
@@ -239,4 +239,3 @@ function validateConfig(config) {
     }
     return config;
 }
-exports.validateConfig = validateConfig;


### PR DESCRIPTION
# How

Upgraded `expo-build-properties` to Typescript 5.8

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
