### PR TITLE
[android][updates] Remove `AsyncTask` usage from `LoaderTask`

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
@@ -1,7 +1,6 @@
 package expo.modules.updates.loader
 
 import android.content.Context
-import android.os.AsyncTask
 import android.os.Handler
 import android.os.HandlerThread
 import expo.modules.updates.UpdatesConfiguration
@@ -20,9 +19,12 @@ import expo.modules.updates.manifest.EmbeddedManifestUtils
 import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.manifest.Update
 import expo.modules.updates.selectionpolicy.SelectionPolicy
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.json.JSONObject
 import java.io.File
 import java.util.Date
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * Controlling class that handles the complex logic that needs to happen each time the app is cold
@@ -159,7 +161,7 @@ class LoaderTask(
   private var candidateLauncher: Launcher? = null
   private var finalizedLauncher: Launcher? = null
 
-  fun start() {
+  suspend fun start() {
     isRunning = true
 
     val shouldCheckForUpdate = UpdatesUtils.shouldCheckForUpdateOnLaunch(configuration, logger, context)
@@ -171,68 +173,54 @@ class LoaderTask(
       timeoutFinished = true
     }
 
-    launchFallbackUpdateFromDisk(
-      object : LaunchUpdateCallback {
-        private fun launchRemoteUpdate() {
-          launchRemoteUpdateInBackground(
-            object : LaunchUpdateCallback {
-              override fun onFailure(e: Exception) {
-                finish(e)
-                isRunning = false
-                runReaper()
-                callback.onFinishedAllLoading()
-              }
-
-              override fun onSuccess() {
-                synchronized(this@LoaderTask) { isReadyToLaunch = true }
-                finish(null)
-                isRunning = false
-                runReaper()
-                callback.onFinishedAllLoading()
-              }
-            }
-          )
+    try {
+      launchFallbackUpdateFromDisk()
+      if (candidateLauncher!!.launchedUpdate != null &&
+        !callback.onCachedUpdateLoaded(candidateLauncher!!.launchedUpdate!!)
+      ) {
+        // ignore timer and other settings and force launch a remote update
+        stopTimer()
+        candidateLauncher = null
+        launchRemoteUpdate()
+      } else {
+        synchronized(this@LoaderTask) {
+          isReadyToLaunch = true
+          maybeFinish()
         }
-
-        override fun onFailure(e: Exception) {
-          // An unexpected failure has occurred here, or we are running in an environment with no
-          // embedded update and we have no update downloaded (e.g. Expo client).
-          // What to do in this case depends on whether or not we're trying to load a remote update.
-          // If we are, then we should wait for the task to finish. If not, we need to fail here.
-          if (!shouldCheckForUpdate) {
-            finish(e)
-            isRunning = false
-            callback.onFinishedAllLoading()
-          } else {
-            launchRemoteUpdate()
-          }
-          logger.error("Failed to launch embedded or launchable update", e, UpdatesErrorCode.UpdateFailedToLoad)
-        }
-
-        override fun onSuccess() {
-          if (candidateLauncher!!.launchedUpdate != null &&
-            !callback.onCachedUpdateLoaded(candidateLauncher!!.launchedUpdate!!)
-          ) {
-            // ignore timer and other settings and force launch a remote update
-            stopTimer()
-            candidateLauncher = null
-            launchRemoteUpdate()
-          } else {
-            synchronized(this@LoaderTask) {
-              isReadyToLaunch = true
-              maybeFinish()
-            }
-            if (shouldCheckForUpdate) {
-              launchRemoteUpdate()
-            } else {
-              isRunning = false
-              runReaper()
-              callback.onFinishedAllLoading()
-            }
-          }
+        if (shouldCheckForUpdate) {
+          launchRemoteUpdate()
+        } else {
+          isRunning = false
+          runReaper()
+          callback.onFinishedAllLoading()
         }
       }
-    )
+    } catch (e: Exception) {
+      if (!shouldCheckForUpdate) {
+        finish(e)
+        isRunning = false
+        callback.onFinishedAllLoading()
+      } else {
+        launchRemoteUpdate()
+      }
+      logger.error("Failed to launch embedded or launchable update", e, UpdatesErrorCode.UpdateFailedToLoad)
+    }
+  }
+
+  private suspend fun launchRemoteUpdate() {
+    try {
+      launchRemoteUpdateInBackground()
+      synchronized(this@LoaderTask) { isReadyToLaunch = true }
+      finish(null)
+      isRunning = false
+      runReaper()
+      callback.onFinishedAllLoading()
+    } catch (e: Exception) {
+      finish(e)
+      isRunning = false
+      runReaper()
+      callback.onFinishedAllLoading()
+    }
   }
 
   /**
@@ -293,72 +281,70 @@ class LoaderTask(
     stopTimer()
   }
 
-  private fun launchFallbackUpdateFromDisk(diskUpdateCallback: LaunchUpdateCallback) {
-    AsyncTask.execute {
-      val database = databaseHolder.database
-      val launcher =
-        DatabaseLauncher(context, configuration, directory, fileDownloader, selectionPolicy, logger)
-      candidateLauncher = launcher
-      val launcherCallback: LauncherCallback = object : LauncherCallback {
-        override fun onFailure(e: Exception) {
-          databaseHolder.releaseDatabase()
-          diskUpdateCallback.onFailure(e)
-        }
-
-        override fun onSuccess() {
-          databaseHolder.releaseDatabase()
-          diskUpdateCallback.onSuccess()
-        }
+  private suspend fun launchFallbackUpdateFromDisk() = suspendCancellableCoroutine { continuation ->
+    val database = databaseHolder.database
+    val launcher =
+      DatabaseLauncher(context, configuration, directory, fileDownloader, selectionPolicy, logger)
+    candidateLauncher = launcher
+    val launcherCallback: LauncherCallback = object : LauncherCallback {
+      override fun onFailure(e: Exception) {
+        databaseHolder.releaseDatabase()
+        continuation.resumeWithException(e)
       }
-      if (configuration.hasEmbeddedUpdate) {
-        // if the embedded update should be launched (e.g. if it's newer than any other update we have
-        // in the database, which can happen if the app binary is updated), load it into the database
-        // so we can launch it
-        val embeddedUpdate =
-          EmbeddedManifestUtils.getEmbeddedUpdate(context, configuration)!!.updateEntity
-        val launchableUpdate = launcher.getLaunchableUpdate(database)
-        val manifestFilters = ManifestMetadata.getManifestFilters(database, configuration)
-        if (selectionPolicy.shouldLoadNewUpdate(
-            embeddedUpdate,
-            launchableUpdate,
-            manifestFilters
-          )
-        ) {
-          EmbeddedLoader(context, configuration, logger, database, directory).start(object :
-            LoaderCallback {
-            override fun onFailure(e: Exception) {
-              logger.error("Unexpected error copying embedded update", e, UpdatesErrorCode.Unknown)
-              launcher.launch(database, launcherCallback)
-            }
 
-            override fun onSuccess(loaderResult: Loader.LoaderResult) {
-              launcher.launch(database, launcherCallback)
-            }
+      override fun onSuccess() {
+        databaseHolder.releaseDatabase()
+        continuation.resume(Unit)
+      }
+    }
+    if (configuration.hasEmbeddedUpdate) {
+      // if the embedded update should be launched (e.g. if it's newer than any other update we have
+      // in the database, which can happen if the app binary is updated), load it into the database
+      // so we can launch it
+      val embeddedUpdate =
+        EmbeddedManifestUtils.getEmbeddedUpdate(context, configuration)!!.updateEntity
+      val launchableUpdate = launcher.getLaunchableUpdate(database)
+      val manifestFilters = ManifestMetadata.getManifestFilters(database, configuration)
+      if (selectionPolicy.shouldLoadNewUpdate(
+          embeddedUpdate,
+          launchableUpdate,
+          manifestFilters
+        )
+      ) {
+        EmbeddedLoader(context, configuration, logger, database, directory).start(object :
+          LoaderCallback {
+          override fun onFailure(e: Exception) {
+            logger.error("Unexpected error copying embedded update", e, UpdatesErrorCode.Unknown)
+            launcher.launch(database, launcherCallback)
+          }
 
-            override fun onAssetLoaded(
-              asset: AssetEntity,
-              successfulAssetCount: Int,
-              failedAssetCount: Int,
-              totalAssetCount: Int
-            ) {
-              // do nothing
-            }
+          override fun onSuccess(loaderResult: Loader.LoaderResult) {
+            launcher.launch(database, launcherCallback)
+          }
 
-            override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
-              return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
-            }
-          })
-        } else {
-          launcher.launch(database, launcherCallback)
-        }
+          override fun onAssetLoaded(
+            asset: AssetEntity,
+            successfulAssetCount: Int,
+            failedAssetCount: Int,
+            totalAssetCount: Int
+          ) {
+            // do nothing
+          }
+
+          override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
+            return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+          }
+        })
       } else {
         launcher.launch(database, launcherCallback)
       }
+    } else {
+      launcher.launch(database, launcherCallback)
     }
   }
 
-  private fun launchRemoteUpdateInBackground(remoteUpdateCallback: LaunchUpdateCallback) {
-    AsyncTask.execute {
+  private suspend fun launchRemoteUpdateInBackground() =
+    suspendCancellableCoroutine { continuation ->
       val database = databaseHolder.database
       callback.onRemoteCheckForUpdateStarted()
       RemoteLoader(context, configuration, logger, database, fileDownloader, directory, candidateLauncher?.launchedUpdate)
@@ -367,7 +353,7 @@ class LoaderTask(
             databaseHolder.releaseDatabase()
             callback.onRemoteUpdateFinished(RemoteUpdateStatus.ERROR, null, e)
             logger.error("Failed to download remote update", e, UpdatesErrorCode.UpdateFailedToLoad)
-            remoteUpdateCallback.onFailure(e)
+            continuation.resumeWithException(e)
           }
 
           override fun onAssetLoaded(
@@ -388,6 +374,7 @@ class LoaderTask(
                   callback.onRemoteCheckForUpdateFinished(RemoteCheckResult.RollBackToEmbedded(updateDirective.commitTime))
                   Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
                 }
+
                 is UpdateDirective.NoUpdateAvailableUpdateDirective -> {
                   isUpToDate = true
                   callback.onRemoteCheckForUpdateFinished(RemoteCheckResult.NoUpdateAvailable(RemoteCheckResultNotAvailableReason.NO_UPDATE_AVAILABLE_ON_SERVER))
@@ -454,7 +441,7 @@ class LoaderTask(
                     null,
                     e
                   )
-                  remoteUpdateCallback.onFailure(e)
+                  continuation.resumeWithException(e)
                   logger.error("Loaded new update but it failed to launch", e, UpdatesErrorCode.UpdateFailedToLoad)
                 }
 
@@ -479,30 +466,27 @@ class LoaderTask(
                       null
                     )
                   }
-                  remoteUpdateCallback.onSuccess()
+                  continuation.resume(Unit)
                 }
               }
             )
           }
         })
     }
-  }
 
   private fun runReaper() {
-    AsyncTask.execute {
-      synchronized(this@LoaderTask) {
-        val finalizedLaunchedUpdate = finalizedLauncher?.launchedUpdate
-        if (finalizedLaunchedUpdate != null) {
-          val database = databaseHolder.database
-          Reaper.reapUnusedUpdates(
-            configuration,
-            database,
-            directory,
-            finalizedLaunchedUpdate,
-            selectionPolicy
-          )
-          databaseHolder.releaseDatabase()
-        }
+    synchronized(this@LoaderTask) {
+      val finalizedLaunchedUpdate = finalizedLauncher?.launchedUpdate
+      if (finalizedLaunchedUpdate != null) {
+        val database = databaseHolder.database
+        Reaper.reapUnusedUpdates(
+          configuration,
+          database,
+          directory,
+          finalizedLaunchedUpdate,
+          selectionPolicy
+        )
+        databaseHolder.releaseDatabase()
       }
     }
   }


### PR DESCRIPTION
# Why
Removes `AsyncTask` usage from the `LoaderTask`. This class requires further work but removing `AsyncTask` was the priority here.

# How
Use coroutines instead of `AsyncTask`.

# Test Plan
For this to pass CI, it will need more PRs in the current stack.

