### PR TITLE
[android][expo-go] Added expo-background-task to expo-go

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -7,6 +7,7 @@ import expo.modules.av.AVModule
 import expo.modules.av.AVPackage
 import expo.modules.av.video.VideoViewModule
 import expo.modules.backgroundfetch.BackgroundFetchModule
+import expo.modules.backgroundtask.BackgroundTaskModule
 import expo.modules.battery.BatteryModule
 import expo.modules.blur.BlurModule
 import expo.modules.brightness.BrightnessModule
@@ -141,6 +142,7 @@ object ExperiencePackagePicker : ModulesProvider {
     // End of Notifications
     BatteryModule::class.java,
     BackgroundFetchModule::class.java,
+    BackgroundTaskModule::class.java,
     BlurModule::class.java,
     CalendarModule::class.java,
     CameraViewModule::class.java,

--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [android] added expo-background-task to Expo Go's configuration
+- [android] added expo-background-task to Expo Go's configuration ([#36000](https://github.com/expo/expo/pull/36000) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [android] added expo-background-task to Expo Go's configuration
+
 ### 💡 Others
 
 ## 0.2.0 — 2025-04-04


### PR DESCRIPTION
# Why

Expo-go was missing a configuration so that the ExpoBackgroundTask module was not available from within the ExpoGo client.

# How

This commit fixes this by Adding it to the ExpoGo configuration.

# Test Plan

- Run ExpoGo with NCL
- Open the BackgroundTask screen and verify that it opens without any issues.

I've successfully scheduled a background task and seen that it runs.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
