### PR TITLE
refactor(cli): drop `react-navigation` ESM workaround

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -713,13 +713,6 @@ export function withExtendedResolver(
         ];
       }
 
-      // HACK:
-      if (moduleName.match(/^@react-navigation\//)) {
-        // Force to use the ESM versions of react-navigation to prevent Metro behavior where it changes the
-        // resolution based on if a module is `import`ing or `require`ing it.
-        context.unstable_conditionNames = ['import', 'require'];
-      }
-
       if (isServerEnvironment(context.customResolverOptions?.environment)) {
         // Adjust nodejs source extensions to sort mjs after js, including platform variants.
         if (nodejsSourceExtensions === null) {


### PR DESCRIPTION
# Why

This was added in https://github.com/expo/expo/pull/35904, because we loaded both CJS and ESM versions of `react-navigation`. Since then, `react-navigation` has moved to be ESM only, resolving this issue properly.

It pulls in both ESM and CJS code due to a factor of things:
- Metro now enables `package.json:exports` by default
- Metro now keeps track of the used import, and resolves it accordingly
  - `require('<module>')` -> CommonJS
  - `import .. from '<module>'` -> ESM
  - `await import('<module>')` -> ESM
- Expo Router ships as (pre)built files due to server code
- Expo Router builds _everything_ to CJS
- Metro resolves imports to `react-navigation` as CJS because Expo Router is all CJS
- When importing `react-navigation` in user-space code, Metro resolves as ESM - because no one should write their app in pure CJS

Because some code of `react-navigation` is stateful (uses `createContext()`) we can't have both CJS and ESM in the bundle.

# How

- Dropped resolution workaround for `react-navigation` due to the package being ESM only

# Test Plan

- `$ bun create expo ./test-36003 --template default@canary`
  - The canary version does need this change, or execute CLI from source
- `$ cd ./test-36003`
- `$ EXPO_ATLAS=1 bun expo export`
- `$ bun expo-atlas`
- Should only show imported ESM code for `@react-navigation`, not CJS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
