### PR TITLE
[android][updates] Refactor `DatabaseHolder`

### DIFF
--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -127,6 +127,7 @@ dependencies {
   def mockk_version = "1.13.11"
 
   implementation "androidx.room:room-runtime:$room_version"
+  implementation "androidx.room:room-ktx:$room_version"
   ksp "androidx.room:room-compiler:$room_version"
 
   implementation("com.squareup.okhttp3:okhttp:4.9.2")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -158,7 +158,6 @@ class EnabledUpdatesController(
     purgeUpdatesLogsOlderThanOneDay()
 
     BuildData.ensureBuildDataIsConsistent(updatesConfiguration, databaseHolder.database)
-    databaseHolder.releaseDatabase()
 
     stateMachine.queueExecution(startupProcedure)
   }
@@ -239,7 +238,6 @@ class EnabledUpdatesController(
           databaseHolder.database,
           updatesConfiguration
         )
-        databaseHolder.releaseDatabase()
         val resultMap = when (result) {
           null -> Bundle()
           else -> {
@@ -252,7 +250,6 @@ class EnabledUpdatesController(
         }
         continuation.resume(resultMap)
       } catch (e: Exception) {
-        databaseHolder.releaseDatabase()
         continuation.resumeWithException(e.toCodedException())
       }
     }
@@ -267,10 +264,8 @@ class EnabledUpdatesController(
           key,
           value
         )
-        databaseHolder.releaseDatabase()
         continuation.resume(Unit)
       }.onFailure { e ->
-        databaseHolder.releaseDatabase()
         continuation.resumeWithException(e.toCodedException())
       }
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -163,7 +163,6 @@ class UpdatesDevLauncherController(
     )
     loader.start(object : Loader.LoaderCallback {
       override fun onFailure(e: Exception) {
-        databaseHolder.releaseDatabase()
         // reset controller's configuration to what it was before this request
         updatesConfiguration = previousUpdatesConfiguration
         callback.onFailure(e)
@@ -171,7 +170,6 @@ class UpdatesDevLauncherController(
 
       override fun onSuccess(loaderResult: Loader.LoaderResult) {
         // the dev launcher doesn't handle roll back to embedded commands
-        databaseHolder.releaseDatabase()
         if (loaderResult.updateEntity == null) {
           callback.onSuccess(null)
           return
@@ -283,14 +281,12 @@ class UpdatesDevLauncherController(
       databaseHolder.database,
       object : Launcher.LauncherCallback {
         override fun onFailure(e: Exception) {
-          databaseHolder.releaseDatabase()
           // reset controller's configuration to what it was before this request
           updatesConfiguration = previousUpdatesConfiguration
           callback.onFailure(e)
         }
 
         override fun onSuccess() {
-          databaseHolder.releaseDatabase()
           this@UpdatesDevLauncherController.launcher = launcher
           callback.onSuccess(object : UpdatesInterface.Update {
             override val manifest: JSONObject
@@ -305,9 +301,6 @@ class UpdatesDevLauncherController(
   }
 
   private fun getDatabase(): UpdatesDatabase = databaseHolder.database
-  private fun releaseDatabase() {
-    databaseHolder.releaseDatabase()
-  }
 
   private fun runReaper() {
     AsyncTask.execute {
@@ -320,7 +313,6 @@ class UpdatesDevLauncherController(
           launchedUpdate,
           selectionPolicy
         )
-        releaseDatabase()
       }
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/DatabaseHolder.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/DatabaseHolder.kt
@@ -1,39 +1,30 @@
 package expo.modules.updates.db
 
-import android.util.Log
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * Wrapper class that provides a rudimentary locking mechanism for the database. This allows us to
  * control what high-level operations involving the database can occur simultaneously. Most classes
  * should access [UpdatesDatabase] through this class.
  *
- * Any process that calls `getDatabase` *must* manually release the lock by calling
- * `releaseDatabase` in every possible case (success, error) as soon as it is finished.
- *
- * On iOS we use GCD queues as a more sophisticated way of achieving the same thing; we may also
- * eventually want to migrate to a coroutine-based or Handler-based system in lieu of this class.
  */
 class DatabaseHolder(private val mDatabase: UpdatesDatabase) {
-  private var isInUse = false
+  private val mutex = Mutex()
 
-  @get:Synchronized
-  val database: UpdatesDatabase
-    get() {
-      while (isInUse) {
-        try {
-          (this as java.lang.Object).wait()
-        } catch (e: InterruptedException) {
-          Log.e(TAG, "Interrupted while waiting for database", e)
-        }
-      }
-      isInUse = true
-      return mDatabase
+  // Less ideal but preserves accessing the database through a property
+  val database = runBlocking {
+    mutex.withLock {
+      mDatabase
     }
+  }
 
-  @Synchronized
-  fun releaseDatabase() {
-    isInUse = false
-    (this as java.lang.Object).notify()
+  // For non blocking access to the database inside suspend functions
+  suspend fun <T> withDatabase(block: suspend (UpdatesDatabase) -> T): T {
+    return mutex.withLock {
+      block(mDatabase)
+    }
   }
 
   companion object {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
@@ -144,11 +144,6 @@ class LoaderTask(
     )
   }
 
-  private interface LaunchUpdateCallback {
-    fun onFailure(e: Exception)
-    fun onSuccess()
-  }
-
   var isRunning = false
     private set
 
@@ -288,12 +283,10 @@ class LoaderTask(
     candidateLauncher = launcher
     val launcherCallback: LauncherCallback = object : LauncherCallback {
       override fun onFailure(e: Exception) {
-        databaseHolder.releaseDatabase()
         continuation.resumeWithException(e)
       }
 
       override fun onSuccess() {
-        databaseHolder.releaseDatabase()
         continuation.resume(Unit)
       }
     }
@@ -350,7 +343,6 @@ class LoaderTask(
       RemoteLoader(context, configuration, logger, database, fileDownloader, directory, candidateLauncher?.launchedUpdate)
         .start(object : LoaderCallback {
           override fun onFailure(e: Exception) {
-            databaseHolder.releaseDatabase()
             callback.onRemoteUpdateFinished(RemoteUpdateStatus.ERROR, null, e)
             logger.error("Failed to download remote update", e, UpdatesErrorCode.UpdateFailedToLoad)
             continuation.resumeWithException(e)
@@ -435,7 +427,6 @@ class LoaderTask(
               database,
               object : LauncherCallback {
                 override fun onFailure(e: Exception) {
-                  databaseHolder.releaseDatabase()
                   callback.onRemoteUpdateFinished(
                     RemoteUpdateStatus.ERROR,
                     null,
@@ -446,7 +437,6 @@ class LoaderTask(
                 }
 
                 override fun onSuccess() {
-                  databaseHolder.releaseDatabase()
                   synchronized(this@LoaderTask) {
                     if (!hasLaunched) {
                       candidateLauncher = newLauncher
@@ -486,7 +476,6 @@ class LoaderTask(
           finalizedLaunchedUpdate,
           selectionPolicy
         )
-        databaseHolder.releaseDatabase()
       }
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
@@ -49,8 +49,6 @@ class CheckForUpdateProcedure(
       procedureContext.processStateEvent(UpdatesStateEvent.CheckError(e.localizedMessageWithCauseLocalizedMessage()))
       callback(IUpdatesController.CheckForUpdateResult.ErrorResult(e))
       procedureContext.onComplete()
-    } finally {
-      databaseHolder.releaseDatabase()
     }
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
@@ -47,7 +47,6 @@ class FetchUpdateProcedure(
       )
       callback(IUpdatesController.FetchUpdateResult.ErrorResult(e))
     } finally {
-      databaseHolder.releaseDatabase()
       procedureContext.onComplete()
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
@@ -106,8 +106,6 @@ class RelaunchProcedure(
         )
       } catch (e: Exception) {
         logger.error("Could not run Reaper.", e, UpdatesErrorCode.Unknown)
-      } finally {
-        databaseHolder.releaseDatabase()
       }
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -244,7 +244,6 @@ class StartupProcedure(
           override fun onFailure(e: Exception) {
             logger.error("UpdatesController loadRemoteUpdate onFailure", e, UpdatesErrorCode.UpdateFailedToLoad, launchedUpdate?.loggingId, null)
             setRemoteLoadStatus(ErrorRecoveryDelegate.RemoteLoadStatus.IDLE)
-            databaseHolder.releaseDatabase()
           }
 
           override fun onSuccess(loaderResult: Loader.LoaderResult) {
@@ -255,7 +254,6 @@ class StartupProcedure(
                 ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
               }
             )
-            databaseHolder.releaseDatabase()
           }
 
           override fun onAssetLoaded(asset: AssetEntity, successfulAssetCount: Int, failedAssetCount: Int, totalAssetCount: Int) { }
@@ -290,8 +288,7 @@ class StartupProcedure(
         }
         procedureScope.launch {
           val launchedUpdate = launchedUpdate ?: return@launch
-          databaseHolder.database.updateDao().incrementFailedLaunchCount(launchedUpdate)
-          databaseHolder.releaseDatabase()
+          databaseHolder.withDatabase { it.updateDao().incrementFailedLaunchCount(launchedUpdate) }
         }
       }
 
@@ -301,8 +298,7 @@ class StartupProcedure(
         }
         procedureScope.launch {
           val launchedUpdate = launchedUpdate ?: return@launch
-          databaseHolder.database.updateDao().incrementSuccessfulLaunchCount(launchedUpdate)
-          databaseHolder.releaseDatabase()
+          databaseHolder.withDatabase { it.updateDao().incrementSuccessfulLaunchCount(launchedUpdate) }
         }
       }
 


### PR DESCRIPTION
# Why
Refactors the `DatabaseHolder` to make it's usage more consistent and idiomatic to kotlin. The intention of this class is to be a mechanism for access control to the database. The drawbacks were it used `wait` and `notify` and I noticed in the tests that it can cause deadlocks. 

# How
Used a mutex instead of `wait` and `notify`. I've also removed `releaseDatabase`. This made usage error prone and easy for someone to forget. `mutex.withLock` will release automatically once the database operation is completed. 

# Test Plan
Running in release working as expected, e2e tests are passing locally, CI. This fixes the tests in the downstack PRs

