### PR TITLE
chore(ci): update home typecheck step and add explicit `--noEmit`

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -48,8 +48,8 @@ jobs:
         run: yarn install --frozen-lockfile
         working-directory: react-native-lab/react-native
 
-      - name: 🛠 Compile Home sources
-        run: yarn tsc
+      - name: 🔎 Type Check Home
+        run: yarn tsc --noEmit
         working-directory: apps/expo-go
 
       - name: 🧪 Run Home tests


### PR DESCRIPTION
# Why

This was failing, and we had to look up why.

# How

- Renamed compile step to type check, tsconfig is also set to `noEmit: true` - but always good to be explicit about that

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
