### PR TITLE
chore: Bump to `@expo/vector-icons@14.1.0`

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,6 +1,6 @@
 {
   "@expo/metro-runtime": "~5.0.0",
-  "@expo/vector-icons": "^14.0.2",
+  "@expo/vector-icons": "^14.1.0",
   "@expo/ui": "~0.1.0-alpha.0",
   "@react-native-async-storage/async-storage": "2.1.2",
   "@react-native-community/datetimepicker": "8.3.0",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -16,7 +16,7 @@
     "preset": "jest-expo"
   },
   "dependencies": {
-    "@expo/vector-icons": "^14.0.2",
+    "@expo/vector-icons": "^14.1.0",
     "@react-navigation/bottom-tabs": "^7.3.0",
     "@react-navigation/elements": "^2.3.6",
     "@react-navigation/native": "^7.0.17",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -15,7 +15,7 @@
     "preset": "jest-expo"
   },
   "dependencies": {
-    "@expo/vector-icons": "^14.0.2",
+    "@expo/vector-icons": "^14.1.0",
     "@react-navigation/native": "^7.0.17",
     "expo": "~53.0.0-preview.0",
     "expo-font": "~13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1571,11 +1571,9 @@
   integrity sha512-VhmMYcOhzQKcng3QH0RBkwK9knhXXFEVzqwjftLK2S4457k6z3OumdyIHp/4P6h5HmfCydtXWvvsFmL7Ui6Pwg==
 
 "@expo/vector-icons@^14.0.0":
-  version "14.0.4"
-  resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-14.0.4.tgz#fa9d4351877312badf91a806598b2f0bab16039a"
-  integrity sha512-+yKshcbpDfbV4zoXOgHxCwh7lkE9VVTT5T03OUlBsqfze1PLy6Hi4jp1vSb1GVbY6eskvMIivGVc9SKzIv0oEQ==
-  dependencies:
-    prop-types "^15.8.1"
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-14.1.0.tgz#d3dddad8b6ea60502e0fe5485b86751827606ce4"
+  integrity sha512-7T09UE9h8QDTsUeMGymB4i+iqvtEeaO5VvUjryFB4tugDTG/bkzViWA74hm5pfjjDEhYMXWaX112mcvhccmIwQ==
 
 "@expo/ws-tunnel@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
# Why

New version for `@expo/vector-icons` that adds missing peer dependencies and removes `prop-types`.

# How

- Bump `@expo/vector-icons` in `yarn.lock`
- Bump `@expo/vector-icons` in templates
- Bump `@expo/vector-icons` in `bundledNativeModules.json`

# Test Plan

- n/a and covered by CI