### PR TITLE
fix(jest-expo): auto-configure compatible `prettier@2` for `jest-snapshots`

### DIFF
--- a/packages/expo-module-scripts/jest-preset.js
+++ b/packages/expo-module-scripts/jest-preset.js
@@ -10,7 +10,4 @@ module.exports = withWatchPlugins({
     createJestPreset(require('jest-expo/node/jest-preset')),
     // Remove sub-watch-plugins from the preset when using multi-project runner.
   ].map(({ watchPlugins, ...config }) => config),
-
-  // See: https://jestjs.io/docs/configuration#prettierpath-string
-  prettierPath: require.resolve('jest-snapshot-prettier'),
 });

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -100,6 +100,7 @@
     "@testing-library/react": "^15.0.7",
     "@testing-library/react-native": "^13.1.0",
     "immer": "^10.1.1",
+    "jest-expo": "53.0.0-preview.0",
     "react-server-dom-webpack": "~19.0.0",
     "tsd": "^0.28.1"
   },

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Auto-configure `prettierPath` to enable Jest snapshot updates ([#36010](https://github.com/expo/expo/pull/36010) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 53.0.0-preview.0 — 2025-04-04

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -110,5 +110,8 @@ if (!Array.isArray(jestPreset.setupFiles)) {
 }
 jestPreset.setupFiles.push(require.resolve('jest-expo/src/preset/setup.js'));
 
+// See: https://jestjs.io/docs/configuration#prettierpath-string
+jestPreset.prettierPath = require.resolve('jest-snapshot-prettier');
+
 // Add typescript custom mapping
 module.exports = withTypescriptMapping(jestPreset);

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -45,6 +45,7 @@
     "find-up": "^5.0.0",
     "jest-environment-jsdom": "^29.2.1",
     "jest-snapshot": "^29.2.1",
+    "jest-snapshot-prettier": "npm:prettier@^2",
     "jest-watch-select-projects": "^2.0.0",
     "jest-watch-typeahead": "2.2.1",
     "json5": "^2.2.3",

--- a/packages/jest-expo/rsc/jest-preset.js
+++ b/packages/jest-expo/rsc/jest-preset.js
@@ -12,6 +12,4 @@ module.exports = withWatchPlugins({
     getWebPreset({ isReactServer: true }),
     // Remove sub-watch-plugins from the preset when using multi-project runner.
   ].map(({ watchPlugins, ...config }) => config),
-  // See: https://jestjs.io/docs/configuration#prettierpath-string
-  prettierPath: require.resolve('jest-snapshot-prettier'),
 });


### PR DESCRIPTION
# Why

We only did this in `expo-module-scripts`, where we added `jest-snapshots-prettier: "npm:prettier@^2"` to compensate for https://jestjs.io/docs/configuration#prettierpath-string.

We also had this already configured, but not set up properly in `jest-expo/rsc/jest-preset.js` - which is a problem.

# How

- Added `prettierPath: require.resolve('jest-snapshot-prettier')` to `jest-expo`'s default preset
- Added `jest-snapshot-prettier: "npm:prettier@^2"` to `jest-expo`'s `dependencies`
- Dropped manual workaround in `expo-router/jest`

# Test Plan

- See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
