### PR TITLE
[docs] tweak section order on Fingerprint reference page

### DIFF
--- a/docs/pages/versions/unversioned/sdk/fingerprint.mdx
+++ b/docs/pages/versions/unversioned/sdk/fingerprint.mdx
@@ -23,12 +23,6 @@ If you wish to use `@expo/fingerprint` as a standalone package, you can install 
 
 <Terminal cmd={['$ npx expo install @expo/fingerprint']} />
 
-## API Usage
-
-```ts
-import * as Fingerprint from '@expo/fingerprint';
-```
-
 ## CLI Usage
 
 <Terminal cmd={['$ npx @expo/fingerprint --help']} />
@@ -37,7 +31,7 @@ import * as Fingerprint from '@expo/fingerprint';
 
 `@expo/fingerprint` provides defaults that should work for most projects, but also provides a few ways to configure the fingerprinting process to better fit your app structure and workflow.
 
-### **.fingerprintignore**
+### .fingerprintignore
 
 Placed in your project root, **.fingerprintignore** is a [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format)-like ignore mechanism used to exclude files from hash calculation. It behaves similarly but instead uses `minimatch` for pattern matching which has some [limitations](#options) (see documentation for `ignorePaths` under [Options](#options)).
 
@@ -52,11 +46,9 @@ For example, to skip a folder but keep some files:
 !/app/ios/Podfile.lock
 ```
 
-### **fingerprint.config.js**
+### fingerprint.config.js
 
-Placed in your project root, **fingerprint.config.js** allows you to specify custom hash calculation configuration beyond what is configurable in the **.fingerprintignore**.
-
-For supported configurations, see [Config](#config) and [`SourceSkips`](#sourceskips).
+Placed in your project root, **fingerprint.config.js** allows you to specify custom hash calculation configuration beyond what is configurable in the **.fingerprintignore**. For supported configurations, see [Config](#config) and [`SourceSkips`](#sourceskips).
 
 Below is an example **fingerprint.config.js** configuration, assuming you have `@expo/fingerprint` installed as a direct dependency:
 
@@ -146,5 +138,11 @@ module.exports = withMyPlugin;
 By following these guidelines, you can effectively manage changes to config plugins and ensure that fingerprinting remains consistent and reliable.
 
 </Collapsible>
+
+## API
+
+```ts
+import * as Fingerprint from '@expo/fingerprint';
+```
 
 <APISection packageName="@expo/fingerprint" apiName="Fingerprint" />

--- a/docs/pages/versions/v52.0.0/sdk/fingerprint.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/fingerprint.mdx
@@ -23,12 +23,6 @@ If you wish to use `@expo/fingerprint` as a standalone package, you can install 
 
 <Terminal cmd={['$ npx expo install @expo/fingerprint']} />
 
-## API Usage
-
-```ts
-import * as Fingerprint from '@expo/fingerprint';
-```
-
 ## CLI Usage
 
 <Terminal cmd={['$ npx @expo/fingerprint --help']} />
@@ -54,9 +48,7 @@ For example, to skip a folder but keep some files:
 
 ### fingerprint.config.js
 
-Placed in your project root, **fingerprint.config.js** allows you to specify custom hash calculation configuration beyond what is configurable in the **.fingerprintignore**.
-
-For supported configurations, see [Config](#config) and [`SourceSkips`](#sourceskips).
+Placed in your project root, **fingerprint.config.js** allows you to specify custom hash calculation configuration beyond what is configurable in the **.fingerprintignore**. For supported configurations, see [Config](#config) and [`SourceSkips`](#sourceskips).
 
 Below is an example **fingerprint.config.js** configuration, assuming you have `@expo/fingerprint` installed as a direct dependency:
 
@@ -146,5 +138,11 @@ module.exports = withMyPlugin;
 By following these guidelines, you can effectively manage changes to config plugins and ensure that fingerprinting remains consistent and reliable.
 
 </Collapsible>
+
+## API
+
+```ts
+import * as Fingerprint from '@expo/fingerprint';
+```
 
 <APISection packageName="@expo/fingerprint" apiName="Fingerprint" />


### PR DESCRIPTION
# Why

Then revieviewing latest docs data, I have spotted that API section has been detached from the package data.

# How

Move API section down, right above package data renderer. Apply few formatting tweaks.

The changes have been backported also to the SDK 52 page.

# Test Plan

The changes have been reviewed by running docs website app locally.

# Preview

![Screenshot 2025-04-08 at 17 04 10](https://github.com/user-attachments/assets/903b33d1-dce1-4371-aeea-dcaccca5d3da)

