### PR TITLE
[docs] APISection: fix multidimensional arrays, component type tweaks

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -110,14 +110,22 @@ exports[`APISection expo-apple-authentication 1`] = `
         data-text="true"
       >
         React.Element
-        &lt;
+        <span
+          class="text-quaternary"
+        >
+          &lt;
+        </span>
         <a
           class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
           href="#appleauthenticationbuttonprops"
         >
           AppleAuthenticationButtonProps
         </a>
-        &gt;
+        <span
+          class="text-quaternary"
+        >
+          &gt;
+        </span>
       </code>
     </p>
     <div

--- a/docs/components/plugins/api/APISectionComponents.tsx
+++ b/docs/components/plugins/api/APISectionComponents.tsx
@@ -1,7 +1,8 @@
 import { mergeClasses } from '@expo/styleguide';
 
+import { hardcodedTypeLinks } from '~/components/plugins/api/APIStaticData';
 import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
-import { H2, DEMI, CODE, CALLOUT } from '~/ui/components/Text';
+import { H2, DEMI, CODE, CALLOUT, A } from '~/ui/components/Text';
 
 import {
   CommentData,
@@ -33,7 +34,12 @@ const getComponentType = ({ signatures }: Partial<GeneratedData>) => {
   if (signatures?.length && signatures[0].type.types) {
     return 'React.' + signatures[0].type.types.filter(t => t.type === 'reference')[0]?.name;
   }
-  return 'React.Element';
+  return (
+    <>
+      React.
+      <A href={hardcodedTypeLinks.Element}>Element</A>
+    </>
+  );
 };
 
 const getComponentTypeParameters = ({
@@ -73,7 +79,10 @@ const renderComponent = (
               <>React.{resolveTypeName(resolvedTypeParameters, sdkVersion)}</>
             ) : (
               <>
-                {resolvedType}&lt;{resolveTypeName(resolvedTypeParameters, sdkVersion)}&gt;
+                {resolvedType}
+                <span className="text-quaternary">&lt;</span>
+                {resolveTypeName(resolvedTypeParameters, sdkVersion)}
+                <span className="text-quaternary">&gt;</span>
               </>
             )}
           </CODE>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -240,9 +240,11 @@ export const resolveTypeName = (
           sdkVersion,
         });
       } else if (type === 'array') {
-        return elementType.name + '[]';
+        return resolveTypeName(elementType, sdkVersion) + '[]';
       }
       return elementType.name + type;
+    } else if (elementType?.type === 'array') {
+      return resolveTypeName(elementType, sdkVersion) + '[]';
     } else if (elementType?.declaration) {
       if (type === 'array') {
         const { parameters, type: paramType } = elementType.declaration.indexSignature ?? {};


### PR DESCRIPTION
# Why

Spotted few, small issues with `APISection` rendering on the new MeshGradient page.

![Screenshot 2025-04-08 at 17 33 35](https://github.com/user-attachments/assets/f5dc74e9-80a4-44b1-b285-5fa49edb8620)

# How

Summary of changes:
* fix rendering multidimensional arrays
* add missing decoration color around component types
* add missing link to `Element` type in hardcoded component type fallback
* updated tests snapshot

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

![Screenshot 2025-04-08 at 17 26 37](https://github.com/user-attachments/assets/09a9f231-f317-4efa-90a8-dc5b5fc53fb2)

