### PR TITLE
Fix podfile syntax issue in installing-expo-modules.mdx

### DIFF
--- a/docs/pages/brownfield/installing-expo-modules.mdx
+++ b/docs/pages/brownfield/installing-expo-modules.mdx
@@ -186,7 +186,7 @@ index f991b7b..17c24b0 100644
 +    'node',
 +    '--no-warnings',
 +    '--eval',
-+    'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
++    'require(require.resolve("expo-modules-autolinking", { paths: [require.resolve("expo/package.json")] }))(process.argv.slice(1))',
 +    'react-native-config',
 +    '--json',
 +    '--platform',


### PR DESCRIPTION
fixes podfile syntax issue, resolves #36015

# Why

The existing documentation caused `pod install` to fail with a syntax error.

# How

Corrected the type of the embedded quotation marks to be alternating in order to have correct syntax.

# Test Plan

Tested the 'pod install' command in a brownfield app after running `npm install expo` and verified that the pods installation finished successfully with no errors thrown.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
