### PR TITLE
add more contextual help to the xcode not installed error message

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,7 +18,10 @@
 
 - Add backup stack trace ([#35913](https://github.com/expo/expo/pull/35913) by [@EvanBacon](https://github.com/EvanBacon))
 
-## 0.23.0 — 2025-04-04
+- Add helpful recommendation to the standard "Xcode not installed" error message to avoid developer frustration by ([#36024](https://github.com/expo/expo/pull/36024) [@quantizor]
+(https://github.com/quantizor)
+
+## 0.23.0 — 2025-04-04)
 
 ### 🛠 Breaking changes
 

--- a/packages/@expo/cli/src/start/doctor/apple/XcodePrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/XcodePrerequisite.ts
@@ -150,7 +150,7 @@ export class XcodePrerequisite extends Prerequisite {
 
       // Almost certainly Xcode isn't installed.
       await promptToOpenAppStoreAsync(
-        `Xcode must be fully installed before you can continue. Continue to the App Store?`
+        `Xcode must be fully installed before you can continue. If this message is still occurring after installing Xcode, you may need to finish the installation of the developer tools via: \`sudo xcode-select -s /Applications/Xcode.app/Contents/Developer\`. Continue to the App Store?`
       );
       throw new AbortCommandError();
     }

--- a/packages/@expo/cli/src/start/doctor/apple/XcodePrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/XcodePrerequisite.ts
@@ -150,7 +150,7 @@ export class XcodePrerequisite extends Prerequisite {
 
       // Almost certainly Xcode isn't installed.
       await promptToOpenAppStoreAsync(
-        `Xcode must be fully installed before you can continue. If this message is still occurring after installing Xcode, you may need to finish the installation of the developer tools via: \`sudo xcode-select -s /Applications/Xcode.app/Contents/Developer\`. Continue to the App Store?`
+        `Xcode must be fully installed before you can continue. If this message is still occurring after installing Xcode, you may need to finish the installation of the developer tools by running: \`sudo xcode-select -s /Applications/Xcode.app/Contents/Developer\`. Continue to the App Store?`
       );
       throw new AbortCommandError();
     }


### PR DESCRIPTION
Closes #21727

# Why

A number of people have run into this issue over the years https://github.com/expo/expo/issues/21727, ideally adding this additional messaging will help avoid developer frustration.

# How

The recommended command seems to resolve the problem for the vast majority of issue commenters.

# Test Plan

n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
