### PR TITLE
[tools] Remove any prerelease suffixes before adding -canary suffix

### DIFF
--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -60,7 +60,7 @@ export const prepareCanaries = new Task<TaskArgs>(
       // Strip any pre-release tag from the baseVersion
       // For example, convert "5.0.0-rc.0" or "5.0.0-preview.0" to "5.0.0"
       // This is to ensure we don't stack the canary suffix on top of another
-      const cleanBaseVersion = semver.coerce(baseVersion).version ?? baseVersion;
+      const cleanBaseVersion = semver.coerce(baseVersion)?.version ?? baseVersion;
 
       state.releaseVersion = findNextAvailableCanaryVersion(
         `${cleanBaseVersion}-${canarySuffix}`,

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -57,8 +57,15 @@ export const prepareCanaries = new Task<TaskArgs>(
         ? nextSdkVersion
         : resolveReleaseTypeAndVersion(parcel, options);
 
+      // Strip any pre-release tag from the baseVersion
+      // For example, convert "5.0.0-rc.0" or "5.0.0-preview.0" to "5.0.0"
+      // This is to ensure we don't stack the canary suffix on top of another
+      const cleanBaseVersion = semver.parse(baseVersion)?.version
+        ? `${semver.major(baseVersion)}.${semver.minor(baseVersion)}.${semver.patch(baseVersion)}`
+        : baseVersion;
+
       state.releaseVersion = findNextAvailableCanaryVersion(
-        `${baseVersion}-${canarySuffix}`,
+        `${cleanBaseVersion}-${canarySuffix}`,
         pkgView?.versions ?? []
       );
     }

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -60,9 +60,7 @@ export const prepareCanaries = new Task<TaskArgs>(
       // Strip any pre-release tag from the baseVersion
       // For example, convert "5.0.0-rc.0" or "5.0.0-preview.0" to "5.0.0"
       // This is to ensure we don't stack the canary suffix on top of another
-      const cleanBaseVersion = semver.parse(baseVersion)?.version
-        ? `${semver.major(baseVersion)}.${semver.minor(baseVersion)}.${semver.patch(baseVersion)}`
-        : baseVersion;
+      const cleanBaseVersion = semver.coerce(baseVersion).version;
 
       state.releaseVersion = findNextAvailableCanaryVersion(
         `${cleanBaseVersion}-${canarySuffix}`,

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -60,7 +60,7 @@ export const prepareCanaries = new Task<TaskArgs>(
       // Strip any pre-release tag from the baseVersion
       // For example, convert "5.0.0-rc.0" or "5.0.0-preview.0" to "5.0.0"
       // This is to ensure we don't stack the canary suffix on top of another
-      const cleanBaseVersion = semver.coerce(baseVersion).version;
+      const cleanBaseVersion = semver.coerce(baseVersion).version ?? baseVersion;
 
       state.releaseVersion = findNextAvailableCanaryVersion(
         `${cleanBaseVersion}-${canarySuffix}`,


### PR DESCRIPTION
# Why

When I published a canary from main, which already had some packages with the `-preview.x` suffixes, we ended up with `a.b.c-preview.x-canary-z` which was not desirable because then canaries will retake precedence over previews for that version.

# How

Only add `-canary` to `major.minor.patch` version from the package