### PR TITLE
[ios][background-task][expo-go] reverted and fixed background task

### DIFF
--- a/apps/expo-go/ios/Exponent/Supporting/Info.plist
+++ b/apps/expo-go/ios/Exponent/Supporting/Info.plist
@@ -161,5 +161,9 @@
 	<string>Automatic</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+    <array>
+      <string>com.expo.modules.backgroundtask.processing</string>
+    </array>
 </dict>
 </plist>

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -424,10 +424,10 @@ async function internalRemoveBackgroundPermissionsFromInfoPlistAsync(): Promise<
   delete parsedPlist.NSLocationAlwaysUsageDescription;
 
   logger.info(
-    `Removing location, audio, background-task and remote-notfication from UIBackgroundModes from ios/Exponent/Supporting/Info.plist`
+    `Removing location, audio and remote-notfication from UIBackgroundModes from ios/Exponent/Supporting/Info.plist`
   );
   parsedPlist.UIBackgroundModes = parsedPlist.UIBackgroundModes.filter(
-    (i: string) => !['location', 'audio', 'remote-notification', 'processing'].includes(i)
+    (i: string) => !['location', 'audio', 'remote-notification'].includes(i)
   );
   await fs.writeFile(INFO_PLIST_PATH, plist.build(parsedPlist));
 }


### PR DESCRIPTION
# Why

A previous PR #35969 was merged that removed the `processing` key from the `UIBackgroundModes` in Expo Go's Info.list file.

There is no real need for removing background tasks from Expo Go since it will work (tested and verified). Expo background fetch was also available in Expo Go.

This was not necessary, since the error we got from AppStore was that we were missing another key when `processing` was set - the `BGTaskSchedulerPermittedIdentifiers` key.

# How

This commit fixes this by reverting the change to the `et eas remove-background-permissions-from-info-plist` script, and adding the missing `BGTaskSchedulerPermittedIdentifiers` so that `expo-background-task` can run in Expo Go.

# Test Plan

Export Expo Go to AppStore and ensure we don't get any errors.

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
