### PR TITLE
[docs] PageHeader: add proper tooltips to buttons, other tweaks

### DIFF
--- a/docs/common/test-utilities.tsx
+++ b/docs/common/test-utilities.tsx
@@ -25,6 +25,8 @@ export function renderWithHeadings(
 
 export function renderWithTestRouter(element: ReactElement, router: Partial<NextRouter> = {}) {
   return render(
-    <RouterContext.Provider value={router as NextRouter}>{element}</RouterContext.Provider>
+    <TooltipProvider>
+      <RouterContext.Provider value={router as NextRouter}>{element}</RouterContext.Provider>
+    </TooltipProvider>
   );
 }

--- a/docs/ui/components/PageHeader/PageHeader.test.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.test.tsx
@@ -1,22 +1,28 @@
-import { render, screen } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import { createRequire } from 'node:module';
 
-import { renderWithTestRouter } from '~/common/test-utilities';
+import { renderWithHeadings, renderWithTestRouter } from '~/common/test-utilities';
 
 import { PageHeader } from './PageHeader';
 
 const require = createRequire(import.meta.url);
 
 describe(PageHeader, () => {
-  test('displays npm registry link', () => {
-    render(<PageHeader title="test-title" packageName="expo-av" testRequire={require} />);
+  test('displays npm registry link', async () => {
+    renderWithHeadings(
+      <PageHeader title="test-title" packageName="expo-av" testRequire={require} />
+    );
     const linkElement = screen.getAllByRole('link', { hidden: false })[0];
     expect(linkElement.getAttribute('href')).toEqual('https://www.npmjs.com/package/expo-av');
-    expect(linkElement.getAttribute('title')).toEqual('View package in npm Registry');
+
+    fireEvent.focus(linkElement);
+    const tooltip = await screen.findByRole('tooltip', {}, { timeout: 1000 });
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent('View package in npm registry');
   });
 
-  test('displays GitHub source code link', () => {
-    render(
+  test('displays GitHub source code link', async () => {
+    renderWithHeadings(
       <PageHeader
         title="test-title"
         packageName="expo-av"
@@ -28,11 +34,15 @@ describe(PageHeader, () => {
     expect(linkElement.getAttribute('href')).toEqual(
       'https://github.com/expo/expo/tree/main/packages/expo-av'
     );
-    expect(linkElement.getAttribute('title')).toEqual('View source code of expo-av on GitHub');
+
+    fireEvent.focus(linkElement);
+    const tooltip = await screen.findByRole('tooltip', {}, { timeout: 1000 });
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent('View source code of expo-av on GitHub');
   });
 
   test('displays bundled version when packageName provided', () => {
-    render(
+    renderWithHeadings(
       <PageHeader
         title="test-title"
         packageName="expo-av"
@@ -52,6 +62,6 @@ describe(PageHeader, () => {
     expect(linkElement.getAttribute('href')).toEqual(
       'https://github.com/expo/expo/edit/main/docs/pages/router/reference/hooks.mdx'
     );
-    expect(linkElement.getAttribute('title')).toEqual('Edit content of this page on GitHub');
+    expect(linkElement.getAttribute('aria-label')).toEqual('Edit content of this page on GitHub');
   });
 });

--- a/docs/ui/components/PageHeader/PageHeader.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.tsx
@@ -43,7 +43,7 @@ export function PageHeader({
           {packageName && packageName.startsWith('expo-') && 'Expo '}
           {title}
         </H1>
-        <span className="flex gap-1 max-xl-gutters:hidden">
+        <span className="-mt-0.5 flex gap-1 max-xl-gutters:hidden">
           <PageTitleButtons packageName={packageName} sourceCodeUrl={sourceCodeUrl} />
         </span>
       </div>

--- a/docs/ui/components/PageHeader/PageTitleButtons.tsx
+++ b/docs/ui/components/PageHeader/PageTitleButtons.tsx
@@ -5,7 +5,8 @@ import { Edit05Icon } from '@expo/styleguide-icons/outline/Edit05Icon';
 import { useRouter } from 'next/compat/router';
 
 import { githubUrl } from '~/ui/components/Footer/utils';
-import { CALLOUT } from '~/ui/components/Text';
+import { FOOTNOTE, MONOSPACE } from '~/ui/components/Text';
+import * as Tooltip from '~/ui/components/Tooltip';
 
 type Props = {
   packageName?: string;
@@ -22,52 +23,66 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
           className="justify-center pl-2.5 pr-2"
           openInNewTab
           href={githubUrl(router.pathname)}
-          title="Edit content of this page on GitHub">
+          aria-label="Edit content of this page on GitHub">
           <div className="flex flex-row items-center gap-2">
             <Edit05Icon className="icon-sm text-icon-secondary" />
-            <CALLOUT crawlable={false} theme="secondary">
+            <FOOTNOTE crawlable={false} theme="secondary">
               Edit this page
-            </CALLOUT>
+            </FOOTNOTE>
           </div>
         </Button>
       )}
       {sourceCodeUrl && (
-        <Button
-          theme="quaternary"
-          className="min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]"
-          openInNewTab
-          href={sourceCodeUrl}
-          title={`View source code of ${packageName} on GitHub`}>
-          <div
-            className={mergeClasses(
-              'flex flex-col items-center',
-              'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
-            )}>
-            <GithubIcon className="mt-0.5 text-icon-secondary" />
-            <CALLOUT crawlable={false} theme="secondary">
-              GitHub
-            </CALLOUT>
-          </div>
-        </Button>
+        <Tooltip.Root delayDuration={500}>
+          <Tooltip.Trigger asChild>
+            <Button
+              theme="quaternary"
+              className="min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]"
+              openInNewTab
+              href={sourceCodeUrl}>
+              <div
+                className={mergeClasses(
+                  'flex flex-col items-center',
+                  'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
+                )}>
+                <GithubIcon className="mt-0.5 text-icon-secondary" />
+                <FOOTNOTE crawlable={false} theme="secondary">
+                  GitHub
+                </FOOTNOTE>
+              </div>
+            </Button>
+          </Tooltip.Trigger>
+          <Tooltip.Content className="max-w-[300px]">
+            <FOOTNOTE>
+              View source code of <MONOSPACE>{packageName}</MONOSPACE> on GitHub
+            </FOOTNOTE>
+          </Tooltip.Content>
+        </Tooltip.Root>
       )}
       {packageName && (
-        <Button
-          theme="quaternary"
-          openInNewTab
-          className="min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]"
-          href={`https://www.npmjs.com/package/${packageName}`}
-          title="View package in npm Registry">
-          <div
-            className={mergeClasses(
-              'flex flex-col items-center',
-              'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
-            )}>
-            <BuildIcon className="mt-0.5 text-icon-secondary" />
-            <CALLOUT crawlable={false} theme="secondary">
-              npm
-            </CALLOUT>
-          </div>
-        </Button>
+        <Tooltip.Root delayDuration={500}>
+          <Tooltip.Trigger asChild>
+            <Button
+              theme="quaternary"
+              openInNewTab
+              className="min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]"
+              href={`https://www.npmjs.com/package/${packageName}`}>
+              <div
+                className={mergeClasses(
+                  'flex flex-col items-center',
+                  'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
+                )}>
+                <BuildIcon className="mt-0.5 text-icon-secondary" />
+                <FOOTNOTE crawlable={false} theme="secondary">
+                  npm
+                </FOOTNOTE>
+              </div>
+            </Button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>
+            <FOOTNOTE>View package in npm registry</FOOTNOTE>
+          </Tooltip.Content>
+        </Tooltip.Root>
       )}
     </>
   );

--- a/docs/ui/components/Tooltip/Content.tsx
+++ b/docs/ui/components/Tooltip/Content.tsx
@@ -10,7 +10,7 @@ export function Content({ children, className, sideOffset = 4, ...rest }: Toolti
       <TooltipPrimitive.Content
         sideOffset={sideOffset}
         className={mergeClasses(
-          'dark-theme flex flex-col rounded-md bg-palette-gray2 px-3 py-1.5 text-default shadow-md',
+          'dark-theme relative z-[101] flex flex-col rounded-md bg-palette-gray2 px-3 py-1.5 text-default shadow-md',
           'data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade data-[side=right]:animate-slideLeftAndFade data-[side=top]:animate-slideDownAndFade',
           className
         )}


### PR DESCRIPTION
# Why

Use tooltip components instead of native to browser `title` attr for hints on buttons in PageHeader.

# How

Add Radix-based tooltips, tweak buttons label size and spacing, add constraints to tooltip size for lengthy package names.

# Test Plan

The changes have been reviewed by running docs app locally, and visiting several package reference pages.

# Preview

![Screenshot 2025-04-09 at 11 09 30](https://github.com/user-attachments/assets/f6936074-2658-4a56-bdf6-03d0664b50bc)

![Screenshot 2025-04-09 at 11 13 53](https://github.com/user-attachments/assets/ae7af60a-cf78-4812-a2a6-b0b27962c9f4)
