### PR TITLE
[docs][task-manager] fix docs on Expo Go usage

### DIFF
--- a/docs/pages/versions/unversioned/sdk/task-manager.mdx
+++ b/docs/pages/versions/unversioned/sdk/task-manager.mdx
@@ -24,9 +24,11 @@ import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 
 <APIInstallSection />
 
-## Configuration&ensp;<PlatformTag platform='ios' />
+<br />
 
-`TaskManager` works out of the box in the Expo Go app on Android. However, on iOS, you'll need to use a [development build](/develop/development-builds/introduction/).
+> **info** You can test `TaskManager` in the Expo Go app. However, check the documentation of each [library](#libraries-using-expo-taskmanager) that uses `TaskManager` to confirm whether it supports testing in Expo Go.
+
+## Configuration&ensp;<PlatformTag platform='ios' />
 
 Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your **Info.plist** file.
 


### PR DESCRIPTION
# Why

Our documentation for the Task Manager contains some unclear instructions about usage in Expo Go that isn't correct. The Task Manager docs shouldn't contain any limitations for Expo Go usage - this is the responsibility of the consuming libraries.

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/0703137e-c975-42e0-addd-34d66693a979" />

Related to ENG-15445

# How

This commit fixes this by adding a note about Expo Go and reference to the libraries that uses this package.

An issue was also mentioning this: #33776

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
