### PR TITLE
[ios][epxo-go] removed local network access test on simulator

### DIFF
--- a/apps/expo-go/ios/Client/LocalNetworkAccessManager.swift
+++ b/apps/expo-go/ios/Client/LocalNetworkAccessManager.swift
@@ -7,12 +7,19 @@ private let type = "_preflight_check._tcp"
 class LocalNetworkAccessManager: NSObject {
   @objc static func requestAccess(completion: @escaping (Bool) -> Void) {
     Task {
+      // on iOS simulator Local Network Privacy is no longer available so we need to
+      // just complete and return true:
+      // https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy
+#if targetEnvironment(simulator)
+      completion(true)
+#else
       do {
         let result = try await requestLocalNetworkAuthorization()
         completion(result)
       } catch {
         completion(false)
       }
+#endif
     }
   }
 }


### PR DESCRIPTION
# Why

After we've upgraded to latest Xcode 16.3 and MacOS Sequioa 5.4 (not sure which since it is a bit hard to roll back and test) we have gotten a lot of feedback saying that Expo Go doesn't allow opening and connecting to apps when it runs on the Simulator.

It complains with the dialog "Local network access required" which indicates that it couldn't display the local network access permissions dialog:

<img src="https://github.com/user-attachments/assets/7693b194-1be5-4c7f-a04f-eb562fb1b612" width="200" />

This works fine when running on a device, but not in the Simulator - here is what we expect to see on a device:

<img src="https://github.com/user-attachments/assets/0384329c-0e9c-4819-b46f-b76446c77bd6" width="200" />

Apple has a document that contains a note about local network privacy not being supported by the Simulator here:

https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy

And there has been similar messages in the Apple dev forums:

https://developer.apple.com/forums/thread/766133

(look at the last message from "peterz")

# How

This commit fixes this by avoiding the permission check when code is complied for the simulator.

Closes ENG-15446

# Test Plan

- Uninstall Expo Go from your simulator
- Run Expo Go on the Simulator and try to open an app. 
- Observe that the app should open fine.

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
