### PR TITLE
[docs] Add expo-iap to In-App Purchases Documentation

### DIFF
--- a/docs/pages/guides/in-app-purchases.mdx
+++ b/docs/pages/guides/in-app-purchases.mdx
@@ -50,8 +50,17 @@ The following libraries provide robust support for in-app purchase functionality
 />
 
 <BoxLink
-  title={<><CODE>react-native-iap</CODE> (deprecated)</>}
-  description={<>A legacy React Native library for in-app purchases. Superseded by <CODE>expo-iap</CODE> for Expo apps.</>}
+  title={
+    <>
+      <CODE>react-native-iap</CODE> (deprecated)
+    </>
+  }
+  description={
+    <>
+      A legacy React Native library for in-app purchases. Superseded by <CODE>expo-iap</CODE> for
+      Expo apps.
+    </>
+  }
   href="https://github.com/hyochan/react-native-iap"
   Icon={GithubIcon}
 />

--- a/docs/pages/guides/in-app-purchases.mdx
+++ b/docs/pages/guides/in-app-purchases.mdx
@@ -50,12 +50,15 @@ The following libraries provide robust support for in-app purchase functionality
 />
 
 <BoxLink
-  title={
-    <>
-      <CODE>react-native-iap</CODE>
-    </>
-  }
-  description="A React Native library providing an interface to the client-side native in-app purchase API's for Android (both Play Store and Amazon) and iOS."
-  href="https://github.com/dooboolab-community/react-native-iap"
+  title={<><CODE>react-native-iap</CODE> (Deprecated)</>}
+  description="A legacy React Native library for in-app purchases. Superseded by expo-iap for Expo users."
+  href="https://github.com/hyochan/react-native-iap"
+  Icon={GithubIcon}
+/>
+
+<BoxLink
+  title={<><CODE>expo-iap</CODE></>}
+  description="The official Expo module for in-app purchases, supporting managed workflows with dev-client."
+  href="https://github.com/hyochan/expo-iap"
   Icon={GithubIcon}
 />

--- a/docs/pages/guides/in-app-purchases.mdx
+++ b/docs/pages/guides/in-app-purchases.mdx
@@ -66,7 +66,11 @@ The following libraries provide robust support for in-app purchase functionality
 />
 
 <BoxLink
-  title={<><CODE>expo-iap</CODE></>}
+  title={
+    <>
+      <CODE>expo-iap</CODE>
+    </>
+  }
   description="A React Native library for in-app purchases that works with development builds."
   href="https://github.com/hyochan/expo-iap"
   Icon={GithubIcon}

--- a/docs/pages/guides/in-app-purchases.mdx
+++ b/docs/pages/guides/in-app-purchases.mdx
@@ -50,15 +50,15 @@ The following libraries provide robust support for in-app purchase functionality
 />
 
 <BoxLink
-  title={<><CODE>react-native-iap</CODE> (Deprecated)</>}
-  description="A legacy React Native library for in-app purchases. Superseded by expo-iap for Expo users."
+  title={<><CODE>react-native-iap</CODE> (deprecated)</>}
+  description={<>A legacy React Native library for in-app purchases. Superseded by <CODE>expo-iap</CODE> for Expo apps.</>}
   href="https://github.com/hyochan/react-native-iap"
   Icon={GithubIcon}
 />
 
 <BoxLink
   title={<><CODE>expo-iap</CODE></>}
-  description="The official Expo module for in-app purchases, supporting managed workflows with dev-client."
+  description="A React Native library for in-app purchases that works with development builds."
   href="https://github.com/hyochan/expo-iap"
   Icon={GithubIcon}
 />


### PR DESCRIPTION
# Why

The `expo-iap` module is now the official solution for in-app purchases in Expo’s managed workflow, offering seamless integration and critical support for React Native’s New Architecture. This addresses limitations in `react-native-iap`, which lacks New Architecture compatibility, making `expo-iap` the modern choice for Expo users. This PR updates the Expo in-app purchases documentation to reflect this shift, deprecates `react-native-iap`, and introduces `expo-iap` as the recommended library.

Relevant discussion: [https://github.com/hyochan/react-native-iap/discussions/2754](https://github.com/hyochan/react-native-iap/discussions/2754)

# How

- Updated the "Using In-App Purchases" documentation to include a new `BoxLink` entry for `expo-iap` with the description: "The official Expo module for in-app purchases, supporting managed workflows with dev-client."
- Modified the existing `react-native-iap` `BoxLink` to mark it as deprecated with an updated description: "A legacy React Native library for in-app purchases. Superseded by expo-iap for Expo users."
- Emphasized New Architecture support as a key differentiator for `expo-iap` in the motivation, aligning with the discussion in the linked thread.

# Test Plan

N/A

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)