### PR TITLE
[notifications] Defer addTokenListener call

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Defer calling `addTokenListener` until `OnCreate`.
+- [Android] Defer calling `addTokenListener` until `OnCreate`. ([#36052](https://github.com/expo/expo/pull/36052) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Defer calling `addTokenListener` until `OnCreate`.
+
 ### 💡 Others
 
 ## 0.30.1 — 2025-04-08
@@ -620,9 +622,11 @@ _This version does not introduce any user-facing changes._
 - Changed class responsible for handling Firebase events from `FirebaseMessagingService` to `.service.NotificationsService` on Android. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override `FirebaseMessagingService` to implement some custom handling logic.
+
 - Changed how you can override ways in which a notification is reinterpreted from a [`StatusBarNotification`](https://developer.android.com/reference/android/service/notification/StatusBarNotification) and in which a [`Notification`](https://developer.android.com/reference/android/app/Notification.html?hl=en) is built from defining an `expo.modules.notifications#NotificationsScoper` meta-data value in `AndroidManifest.xml` to implementing a `BroadcastReceiver` subclassing `NotificationsService` delegating those responsibilities to your custom `PresentationDelegate` instance. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override those methods to implement some custom handling logic.
+
 - Removed `removeAllNotificationListeners` method. You can (and should) still remove listeners using `remove` method on `Subscription` objects returned by `addNotification…Listener`. ([#10883](https://github.com/expo/expo/pull/10883) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier being used to fetch Expo push token being backed up on Android which resulted in multiple devices having the same `deviceId` (and eventually, Expo push token). ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier used when fetching Expo push token being different than `Constants.installationId` in managed workflow apps which resulted in different Expo push tokens returned for the same experience across old and new Expo API and the device push token not being automatically updated on Expo push servers which lead to Expo push tokens corresponding to outdated Firebase tokens. ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenModule.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/tokens/PushTokenModule.kt
@@ -13,11 +13,6 @@ private const val REGISTRATION_FAIL_CODE = "E_REGISTRATION_FAILED"
 private const val UNREGISTER_FOR_NOTIFICATIONS_FAIL_CODE = "E_UNREGISTER_FOR_NOTIFICATIONS_FAILED"
 
 class PushTokenModule : Module(), FirebaseTokenListener {
-
-  init {
-    addTokenListener(this@PushTokenModule)
-  }
-
   /**
    * Callback called when [FirebaseMessagingDelegate] gets notified of a new token.
    * Emits a [NEW_TOKEN_EVENT_NAME] event.
@@ -37,6 +32,10 @@ class PushTokenModule : Module(), FirebaseTokenListener {
     Name("ExpoPushTokenManager")
 
     Events("onDevicePushToken")
+
+    OnCreate {
+      addTokenListener(this@PushTokenModule)
+    }
 
     /**
      * Fetches Firebase push token and resolves the promise.


### PR DESCRIPTION
# Why
Calling `addTokenListener` in an `init` block is too early because firebase will call this immediately if it has a previous token causing a crash because we are trying to emit an event before the `AppContext` is ready. 

# How
Move `addTokenListener` call to `OnCreate`

# Test Plan
Expo go doesn't crash on launch.

