### PR TITLE
fix(cli): fix frame showing and react canary 

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Ensure fast resolver is enabled when react canary is enabled.
+
 ### 💡 Others
 
 ## 0.23.1 — 2025-04-08
@@ -25,8 +27,7 @@
 ### 💡 Others
 
 - Add backup stack trace ([#35913](https://github.com/expo/expo/pull/35913) by [@EvanBacon](https://github.com/EvanBacon))
-- Add helpful recommendation to the standard "Xcode not installed" error message to avoid developer frustration by ([#36024](https://github.com/expo/expo/pull/36024) [@quantizor]
-(https://github.com/quantizor)
+- Add helpful recommendation to the standard "Xcode not installed" error message. ([#36024](https://github.com/expo/expo/pull/36024) by [@quantizor](https://github.com/quantizor)
 
 ## 0.23.0 — 2025-04-04)
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Ensure fast resolver is enabled when react canary is enabled.
+- Ensure fast resolver is enabled when react canary is enabled. ([#36053](https://github.com/expo/expo/pull/36053) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -84,6 +84,17 @@ export async function loadMetroConfigAsync(
     process.env.EXPO_USE_FAST_RESOLVER = '1';
   }
 
+  const isReactCanaryEnabled =
+    (exp.experiments?.reactServerComponentRoutes ||
+      serverActionsEnabled ||
+      exp.experiments?.reactCanary) ??
+    false;
+
+  if (isReactCanaryEnabled) {
+    // The fast resolver is required for React canary to work as it can switch the node_modules location for react imports.
+    process.env.EXPO_USE_FAST_RESOLVER = '1';
+  }
+
   const serverRoot = getMetroServerRoot(projectRoot);
   const terminalReporter = new MetroTerminalReporter(serverRoot, terminal);
 
@@ -150,11 +161,7 @@ export async function loadMetroConfigAsync(
     isTsconfigPathsEnabled: exp.experiments?.tsconfigPaths ?? true,
     isFastResolverEnabled: env.EXPO_USE_FAST_RESOLVER,
     isExporting,
-    isReactCanaryEnabled:
-      (exp.experiments?.reactServerComponentRoutes ||
-        serverActionsEnabled ||
-        exp.experiments?.reactCanary) ??
-      false,
+    isReactCanaryEnabled,
     isNamedRequiresEnabled: env.EXPO_USE_METRO_REQUIRE,
     isReactServerComponentsEnabled: !!exp.experiments?.reactServerComponentRoutes,
     getMetroBundler,

--- a/packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts
+++ b/packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts
@@ -147,7 +147,7 @@ export function getStackAsFormattedLog(
     const backupStackLines: string[] = [];
 
     stackProps.forEach((frame) => {
-      const shouldShow = frame.collapse && !showCollapsedFrames;
+      const shouldShow = !frame.collapse && showCollapsedFrames;
 
       const position = terminalLink.isSupported
         ? terminalLink(frame.subtitle, frame.subtitle)

--- a/packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts
+++ b/packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts
@@ -147,7 +147,7 @@ export function getStackAsFormattedLog(
     const backupStackLines: string[] = [];
 
     stackProps.forEach((frame) => {
-      const shouldShow = !frame.collapse && showCollapsedFrames;
+      const shouldShow = !frame.collapse || showCollapsedFrames;
 
       const position = terminalLink.isSupported
         ? terminalLink(frame.subtitle, frame.subtitle)


### PR DESCRIPTION
This pull request includes several changes to the `packages/@expo/cli` to fix bugs, improve error messages, and enhance functionality. The most important changes include ensuring the fast resolver is enabled when React Canary is enabled, fixing the stack trace formatting, and updating the changelog with the latest changes.

### Bug Fixes and Enhancements:

* [`packages/@expo/cli/src/start/server/metro/instantiateMetro.ts`](diffhunk://#diff-362d97681d5ead3b0b4b966473c0b148267e7dc68dba8af9734dfdfe3e0ad05dR87-R97): Ensured the fast resolver is enabled when React Canary is enabled by adding a check for `isReactCanaryEnabled` and setting the `EXPO_USE_FAST_RESOLVER` environment variable accordingly. [[1]](diffhunk://#diff-362d97681d5ead3b0b4b966473c0b148267e7dc68dba8af9734dfdfe3e0ad05dR87-R97) [[2]](diffhunk://#diff-362d97681d5ead3b0b4b966473c0b148267e7dc68dba8af9734dfdfe3e0ad05dL153-R164)

* [`packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts`](diffhunk://#diff-1b519a55a14b36c361c0683bcfa674fe8b8bfa190d7739ac78bb71ccad7af10cL150-R150): Fixed the stack trace formatting issue by correcting the condition to show collapsed frames.

### Documentation Updates:

* [`packages/@expo/cli/CHANGELOG.md`](diffhunk://#diff-dced9f7f9eaad1257a4d1786ee6facb5010790cec922eb8662e33a83923c7f7dR11-R12): Added an entry to ensure the fast resolver is enabled when React Canary is enabled.

* [`packages/@expo/cli/CHANGELOG.md`](diffhunk://#diff-dced9f7f9eaad1257a4d1786ee6facb5010790cec922eb8662e33a83923c7f7dL28-R30): Corrected the formatting of the changelog entry for the helpful recommendation added to the "Xcode not installed" error message.