### PR TITLE
Update create-a-modal.mdx

### DIFF
--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -730,7 +730,7 @@ type Props = {
 
 export default function EmojiSticker({ imageSize, stickerSource }: Props) {
   return (
-    <View style={{ top: -350 }}>
+    <View>
       <Image source={stickerSource} style={{ width: imageSize, height: imageSize }} />
     </View>
   );
@@ -806,10 +806,14 @@ export default function Index() {
     <View style={styles.container}>
       <View style={styles.imageContainer}>
         <ImageViewer imgSource={PlaceholderImage} selectedImage={selectedImage} />
-        /* @tutinfo Add this line to display the emoji sticker on the image. */
-        {pickedEmoji && <EmojiSticker imageSize={40} stickerSource={pickedEmoji} />}
-        /* @end */
       </View>
+        /* @tutinfo Display emoji sticker on image if selected. */
+        {pickedEmoji && (
+        <View style={styles.stickerContainer}>
+          <EmojiSticker imageSize={40} stickerSource={pickedEmoji} />
+        </View>
+        )}
+        /* @end */
       {showAppOptions ? (
         <View style={styles.optionsContainer}>
           <View style={styles.optionsRow}>
@@ -840,6 +844,17 @@ const styles = StyleSheet.create({
   imageContainer: {
     flex: 1,
   },
+ /* @tutinfo Add styles for the new <CODE>View</CODE> components. */
+  stickerContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+/* @end */
   footerContainer: {
     flex: 1 / 3,
     alignItems: 'center',


### PR DESCRIPTION
I fixed the issue with emojis not appearing after selection by making the following changes:

Modified index.tsx to:

Create a dedicated container for stickers with absolute positioning Move EmojiSticker out of ImageViewer
Ensure the sticker appears centered over the image Updated EmojiSticker.tsx to:

Remove fixed positioning (top: -350)
Leave only image size control
Positioning is now controlled by the parent container Now when you select an emoji in the picker, it should appear correctly centered over the image.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
