### PR TITLE
[updates] no embedded asset copying on android

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [Android] Added `EX_UPDATES_COPY_EMBEDDED_ASSETS` flag which is false by default, to not copy embedded assets. ([#36059](https://github.com/expo/expo/pull/36059) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -72,6 +72,9 @@ def exUpdatesCustomInit = getBoolStringFromPropOrEnv("EX_UPDATES_CUSTOM_INIT", f
 // (default true)
 def exUpdatesAndroidDelayLoadApp = getBoolStringFromPropOrEnv("EX_UPDATES_ANDROID_DELAY_LOAD_APP", true)
 
+// If true, updates will copy embedded assets to file system when startup. (default false)
+def exUpdatesCopyEmbeddedAssets = getBoolStringFromPropOrEnv("EX_UPDATES_COPY_EMBEDDED_ASSETS", false)
+
 def useDevClient = findProject(":expo-dev-client") != null
 
 android {
@@ -89,6 +92,7 @@ android {
     buildConfigField("boolean", "EX_UPDATES_NATIVE_DEBUG", exUpdatesNativeDebug)
     buildConfigField("boolean", "EX_UPDATES_CUSTOM_INIT", exUpdatesCustomInit)
     buildConfigField("boolean", "EX_UPDATES_ANDROID_DELAY_LOAD_APP", exUpdatesAndroidDelayLoadApp)
+    buildConfigField("boolean", "EX_UPDATES_COPY_EMBEDDED_ASSETS", exUpdatesCopyEmbeddedAssets)
     buildConfigField("boolean", "USE_DEV_CLIENT", useDevClient.toString())
   }
   testOptions {

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -140,16 +140,17 @@ dependencies {
   implementation("org.bouncycastle:bcutil-jdk15to18:1.78.1")
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test:core:1.5.0'
+  testImplementation 'androidx.test:core:1.6.1'
+  testImplementation 'com.google.truth:truth:1.1.2'
   testImplementation "io.mockk:mockk:$mockk_version"
   testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${kotlinVersion}"
   testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
   testImplementation 'org.robolectric:robolectric:4.14.1'
 
   androidTestImplementation 'com.squareup.okio:okio:2.9.0'
-  androidTestImplementation 'androidx.test:runner:1.5.2'
-  androidTestImplementation 'androidx.test:core:1.5.0'
-  androidTestImplementation 'androidx.test:rules:1.5.0'
+  androidTestImplementation 'androidx.test:runner:1.6.2'
+  androidTestImplementation 'androidx.test:core:1.6.1'
+  androidTestImplementation 'androidx.test:rules:1.6.1'
   androidTestImplementation "io.mockk:mockk-android:$mockk_version"
   androidTestImplementation "androidx.room:room-testing:$room_version"
   androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
@@ -166,8 +166,8 @@ class EmbeddedLoaderTest {
   @Throws(IOException::class, NoSuchAlgorithmException::class)
   fun testEmbeddedLoaderWithCopyAssets_AssetExists_BothDbAndDisk() {
     // return true when asked if file 54da1e9816c77e30ebc5920e256736f2 exists
-    every { mockLoaderFiles.fileExists(any()) } answers {
-      firstArg<File>().toString().contains("54da1e9816c77e30ebc5920e256736f2")
+    every { mockLoaderFiles.fileExists(any(), any(), any()) } answers {
+      thirdArg<String>().contains("54da1e9816c77e30ebc5920e256736f2")
     }
 
     val existingAsset = AssetEntity("54da1e9816c77e30ebc5920e256736f2", "png")
@@ -194,7 +194,7 @@ class EmbeddedLoaderTest {
   @Throws(IOException::class, NoSuchAlgorithmException::class)
   fun testEmbeddedLoaderWithCopyAssets_AssetExists_DbOnly() {
     // return true when asked if file 54da1e9816c77e30ebc5920e256736f2 exists
-    every { mockLoaderFiles.fileExists(any()) } returns false
+    every { mockLoaderFiles.fileExists(any(), any(), any()) } returns false
 
     val existingAsset = AssetEntity("54da1e9816c77e30ebc5920e256736f2", "png")
     existingAsset.relativePath = "54da1e9816c77e30ebc5920e256736f2.png"
@@ -222,8 +222,8 @@ class EmbeddedLoaderTest {
   @Throws(IOException::class, NoSuchAlgorithmException::class)
   fun testEmbeddedLoaderWithCopyAssets_AssetExists_DiskOnly() {
     // return true when asked if file 54da1e9816c77e30ebc5920e256736f2 exists
-    every { mockLoaderFiles.fileExists(any()) } answers {
-      firstArg<File>().toString().contains("54da1e9816c77e30ebc5920e256736f2")
+    every { mockLoaderFiles.fileExists(any(), any(), any()) } answers {
+      thirdArg<String>().contains("54da1e9816c77e30ebc5920e256736f2")
     }
 
     Assert.assertEquals(0, db.assetDao().loadAllAssets().size.toLong())

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
@@ -127,8 +127,8 @@ class RemoteLoaderTest {
   @Test
   fun testRemoteLoader_AssetExists_BothDbAndDisk() {
     // return true when asked if file 54da1e9816c77e30ebc5920e256736f2 exists on disk
-    every { mockLoaderFiles.fileExists(any()) } answers {
-      firstArg<File>().toString().contains("489ea2f19fa850b65653ab445637a181")
+    every { mockLoaderFiles.fileExists(any(), any(), any()) } answers {
+      thirdArg<String>().contains("489ea2f19fa850b65653ab445637a181")
     }
 
     val existingAsset = AssetEntity("489ea2f19fa850b65653ab445637a181.jpg", ".jpg")
@@ -155,7 +155,7 @@ class RemoteLoaderTest {
   @Test
   fun testRemoteLoader_AssetExists_DbOnly() {
     // return false when asked if file 489ea2f19fa850b65653ab445637a181 exists on disk
-    every { mockLoaderFiles.fileExists(any()) } returns false
+    every { mockLoaderFiles.fileExists(any(), any(), any()) } returns false
 
     val existingAsset = AssetEntity("489ea2f19fa850b65653ab445637a181.jpg", ".jpg")
     existingAsset.relativePath = "489ea2f19fa850b65653ab445637a181.jpg"

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -19,7 +19,6 @@ import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.regex.Pattern
-import kotlin.experimental.and
 
 /**
  * Miscellaneous helper functions that are used by multiple classes in the library.
@@ -28,8 +27,6 @@ object UpdatesUtils {
   private val TAG = UpdatesUtils::class.java.simpleName
 
   private const val UPDATES_DIRECTORY_NAME = ".expo-internal"
-  private const val ANDROID_EMBEDDED_URL_BASE_ASSET = "file:///android_asset/"
-  private const val ANDROID_EMBEDDED_URL_BASE_RESOURCE = "file:///android_res/"
 
   @Throws(Exception::class)
   fun getMapFromJSONString(stringifiedJSON: String): Map<String, String> {
@@ -151,44 +148,12 @@ object UpdatesUtils {
    * Create an asset filename in file system (files are used to save in `.expo-internal` directory)
    */
   fun createFilenameForAsset(asset: AssetEntity): String {
-    val fileExtension = getFileExtension(asset)
+    val fileExtension = asset.getFileExtension()
     return if (asset.key == null) {
       // create a filename that's unlikely to collide with any other asset
       "asset-" + Date().time + "-" + Random().nextInt() + fileExtension
     } else {
       asset.key + fileExtension
-    }
-  }
-
-  /**
-   * Create an embedded asset filename in `file:///android_res/` or `file:///android_asset/` format
-   */
-  fun createEmbeddedFilenameForAsset(asset: AssetEntity): String? {
-    val fileExtension = getFileExtension(asset)
-    if (asset.embeddedAssetFilename != null) {
-      return "${ANDROID_EMBEDDED_URL_BASE_ASSET}${asset.embeddedAssetFilename}$fileExtension"
-    }
-    if (asset.resourcesFolder != null && asset.resourcesFilename != null) {
-      return "${ANDROID_EMBEDDED_URL_BASE_RESOURCE}${asset.resourcesFolder}${getDrawableSuffix(asset.scale)}/${asset.resourcesFilename}$fileExtension"
-    }
-    return null
-  }
-
-  private fun getFileExtension(asset: AssetEntity): String {
-    return asset.type?.let {
-      if (it.startsWith(".")) it else ".$it"
-    } ?: ""
-  }
-
-  private fun getDrawableSuffix(scale: Float?): String {
-    return when (scale) {
-      0.75f -> "-ldpi"
-      1f -> "-mdpi"
-      1.5f -> "-hdpi"
-      2f -> "-xhdpi"
-      3f -> "-xxhdpi"
-      4f -> "-xxxhdpi"
-      else -> ""
     }
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -145,7 +145,7 @@ object UpdatesUtils {
   }
 
   /**
-   * Create an asset filename in file system (files are used to save in `.expo-internal` directory)
+   * Create an asset filename in file system (files are saved in the `.expo-internal` directory)
    */
   fun createFilenameForAsset(asset: AssetEntity): String {
     val fileExtension = asset.getFileExtension()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.kt
@@ -74,7 +74,7 @@ class AssetEntity(@field:ColumnInfo(name = "key") var key: String?, var type: St
     return if (type.startsWith(".")) {
       type
     } else {
-      ".$it"
+      ".$type"
     }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.kt
@@ -68,4 +68,10 @@ class AssetEntity(@field:ColumnInfo(name = "key") var key: String?, var type: St
 
   @Ignore
   var scales: Array<Float>? = null
+
+  internal fun getFileExtension(): String {
+    return this.type?.let {
+      if (it.startsWith(".")) it else ".$it"
+    } ?: ""
+  }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/AssetEntity.kt
@@ -70,8 +70,11 @@ class AssetEntity(@field:ColumnInfo(name = "key") var key: String?, var type: St
   var scales: Array<Float>? = null
 
   internal fun getFileExtension(): String {
-    return this.type?.let {
-      if (it.startsWith(".")) it else ".$it"
-    } ?: ""
+    val type = this.type ?: return ""
+    return if (type.startsWith(".")) {
+      type
+    } else {
+      ".$it"
+    }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -20,6 +20,7 @@ import expo.modules.updates.manifest.EmbeddedManifestUtils
 import expo.modules.updates.manifest.EmbeddedUpdate
 import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.selectionpolicy.SelectionPolicy
+import expo.modules.updates.utils.AndroidResourceAssetUtils
 import org.json.JSONObject
 import java.io.File
 
@@ -117,7 +118,6 @@ class DatabaseLauncher(
     }
 
     val assetEntities = database.assetDao().loadAssetsForUpdate(launchedUpdate!!.id)
-    val isEmbeddedLaunch = embeddedUpdate != null && launchedUpdate?.id?.equals(embeddedUpdate.updateEntity.id) ?: false
 
     localAssetFiles = embeddedAssetFileMap().apply {
       for (asset in assetEntities) {
@@ -126,7 +126,7 @@ class DatabaseLauncher(
           continue
         }
         val filename = asset.relativePath ?: continue
-        if (!isEmbeddedLaunch || shouldCopyEmbeddedAssets) {
+        if (!AndroidResourceAssetUtils.isAndroidResourceAsset(filename)) {
           val assetFile = ensureAssetExists(asset, database, embeddedUpdate, extraHeaders)
           if (assetFile != null) {
             this[asset] = Uri.fromFile(assetFile).toString()
@@ -177,7 +177,7 @@ class DatabaseLauncher(
         }
 
         if (!shouldCopyEmbeddedAssets) {
-          val filename = UpdatesUtils.createEmbeddedFilenameForAsset(asset)
+          val filename = AndroidResourceAssetUtils.createEmbeddedFilenameForAsset(asset)
           if (filename != null) {
             asset.relativePath = filename
             this[asset] = filename

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
@@ -10,6 +10,7 @@ import expo.modules.updates.loader.FileDownloader.RemoteUpdateDownloadCallback
 import expo.modules.updates.UpdatesUtils
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.logging.UpdatesLogger
+import expo.modules.updates.utils.AndroidResourceAssetUtils
 import java.io.File
 import java.io.FileNotFoundException
 import java.lang.AssertionError
@@ -80,7 +81,7 @@ class EmbeddedLoader internal constructor(
   ) {
     if (!shouldCopyEmbeddedAssets) {
       assetEntity.downloadTime = Date()
-      assetEntity.relativePath = UpdatesUtils.createEmbeddedFilenameForAsset(assetEntity)
+      assetEntity.relativePath = AndroidResourceAssetUtils.createEmbeddedFilenameForAsset(assetEntity)
       // Passing `isNew=true` aka `AssetLoadResult.FINISHED` to the callback,
       // because we assume embedded asset is always existed without filesystem out of sync.
       callback.onSuccess(assetEntity, true)
@@ -90,7 +91,7 @@ class EmbeddedLoader internal constructor(
     val filename = UpdatesUtils.createFilenameForAsset(assetEntity)
     val destination = File(updatesDirectory, filename)
 
-    if (loaderFiles.fileExists(destination)) {
+    if (loaderFiles.fileExists(context, updatesDirectory, filename)) {
       assetEntity.relativePath = filename
       callback.onSuccess(assetEntity, false)
     } else {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -233,12 +233,8 @@ abstract class Loader protected constructor(
       }
 
       // if we already have a local copy of this asset, don't try to download it again!
-      if (assetEntity.relativePath != null && loaderFiles.fileExists(
-          File(
-            updatesDirectory,
-            assetEntity.relativePath
-          )
-        )
+      if (assetEntity.relativePath != null &&
+        loaderFiles.fileExists(context, updatesDirectory, assetEntity.relativePath)
       ) {
         handleAssetDownloadCompleted(assetEntity, AssetLoadResult.ALREADY_EXISTS)
         continue

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderFiles.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderFiles.kt
@@ -8,6 +8,7 @@ import expo.modules.updates.UpdatesUtils
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.manifest.EmbeddedManifestUtils
 import expo.modules.updates.manifest.Update
+import expo.modules.updates.utils.AndroidResourceAssetUtils
 import java.io.File
 import java.io.IOException
 import java.security.NoSuchAlgorithmException
@@ -16,8 +17,12 @@ import java.security.NoSuchAlgorithmException
  * Utility class for Loader and its subclasses, to allow for easy mocking
  */
 open class LoaderFiles {
-  fun fileExists(destination: File): Boolean {
-    return destination.exists()
+  fun fileExists(context: Context, updateDirectory: File?, relativePath: String?): Boolean {
+    val filePath = relativePath ?: return false
+    if (AndroidResourceAssetUtils.isAndroidAssetOrResourceExisted(context, filePath)) {
+      return true
+    }
+    return File(updateDirectory, filePath).exists()
   }
 
   fun readEmbeddedUpdate(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/utils/AndroidResourceAssetUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/utils/AndroidResourceAssetUtils.kt
@@ -66,17 +66,27 @@ internal object AndroidResourceAssetUtils {
   fun isAndroidAssetOrResourceExisted(context: Context, filePath: String): Boolean {
     val (embeddedAssetFilename, resourceFolder, resourceFilename) = parseAndroidResponseAssetFromPath(filePath)
     return when {
-        embeddedAssetFilename != null -> isAndroidAssetExisted(context, embeddedAssetFilename)
-        resourceFolder != null && resourceFilename != null -> isAndroidResourceExisted(context, resourceFolder, resourceFilename)
-        else -> {
-            false
-        }
+      embeddedAssetFilename != null -> isAndroidAssetExisted(context, embeddedAssetFilename)
+      resourceFolder != null && resourceFilename != null -> isAndroidResourceExisted(context, resourceFolder, resourceFilename)
+      else -> {
+        false
+      }
+    }
   }
 
   /**
-   * Parse a file path to return as Triple<embeddedAssetFilename, resourcesFolder, resourcesFilename>
+   * Data structure for Android embedded asset and resource
    */
-  fun parseAndroidResponseAssetFromPath(filePath: String): Triple<String?, String?, String?> {
+  data class AndroidResourceAsset(
+    val embeddedAssetFilename: String?,
+    val resourcesFolder: String?,
+    val resourceFilename: String?
+  )
+
+  /**
+   * Parse a file path and return as `AndroidResourceAsset`
+   */
+  fun parseAndroidResponseAssetFromPath(filePath: String): AndroidResourceAsset {
     if (filePath.startsWith(ANDROID_EMBEDDED_URL_BASE_RESOURCE)) {
       val uri = filePath.toUri()
       val pathSegments = uri.pathSegments
@@ -87,13 +97,13 @@ internal object AndroidResourceAssetUtils {
       val resourcesFolder = pathSegments[1].substringBefore('-')
       // Strip file extension for resource name
       val resourceFilename = pathSegments[2].substringBeforeLast('.', pathSegments[2])
-      return Triple(null, resourcesFolder, resourceFilename)
+      return AndroidResourceAsset(null, resourcesFolder, resourceFilename)
     }
     if (filePath.startsWith(ANDROID_EMBEDDED_URL_BASE_ASSET)) {
       val embeddedAssetFilename = filePath.substringAfterLast('/')
-      return Triple(embeddedAssetFilename, null, null)
+      return AndroidResourceAsset(embeddedAssetFilename, null, null)
     }
-    return Triple(null, null, null)
+    return AndroidResourceAsset(null, null, null)
   }
 
   private fun getDrawableSuffix(scale: Float?): String {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/utils/AndroidResourceAssetUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/utils/AndroidResourceAssetUtils.kt
@@ -41,13 +41,11 @@ internal object AndroidResourceAssetUtils {
   /**
    * Check a given file name is existed in Android embedded assets
    */
-  fun isAndroidAssetExisted(context: Context, name: String): Boolean {
-    return try {
-      context.assets.open(name).close()
-      true
-    } catch (e: IOException) {
-      false
-    }
+  fun isAndroidAssetExisted(context: Context, name: String) = try {
+    context.assets.open(name).close()
+    true
+  } catch (e: IOException) {
+    false
   }
 
   /**
@@ -63,17 +61,16 @@ internal object AndroidResourceAssetUtils {
   }
 
   /**
-   * Check if given filePath matches and is existed in Android embedded assets or resources
+   * Check if given filePath matches and exists in the Android embedded assets or resources
    */
   fun isAndroidAssetOrResourceExisted(context: Context, filePath: String): Boolean {
     val (embeddedAssetFilename, resourceFolder, resourceFilename) = parseAndroidResponseAssetFromPath(filePath)
-    if (embeddedAssetFilename != null) {
-      return isAndroidAssetExisted(context, embeddedAssetFilename)
-    }
-    if (resourceFolder != null && resourceFilename != null) {
-      return isAndroidResourceExisted(context, resourceFolder, resourceFilename)
-    }
-    return false
+    return when {
+        embeddedAssetFilename != null -> isAndroidAssetExisted(context, embeddedAssetFilename)
+        resourceFolder != null && resourceFilename != null -> isAndroidResourceExisted(context, resourceFolder, resourceFilename)
+        else -> {
+            false
+        }
   }
 
   /**

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/utils/AndroidResourceAssetUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/utils/AndroidResourceAssetUtils.kt
@@ -1,0 +1,113 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+package expo.modules.updates.utils
+
+import android.annotation.SuppressLint
+import android.content.Context
+import androidx.core.net.toUri
+import expo.modules.core.errors.InvalidArgumentException
+import expo.modules.updates.db.entity.AssetEntity
+import java.io.IOException
+
+/**
+ * Helpers for Android embedded assets and resources
+ */
+internal object AndroidResourceAssetUtils {
+  private const val ANDROID_EMBEDDED_URL_BASE_ASSET = "file:///android_asset/"
+  private const val ANDROID_EMBEDDED_URL_BASE_RESOURCE = "file:///android_res/"
+
+  /**
+   * Create an embedded asset filename in `file:///android_res/` or `file:///android_asset/` format
+   */
+  fun createEmbeddedFilenameForAsset(asset: AssetEntity): String? {
+    val fileExtension = asset.getFileExtension()
+    if (asset.embeddedAssetFilename != null) {
+      return "${ANDROID_EMBEDDED_URL_BASE_ASSET}${asset.embeddedAssetFilename}$fileExtension"
+    }
+    if (asset.resourcesFolder != null && asset.resourcesFilename != null) {
+      return "${ANDROID_EMBEDDED_URL_BASE_RESOURCE}${asset.resourcesFolder}${getDrawableSuffix(asset.scale)}/${asset.resourcesFilename}$fileExtension"
+    }
+    return null
+  }
+
+  /**
+   * Return whether the filePath is an Android asset or resource
+   */
+  fun isAndroidResourceAsset(filePath: String): Boolean {
+    return filePath.startsWith(ANDROID_EMBEDDED_URL_BASE_RESOURCE) ||
+      filePath.startsWith(ANDROID_EMBEDDED_URL_BASE_ASSET)
+  }
+
+  /**
+   * Check a given file name is existed in Android embedded assets
+   */
+  fun isAndroidAssetExisted(context: Context, name: String): Boolean {
+    return try {
+      context.assets.open(name).close()
+      true
+    } catch (e: IOException) {
+      false
+    }
+  }
+
+  /**
+   * Check a given resource folder and filename is existed in Android embedded resources
+   */
+  @SuppressLint("DiscouragedApi")
+  fun isAndroidResourceExisted(context: Context, resourceFolder: String, resourceFilename: String): Boolean {
+    return context.resources.getIdentifier(
+      resourceFilename,
+      resourceFolder,
+      context.packageName
+    ) != 0
+  }
+
+  /**
+   * Check if given filePath matches and is existed in Android embedded assets or resources
+   */
+  fun isAndroidAssetOrResourceExisted(context: Context, filePath: String): Boolean {
+    val (embeddedAssetFilename, resourceFolder, resourceFilename) = parseAndroidResponseAssetFromPath(filePath)
+    if (embeddedAssetFilename != null) {
+      return isAndroidAssetExisted(context, embeddedAssetFilename)
+    }
+    if (resourceFolder != null && resourceFilename != null) {
+      return isAndroidResourceExisted(context, resourceFolder, resourceFilename)
+    }
+    return false
+  }
+
+  /**
+   * Parse a file path to return as Triple<embeddedAssetFilename, resourcesFolder, resourcesFilename>
+   */
+  fun parseAndroidResponseAssetFromPath(filePath: String): Triple<String?, String?, String?> {
+    if (filePath.startsWith(ANDROID_EMBEDDED_URL_BASE_RESOURCE)) {
+      val uri = filePath.toUri()
+      val pathSegments = uri.pathSegments
+      if (pathSegments.size < 3) {
+        throw InvalidArgumentException("Invalid resource file path: $filePath")
+      }
+      // Strip any qualifiers after a dash, for example "drawable-xhdpi" becomes "drawable"
+      val resourcesFolder = pathSegments[1].substringBefore('-')
+      // Strip file extension for resource name
+      val resourceFilename = pathSegments[2].substringBeforeLast('.', pathSegments[2])
+      return Triple(null, resourcesFolder, resourceFilename)
+    }
+    if (filePath.startsWith(ANDROID_EMBEDDED_URL_BASE_ASSET)) {
+      val embeddedAssetFilename = filePath.substringAfterLast('/')
+      return Triple(embeddedAssetFilename, null, null)
+    }
+    return Triple(null, null, null)
+  }
+
+  private fun getDrawableSuffix(scale: Float?): String {
+    return when (scale) {
+      0.75f -> "-ldpi"
+      1f -> "-mdpi"
+      1.5f -> "-hdpi"
+      2f -> "-xhdpi"
+      3f -> "-xxhdpi"
+      4f -> "-xxxhdpi"
+      else -> ""
+    }
+  }
+}

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
@@ -34,6 +34,42 @@ class UpdatesUtilsTest : TestCase() {
     Assert.assertEquals(asset1Name.substring(asset1Name.length - 7), ".bundle")
   }
 
+  fun testCreateEmbeddedFilenameForAsset_WithEmbeddedAsset() {
+    val assetEntity = AssetEntity("key", null)
+    assetEntity.embeddedAssetFilename = "index.android.bundle"
+    Assert.assertEquals(
+      "file:///android_asset/index.android.bundle",
+      UpdatesUtils.createEmbeddedFilenameForAsset(assetEntity)
+    )
+  }
+
+  fun testCreateEmbeddedFilenameForAsset_WithDrawableResource() {
+    val assetEntity = AssetEntity("key", "png")
+    assetEntity.resourcesFolder = "drawable"
+    assetEntity.resourcesFilename = "test"
+    assetEntity.scales = arrayOf(1.0f, 2.0f)
+    assetEntity.scale = 2.0f
+    Assert.assertEquals(
+      "file:///android_res/drawable-xhdpi/test.png",
+      UpdatesUtils.createEmbeddedFilenameForAsset(assetEntity)
+    )
+  }
+
+  fun testCreateEmbeddedFilenameForAsset_WithRawResource() {
+    val assetEntity = AssetEntity("key", "ttf")
+    assetEntity.resourcesFolder = "raw"
+    assetEntity.resourcesFilename = "test"
+    Assert.assertEquals(
+      "file:///android_res/raw/test.ttf",
+      UpdatesUtils.createEmbeddedFilenameForAsset(assetEntity)
+    )
+  }
+
+  fun testCreateEmbeddedFilenameForAsset_WithoutEmbedded() {
+    val assetEntity = AssetEntity("key", null)
+    Assert.assertNull(UpdatesUtils.createEmbeddedFilenameForAsset(assetEntity))
+  }
+
   fun testGetRuntimeVersion() {
     val baseConfig = UpdatesConfiguration(
       scopeKey = "wat",

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
@@ -34,42 +34,6 @@ class UpdatesUtilsTest : TestCase() {
     Assert.assertEquals(asset1Name.substring(asset1Name.length - 7), ".bundle")
   }
 
-  fun testCreateEmbeddedFilenameForAsset_WithEmbeddedAsset() {
-    val assetEntity = AssetEntity("key", null)
-    assetEntity.embeddedAssetFilename = "index.android.bundle"
-    Assert.assertEquals(
-      "file:///android_asset/index.android.bundle",
-      UpdatesUtils.createEmbeddedFilenameForAsset(assetEntity)
-    )
-  }
-
-  fun testCreateEmbeddedFilenameForAsset_WithDrawableResource() {
-    val assetEntity = AssetEntity("key", "png")
-    assetEntity.resourcesFolder = "drawable"
-    assetEntity.resourcesFilename = "test"
-    assetEntity.scales = arrayOf(1.0f, 2.0f)
-    assetEntity.scale = 2.0f
-    Assert.assertEquals(
-      "file:///android_res/drawable-xhdpi/test.png",
-      UpdatesUtils.createEmbeddedFilenameForAsset(assetEntity)
-    )
-  }
-
-  fun testCreateEmbeddedFilenameForAsset_WithRawResource() {
-    val assetEntity = AssetEntity("key", "ttf")
-    assetEntity.resourcesFolder = "raw"
-    assetEntity.resourcesFilename = "test"
-    Assert.assertEquals(
-      "file:///android_res/raw/test.ttf",
-      UpdatesUtils.createEmbeddedFilenameForAsset(assetEntity)
-    )
-  }
-
-  fun testCreateEmbeddedFilenameForAsset_WithoutEmbedded() {
-    val assetEntity = AssetEntity("key", null)
-    Assert.assertNull(UpdatesUtils.createEmbeddedFilenameForAsset(assetEntity))
-  }
-
   fun testGetRuntimeVersion() {
     val baseConfig = UpdatesConfiguration(
       scopeKey = "wat",

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/utils/AndroidResourceAssetUtilsTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/utils/AndroidResourceAssetUtilsTest.kt
@@ -1,0 +1,189 @@
+package expo.modules.updates.utils
+
+import android.content.Context
+import android.content.res.AssetManager
+import android.content.res.Resources
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth
+import expo.modules.core.errors.InvalidArgumentException
+import expo.modules.updates.db.entity.AssetEntity
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.ByteArrayInputStream
+
+@RunWith(RobolectricTestRunner::class)
+class AndroidResourceAssetUtilsTest {
+  private val context: Context = ApplicationProvider.getApplicationContext()
+
+  @Test
+  fun `createEmbeddedFilenameForAsset should return asset URL when embeddedAssetFilename is provided`() {
+    val asset = AssetEntity("key", null)
+    asset.embeddedAssetFilename = "index.android.bundle"
+    val result = AndroidResourceAssetUtils.createEmbeddedFilenameForAsset(asset)
+    Truth.assertThat(result).isEqualTo("file:///android_asset/index.android.bundle")
+  }
+
+  @Test
+  fun `createEmbeddedFilenameForAsset should return resource URL for drawable asset`() {
+    val asset = AssetEntity("key", "png")
+    asset.resourcesFolder = "drawable"
+    asset.resourcesFilename = "test"
+    asset.scales = arrayOf(1.0f, 2.0f)
+    asset.scale = 2.0f
+    val result = AndroidResourceAssetUtils.createEmbeddedFilenameForAsset(asset)
+    Truth.assertThat(result).isEqualTo("file:///android_res/drawable-xhdpi/test.png")
+  }
+
+  @Test
+  fun `createEmbeddedFilenameForAsset should return resource URL for raw asset`() {
+    val asset = AssetEntity("key", "ttf")
+    asset.resourcesFolder = "raw"
+    asset.resourcesFilename = "test"
+    val result = AndroidResourceAssetUtils.createEmbeddedFilenameForAsset(asset)
+    Truth.assertThat(result).isEqualTo("file:///android_res/raw/test.ttf")
+  }
+
+  @Test
+  fun `createEmbeddedFilenameForAsset should return null when neither asset nor resource details are provided`() {
+    val asset = AssetEntity("key", "ttf")
+    val result = AndroidResourceAssetUtils.createEmbeddedFilenameForAsset(asset)
+    Truth.assertThat(result).isNull()
+  }
+
+  @Test
+  fun `isAndroidResourceAsset should return true for android resource and asset URLs and false otherwise`() {
+    val resourcePath = "file:///android_res/some/path"
+    val assetPath = "file:///android_asset/someAsset"
+    val nonResourcePath = "file:///some_other_path"
+
+    Truth.assertThat(AndroidResourceAssetUtils.isAndroidResourceAsset(resourcePath)).isTrue()
+    Truth.assertThat(AndroidResourceAssetUtils.isAndroidResourceAsset(assetPath)).isTrue()
+    Truth.assertThat(AndroidResourceAssetUtils.isAndroidResourceAsset(nonResourcePath)).isFalse()
+  }
+
+  @Test
+  fun `isAndroidAssetExisted should return true when asset exists`() {
+    val assetName = "dummy_asset.txt"
+    val mockContext = mockk<Context>()
+    val mockAssetManager = mockk<AssetManager>()
+    every { mockContext.assets } returns mockAssetManager
+    every { mockAssetManager.open(assetName) } returns ByteArrayInputStream("dummy".toByteArray())
+
+    val result = AndroidResourceAssetUtils.isAndroidAssetExisted(mockContext, assetName)
+    Truth.assertThat(result).isTrue()
+  }
+
+  @Test
+  fun `isAndroidAssetExisted should return false when asset does not exist`() {
+    val assetName = "existing_asset.txt"
+    Truth.assertThat(AndroidResourceAssetUtils.isAndroidAssetExisted(context, assetName)).isFalse()
+  }
+
+  @Test
+  fun `isAndroidResourceExisted should return true for existing resource`() {
+    val mockContext = mockk<Context>()
+    val mockResources = mockk<Resources>()
+    every { mockContext.resources } returns mockResources
+    every { mockContext.packageName } returns "com.example.package"
+    every { mockResources.getIdentifier(any(), any(), any()) } returns 123
+
+    val result = AndroidResourceAssetUtils.isAndroidResourceExisted(
+      mockContext,
+      "drawable",
+      "dummy_resource"
+    )
+    Truth.assertThat(result).isTrue()
+  }
+
+  @Test
+  fun `isAndroidResourceExisted should return false for non-existent resource`() {
+    val exists = AndroidResourceAssetUtils.isAndroidResourceExisted(
+      context,
+      "drawable",
+      "non_existent_resource"
+    )
+    Truth.assertThat(exists).isFalse()
+  }
+
+  @Test
+  fun `isAndroidAssetOrResourceExisted should return true for existing asset file path`() {
+    val assetName = "dummy_asset.txt"
+    val mockContext = mockk<Context>()
+    val mockAssetManager = mockk<AssetManager>()
+    every { mockContext.assets } returns mockAssetManager
+    every { mockAssetManager.open(assetName) } returns ByteArrayInputStream("dummy".toByteArray())
+
+    val filePath = "file:///android_asset/dummy_asset.txt"
+    val result = AndroidResourceAssetUtils.isAndroidAssetOrResourceExisted(mockContext, filePath)
+    Truth.assertThat(result).isTrue()
+  }
+
+  @Test
+  fun `isAndroidAssetOrResourceExisted should return true for existing resource file path`() {
+    val mockContext = mockk<Context>()
+    val mockResources = mockk<Resources>()
+    every { mockContext.resources } returns mockResources
+    every { mockContext.packageName } returns "com.example.package"
+    every { mockResources.getIdentifier(any(), any(), any()) } returns 123
+
+    val filePath = "file:///android_res/drawable/dummy_resource.png"
+    val result = AndroidResourceAssetUtils.isAndroidAssetOrResourceExisted(mockContext, filePath)
+    Truth.assertThat(result).isTrue()
+  }
+
+  @Test
+  fun `isAndroidAssetOrResourceExisted should return false for unrecognized file path`() {
+    val filePath = "file:///some_other_path/something"
+    val result = AndroidResourceAssetUtils.isAndroidAssetOrResourceExisted(context, filePath)
+    Truth.assertThat(result).isFalse()
+  }
+
+  @Test
+  fun `parseAndroidResponseAssetFromPath should correctly parse a valid resource URL`() {
+    val filePath = "file:///android_res/drawable-xhdpi/ic_launcher.png"
+    val (embeddedAssetFilename, resourcesFolder, resourceFilename) =
+      AndroidResourceAssetUtils.parseAndroidResponseAssetFromPath(filePath)
+    Truth.assertThat(embeddedAssetFilename).isNull()
+    Truth.assertThat(resourcesFolder).isEqualTo("drawable")
+    Truth.assertThat(resourceFilename).isEqualTo("ic_launcher")
+  }
+
+  @Test(expected = InvalidArgumentException::class)
+  fun `parseAndroidResponseAssetFromPath should throw InvalidArgumentException for invalid resource path`() {
+    val filePath = "file:///android_res/drawable"
+    AndroidResourceAssetUtils.parseAndroidResponseAssetFromPath(filePath)
+  }
+
+  @Test
+  fun `parseAndroidResponseAssetFromPath should correctly parse a valid asset URL`() {
+    val filePath = "file:///android_asset/testAsset.png"
+    val (embeddedAssetFilename, resourcesFolder, resourceFilename) =
+      AndroidResourceAssetUtils.parseAndroidResponseAssetFromPath(filePath)
+    Truth.assertThat(embeddedAssetFilename).isEqualTo("testAsset.png")
+    Truth.assertThat(resourcesFolder).isNull()
+    Truth.assertThat(resourceFilename).isNull()
+  }
+
+  @Test
+  fun `parseAndroidResponseAssetFromPath should return nulls for classic file path`() {
+    val filePath = "file:///data/test.txt"
+    val (embeddedAssetFilename, resourcesFolder, resourceFilename) =
+      AndroidResourceAssetUtils.parseAndroidResponseAssetFromPath(filePath)
+    Truth.assertThat(embeddedAssetFilename).isNull()
+    Truth.assertThat(resourcesFolder).isNull()
+    Truth.assertThat(resourceFilename).isNull()
+  }
+
+  @Test
+  fun `parseAndroidResponseAssetFromPath should return nulls for relative file path`() {
+    val filePath = "./test.txt"
+    val (embeddedAssetFilename, resourcesFolder, resourceFilename) =
+      AndroidResourceAssetUtils.parseAndroidResponseAssetFromPath(filePath)
+    Truth.assertThat(embeddedAssetFilename).isNull()
+    Truth.assertThat(resourcesFolder).isNull()
+    Truth.assertThat(resourceFilename).isNull()
+  }
+}

--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -1032,10 +1032,7 @@ describe('Asset deletion recovery tests', () => {
     // With asset exclusion, on Android, the number of assets found may be greater than the number in the manifest,
     // as the total will include embedded assets that were copied.
     numAssets = await checkNumAssetsAsync();
-    let expectedNumAssets = 2;
-    if (shouldCopyEmbeddedAssets) {
-      expectedNumAssets += manifest.assets.length;
-    }
+    const expectedNumAssets = shouldCopyEmbeddedAssets ? manifest.assets.length + 1 : 2;
     if (platform === 'ios') {
       jestExpect(numAssets).toBe(expectedNumAssets);
     } else {


### PR DESCRIPTION
# Why

introducing a way to no copy embedded assets on android. embedded assets copying (with sha256 checksum) is slow and introduces anr in the past. whenever people have newer native build or newer runtime version, we will do embedded asset copy. that's is not ideal.
close ENG-15402

# How

- added a `EX_UPDATES_COPY_EMBEDDED_ASSETS` feature flag. which is false by default. i want to people to try out the new change. if there's some regression, people can add `EX_UPDATES_COPY_EMBEDDED_ASSETS=true` to fallback as original behavior.
- for embedded assets, rather than copy to the file system, just turn them into `file:///android_res/` and `file:///android_asset/` format. the format is also supported by android webview. example uris:
  - `file:///android_asset/index.android.bundle`
  - `file:///android_res/drawable/test.png`
  - `file:///android_res/raw/test.ttf`
- **Note:** embedded assets will NOT have the hash value. because we don't go though sha256 checksum state. i think it's fine for not having embedded assets hashes. if embedded assets are corrupted, people have no way to fix them but only have native rebuild.

### Benchmark

i tested the `launchDuration` on bare-expo release build
before: 303ms
after: 101ms
it now takes about 1/3 of launch time. bare-expo don't have much assets. for apps with more assets, i think we can reduce more.

# Test Plan

- update unit tests and e2e tests

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
