### PR TITLE
Update android-production-build.mdx

### DIFF
--- a/docs/pages/tutorial/eas/android-production-build.mdx
+++ b/docs/pages/tutorial/eas/android-production-build.mdx
@@ -278,7 +278,7 @@ To release the app for production:
 
 - We can also use the same EAS Build we did for the internal testing release. Run the `eas submit` command to release to the Play Store:
 
-<Terminal cmd={['$ eas submit -platform android']} />
+<Terminal cmd={['$ eas submit --platform android']} />
 
 - To create a track and submit our app to the Google Play Store's review process, we need to **Release** > **Production** and under **Releases**, select the build we want to send for review.
 


### PR DESCRIPTION
Change the `eas submit` command from `eas submit -platform android` to `eas submit --platform android`.

# Why

The previous command was incorrect — it used a single dash (`-platform`) instead of the correct double dash (`--platform`). This small change ensures the documentation reflects the proper usage of the `eas submit` CLI.

# How

This is a simple documentation fix. No code changes or rebuilds were needed. I corrected the command to use `--platform` which is the correct syntax for the `eas submit` command.

# Test Plan

Verified the correct syntax by running `eas submit --platform android` locally to ensure it works as expected.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)