### PR TITLE
[expo-go] Clean up manifest

### DIFF
--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -283,22 +283,6 @@
             android:value="true" />
         <!-- END GOOGLE MOBILE ADS CONFIG -->
 
-        <!-- ADD BRANCH CONFIG HERE -->
-
-        <!-- ADD FACEBOOK APP ID CONFIG HERE -->
-        <!-- ADD FACEBOOK APP DISPLAY NAME CONFIG HERE -->
-        <!-- Tags below need to be in one line with no whitespace after android:value -->
-        <!-- in order for XDL to be able to replace values in them -->
-        <meta-data
-            android:name="com.facebook.sdk.AutoLogAppEventsEnabled"
-            android:value="false" />
-        <meta-data
-            android:name="com.facebook.sdk.AutoInitEnabled"
-            android:value="false" />
-        <meta-data
-            android:name="com.facebook.sdk.AdvertiserIDCollectionEnabled"
-            android:value="false" />
-
     </application>
-
 </manifest>
+

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -1,320 +1,304 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-  package="host.exp.exponent"
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="host.exp.exponent">
 
-  <permission
-    android:name="host.exp.exponent.permission.C2D_MESSAGE"
-    android:protectionLevel="signature"/>
+    <permission
+        android:name="host.exp.exponent.permission.C2D_MESSAGE"
+        android:protectionLevel="signature" />
 
-  <!-- These are required permissions to make the app run -->
-  <uses-permission android:name="host.exp.exponent.permission.C2D_MESSAGE" />
-  <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
-  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-  <uses-permission android:name="android.permission.INTERNET" />
-  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
-  <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <!-- These are required permissions to make the app run -->
+    <uses-permission android:name="host.exp.exponent.permission.C2D_MESSAGE" />
+    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
-  <!-- ADD PERMISSIONS HERE -->
-  <!-- BEGIN OPTIONAL PERMISSIONS -->
-  <uses-permission android:name="android.permission.MANAGE_DOCUMENTS" />
-  <uses-permission android:name="android.permission.READ_INTERNAL_STORAGE" />
-  <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-  <uses-permission android:name="android.permission.USE_FINGERPRINT" />
-  <uses-permission android:name="android.permission.VIBRATE" />
-  <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
-  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-  <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
-  <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <!-- ADD PERMISSIONS HERE -->
+    <!-- BEGIN OPTIONAL PERMISSIONS -->
+    <uses-permission android:name="android.permission.READ_INTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+    <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
-  <!-- These require runtime permissions on M -->
-  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-  <uses-permission android:name="android.permission.CAMERA" />
-  <uses-permission android:name="android.permission.READ_CONTACTS" />
-  <uses-permission android:name="android.permission.READ_CALENDAR" />
-  <uses-permission android:name="android.permission.WRITE_CALENDAR" />
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-  <uses-permission android:name="android.permission.RECORD_AUDIO" />
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-  <uses-permission android:name="android.permission.WRITE_SETTINGS" />
-  <!-- END OPTIONAL PERMISSIONS -->
+    <!-- These require runtime permissions on M -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
+    <uses-permission android:name="android.permission.WRITE_CALENDAR" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
+    <!-- END OPTIONAL PERMISSIONS -->
 
-  <!-- ADD TEST PERMISSIONS HERE -->
+    <uses-permission android:name="android.permission.WRITE_CONTACTS" />
 
-  <uses-feature android:glEsVersion="0x00020000" android:required="false" />
-  <uses-feature android:name="android.software.leanback" android:required="false" />
-  <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+    <uses-feature
+        android:glEsVersion="0x00020000"
+        android:required="false" />
+    <uses-feature
+        android:name="android.software.leanback"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
 
-  <application
-    android:name=".MainApplication"
-    android:allowBackup="true"
-    android:icon="@mipmap/ic_launcher"
-    android:label="${appLabel}"
-    android:largeHeap="true"
-    android:requestLegacyExternalStorage="true"
-    android:usesCleartextTraffic="true">
+    <application
+        android:name=".MainApplication"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="${appLabel}"
+        android:requestLegacyExternalStorage="true"
+        android:usesCleartextTraffic="true">
 
-    <activity
-      android:name=".LauncherActivity"
-      android:exported="true"
-      android:launchMode="singleTask"
-      android:theme="@style/Theme.Exponent.Translucent">
-      <!-- START LAUNCHER INTENT FILTERS -->
-      <intent-filter>
-        <data android:scheme="exp"/>
-        <data android:scheme="exps"/>
+        <activity
+            android:name=".LauncherActivity"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:theme="@style/Theme.Exponent.Translucent">
+            <!-- START LAUNCHER INTENT FILTERS -->
+            <intent-filter>
+                <data android:scheme="exp" />
+                <data android:scheme="exps" />
 
-        <action android:name="android.intent.action.VIEW"/>
+                <action android:name="android.intent.action.VIEW" />
 
-        <category android:name="android.intent.category.DEFAULT"/>
-        <category android:name="android.intent.category.BROWSABLE"/>
-      </intent-filter>
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
 
-      <intent-filter android:autoVerify="true">
-        <data
-          android:host="expo.io"
-          android:path="/expo-go"
-          android:scheme="https"/>
-        <data
-          android:host="expo.io"
-          android:path="/expo-go"
-          android:scheme="http"/>
+            <intent-filter android:autoVerify="true">
+                <data android:scheme="https" />
+                <data android:host="expo.io" />
+                <data android:path="/expo-go" />
+                <data android:scheme="http" />
+                <data android:host="expo.io" />
+                <data android:path="/expo-go" />
 
-        <data
-          android:host="expo.dev"
-          android:path="/expo-go"
-          android:scheme="https"/>
-        <data
-          android:host="expo.dev"
-          android:path="/expo-go"
-          android:scheme="http"/>
+                <data android:scheme="https" />
+                <data android:host="expo.dev" />
+                <data android:path="/expo-go" />
+                <data android:scheme="http" />
+                <data android:host="expo.dev" />
+                <data android:path="/expo-go" />
 
-        <action android:name="android.intent.action.VIEW"/>
+                <action android:name="android.intent.action.VIEW" />
 
-        <category android:name="android.intent.category.DEFAULT"/>
-        <category android:name="android.intent.category.BROWSABLE"/>
-      </intent-filter>
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
 
-      <!-- This has to be separate from the exp[s]:// scheme filter. No idea why -->
-      <intent-filter>
-        <data
-          android:host="exp.host"
-          android:pathPrefix="/@"
-          android:scheme="http"/>
-        <data
-          android:host="exp.host"
-          android:pathPrefix="/@"
-          android:scheme="https"/>
-        <data
-          android:host="*.exp.direct"
-          android:pathPattern=".*"
-          android:scheme="http"/>
-        <data
-          android:host="*.exp.direct"
-          android:pathPattern=".*"
-          android:scheme="https"/>
+            <!-- This has to be separate from the exp[s]:// scheme filter. No idea why -->
+            <intent-filter>
+                <data android:scheme="http" />
+                <data android:host="exp.host" />
+                <data android:pathPrefix="/@" />
+                <data android:scheme="https" />
+                <data android:host="exp.host" />
+                <data android:pathPrefix="/@" />
+                <data android:scheme="http" />
+                <data android:host="*.exp.direct" />
+                <data android:pathPattern=".*" />
+                <data android:scheme="https" />
+                <data android:host="*.exp.direct" />
+                <data android:pathPattern=".*" />
 
-        <action android:name="android.intent.action.VIEW"/>
+                <action android:name="android.intent.action.VIEW" />
 
-        <category android:name="android.intent.category.DEFAULT"/>
-        <category android:name="android.intent.category.BROWSABLE"/>
-      </intent-filter>
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
 
-      <intent-filter>
-          <category android:name="android.intent.category.DEFAULT" />
-          <category android:name="android.intent.category.BROWSABLE" />
-          <action android:name="expo.modules.notifications.OPEN_APP_ACTION"/>
-      </intent-filter>
-      <!-- END LAUNCHER INTENT FILTERS -->
-    </activity>
+            <intent-filter>
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <action android:name="expo.modules.notifications.OPEN_APP_ACTION" />
+                <data/>
+            </intent-filter>
+            <!-- END LAUNCHER INTENT FILTERS -->
+        </activity>
 
-    <activity
-      android:name=".experience.ExperienceActivity"
-      android:exported="true"
-      android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
-      android:theme="@style/Theme.Exponent.Light"
-      android:windowSoftInputMode="adjustResize"
-      android:supportsPictureInPicture="true">
-    </activity>
+        <activity
+            android:name=".experience.ExperienceActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+            android:exported="true"
+            android:supportsPictureInPicture="true"
+            android:theme="@style/Theme.Exponent.Light"
+            android:windowSoftInputMode="adjustResize" />
 
-    <activity
-      android:name=".experience.HomeActivity"
-      android:exported="true"
-      android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
-      android:label="${appLabel}"
-      android:launchMode="singleTask"
-      android:screenOrientation="portrait"
-      android:theme="@style/Theme.Exponent.HomeActivity">
-      <!-- START HOME INTENT FILTERS -->
-      <intent-filter>
-        <action android:name="android.intent.action.MAIN"/>
+        <activity
+            android:name=".experience.HomeActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.Exponent.HomeActivity">
+            <!-- START HOME INTENT FILTERS -->
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
 
-        <category android:name="android.intent.category.DEFAULT"/>
-        <category android:name="android.intent.category.LAUNCHER"/>
-      </intent-filter>
-      <intent-filter>
-        <data android:scheme="expauth"/>
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <data android:scheme="expauth" />
 
-        <action android:name="android.intent.action.VIEW"/>
+                <action android:name="android.intent.action.VIEW" />
 
-        <category android:name="android.intent.category.DEFAULT"/>
-        <category android:name="android.intent.category.BROWSABLE"/>
-      </intent-filter>
-      <intent-filter>
-        <data android:scheme="expo-home"/>
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
+            <intent-filter>
+                <data android:scheme="expo-home" />
 
-        <action android:name="android.intent.action.VIEW"/>
+                <action android:name="android.intent.action.VIEW" />
 
-        <category android:name="android.intent.category.DEFAULT"/>
-        <category android:name="android.intent.category.BROWSABLE"/>
-      </intent-filter>
-      <!-- END HOME INTENT FILTERS -->
-    </activity>
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
+            <!-- END HOME INTENT FILTERS -->
+        </activity>
 
-    <activity
-      android:name=".experience.TvActivity"
-      android:exported="true"
-      android:label="${appLabel}"
-      android:theme="@style/Theme.Exponent.Light"
-      android:screenOrientation="landscape">
-     <intent-filter>
-       <action android:name="android.intent.action.MAIN" />
-       <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
-     </intent-filter>
-   </activity>
+        <activity
+            android:name=".experience.TvActivity"
+            android:exported="true"
+            android:screenOrientation="landscape"
+            android:theme="@style/Theme.Exponent.Light">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+            </intent-filter>
+        </activity>
 
 
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
 
-    <activity android:name="com.facebook.react.devsupport.DevSettingsActivity"/>
+        <activity
+            android:name="net.openid.appauth.RedirectUriReceiverActivity"
+            android:exported="true"
+            tools:node="replace">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
 
-    <activity
-        android:name="net.openid.appauth.RedirectUriReceiverActivity"
-        android:exported="true"
-        tools:node="replace">
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW"/>
-        <category android:name="android.intent.category.DEFAULT"/>
-        <category android:name="android.intent.category.BROWSABLE"/>
-        <data android:scheme="host.exp.exponent" android:path="/oauthredirect"/>
-      </intent-filter>
-    </activity>
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
 
-    <activity
-      android:name=".experience.ErrorActivity"
-      android:theme="@style/Theme.Exponent.Dark"
-      android:screenOrientation="portrait">
-    </activity>
+                <data
+                    android:host="host.exp.exponent"
+                    android:path="/oauthredirect"
+                    android:scheme="host.exp.exponent" />
+            </intent-filter>
+        </activity>
 
-    <activity
-      android:name="com.facebook.FacebookActivity"
-      android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
-      android:label="${appLabel}"
-      android:theme="@android:style/Theme.Translucent.NoTitleBar"
-      tools:replace="android:theme" />
+        <activity
+            android:name=".experience.ErrorActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.Exponent.Dark" />
 
-    <activity
-      android:name="com.facebook.CustomTabActivity"
-      android:exported="true">
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE" />
-        <!-- REPLACE WITH FACEBOOK SCHEME -->
-      </intent-filter>
-    </activity>
+        <service
+            android:name=".ExponentIntentService"
+            android:exported="false" />
 
-    <activity
-      android:name="com.facebook.ads.InterstitialAdActivity"
-      android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
-      android:label="${appLabel}"
-      android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+        <!-- Analytics -->
+        <!--
+        This crashes: https://code.google.com/p/analytics-issues/issues/detail?id=667
+        TODO: turn it back on when it's fixed
+        <service
+          android:name="com.google.android.gms.analytics.CampaignTrackingService"
+          android:enabled="true"
+          android:exported="false" />-->
 
-    <service
-      android:name=".ExponentIntentService"
-      android:exported="false" />
+        <receiver
+            android:name="com.google.android.gms.analytics.AnalyticsReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.android.gms.analytics.ANALYTICS_DISPATCH" />
+            </intent-filter>
+        </receiver>
 
-    <!-- Analytics -->
-    <!--
-    This crashes: https://code.google.com/p/analytics-issues/issues/detail?id=667
-    TODO: turn it back on when it's fixed
-    <service
-      android:name="com.google.android.gms.analytics.CampaignTrackingService"
-      android:enabled="true"
-      android:exported="false" />-->
+        <service
+            android:name="com.google.android.gms.analytics.AnalyticsService"
+            android:enabled="true"
+            android:exported="false" />
 
-    <receiver android:name="com.google.android.gms.analytics.AnalyticsReceiver"
-              android:enabled="true">
-      <intent-filter>
-        <action android:name="com.google.android.gms.analytics.ANALYTICS_DISPATCH" />
-      </intent-filter>
-    </receiver>
+        <!-- FCM -->
+        <service
+            android:name=".fcm.ExpoFcmMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+        <service
+            android:name=".fcm.FcmRegistrationIntentService"
+            android:exported="false" />
+        <!-- Applied to Firebase data messages -->
+        <meta-data
+            android:name="expo.modules.notifications.default_notification_icon"
+            android:resource="@drawable/shell_notification_icon" />
+        <meta-data
+            android:name="expo.modules.notifications.default_notification_color"
+            android:resource="@color/notification_icon_color" />
 
-    <service android:name="com.google.android.gms.analytics.AnalyticsService"
-             android:enabled="true"
-             android:exported="false"/>
-
-    <!-- FCM -->
-    <service
-      android:name=".fcm.ExpoFcmMessagingService"
-      android:exported="true">
-      <intent-filter>
-        <action android:name="com.google.firebase.MESSAGING_EVENT" />
-      </intent-filter>
-    </service>
-    <service
-      android:name=".fcm.FcmRegistrationIntentService"
-      android:exported="false">
-    </service>
-    <!-- Applied to Firebase data messages -->
-    <meta-data
-      android:name="expo.modules.notifications.default_notification_icon"
-      android:resource="@drawable/shell_notification_icon" />
-    <meta-data
-      android:name="expo.modules.notifications.default_notification_color"
-      android:resource="@color/notification_icon_color" />
-
-    <!-- Applied to Firebase notification messages -->
-    <meta-data
-      android:name="com.google.firebase.messaging.default_notification_icon"
-      android:resource="@drawable/shell_notification_icon" />
-    <meta-data
-      android:name="com.google.firebase.messaging.default_notification_color"
-      android:resource="@color/notification_icon_color" />
+        <!-- Applied to Firebase notification messages -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/shell_notification_icon" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/notification_icon_color" />
 
 
-    <!-- ImagePicker native module -->
-    <activity
-      android:name="com.canhub.cropper.CropImageActivity"
-      android:theme="@style/Base.Theme.AppCompat">
-    </activity>
+        <!-- ImagePicker native module -->
+        <activity
+            android:name="com.canhub.cropper.CropImageActivity"
+            android:theme="@style/Base.Theme.AppCompat" />
 
-    <!-- ADD GOOGLE MAPS CONFIG HERE -->
-    <!-- BEGIN GOOGLE MAPS CONFIG -->
-    <meta-data
-      android:name="com.google.android.geo.API_KEY"
-      android:value="${GOOGLE_MAPS_API_KEY}"/>
-    <!-- END GOOGLE MAPS CONFIG -->
+        <!-- ADD GOOGLE MAPS CONFIG HERE -->
+        <!-- BEGIN GOOGLE MAPS CONFIG -->
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="${GOOGLE_MAPS_API_KEY}"/>
+        <!-- END GOOGLE MAPS CONFIG -->
 
-    <!-- ADD GOOGLE MOBILE ADS CONFIG HERE -->
-    <!-- BEGIN GOOGLE MOBILE ADS CONFIG -->
-    <meta-data
-      android:name="com.google.android.gms.ads.APPLICATION_ID"
-      android:value="ca-app-pub-3940256099942544~3347511713"/>
-    <meta-data android:name="com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT" android:value="true"/>
-    <!-- END GOOGLE MOBILE ADS CONFIG -->
+        <!-- ADD GOOGLE MOBILE ADS CONFIG HERE -->
+        <!-- BEGIN GOOGLE MOBILE ADS CONFIG -->
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713" />
+        <meta-data
+            android:name="com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT"
+            android:value="true" />
+        <!-- END GOOGLE MOBILE ADS CONFIG -->
 
-    <!-- ADD BRANCH CONFIG HERE -->
+        <!-- ADD BRANCH CONFIG HERE -->
 
-    <!-- ADD FACEBOOK APP ID CONFIG HERE -->
-    <!-- ADD FACEBOOK APP DISPLAY NAME CONFIG HERE -->
-    <!-- Tags below need to be in one line with no whitespace after android:value -->
-    <!-- in order for XDL to be able to replace values in them -->
-    <meta-data android:name="com.facebook.sdk.AutoLogAppEventsEnabled" android:value="false"/>
-    <meta-data android:name="com.facebook.sdk.AutoInitEnabled" android:value="false"/>
-    <meta-data android:name="com.facebook.sdk.AdvertiserIDCollectionEnabled" android:value="false"/>
+        <!-- ADD FACEBOOK APP ID CONFIG HERE -->
+        <!-- ADD FACEBOOK APP DISPLAY NAME CONFIG HERE -->
+        <!-- Tags below need to be in one line with no whitespace after android:value -->
+        <!-- in order for XDL to be able to replace values in them -->
+        <meta-data
+            android:name="com.facebook.sdk.AutoLogAppEventsEnabled"
+            android:value="false" />
+        <meta-data
+            android:name="com.facebook.sdk.AutoInitEnabled"
+            android:value="false" />
+        <meta-data
+            android:name="com.facebook.sdk.AdvertiserIDCollectionEnabled"
+            android:value="false" />
 
-  </application>
+    </application>
 
 </manifest>


### PR DESCRIPTION
# Why
Expo go's manifest has been in a bad state for a while. Missing or deprecated tags, activities that were no longer in use, permissions that we can no longer access and the formatting was a mess.

# How
Remove the unnecessary permissions and activities, clean up as many lint warnings as possible, reformat

# Test Plan
Expo go stills runs as expected

