### PR TITLE
[docs] Fix ios dev instructions for EAS Build in set up your environment

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuild.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuild.mdx
@@ -63,6 +63,15 @@ Run the following command to create a development build:
 </Step>
 
 <Step label="7">
+### Install the development build on your device
+
+After the build is complete, scan the QR code in your terminal and tap **Open with iTunes** when it appears inside the Camera app. Alternatively, open the link displayed in the terminal on your device.
+
+After confirming the installation, the app will appear in your device's app library.
+
+</Step>
+
+<Step label="8">
 ### Turn on developer mode
 
 1. Open **Settings** > **Privacy & Security**, scroll down to the **Developer Mode** list item and navigate into it.
@@ -70,14 +79,5 @@ Run the following command to create a development build:
 3. After the device restarts and you unlock it, the device shows an alert confirming that you want to enable Developer Mode. Tap **Turn On**, and enter your device passcode when prompted.
 
 > Alternatively, if you have Xcode installed on your Mac, you can use it to [enable iOS developer mode](/guides/ios-developer-mode/#connect-an-ios-device-with-a-mac).
-
-</Step>
-
-<Step label="8">
-### Install the development build on your device
-
-After the build is complete, scan the QR code in your terminal and tap **Open with iTunes** when it appears inside the Camera app. Alternatively, open the link displayed in the terminal on your device.
-
-After confirming the installation, the app will appear in your device's app library.
 
 </Step>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #35999

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Reverse the order of Step 7 and 8 because only after installing the development build on an iOS device for the _first time_, the setting to enable iOS developer mode will appear on an iOS device.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-04-10 at 15 57 47@2x](https://github.com/user-attachments/assets/d279111d-985b-445b-90ff-98ff1fd9d139)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
