### PR TITLE
[sqlite][Android] Fix logic in `shouldUsePublication`

### DIFF
--- a/packages/expo-sqlite/android/shouldUsePublication.groovy
+++ b/packages/expo-sqlite/android/shouldUsePublication.groovy
@@ -3,4 +3,4 @@
   "expo.sqlite.useLibSQL",
   "expo.sqlite.enableFTS",
   "expo.sqlite.customBuildFlags",
-].any { settings.providers.gradleProperty(it).isPresent() }
+].every { !settings.providers.gradleProperty(it).isPresent() }


### PR DESCRIPTION
# Why

Fixes logic in `shouldUsePublication`. 
The script should return true if all properties have been unset.

# Test Plan

- bare-expo ✅ 