### PR TITLE
[splash-screen] remove committed tsbuildinfo

### DIFF
--- a/packages/expo-splash-screen/plugin/tsconfig.tsbuildinfo
+++ b/packages/expo-splash-screen/plugin/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/withSplashScreen.ts"],"version":"5.8.3"}


### PR DESCRIPTION
# Why

remove accidental comitted tsbuildinfo

# How

tsbuildinfo should already add to gitignore but this one was accidental committed

# Test Plan

ci passed

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
