### PR TITLE
[modules-plugin][Android] Run `shouldUsePublication` script before publishing package

### DIFF
--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
@@ -38,7 +38,7 @@ class SettingsManager(
 
   private val groovyShell by lazy {
     val binding = Binding()
-    binding.setVariable("settings", settings)
+    binding.setVariable("providers", settings.providers)
     GroovyShell(javaClass.classLoader, binding)
   }
 

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/AutolinkingIntegration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/AutolinkingIntegration.kt
@@ -1,7 +1,10 @@
 package expo.modules.plugin
 
 import org.gradle.api.Project
+import java.io.File
 
 interface AutolinkingIntegration {
   fun getExpoDependency(project: Project, name: String): Any
+
+  fun getShouldUsePublicationScriptPath(project: Project): File?
 }

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -84,7 +84,7 @@ internal fun Project.applyPublishing(expoModulesExtension: ExpoModuleExtension) 
       .publications
       .createReleasePublication(publicationInfo)
 
-    createExpoPublishToMavenLocalTask(publicationInfo)
+    createExpoPublishToMavenLocalTask(publicationInfo, expoModulesExtension)
 
     val npmLocalRepositoryRelativePath = "local-maven-repo"
     val npmLocalRepository = URI("file://${project.projectDir.parentFile}/${npmLocalRepositoryRelativePath}")
@@ -93,7 +93,7 @@ internal fun Project.applyPublishing(expoModulesExtension: ExpoModuleExtension) 
       mavenRepo.url = npmLocalRepository
     }
 
-    createExpoPublishTask(publicationInfo, npmLocalRepositoryRelativePath)
+    createExpoPublishTask(publicationInfo, expoModulesExtension, npmLocalRepositoryRelativePath)
   }
 }
 

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/MavenPublicationExtension.kt
@@ -3,7 +3,10 @@
 package expo.modules.plugin.android
 
 import expo.modules.plugin.androidLibraryExtension
+import expo.modules.plugin.gradle.ExpoModuleExtension
 import expo.modules.plugin.publishingExtension
+import groovy.lang.Binding
+import groovy.lang.GroovyShell
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -19,7 +22,6 @@ import org.gradle.api.component.SoftwareComponent
 import org.gradle.api.publish.PublicationContainer
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.TaskProvider
-import java.net.URI
 import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.toPath
@@ -85,10 +87,10 @@ internal fun PublicationContainer.createReleasePublication(publicationInfo: Publ
   }
 }
 
-internal fun Project.createExpoPublishTask(publicationInfo: PublicationInfo, pathToRepository: String): TaskProvider<Task> {
+internal fun Project.createExpoPublishTask(publicationInfo: PublicationInfo, expoModulesExtension: ExpoModuleExtension, pathToRepository: String): TaskProvider<Task> {
   val taskProvider = tasks.register("expoPublish") { task ->
     task.doLast {
-      expoPublishBody(publicationInfo, pathToRepository = pathToRepository)
+      expoPublishBody(publicationInfo, expoModulesExtension, pathToRepository = pathToRepository)
     }
   }
   taskProvider.configure { task ->
@@ -130,10 +132,10 @@ internal fun Project.createEmptyExpoPublishToMavenLocalTask(): TaskProvider<Task
   return taskProvider
 }
 
-internal fun Project.createExpoPublishToMavenLocalTask(publicationInfo: PublicationInfo): TaskProvider<Task> {
+internal fun Project.createExpoPublishToMavenLocalTask(publicationInfo: PublicationInfo, expoModulesExtension: ExpoModuleExtension): TaskProvider<Task> {
   val taskProvider = tasks.register("expoPublishToMavenLocal") { task ->
     task.doLast {
-      expoPublishBody(publicationInfo)
+      expoPublishBody(publicationInfo, expoModulesExtension)
     }
   }
   taskProvider.configure { task ->
@@ -147,7 +149,9 @@ internal fun Project.createExpoPublishToMavenLocalTask(publicationInfo: Publicat
   return taskProvider
 }
 
-private fun Project.expoPublishBody(publicationInfo: PublicationInfo, pathToRepository: String? = null) {
+private fun Project.expoPublishBody(publicationInfo: PublicationInfo, expoModulesExtension: ExpoModuleExtension, pathToRepository: String? = null) {
+  validateProjectConfiguration(expoModulesExtension)
+
   if (pathToRepository == null) {
     val mavenLocal = publishingExtension().repositories.mavenLocal()
     val mavenLocalPath = mavenLocal.url.toPath()
@@ -180,6 +184,19 @@ private fun Project.expoPublishBody(publicationInfo: PublicationInfo, pathToRepo
     // TODO(@lukmccall): support other package managers
     env.commandLine("yarn", "prettier", "--write", "expo-module.config.json")
   }.result.get()
+}
+
+private fun Project.validateProjectConfiguration(expoModulesExtension: ExpoModuleExtension) {
+  val shouldUsePublicationScript = expoModulesExtension.autolinking.getShouldUsePublicationScriptPath(this)
+  val binding = Binding()
+  binding.setVariable("providers", project.providers)
+  val shell = GroovyShell(javaClass.classLoader, binding)
+
+  val shouldUsePublication = shell.run(shouldUsePublicationScript, emptyArray<String>()) as? Boolean == true
+
+  if (!shouldUsePublication) {
+    throw IllegalStateException("The publication script returned false. Please check the script or your project configuration. You're trying to precompile a non-default configuration.")
+  }
 }
 
 private fun modifyModuleConfig(projectName: String, currentConfig: JsonObject, publicationInfo: PublicationInfo, pathToRepository: String?): JsonObject {

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
@@ -17,7 +17,7 @@ open class ExpoModuleExtension(val project: Project) {
     project.gradle.extensions.getByType(ExpoGradleHelperExtension::class.java)
   }
 
-  private val autolinking: AutolinkingIntegration by lazy {
+  internal val autolinking: AutolinkingIntegration by lazy {
     AutolinkingIntegrationImpl()
   }
 

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/withAutolinkingPlugin/kotlin/expo/modules/plugin/AutolinkingIntegrationImpl.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/withAutolinkingPlugin/kotlin/expo/modules/plugin/AutolinkingIntegrationImpl.kt
@@ -1,25 +1,49 @@
 package expo.modules.plugin
 
 import expo.modules.plugin.configuration.ExpoAutolinkingConfig
+import expo.modules.plugin.configuration.GradleProject
 import org.gradle.api.Project
+import java.io.File
 
 class AutolinkingIntegrationImpl : AutolinkingIntegration {
   override fun getExpoDependency(project: Project, name: String): Any {
-    val config = getConfig(project)
-    val dependency = config.allProjects.find { it.name == name }
+    val config = getProjectConfig(project, name)
 
-    if (dependency == null) {
-      throw IllegalStateException("Couldn't find project with name $name in `expo-autolinking-settings` configuration.")
-    }
-
-    if (dependency.usePublication) {
-      val publication = requireNotNull(dependency.publication)
+    if (config.usePublication) {
+      val publication = requireNotNull(config.publication)
       return "${publication.groupId}:${publication.artifactId}:${publication.version}"
     }
 
     return project.rootProject.findProject(":$name")
       ?: throw IllegalStateException("Couldn't find project with name $name.")
   }
+
+  override fun getShouldUsePublicationScriptPath(project: Project): File? {
+    val config = getProjectConfig(project)
+    val scriptPath = config.shouldUsePublicationScriptPath
+      ?: return null
+    val scriptFile = File(scriptPath)
+
+    if (!scriptFile.exists()) {
+      project.logger.warn("[ExpoAutolinkingPlugin] The script file does not exist: $scriptFile")
+      return null
+    }
+
+    return scriptFile
+  }
+
+  private fun getProjectConfig(project: Project, projectName: String): GradleProject {
+    val config = getConfig(project)
+    val dependency = config.allProjects.find { it.name == projectName }
+
+    if (dependency == null) {
+      throw IllegalStateException("Couldn't find project with name $projectName in `expo-autolinking-settings` configuration.")
+    }
+
+    return dependency
+  }
+
+  private fun getProjectConfig(project: Project) = getProjectConfig(project, project.name)
 
   private fun getConfig(project: Project): ExpoAutolinkingConfig {
     val gradleExtension = project.gradle.extensions.findByType(ExpoGradleExtension::class.java)

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/withoutAutolinkingPlugin/kotlin/expo/modules/plugin/AutolinkingIntegrationImpl.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/withoutAutolinkingPlugin/kotlin/expo/modules/plugin/AutolinkingIntegrationImpl.kt
@@ -7,4 +7,8 @@ class AutolinkingIntegrationImpl : AutolinkingIntegration {
     return project.rootProject.findProject(":$name")
       ?: throw IllegalStateException("Couldn't find project with name $name.")
   }
+
+  override fun getShouldUsePublicationScriptPath(project: Project): File? {
+    return null
+  }
 }

--- a/packages/expo-sqlite/android/shouldUsePublication.groovy
+++ b/packages/expo-sqlite/android/shouldUsePublication.groovy
@@ -3,4 +3,4 @@
   "expo.sqlite.useLibSQL",
   "expo.sqlite.enableFTS",
   "expo.sqlite.customBuildFlags",
-].every { !settings.providers.gradleProperty(it).isPresent() }
+].every { !providers.gradleProperty(it).isPresent() }


### PR DESCRIPTION
# Why

Runs `shouldUsePublication` script before publishing packages to verify if the project is using default configuration. Otherwise, we want to throw an error.

# Test Plan

- bare-expo ✅ 