### PR TITLE
[docs] APISection: hide params details block when there is no comment

### DIFF
--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -4,7 +4,7 @@ import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
 import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
 import { APIParamDetailsBlock } from '~/components/plugins/api/components/APIParamDetailsBlock';
 import { APITypeOrSignatureType } from '~/components/plugins/api/components/APITypeOrSignatureType';
-import { CODE, H2, H3, H4, LI, MONOSPACE, UL } from '~/ui/components/Text';
+import { CODE, H2, H3, H4, LI, UL } from '~/ui/components/Text';
 
 import {
   CommentTagData,

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -2,6 +2,7 @@ import { mergeClasses } from '@expo/styleguide';
 
 import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
 import { APIBoxSectionHeader } from '~/components/plugins/api/components/APIBoxSectionHeader';
+import { APIParamDetailsBlock } from '~/components/plugins/api/components/APIParamDetailsBlock';
 import { APITypeOrSignatureType } from '~/components/plugins/api/components/APITypeOrSignatureType';
 import { CODE, H2, H3, H4, LI, MONOSPACE, UL } from '~/ui/components/Text';
 
@@ -151,19 +152,12 @@ export const renderProp = (
       <APICommentTextBlock comment={extractedComment} includePlatforms={false} inlineHeaders />
       {extractedSignatures?.length &&
         extractedSignatures[0].parameters?.map(param => (
-          <div
-            className={mergeClasses(
-              STYLES_SECONDARY,
-              VERTICAL_SPACING,
-              ELEMENT_SPACING,
-              'flex flex-col gap-0.5 border-l-2 border-secondary pl-2.5 font-normal'
-            )}
-            key={param.name}>
-            <MONOSPACE>
-              {param.name}: {resolveTypeName(param.type, sdkVersion)}
-            </MONOSPACE>
-            <APICommentTextBlock comment={param.comment} />
-          </div>
+          <APIParamDetailsBlock
+            key={param.name}
+            param={param}
+            sdkVersion={sdkVersion}
+            className={mergeClasses(VERTICAL_SPACING, ELEMENT_SPACING)}
+          />
         ))}
     </div>
   );

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -4,6 +4,7 @@ import { Fragment, ReactNode } from 'react';
 
 import { APIBox } from '~/components/plugins/APIBox';
 import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
+import { APIParamDetailsBlock } from '~/components/plugins/api/components/APIParamDetailsBlock';
 import { Cell, Row, Table } from '~/ui/components/Table';
 import { H2, CODE, MONOSPACE, CALLOUT, RawH4, DEMI } from '~/ui/components/Text';
 
@@ -109,8 +110,10 @@ const renderTypeMethodEntry = (
   return null;
 };
 
-const renderTypePropertyRow = (x: PropData, sdkVersion: string): JSX.Element => {
-  const { name, flags, type, comment, defaultValue, signatures, kind } = x;
+const renderTypePropertyRow = (
+  { name, flags, type, comment, defaultValue, signatures, kind }: PropData,
+  sdkVersion: string
+): JSX.Element => {
   const defaultTag = getTagData('default', comment);
   const initValue = parseCommentContent(
     defaultValue ?? (defaultTag ? getCommentContent(defaultTag.content) : undefined)
@@ -148,14 +151,12 @@ const renderTypePropertyRow = (x: PropData, sdkVersion: string): JSX.Element => 
           emptyCommentFallback={hasDeprecationNote ? undefined : '-'}
         />
         {params?.map(param => (
-          <div
-            className="mt-2 flex flex-col gap-0.5 border-l-2 border-secondary pl-2.5"
-            key={param.name}>
-            <MONOSPACE>
-              {param.name}: {resolveTypeName(param.type, sdkVersion)}
-            </MONOSPACE>
-            <APICommentTextBlock comment={param.comment} />
-          </div>
+          <APIParamDetailsBlock
+            key={param.name}
+            param={param}
+            sdkVersion={sdkVersion}
+            className="mt-2"
+          />
         ))}
       </Cell>
     </Row>

--- a/docs/components/plugins/api/components/APIParamDetailsBlock.tsx
+++ b/docs/components/plugins/api/components/APIParamDetailsBlock.tsx
@@ -1,0 +1,33 @@
+import { mergeClasses } from '@expo/styleguide';
+
+import { type MethodParamData } from '~/components/plugins/api/APIDataTypes';
+import { resolveTypeName } from '~/components/plugins/api/APISectionUtils';
+import { APICommentTextBlock } from '~/components/plugins/api/components/APICommentTextBlock';
+import { MONOSPACE } from '~/ui/components/Text';
+
+type Props = {
+  param: MethodParamData;
+  sdkVersion: string;
+  className?: string;
+};
+
+export function APIParamDetailsBlock({ param, sdkVersion, className }: Props) {
+  if (!param.comment) {
+    return null;
+  }
+
+  return (
+    <div
+      className={mergeClasses(
+        'flex flex-col gap-0.5 border-l-2 border-secondary pl-2.5 text-xs text-secondary',
+        className
+      )}
+      key={param.name}>
+      <MONOSPACE>
+        {param.name}
+        <span className="text-quaternary">:</span> {resolveTypeName(param.type, sdkVersion)}
+      </MONOSPACE>
+      <APICommentTextBlock comment={param.comment} />
+    </div>
+  );
+}


### PR DESCRIPTION
# Why

We have found out that showing params details block when there is no comment causes a bit of user's confusion, since the details do not add any more information.

![Screenshot 2025-04-10 at 15 38 43](https://github.com/user-attachments/assets/ca4692e4-09e5-4c9c-b186-416a09b9b36e)

# How

Factor out the details block to the dedicated `APIParamDetailsBlock` component for easier maintenance, check for comment existence before rendering.

# Test Plan

The changes have been reviewed by running website app locally. All lint checks and tests are passing.

# Preview

![Screenshot 2025-04-10 at 15 38 28](https://github.com/user-attachments/assets/4c75ceea-6950-48ea-b2ad-e8e4e2eea5e9)

