### PR TITLE
[docs] APISection: improve rendering literal types in props

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -3772,7 +3772,7 @@ for more details.
       Acceptable values are:
        
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 mb-px"
         data-text="true"
       >
         'default'
@@ -3783,7 +3783,7 @@ for more details.
          | 
       </span>
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 mb-px"
         data-text="true"
       >
         'short'
@@ -3794,7 +3794,7 @@ for more details.
          | 
       </span>
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 mb-px"
         data-text="true"
       >
         'medium'
@@ -3805,7 +3805,7 @@ for more details.
          | 
       </span>
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 mb-px"
         data-text="true"
       >
         'long'
@@ -3816,7 +3816,7 @@ for more details.
          | 
       </span>
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 mb-px"
         data-text="true"
       >
         'abbreviated'
@@ -8360,7 +8360,7 @@ On iOS, the
       Acceptable values are:
        
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 mb-px"
         data-text="true"
       >
         'never'
@@ -8371,7 +8371,7 @@ On iOS, the
          | 
       </span>
       <code
-        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 mb-px"
         data-text="true"
       >
         number

--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -201,7 +201,7 @@ export type PropData = {
   name: string;
   kind?: TypeDocKind;
   comment?: CommentData;
-  type: TypeDefinitionData;
+  type?: TypeDefinitionData;
   flags?: TypePropertyDataFlags;
   defaultValue?: string;
   signatures?: MethodSignatureData[];

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -98,7 +98,11 @@ const renderInterfacePropertyRow = (
         {renderFlags(flags, initValue)}
       </Cell>
       <Cell>
-        <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
+        {type ? (
+          <APIDataType typeDefinition={type} sdkVersion={sdkVersion} />
+        ) : (
+          <CODE>undefined</CODE>
+        )}
       </Cell>
       <Cell>{renderInterfaceComment(sdkVersion, comment, signatures, initValue)}</Cell>
     </Row>

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -150,11 +150,11 @@ export const renderProp = (
               signatures={extractedSignatures}
               sdkVersion={sdkVersion}
             />
-            {defaultValue && defaultValue !== UNKNOWN_VALUE && (
-              <>
-                &emsp;&bull;&emsp;Default: <CODE>{defaultValue}</CODE>
-              </>
-            )}
+          </>
+        )}
+        {defaultValue && defaultValue !== UNKNOWN_VALUE && (
+          <>
+            &emsp;&bull;&emsp;Default: <CODE>{defaultValue}</CODE>
           </>
         )}
       </div>

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -123,7 +123,8 @@ export const renderProp = (
   const extractedSignatures = signatures ?? type?.declaration?.signatures;
   const extractedComment = getCommentOrSignatureComment(comment, extractedSignatures);
   const platforms = getAllTagData('platform', extractedComment);
-  const isLiteralType = ['literal', 'templateLiteral', 'union', 'tuple'].includes(type.type);
+  const isLiteralType =
+    type?.type && ['literal', 'templateLiteral', 'union', 'tuple'].includes(type.type);
 
   return (
     <div
@@ -140,7 +141,7 @@ export const renderProp = (
       <div className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING, 'mb-2.5')}>
         {flags?.isOptional && <>Optional&emsp;&bull;&emsp;</>}
         {flags?.isReadonly && <>Read Only&emsp;&bull;&emsp;</>}
-        {type.types && isLiteralType && <>Literal type: {defineLiteralType(type.types)}</>}
+        {type?.types && isLiteralType && <>Literal type: {defineLiteralType(type.types)}</>}
         {!isLiteralType && (
           <>
             Type:{' '}
@@ -167,7 +168,7 @@ export const renderProp = (
             className={mergeClasses(VERTICAL_SPACING, ELEMENT_SPACING)}
           />
         ))}
-      {type.types && isLiteralType && (
+      {type?.types && isLiteralType && (
         <CALLOUT className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING, ELEMENT_SPACING)}>
           Acceptable values are:{' '}
           {type.types.map((lt, index, arr) => (

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -26,6 +26,7 @@ import {
   renderIndexSignature,
   getCommentContent,
   listParams,
+  defineLiteralType,
 } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
 import { APIDataType } from './components/APIDataType';
@@ -36,24 +37,6 @@ import { ELEMENT_SPACING, STYLES_APIBOX, STYLES_SECONDARY, VERTICAL_SPACING } fr
 export type APISectionTypesProps = {
   data: TypeGeneralData[];
   sdkVersion: string;
-};
-
-const defineLiteralType = (types: TypeDefinitionData[]): JSX.Element | null => {
-  const uniqueTypes = Array.from(
-    new Set(
-      types.map((t: TypeDefinitionData) => {
-        if ('head' in t) {
-          return t.head;
-        } else if ('value' in t) {
-          return t.value && typeof t.value;
-        }
-      })
-    )
-  );
-  if (uniqueTypes.length === 1 && uniqueTypes.filter(Boolean).length === 1) {
-    return <CODE>{uniqueTypes[0]}</CODE>;
-  }
-  return null;
 };
 
 const renderTypeDeclarationTable = (
@@ -283,7 +266,7 @@ const renderType = (
             Acceptable values are:{' '}
             {literalTypes.map((lt, index) => (
               <Fragment key={`${name}-literal-type-${index}`}>
-                <CODE>{resolveTypeName(lt, sdkVersion)}</CODE>
+                <CODE className="mb-px">{resolveTypeName(lt, sdkVersion)}</CODE>
                 {index + 1 !== literalTypes.length ? (
                   <span className="text-quaternary"> | </span>
                 ) : null}

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -584,3 +584,21 @@ export function extractDefaultPropValue(
     (defaultProp: PropData) => defaultProp.name === name
   )[0]?.defaultValue;
 }
+
+export function defineLiteralType(types: TypeDefinitionData[]) {
+  const uniqueTypes = Array.from(
+    new Set(
+      types.map((td: TypeDefinitionData) => {
+        if ('head' in td) {
+          return td.head;
+        } else if ('value' in td) {
+          return td.value && typeof td.value;
+        }
+      })
+    )
+  );
+  if (uniqueTypes.length === 1 && uniqueTypes.filter(Boolean).length === 1) {
+    return <CODE>{uniqueTypes[0]}</CODE>;
+  }
+  return null;
+}

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -302,15 +302,20 @@ export const resolveTypeName = (
       return (
         <>
           <span className="text-quaternary">{'{\n'}</span>
-          {declaration?.children.map((child: PropData, i) => (
-            <span key={`reflection-${name}-${i}`}>
-              {'  '}
-              {child.name + ': '}
-              {resolveTypeName(child.type, sdkVersion)}
-              {i + 1 !== declaration?.children?.length ? ', ' : null}
-              {'\n'}
-            </span>
-          ))}
+          {declaration?.children.map((child: PropData, i) => {
+            if (!child.type) {
+              return null;
+            }
+            return (
+              <span key={`reflection-${name}-${i}`}>
+                {'  '}
+                {child.name + ': '}
+                {resolveTypeName(child.type, sdkVersion)}
+                {i + 1 !== declaration?.children?.length ? ', ' : null}
+                {'\n'}
+              </span>
+            );
+          })}
           <span className="text-quaternary">{'}'}</span>
         </>
       );


### PR DESCRIPTION
# Why

During new SDK docs review I have spotted that we do not render correctly literal types in props section.

![Screenshot 2025-04-10 at 16 20 45](https://github.com/user-attachments/assets/972f0cd7-513c-4fda-808d-66eb692046e3)

# How

Apply the similar approach to handling literal types as we do in Types section, where at the top we list common type if any, and then at the bottom list available/valid values.

# Test Plan

The changes have been reviewed by running docs app locally, and visiting Expo UI reference page.

All lint checks and tests are passing.

# Preview

![Screenshot 2025-04-10 at 16 31 20](https://github.com/user-attachments/assets/2495b309-ca1c-4e8c-b9f2-7c9d765e0349)

