### PR TITLE
[babel-preset] throw error for import.meta by default

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Throwing an error if people having `import.meta` in code but not enabled `unstable_transformImportMeta`. ([#36074](https://github.com/expo/expo/pull/36074) by [@kudo](https://github.com/kudo))
+
 ## 13.1.2 — 2025-04-11
 
 ### 🎉 New features

--- a/packages/babel-preset-expo/build/import-meta-transform-plugin.d.ts
+++ b/packages/babel-preset-expo/build/import-meta-transform-plugin.d.ts
@@ -1,4 +1,4 @@
 import { ConfigAPI, types } from '@babel/core';
-export declare function expoImportMetaTransformPlugin(api: ConfigAPI & {
+export declare function expoImportMetaTransformPluginFactory(pluginEnabled: boolean): (api: ConfigAPI & {
     types: typeof types;
-}): babel.PluginObj;
+}) => babel.PluginObj;

--- a/packages/babel-preset-expo/build/import-meta-transform-plugin.js
+++ b/packages/babel-preset-expo/build/import-meta-transform-plugin.js
@@ -2,9 +2,11 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.expoImportMetaTransformPluginFactory = expoImportMetaTransformPluginFactory;
+const common_1 = require("./common");
 function expoImportMetaTransformPluginFactory(pluginEnabled) {
     return (api) => {
         const { types: t } = api;
+        const platform = api.caller(common_1.getPlatform);
         return {
             name: 'expo-import-meta-transform',
             visitor: {
@@ -12,7 +14,10 @@ function expoImportMetaTransformPluginFactory(pluginEnabled) {
                     const { node } = path;
                     if (node.meta.name === 'import' && node.property.name === 'meta') {
                         if (!pluginEnabled) {
-                            throw path.buildCodeFrameError('Your code uses `import.meta` which is not supported in the React Native runtime yet. Enable the `unstable_transformImportMeta` option in babel-preset-expo to use `import.meta`.');
+                            if (platform !== 'web') {
+                                throw path.buildCodeFrameError('Your code uses `import.meta` which is not supported in the React Native runtime yet. Enable the `unstable_transformImportMeta` option in babel-preset-expo to use `import.meta`.');
+                            }
+                            return;
                         }
                         const replacement = t.memberExpression(t.identifier('globalThis'), t.identifier('__ExpoImportMetaRegistry'));
                         path.replaceWith(replacement);

--- a/packages/babel-preset-expo/build/import-meta-transform-plugin.js
+++ b/packages/babel-preset-expo/build/import-meta-transform-plugin.js
@@ -12,7 +12,7 @@ function expoImportMetaTransformPluginFactory(pluginEnabled) {
                     const { node } = path;
                     if (node.meta.name === 'import' && node.property.name === 'meta') {
                         if (!pluginEnabled) {
-                            throw path.buildCodeFrameError('Your code uses `import.meta` which is not supported in the React Native runtime yet. Please enable the `unstable_transformImportMeta` option in babel-preset-expo to use import.meta.');
+                            throw path.buildCodeFrameError('Your code uses `import.meta` which is not supported in the React Native runtime yet. Enable the `unstable_transformImportMeta` option in babel-preset-expo to use `import.meta`.');
                         }
                         const replacement = t.memberExpression(t.identifier('globalThis'), t.identifier('__ExpoImportMetaRegistry'));
                         path.replaceWith(replacement);

--- a/packages/babel-preset-expo/build/import-meta-transform-plugin.js
+++ b/packages/babel-preset-expo/build/import-meta-transform-plugin.js
@@ -15,7 +15,7 @@ function expoImportMetaTransformPluginFactory(pluginEnabled) {
                     if (node.meta.name === 'import' && node.property.name === 'meta') {
                         if (!pluginEnabled) {
                             if (platform !== 'web') {
-                                throw path.buildCodeFrameError('Your code uses `import.meta` which is not supported in the React Native runtime yet. Enable the `unstable_transformImportMeta` option in babel-preset-expo to use `import.meta`.');
+                                throw path.buildCodeFrameError('`import.meta` is not supported in Hermes. Enable the polyfill `unstable_transformImportMeta` in babel-preset-expo to use this syntax.');
                             }
                             return;
                         }

--- a/packages/babel-preset-expo/build/import-meta-transform-plugin.js
+++ b/packages/babel-preset-expo/build/import-meta-transform-plugin.js
@@ -1,19 +1,24 @@
 "use strict";
 // Copyright 2015-present 650 Industries. All rights reserved.
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.expoImportMetaTransformPlugin = expoImportMetaTransformPlugin;
-function expoImportMetaTransformPlugin(api) {
-    const { types: t } = api;
-    return {
-        name: 'expo-import-meta-transform',
-        visitor: {
-            MetaProperty(path) {
-                const { node } = path;
-                if (node.meta.name === 'import' && node.property.name === 'meta') {
-                    const replacement = t.memberExpression(t.identifier('globalThis'), t.identifier('__ExpoImportMetaRegistry'));
-                    path.replaceWith(replacement);
-                }
+exports.expoImportMetaTransformPluginFactory = expoImportMetaTransformPluginFactory;
+function expoImportMetaTransformPluginFactory(pluginEnabled) {
+    return (api) => {
+        const { types: t } = api;
+        return {
+            name: 'expo-import-meta-transform',
+            visitor: {
+                MetaProperty(path) {
+                    const { node } = path;
+                    if (node.meta.name === 'import' && node.property.name === 'meta') {
+                        if (!pluginEnabled) {
+                            throw path.buildCodeFrameError('Your code uses `import.meta` which is not supported in the React Native runtime yet. Please enable the `unstable_transformImportMeta` option in babel-preset-expo to use import.meta.');
+                        }
+                        const replacement = t.memberExpression(t.identifier('globalThis'), t.identifier('__ExpoImportMetaRegistry'));
+                        path.replaceWith(replacement);
+                    }
+                },
             },
-        },
+        };
     };
 }

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -5,6 +5,7 @@ const common_1 = require("./common");
 const environment_restricted_imports_1 = require("./environment-restricted-imports");
 const expo_inline_manifest_plugin_1 = require("./expo-inline-manifest-plugin");
 const expo_router_plugin_1 = require("./expo-router-plugin");
+const import_meta_transform_plugin_1 = require("./import-meta-transform-plugin");
 const inline_env_vars_1 = require("./inline-env-vars");
 const lazyImports_1 = require("./lazyImports");
 const restricted_react_api_plugin_1 = require("./restricted-react-api-plugin");
@@ -180,9 +181,7 @@ function babelPresetExpo(api, options = {}) {
     if (platformOptions.disableImportExportTransform) {
         extraPlugins.push([require('./detect-dynamic-exports').detectDynamicExports]);
     }
-    if (platformOptions.unstable_transformImportMeta === true) {
-        extraPlugins.push(require('./import-meta-transform-plugin').expoImportMetaTransformPlugin);
-    }
+    extraPlugins.push((0, import_meta_transform_plugin_1.expoImportMetaTransformPluginFactory)(platformOptions.unstable_transformImportMeta === true));
     return {
         presets: [
             (() => {

--- a/packages/babel-preset-expo/src/__tests__/import-meta-transform-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/import-meta-transform-plugin.test.ts
@@ -40,6 +40,6 @@ it(`should throw an error when trying to transform import.meta by default`, () =
 
   const sourceCode = `var url = import.meta.url;`;
   expect(() => babel.transform(sourceCode, options)).toThrow(
-    /Your code uses `import.meta` which is not supported in the React Native runtime yet. Please enable the `unstable_transformImportMeta` option in babel-preset-expo to use import.meta./
+    /Your code uses `import.meta` which is not supported in the React Native runtime yet. Enable the `unstable_transformImportMeta` option in babel-preset-expo to use `import.meta`./
   );
 });

--- a/packages/babel-preset-expo/src/__tests__/import-meta-transform-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/import-meta-transform-plugin.test.ts
@@ -41,7 +41,7 @@ it(`should throw an error when trying to transform import.meta by default for na
 
     const sourceCode = `var url = import.meta.url;`;
     expect(() => babel.transform(sourceCode, options)).toThrow(
-      /Your code uses `import.meta` which is not supported in the React Native runtime yet. Enable the `unstable_transformImportMeta` option in babel-preset-expo to use `import.meta`./
+      /`import.meta` is not supported in Hermes. Enable the polyfill `unstable_transformImportMeta` in babel-preset-expo to use this syntax./
     );
   });
 });

--- a/packages/babel-preset-expo/src/__tests__/import-meta-transform-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/import-meta-transform-plugin.test.ts
@@ -32,12 +32,14 @@ it(`transforms import.meta.url to globalThis.__ExpoImportMetaRegistry.url when u
   );
 });
 
-it(`should not transform import.meta by default`, () => {
+it(`should throw an error when trying to transform import.meta by default`, () => {
   const options = {
     ...DEF_OPTIONS,
     caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'ios', isDev: true }),
   };
 
   const sourceCode = `var url = import.meta.url;`;
-  expect(babel.transform(sourceCode, options)!.code).toEqual(sourceCode);
+  expect(() => babel.transform(sourceCode, options)).toThrow(
+    /Your code uses `import.meta` which is not supported in the React Native runtime yet. Please enable the `unstable_transformImportMeta` option in babel-preset-expo to use import.meta./
+  );
 });

--- a/packages/babel-preset-expo/src/__tests__/import-meta-transform-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/import-meta-transform-plugin.test.ts
@@ -32,14 +32,34 @@ it(`transforms import.meta.url to globalThis.__ExpoImportMetaRegistry.url when u
   );
 });
 
-it(`should throw an error when trying to transform import.meta by default`, () => {
-  const options = {
-    ...DEF_OPTIONS,
-    caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'ios', isDev: true }),
-  };
+it(`should throw an error when trying to transform import.meta by default for native platforms`, () => {
+  ['android', 'ios'].forEach((platform) => {
+    const options = {
+      ...DEF_OPTIONS,
+      caller: getCaller({ name: 'metro', engine: 'hermes', platform, isDev: true }),
+    };
 
-  const sourceCode = `var url = import.meta.url;`;
-  expect(() => babel.transform(sourceCode, options)).toThrow(
-    /Your code uses `import.meta` which is not supported in the React Native runtime yet. Enable the `unstable_transformImportMeta` option in babel-preset-expo to use `import.meta`./
-  );
+    const sourceCode = `var url = import.meta.url;`;
+    expect(() => babel.transform(sourceCode, options)).toThrow(
+      /Your code uses `import.meta` which is not supported in the React Native runtime yet. Enable the `unstable_transformImportMeta` option in babel-preset-expo to use `import.meta`./
+    );
+  });
+});
+
+it(`should not transform import.meta by default for web and server platforms`, () => {
+  ['web', 'server'].forEach((platform) => {
+    const options = {
+      ...DEF_OPTIONS,
+      caller: getCaller({
+        name: 'metro',
+        engine: 'hermes',
+        platform: 'web',
+        isDev: true,
+        isServer: platform === 'server',
+      }),
+    };
+
+    const sourceCode = `var url = import.meta.url;`;
+    expect(babel.transform(sourceCode, options)!.code).toEqual(sourceCode);
+  });
 });

--- a/packages/babel-preset-expo/src/import-meta-transform-plugin.ts
+++ b/packages/babel-preset-expo/src/import-meta-transform-plugin.ts
@@ -14,7 +14,7 @@ export function expoImportMetaTransformPluginFactory(pluginEnabled: boolean) {
           if (node.meta.name === 'import' && node.property.name === 'meta') {
             if (!pluginEnabled) {
               throw path.buildCodeFrameError(
-                'Your code uses `import.meta` which is not supported in the React Native runtime yet. Please enable the `unstable_transformImportMeta` option in babel-preset-expo to use import.meta.'
+                'Your code uses `import.meta` which is not supported in the React Native runtime yet. Enable the `unstable_transformImportMeta` option in babel-preset-expo to use `import.meta`.'
               );
             }
             const replacement = t.memberExpression(

--- a/packages/babel-preset-expo/src/import-meta-transform-plugin.ts
+++ b/packages/babel-preset-expo/src/import-meta-transform-plugin.ts
@@ -2,24 +2,29 @@
 
 import { ConfigAPI, types } from '@babel/core';
 
-export function expoImportMetaTransformPlugin(
-  api: ConfigAPI & { types: typeof types }
-): babel.PluginObj {
-  const { types: t } = api;
+export function expoImportMetaTransformPluginFactory(pluginEnabled: boolean) {
+  return (api: ConfigAPI & { types: typeof types }): babel.PluginObj => {
+    const { types: t } = api;
 
-  return {
-    name: 'expo-import-meta-transform',
-    visitor: {
-      MetaProperty(path) {
-        const { node } = path;
-        if (node.meta.name === 'import' && node.property.name === 'meta') {
-          const replacement = t.memberExpression(
-            t.identifier('globalThis'),
-            t.identifier('__ExpoImportMetaRegistry')
-          );
-          path.replaceWith(replacement);
-        }
+    return {
+      name: 'expo-import-meta-transform',
+      visitor: {
+        MetaProperty(path) {
+          const { node } = path;
+          if (node.meta.name === 'import' && node.property.name === 'meta') {
+            if (!pluginEnabled) {
+              throw path.buildCodeFrameError(
+                'Your code uses `import.meta` which is not supported in the React Native runtime yet. Please enable the `unstable_transformImportMeta` option in babel-preset-expo to use import.meta.'
+              );
+            }
+            const replacement = t.memberExpression(
+              t.identifier('globalThis'),
+              t.identifier('__ExpoImportMetaRegistry')
+            );
+            path.replaceWith(replacement);
+          }
+        },
       },
-    },
+    };
   };
 }

--- a/packages/babel-preset-expo/src/import-meta-transform-plugin.ts
+++ b/packages/babel-preset-expo/src/import-meta-transform-plugin.ts
@@ -18,7 +18,7 @@ export function expoImportMetaTransformPluginFactory(pluginEnabled: boolean) {
             if (!pluginEnabled) {
               if (platform !== 'web') {
                 throw path.buildCodeFrameError(
-                  'Your code uses `import.meta` which is not supported in the React Native runtime yet. Enable the `unstable_transformImportMeta` option in babel-preset-expo to use `import.meta`.'
+                  '`import.meta` is not supported in Hermes. Enable the polyfill `unstable_transformImportMeta` in babel-preset-expo to use this syntax.'
                 );
               }
               return;

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -17,6 +17,7 @@ import {
 import { environmentRestrictedImportsPlugin } from './environment-restricted-imports';
 import { expoInlineManifestPlugin } from './expo-inline-manifest-plugin';
 import { expoRouterBabelPlugin } from './expo-router-plugin';
+import { expoImportMetaTransformPluginFactory } from './import-meta-transform-plugin';
 import { expoInlineEnvVars } from './inline-env-vars';
 import { lazyImports } from './lazyImports';
 import { environmentRestrictedReactAPIsPlugin } from './restricted-react-api-plugin';
@@ -327,9 +328,9 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
   if (platformOptions.disableImportExportTransform) {
     extraPlugins.push([require('./detect-dynamic-exports').detectDynamicExports]);
   }
-  if (platformOptions.unstable_transformImportMeta === true) {
-    extraPlugins.push(require('./import-meta-transform-plugin').expoImportMetaTransformPlugin);
-  }
+  extraPlugins.push(
+    expoImportMetaTransformPluginFactory(platformOptions.unstable_transformImportMeta === true)
+  );
 
   return {
     presets: [


### PR DESCRIPTION
# Why

follow up #34756

# How

add a default transform error if people having `import.meta` but not enable unstable_transformImportMeta

# Test Plan

update unit test

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
