### PR TITLE
[doctor] Add React 19 override check to package.json validation

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add React 19 override check to package.json validation
+- Add React 19 override check to package.json validation ([#36076](https://github.com/expo/expo/pull/36076) by [@leonhh](https://github.com/leonhh))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add React 19 override check to package.json validation
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-doctor/src/checks/PackageJsonCheck.ts
+++ b/packages/expo-doctor/src/checks/PackageJsonCheck.ts
@@ -42,6 +42,27 @@ export class PackageJsonCheck implements DoctorCheck {
       );
     }
 
+    // ** check if the package.json contains react 19 and if an override is set for it. If an override is not set this can cause a runtime issue:
+    // "Warning: Error: A React Element from an older version of React was rendered. This is not supported"
+    //  **
+
+    const reactVersion = pkg.dependencies?.react;
+    const reactOverride = pkg.overrides?.react;
+
+    if (
+      reactVersion &&
+      reactVersion.includes('19.') &&
+      (!reactOverride || !reactOverride.includes('19.'))
+    ) {
+      issues.push(
+        'React 19 is installed but no override is set for it in the package.json. To prevent runtime issues, please add the following override to your package.json:\n' +
+          `\n"overrides": {\n` +
+          `  "react": "${reactVersion}"\n` +
+          `}\n` +
+          `\nThis will ensure that react-native will always use the correct version of React.`
+      );
+    }
+
     return {
       isSuccessful: issues.length === 0,
       issues,

--- a/packages/expo-doctor/src/checks/__tests__/PackageJsonCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/PackageJsonCheck.test.ts
@@ -122,4 +122,28 @@ describe('runAsync', () => {
     });
     expect(result.isSuccessful).toBeFalsy();
   });
+
+  // React 19 override check
+  it('returns result with isSuccessful = true if React 19 is installed and an override is set', async () => {
+    const check = new PackageJsonCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'name',
+        version: '1.0.0',
+        dependencies: { react: '19.0.0' },
+        overrides: { react: '19.0.0' },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = false if React 19 is installed and no override is set ', async () => {
+    const check = new PackageJsonCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0', dependencies: { react: '19.0.0' } },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
 });


### PR DESCRIPTION
# Why

SDK 53 will ship with React 19. However some packages still ship with React 18 which can cause conflicts. The default template will already ship with an [override](https://github.com/expo/expo/pull/35331). But to help developers that are manually upgrading to SDK 53 it might be useful to check if they also have this override set.

# How

It checks if react 19 is installed, if it is and no override is set we will give them a helpful warning message.

# Test Plan

Tested locally by creating a new project:
```
npx create-expo-app my-app --template bare-minimum@next
```
Removing the override in package.json

Run `nexpo-doctor` (if aliased) or `packages/expo-doctor/build/index.js` in the `my-app` project.

Then this message is shown:

```
✖ Check package.json for common issues
  React 19 is installed but no override is set for it in the package.json. To prevent runtime issues, please add the following override to your package.json:
  
  "overrides": {
    "react": "19.0.0"
  }
  
  This will ensure that react-native will always use the correct version of React
  ```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
