### PR TITLE
[doc] add sqlite web experimental callout

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -75,6 +75,8 @@ You can configure `expo-sqlite` for advanced configurations using its built-in [
 
 ## Web setup
 
+> **info** Web support is still experimental and may be unstable. [Create an issue on GitHub](https://github.com/expo/expo/issues) if you encounter any issues.
+
 To use `expo-sqlite` on web, you need to configure Metro bundler to support **wasm** files and add HTTP headers to allow [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) usage.
 
 Add the following configuration to your **metro.config.js**. If you don't have the **metro.config.js** yet, you can run `npx expo customize metro.config.js`. [Learn more](/guides/customizing-metro/).

--- a/docs/pages/versions/v53.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/sqlite.mdx
@@ -75,6 +75,8 @@ You can configure `expo-sqlite` for advanced configurations using its built-in [
 
 ## Web setup
 
+> **info** Web support is still experimental and may be unstable. [Create an issue on GitHub](https://github.com/expo/expo/issues) if you encounter any issues.
+
 To use `expo-sqlite` on web, you need to configure Metro bundler to support **wasm** files and add HTTP headers to allow [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) usage.
 
 Add the following configuration to your **metro.config.js**. If you don't have the **metro.config.js** yet, you can run `npx expo customize metro.config.js`. [Learn more](/guides/customizing-metro/).


### PR DESCRIPTION
# Why

add note for expo-sqlite web is still experimental

# How

add an experimental callout

![Screenshot 2025-04-11 at 3 00 17 AM](https://github.com/user-attachments/assets/06126b98-a845-4849-8146-bfa2e1f0a092)

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
