### PR TITLE
chore(cli): deprecate --https flag

### DIFF
--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -749,7 +749,7 @@ export default function App() {
 
   **Web dev**: `https://localhost:19006`
 
-  - Run `expo start --web --https` to run with **https**, auth won't work otherwise.
+  - Run `npx expo start --tunnel` to run with **https**, auth won't work otherwise.
   - Adding a slash to the end of the URL doesn't matter.
 
   **Standalone / development build**: `your-scheme://`
@@ -1639,7 +1639,7 @@ export default function App() {
   **Web dev**: `https://localhost:19006`
 
   - Important: Ensure there's no slash at the end of the URL unless manually changed in the app code with `makeRedirectUri({ path: '/' })`.
-  - Run `expo start --web --https` to run with **https**, auth won't work otherwise.
+  - Run `npx expo start --tunnel` to run with **https**, auth won't work otherwise.
 
   **Standalone / development build**: `your-scheme://`
 
@@ -1962,7 +1962,7 @@ export default function App() {
 - Web does not appear to work, the Twitter authentication website appears to block the popup, causing the `response` of `useAuthRequest` to always be `{type: 'dismiss'}`.
 - Example redirects:
   - Standalone / development build: `com.your.app://`
-  - Web (dev `expo start --https`): `https://localhost:19006` (no ending slash)
+  - Web (dev `npx expo start --tunnel`): `https://xxxxxxx.bacon.19000.exp.direct:80` the hash will change between runs, use the `EXPO_TUNNEL_SUBDOMAIN` environment variable to create a stable URL.
 - The `redirectUri` requires two slashes (`://`).
 
 {/* prettier-ignore */}

--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -747,9 +747,9 @@ export default function App() {
 - Scopes must be joined with `:` so just create one long string.
 - Setup redirect URIs: Your Project > Permitted Redirect URIs: (be sure to save after making changes).
 
-  **Web dev**: `https://localhost:19006`
+  **Web dev**: public temporary domain like `https://xxxxxxx.bacon.19000.exp.direct:80`
 
-  - Run `npx expo start --tunnel` to run with **https**, auth won't work otherwise.
+  - Run `npx expo start --tunnel` to run with **https**. Learn more about [tunneling in Expo](/more/expo-cli/#tunneling).
   - Adding a slash to the end of the URL doesn't matter.
 
   **Standalone / development build**: `your-scheme://`
@@ -1636,10 +1636,10 @@ export default function App() {
 
 - Setup your redirect URIs: **Your project > Edit Settings > Redirect URIs**, be sure to save after making changes.
 
-  **Web dev**: `https://localhost:19006`
+  **Web dev**: public temporary domain like `https://xxxxxxx.bacon.19000.exp.direct:80`
 
   - Important: Ensure there's no slash at the end of the URL unless manually changed in the app code with `makeRedirectUri({ path: '/' })`.
-  - Run `npx expo start --tunnel` to run with **https**, auth won't work otherwise.
+  - Run `npx expo start --tunnel` to run with **https**. Learn more about [tunneling in Expo](/more/expo-cli/#tunneling).
 
   **Standalone / development build**: `your-scheme://`
 

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -98,7 +98,7 @@ By default, the project is served over a LAN connection. You can change this beh
 Other available options are:
 
 - `--port`: Port to start the dev server on (does not apply to webpack or [tunnel URLs](#tunneling)). Use `--port 0` to automatically use the first available port. Default: **8081**.
-- `--https`: Start the dev server using a secure origin. This is currently only supported on web.
+- `--https`: **(Deprecated in favor of `--tunnel`)** Start the dev server using a secure origin. This is currently only supported on web.
 
 You can force the URL to be any value with the `EXPO_PACKAGER_PROXY_URL` environment variable. For example:
 
@@ -120,7 +120,9 @@ Then run the following to start your dev server from a _tunnel_ URL:
 
 <Terminal cmd={['$ npx expo start --tunnel']} />
 
-This will serve your app from a public URL like: `http://xxxxxxx.bacon.19000.exp.direct:80`.
+This will serve your app from a public URL like: `https://xxxxxxx.bacon.19000.exp.direct:80`.
+
+Use the `EXPO_TUNNEL_SUBDOMAIN` environment variable to experimentally set the subdomain for the tunnel URL. This is useful for testing universal links on iOS. This may cause unexpected issues with `expo-linking` and Expo Go. Select the exact subdomain to use by passing a `string` value that is not one of: `true`, `false`, `1`, `0`.
 
 **Drawbacks**
 

--- a/docs/pages/versions/unversioned/sdk/sharing.mdx
+++ b/docs/pages/versions/unversioned/sdk/sharing.mdx
@@ -18,7 +18,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 #### Sharing limitations on web
 
 - `expo-sharing` for web is built on top of the Web Share API, which still has [very limited browser support](https://caniuse.com/#feat=web-share). Be sure to check that the API can be used before calling it by using `Sharing.isAvailableAsync()`.
-- **HTTPS required on web**: The Web Share API is only available on web when the page is served over https. Run your app with `npx expo start --https` to enable it.
+- **HTTPS required on web**: The Web Share API is only available on web when the page is served over https. Run your app with `npx expo start --tunnel` to enable it.
 - **No local file sharing on web**: Sharing local files by URI works on Android and iOS, but not on web. You cannot share local files on web by URI &mdash; you will need to upload them somewhere and share that URI.
 
 #### Sharing to your app from other apps

--- a/docs/pages/versions/v50.0.0/sdk/sharing.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/sharing.mdx
@@ -20,7 +20,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 #### Sharing limitations on web
 
 - `expo-sharing` for web is built on top of the Web Share API, which still has [very limited browser support](https://caniuse.com/#feat=web-share). Be sure to check that the API can be used before calling it by using `Sharing.isAvailableAsync()`.
-- **HTTPS required on web**: The Web Share API is only available on web when the page is served over https. Run your app with `npx expo start --https` to enable it.
+- **HTTPS required on web**: The Web Share API is only available on web when the page is served over https. Run your app with `npx expo start --tunnel` to enable it.
 - **No local file sharing on web**: Sharing local files by URI works on Android and iOS, but not on web. You cannot share local files on web by URI &mdash; you will need to upload them somewhere and share that URI.
 
 #### Sharing to your app from other apps

--- a/docs/pages/versions/v51.0.0/sdk/sharing.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/sharing.mdx
@@ -18,7 +18,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 #### Sharing limitations on web
 
 - `expo-sharing` for web is built on top of the Web Share API, which still has [very limited browser support](https://caniuse.com/#feat=web-share). Be sure to check that the API can be used before calling it by using `Sharing.isAvailableAsync()`.
-- **HTTPS required on web**: The Web Share API is only available on web when the page is served over https. Run your app with `npx expo start --https` to enable it.
+- **HTTPS required on web**: The Web Share API is only available on web when the page is served over https. Run your app with `npx expo start --tunnel` to enable it.
 - **No local file sharing on web**: Sharing local files by URI works on Android and iOS, but not on web. You cannot share local files on web by URI &mdash; you will need to upload them somewhere and share that URI.
 
 #### Sharing to your app from other apps

--- a/docs/pages/versions/v52.0.0/sdk/sharing.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/sharing.mdx
@@ -18,7 +18,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 #### Sharing limitations on web
 
 - `expo-sharing` for web is built on top of the Web Share API, which still has [very limited browser support](https://caniuse.com/#feat=web-share). Be sure to check that the API can be used before calling it by using `Sharing.isAvailableAsync()`.
-- **HTTPS required on web**: The Web Share API is only available on web when the page is served over https. Run your app with `npx expo start --https` to enable it.
+- **HTTPS required on web**: The Web Share API is only available on web when the page is served over https. Run your app with `npx expo start --tunnel` to enable it.
 - **No local file sharing on web**: Sharing local files by URI works on Android and iOS, but not on web. You cannot share local files on web by URI &mdash; you will need to upload them somewhere and share that URI.
 
 #### Sharing to your app from other apps

--- a/docs/pages/versions/v53.0.0/sdk/sharing.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/sharing.mdx
@@ -18,7 +18,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 #### Sharing limitations on web
 
 - `expo-sharing` for web is built on top of the Web Share API, which still has [very limited browser support](https://caniuse.com/#feat=web-share). Be sure to check that the API can be used before calling it by using `Sharing.isAvailableAsync()`.
-- **HTTPS required on web**: The Web Share API is only available on web when the page is served over https. Run your app with `npx expo start --https` to enable it.
+- **HTTPS required on web**: The Web Share API is only available on web when the page is served over https. Run your app with `npx expo start --tunnel` to enable it.
 - **No local file sharing on web**: Sharing local files by URI works on Android and iOS, but not on web. You cannot share local files on web by URI &mdash; you will need to upload them somewhere and share that URI.
 
 #### Sharing to your app from other apps

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Mark `--https` as deprecated in favor of `--tunnel`.
+
 ## 0.23.3 — 2025-04-10
 
 ### 🎉 New features

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Mark `--https` as deprecated in favor of `--tunnel`.
+- Mark `--https` as deprecated in favor of `--tunnel`. ([#36083](https://github.com/expo/expo/pull/36083) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.23.3 — 2025-04-10
 

--- a/packages/@expo/cli/e2e/__tests__/start-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/start-test.ts
@@ -67,7 +67,7 @@ it('runs `npx expo start --help`', async () => {
         --localhost                     Same as --host localhost
         
         --offline                       Skip network requests and use anonymous manifest signatures
-        --https                         Start the dev server with https protocol
+        --https                         Start the dev server with https protocol. Deprecated in favor of --tunnel
         --scheme <scheme>               Custom URI protocol to use when launching an app
         -p, --port <number>             Port to start the dev server on (does not apply to web or tunnel). Default: 8081
         

--- a/packages/@expo/cli/src/start/index.ts
+++ b/packages/@expo/cli/src/start/index.ts
@@ -71,7 +71,7 @@ export const expoStart: Command = async (argv) => {
         `--localhost                     Same as --host localhost`,
         ``,
         `--offline                       Skip network requests and use anonymous manifest signatures`,
-        `--https                         Start the dev server with https protocol`,
+        chalk`--https                         Start the dev server with https protocol. {bold Deprecated in favor of --tunnel}`,
         `--scheme <scheme>               Custom URI protocol to use when launching an app`,
         chalk`-p, --port <number>             Port to start the dev server on (does not apply to web or tunnel). {dim Default: 8081}`,
         ``,

--- a/packages/@expo/cli/src/start/resolveOptions.ts
+++ b/packages/@expo/cli/src/start/resolveOptions.ts
@@ -37,6 +37,10 @@ export async function resolveOptionsAsync(projectRoot: string, args: any): Promi
     tunnel: args['--tunnel'],
   });
 
+  if (args['--https']) {
+    Log.warn(chalk`{bold --https} option is deprecated in favor of {bold --tunnel}`);
+  }
+
   // User can force the default target by passing either `--dev-client` or `--go`. They can also
   // swap between them during development by pressing `s`.
   const isUserDefinedDevClient =

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Update doc comment about `--https` flag.
+- Update doc comment about `--https` flag. ([#36083](https://github.com/expo/expo/pull/36083) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 14.1.1 — 2025-04-09
 

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update doc comment about `--https` flag.
+
 ## 14.1.1 — 2025-04-09
 
 _This version does not introduce any user-facing changes._


### PR DESCRIPTION
# Why

- The `--https` flag generates an insecure certificate which is fragile, heavy, doesn't work well across computers, and breaks in Expo Go. 
- Using `https://localhost` is only partially supported in many tools, e.g. Apple auth does not support localhost at all.
- `https` used to be required for even basic web APIs such as crypto but these often work fine with `http://localhost`, reducing the need for the insecure method.
- A better alternative is to use the free tunneling service we provide via `expo start --tunnel` to generate a temporary hosted https URL with proper certificates that work across all platforms and enable authentication development.

# How

- Mark `--https` flag as deprecated in the docs and CLI.
- Update docs to inform users about the `--tunnel` flag instead of `--https`.
