### PR TITLE
chore(cli): Use eas-cli fingerprint:generate to generate fingerprints

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Mark `--https` as deprecated in favor of `--tunnel`. ([#36083](https://github.com/expo/expo/pull/36083) by [@EvanBacon](https://github.com/EvanBacon))
+- Use `eas-cli fingerprint:generate` to generate fingerprints for remote builds cache. ([#36085](https://github.com/expo/expo/pull/36085) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 0.23.3 — 2025-04-10
 


### PR DESCRIPTION
# Why

To ensure that locally calculated fingerprints match `eas build` fingerprints, we should use the same configurations. Utilizing `eas-cli fingerprint:generate` directly simplifies keeping these configurations in sync. Additionally, when we calculate fingerprints with eas cli, the sources get automatically uploaded.

# How

Attempt to use `eas fingerprint:generate` to check for compatible builds when remove build cache provider is `eas`

# Test Plan

Run `nexpo run:android` and `nexpo run:ios` locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
