### PR TITLE
[docs] Snippet: more compact actions on mobile, overflow tweaks

### DIFF
--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -33,11 +33,11 @@ export const SnippetHeader = ({
     )}>
     <LABEL
       className={mergeClasses(
-        'flex min-h-10 w-full items-center gap-2 py-1 pr-4 font-medium !leading-tight',
+        'flex min-h-10 w-full items-center gap-2 overflow-x-auto py-1 pr-4 font-medium !leading-tight',
         alwaysDark && 'text-palette-white'
       )}>
       {Icon && <Icon className="icon-sm shrink-0" />}
-      <span className="break-words">{title}</span>
+      <span className="break-words w-max max-w-[60dvw] truncate">{title}</span>
       {showOperation && operationType ? <FileStatus type={operationType} /> : null}
     </LABEL>
     {!!children && <div className="flex items-center justify-end">{children}</div>}

--- a/docs/ui/components/Snippet/actions/CopyAction.tsx
+++ b/docs/ui/components/Snippet/actions/CopyAction.tsx
@@ -20,12 +20,12 @@ export const CopyAction = ({ text, ...rest }: CopyActionProps) => {
 
   return (
     <SnippetAction
-      leftSlot={<ClipboardIcon className="icon-sm text-icon-default" />}
+      leftSlot={<ClipboardIcon className="icon-sm text-icon-secondary max-sm-gutters:-mr-1" />}
       onClick={onCopyClick}
       disabled={copyDone}
       aria-label="Copy content"
       {...rest}>
-      {copyDone ? 'Copied!' : 'Copy'}
+      <span className="max-sm-gutters:hidden">{copyDone ? 'Copied!' : 'Copy'}</span>
     </SnippetAction>
   );
 };

--- a/docs/ui/components/Snippet/blocks/SnackInline.tsx
+++ b/docs/ui/components/Snippet/blocks/SnackInline.tsx
@@ -100,9 +100,13 @@ export const SnackInline = ({
           <CopyAction text={cleanCopyValue(value)} />
           <SnippetAction
             disabled={!isReady}
-            rightSlot={<ArrowUpRightIcon className="icon-sm text-icon-secondary" />}
+            rightSlot={
+              <ArrowUpRightIcon className="icon-sm text-icon-secondary max-sm-gutters:-ml-1.5" />
+            }
             type="submit">
-            <span className="max-md-gutters:hidden">Open in </span>Snack
+            <span className="max-sm-gutters:hidden">
+              <span className="max-md-gutters:hidden">Open in </span>Snack
+            </span>
           </SnippetAction>
           <SettingsAction />
         </form>


### PR DESCRIPTION
# Why

Fixes #31618 

# How

Add more compact variant for snippet actions on mobile, overflow tweaks for title/header of a snippet.

# Test Plan

The changes have been reviewed by running docs app locally, and visiting few pages which use code snippet component.

All lint checks and tests are passing.

# Preview

![Screenshot 2025-04-11 at 14 20 48](https://github.com/user-attachments/assets/8c77741c-a5e6-4da2-a90a-43083d0f8f0d)

![Screenshot 2025-04-11 at 14 22 38](https://github.com/user-attachments/assets/20955cd3-b2c8-4390-a35d-b621c42127c7)

![Screenshot 2025-04-11 at 14 23 01](https://github.com/user-attachments/assets/1a6c6c4a-ff8f-401d-9ab8-23b567ca60c9)
