### PR TITLE
[docs] Add OnActivityResult documentation to the Module API page

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -439,7 +439,7 @@ Defines the activity lifecycle listener that is called when the activity launche
 - **activity** — The Android activity that received the result.
 - **payload** — An object containing data about the activity result.
   - **requestCode**: `Int` — The request code originally supplied to `startActivityForResult`, used to identify the source of the result.
-  - **resultCode**: `Int` — The result code returned by the child activity (e.g., `Activity.RESULT_OK` or `Activity.RESULT_CANCELED`).
+  - **resultCode**: `Int` — The result code returned by the child activity (for example, `Activity.RESULT_OK` or `Activity.RESULT_CANCELED`).
   - **data** — An optional intent that carries the result data returned from the launched activity. Can be `null`.
 
 ```kotlin Kotlin

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -432,7 +432,7 @@ Defines the activity lifecycle listener that is called when the activity owning 
 
 <PaddedAPIBox header="OnActivityResult" platforms={["android"]}>
 
-Defines the activity lifecycle listener that is called when the activity launched with startActivityForResult returns a result.
+Defines the activity lifecycle listener that is called when the activity launched with `startActivityForResult` returns a result.
 
 #### Arguments
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -448,7 +448,7 @@ AsyncFunction('someFunc') {
   activity.startActivityForResult(someIntent, SOME_REQUEST_CODE)
 }
 
-OnActivityResult { activity, (requestCode, resultCode, data) ->
+OnActivityResult { activity, payload ->
   ...
 }
 ```

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -430,6 +430,31 @@ Defines the activity lifecycle listener that is called when the activity owning 
 
 </PaddedAPIBox>
 
+<PaddedAPIBox header="OnActivityResult" platforms={["android"]}>
+
+Defines the activity lifecycle listener that is called when the activity launched with startActivityForResult returns a result.
+
+#### Arguments
+
+- **activity** — The Android activity that received the result.
+- **payload** — An object containing data about the activity result.
+  - **requestCode**: `Int` — The request code originally supplied to `startActivityForResult`, used to identify the source of the result.
+  - **resultCode**: `Int` — The result code returned by the child activity (e.g., `Activity.RESULT_OK` or `Activity.RESULT_CANCELED`).
+  - **data** — An optional intent that carries the result data returned from the launched activity. Can be `null`.
+
+```kotlin Kotlin
+AsyncFunction('someFunc') {
+  ...
+  activity.startActivityForResult(someIntent, SOME_REQUEST_CODE)
+}
+
+OnActivityResult { activity, (requestCode, resultCode, data) ->
+  ...
+}
+```
+
+</PaddedAPIBox>
+
 <PaddedAPIBox header="GroupView" platforms={["android"]}>
 
 Enables the view to be used as a view group. Definition components that are accepted as part of the group view definition: [`AddChildView`](#addchildview), [`GetChildCount`](#getchildcount), [`GetChildViewAt`](#getchildviewat), [`RemoveChildView`](#removechildview), [`RemoveChildViewAt`](#removechildviewat).


### PR DESCRIPTION
# Why
The Module API documentation currently does not mention `OnActivityResult`, which is important when working with native modules that start Android activities and need to handle their results.

Related issue: https://github.com/expo/expo/issues/33260

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
Added a new section to the [Module API](https://docs.expo.dev/modules/module-api/) page documenting `OnActivityResult`, with a brief description of the method, its arguments, and a minimal usage example.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
By running the docs app locally.

<!-- disable:changelog-checks -->

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Preview
![image](https://github.com/user-attachments/assets/e822730f-fdc1-48cf-9cf5-746b888e5053)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
