### PR TITLE
chore(cli): Warn users to upgrade eas-cli version

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add a warning for users to upgrade their `eas-cli` when using `remoteBuildCache`. ([#36103](https://github.com/expo/expo/pull/36103) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 0.23.4 — 2025-04-11
 
 ### 💡 Others

--- a/packages/@expo/cli/src/run/remoteBuildCache.ts
+++ b/packages/@expo/cli/src/run/remoteBuildCache.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { Log } from '../log';
+import { isSpawnResultError } from '../start/platforms/ios/xcrun';
 
 const debug = require('debug')('expo:run:remote-build') as typeof console.log;
 
@@ -56,6 +57,12 @@ export async function resolveRemoteBuildCache(
       return json?.path;
     } catch (error) {
       debug('eas-cli error:', error);
+      // @TODO(2025-04-11): remove this in a future release
+      if (isSpawnResultError(error) && error.stderr.includes('command build:download not found')) {
+        Log.warn(
+          `To take advantage of remote build cache, upgrade your eas-cli installation to latest.`
+        );
+      }
       return null;
     }
   }


### PR DESCRIPTION
# Why

For the remote builds cache feature to work, users have to be running the latest version of eas-cli

# How

Add a warning for users to upgrade their eas-cli

# Test Plan

Run `nexpo run:ios`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
