### PR TITLE
[vector-icons] include instructions for config-plugin use

### DIFF
--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -12,6 +12,8 @@ Not every app needs to use emojis for icons. You can use a popular icon set thro
 
 The `@expo/vector-icons` library is installed by default on the template project using `npx create-expo-app` and is part of the `expo` package. It is built on top of [`react-native-vector-icons`](https://github.com/oblador/react-native-vector-icons) and uses a similar API. It includes popular icon sets you can browse at [icons.expo.fyi](https://icons.expo.fyi).
 
+`@expo/vector-icons` doesn't require any setup because the fonts are loaded at runtime but if you want to optimize the runtime cost a tiny bit, you can use the `expo-font` config plugin to bundle the fonts at build time, similar to [these instructions](https://docs.expo.dev/develop/user-interface/fonts/#with-expo-font-config-plugin-1), where the path to a font file would be (for example) `node_modules/@expo/vector-icons/build/vendor/react-native-vector-icons/Fonts/Ionicons.ttf`.
+
 The component loads the `Ionicons` font and renders a checkmark icon in the following example:
 
 <SnackInline label='Vector icons' dependencies={['@expo/vector-icons']}>


### PR DESCRIPTION
# Why

This is in reaction to https://exponent-internal.slack.com/archives/C03035K1JP9/p1744369184100679 though I'm unsure whether there is any real benefit to doing this.
It does follow the other font docs though, such as https://docs.expo.dev/develop/user-interface/fonts/#with-expo-font-config-plugin-1

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
