### PR TITLE
fix(docs): update route group syntax in Tabs.Screen example

### DIFF
--- a/docs/pages/router/basics/common-navigation-patterns.mdx
+++ b/docs/pages/router/basics/common-navigation-patterns.mdx
@@ -105,7 +105,7 @@ export default function TabLayout() {
   return (
     <Tabs>
       <Tabs.Screen name="(feed)" options={{ title: 'Feed' }} />
-      <Tabs.Screen name="search" options={{ title: 'Search' }} />
+      <Tabs.Screen name="(search)" options={{ title: 'Search' }} />
     </Tabs>
   );
 }


### PR DESCRIPTION
# Why
`app/(tabs)/_layout.tsx` in the [One screen, two tabs: sharing routes](https://docs.expo.dev/router/basics/common-navigation-patterns/#one-screen-two-tabs-sharing-routes) defined `<Tabs.Screen name="search" options={{ title: 'Search' }} />` when what should have been used is a route group.

# How
I added parentesis around `search` to signify that it's a route group.
>

