### PR TITLE
chore: fixed peer version

### DIFF
--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -102,8 +102,8 @@
   "peerDependencies": {
     "@expo/dom-webview": "*",
     "@expo/metro-runtime": "*",
-    "react": "*",
-    "react-native": "*",
+    "react": "19.0.0",
+    "react-native": "0.79.0",
     "react-native-webview": "*"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
# Why
give the exact peer version for react and react-native, so that user don't have to list them in package.json. 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
see changed lines
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
