### PR TITLE
[templates] remove package.json overrides for react 19

### DIFF
--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -16,9 +16,6 @@
     "react": "19.0.0",
     "react-native": "0.79.0"
   },
-  "overrides": {
-    "react": "19.0.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.20.0"
   }

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -16,9 +16,6 @@
     "react": "19.0.0",
     "react-native": "0.79.0"
   },
-  "overrides": {
-    "react": "19.0.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -16,9 +16,6 @@
     "react": "19.0.0",
     "react-native": "0.79.0"
   },
-  "overrides": {
-    "react": "19.0.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.20.0"
   }

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -42,9 +42,6 @@
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5"
   },
-  "overrides": {
-    "react": "19.0.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/jest": "^29.5.12",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -33,9 +33,6 @@
     "react-native-screens": "~4.10.0",
     "react-native-web": "~0.20.0"
   },
-  "overrides": {
-    "react": "19.0.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",


### PR DESCRIPTION
# Why

expo-router's dependencies no longer have peer dependencies on old React versions. The base templates now work fine without an override for React 19.

# How

Removed overrides in package.json

# Test Plan

```
npx create-expo-app@next --template https://github.com/leonhh/expo/tree/remove-overrides/templates/expo-template-tabs

cd myapp
npm run web

or

npm run ios

```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
