### PR TITLE
[core] fix UnwrappedChildren regression

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `UnwrappedChildren` not get the unwrapped content view for SwiftUI integration. ([#36112](https://github.com/expo/expo/pull/36112) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.3.4 — 2025-04-11

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -45,8 +45,9 @@ public extension ExpoSwiftUIView {
       }
       return AnyView(
         Group {
-          if let hostingView = child as? ExpoSwiftUI.UIViewHost {
-            let content = hostingView.childView
+          if let hostingView = child as? ExpoSwiftUI.UIViewHost,
+            let hostingUIView = hostingView.view as? (any ExpoSwiftUI.AnyHostingView) {
+            let content = hostingUIView.getContentView()
             transform(
               AnyView(
                 content


### PR DESCRIPTION
# Why

fix `UnwrappedChildren` regression from #35553

# How

the `UnwrappedChildren` does not actually get the unwrapped children. we should further get the unwrapped content view

# Test Plan

NCL expo-ui List component

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
