### PR TITLE
[expo][SDK53] bump recommended @sentry/react-native version

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -110,5 +110,5 @@
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "v2.0.0-next.2",
   "@shopify/flash-list": "1.7.6",
-  "@sentry/react-native": "~6.3.0"
+  "@sentry/react-native": "~6.10.0"
 }


### PR DESCRIPTION
# Why

Sentry fails to build on SDK 53 in combination with Xcode 16.3. Some more information about this: https://github.com/getsentry/sentry-react-native/issues/4715

# How

Bump version in bundledNativeModules.json. Sentry version 6.10.0 solves this issue.

# Test Plan

This fails:

```
npx create-expo-app@latest --template default@sdk-53
cd myapp
npx expo install @sentry/react-native -- --force
npx expo prebuild
npm run ios
```

This works:

```
npx expo install @sentry/react-native@6.10.0 -- --force
npx expo prebuild
npm run ios
```

`--force` to bypass peer dependency requirement

# Checklist
- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
