### PR TITLE
Fix submit-ios.yml

### DIFF
--- a/docs/pages/submit/ios.mdx
+++ b/docs/pages/submit/ios.mdx
@@ -193,6 +193,7 @@ You can use [EAS Workflows](/eas-workflows/get-started/) to build and submit you
      # @info #
      submit_ios:
        name: Submit to Apple App Store
+       needs: [build_ios]
        type: submit
        params:
          platform: ios


### PR DESCRIPTION

# Why


The dependency to the build_ios job is needed, otherwise the submission job fails as it misses the build_id.

# How


Following the documentation. 


# Test Plan


I fixed it in my repo and tested on the expo.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
