### PR TITLE
[docs] Update pedometer example (fixed type error)

### DIFF
--- a/docs/pages/versions/unversioned/sdk/pedometer.mdx
+++ b/docs/pages/versions/unversioned/sdk/pedometer.mdx
@@ -31,29 +31,34 @@ export default function App() {
   const [pastStepCount, setPastStepCount] = useState(0);
   const [currentStepCount, setCurrentStepCount] = useState(0);
 
-  const subscribe = async () => {
-    const isAvailable = await Pedometer.isAvailableAsync();
-    setIsPedometerAvailable(String(isAvailable));
-
-    if (isAvailable) {
-      const end = new Date();
-      const start = new Date();
-      start.setDate(end.getDate() - 1);
-
-      const pastStepCountResult = await Pedometer.getStepCountAsync(start, end);
-      if (pastStepCountResult) {
-        setPastStepCount(pastStepCountResult.steps);
-      }
-
-      return Pedometer.watchStepCount(result => {
-        setCurrentStepCount(result.steps);
-      });
-    }
-  };
-
   useEffect(() => {
-    const subscription = subscribe();
-    return () => subscription && subscription.remove();
+    let subscription: Pedometer.Subscription | undefined;
+
+    const subscribe = async () => {
+      const isAvailable = await Pedometer.isAvailableAsync();
+      setIsPedometerAvailable(String(isAvailable));
+
+      if (isAvailable) {
+        const end = new Date();
+        const start = new Date();
+        start.setDate(end.getDate() - 1);
+
+        const pastStepCountResult = await Pedometer.getStepCountAsync(start, end);
+        if (pastStepCountResult) {
+          setPastStepCount(pastStepCountResult.steps);
+        }
+
+        subscription = Pedometer.watchStepCount(result => {
+          setCurrentStepCount(result.steps);
+        });
+      }
+    };
+
+    subscribe();
+
+    return () => {
+      subscription?.remove()
+    };
   }, []);
 
   return (

--- a/docs/pages/versions/v50.0.0/sdk/pedometer.mdx
+++ b/docs/pages/versions/v50.0.0/sdk/pedometer.mdx
@@ -33,29 +33,34 @@ export default function App() {
   const [pastStepCount, setPastStepCount] = useState(0);
   const [currentStepCount, setCurrentStepCount] = useState(0);
 
-  const subscribe = async () => {
-    const isAvailable = await Pedometer.isAvailableAsync();
-    setIsPedometerAvailable(String(isAvailable));
-
-    if (isAvailable) {
-      const end = new Date();
-      const start = new Date();
-      start.setDate(end.getDate() - 1);
-
-      const pastStepCountResult = await Pedometer.getStepCountAsync(start, end);
-      if (pastStepCountResult) {
-        setPastStepCount(pastStepCountResult.steps);
-      }
-
-      return Pedometer.watchStepCount(result => {
-        setCurrentStepCount(result.steps);
-      });
-    }
-  };
-
   useEffect(() => {
-    const subscription = subscribe();
-    return () => subscription && subscription.remove();
+    let subscription: Pedometer.Subscription | undefined;
+
+    const subscribe = async () => {
+      const isAvailable = await Pedometer.isAvailableAsync();
+      setIsPedometerAvailable(String(isAvailable));
+
+      if (isAvailable) {
+        const end = new Date();
+        const start = new Date();
+        start.setDate(end.getDate() - 1);
+
+        const pastStepCountResult = await Pedometer.getStepCountAsync(start, end);
+        if (pastStepCountResult) {
+          setPastStepCount(pastStepCountResult.steps);
+        }
+
+        subscription = Pedometer.watchStepCount(result => {
+          setCurrentStepCount(result.steps);
+        });
+      }
+    };
+
+    subscribe();
+
+    return () => {
+      subscription?.remove()
+    };
   }, []);
 
   return (

--- a/docs/pages/versions/v51.0.0/sdk/pedometer.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/pedometer.mdx
@@ -31,29 +31,34 @@ export default function App() {
   const [pastStepCount, setPastStepCount] = useState(0);
   const [currentStepCount, setCurrentStepCount] = useState(0);
 
-  const subscribe = async () => {
-    const isAvailable = await Pedometer.isAvailableAsync();
-    setIsPedometerAvailable(String(isAvailable));
-
-    if (isAvailable) {
-      const end = new Date();
-      const start = new Date();
-      start.setDate(end.getDate() - 1);
-
-      const pastStepCountResult = await Pedometer.getStepCountAsync(start, end);
-      if (pastStepCountResult) {
-        setPastStepCount(pastStepCountResult.steps);
-      }
-
-      return Pedometer.watchStepCount(result => {
-        setCurrentStepCount(result.steps);
-      });
-    }
-  };
-
   useEffect(() => {
-    const subscription = subscribe();
-    return () => subscription && subscription.remove();
+    let subscription: Pedometer.Subscription | undefined;
+
+    const subscribe = async () => {
+      const isAvailable = await Pedometer.isAvailableAsync();
+      setIsPedometerAvailable(String(isAvailable));
+
+      if (isAvailable) {
+        const end = new Date();
+        const start = new Date();
+        start.setDate(end.getDate() - 1);
+
+        const pastStepCountResult = await Pedometer.getStepCountAsync(start, end);
+        if (pastStepCountResult) {
+          setPastStepCount(pastStepCountResult.steps);
+        }
+
+        subscription = Pedometer.watchStepCount(result => {
+          setCurrentStepCount(result.steps);
+        });
+      }
+    };
+
+    subscribe();
+
+    return () => {
+      subscription?.remove()
+    };
   }, []);
 
   return (

--- a/docs/pages/versions/v52.0.0/sdk/pedometer.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/pedometer.mdx
@@ -31,29 +31,34 @@ export default function App() {
   const [pastStepCount, setPastStepCount] = useState(0);
   const [currentStepCount, setCurrentStepCount] = useState(0);
 
-  const subscribe = async () => {
-    const isAvailable = await Pedometer.isAvailableAsync();
-    setIsPedometerAvailable(String(isAvailable));
-
-    if (isAvailable) {
-      const end = new Date();
-      const start = new Date();
-      start.setDate(end.getDate() - 1);
-
-      const pastStepCountResult = await Pedometer.getStepCountAsync(start, end);
-      if (pastStepCountResult) {
-        setPastStepCount(pastStepCountResult.steps);
-      }
-
-      return Pedometer.watchStepCount(result => {
-        setCurrentStepCount(result.steps);
-      });
-    }
-  };
-
   useEffect(() => {
-    const subscription = subscribe();
-    return () => subscription && subscription.remove();
+    let subscription: Pedometer.Subscription | undefined;
+
+    const subscribe = async () => {
+      const isAvailable = await Pedometer.isAvailableAsync();
+      setIsPedometerAvailable(String(isAvailable));
+
+      if (isAvailable) {
+        const end = new Date();
+        const start = new Date();
+        start.setDate(end.getDate() - 1);
+
+        const pastStepCountResult = await Pedometer.getStepCountAsync(start, end);
+        if (pastStepCountResult) {
+          setPastStepCount(pastStepCountResult.steps);
+        }
+
+        subscription = Pedometer.watchStepCount(result => {
+          setCurrentStepCount(result.steps);
+        });
+      }
+    };
+
+    subscribe();
+
+    return () => {
+      subscription?.remove()
+    };
   }, []);
 
   return (

--- a/docs/pages/versions/v53.0.0/sdk/pedometer.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/pedometer.mdx
@@ -31,29 +31,34 @@ export default function App() {
   const [pastStepCount, setPastStepCount] = useState(0);
   const [currentStepCount, setCurrentStepCount] = useState(0);
 
-  const subscribe = async () => {
-    const isAvailable = await Pedometer.isAvailableAsync();
-    setIsPedometerAvailable(String(isAvailable));
-
-    if (isAvailable) {
-      const end = new Date();
-      const start = new Date();
-      start.setDate(end.getDate() - 1);
-
-      const pastStepCountResult = await Pedometer.getStepCountAsync(start, end);
-      if (pastStepCountResult) {
-        setPastStepCount(pastStepCountResult.steps);
-      }
-
-      return Pedometer.watchStepCount(result => {
-        setCurrentStepCount(result.steps);
-      });
-    }
-  };
-
   useEffect(() => {
-    const subscription = subscribe();
-    return () => subscription && subscription.remove();
+    let subscription: Pedometer.Subscription | undefined;
+
+    const subscribe = async () => {
+      const isAvailable = await Pedometer.isAvailableAsync();
+      setIsPedometerAvailable(String(isAvailable));
+
+      if (isAvailable) {
+        const end = new Date();
+        const start = new Date();
+        start.setDate(end.getDate() - 1);
+
+        const pastStepCountResult = await Pedometer.getStepCountAsync(start, end);
+        if (pastStepCountResult) {
+          setPastStepCount(pastStepCountResult.steps);
+        }
+
+        subscription = Pedometer.watchStepCount(result => {
+          setCurrentStepCount(result.steps);
+        });
+      }
+    };
+
+    subscribe();
+
+    return () => {
+      subscription?.remove()
+    };
   }, []);
 
   return (


### PR DESCRIPTION
# Why

The Pedometer example in the documentation contained a subtle bug where the subscription variable was a Promise, but subscription.remove() was being called directly. This leads to a type error at runtime or in TypeScript, as .remove() is not available on a Promise.

# How

Refactored the useEffect block to properly await the Promise returned by subscribe() and ensure that the cleanup function only calls .remove() on the resolved subscription object.

# Test Plan

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
