### PR TITLE
[expo] Bump `react-native-edge-to-edge` to 1.6.0

### DIFF
--- a/packages/expo-status-bar/package.json
+++ b/packages/expo-status-bar/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/status-bar/",
   "dependencies": {
-    "react-native-edge-to-edge": "1.5.1",
+    "react-native-edge-to-edge": "1.6.0",
     "react-native-is-edge-to-edge": "^1.1.6"
   },
   "devDependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -94,7 +94,7 @@
   "react-dom": "19.0.0",
   "react-native": "0.79.0",
   "react-native-web": "~0.20.0",
-  "react-native-edge-to-edge": "1.5.1",
+  "react-native-edge-to-edge": "1.6.0",
   "react-native-gesture-handler": "~2.24.0",
   "react-native-get-random-values": "~1.11.0",
   "react-native-maps": "1.20.1",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -86,7 +86,7 @@
     "expo-keep-awake": "~14.1.1",
     "expo-modules-autolinking": "2.1.3",
     "expo-modules-core": "2.3.4",
-    "react-native-edge-to-edge": "1.5.1",
+    "react-native-edge-to-edge": "1.6.0",
     "web-streams-polyfill": "^3.3.2",
     "whatwg-url-without-unicode": "8.0.0-3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12934,10 +12934,10 @@ react-native-dropdown-picker@^5.3.0:
   resolved "https://registry.yarnpkg.com/react-native-dropdown-picker/-/react-native-dropdown-picker-5.4.2.tgz#3d17de3d8a84cb8e74a2ffda6be417d287245b81"
   integrity sha512-cZBPyN+k52jA9XguFnKoF5tLf31z6gjZ8GijO/pfVNSSEtPwZ14UTUrr87JiiOnMh5K/O2kRzZ/jZN8D0MmUMA==
 
-react-native-edge-to-edge@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/react-native-edge-to-edge/-/react-native-edge-to-edge-1.5.1.tgz#2cfb281155a6a83a2c53e1a2f30078fe95ee6638"
-  integrity sha512-x9ldVAgSzxlgudxd8FDbl5fYJjXiFBpwaiTBvmUY3u6Tl7Own5DFSH6UUEbS57NWVYGJftvnsNyuNH/6c9Kvrg==
+react-native-edge-to-edge@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz#2ba63b941704a7f713e298185c26cde4d9e4b973"
+  integrity sha512-2WCNdE3Qd6Fwg9+4BpbATUxCLcouF6YRY7K+J36KJ4l3y+tWN6XCqAC4DuoGblAAbb2sLkhEDp4FOlbOIot2Og==
 
 react-native-fade-in-image@^1.6.1:
   version "1.6.1"


### PR DESCRIPTION
# Why

Bump react-native-edge-to-edge to support the new imperative API

# How

Bumped the package version in the expo, expo-status-bar, and Expo Go dependency

# Test Plan

Tested in a test app on Android Emulator
