### PR TITLE
[workspace] add code mentions for ESLint packages

### DIFF
--- a/.github/codemention.yml
+++ b/.github/codemention.yml
@@ -232,5 +232,7 @@ rules:
     mentions: ['bycedric', 'EvanBacon']
   - patterns: ['packages/uri-scheme/**']
     mentions: ['bycedric', 'EvanBacon']
+  - patterns: ['packages/eslint-config-expo/**', 'packages/eslint-config-universe/**', 'packages/eslint-plugin-expo/**']
+    mentions: ['kadikraman', 'Simek']
   - patterns: ['tools/**']
     mentions: ['kudo']


### PR DESCRIPTION
# Why

With @kadikraman, we are the main maintainers of the ESLint packages we offer, so would be nice to get a ping when contribution for any of these packages is proposed.

# How

Add all ESLint packages to codemention config, and Kadi and me as team members to mention.

# Test Plan

N/A