### PR TITLE
[core] disable collapsableChildren for SwiftUI container by default

### DIFF
--- a/apps/native-component-list/src/screens/UI/SwiftUIContainerScreen.tsx
+++ b/apps/native-component-list/src/screens/UI/SwiftUIContainerScreen.tsx
@@ -71,9 +71,9 @@ export default function SwiftUIContainerScreen() {
             <SwiftUI.Text>H1V1</SwiftUI.Text>
           </SwiftUI.HStack>
 
-          {/* NOTE: To host UIView inside SwiftUI, we may need fixed size and `collapsable={false}` */}
+          {/* NOTE: To host UIView inside SwiftUI, we may need fixed size */}
           <SwiftUI.HStack frame={{ width: 300, height: 100 }}>
-            <View style={[styles.uiView, { width: 300, height: 100 }]} collapsable={false}>
+            <View style={[styles.uiView, { width: 300, height: 100 }]}>
               <Text style={styles.uiViewText}>Text in UIView</Text>
             </View>
           </SwiftUI.HStack>

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `UnwrappedChildren` not get the unwrapped content view for SwiftUI integration. ([#36112](https://github.com/expo/expo/pull/36112) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.3.4 — 2025-04-11

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Removed the limitation to use `collapsable={false}` when hosting a UIView in SwiftUI views. ([#36153](https://github.com/expo/expo/pull/36153) by [@kudo](https://github.com/kudo))
+
 ## 2.3.4 — 2025-04-11
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewProps.h
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewProps.h
@@ -10,7 +10,7 @@
 
 namespace expo {
 
-class ExpoViewProps final : public facebook::react::ViewProps {
+class ExpoViewProps : public facebook::react::ViewProps {
 public:
   ExpoViewProps() = default;
   ExpoViewProps(const facebook::react::PropsParserContext &context,

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewShadowNode.cpp
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewShadowNode.cpp
@@ -2,8 +2,35 @@
 
 #include "ExpoViewShadowNode.h"
 
+namespace react = facebook::react;
+
 namespace expo {
 
-  extern const char ExpoViewComponentName[] = "ExpoFabricView";
+extern const char ExpoViewComponentName[] = "ExpoFabricView";
+
+ExpoViewShadowNode::ExpoViewShadowNode(
+    const react::ShadowNodeFragment &fragment,
+    const react::ShadowNodeFamily::Shared &family,
+    react::ShadowNodeTraits traits)
+    : ConcreteViewShadowNode(fragment, family, traits) {
+  initialize();
+}
+
+ExpoViewShadowNode::ExpoViewShadowNode(
+    const react::ShadowNode &sourceShadowNode,
+    const react::ShadowNodeFragment &fragment)
+    : ConcreteViewShadowNode(sourceShadowNode, fragment) {
+  initialize();
+}
+
+void ExpoViewShadowNode::initialize() noexcept {
+  auto &viewProps = static_cast<const ExpoViewProps &>(*props_);
+
+  if (viewProps.collapsableChildren) {
+    traits_.set(react::ShadowNodeTraits::Trait::ChildrenFormStackingContext);
+  } else {
+    traits_.unset(react::ShadowNodeTraits::Trait::ChildrenFormStackingContext);
+  }
+}
 
 } // namespace expo

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewShadowNode.h
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewShadowNode.h
@@ -6,17 +6,35 @@
 
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 
-#include "ExpoViewProps.h"
 #include "ExpoViewEventEmitter.h"
+#include "ExpoViewProps.h"
 #include "ExpoViewState.h"
 
 namespace expo {
 
 extern const char ExpoViewComponentName[];
 
-class ExpoViewShadowNode final : public facebook::react::ConcreteViewShadowNode<ExpoViewComponentName, ExpoViewProps, ExpoViewEventEmitter, ExpoViewState> {
+class ExpoViewShadowNode final : public facebook::react::ConcreteViewShadowNode<
+                                     ExpoViewComponentName, ExpoViewProps,
+                                     ExpoViewEventEmitter, ExpoViewState> {
 public:
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
+
+  ExpoViewShadowNode(const facebook::react::ShadowNodeFragment &fragment,
+                     const facebook::react::ShadowNodeFamily::Shared &family,
+                     facebook::react::ShadowNodeTraits traits);
+
+  ExpoViewShadowNode(const facebook::react::ShadowNode &sourceShadowNode,
+                     const facebook::react::ShadowNodeFragment &fragment);
+
+public:
+  static facebook::react::ShadowNodeTraits BaseTraits() {
+    auto traits = ConcreteViewShadowNode::BaseTraits();
+    return traits;
+  }
+
+private:
+  void initialize() noexcept;
 };
 
 } // namespace expo

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -45,8 +45,9 @@ public extension ExpoSwiftUIView {
       }
       return AnyView(
         Group {
-          if let hostingView = child as? ExpoSwiftUI.UIViewHost {
-            let content = hostingView.childView
+          if let hostingView = child as? ExpoSwiftUI.UIViewHost,
+            let hostingUIView = hostingView.view as? (any ExpoSwiftUI.AnyHostingView) {
+            let content = hostingUIView.getContentView()
             transform(
               AnyView(
                 content

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewProps.h
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewProps.h
@@ -1,0 +1,30 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include <ExpoModulesCore/ExpoViewProps.h>
+
+namespace expo {
+
+/**
+ An `ExpoViewProps` derived class specific for SwiftUI that disables `collapsableChildren` by default
+ */
+class SwiftUIViewProps final : public ExpoViewProps {
+public:
+  SwiftUIViewProps() : ExpoViewProps() {
+    this->collapsableChildren = false;
+  }
+
+  SwiftUIViewProps(const facebook::react::PropsParserContext &context,
+                       const ExpoViewProps &sourceProps,
+                       const facebook::react::RawProps &rawProps)
+      : ExpoViewProps(context, sourceProps, rawProps) {
+    this->collapsableChildren = false;
+  }
+};
+
+} // namespace expo
+
+#endif // __cplusplus

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjC.mm
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjC.mm
@@ -11,6 +11,7 @@
 
 #import <ExpoModulesCore/ExpoViewComponentDescriptor.h>
 #import <ExpoModulesCore/EXJSIConversions.h>
+#import <ExpoModulesCore/SwiftUIViewProps.h>
 #import <React/RCTAssert.h>
 #import <React/RCTComponentViewProtocol.h>
 
@@ -89,7 +90,7 @@ static std::unordered_map<std::string, expo::ExpoViewComponentDescriptor::Flavor
 - (instancetype)init
 {
   if (self = [super init]) {
-    static const auto defaultProps = std::make_shared<const expo::ExpoViewProps>();
+    static const auto defaultProps = std::make_shared<const expo::SwiftUIViewProps>();
     _props = defaultProps;
   }
   return self;


### PR DESCRIPTION
# Why

fixed the other regression from #35553 where ContextMenu preview was broken because content is collapsed.

# How

for swiftui views, disable `collapsableChildren` by default

# Test Plan

test swift ui NCL

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
