### PR TITLE
chore(expo-go): Address `catch (error)` type errors after merging #36075)

### DIFF
--- a/apps/expo-go/src/screens/AccountModal/LoggedOutAccountView.tsx
+++ b/apps/expo-go/src/screens/AccountModal/LoggedOutAccountView.tsx
@@ -144,7 +144,7 @@ export function LoggedOutAccountView({ refetch }: Props) {
         setAccountName(primaryAccountName);
         setIsFinishedAuthenticating(true);
       }
-    } catch (e) {
+    } catch (e: any) {
       // TODO(wschurman): Put this into Sentry
       console.error({ e });
       setAuthenticationError(e.message);

--- a/apps/expo-go/src/screens/FeedbackFormScreen/index.tsx
+++ b/apps/expo-go/src/screens/FeedbackFormScreen/index.tsx
@@ -58,7 +58,7 @@ export function FeedbackFormScreen() {
         body,
       });
       setSubmitted(true);
-    } catch (error) {
+    } catch (error: any) {
       setError(error.message);
     } finally {
       setSubmitting(false);

--- a/apps/expo-go/src/screens/SettingsScreen/DeleteAccountSection.tsx
+++ b/apps/expo-go/src/screens/SettingsScreen/DeleteAccountSection.tsx
@@ -52,7 +52,7 @@ export function DeleteAccountSection() {
         dispatch(SessionActions.signOut());
         navigation.navigate('Home');
       }
-    } catch (e) {
+    } catch (e: any) {
       // TODO(wschurman): Put this into Sentry
       console.error({ e });
       setDeletionError(e.message);

--- a/apps/expo-go/src/utils/addListenerWithNativeCallback.ts
+++ b/apps/expo-go/src/utils/addListenerWithNativeCallback.ts
@@ -13,7 +13,7 @@ const addListenerWithNativeCallback = (
         result = {};
       }
       Kernel.onEventSuccess(event.eventId, result);
-    } catch (e) {
+    } catch (e: any) {
       Kernel.onEventFailure(event.eventId, e.message);
     }
   });


### PR DESCRIPTION
# Why

Type errors introduced due to `tsconfig.json` preset changes during #36075

# How

- Add missing `: any` types to `catch (error)`

# Test Plan

- CI