### PR TITLE
[docs] correct categorization of two packages reference pages

### DIFF
--- a/docs/pages/versions/unversioned/sdk/segmented-control.mdx
+++ b/docs/pages/versions/unversioned/sdk/segmented-control.mdx
@@ -1,12 +1,16 @@
 ---
-title: SegmentedControl
+title: '@react-native-segmented-control/segmented-control'
 description: A React Native library that provides a component to render UISegmentedControl from iOS.
 sourceCodeUrl: 'https://github.com/react-native-community/segmented-control'
 packageName: '@react-native-segmented-control/segmented-control'
 platforms: ['android', 'ios', 'web']
+inExpoGo: true
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 It's like a fancy radio button, or in Apple's words: "A horizontal control that consists of multiple segments, each segment functioning as a discrete button" ([source](https://developer.apple.com/documentation/uikit/uisegmentedcontrol)). This component renders to a [`UISegmentedControl`](https://developer.apple.com/documentation/uikit/uisegmentedcontrol) on iOS, and to faithful recreations of that control on Android and web (because no equivalent exists on those platforms' standard libraries).
 
@@ -14,6 +18,11 @@ It's like a fancy radio button, or in Apple's words: "A horizontal control that 
 
 <APIInstallSection href="https://github.com/react-native-segmented-control/segmented-control#getting-started" />
 
-## Usage
+## Learn more
 
-See full documentation at [`react-native-community/segmented-control`](https://github.com/react-native-community/segmented-control#usage).
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://github.com/react-native-community/segmented-control"
+/>

--- a/docs/pages/versions/unversioned/sdk/slider.mdx
+++ b/docs/pages/versions/unversioned/sdk/slider.mdx
@@ -1,16 +1,18 @@
 ---
-title: Slider
+title: '@react-native-community/slider'
 description: A React Native component library that provides access to the system UI for a slider control.
 sourceCodeUrl: 'https://github.com/callstack/react-native-slider'
 packageName: '@react-native-community/slider'
 platforms: ['android', 'ios', 'web']
+inExpoGo: true
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 {/* todo: add video */}
-
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 A component library that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 
@@ -18,6 +20,11 @@ A component library that provides access to the system UI for a slider control, 
 
 <APIInstallSection href="https://github.com/callstack/react-native-slider#installation--usage" />
 
-## Usage
+## Learn more
 
-See full documentation at [`@react-native-community/slider`](https://github.com/callstack/react-native-slider).
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://github.com/callstack/react-native-slider"
+/>

--- a/docs/pages/versions/v53.0.0/sdk/segmented-control.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/segmented-control.mdx
@@ -1,12 +1,16 @@
 ---
-title: SegmentedControl
+title: '@react-native-segmented-control/segmented-control'
 description: A React Native library that provides a component to render UISegmentedControl from iOS.
 sourceCodeUrl: 'https://github.com/react-native-community/segmented-control'
 packageName: '@react-native-segmented-control/segmented-control'
 platforms: ['android', 'ios', 'web']
+inExpoGo: true
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 It's like a fancy radio button, or in Apple's words: "A horizontal control that consists of multiple segments, each segment functioning as a discrete button" ([source](https://developer.apple.com/documentation/uikit/uisegmentedcontrol)). This component renders to a [`UISegmentedControl`](https://developer.apple.com/documentation/uikit/uisegmentedcontrol) on iOS, and to faithful recreations of that control on Android and web (because no equivalent exists on those platforms' standard libraries).
 
@@ -14,6 +18,11 @@ It's like a fancy radio button, or in Apple's words: "A horizontal control that 
 
 <APIInstallSection href="https://github.com/react-native-segmented-control/segmented-control#getting-started" />
 
-## Usage
+## Learn more
 
-See full documentation at [`react-native-community/segmented-control`](https://github.com/react-native-community/segmented-control#usage).
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://github.com/react-native-community/segmented-control"
+/>

--- a/docs/pages/versions/v53.0.0/sdk/slider.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/slider.mdx
@@ -1,16 +1,18 @@
 ---
-title: Slider
+title: '@react-native-community/slider'
 description: A React Native component library that provides access to the system UI for a slider control.
 sourceCodeUrl: 'https://github.com/callstack/react-native-slider'
 packageName: '@react-native-community/slider'
 platforms: ['android', 'ios', 'web']
+inExpoGo: true
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 {/* todo: add video */}
-
-> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](https://expo.dev/go). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 A component library that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 
@@ -18,6 +20,11 @@ A component library that provides access to the system UI for a slider control, 
 
 <APIInstallSection href="https://github.com/callstack/react-native-slider#installation--usage" />
 
-## Usage
+## Learn more
 
-See full documentation at [`@react-native-community/slider`](https://github.com/callstack/react-native-slider).
+<BoxLink
+  title="Visit offical documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://github.com/callstack/react-native-slider"
+/>


### PR DESCRIPTION
# Why

Spotted that I have missed two pages in the grouping changeset for the latest SDK reference.

# How

Move `@react-native-community/slider` and `@react-native-segmented-control/segmented-control` pages into "Third-party libraries" group, and updated the content to match pattern used on other pages from that section.

The changes have been applied for unversioned and SDK 53 pages.

# Test Plan

Run the docs app locally, visit SDK 53 and Next docs to confirm the correct placement and appearance of updated pages.

# Preview

![Screenshot 2025-04-14 at 19 00 48](https://github.com/user-attachments/assets/0f5b3200-8033-43b0-a0fb-ad3bbad7e2e9)

