### PR TITLE
fix(cli): Fix support for using build variants with remote builds

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix support for using build variants with remote build cache ([#36165](https://github.com/expo/expo/pull/36165) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 0.24.0 — 2025-04-11

--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import path from 'path';
 
 import * as Log from '../../log';
+import { hasDirectDevClientDependency } from '../../start/detectDevClient';
 import { AppleAppIdResolver } from '../../start/platforms/ios/AppleAppIdResolver';
 import { maybePromptToSyncPodsAsync } from '../../utils/cocoapods';
 import { setNodeEnv } from '../../utils/nodeEnv';
@@ -46,6 +47,7 @@ export async function runIosAsync(projectRoot: string, options: Options) {
     const localPath = await resolveRemoteBuildCache(projectRoot, {
       platform: 'ios',
       provider: projectConfig.exp.experiments?.remoteBuildCache.provider,
+      runOptions: options,
     });
     if (localPath) {
       options.binary = localPath;
@@ -186,6 +188,7 @@ export async function runIosAsync(projectRoot: string, options: Options) {
     await uploadRemoteBuildCache(projectRoot, {
       platform: 'ios',
       provider: projectConfig.exp.experiments?.remoteBuildCache.provider,
+      buildPath: binaryPath,
     });
   }
 }

--- a/packages/@expo/cli/src/run/remoteBuildCache.ts
+++ b/packages/@expo/cli/src/run/remoteBuildCache.ts
@@ -6,8 +6,8 @@ import fs from 'fs';
 import path from 'path';
 
 import { Log } from '../log';
-import { Options as AndroidRunOptions } from './android/resolveOptions';
-import { Options as IosRunOptions } from './ios/XcodeBuild.types';
+import { type Options as AndroidRunOptions } from './android/resolveOptions';
+import { type Options as IosRunOptions } from './ios/XcodeBuild.types';
 import { hasDirectDevClientDependency } from '../start/detectDevClient';
 import { isSpawnResultError } from '../start/platforms/ios/xcrun';
 const debug = require('debug')('expo:run:remote-build') as typeof console.log;

--- a/packages/@expo/cli/src/run/remoteBuildCache.ts
+++ b/packages/@expo/cli/src/run/remoteBuildCache.ts
@@ -176,7 +176,7 @@ function importFingerprintForDev(projectRoot: string): null | typeof import('@ex
   }
 }
 
-function isDevClientBuild({
+export function isDevClientBuild({
   runOptions,
   projectRoot,
 }: {
@@ -187,10 +187,10 @@ function isDevClientBuild({
     return false;
   }
 
-  if ('variant' in runOptions && runOptions.variant) {
+  if ('variant' in runOptions && runOptions.variant !== undefined) {
     return runOptions.variant === 'debug';
   }
-  if ('configuration' in runOptions && runOptions.configuration) {
+  if ('configuration' in runOptions && runOptions.configuration !== undefined) {
     return runOptions.configuration === 'Debug';
   }
 


### PR DESCRIPTION
# Why

When users specify a custom build variant or configuration we should not download dev-client builds, even if fingerprints match.

# How

Update `resolveRemoteBuildCache` to use the `no-dev-build` flag and specify the `buildPath` when uploading a build to ensure the correct build is selected 

# Test Plan

Run `nexpo run:android` and `nexpo run:ios` locally


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
