### PR TITLE
[expo-go][android] add logging of manifest exception

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ExceptionUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ExceptionUtils.kt
@@ -63,8 +63,14 @@ object ExceptionUtils {
 
   fun exceptionToPlainText(exception: Exception): String {
     if (exception is ManifestException) {
-      return "${exceptionToErrorHeader(exception)}\n\n${replaceHtml(exception.errorMessage)
-      }\n\nHow to fix this error:\n${replaceHtml(exception.fixInstructions)}"
+      return """
+${exceptionToErrorHeader(exception)}
+
+${replaceHtml(exception.errorMessage)}
+
+How to fix this error:
+${replaceHtml(exception.fixInstructions)}"
+""".trimIndent()
     }
     return exception.toString()
   }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ExceptionUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ExceptionUtils.kt
@@ -64,7 +64,7 @@ object ExceptionUtils {
   fun exceptionToPlainText(exception: Exception): String {
     if (exception is ManifestException) {
       return "${exceptionToErrorHeader(exception)}\n\n${replaceHtml(exception.errorMessage)
-        }\n\nHow to fix this error:\n${replaceHtml(exception.fixInstructions)}"
+      }\n\nHow to fix this error:\n${replaceHtml(exception.fixInstructions)}"
     }
     return exception.toString()
   }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ExceptionUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ExceptionUtils.kt
@@ -69,8 +69,8 @@ ${exceptionToErrorHeader(exception)}
 ${replaceHtml(exception.errorMessage)}
 
 How to fix this error:
-${replaceHtml(exception.fixInstructions)}"
-""".trimIndent()
+${replaceHtml(exception.fixInstructions)}
+      """.trimIndent()
     }
     return exception.toString()
   }
@@ -82,8 +82,8 @@ ${replaceHtml(exception.fixInstructions)}"
     return true
   }
 
-  private fun replaceHtml(string: String?): String {
-    return string
+  private fun replaceHtml(input: String?): String {
+    return input
       ?.replace("<br>", "\n")
       ?.replace("<b>", "")
       ?.replace("</b>", "") ?: ""

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ExceptionUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ExceptionUtils.kt
@@ -61,11 +61,26 @@ object ExceptionUtils {
     return null
   }
 
+  fun exceptionToPlainText(exception: Exception): String {
+    if (exception is ManifestException) {
+      return "${exceptionToErrorHeader(exception)}\n\n${replaceHtml(exception.errorMessage)
+        }\n\nHow to fix this error:\n${replaceHtml(exception.fixInstructions)}"
+    }
+    return exception.toString()
+  }
+
   fun exceptionToCanRetry(exception: Exception): Boolean {
     if (exception is ManifestException) {
       return exception.canRetry
     }
     return true
+  }
+
+  private fun replaceHtml(string: String?): String {
+    return string
+      ?.replace("<br>", "\n")
+      ?.replace("<b>", "")
+      ?.replace("</b>", "") ?: ""
   }
 
   private fun getUserErrorMessage(exception: Exception?, context: Context): String? {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
@@ -14,13 +14,17 @@ private const val SNACK_STAGING = "2dce2748-c51f-4865-bae0-392af794d60a"
 private const val SNACK_PROD = "933fd9c0-1666-11e7-afca-d980795c5824"
 
 class ManifestException : ExponentException {
-  private val manifestUrl: String
   private var errorJSON: JSONObject? = null
-  private lateinit var errorMessage: String
-  private var fixInstructions: String? = null
   private val isSnackURL: Boolean
     get() =
       manifestUrl.contains(SNACK_STAGING) || manifestUrl.contains(SNACK_PROD)
+
+  val manifestUrl: String
+  lateinit var errorMessage: String
+    private set
+
+  var fixInstructions: String? = null
+    private set
 
   var canRetry: Boolean = true
   val errorHeader: String?

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentPackageLogger.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentPackageLogger.kt
@@ -1,0 +1,117 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+package host.exp.exponent.kernel
+
+import android.net.Uri
+import android.util.Log
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import org.json.JSONException
+import org.json.JSONObject
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+
+class ExponentPackageLogger private constructor(private val appUrl: Uri) {
+  enum class LogLevel {
+    WARNING,
+    ERROR,
+    INFO
+  }
+
+  private var okHttpClient: OkHttpClient = OkHttpClient.Builder()
+    .connectTimeout(10, TimeUnit.SECONDS)
+    .writeTimeout(10, TimeUnit.SECONDS)
+    .readTimeout(0, TimeUnit.MINUTES) // Disable timeouts for read
+    .build()
+
+  private var webSocket: WebSocket? = null
+  private var connected: Boolean = false
+  private var pendingMessage: String? = null
+  private var logLevel: LogLevel = LogLevel.INFO
+
+  private fun sendMessage(message: String, logLevel: LogLevel): CompletableFuture<Void> {
+    val future = CompletableFuture<Void>()
+    pendingMessage = message
+    this.logLevel = logLevel
+
+    val request: Request = Request.Builder().url(getMessageSocketUrl(appUrl)).build()
+    okHttpClient.newWebSocket(
+      request,
+      object : WebSocketListener() {
+        override fun onOpen(webSocket: WebSocket, response: Response) {
+          connected = true
+          this@ExponentPackageLogger.webSocket = webSocket
+          sendPendingMessage()
+          future.complete(null)
+        }
+
+        override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+          Log.e(TAG, "Error opening web socket to url: ${getMessageSocketUrl(appUrl)}")
+          future.completeExceptionally(t)
+        }
+
+        override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+          connected = false
+        }
+      }
+    )
+
+    return future
+  }
+
+  private fun sendPendingMessage() {
+    if (!connected) {
+      return
+    }
+
+    if (pendingMessage != null && webSocket != null) {
+      val msg = mapOf(
+        "type" to "log",
+        "level" to when (logLevel) {
+          LogLevel.WARNING -> "warn"
+          LogLevel.ERROR -> "error"
+          LogLevel.INFO -> "info"
+        },
+        "data" to arrayOf(pendingMessage)
+      )
+
+      try {
+        val json = JSONObject(msg).toString()
+        webSocket?.send(json)
+      } catch (e: JSONException) {
+        Log.e(TAG, "Failed to stringify message: ${e.message}")
+      }
+      pendingMessage = null
+      try {
+        webSocket?.close(1000, "End of session")
+      } catch (e: Exception) {
+        // swallow, no need to handle it here
+      }
+      webSocket = null
+      connected = false
+    }
+  }
+
+  private fun getMessageSocketUrl(appUrl: Uri): String {
+    val host = appUrl.host ?: "localhost"
+    val port = if (appUrl.port > 0) appUrl.port else 8081
+    val scheme = if (appUrl.scheme == "https") "wss" else "ws"
+    return "$scheme://$host:$port/hot"
+  }
+
+  companion object {
+    private val TAG = ExponentPackageLogger::class.java.simpleName
+
+    fun send(appUrl: Uri, message: String, logLevel: LogLevel) {
+      val logger = ExponentPackageLogger(appUrl)
+      logger.sendMessage(message, logLevel)
+        .thenAccept { /* Success - no further action needed */ }
+        .exceptionally {
+          Log.e(TAG, "Failed to send message: ${it.message}")
+          null
+        }
+    }
+  }
+}

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentPackageLogger.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentPackageLogger.kt
@@ -12,9 +12,6 @@ import okhttp3.WebSocketListener
 import org.json.JSONException
 import org.json.JSONObject
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit
 
 class ExponentPackageLogger private constructor(private val appUrl: Uri) {
@@ -117,14 +114,12 @@ class ExponentPackageLogger private constructor(private val appUrl: Uri) {
      * @param logLevel log level to use, will be sent to the packager which can format or
      * display different log levels in different ways.
      */
-    fun send(appUrl: String, message: String, logLevel: LogLevel) {
+    suspend fun send(appUrl: String, message: String, logLevel: LogLevel) {
       val logger = ExponentPackageLogger(appUrl.toUri())
-      CoroutineScope(Dispatchers.IO).launch {
-        try {
-          logger.sendMessage(message, logLevel)
-        } catch (e: Exception) {
-          Log.e(TAG, "Failed to send message: ${e.message}")
-        }
+      try {
+        logger.sendMessage(message, logLevel)
+      } catch (e: Exception) {
+        Log.e(TAG, "Failed to send message: ${e.message}")
       }
     }
   }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentPackageLogger.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentPackageLogger.kt
@@ -3,6 +3,7 @@ package host.exp.exponent.kernel
 
 import android.net.Uri
 import android.util.Log
+import androidx.core.net.toUri
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -104,8 +105,8 @@ class ExponentPackageLogger private constructor(private val appUrl: Uri) {
   companion object {
     private val TAG = ExponentPackageLogger::class.java.simpleName
 
-    fun send(appUrl: Uri, message: String, logLevel: LogLevel) {
-      val logger = ExponentPackageLogger(appUrl)
+    fun send(appUrl: String, message: String, logLevel: LogLevel) {
+      val logger = ExponentPackageLogger(appUrl.toUri())
       logger.sendMessage(message, logLevel)
         .thenAccept { /* Success - no further action needed */ }
         .exceptionally {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentPackageLogger.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentPackageLogger.kt
@@ -14,8 +14,6 @@ import org.json.JSONObject
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -15,6 +15,7 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
+import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.ReactHost
@@ -39,6 +40,7 @@ import host.exp.exponent.ExpoUpdatesAppLoader.AppLoaderStatus
 import host.exp.exponent.analytics.EXL
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.exceptions.ExceptionUtils
+import host.exp.exponent.exceptions.ManifestException
 import host.exp.exponent.experience.BaseExperienceActivity
 import host.exp.exponent.experience.ErrorActivity
 import host.exp.exponent.experience.ExperienceActivity
@@ -903,6 +905,13 @@ class Kernel : KernelInterface() {
       ExceptionUtils.exceptionToErrorHeader(exception),
       ExceptionUtils.exceptionToCanRetry(exception)
     )
+    if (exception is ManifestException) {
+      ExponentPackageLogger.send(
+        exception.manifestUrl.toUri(),
+        ExceptionUtils.exceptionToPlainText(exception),
+        ExponentPackageLogger.LogLevel.ERROR
+      )
+    }
   }
 
   // TODO: probably need to call this from other places.

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -905,11 +905,13 @@ class Kernel : KernelInterface() {
       ExceptionUtils.exceptionToCanRetry(exception)
     )
     if (exception is ManifestException) {
-      ExponentPackageLogger.send(
-        exception.manifestUrl,
-        ExceptionUtils.exceptionToPlainText(exception),
-        ExponentPackageLogger.LogLevel.ERROR
-      )
+      kernelScope.launch {
+        ExponentPackageLogger.send(
+          exception.manifestUrl,
+          ExceptionUtils.exceptionToPlainText(exception),
+          ExponentPackageLogger.LogLevel.ERROR
+        )
+      }
     }
   }
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -15,7 +15,6 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
-import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.ReactHost
@@ -907,7 +906,7 @@ class Kernel : KernelInterface() {
     )
     if (exception is ManifestException) {
       ExponentPackageLogger.send(
-        exception.manifestUrl.toUri(),
+        exception.manifestUrl,
         ExceptionUtils.exceptionToPlainText(exception),
         ExponentPackageLogger.LogLevel.ERROR
       )

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -69,6 +69,7 @@ import host.exp.expoview.Exponent.BundleListener
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.json.JSONException
 import org.json.JSONObject
 import java.lang.ref.WeakReference
@@ -906,11 +907,13 @@ class Kernel : KernelInterface() {
     )
     if (exception is ManifestException) {
       kernelScope.launch {
-        ExponentPackageLogger.send(
-          exception.manifestUrl,
-          ExceptionUtils.exceptionToPlainText(exception),
-          ExponentPackageLogger.LogLevel.ERROR
-        )
+        withContext(Dispatchers.IO) {
+          ExponentPackageLogger.send(
+            exception.manifestUrl,
+            ExceptionUtils.exceptionToPlainText(exception),
+            ExponentPackageLogger.LogLevel.ERROR
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
# Why

When manifest exceptions happens in Expo Go we aren't starting/loading the bundle in a JS context, meaning we don't log errors to the packager - just displaying the error message to the user:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/9ef95e07-d137-4387-8302-107b71f60f92" />

Resolves ENG-15442 together with #36170

# How

This commit fixes this by introducing a helper class that can log to the packager without a JS context in Expo Go:

- Added `ExponentPackageLogger` class for connecting and logging to the packager. It logs a single message using a static method and then closes the web socket.
- Added calling the log function in the Kernel's `handleError` function
- Exposed some internal props in the ManifestException class to be able to create a plain-text edition of the error
- Added methods to `ExceptionUtils` so that we can create a plain-text version to print out on the console

<img width="907" alt="image" src="https://github.com/user-attachments/assets/03bf7f16-de67-41c7-9ade-818b2ce4b5cb" />

# Test Plan

- Run Expo Go and try to open a running app with SDK-52 against main
- Observe that Expo Go displays and error and that the same error is displayed in the CLI

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
