### PR TITLE
[docs] Add EAS Hosting to list of static site deployment options

### DIFF
--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -387,7 +387,7 @@ Rendering at request-time (SSR) is not supported in `web.output: 'static'`. This
 
 You can deploy your statically rendered website to any static hosting service. Here are some popular options:
 
-- [EAS Hosting](https://docs.expo.dev/eas/hosting/introduction/)
+- [EAS Hosting](/eas/hosting/introduction/)
 - [Netlify](https://www.netlify.com/)
 - [Cloudflare Pages](https://pages.cloudflare.com/)
 - [AWS Amplify](https://aws.amazon.com/amplify/)

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -387,6 +387,7 @@ Rendering at request-time (SSR) is not supported in `web.output: 'static'`. This
 
 You can deploy your statically rendered website to any static hosting service. Here are some popular options:
 
+- [EAS Hosting](https://docs.expo.dev/eas/hosting/introduction/)
 - [Netlify](https://www.netlify.com/)
 - [Cloudflare Pages](https://pages.cloudflare.com/)
 - [AWS Amplify](https://aws.amazon.com/amplify/)


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

EAS Hosting works great for deploying statically rendered websites too. Not sure if it was intentionally left out before or just missed by accident, but the developer experience is solid and it feels like it definitely deserves to be mentioned here.

This is the URL:
https://docs.expo.dev/router/reference/static-rendering/#where-can-i-deploy-statically-rendered-websites

# How

<!--
How did you build this feature or fix this bug and why?
-->

I edited this path to add EAS Hosting: docs/pages/router/reference/static-rendering.mdx

**Screenshot:**
![image](https://github.com/user-attachments/assets/bc1d2467-5f00-4e32-8259-76ef5db8ce72)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
