### PR TITLE
[cli][doctor] do not check `@expo/*` packages compatibility

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Exclude `@expo/*` packages from the New Architecture compatibility check.
+
 ## 0.24.2 — 2025-04-14
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Exclude `@expo/*` packages from the New Architecture compatibility check.
+- Exclude `@expo/*` packages from the New Architecture compatibility check. ([#36175](https://github.com/expo/expo/pull/36175) by [@Simek](https://github.com/Simek))
 
 ## 0.24.2 — 2025-04-14
 

--- a/packages/@expo/cli/src/install/utils/__tests__/checkPackagesCompatibility-test.ts
+++ b/packages/@expo/cli/src/install/utils/__tests__/checkPackagesCompatibility-test.ts
@@ -57,7 +57,7 @@ describe(checkPackagesCompatibility, () => {
     expect(Log.warn).toHaveBeenCalledTimes(0);
   });
 
-  it(`does not fetch or warn when installing @expo-google-fonts/* packages`, async () => {
+  it(`does not fetch or warn when installing ignored packages`, async () => {
     let wasCalled = false;
 
     nock('https://reactnative.directory')
@@ -67,7 +67,11 @@ describe(checkPackagesCompatibility, () => {
         return {};
       });
 
-    await checkPackagesCompatibility(['@expo-google-fonts/inter']);
+    await checkPackagesCompatibility([
+      '@expo-google-fonts/inter',
+      '@expo/metro-runtime',
+      '@expo/styleguide',
+    ]);
 
     expect(wasCalled).toBe(false);
     expect(Log.warn).toHaveBeenCalledTimes(0);

--- a/packages/@expo/cli/src/install/utils/checkPackagesCompatibility.ts
+++ b/packages/@expo/cli/src/install/utils/checkPackagesCompatibility.ts
@@ -16,7 +16,8 @@ const ERROR_MESSAGE =
 export async function checkPackagesCompatibility(packages: string[]) {
   try {
     const packagesToCheck = packages.filter(
-      (packageName) => !packageName.startsWith('@expo-google-fonts/')
+      (packageName) =>
+        !packageName.startsWith('@expo/') && !packageName.startsWith('@expo-google-fonts/')
     );
 
     if (!packagesToCheck.length) {

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Exclude `@expo/*` packages from the New Architecture compatibility check.
+- Exclude `@expo/*` packages from the New Architecture compatibility check. ([#36175](https://github.com/expo/expo/pull/36175) by [@Simek](https://github.com/Simek))
 
 ## 1.12.10 — 2025-04-14
 

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Exclude `@expo/*` packages from the New Architecture compatibility check.
+
 ## 1.12.10 — 2025-04-14
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts
@@ -7,13 +7,14 @@ import {
 } from '../utils/doctorConfig';
 
 // Filter out common packages that don't make sense for us to validate on the directory.
-const DEFAULT_PACKAGES_TO_IGNORE = [
+export const DEFAULT_PACKAGES_TO_IGNORE = [
   'jest',
   'react',
   'react-dom',
   'react-native',
   'react-native-web',
   /^babel-.*$/,
+  /^@expo\/.*$/,
   /^@expo-google-fonts\/.*$/,
   /^@types\/.*$/,
 ];

--- a/packages/expo-doctor/src/checks/__tests__/DirectoryCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/DirectoryCheck.test.ts
@@ -1,4 +1,4 @@
-import { filterPackages } from '../../checks/ReactNativeDirectoryCheck';
+import { DEFAULT_PACKAGES_TO_IGNORE, filterPackages } from '../ReactNativeDirectoryCheck';
 
 describe('filterPackages', () => {
   it('returns all packages if no ignored packages are provided', () => {
@@ -11,5 +11,20 @@ describe('filterPackages', () => {
 
   it('filters packages by string', () => {
     expect(filterPackages(['a', 'b', 'c'], ['a'])).toEqual(['b', 'c']);
+  });
+
+  it('filters predefined packages to ignore', () => {
+    expect(
+      filterPackages(
+        [
+          'react-native',
+          'babel-runtime',
+          '@expo/metro-runtime',
+          '@expo-google-fonts/inter',
+          '@types/lodash',
+        ],
+        DEFAULT_PACKAGES_TO_IGNORE
+      )
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
# Why

Fixes ENG-15497

# How

Ignore `@expo` packages in New Architecture compatibility checks against React Native Directory data in CLI and doctor checks.

# Test Plan

Add new/modify tests to cover the updated logic. Make sure that package builds, all lint checks and tests are passing.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
