### PR TITLE
[maps] Export missing config plugin

### DIFF
--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Exported missing config plugin.
+- Exported missing config plugin. ([#36177](https://github.com/expo/expo/pull/36177) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Exported missing config plugin.
+
 ### 💡 Others
 
 ## 0.9.3 — 2025-04-14

--- a/packages/expo-maps/app.plugin.js
+++ b/packages/expo-maps/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build/withMapsLocation');


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/35987.

# How

Exports missing config plugin, by creating `app.plugin.js` file.

# Test Plan

- run expo prebuilt inside of the NCL ✅ 