### PR TITLE
[template] Use expo-image instead of RN image in default template

### DIFF
--- a/templates/expo-template-default/app/(tabs)/explore.tsx
+++ b/templates/expo-template-default/app/(tabs)/explore.tsx
@@ -1,4 +1,5 @@
-import { StyleSheet, Image, Platform } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
+import { Image } from 'expo-image';
 
 import { Collapsible } from '@/components/Collapsible';
 import { ExternalLink } from '@/components/ExternalLink';

--- a/templates/expo-template-default/app/(tabs)/index.tsx
+++ b/templates/expo-template-default/app/(tabs)/index.tsx
@@ -1,4 +1,5 @@
-import { Image, StyleSheet, Platform } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
+import { Image } from 'expo-image';
 
 import { HelloWave } from '@/components/HelloWave';
 import ParallaxScrollView from '@/components/ParallaxScrollView';

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -25,6 +25,7 @@
     "expo-constants": "~17.1.2",
     "expo-font": "~13.1.2",
     "expo-haptics": "~14.1.2",
+    "expo-image": "~2.1.3",
     "expo-linking": "~7.1.2",
     "expo-router": "~5.0.2-preview.4",
     "expo-splash-screen": "~0.30.4",


### PR DESCRIPTION
# Why

Resolves ENG-15493

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- add `expo-image` to dependencies
- replace instances of RN Image with `expo-image`.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

```sh
bun install
npx expo start
```

Verify that the app loads on iOS, Android and web.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
