### PR TITLE
[autolinking] fix build error on windows

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed Android building error on Windows. ([#36179](https://github.com/expo/expo/pull/36179) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.1.4 — 2025-04-14

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/ProjectExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/ProjectExtension.kt
@@ -23,8 +23,7 @@ internal fun Project.linkBuildDependence(plugin: GradlePlugin) {
 
 internal fun Project.linkLocalMavenRepository(path: String, publications: List<Publication>) {
   repositories.mavenLocal { maven ->
-    val repositoryFile = file(path).absolutePath
-    maven.url = URI.create("file://$repositoryFile")
+    maven.url = file(path).toURI()
 
     maven.content { content ->
       publications.forEach { publication ->


### PR DESCRIPTION
# Why

fixes #36134

# How

originally on windows, the `file://C:\Users\user\myapp\node_modules\expo-web-browser\local-maven-repo\` is not a valid url. we can use `File.toURI()` to convert File to URI directly
the paths using `File.toURI()` are like:
- macos: `file:/Users/user/myapp/node_modules/expo-web-browser/local-maven-repo/`
- windows: `file:/C:/Users/user/myapp/node_modules/expo-web-browser/local-maven-repo/`
not exactly same as previous url format but works fine.

# Test Plan

tested android building on default sdk53 project (windows and macos)

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
