### PR TITLE
fix: update namespace for react-native-branch config plugin

### DIFF
--- a/packages/expo-haptics/android/build.gradle
+++ b/packages/expo-haptics/android/build.gradle
@@ -7,7 +7,7 @@ group = 'host.exp.exponent'
 version = '14.1.2'
 
 android {
-  namespace "expo.modules.haptics"
+  namespace "expo.configplugins.branch"
   defaultConfig {
     versionCode 16
     versionName '14.1.2'


### PR DESCRIPTION
Replace conflicting namespace which would cause android build to fail if using expo-haptics.
