### PR TITLE
[docs] Add latest iOS build image

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -72,15 +72,15 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 <Collapsible summary="Details">
 
-- Docker image: `ubuntu:jammy-v20240614`
+- Docker image: `ubuntu:jammy-v20250112`
 - NDK 26.1.10909125
-- Node.js 18.18.0
-- Bun 1.1.13
-- Yarn 1.22.21
-- pnpm 9.3.0
-- npm 9.8.1
+- Node.js 20.18.3
+- Bun 1.2.4
+- Yarn 1.22.22
+- pnpm 9.15.5
+- npm 10.8.2
 - Java 17
-- node-gyp 10.1.0
+- node-gyp 11.1.0
 
 </Collapsible>
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -68,23 +68,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 ### Android server images
 
-#### `ubuntu-22.04-jdk-17-ndk-26.1.10909125` (`latest`)
-
-<Collapsible summary="Details">
-
-- Docker image: `ubuntu-2204-jammy-v202501124`
-- NDK 26.1.10909125
-- Node.js 20.18.3
-- Bun 1.2.4
-- Yarn 1.22.22
-- pnpm 9.15.5
-- npm 10.8.2
-- Java 17
-- node-gyp 11.1.0
-
-</Collapsible>
-
-#### `ubuntu-22.04-jdk-17-ndk-r26b` (`sdk-51`, `sdk-52`)
+#### `ubuntu-22.04-jdk-17-ndk-r26b` (`latest`, `sdk-51`, `sdk-52`)
 
 <Collapsible summary="Details">
 
@@ -288,7 +272,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 ### iOS server images
 
-#### `macos-sequoia-15.3-xcode-16.2` (`latest`)
+#### `macos-sequoia-15.3-xcode-16.2` (`latest`, `sdk-52`)
 
 <Collapsible summary="Details">
 
@@ -306,7 +290,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-sonoma-14.6-xcode-16.1` (`sdk-52`)
+#### `macos-sonoma-14.6-xcode-16.1`
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -272,7 +272,25 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 ### iOS server images
 
-#### `macos-sonoma-14.6-xcode-16.1` (`latest`, `sdk-52`)
+#### `macos-sequoia-15.3-xcode-16.2` (`latest`)
+
+<Collapsible summary="Details">
+
+- macOS Sequoia 15.3
+- Xcode 16.2 (16C5032a)
+- Node.js 20.18.3
+- Bun 1.2.4
+- Yarn 1.22.22
+- pnpm 9.15.5
+- npm 9.8.1
+- fastlane 2.226.0
+- CocoaPods 1.16.2
+- Ruby 3.2
+- node-gyp 11.1.0
+
+</Collapsible>
+
+#### `macos-sonoma-14.6-xcode-16.1` (`sdk-52`)
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -68,7 +68,23 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 ### Android server images
 
-#### `ubuntu-22.04-jdk-17-ndk-r26b` (`latest`, `sdk-51`, `sdk-52`)
+#### `ubuntu-22.04-jdk-17-ndk-26.1.10909125` (`latest`)
+
+<Collapsible summary="Details">
+
+- Docker image: `ubuntu-2204-jammy-v202501124`
+- NDK 26.1.10909125
+- Node.js 20.18.3
+- Bun 1.2.4
+- Yarn 1.22.22
+- pnpm 9.15.5
+- npm 10.8.2
+- Java 17
+- node-gyp 11.1.0
+
+</Collapsible>
+
+#### `ubuntu-22.04-jdk-17-ndk-r26b` (`sdk-51`, `sdk-52`)
 
 <Collapsible summary="Details">
 


### PR DESCRIPTION
# Why

I noticed when using the tag 'latest' on both iOS and Android that I would get a different build image than the one mentioned in the docs.

# How

I'm not 100% sure which one you get with the sdk-51 or sdk-52 tag currently, so I left that as-is, and just added new entries for latest.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
