### PR TITLE
[expo] Bump reanimated to `3.17.4`

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -67,7 +67,7 @@
     "react-native": "0.79.1",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-pager-view": "6.7.0",
-    "react-native-reanimated": "3.17.3",
+    "react-native-reanimated": "3.17.4",
     "react-native-safe-area-context": "5.3.0",
     "react-native-screens": "4.10.0",
     "react-native-svg": "15.11.2",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -76,7 +76,7 @@
     "react-native-maps": "1.20.1",
     "react-native-pager-view": "6.7.0",
     "react-native-paper": "^5.12.5",
-    "react-native-reanimated": "3.17.3",
+    "react-native-reanimated": "3.17.4",
     "react-native-safe-area-context": "5.3.0",
     "react-native-screens": "4.10.0",
     "react-native-svg": "15.11.2",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -143,7 +143,7 @@
     "react-native-maps": "1.20.1",
     "react-native-pager-view": "6.7.0",
     "react-native-paper": "^5.12.5",
-    "react-native-reanimated": "3.17.3",
+    "react-native-reanimated": "3.17.4",
     "react-native-safe-area-context": "5.3.0",
     "react-native-screens": "4.10.0",
     "react-native-svg": "15.11.2",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -99,7 +99,7 @@
   "react-native-get-random-values": "~1.11.0",
   "react-native-maps": "1.20.1",
   "react-native-pager-view": "6.7.0",
-  "react-native-reanimated": "~3.17.3",
+  "react-native-reanimated": "~3.17.4",
   "react-native-screens": "~4.10.0",
   "react-native-safe-area-context": "5.3.0",
   "react-native-svg": "15.11.2",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -37,7 +37,7 @@
     "react-dom": "19.0.0",
     "react-native": "0.79.1",
     "react-native-gesture-handler": "~2.24.0",
-    "react-native-reanimated": "~3.17.3",
+    "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.3.0",
     "react-native-screens": "~4.10.0",
     "react-native-web": "~0.20.0",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -28,7 +28,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.1",
-    "react-native-reanimated": "~3.17.3",
+    "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.3.0",
     "react-native-screens": "~4.10.0",
     "react-native-web": "~0.20.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13020,10 +13020,10 @@ react-native-paper@^5.12.5:
     color "^3.1.2"
     use-latest-callback "^0.1.5"
 
-react-native-reanimated@3.17.3:
-  version "3.17.3"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.17.3.tgz#1166e1bca3ea870204e8288591b8c19f5d824117"
-  integrity sha512-0dN+AB7Om9Fdq3Bvq4+ClGhv2sl1o6BhKum18CFNPh4dgMKybDSdRo2vhxTaZUJq6R3LC8gFI84IV0qCZmPbiw==
+react-native-reanimated@3.17.4:
+  version "3.17.4"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.17.4.tgz#a8c95ea7c2a089b6ca8f513c7bbff4e450986c7c"
+  integrity sha512-vmkG/N5KZrexHr4v0rZB7ohPVseGVNaCXjGxoRo+NYKgC9+mIZAkg/QIfy9xxfJ73FfTrryO9iYUrxks3ZfKbA==
   dependencies:
     "@babel/plugin-transform-arrow-functions" "^7.0.0-0"
     "@babel/plugin-transform-class-properties" "^7.0.0-0"


### PR DESCRIPTION
# Why

I was asked by the reanimated team to bump the default version to `3.17.4`, so I did it.
This version doesn't contain any native changes.

# Test Plan

- bare-expo ✅ 