### PR TITLE
[docs] Fix typo in box links used in SDK docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/async-storage.mdx
+++ b/docs/pages/versions/unversioned/sdk/async-storage.mdx
@@ -21,7 +21,7 @@ Async Storage is asynchronous, unencrypted, persistent, key-value storage soluti
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://react-native-async-storage.github.io/async-storage/docs/usage"

--- a/docs/pages/versions/unversioned/sdk/date-time-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/date-time-picker.mdx
@@ -24,7 +24,7 @@ A component that provides access to the system UI for date and time selection.
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/react-native-datetimepicker/datetimepicker"

--- a/docs/pages/versions/unversioned/sdk/flash-list.mdx
+++ b/docs/pages/versions/unversioned/sdk/flash-list.mdx
@@ -21,7 +21,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://shopify.github.io/flash-list/"

--- a/docs/pages/versions/unversioned/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/unversioned/sdk/gesture-handler.mdx
@@ -23,7 +23,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://docs.swmansion.com/react-native-gesture-handler/"

--- a/docs/pages/versions/unversioned/sdk/lottie.mdx
+++ b/docs/pages/versions/unversioned/sdk/lottie.mdx
@@ -87,7 +87,7 @@ const styles = StyleSheet.create({
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://airbnb.io/lottie/#/react-native"

--- a/docs/pages/versions/unversioned/sdk/masked-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/masked-view.mdx
@@ -25,7 +25,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/react-native-masked-view/masked-view"

--- a/docs/pages/versions/unversioned/sdk/netinfo.mdx
+++ b/docs/pages/versions/unversioned/sdk/netinfo.mdx
@@ -71,7 +71,7 @@ To access the `ssid` property (available under `state.details.ssid`), there are 
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/react-native-netinfo/react-native-netinfo"

--- a/docs/pages/versions/unversioned/sdk/picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/picker.mdx
@@ -21,7 +21,7 @@ A component that provides access to the system UI for picking between several op
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/react-native-picker/picker"

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -88,7 +88,7 @@ const styles = StyleSheet.create({
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation"

--- a/docs/pages/versions/unversioned/sdk/screens.mdx
+++ b/docs/pages/versions/unversioned/sdk/screens.mdx
@@ -21,7 +21,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://docs.swmansion.com/react-native-screens/"

--- a/docs/pages/versions/unversioned/sdk/segmented-control.mdx
+++ b/docs/pages/versions/unversioned/sdk/segmented-control.mdx
@@ -21,7 +21,7 @@ It's like a fancy radio button, or in Apple's words: "A horizontal control that 
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/react-native-community/segmented-control"

--- a/docs/pages/versions/unversioned/sdk/skia.mdx
+++ b/docs/pages/versions/unversioned/sdk/skia.mdx
@@ -25,7 +25,7 @@ If you want to use Skia on web, you will need to follow [web installation instru
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://shopify.github.io/react-native-skia/"

--- a/docs/pages/versions/unversioned/sdk/slider.mdx
+++ b/docs/pages/versions/unversioned/sdk/slider.mdx
@@ -23,7 +23,7 @@ A component library that provides access to the system UI for a slider control, 
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/callstack/react-native-slider"

--- a/docs/pages/versions/unversioned/sdk/svg.mdx
+++ b/docs/pages/versions/unversioned/sdk/svg.mdx
@@ -61,7 +61,7 @@ Here are some helpful links that will get you moving fast!
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/software-mansion/react-native-svg"

--- a/docs/pages/versions/unversioned/sdk/view-pager.mdx
+++ b/docs/pages/versions/unversioned/sdk/view-pager.mdx
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/callstack/react-native-pager-view"

--- a/docs/pages/versions/unversioned/sdk/webview.mdx
+++ b/docs/pages/versions/unversioned/sdk/webview.mdx
@@ -80,7 +80,7 @@ const styles = StyleSheet.create({
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md"

--- a/docs/pages/versions/v53.0.0/sdk/async-storage.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/async-storage.mdx
@@ -21,7 +21,7 @@ Async Storage is asynchronous, unencrypted, persistent, key-value storage soluti
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://react-native-async-storage.github.io/async-storage/docs/usage"

--- a/docs/pages/versions/v53.0.0/sdk/captureRef.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/captureRef.mdx
@@ -44,7 +44,7 @@ const result = await captureRef(this.imageContainer, {
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/gre/react-native-view-shot"

--- a/docs/pages/versions/v53.0.0/sdk/date-time-picker.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/date-time-picker.mdx
@@ -24,7 +24,7 @@ A component that provides access to the system UI for date and time selection.
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/react-native-datetimepicker/datetimepicker"

--- a/docs/pages/versions/v53.0.0/sdk/flash-list.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/flash-list.mdx
@@ -21,7 +21,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://shopify.github.io/flash-list/"

--- a/docs/pages/versions/v53.0.0/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/gesture-handler.mdx
@@ -23,7 +23,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://docs.swmansion.com/react-native-gesture-handler/"

--- a/docs/pages/versions/v53.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/lottie.mdx
@@ -87,7 +87,7 @@ const styles = StyleSheet.create({
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://airbnb.io/lottie/#/react-native"

--- a/docs/pages/versions/v53.0.0/sdk/masked-view.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/masked-view.mdx
@@ -25,7 +25,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/react-native-masked-view/masked-view"

--- a/docs/pages/versions/v53.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/netinfo.mdx
@@ -71,7 +71,7 @@ To access the `ssid` property (available under `state.details.ssid`), there are 
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/react-native-netinfo/react-native-netinfo"

--- a/docs/pages/versions/v53.0.0/sdk/picker.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/picker.mdx
@@ -21,7 +21,7 @@ A component that provides access to the system UI for picking between several op
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/react-native-picker/picker"

--- a/docs/pages/versions/v53.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/reanimated.mdx
@@ -88,7 +88,7 @@ const styles = StyleSheet.create({
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation"

--- a/docs/pages/versions/v53.0.0/sdk/screens.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/screens.mdx
@@ -21,7 +21,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://docs.swmansion.com/react-native-screens/"

--- a/docs/pages/versions/v53.0.0/sdk/segmented-control.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/segmented-control.mdx
@@ -21,7 +21,7 @@ It's like a fancy radio button, or in Apple's words: "A horizontal control that 
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/react-native-community/segmented-control"

--- a/docs/pages/versions/v53.0.0/sdk/skia.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/skia.mdx
@@ -25,7 +25,7 @@ If you want to use Skia on web, you will need to follow [web installation instru
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://shopify.github.io/react-native-skia/"

--- a/docs/pages/versions/v53.0.0/sdk/slider.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/slider.mdx
@@ -23,7 +23,7 @@ A component library that provides access to the system UI for a slider control, 
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/callstack/react-native-slider"

--- a/docs/pages/versions/v53.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/svg.mdx
@@ -61,7 +61,7 @@ Here are some helpful links that will get you moving fast!
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/software-mansion/react-native-svg"

--- a/docs/pages/versions/v53.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/view-pager.mdx
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/callstack/react-native-pager-view"

--- a/docs/pages/versions/v53.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/webview.mdx
@@ -80,7 +80,7 @@ const styles = StyleSheet.create({
 ## Learn more
 
 <BoxLink
-  title="Visit offical documentation"
+  title="Visit official documentation"
   description="Get full information on API and its usage."
   Icon={BookOpen02Icon}
   href="https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Current state:

![CleanShot 2025-04-16 at 16 23 28@2x](https://github.com/user-attachments/assets/01941e5b-193f-42d5-880d-31fafcb079ac)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By proofreading it.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
