### PR TITLE
[install-expo-modules] add rn078 support

### DIFF
--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Added react-native 0.77 support. ([#36204](https://github.com/expo/expo/pull/36204) by [@kudo](https://github.com/kudo))
+- Added react-native 0.78 support. ([#36205](https://github.com/expo/expo/pull/36205) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/install-expo-modules/src/index.ts
+++ b/packages/install-expo-modules/src/index.ts
@@ -123,7 +123,8 @@ async function runAsync() {
   );
 
   const {
-    expoSdkVersion: sdkVersion,
+    sdkVersion,
+    expoPackageVersion,
     iosDeploymentTarget,
     androidAgpVersion,
     supportCliIntegration,
@@ -184,7 +185,7 @@ async function runAsync() {
   });
 
   console.log('\u203A Installing expo packages...');
-  await installExpoPackageAsync(projectRoot, sdkVersion);
+  await installExpoPackageAsync(projectRoot, expoPackageVersion);
 
   console.log('\u203A Installing ios pods...');
   await installPodsAsync(projectRoot);

--- a/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
@@ -99,5 +99,5 @@ function getSdkVersion(reactNativeVersion: string): string {
     semver.satisfies(reactNativeVersion, info.reactNativeVersionRange)
   );
   assert(versionInfo, `Unsupported react-native version: ${reactNativeVersion}`);
-  return versionInfo?.expoSdkVersion;
+  return versionInfo?.sdkVersion;
 }

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
@@ -18,7 +18,7 @@ describe(updateModulesAppDelegateObjcHeader, () => {
       fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn071-updated.h'), 'utf8'),
     ]);
 
-    const sdkVersion = getLatestSdkVersion().expoSdkVersion;
+    const sdkVersion = getLatestSdkVersion().sdkVersion;
     const contents = updateModulesAppDelegateObjcHeader(rawContents, sdkVersion);
     expect(updateModulesAppDelegateObjcHeader(contents, sdkVersion)).toEqual(expectContents);
     // Try it twice...
@@ -32,7 +32,7 @@ describe(updateModulesAppDelegateObjcHeader, () => {
       fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn067-updated.h'), 'utf8'),
     ]);
 
-    const sdkVersion = getLatestSdkVersion().expoSdkVersion;
+    const sdkVersion = getLatestSdkVersion().sdkVersion;
     const contents = updateModulesAppDelegateObjcHeader(rawContents, sdkVersion);
     expect(updateModulesAppDelegateObjcHeader(contents, sdkVersion)).toEqual(expectContents);
     // Try it twice...
@@ -48,7 +48,7 @@ describe(updateModulesAppDelegateObjcImpl, () => {
       fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn068-updated.mm'), 'utf8'),
     ]);
 
-    const sdkVersion = getLatestSdkVersion().expoSdkVersion;
+    const sdkVersion = getLatestSdkVersion().sdkVersion;
     const contents = updateModulesAppDelegateObjcImpl(rawContents, sdkVersion);
     expect(contents).toEqual(expectContents);
     // Try it twice...
@@ -62,7 +62,7 @@ describe(updateModulesAppDelegateObjcImpl, () => {
       fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn067-updated.m'), 'utf8'),
     ]);
 
-    const sdkVersion = getLatestSdkVersion().expoSdkVersion;
+    const sdkVersion = getLatestSdkVersion().sdkVersion;
     const contents = updateModulesAppDelegateObjcImpl(rawContents, sdkVersion);
     expect(contents).toEqual(expectContents);
     // Try it twice...
@@ -78,7 +78,7 @@ describe(updateModulesAppDelegateSwift, () => {
       'utf8'
     );
 
-    const sdkVersion = getLatestSdkVersion().expoSdkVersion;
+    const sdkVersion = getLatestSdkVersion().sdkVersion;
     expect(updateModulesAppDelegateSwift(rawContents, sdkVersion)).toMatchSnapshot();
   });
 
@@ -88,7 +88,7 @@ describe(updateModulesAppDelegateSwift, () => {
       'utf8'
     );
 
-    const sdkVersion = getLatestSdkVersion().expoSdkVersion;
+    const sdkVersion = getLatestSdkVersion().sdkVersion;
     let expectedContents = updateModulesAppDelegateSwift(rawContents, sdkVersion);
     expectedContents = updateVirtualMetroEntryIos(expectedContents);
     expect(expectedContents).toMatchSnapshot();

--- a/packages/install-expo-modules/src/utils/__tests__/expoVersionMappings-test.ts
+++ b/packages/install-expo-modules/src/utils/__tests__/expoVersionMappings-test.ts
@@ -17,16 +17,16 @@ describe(getDefaultSdkVersion, () => {
 
   it('should resolve as sdk 45 from react-native 0.68 project', async () => {
     setupReactNativeVersionMock('0.68.0');
-    expect(getDefaultSdkVersion('/projectRoot').expoSdkVersion).toBe('45.0.0');
+    expect(getDefaultSdkVersion('/projectRoot').sdkVersion).toBe('45.0.0');
   });
 
   it('should resolve as sdk 45 from react-native 0.65 project', async () => {
     setupReactNativeVersionMock('0.65.0');
-    expect(getDefaultSdkVersion('/projectRoot').expoSdkVersion).toBe('45.0.0');
+    expect(getDefaultSdkVersion('/projectRoot').sdkVersion).toBe('45.0.0');
   });
 
   it('should resolve as sdk 44 from react-native 0.64 project', async () => {
     setupReactNativeVersionMock('0.64.3');
-    expect(getDefaultSdkVersion('/projectRoot').expoSdkVersion).toBe('44.0.0');
+    expect(getDefaultSdkVersion('/projectRoot').sdkVersion).toBe('44.0.0');
   });
 });

--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -2,7 +2,8 @@ import resolveFrom from 'resolve-from';
 import semver from 'semver';
 
 export interface VersionInfo {
-  expoSdkVersion: string;
+  expoPackageVersion: string;
+  sdkVersion: string;
   iosDeploymentTarget: string;
   reactNativeVersionRange: string;
   androidAgpVersion?: string;
@@ -12,57 +13,76 @@ export interface VersionInfo {
 export const ExpoVersionMappings: VersionInfo[] = [
   // Please keep sdk versions in sorted order (latest sdk first)
   {
-    expoSdkVersion: '52.0.0',
+    // react-native 0.78 support was serving through canary.
+    // see: https://expo.dev/changelog/react-native-78
+    expoPackageVersion: '53.0.0-canary-20250306-d9d3e02',
+    sdkVersion: '52.0.0',
+    iosDeploymentTarget: '15.1',
+    reactNativeVersionRange: '~0.78.0',
+    supportCliIntegration: true,
+  },
+  {
+    expoPackageVersion: '~52.0.0',
+    sdkVersion: '52.0.0',
     iosDeploymentTarget: '15.1',
     reactNativeVersionRange: '>= 0.76.0 < 0.78.0',
     supportCliIntegration: true,
   },
   {
-    expoSdkVersion: '51.0.0',
+    expoPackageVersion: '~51.0.0',
+    sdkVersion: '51.0.0',
     iosDeploymentTarget: '13.4',
     reactNativeVersionRange: '>= 0.74.0',
     supportCliIntegration: true,
   },
   {
-    expoSdkVersion: '50.0.0',
+    expoPackageVersion: '~50.0.0',
+    sdkVersion: '50.0.0',
     iosDeploymentTarget: '13.4',
     reactNativeVersionRange: '>= 0.73.0',
     supportCliIntegration: true,
   },
   {
-    expoSdkVersion: '49.0.0',
+    expoPackageVersion: '~49.0.0',
+    sdkVersion: '49.0.0',
     iosDeploymentTarget: '13.0',
     reactNativeVersionRange: '>= 0.72.0',
     supportCliIntegration: true,
   },
   {
-    expoSdkVersion: '48.0.0',
+    expoPackageVersion: '~48.0.0',
+    sdkVersion: '48.0.0',
     iosDeploymentTarget: '13.0',
     reactNativeVersionRange: '>= 0.71.0',
     androidAgpVersion: '7.4.1',
   },
   {
-    expoSdkVersion: '47.0.0',
+    expoPackageVersion: '~47.0.0',
+    sdkVersion: '47.0.0',
     iosDeploymentTarget: '13.0',
     reactNativeVersionRange: '>= 0.70.0',
   },
   {
-    expoSdkVersion: '46.0.0',
+    expoPackageVersion: '~46.0.0',
+    sdkVersion: '46.0.0',
     iosDeploymentTarget: '12.4',
     reactNativeVersionRange: '>= 0.69.0',
   },
   {
-    expoSdkVersion: '45.0.0',
+    expoPackageVersion: '~45.0.0',
+    sdkVersion: '45.0.0',
     iosDeploymentTarget: '12.0',
     reactNativeVersionRange: '>= 0.65.0',
   },
   {
-    expoSdkVersion: '44.0.0',
+    expoPackageVersion: '~44.0.0',
+    sdkVersion: '44.0.0',
     iosDeploymentTarget: '12.0',
     reactNativeVersionRange: '< 0.68.0',
   },
   {
-    expoSdkVersion: '43.0.0',
+    expoPackageVersion: '~43.0.0',
+    sdkVersion: '43.0.0',
     iosDeploymentTarget: '12.0',
     reactNativeVersionRange: '< 0.68.0',
   },
@@ -86,9 +106,15 @@ export function getDefaultSdkVersion(projectRoot: string): VersionInfo {
 }
 
 export function getLatestSdkVersion(): VersionInfo {
-  return ExpoVersionMappings[0];
+  const latestSdkVersion = ExpoVersionMappings.find(
+    ({ expoPackageVersion }) => semver.prerelease(expoPackageVersion) == null
+  );
+  if (!latestSdkVersion) {
+    throw new Error('No latest SDK version found');
+  }
+  return latestSdkVersion;
 }
 
 export function getVersionInfo(sdkVersion: string): VersionInfo | null {
-  return ExpoVersionMappings.find((info) => info.expoSdkVersion === sdkVersion) ?? null;
+  return ExpoVersionMappings.find((info) => info.sdkVersion === sdkVersion) ?? null;
 }

--- a/packages/install-expo-modules/src/utils/packageInstaller.ts
+++ b/packages/install-expo-modules/src/utils/packageInstaller.ts
@@ -29,16 +29,21 @@ async function installPackageNonInteractiveAsync(projectRoot: string, pkg: strin
  */
 export async function installExpoPackageAsync(projectRoot: string, sdkVersion: string) {
   try {
-    // First try to install from released versions, e.g. `expo@^45.0.0`
-    await installPackageNonInteractiveAsync(projectRoot, `expo@^${sdkVersion}`);
-  } catch {
-    // Fallback to install from prerelease versions,
-    // e.g. `expo@>=45.0.0-0 <46.0.0`, this will cover prerelease version for beta testing.
-    await installPackageNonInteractiveAsync(
-      projectRoot,
-      `expo@>=${sdkVersion}-0 <${semver.inc(sdkVersion, 'major')}`
-    );
+    // First try to install from released versions, e.g. `expo@~45.0.0`
+    await installPackageNonInteractiveAsync(projectRoot, `expo@${sdkVersion}`);
+    return;
+  } catch {}
+
+  // Fallback to install from prerelease versions,
+  // e.g. `expo@>=45.0.0-0 <46.0.0`, this will cover prerelease version for beta testing.
+  const majorVersion = semver.minVersion(sdkVersion)?.major;
+  if (!majorVersion) {
+    throw new Error('Invalid SDK version');
   }
+  await installPackageNonInteractiveAsync(
+    projectRoot,
+    `expo@>=${majorVersion}.0.0-0 <${majorVersion + 1}.0.0`
+  );
 }
 
 /**


### PR DESCRIPTION
# Why

close ENG-15503

# How

- add react-native 0.78 support which uses the fixed `53.0.0-canary-20250306-d9d3e02` canary version. we still keep it as sdk 52 even though the package version is 53.
- introduce `expoPackageVersion` and `sdkVersion` in ExpoVersionMappings because the 53 canary version is still sdk 52 based.
- support version range in `expoPackageVersion`

# Test Plan

manual test on a rnc-cli 0.78 project

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
