### PR TITLE
[install-expo-modules] add rn079 support

### DIFF
--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added react-native 0.77 support. ([#36204](https://github.com/expo/expo/pull/36204) by [@kudo](https://github.com/kudo))
 - Added react-native 0.78 support. ([#36205](https://github.com/expo/expo/pull/36205) by [@kudo](https://github.com/kudo))
+- Added react-native 0.79 support. ([#36206](https://github.com/expo/expo/pull/36206) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/ProjectBuild-rn079-updated.gradle
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/ProjectBuild-rn079-updated.gradle
@@ -1,0 +1,22 @@
+buildscript {
+    ext {
+        buildToolsVersion = "35.0.0"
+        minSdkVersion = 24
+        compileSdkVersion = 35
+        targetSdkVersion = 35
+        ndkVersion = "27.1.12297006"
+        kotlinVersion = "2.0.21"
+    }
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle")
+        classpath("com.facebook.react:react-native-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+    }
+}
+
+apply plugin: "com.facebook.react.rootproject"
+apply plugin: "expo-root-project"

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/ProjectBuild-rn079.gradle
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/ProjectBuild-rn079.gradle
@@ -1,0 +1,21 @@
+buildscript {
+    ext {
+        buildToolsVersion = "35.0.0"
+        minSdkVersion = 24
+        compileSdkVersion = 35
+        targetSdkVersion = 35
+        ndkVersion = "27.1.12297006"
+        kotlinVersion = "2.0.21"
+    }
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle")
+        classpath("com.facebook.react:react-native-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+    }
+}
+
+apply plugin: "com.facebook.react.rootproject"

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/settings-rn079-updated.gradle
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/settings-rn079-updated.gradle
@@ -1,0 +1,20 @@
+pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") 
+  def expoPluginsPath = new File(
+    providers.exec {
+      workingDir(rootDir)
+      commandLine("node", "--print", "require.resolve('expo-modules-autolinking/package.json', { paths: [require.resolve('expo/package.json')] })")
+    }.standardOutput.asText.get().trim(),
+    "../android/expo-gradle-plugin"
+  ).absolutePath
+  includeBuild(expoPluginsPath)
+}
+plugins { id("com.facebook.react.settings") 
+id("expo-autolinking-settings")
+}
+extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand(expoAutolinking.rnConfigCommand) }
+rootProject.name = 'RN079'
+include ':app'
+includeBuild('../node_modules/@react-native/gradle-plugin')
+expoAutolinking.useExpoModules()
+expoAutolinking.useExpoVersionCatalog()
+includeBuild(expoAutolinking.reactNativeGradlePlugin)

--- a/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/settings-rn079.gradle
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/fixtures/settings-rn079.gradle
@@ -1,0 +1,6 @@
+pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
+plugins { id("com.facebook.react.settings") }
+extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
+rootProject.name = 'RN079'
+include ':app'
+includeBuild('../node_modules/@react-native/gradle-plugin')

--- a/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidModulesMainApplication-test.ts
@@ -1,9 +1,8 @@
-import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
 import semver from 'semver';
 
-import { ExpoVersionMappings } from '../../../utils/expoVersionMappings';
+import { getSdkVersion } from '../../../utils/expoVersionMappings';
 import { setModulesMainApplication } from '../withAndroidModulesMainApplication';
 
 const fixturesPath = path.resolve(__dirname, 'fixtures');
@@ -93,11 +92,3 @@ describe(setModulesMainApplication, () => {
     expect(nextContents).toEqual(expectContents);
   });
 });
-
-function getSdkVersion(reactNativeVersion: string): string {
-  const versionInfo = ExpoVersionMappings.find((info) =>
-    semver.satisfies(reactNativeVersion, info.reactNativeVersionRange)
-  );
-  assert(versionInfo, `Unsupported react-native version: ${reactNativeVersion}`);
-  return versionInfo?.sdkVersion;
-}

--- a/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidSettingsGradle-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/withAndroidSettingsGradle-test.ts
@@ -6,6 +6,27 @@ import { updateAndroidSettingsGradle } from '../withAndroidSettingsGradle';
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 describe(updateAndroidSettingsGradle, () => {
+  it(`should be able to update settings.gradle for react-native@0.79.0`, async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'settings-rn079.gradle'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'settings-rn079-updated.gradle'), 'utf8'),
+    ]);
+
+    const contents = updateAndroidSettingsGradle({
+      contents: rawContents,
+      isGroovy: true,
+      sdkVersion: '53.0.0',
+    });
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = updateAndroidSettingsGradle({
+      contents,
+      isGroovy: true,
+      sdkVersion: '53.0.0',
+    });
+    expect(nextContents).toEqual(expectContents);
+  });
+
   it(`should be able to update settings.gradle for react-native@0.74.0`, async () => {
     const [rawContents, expectContents] = await Promise.all([
       fs.promises.readFile(path.join(fixturesPath, 'settings-rn074.gradle'), 'utf8'),

--- a/packages/install-expo-modules/src/plugins/android/__tests__/witnAndroidGradles-test.ts
+++ b/packages/install-expo-modules/src/plugins/android/__tests__/witnAndroidGradles-test.ts
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+
+import { updateAndroidProjectBuildGradle } from '../withAndroidGradles';
+
+const fixturesPath = path.resolve(__dirname, 'fixtures');
+
+describe(updateAndroidProjectBuildGradle, () => {
+  it(`should be able to update build.gradle for react-native@0.79.0`, async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'ProjectBuild-rn079.gradle'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'ProjectBuild-rn079-updated.gradle'), 'utf8'),
+    ]);
+
+    const contents = updateAndroidProjectBuildGradle({
+      contents: rawContents,
+      isGroovy: true,
+      sdkVersion: '53.0.0',
+    });
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = updateAndroidProjectBuildGradle({
+      contents,
+      isGroovy: true,
+      sdkVersion: '53.0.0',
+    });
+    expect(nextContents).toEqual(expectContents);
+  });
+});

--- a/packages/install-expo-modules/src/plugins/android/withAndroidModules.ts
+++ b/packages/install-expo-modules/src/plugins/android/withAndroidModules.ts
@@ -1,5 +1,6 @@
 import { ConfigPlugin, withPlugins } from '@expo/config-plugins';
 
+import { withAndroidModulesProjectBuildGradle } from './withAndroidGradles';
 import { withAndroidModulesMainActivity } from './withAndroidModulesMainActivity';
 import { withAndroidModulesMainApplication } from './withAndroidModulesMainApplication';
 import { withAndroidModulesSettingGradle } from './withAndroidSettingsGradle';
@@ -9,5 +10,6 @@ export const withAndroidModules: ConfigPlugin = (config) => {
     withAndroidModulesMainApplication,
     withAndroidModulesMainActivity,
     withAndroidModulesSettingGradle,
+    withAndroidModulesProjectBuildGradle,
   ]);
 };

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn079-updated.swift
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn079-updated.swift
@@ -1,0 +1,27 @@
+import UIKit
+import Expo
+import React
+import React_RCTAppDelegate
+import ReactAppDependencyProvider
+
+@main
+class AppDelegate: ExpoAppDelegate {
+
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    self.moduleName = "HelloWorld"
+    self.initialProps = [:]
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
+}
+

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn079.swift
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn079.swift
@@ -1,0 +1,48 @@
+import UIKit
+import React
+import React_RCTAppDelegate
+import ReactAppDependencyProvider
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
+
+  var reactNativeDelegate: ReactNativeDelegate?
+  var reactNativeFactory: RCTReactNativeFactory?
+
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    let delegate = ReactNativeDelegate()
+    let factory = RCTReactNativeFactory(delegate: delegate)
+    delegate.dependencyProvider = RCTAppDependencyProvider()
+
+    reactNativeDelegate = delegate
+    reactNativeFactory = factory
+
+    window = UIWindow(frame: UIScreen.main.bounds)
+
+    factory.startReactNative(
+      withModuleName: "HelloWorld",
+      in: window,
+      launchOptions: launchOptions
+    )
+
+    return true
+  }
+}
+
+class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
+  override func sourceURL(for bridge: RCTBridge) -> URL? {
+    self.bundleURL()
+  }
+
+  override func bundleURL() -> URL? {
+#if DEBUG
+    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
+#else
+    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
+}

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/withIosModulesAppDelegate-test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { getLatestSdkVersion } from '../../../utils/expoVersionMappings';
+import { getLatestSdkVersion, getSdkVersion } from '../../../utils/expoVersionMappings';
 import { updateVirtualMetroEntryIos } from '../../cli/withCliIntegration';
 import {
   updateModulesAppDelegateObjcHeader,
@@ -12,13 +12,27 @@ import {
 const fixturesPath = path.resolve(__dirname, 'fixtures');
 
 describe(updateModulesAppDelegateObjcHeader, () => {
+  it('should migrate from react-native@>=0.79.0 AppDelegate.swift', async () => {
+    const [rawContents, expectContents] = await Promise.all([
+      fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn079.swift'), 'utf8'),
+      fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn079-updated.swift'), 'utf8'),
+    ]);
+
+    const sdkVersion = getLatestSdkVersion().sdkVersion;
+    const contents = updateModulesAppDelegateSwift(rawContents, sdkVersion);
+    expect(contents).toEqual(expectContents);
+    // Try it twice...
+    const nextContents = updateModulesAppDelegateSwift(contents, sdkVersion);
+    expect(nextContents).toEqual(expectContents);
+  });
+
   it('should migrate from react-native@>=0.71.0 AppDelegate header', async () => {
     const [rawContents, expectContents] = await Promise.all([
       fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn071.h'), 'utf8'),
       fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn071-updated.h'), 'utf8'),
     ]);
 
-    const sdkVersion = getLatestSdkVersion().sdkVersion;
+    const sdkVersion = getSdkVersion('0.71.0');
     const contents = updateModulesAppDelegateObjcHeader(rawContents, sdkVersion);
     expect(updateModulesAppDelegateObjcHeader(contents, sdkVersion)).toEqual(expectContents);
     // Try it twice...
@@ -32,7 +46,7 @@ describe(updateModulesAppDelegateObjcHeader, () => {
       fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn067-updated.h'), 'utf8'),
     ]);
 
-    const sdkVersion = getLatestSdkVersion().sdkVersion;
+    const sdkVersion = getSdkVersion('0.67.0');
     const contents = updateModulesAppDelegateObjcHeader(rawContents, sdkVersion);
     expect(updateModulesAppDelegateObjcHeader(contents, sdkVersion)).toEqual(expectContents);
     // Try it twice...
@@ -48,7 +62,7 @@ describe(updateModulesAppDelegateObjcImpl, () => {
       fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn068-updated.mm'), 'utf8'),
     ]);
 
-    const sdkVersion = getLatestSdkVersion().sdkVersion;
+    const sdkVersion = getSdkVersion('0.68.0');
     const contents = updateModulesAppDelegateObjcImpl(rawContents, sdkVersion);
     expect(contents).toEqual(expectContents);
     // Try it twice...
@@ -62,7 +76,7 @@ describe(updateModulesAppDelegateObjcImpl, () => {
       fs.promises.readFile(path.join(fixturesPath, 'AppDelegate-rn067-updated.m'), 'utf8'),
     ]);
 
-    const sdkVersion = getLatestSdkVersion().sdkVersion;
+    const sdkVersion = getSdkVersion('0.67.0');
     const contents = updateModulesAppDelegateObjcImpl(rawContents, sdkVersion);
     expect(contents).toEqual(expectContents);
     // Try it twice...
@@ -78,7 +92,7 @@ describe(updateModulesAppDelegateSwift, () => {
       'utf8'
     );
 
-    const sdkVersion = getLatestSdkVersion().sdkVersion;
+    const sdkVersion = getSdkVersion('0.77.0');
     expect(updateModulesAppDelegateSwift(rawContents, sdkVersion)).toMatchSnapshot();
   });
 
@@ -88,7 +102,7 @@ describe(updateModulesAppDelegateSwift, () => {
       'utf8'
     );
 
-    const sdkVersion = getLatestSdkVersion().sdkVersion;
+    const sdkVersion = getSdkVersion('0.77.0');
     let expectedContents = updateModulesAppDelegateSwift(rawContents, sdkVersion);
     expectedContents = updateVirtualMetroEntryIos(expectedContents);
     expect(expectedContents).toMatchSnapshot();

--- a/packages/install-expo-modules/src/plugins/ios/withIosModulesAppDelegate.ts
+++ b/packages/install-expo-modules/src/plugins/ios/withIosModulesAppDelegate.ts
@@ -134,16 +134,91 @@ export function updateModulesAppDelegateSwift(
   contents: string,
   sdkVersion: string | undefined
 ): string {
-  if (sdkVersion && semver.lt(sdkVersion, '52.0.0')) {
-    return updateModulesAppDelegateSwiftLegacy(contents, sdkVersion);
+  if (sdkVersion) {
+    if (semver.lt(sdkVersion, '52.0.0')) {
+      return updateModulesAppDelegateSwiftLegacy(contents, sdkVersion);
+    }
+    if (semver.lt(sdkVersion, '53.0.0')) {
+      return updateModulesAppDelegateSwiftSdk52(contents, sdkVersion);
+    }
   }
 
   // Add imports if needed
   if (!contents.match(/^import\s+Expo\s*$/m)) {
     contents = addSwiftImports(contents, ['Expo']);
   }
-  if (sdkVersion === '52.0.0' && !contents.match(/^import\s+ExpoModulesCore\s*$/m)) {
-    // SDK 52 serves ExpoAppDelegate from ExpoModulesCore. We also need to import it.
+
+  // Replace superclass with ExpoAppDelegate
+  contents = contents.replace(
+    /^(class\s+AppDelegate\s*:\s*)UIResponder,\s*UIApplicationDelegate(\W+)/m,
+    '$1ExpoAppDelegate$2'
+  );
+  // Remove non-overridable properties
+  contents = contents.replace(/^\s*var window: UIWindow\?\n/m, '');
+  contents = contents.replace(/^\s*var reactNativeDelegate: ReactNativeDelegate\?\n/m, '');
+  contents = contents.replace(/^\s*var reactNativeFactory: RCTReactNativeFactory\?\n/m, '');
+  // Add `override` keyword and return super call to didFinishLaunchingWithOptions
+  contents = contents.replace(
+    /\b(func application\([\s\S]+?didFinishLaunchingWithOptions launchOptions[\s\S]+?\{[\s\S]+?)(return true)([\s\S]+?\})/m,
+    'override $1return super.application(application, didFinishLaunchingWithOptions: launchOptions)$3'
+  );
+  // Remove implementation in didFinishLaunchingWithOptions,
+  // most of the code is not overridable from ExpoAppDelegate
+  contents = contents.replace(/^\s*let delegate = ReactNativeDelegate\(\)\n/m, '');
+  contents = contents.replace(
+    /^\s*let factory = RCTReactNativeFactory\(delegate: delegate\)\n/m,
+    ''
+  );
+  contents = contents.replace(/^\s*window = UIWindow\(frame: UIScreen\.main\.bounds\)\n/m, '');
+  contents = contents.replace(
+    /^\s*delegate.dependencyProvider = RCTAppDependencyProvider\(\)\n/m,
+    ''
+  );
+  contents = contents.replace(/^\s*reactNativeDelegate = delegate\n/m, '');
+  contents = contents.replace(/^\s*reactNativeFactory = factory\n/m, '');
+  contents = contents.replace(/^\s*window = UIWindow(frame: UIScreen.main.bounds)\n/m, '');
+  contents = contents.replace(
+    /^\s*factory\.startReactNative\([\s\S]+?withModuleName:\s*"(.+)",[\s\S]+?\)\n/m,
+    `\
+    self.moduleName = "$1"
+    self.initialProps = [:]`
+  );
+
+  // Remove derived `ReactNativeDelegate` class
+  contents = contents.replace(
+    /^class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate\s*?\{[\s\S]+?\n\}\n/m,
+    ''
+  );
+
+  // Add derived `bundleURL` in the `AppDelegate` class
+  if (!contents.match(/override func bundleURL\(\) -> URL\? \{/m)) {
+    contents = contents.replace(
+      /^(class\s+AppDelegate:.+\{[\s\S]+)(\n\})/m,
+      `$1
+
+  override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }$2`
+    );
+  }
+
+  return contents;
+}
+
+function updateModulesAppDelegateSwiftSdk52(
+  contents: string,
+  sdkVersion: string | undefined
+): string {
+  // Add imports if needed
+  if (!contents.match(/^import\s+Expo\s*$/m)) {
+    contents = addSwiftImports(contents, ['Expo']);
+  }
+  // SDK 52 serves ExpoAppDelegate from ExpoModulesCore. We also need to import it.
+  if (!contents.match(/^import\s+ExpoModulesCore\s*$/m)) {
     contents = addSwiftImports(contents, ['ExpoModulesCore']);
   }
 

--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import resolveFrom from 'resolve-from';
 import semver from 'semver';
 
@@ -12,6 +13,13 @@ export interface VersionInfo {
 
 export const ExpoVersionMappings: VersionInfo[] = [
   // Please keep sdk versions in sorted order (latest sdk first)
+  {
+    expoPackageVersion: '~53.0.0',
+    sdkVersion: '53.0.0',
+    iosDeploymentTarget: '15.1',
+    reactNativeVersionRange: '~0.79.0',
+    supportCliIntegration: true,
+  },
   {
     // react-native 0.78 support was serving through canary.
     // see: https://expo.dev/changelog/react-native-78
@@ -109,12 +117,18 @@ export function getLatestSdkVersion(): VersionInfo {
   const latestSdkVersion = ExpoVersionMappings.find(
     ({ expoPackageVersion }) => semver.prerelease(expoPackageVersion) == null
   );
-  if (!latestSdkVersion) {
-    throw new Error('No latest SDK version found');
-  }
+  assert(latestSdkVersion, 'No latest SDK version found');
   return latestSdkVersion;
 }
 
 export function getVersionInfo(sdkVersion: string): VersionInfo | null {
   return ExpoVersionMappings.find((info) => info.sdkVersion === sdkVersion) ?? null;
+}
+
+export function getSdkVersion(reactNativeVersion: string): string {
+  const versionInfo = ExpoVersionMappings.find((info) =>
+    semver.satisfies(reactNativeVersion, info.reactNativeVersionRange)
+  );
+  assert(versionInfo, `Unsupported react-native version: ${reactNativeVersion}`);
+  return versionInfo?.sdkVersion;
 }


### PR DESCRIPTION
# Why

close ENG-15503

# How

- add react-native 0.79 support for sdk 53
- the main change on ios is AppDelegate.swift which replaced `RCTAppDelegate` with `ReactNativeFactory` member property. we still need to change the base class to `ExpoAppDelegate` because of AppDelegateSubscribers. and unfortunately our current integration in `ExpoAppDelegate` is not ideal. we have to replace the whole AppDelegate to be like react-native 0.77
- the main change on android is new autolinking plugin integration coming from #35790. this pr tries to support the changes

# Test Plan

- add unit tests for AppDelegate.swift, build.gradle, and settings.gradle changes
- manual test on a rnc-cli 0.79 project

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
