### PR TITLE
chore(cli): Move EAS remote build cache to a separate file

### DIFF
--- a/packages/@expo/cli/src/run/remoteBuildCache.ts
+++ b/packages/@expo/cli/src/run/remoteBuildCache.ts
@@ -1,15 +1,13 @@
 import { ExpoConfig } from '@expo/config';
 import { ModPlatform } from '@expo/config-plugins';
-import spawnAsync from '@expo/spawn-async';
-import chalk from 'chalk';
-import fs from 'fs';
-import path from 'path';
 
-import { Log } from '../log';
 import { type Options as AndroidRunOptions } from './android/resolveOptions';
 import { type Options as IosRunOptions } from './ios/XcodeBuild.types';
-import { hasDirectDevClientDependency } from '../start/detectDevClient';
-import { isSpawnResultError } from '../start/platforms/ios/xcrun';
+import {
+  calculateEASFingerprintHashAsync,
+  resolveEASRemoteBuildCache,
+  uploadEASRemoteBuildCache,
+} from '../utils/remote-build-cache-providers/eas';
 const debug = require('debug')('expo:run:remote-build') as typeof console.log;
 
 export async function resolveRemoteBuildCache(
@@ -25,50 +23,12 @@ export async function resolveRemoteBuildCache(
   }
 ): Promise<string | null> {
   const fingerprintHash = await calculateFingerprintHashAsync(projectRoot, platform, provider);
+  if (!fingerprintHash) {
+    return null;
+  }
 
   if (provider === 'eas') {
-    const easJsonPath = path.join(projectRoot, 'eas.json');
-    if (!fs.existsSync(easJsonPath)) {
-      debug('eas.json not found, skip checking for remote builds');
-      return null;
-    }
-
-    Log.log(
-      chalk`{whiteBright \u203A} {bold Searching builds with matching fingerprint on EAS servers}`
-    );
-    try {
-      const results = await spawnAsync(
-        'npx',
-        [
-          'eas-cli',
-          'build:download',
-          `--platform=${platform}`,
-          `--fingerprint=${fingerprintHash}`,
-          '--non-interactive',
-          isDevClientBuild({ runOptions, projectRoot }) ? '--dev-client' : '--no-dev-client',
-          '--json',
-        ],
-        {
-          cwd: projectRoot,
-        }
-      );
-
-      Log.log(chalk`{whiteBright \u203A} {bold Successfully downloaded cached build}`);
-      // {
-      //   "path": "/var/folders/03/lppcpcnn61q3mz5ckzmzd8w80000gn/T/eas-cli-nodejs/eas-build-run-cache/c0f9ba9c-0cf1-4c5c-8566-b28b7971050f_22f1bbfa-1c09-4b67-9e4a-721906546b58.app"
-      // }
-      const json = JSON.parse(results.stdout.trim());
-      return json?.path;
-    } catch (error) {
-      debug('eas-cli error:', error);
-      // @TODO(2025-04-11): remove this in a future release
-      if (isSpawnResultError(error) && error.stderr.includes('command build:download not found')) {
-        Log.warn(
-          `To take advantage of remote build cache, upgrade your eas-cli installation to latest.`
-        );
-      }
-      return null;
-    }
+    return await resolveEASRemoteBuildCache({ platform, fingerprintHash, projectRoot, runOptions });
   }
 
   return null;
@@ -85,45 +45,20 @@ export async function uploadRemoteBuildCache(
     provider?: Required<Required<ExpoConfig>['experiments']>['remoteBuildCache']['provider'];
     buildPath?: string;
   }
-): Promise<string | null> {
+): Promise<void> {
   const fingerprintHash = await calculateFingerprintHashAsync(projectRoot, platform, provider);
-
-  if (provider === 'eas') {
-    const easJsonPath = path.join(projectRoot, 'eas.json');
-    if (!fs.existsSync(easJsonPath)) {
-      debug('eas.json not found, skip checking for remote builds');
-      return null;
-    }
-
-    try {
-      Log.log(chalk`{whiteBright \u203A} {bold Uploading build to remote cache}`);
-      const results = await spawnAsync(
-        'npx',
-        [
-          'eas-cli',
-          'upload',
-          `--platform=${platform}`,
-          `--fingerprint=${fingerprintHash}`,
-          buildPath ? `--build-path=${buildPath}` : '',
-          '--non-interactive',
-          '--json',
-        ],
-        {
-          cwd: projectRoot,
-        }
-      );
-      // {
-      //   "url": "/var/folders/03/lppcpcnn61q3mz5ckzmzd8w80000gn/T/eas-cli-nodejs/eas-build-run-cache/c0f9ba9c-0cf1-4c5c-8566-b28b7971050f_22f1bbfa-1c09-4b67-9e4a-721906546b58.app"
-      // }
-      const json = JSON.parse(results.stdout.trim());
-      Log.log(chalk`{whiteBright \u203A} {bold Build successfully uploaded: ${json?.url}}`);
-    } catch (error) {
-      debug('eas-cli error:', error);
-      return null;
-    }
+  if (!fingerprintHash) {
+    return;
   }
 
-  return null;
+  if (provider === 'eas') {
+    await uploadEASRemoteBuildCache({
+      projectRoot,
+      platform,
+      fingerprintHash,
+      buildPath,
+    });
+  }
 }
 
 async function calculateFingerprintHashAsync(
@@ -132,29 +67,9 @@ async function calculateFingerprintHashAsync(
   provider?: Required<Required<ExpoConfig>['experiments']>['remoteBuildCache']['provider']
 ): Promise<string | null> {
   if (provider === 'eas') {
-    // prefer using `eas fingerprint:generate` because it automatically upload sources
-    try {
-      const results = await spawnAsync(
-        'npx',
-        [
-          'eas-cli',
-          'fingerprint:generate',
-          `--platform=${platform}`,
-          '--json',
-          '--non-interactive',
-        ],
-        {
-          cwd: projectRoot,
-        }
-      );
-      // {
-      //   "hash": "203f960b965e154b77dc31c6c42e5582e8d77196"
-      // }
-      const json = JSON.parse(results.stdout.trim());
-      return json?.hash;
-    } catch (error) {
-      // if eas-cli is not installed, fallback to @expo/fingerprint
-      debug('eas-cli error:', error);
+    const easFingerprintHash = await calculateEASFingerprintHashAsync({ projectRoot, platform });
+    if (easFingerprintHash) {
+      return easFingerprintHash;
     }
   }
 
@@ -174,25 +89,4 @@ function importFingerprintForDev(projectRoot: string): null | typeof import('@ex
   } catch {
     return null;
   }
-}
-
-export function isDevClientBuild({
-  runOptions,
-  projectRoot,
-}: {
-  runOptions: AndroidRunOptions | IosRunOptions;
-  projectRoot: string;
-}) {
-  if (!hasDirectDevClientDependency(projectRoot)) {
-    return false;
-  }
-
-  if ('variant' in runOptions && runOptions.variant !== undefined) {
-    return runOptions.variant === 'debug';
-  }
-  if ('configuration' in runOptions && runOptions.configuration !== undefined) {
-    return runOptions.configuration === 'Debug';
-  }
-
-  return true;
 }

--- a/packages/@expo/cli/src/utils/remote-build-cache-providers/eas.ts
+++ b/packages/@expo/cli/src/utils/remote-build-cache-providers/eas.ts
@@ -1,0 +1,139 @@
+import { ModPlatform } from '@expo/config-plugins';
+import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import fs from 'fs';
+import path from 'path';
+
+import { isDevClientBuild } from './helpers';
+import { Log } from '../../log';
+import { type Options as AndroidRunOptions } from '../../run/android/resolveOptions';
+import { type Options as IosRunOptions } from '../../run/ios/XcodeBuild.types';
+import { isSpawnResultError } from '../../start/platforms/ios/xcrun';
+
+const debug = require('debug')('expo:eas-remote-build-cache') as typeof console.log;
+
+export async function resolveEASRemoteBuildCache({
+  projectRoot,
+  platform,
+  fingerprintHash,
+  runOptions,
+}: {
+  projectRoot: string;
+  platform: ModPlatform;
+  fingerprintHash: string;
+  runOptions: AndroidRunOptions | IosRunOptions;
+}): Promise<string | null> {
+  const easJsonPath = path.join(projectRoot, 'eas.json');
+  if (!fs.existsSync(easJsonPath)) {
+    debug('eas.json not found, skip checking for remote builds');
+    return null;
+  }
+
+  Log.log(
+    chalk`{whiteBright \u203A} {bold Searching builds with matching fingerprint on EAS servers}`
+  );
+  try {
+    const results = await spawnAsync(
+      'npx',
+      [
+        'eas-cli',
+        'build:download',
+        `--platform=${platform}`,
+        `--fingerprint=${fingerprintHash}`,
+        '--non-interactive',
+        isDevClientBuild({ runOptions, projectRoot }) ? '--dev-client' : '--no-dev-client',
+        '--json',
+      ],
+      {
+        cwd: projectRoot,
+      }
+    );
+
+    Log.log(chalk`{whiteBright \u203A} {bold Successfully downloaded cached build}`);
+    // {
+    //   "path": "/var/folders/03/lppcpcnn61q3mz5ckzmzd8w80000gn/T/eas-cli-nodejs/eas-build-run-cache/c0f9ba9c-0cf1-4c5c-8566-b28b7971050f_22f1bbfa-1c09-4b67-9e4a-721906546b58.app"
+    // }
+    const json = JSON.parse(results.stdout.trim());
+    return json?.path;
+  } catch (error) {
+    debug('eas-cli error:', error);
+    // @TODO(2025-04-11): remove this in a future release
+    if (isSpawnResultError(error) && error.stderr.includes('command build:download not found')) {
+      Log.warn(
+        `To take advantage of remote build cache, upgrade your eas-cli installation to latest.`
+      );
+    }
+    return null;
+  }
+}
+
+export async function uploadEASRemoteBuildCache({
+  projectRoot,
+  platform,
+  fingerprintHash,
+  buildPath,
+}: {
+  projectRoot: string;
+  platform: ModPlatform;
+  fingerprintHash: string;
+  buildPath?: string;
+}): Promise<void> {
+  const easJsonPath = path.join(projectRoot, 'eas.json');
+  if (!fs.existsSync(easJsonPath)) {
+    debug('eas.json not found, skip checking for remote builds');
+    return;
+  }
+
+  try {
+    Log.log(chalk`{whiteBright \u203A} {bold Uploading build to remote cache}`);
+    const results = await spawnAsync(
+      'npx',
+      [
+        'eas-cli',
+        'upload',
+        `--platform=${platform}`,
+        `--fingerprint=${fingerprintHash}`,
+        buildPath ? `--build-path=${buildPath}` : '',
+        '--non-interactive',
+        '--json',
+      ],
+      {
+        cwd: projectRoot,
+      }
+    );
+    // {
+    //   "url": "/var/folders/03/lppcpcnn61q3mz5ckzmzd8w80000gn/T/eas-cli-nodejs/eas-build-run-cache/c0f9ba9c-0cf1-4c5c-8566-b28b7971050f_22f1bbfa-1c09-4b67-9e4a-721906546b58.app"
+    // }
+    const json = JSON.parse(results.stdout.trim());
+    Log.log(chalk`{whiteBright \u203A} {bold Build successfully uploaded: ${json?.url}}`);
+  } catch (error) {
+    debug('eas-cli error:', error);
+  }
+}
+
+export async function calculateEASFingerprintHashAsync({
+  projectRoot,
+  platform,
+}: {
+  projectRoot: string;
+  platform: ModPlatform;
+}): Promise<string | null> {
+  // prefer using `eas fingerprint:generate` because it automatically upload sources
+  try {
+    const results = await spawnAsync(
+      'npx',
+      ['eas-cli', 'fingerprint:generate', `--platform=${platform}`, '--json', '--non-interactive'],
+      {
+        cwd: projectRoot,
+      }
+    );
+    // {
+    //   "hash": "203f960b965e154b77dc31c6c42e5582e8d77196"
+    // }
+    const json = JSON.parse(results.stdout.trim());
+    return json?.hash;
+  } catch (error) {
+    debug('eas-cli error:', error);
+  }
+  return null;
+}

--- a/packages/@expo/cli/src/utils/remote-build-cache-providers/helpers.ts
+++ b/packages/@expo/cli/src/utils/remote-build-cache-providers/helpers.ts
@@ -1,0 +1,24 @@
+import { type Options as AndroidRunOptions } from '../../run/android/resolveOptions';
+import { type Options as IosRunOptions } from '../../run/ios/XcodeBuild.types';
+import { hasDirectDevClientDependency } from '../../start/detectDevClient';
+
+export function isDevClientBuild({
+  runOptions,
+  projectRoot,
+}: {
+  runOptions: AndroidRunOptions | IosRunOptions;
+  projectRoot: string;
+}) {
+  if (!hasDirectDevClientDependency(projectRoot)) {
+    return false;
+  }
+
+  if ('variant' in runOptions && runOptions.variant !== undefined) {
+    return runOptions.variant === 'debug';
+  }
+  if ('configuration' in runOptions && runOptions.configuration !== undefined) {
+    return runOptions.configuration === 'Debug';
+  }
+
+  return true;
+}


### PR DESCRIPTION
# Why

To better support different remote build cache providers, we should extract EAS functions from `remoteBuildCache.ts`

# How

Extract EAS remote build cache specific functions from `remoteBuildCache.ts` and move it to a separate file

# Test Plan

test locally `nexpo run:ios` and `nexpo run:android`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
