### PR TITLE
[core] fix build error on windows

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed build errors on Windows. ([#36211](https://github.com/expo/expo/pull/36211) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.3.5 — 2025-04-14

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -16,6 +16,7 @@ import expo.modules.plugin.gradle.ExpoModuleExtension
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.internal.extensions.core.extra
+import java.io.File
 import java.net.URI
 
 internal fun Project.applyDefaultPlugins() {
@@ -87,7 +88,7 @@ internal fun Project.applyPublishing(expoModulesExtension: ExpoModuleExtension) 
     createExpoPublishToMavenLocalTask(publicationInfo, expoModulesExtension)
 
     val npmLocalRepositoryRelativePath = "local-maven-repo"
-    val npmLocalRepository = URI("file://${project.projectDir.parentFile}/${npmLocalRepositoryRelativePath}")
+    val npmLocalRepository = File("${project.projectDir.parentFile}/${npmLocalRepositoryRelativePath}").toURI()
     publishingExtension().repositories.mavenLocal { mavenRepo ->
       mavenRepo.name = "NPMPackage"
       mavenRepo.url = npmLocalRepository

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -17,7 +17,6 @@ import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.internal.extensions.core.extra
 import java.io.File
-import java.net.URI
 
 internal fun Project.applyDefaultPlugins() {
   if (!plugins.hasPlugin("com.android.library")) {


### PR DESCRIPTION
# Why

fixes #36134

# How

reported from https://github.com/expo/expo/pull/36179#issuecomment-2807650019 that there's another call path which coming from non local modules. this pr applies the same solution as #36179.

# Test Plan

tested on both macos and windows

```sh
$ bunx create-expo-app -t default@sdk-53 sdk53
$ cd sdk53
$ npx expo install expo-dev-client expo-image-loader
$ npx expo prebuild -p android
$ cd android
$ ./gradlew :app:assembleDebug
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
