### PR TITLE
[docs] Updates custom initialization changes for SDK 53

### DIFF
--- a/docs/pages/eas-update/integration-in-existing-native-apps.mdx
+++ b/docs/pages/eas-update/integration-in-existing-native-apps.mdx
@@ -10,9 +10,9 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 > **info** If your project is a **greenfield React Native app** &mdash; primarily built with React Native from the start, and the entry point of the app is React Native, then skip this guide and proceed to [Get started with EAS Update](/eas-update/getting-started/).
 
-This guide explains how to integrate EAS Update in an existing native app, sometimes referred to as a brownfield app. It assumes that you are using Expo SDK 52 and React Native 0.76.
+This guide explains how to integrate EAS Update in an existing native app, sometimes referred to as a brownfield app. It assumes that you are using Expo SDK 52 or later, and React Native 0.76 or later.
 
-Instructions are not available for older Expo SDK and React Native version. Additional hands-on support for integrating with older versions can only be provided for enterprise customers ([contact us](https://expo.dev/contact)).
+Instructions are not available for older Expo SDK and React Native versions. Additional hands-on support for integrating with older versions can only be provided for enterprise customers ([contact us](https://expo.dev/contact)).
 
 ## Prerequisites
 
@@ -168,156 +168,6 @@ The following instructions assume you have an app written in Swift, with one or 
 
 <Tabs>
 
-<Tab label="SDK 52">
-
-#### AppDelegate changes
-
-1. Modify **AppDelegate.swift** so that it extends `EXAppDelegateWrapper`.
-2. If you are not already doing so, add a public method to get the running `AppDelegate` instance, so that your custom view controller can access it later.
-3. Add a reference to the singleton instance of the `expo-updates` `AppController` class, which manages the updates system on iOS.
-4. Override the `bundleUrl()` method to return the correct bundle URL for updates, if the updates system is running.
-5. The `didFinishLaunchingWithOptions()` method needs to perform two steps:
-   1. Initialize the root view factory used later to create the React Native root view.
-   2. Call `AppController.initializeWithoutStarting()` . This creates the controller instance, but defers the rest of the updates startup procedure until it is needed.
-
-```swift ios/<your-app-name>/AppDelegate.swift
-import ExpoModulesCore
-import EXUpdates
-import React
-import UIKit
-
-@UIApplicationMain
-// Step 1
-class AppDelegate: EXAppDelegateWrapper {
-  let bundledUrl = Bundle.main.url(forResource: "main", withExtension: "jsbundle")
-  var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-
-  // Step 2
-  public static func shared() -> AppDelegate {
-    guard let delegate = UIApplication.shared.delegate as? AppDelegate else {
-      fatalError("Could not get app delegate")
-    }
-    return delegate
-  }
-
-  // Step 3
-  var updatesController: (any InternalAppControllerInterface)?
-
-  // Step 4
-  override func bundleURL() -> URL? {
-    if let updatesUrl = updatesController?.launchAssetUrl() {
-      return updatesUrl
-    }
-    return bundledUrl
-  }
-
-  // Step 5
-  private func initializeReactNativeAndUpdates(_ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
-    self.launchOptions = launchOptions
-    self.moduleName = "App"
-    self.initialProps = [:]
-    self.rootViewFactory = createRCTRootViewFactory()
-    AppController.initializeWithoutStarting()
-  }
-
-  /**
-   * Application launch initializes the custom view controller; all React Native
-   * and updates initialization is handled there
-   */
-  override func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
-  ) -> Bool {
-
-    initializeReactNativeAndUpdates(launchOptions)
-
-    // Create custom view controller, where the React Native view will be created
-    self.window = UIWindow(frame: UIScreen.main.bounds)
-    let controller = CustomViewController()
-    controller.view.clipsToBounds = true
-    self.window.rootViewController = controller
-    window.makeKeyAndVisible()
-    return true
-  }
-}
-```
-
-#### Implementing a custom view controller
-
-1. The view controller should implement the updates protocol `AppControllerDelegate`.
-2. The view controller initialization should
-   1. Set the app delegate's updates controller instance, so that its `bundleURL()` method above works correctly for updates.
-   2. Set the `AppController` delegate to the view controller instance
-   3. Start the `AppController`
-3. Finally, the view controller must implement the one method in the `AppControllerDelegate` protocol, `appController(_ appController: AppControllerInterface, didStartWithSuccess success: Bool)`. This method will be called once the updates system is fully initialized, and the latest update (or the embedded bundle) is ready to be rendered.
-   1. Create the React Native root view using the root view factory created by the app delegate. The app name passed in must match the app name that you registered in your JS entry point above.
-   2. Add this root view to the view controller.
-
-```swift ios/<your-app-name>/CustomViewController.swift
-import UIKit
-import EXUpdates
-import ExpoModulesCore
-
-// Step 1
-public class CustomViewController: UIViewController, AppControllerDelegate {
-  let appDelegate = AppDelegate.shared()
-
-  // Step 2
-  public convenience init() {
-    self.init(nibName: nil, bundle: nil)
-    self.view.backgroundColor = .clear
-    // Step 2.1
-    appDelegate.updatesController = AppController.sharedInstance
-    // Step 2.2
-    AppController.sharedInstance.delegate = self
-    // Step 2.3
-    AppController.sharedInstance.start()
-  }
-
-  required public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-  }
-
-  @available(*, unavailable)
-  required public init?(coder aDecoder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-
-  // Step 3
-  public func appController(
-    _ appController: AppControllerInterface,
-    didStartWithSuccess success: Bool
-  ) {
-    createView()
-  }
-
-  private func createView() {
-    // Step 3.1
-    guard let rootViewFactory: RCTRootViewFactory = appDelegate.reactNativeFactory?.rootViewFactory else {
-      fatalError("rootViewFactory has not been initialized")
-    }
-    let rootView = rootViewFactory.view(
-      withModuleName: appDelegate.moduleName,
-      initialProperties: appDelegate.initialProps,
-      launchOptions: appDelegate.launchOptions
-    )
-    // Step 3.2
-    let controller = self
-    controller.view.clipsToBounds = true
-    controller.view.addSubview(rootView)
-    rootView.translatesAutoresizingMaskIntoConstraints = false
-    NSLayoutConstraint.activate([
-      rootView.topAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.topAnchor),
-      rootView.bottomAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.bottomAnchor),
-      rootView.leadingAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.leadingAnchor),
-      rootView.trailingAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.trailingAnchor)
-    ])
-  }
-}
-```
-
-</Tab>
-
 <Tab label="SDK 53 and above">
 
 #### AppDelegate changes
@@ -417,6 +267,156 @@ import ExpoModulesCore
 /**
  Custom view controller that handles React Native and expo-updates initialization
  */
+// Step 1
+public class CustomViewController: UIViewController, AppControllerDelegate {
+  let appDelegate = AppDelegate.shared()
+
+  // Step 2
+  public convenience init() {
+    self.init(nibName: nil, bundle: nil)
+    self.view.backgroundColor = .clear
+    // Step 2.1
+    appDelegate.updatesController = AppController.sharedInstance
+    // Step 2.2
+    AppController.sharedInstance.delegate = self
+    // Step 2.3
+    AppController.sharedInstance.start()
+  }
+
+  required public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+  }
+
+  @available(*, unavailable)
+  required public init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // Step 3
+  public func appController(
+    _ appController: AppControllerInterface,
+    didStartWithSuccess success: Bool
+  ) {
+    createView()
+  }
+
+  private func createView() {
+    // Step 3.1
+    guard let rootViewFactory: RCTRootViewFactory = appDelegate.reactNativeFactory?.rootViewFactory else {
+      fatalError("rootViewFactory has not been initialized")
+    }
+    let rootView = rootViewFactory.view(
+      withModuleName: appDelegate.moduleName,
+      initialProperties: appDelegate.initialProps,
+      launchOptions: appDelegate.launchOptions
+    )
+    // Step 3.2
+    let controller = self
+    controller.view.clipsToBounds = true
+    controller.view.addSubview(rootView)
+    rootView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      rootView.topAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.topAnchor),
+      rootView.bottomAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.bottomAnchor),
+      rootView.leadingAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.leadingAnchor),
+      rootView.trailingAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.trailingAnchor)
+    ])
+  }
+}
+```
+
+</Tab>
+
+<Tab label="SDK 52">
+
+#### AppDelegate changes
+
+1. Modify **AppDelegate.swift** so that it extends `EXAppDelegateWrapper`.
+2. If you are not already doing so, add a public method to get the running `AppDelegate` instance, so that your custom view controller can access it later.
+3. Add a reference to the singleton instance of the `expo-updates` `AppController` class, which manages the updates system on iOS.
+4. Override the `bundleUrl()` method to return the correct bundle URL for updates, if the updates system is running.
+5. The `didFinishLaunchingWithOptions()` method needs to perform two steps:
+   1. Initialize the root view factory used later to create the React Native root view.
+   2. Call `AppController.initializeWithoutStarting()` . This creates the controller instance, but defers the rest of the updates startup procedure until it is needed.
+
+```swift ios/<your-app-name>/AppDelegate.swift
+import ExpoModulesCore
+import EXUpdates
+import React
+import UIKit
+
+@UIApplicationMain
+// Step 1
+class AppDelegate: EXAppDelegateWrapper {
+  let bundledUrl = Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+  var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+
+  // Step 2
+  public static func shared() -> AppDelegate {
+    guard let delegate = UIApplication.shared.delegate as? AppDelegate else {
+      fatalError("Could not get app delegate")
+    }
+    return delegate
+  }
+
+  // Step 3
+  var updatesController: (any InternalAppControllerInterface)?
+
+  // Step 4
+  override func bundleURL() -> URL? {
+    if let updatesUrl = updatesController?.launchAssetUrl() {
+      return updatesUrl
+    }
+    return bundledUrl
+  }
+
+  // Step 5
+  private func initializeReactNativeAndUpdates(_ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
+    self.launchOptions = launchOptions
+    self.moduleName = "App"
+    self.initialProps = [:]
+    self.rootViewFactory = createRCTRootViewFactory()
+    AppController.initializeWithoutStarting()
+  }
+
+  /**
+   * Application launch initializes the custom view controller; all React Native
+   * and updates initialization is handled there
+   */
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+
+    initializeReactNativeAndUpdates(launchOptions)
+
+    // Create custom view controller, where the React Native view will be created
+    self.window = UIWindow(frame: UIScreen.main.bounds)
+    let controller = CustomViewController()
+    controller.view.clipsToBounds = true
+    self.window.rootViewController = controller
+    window.makeKeyAndVisible()
+    return true
+  }
+}
+```
+
+#### Implementing a custom view controller
+
+1. The view controller should implement the updates protocol `AppControllerDelegate`.
+2. The view controller initialization should
+   1. Set the app delegate's updates controller instance, so that its `bundleURL()` method above works correctly for updates.
+   2. Set the `AppController` delegate to the view controller instance
+   3. Start the `AppController`
+3. Finally, the view controller must implement the one method in the `AppControllerDelegate` protocol, `appController(_ appController: AppControllerInterface, didStartWithSuccess success: Bool)`. This method will be called once the updates system is fully initialized, and the latest update (or the embedded bundle) is ready to be rendered.
+   1. Create the React Native root view using the root view factory created by the app delegate. The app name passed in must match the app name that you registered in your JS entry point above.
+   2. Add this root view to the view controller.
+
+```swift ios/<your-app-name>/CustomViewController.swift
+import UIKit
+import EXUpdates
+import ExpoModulesCore
+
 // Step 1
 public class CustomViewController: UIViewController, AppControllerDelegate {
   let appDelegate = AppDelegate.shared()

--- a/docs/pages/eas-update/integration-in-existing-native-apps.mdx
+++ b/docs/pages/eas-update/integration-in-existing-native-apps.mdx
@@ -6,6 +6,7 @@ description: Learn how to integrate EAS Update into your existing native Android
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal, DiffBlock } from '~/ui/components/Snippet';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
 > **info** If your project is a **greenfield React Native app** &mdash; primarily built with React Native from the start, and the entry point of the app is React Native, then skip this guide and proceed to [Get started with EAS Update](/eas-update/getting-started/).
 
@@ -165,6 +166,10 @@ class MainActivity : ReactActivity() {
 
 The following instructions assume you have an app written in Swift, with one or more native screens that have custom UIViewControllers. We will add a custom view controller that renders your React Native app.
 
+<Tabs>
+
+<Tab label="SDK 52">
+
 #### AppDelegate changes
 
 1. Modify **AppDelegate.swift** so that it extends `EXAppDelegateWrapper`.
@@ -226,6 +231,12 @@ class AppDelegate: EXAppDelegateWrapper {
 
     initializeReactNativeAndUpdates(launchOptions)
 
+    // Create custom view controller, where the React Native view will be created
+    self.window = UIWindow(frame: UIScreen.main.bounds)
+    let controller = CustomViewController()
+    controller.view.clipsToBounds = true
+    self.window.rootViewController = controller
+    window.makeKeyAndVisible()
     return true
   }
 }
@@ -282,13 +293,15 @@ public class CustomViewController: UIViewController, AppControllerDelegate {
 
   private func createView() {
     // Step 3.1
-    let rootView = appDelegate.rootViewFactory.view(
-      withModuleName: appDelegate.moduleName ?? "main",
+    guard let rootViewFactory: RCTRootViewFactory = appDelegate.reactNativeFactory?.rootViewFactory else {
+      fatalError("rootViewFactory has not been initialized")
+    }
+    let rootView = rootViewFactory.view(
+      withModuleName: appDelegate.moduleName,
       initialProperties: appDelegate.initialProps,
       launchOptions: appDelegate.launchOptions
     )
     // Step 3.2
-    self.view.addSubview(rootView)
     let controller = self
     controller.view.clipsToBounds = true
     controller.view.addSubview(rootView)
@@ -302,6 +315,169 @@ public class CustomViewController: UIViewController, AppControllerDelegate {
   }
 }
 ```
+
+</Tab>
+
+<Tab label="SDK 53 and above">
+
+#### AppDelegate changes
+
+1. Modify **AppDelegate.swift** so that it extends `ExpoAppDelegate`.
+2. If you are not already doing so, add a public method to get the running `AppDelegate` instance, so that your custom view controller can access it later.
+3. Add a reference to the singleton instance of the `expo-updates` `AppController` class, which manages the updates system on iOS.
+4. Override the `bundleUrl()` method to return the correct bundle URL for updates, if the updates system is running.
+5. The `didFinishLaunchingWithOptions()` method needs to perform two steps:
+   1. Initialize the `ExpoReactNativeFactory` used later to create the React Native root view.
+   2. Call `AppController.initializeWithoutStarting()` . This creates the controller instance, but defers the rest of the updates startup procedure until it is needed.
+
+```swift ios/<your-app-name>/AppDelegate.swift
+import Expo
+import EXUpdates
+import React
+import UIKit
+
+@UIApplicationMain
+// Step 1
+class AppDelegate: EXAppDelegateWrapper {
+  let bundledUrl = Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+  var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+
+  // Step 2
+  public static func shared() -> AppDelegate {
+    guard let delegate = UIApplication.shared.delegate as? AppDelegate else {
+      fatalError("Could not get app delegate")
+    }
+    return delegate
+  }
+
+  // Step 3
+  var updatesController: (any InternalAppControllerInterface)?
+
+  // Step 4
+  override func bundleURL() -> URL? {
+    if let updatesUrl = updatesController?.launchAssetUrl() {
+      return updatesUrl
+    }
+    return bundledUrl
+  }
+
+  // Step 5
+  private func initializeReactNativeAndUpdates(_ launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
+    self.launchOptions = launchOptions
+    self.moduleName = "main"
+    self.initialProps = [:]
+    self.reactNativeFactory = ExpoReactNativeFactory(delegate: self, reactDelegate: self.reactDelegate)
+    AppController.initializeWithoutStarting()
+  }
+
+  /**
+   Application launch initializes the custom view controller: all React Native
+   and updates initialization is handled there
+   */
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    initializeReactNativeAndUpdates(launchOptions)
+
+    // Create custom view controller, where the React Native view will be created
+    self.window = UIWindow(frame: UIScreen.main.bounds)
+    let controller = CustomViewController()
+    controller.view.clipsToBounds = true
+    self.window?.rootViewController = controller
+    window?.makeKeyAndVisible()
+
+    return true
+  }
+
+  override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+    return super.application(app, open: url, options: options) ||
+      RCTLinkingManager.application(app, open: url, options: options)
+  }
+}
+```
+
+#### Implementing a custom view controller
+
+1. The view controller should implement the updates protocol `AppControllerDelegate`.
+2. The view controller initialization should
+   1. Set the app delegate's updates controller instance, so that its `bundleURL()` method above works correctly for updates.
+   2. Set the `AppController` delegate to the view controller instance
+   3. Start the `AppController`
+3. Finally, the view controller must implement the one method in the `AppControllerDelegate` protocol, `appController(_ appController: AppControllerInterface, didStartWithSuccess success: Bool)`. This method will be called once the updates system is fully initialized, and the latest update (or the embedded bundle) is ready to be rendered.
+   1. Create the React Native root view using the `ExpoReactNativeFactory` created by the app delegate. The app name passed in must match the app name that you registered in your JS entry point above.
+   2. Add this root view to the view controller.
+
+```swift ios/<your-app-name>/CustomViewController.swift
+import UIKit
+import EXUpdates
+import ExpoModulesCore
+
+
+/**
+ Custom view controller that handles React Native and expo-updates initialization
+ */
+// Step 1
+public class CustomViewController: UIViewController, AppControllerDelegate {
+  let appDelegate = AppDelegate.shared()
+
+  // Step 2
+  public convenience init() {
+    self.init(nibName: nil, bundle: nil)
+    self.view.backgroundColor = .clear
+    // Step 2.1
+    appDelegate.updatesController = AppController.sharedInstance
+    // Step 2.2
+    AppController.sharedInstance.delegate = self
+    // Step 2.3
+    AppController.sharedInstance.start()
+  }
+
+  required public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+  }
+
+  @available(*, unavailable)
+  required public init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // Step 3
+  public func appController(
+    _ appController: AppControllerInterface,
+    didStartWithSuccess success: Bool
+  ) {
+    createView()
+  }
+
+  private func createView() {
+    // Step 3.1
+    guard let rootViewFactory: RCTRootViewFactory = appDelegate.reactNativeFactory?.rootViewFactory else {
+      fatalError("rootViewFactory has not been initialized")
+    }
+    let rootView = rootViewFactory.view(
+      withModuleName: appDelegate.moduleName,
+      initialProperties: appDelegate.initialProps,
+      launchOptions: appDelegate.launchOptions
+    )
+    // Step 3.2
+    let controller = self
+    controller.view.clipsToBounds = true
+    controller.view.addSubview(rootView)
+    rootView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      rootView.topAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.topAnchor),
+      rootView.bottomAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.bottomAnchor),
+      rootView.leadingAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.leadingAnchor),
+      rootView.trailingAnchor.constraint(equalTo: controller.view.safeAreaLayoutGuide.trailingAnchor)
+    ])
+  }
+}
+```
+
+</Tab>
+
+</Tabs>
 
 ## Common questions
 


### PR DESCRIPTION
# Why

The existing doc is correct for SDK 52, but needs to be updated for SDK 53, as iOS has moved to using the new `ReactNativeFactory` in RN 0.79.

# How

Added SDK 52 and SDK 53 tabs in the doc, with the correct sample code for each for iOS. No changes for Android.

# Test Plan

Docs CI should pass

# Checklist


- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
