### PR TITLE
[docs] Add missing '/' in 'app/(tabs)_layout.tsx'

### DIFF
--- a/docs/pages/router/basics/common-navigation-patterns.mdx
+++ b/docs/pages/router/basics/common-navigation-patterns.mdx
@@ -28,7 +28,7 @@ Consider the following navigation tree:
   ]}
 />
 
-In the **app/(tabs)\_layout.tsx** file, return a `Tabs` component:
+In the **app/(tabs)/\_layout.tsx** file, return a `Tabs` component:
 
 {/* prettier-ignore */}
 ```tsx app/(tabs)/_layout.tsx


### PR DESCRIPTION
# Why

Currently the documentation has the following "In the **app/(tabs)_layout.tsx** file, return a Tabs component:".

But from what I understand should be: "In the **app/(tabs)/_layout.tsx** file, return a Tabs component:" with slash.

Screenshot:
![image](https://github.com/user-attachments/assets/3913af0e-e809-484d-9e81-e5113e0ea252)

Page in question: https://docs.expo.dev/router/basics/common-navigation-patterns/#stacks-inside-tabs-nested-navigators

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Added the missing `/` infront of _layout.tsx :)

# Test Plan

This PR only changese the docs. 
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
