### PR TITLE
[docs] Add router tutorials to the docs

### DIFF
--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -12,13 +12,14 @@ import { FileTree } from '~/ui/components/FileTree';
 import { Step } from '~/ui/components/Step';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-With Expo Router, all routes are always defined and accessible. You can use runtime logic to redirect users away from specific screens depending on whether they are authenticated. There are two different techniques for authenticating users within routes. This guide provides an example that demonstrates the functionality of standard native apps.
-
 <VideoBoxLink
   videoId="yNaOaR2kIa0"
   title="Building an Auth Flow with Expo Router"
   description="Learn how to implement an auth flow in your Expo Router project."
+  className="mb-6"
 />
+
+With Expo Router, all routes are always defined and accessible. You can use runtime logic to redirect users away from specific screens depending on whether they are authenticated. There are two different techniques for authenticating users within routes. This guide provides an example that demonstrates the functionality of standard native apps.
 
 ## Using React Context and Route Groups
 

--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -10,8 +10,15 @@ import { LockUnlocked01Icon } from '@expo/styleguide-icons/outline/LockUnlocked0
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
 import { Step } from '~/ui/components/Step';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 With Expo Router, all routes are always defined and accessible. You can use runtime logic to redirect users away from specific screens depending on whether they are authenticated. There are two different techniques for authenticating users within routes. This guide provides an example that demonstrates the functionality of standard native apps.
+
+<VideoBoxLink
+  videoId="yNaOaR2kIa0"
+  title="Building an Auth Flow with Expo Router"
+  description="Learn how to implement an auth flow in your Expo Router project."
+/>
 
 ## Using React Context and Route Groups
 

--- a/docs/pages/router/advanced/modals.mdx
+++ b/docs/pages/router/advanced/modals.mdx
@@ -7,18 +7,19 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { FileTree } from '~/ui/components/FileTree';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
+<VideoBoxLink
+  videoId="gNzuJVRmyDk"
+  title="Using Modals with Expo Router"
+  description="Learn about the different ways to display content over the rest of your app."
+  className="mb-6"
+/>
+
 Modals are a common user interface pattern in mobile apps. They are used to present content on top of the existing screen and is used for different purposes, such as displaying confirmation alerts or standalone forms. You can create modals in your app using the following methods:
 
 - Use React Native's [`Modal`](https://reactnative.dev/docs/modal) component.
 - Use Expo Router's special file-based syntax to create a modal screen within the app's navigation system.
 
 Each approach has its specific use case. Understanding when to use each method is important for creating a positive user experience.
-
-<VideoBoxLink
-  videoId="gNzuJVRmyDk"
-  title="Using Modals with Expo Router"
-  description="Learn about the different ways to display content over the rest of your app."
-/>
 
 ## React Native's Modal component
 

--- a/docs/pages/router/advanced/modals.mdx
+++ b/docs/pages/router/advanced/modals.mdx
@@ -5,6 +5,7 @@ description: Learn how to use modals in Expo Router.
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { FileTree } from '~/ui/components/FileTree';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 Modals are a common user interface pattern in mobile apps. They are used to present content on top of the existing screen and is used for different purposes, such as displaying confirmation alerts or standalone forms. You can create modals in your app using the following methods:
 
@@ -12,6 +13,12 @@ Modals are a common user interface pattern in mobile apps. They are used to pres
 - Use Expo Router's special file-based syntax to create a modal screen within the app's navigation system.
 
 Each approach has its specific use case. Understanding when to use each method is important for creating a positive user experience.
+
+<VideoBoxLink
+  videoId="gNzuJVRmyDk"
+  title="Using Modals with Expo Router"
+  description="Learn about the different ways to display content over the rest of your app."
+/>
 
 ## React Native's Modal component
 

--- a/docs/pages/router/advanced/nesting-navigators.mdx
+++ b/docs/pages/router/advanced/nesting-navigators.mdx
@@ -6,14 +6,14 @@ description: Learn how to nest navigators in Expo Router.
 import { FileTree } from '~/ui/components/FileTree';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
+> **warning** Navigation UI elements (Link, Tabs, Stack) may move out of the Expo Router library in the future.
+
 <VideoBoxLink
   videoId="izZv6a99Roo"
   title="Using a Stack Navigator with Expo Router"
   description="Navigate between screens, pass params between screens, create dynamic routes, and configure the screen titles and animations."
   className="mb-6"
 />
-
-> **warning** Navigation UI elements (Link, Tabs, Stack) may move out of the Expo Router library in the future.
 
 Nesting navigators allow rendering a navigator inside the screen of another navigator. This guide is an extension of [React Navigation: Nesting navigators](https://reactnavigation.org/docs/nesting-navigators) to Expo Router. It provides an example of how nesting navigators work when using Expo Router.
 

--- a/docs/pages/router/advanced/nesting-navigators.mdx
+++ b/docs/pages/router/advanced/nesting-navigators.mdx
@@ -13,7 +13,7 @@ Nesting navigators allow rendering a navigator inside the screen of another navi
 <VideoBoxLink
   videoId="izZv6a99Roo"
   title="Using a Stack Navigator with Expo Router"
-  description="Navigate between screens, pass params between screens, create dynamic routes and configure the screen titles and animations."
+  description="Navigate between screens, pass params between screens, create dynamic routes, and configure the screen titles and animations."
 />
 
 ## Example

--- a/docs/pages/router/advanced/nesting-navigators.mdx
+++ b/docs/pages/router/advanced/nesting-navigators.mdx
@@ -6,15 +6,16 @@ description: Learn how to nest navigators in Expo Router.
 import { FileTree } from '~/ui/components/FileTree';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-> **warning** Navigation UI elements (Link, Tabs, Stack) may move out of the Expo Router library in the future.
-
-Nesting navigators allow rendering a navigator inside the screen of another navigator. This guide is an extension of [React Navigation: Nesting navigators](https://reactnavigation.org/docs/nesting-navigators) to Expo Router. It provides an example of how nesting navigators work when using Expo Router.
-
 <VideoBoxLink
   videoId="izZv6a99Roo"
   title="Using a Stack Navigator with Expo Router"
   description="Navigate between screens, pass params between screens, create dynamic routes, and configure the screen titles and animations."
+  className="mb-6"
 />
+
+> **warning** Navigation UI elements (Link, Tabs, Stack) may move out of the Expo Router library in the future.
+
+Nesting navigators allow rendering a navigator inside the screen of another navigator. This guide is an extension of [React Navigation: Nesting navigators](https://reactnavigation.org/docs/nesting-navigators) to Expo Router. It provides an example of how nesting navigators work when using Expo Router.
 
 ## Example
 

--- a/docs/pages/router/advanced/nesting-navigators.mdx
+++ b/docs/pages/router/advanced/nesting-navigators.mdx
@@ -4,10 +4,17 @@ description: Learn how to nest navigators in Expo Router.
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 > **warning** Navigation UI elements (Link, Tabs, Stack) may move out of the Expo Router library in the future.
 
 Nesting navigators allow rendering a navigator inside the screen of another navigator. This guide is an extension of [React Navigation: Nesting navigators](https://reactnavigation.org/docs/nesting-navigators) to Expo Router. It provides an example of how nesting navigators work when using Expo Router.
+
+<VideoBoxLink
+  videoId="izZv6a99Roo"
+  title="Using a Stack Navigator with Expo Router"
+  description="Navigate between screens, pass params between screens, create dynamic routes and configure the screen titles and animations."
+/>
 
 ## Example
 

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -7,10 +7,17 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 A stack navigator is the foundational way of navigating between routes in an app. On Android, a stacked route animates on top of the current screen. On iOS, a stacked route animates from the right. Expo Router provides a `Stack` navigation component that creates a navigation stack and allows you to add new routes in your app.
 
 This guide provides information on how you can create a `Stack` navigator in your project and customize an individual route's options and header.
+
+<VideoBoxLink
+  videoId="izZv6a99Roo"
+  title="Using a Stack Navigator with Expo Router"
+  description="Navigate between screens, pass params between screens, create dynamic routes and configure the screen titles and animations."
+/>
 
 ## Get started
 

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -16,7 +16,7 @@ This guide provides information on how you can create a `Stack` navigator in you
 <VideoBoxLink
   videoId="izZv6a99Roo"
   title="Using a Stack Navigator with Expo Router"
-  description="Navigate between screens, pass params between screens, create dynamic routes and configure the screen titles and animations."
+  description="Navigate between screens, pass params between screens, create dynamic routes, and configure the screen titles and animations."
 />
 
 ## Get started

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -9,15 +9,16 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-A stack navigator is the foundational way of navigating between routes in an app. On Android, a stacked route animates on top of the current screen. On iOS, a stacked route animates from the right. Expo Router provides a `Stack` navigation component that creates a navigation stack and allows you to add new routes in your app.
-
-This guide provides information on how you can create a `Stack` navigator in your project and customize an individual route's options and header.
-
 <VideoBoxLink
   videoId="izZv6a99Roo"
   title="Using a Stack Navigator with Expo Router"
   description="Navigate between screens, pass params between screens, create dynamic routes, and configure the screen titles and animations."
+  className="mb-6"
 />
+
+A stack navigator is the foundational way of navigating between routes in an app. On Android, a stacked route animates on top of the current screen. On iOS, a stacked route animates from the right. Expo Router provides a `Stack` navigation component that creates a navigation stack and allows you to add new routes in your app.
+
+This guide provides information on how you can create a `Stack` navigator in your project and customize an individual route's options and header.
 
 ## Get started
 

--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -5,10 +5,17 @@ description: Learn how to use the Tabs layout in Expo Router.
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { FileTree } from '~/ui/components/FileTree';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 Tabs are a common way to navigate between different sections of an app. Expo Router provides a tabs layout to help you create a tab bar at the bottom of your app. The fastest way to get started is to use a template. See the [quick start installation](/router/installation/#quick-start) to get started.
 
 Continue reading to add tabs to an existing project or to customize your app's tabs.
+
+<VideoBoxLink
+  videoId="BElPB4Ai3j0"
+  title="Using a Tab Navigator with Expo Router"
+  description="Configure the tab icons, nest navigators and manage navigation history."
+/>
 
 ## Get started
 

--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -14,7 +14,7 @@ Continue reading to add tabs to an existing project or to customize your app's t
 <VideoBoxLink
   videoId="BElPB4Ai3j0"
   title="Using a Tab Navigator with Expo Router"
-  description="Configure the tab icons, nest navigators and manage navigation history."
+  description="Configure the tab icons, nest navigators, and manage navigation history."
 />
 
 ## Get started

--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -7,15 +7,16 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { FileTree } from '~/ui/components/FileTree';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-Tabs are a common way to navigate between different sections of an app. Expo Router provides a tabs layout to help you create a tab bar at the bottom of your app. The fastest way to get started is to use a template. See the [quick start installation](/router/installation/#quick-start) to get started.
-
-Continue reading to add tabs to an existing project or to customize your app's tabs.
-
 <VideoBoxLink
   videoId="BElPB4Ai3j0"
   title="Using a Tab Navigator with Expo Router"
   description="Configure the tab icons, nest navigators, and manage navigation history."
+  className="mb-6"
 />
+
+Tabs are a common way to navigate between different sections of an app. Expo Router provides a tabs layout to help you create a tab bar at the bottom of your app. The fastest way to get started is to use a template. See the [quick start installation](/router/installation/#quick-start) to get started.
+
+Continue reading to add tabs to an existing project or to customize your app's tabs.
 
 ## Get started
 

--- a/docs/pages/router/basics/layout.mdx
+++ b/docs/pages/router/basics/layout.mdx
@@ -5,10 +5,17 @@ sidebar_title: Layout
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 Each directory within the **app** directory (including **app** itself) can define a layout in the form of a **\_layout.tsx** file inside that directory. This file defines how all the pages within that directory are arranged. This is where you would define a stack navigator, tab navigator, drawer navigator, or any other layout that you want to use for the pages in that directory. The layout file exports a default component that is rendered before whatever page you are navigating to within that directory.
 
 Let's look at a few common layout scenarios.
+
+<VideoBoxLink
+  videoId="Yh6Qlg2CYwQ"
+  title="Introduction to Expo Router Layout Files"
+  description="What are layout files, how to navigate between screens and block access using redirects."
+/>
 
 ## Root layout
 

--- a/docs/pages/router/basics/layout.mdx
+++ b/docs/pages/router/basics/layout.mdx
@@ -14,7 +14,7 @@ Let's look at a few common layout scenarios.
 <VideoBoxLink
   videoId="Yh6Qlg2CYwQ"
   title="Introduction to Expo Router Layout Files"
-  description="What are layout files, how to navigate between screens and block access using redirects."
+  description="What are layout files, how to navigate between screens, and block access using redirects."
 />
 
 ## Root layout

--- a/docs/pages/router/basics/layout.mdx
+++ b/docs/pages/router/basics/layout.mdx
@@ -7,15 +7,16 @@ sidebar_title: Layout
 import { FileTree } from '~/ui/components/FileTree';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-Each directory within the **app** directory (including **app** itself) can define a layout in the form of a **\_layout.tsx** file inside that directory. This file defines how all the pages within that directory are arranged. This is where you would define a stack navigator, tab navigator, drawer navigator, or any other layout that you want to use for the pages in that directory. The layout file exports a default component that is rendered before whatever page you are navigating to within that directory.
-
-Let's look at a few common layout scenarios.
-
 <VideoBoxLink
   videoId="Yh6Qlg2CYwQ"
   title="Introduction to Expo Router Layout Files"
   description="What are layout files, how to navigate between screens, and block access using redirects."
+  className="mb-6"
 />
+
+Each directory within the **app** directory (including **app** itself) can define a layout in the form of a **\_layout.tsx** file inside that directory. This file defines how all the pages within that directory are arranged. This is where you would define a stack navigator, tab navigator, drawer navigator, or any other layout that you want to use for the pages in that directory. The layout file exports a default component that is rendered before whatever page you are navigating to within that directory.
+
+Let's look at a few common layout scenarios.
 
 ## Root layout
 

--- a/docs/pages/router/basics/navigation.mdx
+++ b/docs/pages/router/basics/navigation.mdx
@@ -94,6 +94,14 @@ router.navigate('./article');
 
 ## Dynamic routes and URL parameters
 
+<VideoBoxLink
+  videoId="izZv6a99Roo"
+  time={350}
+  title="Using dynamic routes with Expo Router"
+  description="Learn how to make a segment of a route dynamic."
+  className="mb-6"
+/>
+
 Dynamic routes can be linked to with their full URL, or by passing a `params` object.
 
 Consider the following file structure:
@@ -130,13 +138,6 @@ export default function Page() {
   );
 }
 ```
-
-<VideoBoxLink
-  videoId="izZv6a99Roo"
-  time={350}
-  title="Using dynamic routes with Expo Router"
-  description="Learn how to make a segment of a route dynamic."
-/>
 
 ### Passing query parameters
 

--- a/docs/pages/router/basics/navigation.mdx
+++ b/docs/pages/router/basics/navigation.mdx
@@ -5,6 +5,7 @@ sidebar_title: Navigation
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 Once you have a few pages in your app and their layouts setup, it's time to start navigating between them. Navigation in Expo Router works a lot like React Navigation, but with all pages having a URL by default, we can create links and use these URLs to move about our app using familiar web patterns.
 
@@ -129,6 +130,13 @@ export default function Page() {
   );
 }
 ```
+
+<VideoBoxLink
+  videoId="izZv6a99Roo"
+  time={350}
+  title="Using dynamic routes with Expo Router"
+  description="Learn how to make a segment of a route dynamic."
+/>
 
 ### Passing query parameters
 


### PR DESCRIPTION
# Why

Add the new router tutorials to our docs.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

<img width="792" alt="Screenshot 2025-04-17 at 09 18 00" src="https://github.com/user-attachments/assets/48cd5eef-47d5-49b8-b984-b6e77a3d7e85" />


# Test Plan

Verify that the correct video is added to the following pages

- Layout: /router/basics/layout/
- Stack: /router/advanced/stack/
- Stack: /router/advanced/nesting-navigators/
- Stack: /router/basics/navigation/
- Tab: /router/advanced/tabs/
- Modal: /router/advanced/modals/
- Auth: /router/advanced/authentication/

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
