### PR TITLE
[ios][camera] Remove unnecessary async calls

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [iOS] Remove unnecessary async calls.([#36222](https://github.com/expo/expo/pull/36222) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Remove unnecessary async calls. ([#36222](https://github.com/expo/expo/pull/36222) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 16.1.2 — 2025-04-14
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Remove unnecessary async calls.([#36222](https://github.com/expo/expo/pull/36222) by [@alanjhughes](https://github.com/alanjhughes))
+
 ## 16.1.2 — 2025-04-14
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-camera/ios/Current/MetaDataDelegate.swift
+++ b/packages/expo-camera/ios/Current/MetaDataDelegate.swift
@@ -1,7 +1,7 @@
 import ZXingObjC
 
 protocol BarcodeScanningResponseHandler {
-  func onScanningResult(_ result: [String: Any]) async
+  func onScanningResult(_ result: [String: Any])
 }
 
 class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptureVideoDataOutputSampleBufferDelegate {
@@ -44,9 +44,7 @@ class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCapt
 
         if let codeMetadata {
           if codeMetadata.stringValue != nil && codeMetadata.type == barcodeType {
-            Task {
-              await responseHandler.onScanningResult(BarcodeScannerUtils.avMetadataCodeObjectToDictionary(codeMetadata))
-            }
+            self.responseHandler.onScanningResult(BarcodeScannerUtils.avMetadataCodeObjectToDictionary(codeMetadata))
           }
         }
       }
@@ -72,9 +70,7 @@ class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCapt
       if let videoFrame = CMSampleBufferGetImageBuffer(sampleBuffer),
       let videoFrameImage = ZXCGImageLuminanceSource.createImage(from: videoFrame) {
         self.scanBarcodes(from: videoFrameImage) { barcodeScannerResult in
-          Task {
-            await self.responseHandler.onScanningResult(BarcodeScannerUtils.zxResultToDictionary(barcodeScannerResult))
-          }
+          self.responseHandler.onScanningResult(BarcodeScannerUtils.zxResultToDictionary(barcodeScannerResult))
         }
       }
     }


### PR DESCRIPTION
# Why
Clean up unnecessary async calls from the barcode scanner

# How
Removed the `Task` usage and `async` keyword of function declaration

# Test Plan
bare-expo. Scanning works as normal
