### PR TITLE
[docs] Fix `submit-android` workflow example

### DIFF
--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -22,8 +22,9 @@ This guide outlines how to submit your app to the Google Play Store from your co
   </Requirement>
   <Requirement number={4} title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and login with your Expo account:
-    
+
     <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
+
   </Requirement>
   <Requirement number={5} title="Include a package name in app.json">
     Include your app's package name in **app.json**:
@@ -39,7 +40,7 @@ This guide outlines how to submit your app to the Google Play Store from your co
   </Requirement>
   <Requirement number={6} title="Build a production app">
     You'll need a production build ready for store submission. You can create one using [EAS Build](/build/introduction/):
-    
+
     <Terminal cmd={['$ eas build --platform android --profile production']} />
 
     Alternatively, you can build the app on your own computer with `eas build --platform android --profile production --local` or with Android Studio.
@@ -81,8 +82,9 @@ Learn more about the `--auto-submit` flag in the [automate submissions](/build/a
   </Requirement>
   <Requirement number={4} title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and login with your Expo account:
-    
+
     <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
+
   </Requirement>
   <Requirement number={5} title="Include a package name in app.json">
     Include your app's package name in **app.json**:
@@ -116,7 +118,7 @@ Learn more about the `--auto-submit` flag in the [automate submissions](/build/a
   </Requirement>
   <Requirement number={7} title="Build a production app">
     You'll need a production build ready for store submission. You can create one using [EAS Build](/build/introduction/):
-    
+
     <Terminal cmd={['$ eas build --platform android --profile production']} />
 
     Alternatively, you can build the app on your own computer with `eas build --platform android --profile production --local` or with Android Studio.
@@ -155,6 +157,7 @@ You can use [EAS Workflows](/eas-workflows/get-started/) to build and submit you
      # @info #
      submit_android:
        name: Submit to Google Play Store
+       needs: [build_android]
        type: submit
        params:
          platform: android


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #36115

Currently, the submit to Play Store example is missing the Android build job name.

![CleanShot 2025-04-17 at 17 09 55](https://github.com/user-attachments/assets/5bfbb288-f831-4e82-b782-7ad5e3dd6dee)


# How

<!--
How did you build this feature or fix this bug and why?
-->

The dependency `build_android` is required to submit to the Play Store successfully in EAS Submit > Submit to Google Play Store guide. Following up changes from #36115 which fixed the example for iOS.

Note: The Prettier formatting changes were automatically applied when I opened the file in the code editor.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-04-17 at 17 06 36](https://github.com/user-attachments/assets/74c75eba-c0c6-4386-ac45-0c5a2d67a63b)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
