### PR TITLE
[docs] Add worker names to `TokenIgnores` for Vale to ignore

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -5,7 +5,7 @@ MinAlertLevel = warning
 mdx = md
 
 # Ignore code on basis of certain HTML tags.
-IgnoredClasses= whitesapce-pre, prose-code
+IgnoredClasses = whitesapce-pre, prose-code
 SkippedScopes = script, style, pre, figure, code, tt, tr, td, span
 
 # Settings applied to md/mdx format.
@@ -18,4 +18,4 @@ CommentDelimiters = {/*, */}
 
 # Ignore code surrounded by backticks or plus sign, parameters defaults, URLs and so on.
 BlockIgnores = (?s)<Terminal.*?/>,
-TokenIgnores = (\x60[^\n\x60]+\x60), ([^\n]+=[^\n]*), (\+[^\n]+\+), (http[^\n]+\[), .github, .gitlab, vscode-, Signing & Capabilities, eas.json, eas-json, .yarn+, yarn: "# yarn", eas+, eas-cli, npx+, Build & deploy, OAuth & Permissions, Languages & Frameworks, typescript, Privacy & Security, Certificates, IDs & Profiles, application/javascript, Motion & Orientation Access, Show devices and ask me again, my-app,  Still having trouble?, "my app runs well locally by crashes immediately when I run a build", my-app, MY_CUSTOM_API_KEY, withMyApiKey, My App, com.my., myFunction, my app, my-plugin, my-module, 'Hello from my TypeScript function!', my-scheme, my-root, Change my environment variables, my custom plugin, my, cocoapods, javascript, Ink & Switch,
+TokenIgnores = (\x60[^\n\x60]+\x60), ([^\n]+=[^\n]*), (\+[^\n]+\+), (http[^\n]+\[), .github, .gitlab, vscode-, Signing & Capabilities, eas.json, eas-json, .yarn+, yarn: "# yarn", eas+, eas-cli, npx+, Build & deploy, OAuth & Permissions, Languages & Frameworks, typescript, Privacy & Security, Certificates, IDs & Profiles, application/javascript, Motion & Orientation Access, Show devices and ask me again, my-app,  Still having trouble?, "my app runs well locally by crashes immediately when I run a build", my-app, MY_CUSTOM_API_KEY, withMyApiKey, My App, com.my., myFunction, my app, my-plugin, my-module, 'Hello from my TypeScript function!', my-scheme, my-root, Change my environment variables, my custom plugin, my, cocoapods, javascript, Ink & Switch, macos-medium, macos-large,

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -647,8 +647,6 @@ jobs:
     # @end #
 ```
 
-{/* vale off */}
-
 | Worker                             | vCPU | Memory (GiB RAM) | SSD (GiB) | Notes                                |
 | ---------------------------------- | ---- | ---------------- | --------- | ------------------------------------ |
 | linux-medium                       | 4    | 16               | 14        | Default worker.                      |
@@ -657,8 +655,6 @@ jobs:
 | linux-large-nested-virtualization  | 4    | 16               | 28        | Allows running Android Emulators.    |
 | macos-medium                       | 5    | 12               | 85        | Runs iOS jobs, including simulators. |
 | macos-large                        | 10   | 20               | 85        | Runs iOS jobs, including simulators. |
-
-{/* vale on */}
 
 > **Note:** For Android Emulator jobs, you must use a `linux-*-nested-virtualization` worker. For iOS builds and iOS Simulator jobs, you must use a `macos-*` worker.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The worker names in EAS Workflows schema table are common way to reference them. We should ignore them as tokens under Vale rules.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run lint-prose` and it should pass without any error or warning.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
