### PR TITLE
[docs] Improve deprecated callouts in Reference docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio-av.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio-av.mdx
@@ -13,7 +13,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
-> **warning** The `Audio` component from `expo-av`, which is documented on this page, has now been deprecated and replaced by an improved version in `expo-audio`. [Learn about `expo-audio`](./audio/).
+> **warning** **Deprecated:** The `Audio` component from `expo-av`, which is documented on this page, has now been deprecated and replaced by an improved version in `expo-audio`. [Learn about `expo-audio`](./audio/).
 
 `Audio` from `expo-av` allows you to implement audio playback and recording in your app.
 

--- a/docs/pages/versions/unversioned/sdk/av.mdx
+++ b/docs/pages/versions/unversioned/sdk/av.mdx
@@ -18,7 +18,7 @@ import {
 } from '~/ui/components/ConfigSection';
 import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
-> **warning** The `Video` and `Audio` APIs from `expo-av` have now been deprecated and replaced by improved versions in [`expo-video`](video.mdx) and [`expo-audio`](audio.mdx). We recommend using those libraries instead. `expo-av` is not receiving patches and will be removed in SDK 54.
+> **warning** **Deprecated:** The `Video` and `Audio` APIs from `expo-av` have now been deprecated and replaced by improved versions in [`expo-video`](video.mdx) and [`expo-audio`](audio.mdx). We recommend using those libraries instead. `expo-av` is not receiving patches and will be removed in SDK 54.
 
 The [`Audio.Sound`](audio.mdx) objects and [`Video`](video-av.mdx) components share a unified imperative API for media playback.
 

--- a/docs/pages/versions/unversioned/sdk/background-fetch.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.mdx
@@ -15,7 +15,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
-> **warning** The `expo-background-fetch` library is being replaced by a new version in [`expo-background-task`](background-task.mdx). `expo-background-fetch` is not receiving patches and will be removed in an upcoming release.
+> **warning** **Deprecated:** The `expo-background-fetch` library is being replaced by a new version in [`expo-background-task`](background-task.mdx). `expo-background-fetch` is not receiving patches and will be removed in an upcoming release.
 
 `expo-background-fetch` provides an API to perform [background fetch](https://developer.apple.com/documentation/uikit/core_app/managing_your_app_s_life_cycle/preparing_your_app_to_run_in_the_background/updating_your_app_with_background_app_refresh) tasks, allowing you to run specific code periodically in the background to update your app. This module uses [TaskManager](task-manager.mdx) Native API under the hood.
 

--- a/docs/pages/versions/unversioned/sdk/video-av.mdx
+++ b/docs/pages/versions/unversioned/sdk/video-av.mdx
@@ -12,7 +12,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **warning** The `Video` component from `expo-av`, which is documented on this page, has now been deprecated and replaced by an improved version in `expo-video`. [Learn about `expo-video`](video.mdx).
+> **warning** **Deprecated:** The `Video` component from `expo-av`, which is documented on this page, has now been deprecated and replaced by an improved version in `expo-video`. [Learn about `expo-video`](video.mdx).
 
 The `Video` component from `expo-av` displays a video inline with the other UI elements in your app.
 

--- a/docs/pages/versions/v53.0.0/sdk/audio-av.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/audio-av.mdx
@@ -13,7 +13,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
-> **warning** The `Audio` component from `expo-av`, which is documented on this page, has now been deprecated and replaced by an improved version in `expo-audio`. [Learn about `expo-audio`](./audio/).
+> **warning** **Deprecated:** The `Audio` component from `expo-av`, which is documented on this page, has now been deprecated and replaced by an improved version in `expo-audio`. [Learn about `expo-audio`](./audio/).
 
 `Audio` from `expo-av` allows you to implement audio playback and recording in your app.
 

--- a/docs/pages/versions/v53.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/av.mdx
@@ -18,7 +18,7 @@ import {
 } from '~/ui/components/ConfigSection';
 import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
-> **warning** The `Video` and `Audio` APIs from `expo-av` have now been deprecated and replaced by improved versions in [`expo-video`](video.mdx) and [`expo-audio`](audio.mdx). We recommend using those libraries instead. `expo-av` is not receiving patches and will be removed in SDK 54.
+> **warning** **Deprecated:** The `Video` and `Audio` APIs from `expo-av` have now been deprecated and replaced by improved versions in [`expo-video`](video.mdx) and [`expo-audio`](audio.mdx). We recommend using those libraries instead. `expo-av` is not receiving patches and will be removed in SDK 54.
 
 The [`Audio.Sound`](audio.mdx) objects and [`Video`](video-av.mdx) components share a unified imperative API for media playback.
 

--- a/docs/pages/versions/v53.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/background-fetch.mdx
@@ -15,7 +15,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
-> **warning** The `expo-background-fetch` library is being replaced by a new version in [`expo-background-task`](background-task.mdx). `expo-background-fetch` is not receiving patches and will be removed in an upcoming release.
+> **warning** **Deprecated:** The `expo-background-fetch` library is being replaced by a new version in [`expo-background-task`](background-task.mdx). `expo-background-fetch` is not receiving patches and will be removed in an upcoming release.
 
 `expo-background-fetch` provides an API to perform [background fetch](https://developer.apple.com/documentation/uikit/core_app/managing_your_app_s_life_cycle/preparing_your_app_to_run_in_the_background/updating_your_app_with_background_app_refresh) tasks, allowing you to run specific code periodically in the background to update your app. This module uses [TaskManager](task-manager.mdx) Native API under the hood.
 

--- a/docs/pages/versions/v53.0.0/sdk/video-av.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/video-av.mdx
@@ -12,7 +12,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-> **warning** The `Video` component from `expo-av`, which is documented on this page, has now been deprecated and replaced by an improved version in `expo-video`. [Learn about `expo-video`](video.mdx).
+> **warning** **Deprecated:** The `Video` component from `expo-av`, which is documented on this page, has now been deprecated and replaced by an improved version in `expo-video`. [Learn about `expo-video`](video.mdx).
 
 The `Video` component from `expo-av` displays a video inline with the other UI elements in your app.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

A warning callout is not a deprecation callout. For improved readability and consistency with other docs, we must explicitly say _**Deprecated**_ within the callout when adding a deprecation note.

# How

<!--
How did you build this feature or fix this bug and why?
-->

 Improve deprecated callouts in multiple Reference docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-04-17 at 18 16 11](https://github.com/user-attachments/assets/aed88679-0f65-4862-b17e-5f73af38554c)

![CleanShot 2025-04-17 at 18 17 29](https://github.com/user-attachments/assets/046b9cac-fc29-4030-8afd-cc34ffd7c86a)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
