### PR TITLE
[docs] include example of notification service extension

### DIFF
--- a/docs/pages/guides/using-push-notifications-services.mdx
+++ b/docs/pages/guides/using-push-notifications-services.mdx
@@ -24,7 +24,7 @@ Expo apps can work with any notification service or any of the notification capa
 
 ### Considerations and limitations
 
-- iOS notification extensions for adding additional content to notifications, such as images, are not formally included or supported, but you can add them with custom native code and configuration.
+- iOS Notification Service Extension for adding additional content to notifications, such as images, is not formally included, but you can add it using a config plugin with custom native code and configuration ([example](https://github.com/expo/expo/pull/36202)).
 - Volumes are limited to 600 notifications per second per project.
 
 For implementation details, see the following guides:


### PR DESCRIPTION
# Why

Update the documentation for iOS Notification Service Extension to include a reference to a practical example implementation using a config plugin.

# How

Modified the documentation to clarify that while iOS Notification Service Extension is not formally included in Expo, it can be added using a config plugin with custom native code. Added a link to a pull request example (#36202) that demonstrates this implementation.

# Test Plan


# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)