### PR TITLE
[create-expo-app] add template and example links to the default output

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- add template and example links to the default output ([#36235](https://github.com/expo/expo/pull/36235) by [@vonovak](https://github.com/vonovak))
+
 ## 3.4.0 — 2025-04-28
 
 ### 🎉 New features

--- a/packages/create-expo/src/createAsync.ts
+++ b/packages/create-expo/src/createAsync.ts
@@ -102,9 +102,13 @@ async function createTemplateAsync(inputPath: string, props: Options): Promise<v
       chalk`Creating an Expo project using the {cyan ${resolvedTemplate ?? 'default'}} template.\n`
     );
     if (!resolvedTemplate) {
-      console.log(chalk`{gray To choose from all available templates pass in the --template arg:}`);
+      console.log(
+        chalk`{gray To choose from all available templates ({underline https://github.com/expo/expo/tree/main/templates}) pass in the --template arg:}`
+      );
       console.log(chalk`  {gray $} ${formatSelfCommand()} {cyan --template}\n`);
-      console.log(chalk`{gray To choose from all available examples pass in the --example arg:}`);
+      console.log(
+        chalk`{gray To choose from all available examples ({underline https://github.com/expo/examples}) pass in the --example arg:}`
+      );
       console.log(chalk`  {gray $} ${formatSelfCommand()} {cyan --example}\n`);
     }
   }


### PR DESCRIPTION
# Why

Because I'm curious what exactly the example and template sources look like and I'm lazy to look for them, just wanna cmd+click to see them.


# How

Add https links to github

# Test Plan

ran it locally, links work:

```
Creating an Expo project using the default template.

To choose from all available templates (https://github.com/expo/expo/tree/main/templates) pass in the --template arg:
  $ npx create-expo --template

To choose from all available examples (https://github.com/expo/examples) pass in the --example arg:
  $ npx create-expo --example
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
