### PR TITLE
[expo-modules-core] Fix call invocation in tests

### DIFF
--- a/packages/expo-modules-core/common/cpp/TestingSyncJSCallInvoker.h
+++ b/packages/expo-modules-core/common/cpp/TestingSyncJSCallInvoker.h
@@ -21,7 +21,6 @@ class TestingSyncJSCallInvoker : public react::CallInvoker {
 public:
   explicit TestingSyncJSCallInvoker(const std::shared_ptr<jsi::Runtime>& runtime) : runtime(runtime) {}
 
-#if REACT_NATIVE_TARGET_VERSION >= 75
   void invokeAsync(react::CallFunc &&func) noexcept override {
     func(*runtime.lock());
   }
@@ -29,15 +28,6 @@ public:
   void invokeSync(react::CallFunc &&func) override {
     func(*runtime.lock());
   }
-#else
-  void invokeAsync(std::function<void()> &&func) noexcept override {
-    func();
-  }
-
-  void invokeSync(std::function<void()> &&func) override {
-    func();
-  }
-#endif
 
   ~TestingSyncJSCallInvoker() override = default;
 

--- a/packages/expo-modules-core/ios/Core/Promise.swift
+++ b/packages/expo-modules-core/ios/Core/Promise.swift
@@ -20,12 +20,13 @@ public struct Promise: AnyArgument {
 
   public func resolve(_ value: Any? = nil) {
     if let value = value as? AnySharedObject {
-      let result = Conversions.convertFunctionResult(
-        value,
-        appContext: appContext,
-        dynamicType: type(of: value).getDynamicType()
-      )
-      resolver(result)
+      resolver(JavaScriptSharedObjectBinding.init {
+        return Conversions.convertFunctionResult(
+          value,
+          appContext: appContext,
+          dynamicType: type(of: value).getDynamicType()
+        ) as! JavaScriptObject
+      })
       return
     }
     resolver(value)

--- a/packages/expo-modules-core/ios/Core/Promise.swift
+++ b/packages/expo-modules-core/ios/Core/Promise.swift
@@ -25,6 +25,7 @@ public struct Promise: AnyArgument {
           value,
           appContext: appContext,
           dynamicType: type(of: value).getDynamicType()
+          // swiftlint:disable:next force_cast
         ) as! JavaScriptObject
       })
       return

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -7,7 +7,7 @@
 #import <ExpoModulesCore/EXJSIConversions.h>
 #import <ExpoModulesCore/EXJavaScriptValue.h>
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>
-
+#import <ExpoModulesCore/EXJavaScriptSharedObjectBinding.h>
 namespace expo {
 
 /**
@@ -77,6 +77,9 @@ jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value)
   }
   if ([value isKindOfClass:[EXJavaScriptWeakObject class]]) {
     return jsi::Value(runtime, *[[(EXJavaScriptWeakObject *)value lock] get]);
+  }
+  if ([value isKindOfClass:[EXJavaScriptSharedObjectBinding class]]) {
+    return jsi::Value(runtime, *[[(EXJavaScriptSharedObjectBinding *)value get] get]);
   }
   if ([value isKindOfClass:[NSString class]]) {
     return convertNSStringToJSIString(runtime, (NSString *)value);

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -8,6 +8,7 @@
 #import <ExpoModulesCore/EXJavaScriptValue.h>
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>
 #import <ExpoModulesCore/EXJavaScriptSharedObjectBinding.h>
+
 namespace expo {
 
 /**

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -14,7 +14,7 @@
 #import <ExpoModulesCore/EXJSIConversions.h>
 #import <ExpoModulesCore/SharedObject.h>
 #import <ExpoModulesCore/Swift.h>
-#import <ExpoModulesCore/TestingSyncJSCallInvoker.h>
+#import <ExpoModulesCore/TestingJSCallInvoker.h>
 
 @implementation EXJavaScriptRuntime {
   std::shared_ptr<jsi::Runtime> _runtime;
@@ -45,7 +45,7 @@
 #else
     _runtime = jsc::makeJSCRuntime();
 #endif
-    _jsCallInvoker = std::make_shared<expo::TestingSyncJSCallInvoker>(_runtime);
+    _jsCallInvoker = std::make_shared<expo::TestingJSCallInvoker>(_runtime);
   }
   return self;
 }

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptSharedObjectBinding.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptSharedObjectBinding.h
@@ -1,0 +1,16 @@
+
+// Copyright 2023-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <ExpoModulesCore/EXJavaScriptRuntime.h>
+
+NS_SWIFT_NAME(JavaScriptSharedObjectBinding)
+@interface EXJavaScriptSharedObjectBinding : NSObject
+
+@property (nonatomic, copy) EXJavaScriptObject* _Nonnull (^ _Nonnull getter)(void);
+
+- (nonnull instancetype)initWith:(EXJavaScriptObject* _Nonnull (^_Nonnull)(void))getter;
+
+- (EXJavaScriptObject*_Nonnull)get;
+
+@end

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptSharedObjectBinding.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptSharedObjectBinding.h
@@ -1,16 +1,25 @@
-
 // Copyright 2023-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
+typedef EXJavaScriptObject * _Nonnull (^EXJavaScriptObjectBindingGetter)(void);
+
 NS_SWIFT_NAME(JavaScriptSharedObjectBinding)
 @interface EXJavaScriptSharedObjectBinding : NSObject
 
-@property (nonatomic, copy) EXJavaScriptObject* _Nonnull (^ _Nonnull getter)(void);
+@property (nonatomic, copy) EXJavaScriptObjectBindingGetter getter;
 
-- (nonnull instancetype)initWith:(EXJavaScriptObject* _Nonnull (^_Nonnull)(void))getter;
+- (instancetype)initWithGetter:(EXJavaScriptObjectBindingGetter)getter
+      NS_DESIGNATED_INITIALIZER
+      NS_SWIFT_NAME(init(getter:));
 
-- (EXJavaScriptObject*_Nonnull)get;
+- (instancetype)init NS_UNAVAILABLE;
+
+- (EXJavaScriptObject *)get;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptSharedObjectBinding.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptSharedObjectBinding.mm
@@ -5,12 +5,14 @@
 
 @implementation EXJavaScriptSharedObjectBinding
 
-- (nonnull instancetype)initWith:(EXJavaScriptObject* (^_Nonnull)(void))getter {
+- (nonnull instancetype)initWithGetter:(EXJavaScriptObjectBindingGetter) getter
+{
   self.getter = getter;
   return self;
 }
 
-- (EXJavaScriptObject*)get {
+- (EXJavaScriptObject *)get
+{
   auto obj = self.getter();
   return obj;
 }

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptSharedObjectBinding.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptSharedObjectBinding.mm
@@ -3,9 +3,13 @@
 #import <ExpoModulesCore/EXJSIConversions.h>
 #import <ExpoModulesCore/EXJavaScriptSharedObjectBinding.h>
 
+/**
+  A wrapper around a SharedObject getter – The getter is a Swift lambda that creates the JS object and registers the pair in registry.
+  Needed to make sure the registration happens on the correct thread when called from inside EXJSIConversions.
+ */
 @implementation EXJavaScriptSharedObjectBinding
 
-- (nonnull instancetype)initWithGetter:(EXJavaScriptObjectBindingGetter) getter
+- (nonnull instancetype)initWithGetter:(EXJavaScriptObjectBindingGetter)getter
 {
   self.getter = getter;
   return self;

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptSharedObjectBinding.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptSharedObjectBinding.mm
@@ -1,0 +1,18 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXJSIConversions.h>
+#import <ExpoModulesCore/EXJavaScriptSharedObjectBinding.h>
+
+@implementation EXJavaScriptSharedObjectBinding
+
+- (nonnull instancetype)initWith:(EXJavaScriptObject* (^_Nonnull)(void))getter {
+  self.getter = getter;
+  return self;
+}
+
+- (EXJavaScriptObject*)get {
+  auto obj = self.getter();
+  return obj;
+}
+
+@end

--- a/packages/expo-modules-core/ios/TestUtils/MainThreadInvoker.h
+++ b/packages/expo-modules-core/ios/TestUtils/MainThreadInvoker.h
@@ -1,7 +1,8 @@
 // Copyright 2023-present 650 Industries. All rights reserved.
 
-#ifndef MainThreadInvoker_h
-#define MainThreadInvoker_h
+#pragma once
+
+#ifdef __cplusplus
 
 #include <functional>
 
@@ -10,4 +11,4 @@ public:
   static void invokeOnMainThread(const std::function<void()> task);
 };
 
-#endif
+#endif // __cplusplus

--- a/packages/expo-modules-core/ios/TestUtils/MainThreadInvoker.h
+++ b/packages/expo-modules-core/ios/TestUtils/MainThreadInvoker.h
@@ -1,0 +1,13 @@
+// Copyright 2023-present 650 Industries. All rights reserved.
+
+#ifndef MainThreadInvoker_h
+#define MainThreadInvoker_h
+
+#include <functional>
+
+class MainThreadInvoker {
+public:
+  static void invokeOnMainThread(const std::function<void()> task);
+};
+
+#endif

--- a/packages/expo-modules-core/ios/TestUtils/MainThreadInvoker.mm
+++ b/packages/expo-modules-core/ios/TestUtils/MainThreadInvoker.mm
@@ -1,0 +1,15 @@
+// Copyright 2023-present 650 Industries. All rights reserved.
+
+#include "MainThreadInvoker.h"
+#import <Foundation/Foundation.h>
+
+void MainThreadInvoker::invokeOnMainThread(const std::function<void()> task) {
+  dispatch_block_t block = [task]() {
+    task();
+  };
+  if ([NSThread isMainThread]) {
+      block();
+  } else {
+      dispatch_async(dispatch_get_main_queue(), block);
+  }
+}

--- a/packages/expo-modules-core/ios/TestUtils/MainThreadInvoker.mm
+++ b/packages/expo-modules-core/ios/TestUtils/MainThreadInvoker.mm
@@ -1,6 +1,8 @@
 // Copyright 2023-present 650 Industries. All rights reserved.
 
-#include "MainThreadInvoker.h"
+#ifdef __cplusplus
+
+#import <ExpoModulesCore/MainThreadInvoker.h>
 #import <Foundation/Foundation.h>
 
 void MainThreadInvoker::invokeOnMainThread(const std::function<void()> task) {
@@ -13,3 +15,5 @@ void MainThreadInvoker::invokeOnMainThread(const std::function<void()> task) {
       dispatch_async(dispatch_get_main_queue(), block);
   }
 }
+
+#endif // __cplusplus

--- a/packages/expo-modules-core/ios/TestUtils/TestingJSCallInvoker.h
+++ b/packages/expo-modules-core/ios/TestUtils/TestingJSCallInvoker.h
@@ -15,7 +15,7 @@ namespace react = facebook::react;
 namespace expo {
 
 /**
- * Dummy CallInvoker that invokes everything immediately.
+ * Dummy CallInvoker.
  * Used in the test environment to check the async flow.
  */
 class TestingJSCallInvoker : public react::CallInvoker {

--- a/packages/expo-modules-core/ios/TestUtils/TestingJSCallInvoker.h
+++ b/packages/expo-modules-core/ios/TestUtils/TestingJSCallInvoker.h
@@ -5,7 +5,7 @@
 #ifdef __cplusplus
 
 #include <ReactCommon/CallInvoker.h>
-#include "MainThreadInvoker.h"
+#include <ExpoModulesCore/MainThreadInvoker.h>
 
 #include <jsi/jsi.h>
 
@@ -22,7 +22,6 @@ class TestingJSCallInvoker : public react::CallInvoker {
 public:
   explicit TestingJSCallInvoker(const std::shared_ptr<jsi::Runtime>& runtime) : runtime(runtime) {}
 
-#if REACT_NATIVE_TARGET_VERSION >= 75
   void invokeAsync(react::CallFunc &&func) noexcept override {
     auto weakRuntime = runtime;
     std::function<void()> mainThreadFunc = [weakRuntime, func]() {
@@ -35,18 +34,6 @@ public:
   void invokeSync(react::CallFunc &&func) override {
     func(*runtime.lock());
   }
-#else
-  void invokeAsync(react::CallFunc &&func) noexcept override {
-    std::function<void()> mainThreadFunc = [func]() {
-      func();
-    };
-    MainThreadInvoker::invokeOnMainThread(mainThreadFunc);
-  }
-
-  void invokeSync(std::function<void()> &&func) override {
-    func();
-  }
-#endif
 
   ~TestingJSCallInvoker() override = default;
 

--- a/packages/expo-modules-core/ios/TestUtils/TestingJSCallInvoker.h
+++ b/packages/expo-modules-core/ios/TestUtils/TestingJSCallInvoker.h
@@ -16,6 +16,7 @@ namespace expo {
 
 /**
  * Dummy CallInvoker.
+ * Async functions are invoked on the main thread on iOS.
  * Used in the test environment to check the async flow.
  */
 class TestingJSCallInvoker : public react::CallInvoker {

--- a/packages/expo-modules-core/ios/TestUtils/TestingJSCallInvoker.h
+++ b/packages/expo-modules-core/ios/TestUtils/TestingJSCallInvoker.h
@@ -1,0 +1,58 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#ifdef __cplusplus
+
+#include <ReactCommon/CallInvoker.h>
+#include "MainThreadInvoker.h"
+
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+namespace react = facebook::react;
+
+namespace expo {
+
+/**
+ * Dummy CallInvoker that invokes everything immediately.
+ * Used in the test environment to check the async flow.
+ */
+class TestingJSCallInvoker : public react::CallInvoker {
+public:
+  explicit TestingJSCallInvoker(const std::shared_ptr<jsi::Runtime>& runtime) : runtime(runtime) {}
+
+#if REACT_NATIVE_TARGET_VERSION >= 75
+  void invokeAsync(react::CallFunc &&func) noexcept override {
+    auto weakRuntime = runtime;
+    std::function<void()> mainThreadFunc = [weakRuntime, func]() {
+      auto strongRuntime = weakRuntime.lock();
+      func(*strongRuntime);
+    };
+    MainThreadInvoker::invokeOnMainThread(mainThreadFunc);
+  }
+
+  void invokeSync(react::CallFunc &&func) override {
+    func(*runtime.lock());
+  }
+#else
+  void invokeAsync(react::CallFunc &&func) noexcept override {
+    std::function<void()> mainThreadFunc = [func]() {
+      func();
+    };
+    MainThreadInvoker::invokeOnMainThread(mainThreadFunc);
+  }
+
+  void invokeSync(std::function<void()> &&func) override {
+    func();
+  }
+#endif
+
+  ~TestingJSCallInvoker() override = default;
+
+  std::weak_ptr<jsi::Runtime> runtime;
+};
+
+} // namespace expo
+
+#endif // __cplusplus

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -290,7 +290,11 @@ class FunctionSpec: ExpoSpec {
             return "\(f?.property ?? "no value")"
           }
           
-          AsyncFunction("withSharedObject") {
+          Function("withSharedObject") {
+            return SharedString("Test")
+          }
+
+          AsyncFunction("withSharedObjectAsync") {
             return SharedString("Test")
           }
           
@@ -353,13 +357,21 @@ class FunctionSpec: ExpoSpec {
         expect(try runtime.eval("expo.modules.TestModule.withOptionalRecord({property: \"123\"})").asString()) == "123"
       }
       
+      it("returns a SharedObject (sync)") {
+        let object = try runtime.eval("expo.modules.TestModule.withSharedObject()")
+        
+        expect(object.kind) == .object
+        expect(object.getObject().hasProperty("value")) == true
+        expect(object.getObject().getProperty("value").getString()) == "Test"
+      }
+      
       it("returns a SharedObject (async)") {
-        try runtime
-          .eval(
-            "expo.modules.TestModule.withSharedObject().then((result) => { globalThis.result = result; })"
-          )
-
-        expect(safeBoolEval("globalThis.result != null")).toEventually(beTrue(), timeout: .milliseconds(2000))
+          try runtime
+            .eval(
+              "expo.modules.TestModule.withSharedObjectAsync().then((result) => { globalThis.result = result; })"
+            )
+       
+        expect(safeBoolEval("globalThis.result != null")).toEventually(beTrue(), timeout: .milliseconds(4000))
         let object = try runtime.eval("object = globalThis.result")
         
         expect(object.kind) == .object
@@ -373,11 +385,11 @@ class FunctionSpec: ExpoSpec {
       it("returns a SharedObject with Promise") {
         try runtime
           .eval(
-            "expo.modules.TestModule.withSharedObjectPromise().then((result) => { globalThis.result = result; })"
+            "expo.modules.TestModule.withSharedObjectPromise().then((result) => { globalThis.promiseResult = result; })"
           )
 
-        expect(safeBoolEval("globalThis.result != null")).toEventually(beTrue(), timeout: .milliseconds(2000))
-        let object = try runtime.eval("object = globalThis.result")
+        expect(safeBoolEval("globalThis.promiseResult != null")).toEventually(beTrue(), timeout: .milliseconds(2000))
+        let object = try runtime.eval("object = globalThis.promiseResult")
         
         expect(object.kind) == .object
         expect(object.getObject().hasProperty("value")) == true

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -366,11 +366,11 @@ class FunctionSpec: ExpoSpec {
       }
       
       it("returns a SharedObject (async)") {
-          try runtime
-            .eval(
-              "expo.modules.TestModule.withSharedObjectAsync().then((result) => { globalThis.result = result; })"
-            )
-       
+        try runtime
+          .eval(
+            "expo.modules.TestModule.withSharedObjectAsync().then((result) => { globalThis.result = result; })"
+          )
+
         expect(safeBoolEval("globalThis.result != null")).toEventually(beTrue(), timeout: .milliseconds(4000))
         let object = try runtime.eval("object = globalThis.result")
         


### PR DESCRIPTION
# Why

I observed native tests failing with EXC_BAD_ACCESS errors on CI.

# How

Moved sharedobject lookup and registration to a block called by EXJSIConversions (so it happens on invokeAsync on the same thread as the runtime).

Also changed our JSCallInvoker to schedule things on the main thread when `invokeAsync` is called. Incorrect implementation caused runtime access from our async function dispatch queues and crashes.

# Test Plan
Native Tests now pass.
Now testing bare-expo.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
