### PR TITLE
[docs] Add config plugin info in WebBrowser

### DIFF
--- a/docs/pages/versions/unversioned/sdk/webbrowser.mdx
+++ b/docs/pages/versions/unversioned/sdk/webbrowser.mdx
@@ -9,6 +9,7 @@ platforms: ['android', 'ios', 'web']
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/ConfigSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
@@ -17,6 +18,41 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app config
+
+You can configure `expo-web-browser` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure a property that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-web-browser",
+        {
+          "experimentalLauncherActivity": true
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'experimentalLauncherActivity',
+      platform: 'android',
+      description:
+        "A boolean that enables a launcher activity to persist the system's web browser state when the app is in the background.",
+      default: 'false',
+    },
+  ]}
+/>
 
 ## Usage
 

--- a/docs/pages/versions/v53.0.0/sdk/webbrowser.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/webbrowser.mdx
@@ -9,6 +9,7 @@ platforms: ['android', 'ios', 'web']
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/ConfigSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
@@ -17,6 +18,41 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app config
+
+You can configure `expo-web-browser` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure a property that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-web-browser",
+        {
+          "experimentalLauncherActivity": true
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'experimentalLauncherActivity',
+      platform: 'android',
+      description:
+        "A boolean that enables a launcher activity to persist the system's web browser state when the app is in the background.",
+      default: 'false',
+    },
+  ]}
+/>
 
 ## Usage
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15514

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add info about the `expo-web-browser` config plugin, app config example usage, and its configurable property.
Changes backported to SDK 53 (beta) reference as well.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-04-17 at 22 25 35](https://github.com/user-attachments/assets/3f38892e-00e1-4f3f-aeea-85cfb555f4f0)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
