### PR TITLE
[docs] add Sentry release name configuration to the snippet to facilitate better results with the Sentry integration

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -130,11 +130,22 @@ import { Slot, useNavigationContainerRef } from 'expo-router';
 import { useEffect } from 'react';
 import * as Sentry from '@sentry/react-native';
 import { isRunningInExpoGo } from 'expo';
+import * as Updates from "expo-updates";
+import * as Application from "expo-application";
 
 // Construct a new integration instance. This is needed to communicate between the integration and React
 const navigationIntegration = Sentry.reactNavigationIntegration({
   enableTimeToInitialDisplay: !isRunningInExpoGo(),
 });
+
+const version = Application.nativeApplicationVersion ?? "unknown-version";
+const updateId = Updates.isEmbeddedLaunch ? null : Updates.updateId;
+const channel = Updates.channel || "development";
+
+// Specifying your release name with this format allows you to see related Sentry errors in Expo dashboard if you have the integration enabled on the website for this project.
+const release = updateId
+  ? `${version}#${channel}:${updateId}`
+  : `${version}#${channel}`;
 
 Sentry.init({
   dsn: 'YOUR DSN HERE',
@@ -145,6 +156,7 @@ Sentry.init({
     navigationIntegration,
   ],
   enableNativeFramesTracking: !isRunningInExpoGo(), // Tracks slow and frozen frames in the application
+  release,
 });
 
 function RootLayout() {
@@ -172,10 +184,22 @@ Add the following to your app's main file such as **App.js**:
 
 ```js
 import * as Sentry from '@sentry/react-native';
+import * as Updates from "expo-updates";
+import * as Application from "expo-application";
+
+const version = Application.nativeApplicationVersion ?? "unknown-version";
+const updateId = Updates.isEmbeddedLaunch ? null : Updates.updateId;
+const channel = Updates.channel || "development";
+
+// Specifying your release name with this format allows you to see related Sentry errors in Expo dashboard if you have the integration enabled on the website for this project.
+const release = updateId
+  ? `${version}#${channel}:${updateId}`
+  : `${version}#${channel}`;
 
 Sentry.init({
   dsn: 'YOUR DSN HERE',
   debug: true, // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
+  release,
 });
 ```
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -130,22 +130,11 @@ import { Slot, useNavigationContainerRef } from 'expo-router';
 import { useEffect } from 'react';
 import * as Sentry from '@sentry/react-native';
 import { isRunningInExpoGo } from 'expo';
-import * as Updates from "expo-updates";
-import * as Application from "expo-application";
 
 // Construct a new integration instance. This is needed to communicate between the integration and React
 const navigationIntegration = Sentry.reactNavigationIntegration({
   enableTimeToInitialDisplay: !isRunningInExpoGo(),
 });
-
-const version = Application.nativeApplicationVersion ?? "unknown-version";
-const updateId = Updates.isEmbeddedLaunch ? null : Updates.updateId;
-const channel = Updates.channel || "development";
-
-// Specifying your release name with this format allows you to see related Sentry errors in Expo dashboard if you have the integration enabled on the website for this project.
-const release = updateId
-  ? `${version}#${channel}:${updateId}`
-  : `${version}#${channel}`;
 
 Sentry.init({
   dsn: 'YOUR DSN HERE',
@@ -156,7 +145,6 @@ Sentry.init({
     navigationIntegration,
   ],
   enableNativeFramesTracking: !isRunningInExpoGo(), // Tracks slow and frozen frames in the application
-  release,
 });
 
 function RootLayout() {
@@ -184,22 +172,10 @@ Add the following to your app's main file such as **App.js**:
 
 ```js
 import * as Sentry from '@sentry/react-native';
-import * as Updates from "expo-updates";
-import * as Application from "expo-application";
-
-const version = Application.nativeApplicationVersion ?? "unknown-version";
-const updateId = Updates.isEmbeddedLaunch ? null : Updates.updateId;
-const channel = Updates.channel || "development";
-
-// Specifying your release name with this format allows you to see related Sentry errors in Expo dashboard if you have the integration enabled on the website for this project.
-const release = updateId
-  ? `${version}#${channel}:${updateId}`
-  : `${version}#${channel}`;
 
 Sentry.init({
   dsn: 'YOUR DSN HERE',
   debug: true, // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
-  release,
 });
 ```
 
@@ -216,6 +192,29 @@ export default Sentry.wrap(App);
 </Tab>
 
 </Tabs>
+
+> **info** Additionally, if your app is using EAS Update, we recommend configuring your Sentry release with the
+following format to see related Sentry errors in Expo dashboard with the Sentry integration enabled:
+
+```js
+// other imports
+import * as Updates from "expo-updates";
+import * as Application from "expo-application";
+
+const version = Application.nativeApplicationVersion ?? "unknown-version";
+const updateId = Updates.isEmbeddedLaunch ? null : Updates.updateId;
+const channel = Updates.channel || "development";
+
+// Specifying your release name with this format allows you to see related Sentry errors in Expo dashboard if you have the integration enabled on the website for this project.
+const release = updateId
+  ? `${version}#${channel}:${updateId}`
+  : `${version}#${channel}`;
+
+Sentry.init({
+  // other init options
+  release,
+});
+```
 
 </Step>
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -194,21 +194,19 @@ export default Sentry.wrap(App);
 </Tabs>
 
 > **info** Additionally, if your app is using EAS Update, we recommend configuring your Sentry release with the
-following format to see related Sentry errors in Expo dashboard with the Sentry integration enabled:
+> following format to see related Sentry errors in Expo dashboard with the Sentry integration enabled:
 
 ```js
 // other imports
-import * as Updates from "expo-updates";
-import * as Application from "expo-application";
+import * as Updates from 'expo-updates';
+import * as Application from 'expo-application';
 
-const version = Application.nativeApplicationVersion ?? "unknown-version";
+const version = Application.nativeApplicationVersion ?? 'unknown-version';
 const updateId = Updates.isEmbeddedLaunch ? null : Updates.updateId;
-const channel = Updates.channel || "development";
+const channel = Updates.channel || 'development';
 
 // Specifying your release name with this format allows you to see related Sentry errors in Expo dashboard if you have the integration enabled on the website for this project.
-const release = updateId
-  ? `${version}#${channel}:${updateId}`
-  : `${version}#${channel}`;
+const release = updateId ? `${version}#${channel}:${updateId}` : `${version}#${channel}`;
 
 Sentry.init({
   // other init options


### PR DESCRIPTION
# Why

For the upcoming Expo.dev + Sentry integration to provide the most value, we need to be able to associate Sentry objects with specific updates/deployments. Specifying a release name that includes EAS Update information when appropriate allows us to do so. 

# How

In the "Using Sentry" docs, I updated the `init` setup snippet to include the `release` format convention expected by our integration. I added this to a separate section under the "Expo Router/Normal" tabs to make it more obvious that it's optional compared to the rest of the standard setup.

# Test Plan

- View the text changes in the diff.
- Run the docs site locally to see the changes as our users will:
![Screenshot 2025-04-17 at 18 02 45](https://github.com/user-attachments/assets/2aead161-df3b-4696-85fa-f77c788446f2)

