### PR TITLE
[document-picker] avoid int overflow for large files

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- avoid int overflow for large files ([#36245](https://github.com/expo/expo/pull/36245) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 ## 13.1.2 — 2025-04-14

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- avoid int overflow for large files ([#36245](https://github.com/expo/expo/pull/36245) by [@vonovak](https://github.com/vonovak))
+- [Android] Avoid int overflow for large files ([#36245](https://github.com/expo/expo/pull/36245) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentDetailsReader.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentDetailsReader.kt
@@ -4,10 +4,8 @@ import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
 
-data class DocumentDetails(val name: String, val uri: String, val size: Long?, val mimeType: String?)
-
 class DocumentDetailsReader(private val context: Context) {
-  fun read(uri: Uri): DocumentDetails? {
+  fun read(uri: Uri): DocumentInfo? {
     context
       .contentResolver
       .query(uri, null, null, null, null)
@@ -15,7 +13,6 @@ class DocumentDetailsReader(private val context: Context) {
         cursor.moveToFirst()
         val columnIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
         val name = cursor.getString(columnIndex)
-        val uriString = uri.toString()
         val size = cursor.getColumnIndex(OpenableColumns.SIZE).let { sizeColumnIndex ->
           if (!cursor.isNull(sizeColumnIndex)) {
             cursor.getLong(sizeColumnIndex)
@@ -24,7 +21,7 @@ class DocumentDetailsReader(private val context: Context) {
           }
         }
         val mimeType = context.contentResolver.getType(uri)
-        return DocumentDetails(name, uriString, size, mimeType)
+        return DocumentInfo(uri, name, mimeType, size)
       }
     return null
   }

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentDetailsReader.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentDetailsReader.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
 
-data class DocumentDetails(val name: String, val uri: String, val size: Int?, val mimeType: String?)
+data class DocumentDetails(val name: String, val uri: String, val size: Long?, val mimeType: String?)
 
 class DocumentDetailsReader(private val context: Context) {
   fun read(uri: Uri): DocumentDetails? {
@@ -18,7 +18,7 @@ class DocumentDetailsReader(private val context: Context) {
         val uriString = uri.toString()
         val size = cursor.getColumnIndex(OpenableColumns.SIZE).let { sizeColumnIndex ->
           if (!cursor.isNull(sizeColumnIndex)) {
-            cursor.getInt(sizeColumnIndex)
+            cursor.getLong(sizeColumnIndex)
           } else {
             null
           }

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
@@ -73,7 +73,7 @@ class DocumentPickerModule : Module() {
     }
   }
 
-  private fun copyDocumentToCacheDirectory(documentUri: Uri, name: String): String? {
+  private fun copyDocumentToCacheDirectory(documentUri: Uri, name: String): Uri? {
     val outputFilePath = FileUtilities.generateOutputPath(
       context.cacheDir,
       "DocumentPicker",
@@ -90,7 +90,7 @@ class DocumentPickerModule : Module() {
       e.printStackTrace()
       return null
     }
-    return Uri.fromFile(outputFile).toString()
+    return Uri.fromFile(outputFile)
   }
 
   private fun handleSingleSelection(intent: Intent?) {
@@ -129,13 +129,6 @@ class DocumentPickerModule : Module() {
       } ?: throw FailedToCopyToCacheException()
     }
 
-    return details?.let { it ->
-      DocumentInfo(
-        uri = it.uri,
-        name = it.name,
-        mimeType = it.mimeType,
-        size = it.size
-      )
-    } ?: throw FailedToReadDocumentException()
+    return details ?: throw FailedToReadDocumentException()
   }
 }

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerResults.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerResults.kt
@@ -22,5 +22,5 @@ data class DocumentInfo(
   val mimeType: String?,
 
   @Field
-  val size: Int?
+  val size: Long?
 ) : Record

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerResults.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerResults.kt
@@ -1,5 +1,6 @@
 package expo.modules.documentpicker
 
+import android.net.Uri
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 
@@ -13,7 +14,7 @@ data class DocumentPickerResult(
 
 data class DocumentInfo(
   @Field
-  val uri: String,
+  val uri: Uri,
 
   @Field
   val name: String,


### PR DESCRIPTION
# Why

This PR refactors the document picker implementation on Android to fix potential for int overflow in (very) large files. Also removes some unnecessary code.

iOS doesn't suffer from the overflow

# How

- Modified the size property type from `Int?` to `Long?` to handle larger file sizes correctly
- Changed `DocumentDetailsReader.read` class to use the `DocumentInfo` record directly - `DocumentDetails` was an unnecessary intermediary

# Test Plan

- create a large file `mkfile -n 10g temp_10GB_file.txt` and drag it over to emulator
- pick it in bare expo and observe positive size returned (previously would return negative size)

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)