### PR TITLE
[docs] Add known limitation about testing FaceID for iOS not supported on Expo Go in LocalAuthentication reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/local-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.mdx
@@ -15,8 +15,15 @@ import {
   ConfigPluginExample,
   ConfigPluginProperties,
 } from '~/ui/components/ConfigSection';
+import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 `expo-local-authentication` allows you to use the Biometric Prompt (Android) or FaceID and TouchID (iOS) to authenticate the user with a fingerprint or face scan.
+
+## Known limitation
+
+### iOS&ensp;<PlatformTags platforms={['ios']} />
+
+The FaceID authentication for iOS is not supported in Expo Go. You will need to create a [development build](/develop/development-builds/introduction/) to test FaceID.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/local-authentication.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/local-authentication.mdx
@@ -15,8 +15,15 @@ import {
   ConfigPluginExample,
   ConfigPluginProperties,
 } from '~/ui/components/ConfigSection';
+import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 `expo-local-authentication` allows you to use the Biometric Prompt (Android) or FaceID and TouchID (iOS) to authenticate the user with a fingerprint or face scan.
+
+## Known limitation
+
+### iOS&ensp;<PlatformTags platforms={['ios']} />
+
+The FaceID authentication for iOS is not supported in Expo Go. You will need to create a [development build](/develop/development-builds/introduction/) to test FaceID.
 
 ## Installation
 

--- a/docs/pages/versions/v52.0.0/sdk/local-authentication.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/local-authentication.mdx
@@ -15,8 +15,15 @@ import {
   ConfigPluginExample,
   ConfigPluginProperties,
 } from '~/ui/components/ConfigSection';
+import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 `expo-local-authentication` allows you to use the Biometric Prompt (Android) or FaceID and TouchID (iOS) to authenticate the user with a fingerprint or face scan.
+
+## Known limitation
+
+### iOS&ensp;<PlatformTags platforms={['ios']} />
+
+The FaceID authentication for iOS is not supported in Expo Go. You will need to create a [development build](/develop/development-builds/introduction/) to test FaceID.
 
 ## Installation
 

--- a/docs/pages/versions/v53.0.0/sdk/local-authentication.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/local-authentication.mdx
@@ -15,8 +15,15 @@ import {
   ConfigPluginExample,
   ConfigPluginProperties,
 } from '~/ui/components/ConfigSection';
+import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 `expo-local-authentication` allows you to use the Biometric Prompt (Android) or FaceID and TouchID (iOS) to authenticate the user with a fingerprint or face scan.
+
+## Known limitation
+
+### iOS&ensp;<PlatformTags platforms={['ios']} />
+
+The FaceID authentication for iOS is not supported in Expo Go. You will need to create a [development build](/develop/development-builds/introduction/) to test FaceID.
 
 ## Installation
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Fix ENG-10498

# How

<!--
How did you build this feature or fix this bug and why?
-->
- Add a known limitation section for iOS in Expo LocalAuthentication API reference.
- Backport changes to SDK 53, 52, 51.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-04-18 at 18 55 54@2x](https://github.com/user-attachments/assets/d2eca301-ce97-423c-a44c-eb056ed74295)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
