### PR TITLE
Fix android submit workflow

### DIFF
--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -155,6 +155,7 @@ You can use [EAS Workflows](/eas-workflows/get-started/) to build and submit you
      # @info #
      submit_android:
        name: Submit to Google Play Store
+       needs: [build_android]
        type: submit
        params:
          platform: android


### PR DESCRIPTION
# Why

See the same fix for ios: https://github.com/expo/expo/pull/36115

The dependency to the build_android job is needed, otherwise the submission job fails as it misses the build_id. 

# How


Following the documentation. 


# Test Plan


I fixed it in my repo and tested on the expo.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
