### PR TITLE
[core] support virtual view for ExpoComposeView

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [Android] Reduce the memory footprint of calling function from the native module. ([#37080](https://github.com/expo/expo/pull/37080) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Changed how nullable types are converted. ([#37055](https://github.com/expo/expo/pull/37055) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Reduce the number of conversions needed to call a function from the native module. ([#37099](https://github.com/expo/expo/pull/37099) by [@lukmccall](https://github.com/lukmccall))
+- Updated `ExpoComposeView` to support virtual view. ([#36255](https://github.com/expo/expo/pull/36255) by [@kudo](https://github.com/kudo))
 
 ## 2.3.13 — 2025-05-08
 

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeAndroidView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeAndroidView.kt
@@ -12,7 +12,7 @@ import expo.modules.kotlin.AppContext
 /**
  * An ExpoComposeView for [AndroidView] wrapping with existing view
  */
-class ExpoComposeAndroidView(private val view: View, appContext: AppContext) : ExpoComposeView<ComposeProps>(view.context, appContext) {
+internal class ExpoComposeAndroidView(private val view: View, appContext: AppContext) : ExpoComposeView<ComposeProps>(view.context, appContext) {
   @Composable
   override fun Content() {
     AndroidView(

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -15,7 +15,7 @@ import expo.modules.kotlin.AppContext
 abstract class ExpoComposeView<T : ComposeProps>(
   context: Context,
   appContext: AppContext,
-  private val withHostingView: Boolean = false,
+  private val withHostingView: Boolean = false
 ) : ExpoView(context, appContext) {
   open val props: T? = null
 

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -2,38 +2,67 @@ package expo.modules.kotlin.views
 
 import android.content.Context
 import android.view.View
+import android.view.ViewGroup
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.ComposeView
-import expo.modules.kotlin.AppContext
-import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.view.size
+import expo.modules.kotlin.AppContext
 
 /**
  * A base class that should be used by compose views.
  */
 abstract class ExpoComposeView<T : ComposeProps>(
   context: Context,
-  appContext: AppContext
+  appContext: AppContext,
+  private val withHostingView: Boolean = false,
 ) : ExpoView(context, appContext) {
   open val props: T? = null
 
-  override val shouldUseAndroidLayout = true
+  @Composable
+  abstract fun Content()
+
+  override val shouldUseAndroidLayout = withHostingView
 
   override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-    // In case of issues there's an alternative solution in previous commits at https://github.com/expo/expo/pull/33759
-    if (!isAttachedToWindow) {
-      setMeasuredDimension(widthMeasureSpec, heightMeasureSpec)
-      return
+    if (shouldUseAndroidLayout) {
+      // In case of issues there's an alternative solution in previous commits at https://github.com/expo/expo/pull/33759
+      if (!isAttachedToWindow) {
+        setMeasuredDimension(widthMeasureSpec, heightMeasureSpec)
+        return
+      }
     }
     super.onMeasure(widthMeasureSpec, heightMeasureSpec)
   }
 
-  @OptIn(InternalComposeUiApi::class)
-  val layout by lazy {
-    ComposeView(context).also {
+  @Composable
+  protected fun Children() {
+    if (withHostingView) {
+      return Content()
+    }
+
+    for (index in 0..<this.size) {
+      val child = getChildAt(index) as? ExpoComposeView<*> ?: continue
+      child.Content()
+    }
+  }
+
+  init {
+    if (withHostingView) {
+      addComposeView()
+    } else {
+      this.visibility = GONE
+      this.setWillNotDraw(true)
+    }
+  }
+
+  private fun addComposeView() {
+    val composeView = ComposeView(context).also {
       it.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
       it.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-      addView(it)
+      it.setContent {
+        Children()
+      }
       it.addOnAttachStateChangeListener(object : OnAttachStateChangeListener {
         override fun onViewAttachedToWindow(v: View) {
           it.disposeComposition()
@@ -42,11 +71,15 @@ abstract class ExpoComposeView<T : ComposeProps>(
         override fun onViewDetachedFromWindow(v: View) = Unit
       })
     }
+    addView(composeView)
   }
 
-  fun setContent(
-    content: @Composable () -> Unit
-  ) {
-    layout.setContent { content() }
+  override fun addView(child: View, index: Int, params: ViewGroup.LayoutParams) {
+    val view = if (child !is ExpoComposeView<*> && child !is ComposeView) {
+      ExpoComposeAndroidView(child, appContext)
+    } else {
+      child
+    }
+    super.addView(view, index, params)
   }
 }

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -25,12 +25,10 @@ abstract class ExpoComposeView<T : ComposeProps>(
   override val shouldUseAndroidLayout = withHostingView
 
   override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-    if (shouldUseAndroidLayout) {
-      // In case of issues there's an alternative solution in previous commits at https://github.com/expo/expo/pull/33759
-      if (!isAttachedToWindow) {
-        setMeasuredDimension(widthMeasureSpec, heightMeasureSpec)
-        return
-      }
+    // In case of issues there's an alternative solution in previous commits at https://github.com/expo/expo/pull/33759
+    if (shouldUseAndroidLayout && !isAttachedToWindow) {
+      setMeasuredDimension(widthMeasureSpec, heightMeasureSpec)
+      return
     }
     super.onMeasure(widthMeasureSpec, heightMeasureSpec)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ExpoComposeAndroidView.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ExpoComposeAndroidView.kt
@@ -1,0 +1,23 @@
+package expo.modules.kotlin.views
+
+import android.view.View
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.facebook.react.uimanager.PixelUtil.pxToDp
+import expo.modules.kotlin.AppContext
+
+/**
+ * An ExpoComposeView for [AndroidView] wrapping with existing view
+ */
+class ExpoComposeAndroidView(private val view: View, appContext: AppContext) : ExpoComposeView<ComposeProps>(view.context, appContext) {
+  @Composable
+  override fun Content() {
+    AndroidView(
+      factory = { view },
+      modifier = Modifier.size(view.width.toFloat().pxToDp().dp, view.height.toFloat().pxToDp().dp)
+    )
+  }
+}


### PR DESCRIPTION
# Why

remove extra ComposeView. #35553 for jetpack compose

# How

- i don't have a way like `SwiftUIVirtualView` to use fake object as View to cheat the android view system. i still need to create a View but use `visibility = GONE` and `setWillNotDraw(true)` to prevent extra drawing overhead
- add `withHostingView` parameter to support backward compatibility for existing expo-ui components. we only create `ComposeView` when withHostingView=true.
- add an abstract `Content` composable for each view to define it's content
- add `Children` composable to get content from all children
- add `ExpoComposeAndroidView` to use `AndroidView` to host an existing android views to jetpack compose children

# Test Plan

tested on upstack pr. there is a breaking change to ExpoComposeView and causes build failure. will also resolve by upstack pr.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
