### PR TITLE
[ui] migrate ExpoComposeView withHostingView=true

### DIFF
--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- Fixed `ExpoComposeView` breaking change errors. ([#36256](https://github.com/expo/expo/pull/36256) by [@kudo](https://github.com/kudo))
+
 ## 0.10.0 — 2025-05-08
 
 ### 🎉 New features

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
@@ -54,7 +54,8 @@ data class GoogleMapsViewProps(
 ) : ComposeProps
 
 @SuppressLint("ViewConstructor")
-class GoogleMapsView(context: Context, appContext: AppContext) : ExpoComposeView<GoogleMapsViewProps>(context, appContext, withHostingView = true) {
+class GoogleMapsView(context: Context, appContext: AppContext) :
+  ExpoComposeView<GoogleMapsViewProps>(context, appContext, withHostingView = true) {
   override val props = GoogleMapsViewProps()
 
   private val onMapLoaded by EventDispatcher<Unit>()

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleStreetView.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleStreetView.kt
@@ -1,6 +1,7 @@
 package expo.modules.maps
 
 import android.content.Context
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -24,26 +25,25 @@ data class GoogleStreetViewProps(
 class GoogleStreetView(
   context: Context,
   appContext: AppContext
-) : ExpoComposeView<GoogleStreetViewProps>(context, appContext) {
+) : ExpoComposeView<GoogleStreetViewProps>(context, appContext, withHostingView = true) {
   override val props = GoogleStreetViewProps()
 
-  init {
-    setContent {
-      key(props.position.value.coordinates.toString()) {
-        StreetView(
-          streetViewPanoramaOptionsFactory = {
-            props.position.value.let { camera ->
-              StreetViewPanoramaOptions()
-                .position(camera.coordinates.toLatLng())
-                .panoramaCamera(StreetViewPanoramaCamera(camera.zoom, camera.tilt, camera.bearing))
-            }
-          },
-          isPanningGesturesEnabled = props.isPanningGesturesEnabled.value,
-          isStreetNamesEnabled = props.isStreetNamesEnabled.value,
-          isUserNavigationEnabled = props.isUserNavigationEnabled.value,
-          isZoomGesturesEnabled = props.isZoomGesturesEnabled.value
-        )
-      }
+  @Composable
+  override fun Content() {
+    key(props.position.value.coordinates.toString()) {
+      StreetView(
+        streetViewPanoramaOptionsFactory = {
+          props.position.value.let { camera ->
+            StreetViewPanoramaOptions()
+              .position(camera.coordinates.toLatLng())
+              .panoramaCamera(StreetViewPanoramaCamera(camera.zoom, camera.tilt, camera.bearing))
+          }
+        },
+        isPanningGesturesEnabled = props.isPanningGesturesEnabled.value,
+        isStreetNamesEnabled = props.isStreetNamesEnabled.value,
+        isUserNavigationEnabled = props.isUserNavigationEnabled.value,
+        isZoomGesturesEnabled = props.isZoomGesturesEnabled.value
+      )
     }
   }
 }

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Improved `@expo/ui/swift-ui-primitives` integrations. ([#36937](https://github.com/expo/expo/pull/36937), [#36938](https://github.com/expo/expo/pull/36938) by [@kudo](https://github.com/kudo))
+- Fixed `ExpoComposeView` breaking change errors. ([#36256](https://github.com/expo/expo/pull/36256) by [@kudo](https://github.com/kudo))
 
 ## 0.1.1-alpha.7 — 2025-04-30
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
@@ -66,8 +66,8 @@ data class DateTimePickerProps(
 
 @SuppressLint("ViewConstructor")
 @OptIn(ExperimentalMaterial3Api::class)
-class DateTimePickerView(context: Context, appContext: AppContext)
-  : ExpoComposeView<DateTimePickerProps>(context, appContext, withHostingView = true) {
+class DateTimePickerView(context: Context, appContext: AppContext) :
+  ExpoComposeView<DateTimePickerProps>(context, appContext, withHostingView = true) {
   override val props = DateTimePickerProps()
   private val onDateSelected by EventDispatcher<DatePickerResult>()
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
@@ -66,20 +66,20 @@ data class DateTimePickerProps(
 
 @SuppressLint("ViewConstructor")
 @OptIn(ExperimentalMaterial3Api::class)
-class DateTimePickerView(context: Context, appContext: AppContext) : ExpoComposeView<DateTimePickerProps>(context, appContext) {
+class DateTimePickerView(context: Context, appContext: AppContext)
+  : ExpoComposeView<DateTimePickerProps>(context, appContext, withHostingView = true) {
   override val props = DateTimePickerProps()
   private val onDateSelected by EventDispatcher<DatePickerResult>()
 
-  init {
-    setContent {
-      if (props.displayedComponents.value == DisplayedComponents.HOUR_AND_MINUTE) {
-        ExpoTimePicker(props = props) {
-          onDateSelected(it)
-        }
-      } else {
-        ExpoDatePicker(props = props) {
-          onDateSelected(it)
-        }
+  @Composable
+  override fun Content() {
+    if (props.displayedComponents.value == DisplayedComponents.HOUR_AND_MINUTE) {
+      ExpoTimePicker(props = props) {
+        onDateSelected(it)
+      }
+    } else {
+      ExpoDatePicker(props = props) {
+        onDateSelected(it)
       }
     }
   }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
@@ -43,7 +43,7 @@ class ExpoUIModule : Module() {
 
     View(ProgressView::class)
 
-    View(TextInputView::class)  {
+    View(TextInputView::class) {
       Events("onValueChanged")
     }
   }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/PickerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/PickerView.kt
@@ -29,7 +29,6 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.ExpoComposeView
-import expo.modules.ui.button.ButtonColors
 
 class PickerColors : Record {
   @Field
@@ -76,8 +75,8 @@ data class PickerProps(
   val variant: MutableState<String> = mutableStateOf("segmented")
 ) : ComposeProps
 
-class PickerView(context: Context, appContext: AppContext)
-  : ExpoComposeView<PickerProps>(context, appContext, withHostingView = true) {
+class PickerView(context: Context, appContext: AppContext) :
+  ExpoComposeView<PickerProps>(context, appContext, withHostingView = true) {
   override val props = PickerProps()
   private val onOptionSelected by EventDispatcher()
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/PickerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/PickerView.kt
@@ -76,95 +76,95 @@ data class PickerProps(
   val variant: MutableState<String> = mutableStateOf("segmented")
 ) : ComposeProps
 
-class PickerView(context: Context, appContext: AppContext) : ExpoComposeView<PickerProps>(context, appContext) {
+class PickerView(context: Context, appContext: AppContext)
+  : ExpoComposeView<PickerProps>(context, appContext, withHostingView = true) {
   override val props = PickerProps()
   private val onOptionSelected by EventDispatcher()
 
-  init {
-    setContent {
-      val (selectedIndex) = props.selectedIndex
-      val (options) = props.options
-      val (colors) = props.elementColors
-      val (variant) = props.variant
+  @Composable
+  override fun Content() {
+    val (selectedIndex) = props.selectedIndex
+    val (options) = props.options
+    val (colors) = props.elementColors
+    val (variant) = props.variant
 
-      @Composable
-      fun SegmentedComposable() {
-        DynamicTheme {
-          AutoSizingComposable(shadowNodeProxy) {
-            SingleChoiceSegmentedButtonRow {
-              options.forEachIndexed { index, label ->
-                SegmentedButton(
-                  shape = SegmentedButtonDefaults.itemShape(
-                    index = index,
-                    count = options.size
+    @Composable
+    fun SegmentedComposable() {
+      DynamicTheme {
+        AutoSizingComposable(shadowNodeProxy) {
+          SingleChoiceSegmentedButtonRow {
+            options.forEachIndexed { index, label ->
+              SegmentedButton(
+                shape = SegmentedButtonDefaults.itemShape(
+                  index = index,
+                  count = options.size
+                ),
+                onClick = {
+                  onOptionSelected(mapOf("index" to index, "label" to label))
+                },
+                selected = index == selectedIndex,
+                label = { Text(label) },
+                colors = SegmentedButtonDefaults.colors(
+                  activeBorderColor = colors.activeBorderColor.compose,
+                  activeContentColor = colors.activeContentColor.compose,
+                  inactiveBorderColor = colors.inactiveBorderColor.compose,
+                  inactiveContentColor = colors.inactiveContentColor.compose,
+                  disabledActiveBorderColor = colors.disabledActiveBorderColor.compose,
+                  disabledActiveContentColor = colors.disabledActiveContentColor.compose,
+                  disabledInactiveBorderColor = colors.disabledInactiveBorderColor.compose,
+                  disabledInactiveContentColor = colors.disabledInactiveContentColor.compose,
+                  activeContainerColor = colors.activeContainerColor.compose,
+                  inactiveContainerColor = colors.inactiveContainerColor.compose,
+                  disabledActiveContainerColor = colors.disabledActiveContainerColor.compose,
+                  disabledInactiveContainerColor = colors.disabledInactiveContainerColor.compose
+                )
+              )
+            }
+          }
+        }
+      }
+    }
+
+    @Composable
+    fun RadioComposable() {
+      DynamicTheme {
+        AutoSizingComposable(shadowNodeProxy) {
+          Column(Modifier.selectableGroup()) {
+            options.forEachIndexed { index, label ->
+              Row(
+                Modifier.fillMaxWidth()
+                  .height(28.dp)
+                  .selectable(
+                    selected = index == selectedIndex,
+                    onClick = {
+                      onOptionSelected(mapOf("index" to index, "label" to label))
+                    },
+                    role = Role.RadioButton
                   ),
-                  onClick = {
-                    onOptionSelected(mapOf("index" to index, "label" to label))
-                  },
+                verticalAlignment = Alignment.CenterVertically
+              ) {
+                RadioButton(
                   selected = index == selectedIndex,
-                  label = { Text(label) },
-                  colors = SegmentedButtonDefaults.colors(
-                    activeBorderColor = colors.activeBorderColor.compose,
-                    activeContentColor = colors.activeContentColor.compose,
-                    inactiveBorderColor = colors.inactiveBorderColor.compose,
-                    inactiveContentColor = colors.inactiveContentColor.compose,
-                    disabledActiveBorderColor = colors.disabledActiveBorderColor.compose,
-                    disabledActiveContentColor = colors.disabledActiveContentColor.compose,
-                    disabledInactiveBorderColor = colors.disabledInactiveBorderColor.compose,
-                    disabledInactiveContentColor = colors.disabledInactiveContentColor.compose,
-                    activeContainerColor = colors.activeContainerColor.compose,
-                    inactiveContainerColor = colors.inactiveContainerColor.compose,
-                    disabledActiveContainerColor = colors.disabledActiveContainerColor.compose,
-                    disabledInactiveContainerColor = colors.disabledInactiveContainerColor.compose
-                  )
+                  onClick = null
+                )
+                Text(
+                  text = label,
+                  modifier = Modifier.padding(start = 12.dp)
                 )
               }
             }
           }
         }
       }
+    }
 
-      @Composable
-      fun RadioComposable() {
-        DynamicTheme {
-          AutoSizingComposable(shadowNodeProxy) {
-            Column(Modifier.selectableGroup()) {
-              options.forEachIndexed { index, label ->
-                Row(
-                  Modifier.fillMaxWidth()
-                    .height(28.dp)
-                    .selectable(
-                      selected = index == selectedIndex,
-                      onClick = {
-                        onOptionSelected(mapOf("index" to index, "label" to label))
-                      },
-                      role = Role.RadioButton
-                    ),
-                  verticalAlignment = Alignment.CenterVertically
-                ) {
-                  RadioButton(
-                    selected = index == selectedIndex,
-                    onClick = null
-                  )
-                  Text(
-                    text = label,
-                    modifier = Modifier.padding(start = 12.dp)
-                  )
-                }
-              }
-            }
-          }
-        }
-      }
-
-      if (variant == "segmented") {
-        SegmentedComposable()
-      } else if (variant == "radio") {
-        RadioComposable()
-      } else {
-        // Default to segmented picker
-        SegmentedComposable()
-      }
+    if (variant == "segmented") {
+      SegmentedComposable()
+    } else if (variant == "radio") {
+      RadioComposable()
+    } else {
+      // Default to segmented picker
+      SegmentedComposable()
     }
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ProgressView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ProgressView.kt
@@ -6,6 +6,7 @@ import expo.modules.kotlin.views.ExpoComposeView
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import expo.modules.kotlin.AppContext
@@ -34,49 +35,49 @@ data class ProgressProps(
   val elementColors: MutableState<ProgressColors> = mutableStateOf(ProgressColors())
 ) : ComposeProps
 
-class ProgressView(context: Context, appContext: AppContext) : ExpoComposeView<ProgressProps>(context, appContext) {
+class ProgressView(context: Context, appContext: AppContext)
+  : ExpoComposeView<ProgressProps>(context, appContext, withHostingView = true) {
   override val props = ProgressProps()
 
-  init {
-    setContent {
-      val (variant) = props.variant
-      val (progress) = props.progress
-      val (color) = props.color
-      val (colors) = props.elementColors
-      DynamicTheme {
-        when (variant) {
-          ProgressVariant.LINEAR ->
-            AutoSizingComposable(shadowNodeProxy, axis = EnumSet.of(Direction.VERTICAL)) {
-              val composeColor = color.composeOrNull ?: ProgressIndicatorDefaults.linearColor
-              val trackColor = colors.trackColor.composeOrNull ?: ProgressIndicatorDefaults.linearTrackColor
-              if (progress != null) {
-                LinearProgressIndicator(
-                  progress = { progress },
-                  color = composeColor,
-                  trackColor = trackColor,
-                  drawStopIndicator = {},
-                )
-              } else {
-                LinearProgressIndicator(color = composeColor, trackColor = trackColor)
-              }
+  @Composable
+  override fun Content() {
+    val (variant) = props.variant
+    val (progress) = props.progress
+    val (color) = props.color
+    val (colors) = props.elementColors
+    DynamicTheme {
+      when (variant) {
+        ProgressVariant.LINEAR ->
+          AutoSizingComposable(shadowNodeProxy, axis = EnumSet.of(Direction.VERTICAL)) {
+            val composeColor = color.composeOrNull ?: ProgressIndicatorDefaults.linearColor
+            val trackColor = colors.trackColor.composeOrNull ?: ProgressIndicatorDefaults.linearTrackColor
+            if (progress != null) {
+              LinearProgressIndicator(
+                progress = { progress },
+                color = composeColor,
+                trackColor = trackColor,
+                drawStopIndicator = {},
+              )
+            } else {
+              LinearProgressIndicator(color = composeColor, trackColor = trackColor)
             }
-          ProgressVariant.CIRCULAR ->
-            AutoSizingComposable(shadowNodeProxy) {
-              val composeColor = color.composeOrNull ?: ProgressIndicatorDefaults.circularColor
-              if (progress != null) {
-                CircularProgressIndicator(
-                  progress = { progress },
-                  color = composeColor,
-                  trackColor = colors.trackColor.composeOrNull ?: ProgressIndicatorDefaults.circularDeterminateTrackColor,
-                )
-              } else {
-                CircularProgressIndicator(
-                  color = composeColor,
-                  trackColor = colors.trackColor.composeOrNull ?: ProgressIndicatorDefaults.circularIndeterminateTrackColor,
-                )
-              }
+          }
+        ProgressVariant.CIRCULAR ->
+          AutoSizingComposable(shadowNodeProxy) {
+            val composeColor = color.composeOrNull ?: ProgressIndicatorDefaults.circularColor
+            if (progress != null) {
+              CircularProgressIndicator(
+                progress = { progress },
+                color = composeColor,
+                trackColor = colors.trackColor.composeOrNull ?: ProgressIndicatorDefaults.circularDeterminateTrackColor,
+              )
+            } else {
+              CircularProgressIndicator(
+                color = composeColor,
+                trackColor = colors.trackColor.composeOrNull ?: ProgressIndicatorDefaults.circularIndeterminateTrackColor,
+              )
             }
-        }
+          }
       }
     }
   }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ProgressView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ProgressView.kt
@@ -20,7 +20,7 @@ import java.util.EnumSet
 
 enum class ProgressVariant(val value: String) : Enumerable {
   CIRCULAR("circular"),
-  LINEAR("linear"),
+  LINEAR("linear")
 }
 
 class ProgressColors : Record {
@@ -35,8 +35,8 @@ data class ProgressProps(
   val elementColors: MutableState<ProgressColors> = mutableStateOf(ProgressColors())
 ) : ComposeProps
 
-class ProgressView(context: Context, appContext: AppContext)
-  : ExpoComposeView<ProgressProps>(context, appContext, withHostingView = true) {
+class ProgressView(context: Context, appContext: AppContext) :
+  ExpoComposeView<ProgressProps>(context, appContext, withHostingView = true) {
   override val props = ProgressProps()
 
   @Composable
@@ -56,7 +56,7 @@ class ProgressView(context: Context, appContext: AppContext)
                 progress = { progress },
                 color = composeColor,
                 trackColor = trackColor,
-                drawStopIndicator = {},
+                drawStopIndicator = {}
               )
             } else {
               LinearProgressIndicator(color = composeColor, trackColor = trackColor)
@@ -69,12 +69,12 @@ class ProgressView(context: Context, appContext: AppContext)
               CircularProgressIndicator(
                 progress = { progress },
                 color = composeColor,
-                trackColor = colors.trackColor.composeOrNull ?: ProgressIndicatorDefaults.circularDeterminateTrackColor,
+                trackColor = colors.trackColor.composeOrNull ?: ProgressIndicatorDefaults.circularDeterminateTrackColor
               )
             } else {
               CircularProgressIndicator(
                 color = composeColor,
-                trackColor = colors.trackColor.composeOrNull ?: ProgressIndicatorDefaults.circularIndeterminateTrackColor,
+                trackColor = colors.trackColor.composeOrNull ?: ProgressIndicatorDefaults.circularIndeterminateTrackColor
               )
             }
           }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ShapeView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ShapeView.kt
@@ -14,6 +14,7 @@ import androidx.graphics.shapes.RoundedPolygon
 import androidx.graphics.shapes.toPath
 import androidx.compose.ui.graphics.asComposePath
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.geometry.Size
@@ -43,7 +44,7 @@ data class ShapeProps(
   val innerRadius: MutableState<Float> = mutableFloatStateOf(0.0f),
   val radius: MutableState<Float> = mutableFloatStateOf(0.0f),
   val type: MutableState<ShapeType> = mutableStateOf(ShapeType.CIRCLE),
-  val color: MutableState<GraphicsColor?> = mutableStateOf(null),
+  val color: MutableState<GraphicsColor?> = mutableStateOf(null)
 ) : ComposeProps
 
 private fun Size.centerX() = this.width / 2
@@ -91,7 +92,7 @@ private fun createPolygonPath(size: Size, cornerRounding: Float, smoothing: Floa
     radius = size.minDimension / 2,
     centerX = size.centerX(),
     centerY = size.centerY(),
-    rounding = rounding,
+    rounding = rounding
   ).toPath().asComposePath()
 }
 
@@ -100,7 +101,7 @@ private fun createCirclePath(size: Size, radius: Float, verticesCount: Int): Pat
     centerX = size.centerX(),
     centerY = size.centerY(),
     radius = size.minDimension * 0.5f * radius.coerceAtLeast(0.002f),
-    numVertices = verticesCount.coerceAtLeast(3),
+    numVertices = verticesCount.coerceAtLeast(3)
   ).toPath().asComposePath()
 }
 
@@ -111,39 +112,39 @@ private fun createRectanglePath(size: Size, cornerRounding: Float, smoothing: Fl
     centerY = size.centerY(),
     rounding = rounding,
     width = size.width,
-    height = size.height,
+    height = size.height
   ).toPath().asComposePath()
 }
 
-class ShapeView(context: Context, appContext: AppContext) : ExpoComposeView<ShapeProps>(context, appContext) {
+class ShapeView(context: Context, appContext: AppContext) : ExpoComposeView<ShapeProps>(context, appContext, withHostingView = true) {
   override val props = ShapeProps()
-  init {
-    setContent {
-      val (smoothing) = props.smoothing
-      val (cornerRounding) = props.cornerRounding
-      val (innerRadius) = props.innerRadius
-      val (radius) = props.radius
-      val (shapeType) = props.type
-      val (verticesCount) = props.verticesCount
-      val (color) = props.color
-      Box(
-        modifier = Modifier
-          .drawWithCache {
-            val path = when (shapeType) {
-              ShapeType.STAR -> createStarPath(size = size, cornerRounding = cornerRounding, smoothing = smoothing, innerRadius = innerRadius, radius = radius, verticesCount = verticesCount)
-              ShapeType.PILL_STAR -> createPillStarPath(size = size, cornerRounding = cornerRounding, smoothing = smoothing, innerRadius = innerRadius, verticesCount = verticesCount)
-              ShapeType.PILL -> createPillPath(size = size, smoothing = smoothing)
-              ShapeType.CIRCLE -> createCirclePath(size = size, radius = radius, verticesCount = verticesCount)
-              ShapeType.RECTANGLE -> createRectanglePath(size = size, cornerRounding = cornerRounding, smoothing = smoothing)
-              ShapeType.POLYGON -> createPolygonPath(size = size, cornerRounding = cornerRounding, smoothing = smoothing, verticesCount = verticesCount)
-            }
 
-            onDrawBehind {
-              drawPath(path, color = color.composeOrNull ?: Color.Transparent)
-            }
+  @Composable
+  override fun Content() {
+    val (smoothing) = props.smoothing
+    val (cornerRounding) = props.cornerRounding
+    val (innerRadius) = props.innerRadius
+    val (radius) = props.radius
+    val (shapeType) = props.type
+    val (verticesCount) = props.verticesCount
+    val (color) = props.color
+    Box(
+      modifier = Modifier
+        .drawWithCache {
+          val path = when (shapeType) {
+            ShapeType.STAR -> createStarPath(size = size, cornerRounding = cornerRounding, smoothing = smoothing, innerRadius = innerRadius, radius = radius, verticesCount = verticesCount)
+            ShapeType.PILL_STAR -> createPillStarPath(size = size, cornerRounding = cornerRounding, smoothing = smoothing, innerRadius = innerRadius, verticesCount = verticesCount)
+            ShapeType.PILL -> createPillPath(size = size, smoothing = smoothing)
+            ShapeType.CIRCLE -> createCirclePath(size = size, radius = radius, verticesCount = verticesCount)
+            ShapeType.RECTANGLE -> createRectanglePath(size = size, cornerRounding = cornerRounding, smoothing = smoothing)
+            ShapeType.POLYGON -> createPolygonPath(size = size, cornerRounding = cornerRounding, smoothing = smoothing, verticesCount = verticesCount)
           }
-          .fillMaxSize()
-      )
-    }
+
+          onDrawBehind {
+            drawPath(path, color = color.composeOrNull ?: Color.Transparent)
+          }
+        }
+        .fillMaxSize()
+    )
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SliderView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SliderView.kt
@@ -6,6 +6,7 @@ import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoComposeView
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -40,34 +41,34 @@ data class SliderProps(
   val elementColors: MutableState<SliderColors> = mutableStateOf(SliderColors())
 ) : ComposeProps
 
-class SliderView(context: Context, appContext: AppContext) : ExpoComposeView<SliderProps>(context, appContext) {
+class SliderView(context: Context, appContext: AppContext)
+  : ExpoComposeView<SliderProps>(context, appContext, withHostingView = true) {
   override val props = SliderProps()
   private val onValueChanged by EventDispatcher()
 
-  init {
-    setContent {
-      val (value) = props.value
-      val (min) = props.min
-      val (max) = props.max
-      val (steps) = props.steps
-      val (colors) = props.elementColors
-      DynamicTheme {
-        Slider(
-          value = value.coerceAtLeast(min).coerceAtMost(max),
-          valueRange = min..max,
-          steps = steps,
-          onValueChange = {
-            onValueChanged(mapOf("value" to it))
-          },
-          colors = SliderDefaults.colors(
-            thumbColor = colors.thumbColor.compose,
-            activeTrackColor = colors.activeTrackColor.compose,
-            inactiveTrackColor = colors.inactiveTrackColor.compose,
-            activeTickColor = colors.activeTickColor.compose,
-            inactiveTickColor = colors.inactiveTickColor.compose
-          )
+  @Composable
+  override fun Content() {
+    val (value) = props.value
+    val (min) = props.min
+    val (max) = props.max
+    val (steps) = props.steps
+    val (colors) = props.elementColors
+    DynamicTheme {
+      Slider(
+        value = value.coerceAtLeast(min).coerceAtMost(max),
+        valueRange = min..max,
+        steps = steps,
+        onValueChange = {
+          onValueChanged(mapOf("value" to it))
+        },
+        colors = SliderDefaults.colors(
+          thumbColor = colors.thumbColor.compose,
+          activeTrackColor = colors.activeTrackColor.compose,
+          inactiveTrackColor = colors.inactiveTrackColor.compose,
+          activeTickColor = colors.activeTickColor.compose,
+          inactiveTickColor = colors.inactiveTickColor.compose
         )
-      }
+      )
     }
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SliderView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SliderView.kt
@@ -41,8 +41,8 @@ data class SliderProps(
   val elementColors: MutableState<SliderColors> = mutableStateOf(SliderColors())
 ) : ComposeProps
 
-class SliderView(context: Context, appContext: AppContext)
-  : ExpoComposeView<SliderProps>(context, appContext, withHostingView = true) {
+class SliderView(context: Context, appContext: AppContext) :
+  ExpoComposeView<SliderProps>(context, appContext, withHostingView = true) {
   override val props = SliderProps()
   private val onValueChanged by EventDispatcher()
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
@@ -114,8 +114,8 @@ fun ThemedHybridSwitch(
   }
 }
 
-class SwitchView(context: Context, appContext: AppContext)
-  : ExpoComposeView<SwitchProps>(context, appContext, withHostingView = true) {
+class SwitchView(context: Context, appContext: AppContext) :
+  ExpoComposeView<SwitchProps>(context, appContext, withHostingView = true) {
   override val props = SwitchProps()
   private val onValueChange by EventDispatcher<ValueChangeEvent>()
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.graphics.Color
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
-import expo.modules.kotlin.viewevent.EventDispatcher
-import expo.modules.kotlin.views.ExpoComposeView
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
@@ -13,10 +11,12 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.views.AutoSizingComposable
-import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.viewevent.EventDispatcher
+import expo.modules.kotlin.views.AutoSizingComposable
+import expo.modules.kotlin.views.ComposeProps
+import expo.modules.kotlin.views.ExpoComposeView
 import java.io.Serializable
 
 open class ValueChangeEvent(
@@ -114,22 +114,22 @@ fun ThemedHybridSwitch(
   }
 }
 
-class SwitchView(context: Context, appContext: AppContext) : ExpoComposeView<SwitchProps>(context, appContext) {
+class SwitchView(context: Context, appContext: AppContext)
+  : ExpoComposeView<SwitchProps>(context, appContext, withHostingView = true) {
   override val props = SwitchProps()
   private val onValueChange by EventDispatcher<ValueChangeEvent>()
 
-  init {
-    setContent {
-      val (checked) = props.value
-      val (variant) = props.variant
-      val (colors) = props.elementColors
-      val onCheckedChange = { checked: Boolean ->
-        onValueChange(ValueChangeEvent(checked))
-      }
+  @Composable
+  override fun Content() {
+    val (checked) = props.value
+    val (variant) = props.variant
+    val (colors) = props.elementColors
+    val onCheckedChange = { checked: Boolean ->
+      onValueChange(ValueChangeEvent(checked))
+    }
 
-      AutoSizingComposable(shadowNodeProxy) {
-        ThemedHybridSwitch(variant, checked, onCheckedChange, colors)
-      }
+    AutoSizingComposable(shadowNodeProxy) {
+      ThemedHybridSwitch(variant, checked, onCheckedChange, colors)
     }
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TextInputView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TextInputView.kt
@@ -23,14 +23,13 @@ import expo.modules.kotlin.views.AutoSizingComposable
 import expo.modules.kotlin.views.Direction
 import java.util.EnumSet
 
-
 data class TextInputProps(
   val defaultValue: MutableState<String> = mutableStateOf(""),
   val placeholder: MutableState<String> = mutableStateOf(""),
   val multiline: MutableState<Boolean> = mutableStateOf(false),
   val numberOfLines: MutableState<Int?> = mutableStateOf(null),
   val keyboardType: MutableState<String> = mutableStateOf("default"),
-  val autocorrection: MutableState<Boolean> = mutableStateOf(true),
+  val autocorrection: MutableState<Boolean> = mutableStateOf(true)
 ) : ComposeProps
 
 fun String.keyboardType(): KeyboardType {
@@ -48,8 +47,8 @@ fun String.keyboardType(): KeyboardType {
   }
 }
 
-class TextInputView(context: Context, appContext: AppContext)
-  : ExpoComposeView<TextInputProps>(context, appContext, withHostingView = true) {
+class TextInputView(context: Context, appContext: AppContext) :
+  ExpoComposeView<TextInputProps>(context, appContext, withHostingView = true) {
   override val props = TextInputProps()
   private val onValueChanged by EventDispatcher()
 
@@ -68,8 +67,8 @@ class TextInputView(context: Context, appContext: AppContext)
         singleLine = !props.multiline.value,
         keyboardOptions = KeyboardOptions.Default.copy(
           keyboardType = props.keyboardType.value.keyboardType(),
-          autoCorrectEnabled = props.autocorrection.value,
-        ),
+          autoCorrectEnabled = props.autocorrection.value
+        )
       )
     }
   }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TextInputView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TextInputView.kt
@@ -8,6 +8,7 @@ import expo.modules.kotlin.views.ExpoComposeView
 
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 
@@ -47,29 +48,29 @@ fun String.keyboardType(): KeyboardType {
   }
 }
 
-class TextInputView(context: Context, appContext: AppContext) : ExpoComposeView<TextInputProps>(context, appContext) {
+class TextInputView(context: Context, appContext: AppContext)
+  : ExpoComposeView<TextInputProps>(context, appContext, withHostingView = true) {
   override val props = TextInputProps()
   private val onValueChanged by EventDispatcher()
 
-  init {
-    setContent {
-      var value by remember { props.defaultValue }
-      AutoSizingComposable(shadowNodeProxy, axis = EnumSet.of(Direction.VERTICAL)) {
-        TextField(
-          value = value,
-          onValueChange = {
-            value = it
-            onValueChanged(mapOf("value" to it))
-          },
-          placeholder = { Text(props.placeholder.value) },
-          maxLines = if (props.multiline.value) props.numberOfLines.value ?: Int.MAX_VALUE else 1,
-          singleLine = !props.multiline.value,
-          keyboardOptions = KeyboardOptions.Default.copy(
-            keyboardType = props.keyboardType.value.keyboardType(),
-            autoCorrectEnabled = props.autocorrection.value,
-          ),
-        )
-      }
+  @Composable
+  override fun Content() {
+    var value by remember { props.defaultValue }
+    AutoSizingComposable(shadowNodeProxy, axis = EnumSet.of(Direction.VERTICAL)) {
+      TextField(
+        value = value,
+        onValueChange = {
+          value = it
+          onValueChanged(mapOf("value" to it))
+        },
+        placeholder = { Text(props.placeholder.value) },
+        maxLines = if (props.multiline.value) props.numberOfLines.value ?: Int.MAX_VALUE else 1,
+        singleLine = !props.multiline.value,
+        keyboardOptions = KeyboardOptions.Default.copy(
+          keyboardType = props.keyboardType.value.keyboardType(),
+          autoCorrectEnabled = props.autocorrection.value,
+        ),
+      )
     }
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
@@ -127,8 +127,8 @@ fun StyledButton(variant: ButtonVariant, colors: ButtonColors, disabled: Boolean
   }
 }
 
-class Button(context: Context, appContext: AppContext)
-  : ExpoComposeView<ButtonProps>(context, appContext, withHostingView = true) {
+class Button(context: Context, appContext: AppContext) :
+  ExpoComposeView<ButtonProps>(context, appContext, withHostingView = true) {
   override val props = ButtonProps()
   private val onButtonPressed by EventDispatcher<ButtonPressedEvent>()
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
@@ -127,41 +127,43 @@ fun StyledButton(variant: ButtonVariant, colors: ButtonColors, disabled: Boolean
   }
 }
 
-class Button(context: Context, appContext: AppContext) : ExpoComposeView<ButtonProps>(context, appContext) {
+class Button(context: Context, appContext: AppContext)
+  : ExpoComposeView<ButtonProps>(context, appContext, withHostingView = true) {
   override val props = ButtonProps()
   private val onButtonPressed by EventDispatcher<ButtonPressedEvent>()
 
   init {
     clipToPadding = false // needed for elevated buttons to work
     clipChildren = false
+  }
 
-    setContent {
-      val (variant) = props.variant
-      val (text) = props.text
-      val (colors) = props.elementColors
-      val (systemImage) = props.systemImage
-      val (disabled) = props.disabled
-      DynamicTheme {
-        StyledButton(
-          variant ?: ButtonVariant.DEFAULT,
-          colors,
-          disabled,
-          { onButtonPressed.invoke(ButtonPressedEvent()) }
-        ) {
-          if (systemImage != null) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-              getImageVector(systemImage)?.let {
-                Icon(
-                  it,
-                  contentDescription = systemImage,
-                  modifier = Modifier.padding(end = 8.dp)
-                )
-              }
-              Text(text)
+  @Composable
+  override fun Content() {
+    val (variant) = props.variant
+    val (text) = props.text
+    val (colors) = props.elementColors
+    val (systemImage) = props.systemImage
+    val (disabled) = props.disabled
+    DynamicTheme {
+      StyledButton(
+        variant ?: ButtonVariant.DEFAULT,
+        colors,
+        disabled,
+        { onButtonPressed.invoke(ButtonPressedEvent()) }
+      ) {
+        if (systemImage != null) {
+          Row(verticalAlignment = Alignment.CenterVertically) {
+            getImageVector(systemImage)?.let {
+              Icon(
+                it,
+                contentDescription = systemImage,
+                modifier = Modifier.padding(end = 8.dp)
+              )
             }
-          } else {
             Text(text)
           }
+        } else {
+          Text(text)
         }
       }
     }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/ContextMenu.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/ContextMenu.kt
@@ -114,8 +114,8 @@ data class ContextMenuDispatchers(
   val switchCheckedChanged: ViewEventCallback<ContextMenuSwitchValueChangeEvent>
 )
 
-class ContextMenu(context: Context, appContext: AppContext)
-  : ExpoComposeView<ContextMenuProps>(context, appContext, withHostingView = true) {
+class ContextMenu(context: Context, appContext: AppContext) :
+  ExpoComposeView<ContextMenuProps>(context, appContext, withHostingView = true) {
   override val props = ContextMenuProps()
   val expanded = mutableStateOf(false)
   val onContextMenuButtonPressed by EventDispatcher<ContextMenuButtonPressedEvent>()

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/ContextMenu.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/ContextMenu.kt
@@ -114,7 +114,8 @@ data class ContextMenuDispatchers(
   val switchCheckedChanged: ViewEventCallback<ContextMenuSwitchValueChangeEvent>
 )
 
-class ContextMenu(context: Context, appContext: AppContext) : ExpoComposeView<ContextMenuProps>(context, appContext) {
+class ContextMenu(context: Context, appContext: AppContext)
+  : ExpoComposeView<ContextMenuProps>(context, appContext, withHostingView = true) {
   override val props = ContextMenuProps()
   val expanded = mutableStateOf(false)
   val onContextMenuButtonPressed by EventDispatcher<ContextMenuButtonPressedEvent>()
@@ -146,30 +147,29 @@ class ContextMenu(context: Context, appContext: AppContext) : ExpoComposeView<Co
     return super.dispatchTouchEvent(ev)
   }
 
-  init {
-    setContent {
-      var elements by remember { props.elements }
-      val color by remember { props.color }
+  @Composable
+  override fun Content() {
+    var elements by remember { props.elements }
+    val color by remember { props.color }
 
-      return@setContent Box {
-        DynamicTheme {
-          DropdownMenu(
-            containerColor = color?.composeOrNull ?: MenuDefaults.containerColor,
-            expanded = expanded.value,
-            onDismissRequest = {
-              expanded.value = !expanded.value
-            }
-          ) {
-            FlatMenu(
-              elements,
-              null,
-              dispatchers = ContextMenuDispatchers(
-                buttonPressed = onContextMenuButtonPressed,
-                switchCheckedChanged = onContextMenuSwitchValueChanged
-              ),
-              expanded = expanded
-            )
+    return Box {
+      DynamicTheme {
+        DropdownMenu(
+          containerColor = color?.composeOrNull ?: MenuDefaults.containerColor,
+          expanded = expanded.value,
+          onDismissRequest = {
+            expanded.value = !expanded.value
           }
+        ) {
+          FlatMenu(
+            elements,
+            null,
+            dispatchers = ContextMenuDispatchers(
+              buttonPressed = onContextMenuButtonPressed,
+              switchCheckedChanged = onContextMenuSwitchValueChanged
+            ),
+            expanded = expanded
+          )
         }
       }
     }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/ContextMenuRecords.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/ContextMenuRecords.kt
@@ -42,7 +42,7 @@ class ContextMenuButtonProps(
   @Field val text: String = "",
   @Field val variant: ButtonVariant? = ButtonVariant.DEFAULT,
   @Field val elementColors: ButtonColors = ButtonColors(),
-  @Field val disabled: Boolean = false,
+  @Field val disabled: Boolean = false
 ) : Record, Serializable
 
 class ContextMenuSwitchProps(


### PR DESCRIPTION
# Why

resolve breaking change from #36256 for exisitng views

# How

- add `withHostingView = true` to `ExpoComposeView`
- replace `init { setContent { ... } }` to `@Composable override fun Content() { ... }`

# Test Plan

- ci passed
- test ui test cases in ncl

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
