### PR TITLE
[docs] Collapse third-level nested items in TOC for improved visibility in Reference

### DIFF
--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -44,6 +44,7 @@ export const TableOfContents = forwardRef<
   const router = useRouter();
   const isVersioned = isVersionedPath(router?.pathname ?? '');
   const [activeSlug, setActiveSlug] = useState<string | null>(null);
+  const [activeParentSlug, setActiveParentSlug] = useState<string | null>(null);
   const [showScrollTop, setShowScrollTop] = useState(false);
   const [reducedMotion, setReducedMotion] = useState(false);
   const [collapsedH3s, setCollapsedH3s] = useState<Set<string>>(() =>
@@ -84,31 +85,24 @@ export const TableOfContents = forwardRef<
           contentScrollPosition + window.innerHeight * ACTIVE_ITEM_OFFSET_FACTOR &&
         ref.current.offsetTop <= contentScrollPosition + window.innerHeight / 2;
 
-      if (isInView) {
-        if (isVersioned && level > BASE_HEADING_LEVEL + 1) {
+      if (isInView && isVersioned) {
+        if (level > BASE_HEADING_LEVEL + 1) {
           const currentIndex = headings.findIndex(h => h.slug === slug);
           for (let i = currentIndex; i >= 0; i--) {
             const h = headings[i];
             if (h.level === BASE_HEADING_LEVEL + 1) {
-              if (collapsedH3s.has(h.slug)) {
-                if (h.slug !== activeSlug) {
-                  if (h.slug === slugScrollingTo.current) {
-                    slugScrollingTo.current = null;
-                  }
-                  setActiveSlug(h.slug);
-                  updateSelfScroll();
-                }
-                return;
-              }
-              break;
+              setActiveParentSlug(h.slug);
+              setActiveSlug(slug);
+              updateSelfScroll();
+              return;
             }
           }
         }
-
         if (slug !== activeSlug) {
           if (slug === slugScrollingTo.current) {
             slugScrollingTo.current = null;
           }
+          setActiveParentSlug(null);
           setActiveSlug(slug);
           updateSelfScroll();
         }
@@ -195,7 +189,7 @@ export const TableOfContents = forwardRef<
     let currentH3: string | null = null;
 
     return displayedHeadings.map((heading, index) => {
-      const isActive = heading.slug === activeSlug;
+      const isActive = heading.slug === activeSlug || heading.slug === activeParentSlug;
       const isH3 = heading.level === BASE_HEADING_LEVEL + 1;
 
       if (isH3 && isVersioned) {

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -12,6 +12,9 @@ import {
   useImperativeHandle,
   useEffect,
 } from 'react';
+import { useRouter } from 'next/router';
+
+import { isVersionedPath } from '~/common/routes';
 
 import { BASE_HEADING_LEVEL, Heading } from '~/common/headingManager';
 import { prefersReducedMotion } from '~/common/window';
@@ -39,11 +42,15 @@ export const TableOfContents = forwardRef<
   TableOfContentsHandles,
   HeadingManagerProps & TableOfContentsProps
 >(({ headingManager: { headings }, contentRef, selfRef, maxNestingDepth = 4 }, ref) => {
+  const router = useRouter();
+  const isVersioned = isVersionedPath(router.pathname);
   const [activeSlug, setActiveSlug] = useState<string | null>(null);
   const [showScrollTop, setShowScrollTop] = useState(false);
   const [reducedMotion, setReducedMotion] = useState(false);
-  const [collapsedH3s, setCollapsedH3s] = useState<Set<string>>(
-    () => new Set(headings.filter(h => h.level === BASE_HEADING_LEVEL + 1).map(h => h.slug))
+  const [collapsedH3s, setCollapsedH3s] = useState<Set<string>>(() =>
+    isVersioned
+      ? new Set(headings.filter(h => h.level === BASE_HEADING_LEVEL + 1).map(h => h.slug))
+      : new Set()
   );
 
   const slugScrollingTo = useRef<string | null>(null);
@@ -171,7 +178,7 @@ export const TableOfContents = forwardRef<
       const isActive = heading.slug === activeSlug;
       const isH3 = heading.level === BASE_HEADING_LEVEL + 1;
 
-      if (isH3) {
+      if (isH3 && isVersioned) {
         currentH3 = heading.slug;
       } else if (heading.level <= BASE_HEADING_LEVEL) {
         currentH3 = null;
@@ -207,10 +214,10 @@ export const TableOfContents = forwardRef<
             'flex items-center',
             currentH3 && heading.level > BASE_HEADING_LEVEL + 2 && 'ml-0'
           )}>
-          {hasChildren && (
+          {hasChildren && isVersioned && (
             <div
               onClick={e => toggleH3(heading.slug, e)}
-              className="flex h-full items-center justify-center self-start pt-[3px]">
+              className="flex h-full items-center justify-center self-start pt-[4px]">
               <ChevronDownIcon
                 className={mergeClasses(
                   'icon-xs -mr-2 text-icon-secondary transition-transform',

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -1,7 +1,8 @@
 import { Button, mergeClasses } from '@expo/styleguide';
 import { ArrowCircleUpIcon } from '@expo/styleguide-icons/outline/ArrowCircleUpIcon';
-import { LayoutAlt03Icon } from '@expo/styleguide-icons/outline/LayoutAlt03Icon';
 import { ChevronDownIcon } from '@expo/styleguide-icons/outline/ChevronDownIcon';
+import { LayoutAlt03Icon } from '@expo/styleguide-icons/outline/LayoutAlt03Icon';
+import { useRouter } from 'next/compat/router';
 import {
   PropsWithChildren,
   RefObject,
@@ -12,11 +13,9 @@ import {
   useImperativeHandle,
   useEffect,
 } from 'react';
-import { useRouter } from 'next/compat/router';
-
-import { isVersionedPath } from '~/common/routes';
 
 import { BASE_HEADING_LEVEL, Heading } from '~/common/headingManager';
+import { isVersionedPath } from '~/common/routes';
 import { prefersReducedMotion } from '~/common/window';
 import { HeadingManagerProps, HeadingsContext } from '~/common/withHeadingManager';
 import { ScrollContainer } from '~/components/ScrollContainer';
@@ -205,7 +204,7 @@ export const TableOfContents = forwardRef<
         currentH3 = null;
       }
 
-      const parentH3 = currentH3 || '';
+      const parentH3 = currentH3 ?? '';
       const shouldHide =
         Boolean(currentH3) && heading.level > BASE_HEADING_LEVEL + 1 && collapsedH3s.has(parentH3);
 
@@ -237,7 +236,9 @@ export const TableOfContents = forwardRef<
           )}>
           {hasChildren && isVersioned && (
             <div
-              onClick={e => toggleH3(heading.slug, e)}
+              onClick={event => {
+                toggleH3(heading.slug, event);
+              }}
               className="flex h-full cursor-pointer items-center justify-center self-start pt-[4px] hover:opacity-70">
               <ChevronDownIcon
                 className={mergeClasses(

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -3,7 +3,7 @@ import { ArrowCircleUpIcon } from '@expo/styleguide-icons/outline/ArrowCircleUpI
 import { ChevronDownIcon } from '@expo/styleguide-icons/outline/ChevronDownIcon';
 import { ChevronRightIcon } from '@expo/styleguide-icons/outline/ChevronRightIcon';
 import { LayoutAlt03Icon } from '@expo/styleguide-icons/outline/LayoutAlt03Icon';
-import { useRouter } from 'next/router';
+import { useRouter } from 'next/compat/router';
 import {
   PropsWithChildren,
   RefObject,
@@ -53,7 +53,7 @@ export const TableOfContents = forwardRef<
   const hasInitialized = useRef(false);
 
   const router = useRouter();
-  const isVersionsPath = router.asPath.startsWith('/versions/');
+  const isVersionsPath = router?.asPath?.startsWith('/versions/');
 
   const slugScrollingTo = useRef<string | null>(null);
   const activeItemRef = useRef<HTMLAnchorElement | null>(null);

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -68,7 +68,6 @@ export const TableOfContents = forwardRef<
     function didActiveSlugChanged() {
       updateSelfScroll();
 
-      // Auto-expand the group that contains the active heading when in versions path
       if (isVersionsPath && activeSlug && groupedHeadings) {
         for (const group of groupedHeadings) {
           const childInGroup = group.children.find(child => child.slug === activeSlug);
@@ -176,7 +175,6 @@ export const TableOfContents = forwardRef<
       head.level <= BASE_HEADING_LEVEL + maxNestingDepth && head.title.toLowerCase() !== 'see also'
   );
 
-  // Group headings for versions pages
   const groupedHeadings = useMemo(() => {
     if (!isVersionsPath) {
       return null;
@@ -185,17 +183,14 @@ export const TableOfContents = forwardRef<
     const groups: GroupedHeading[] = [];
     const level1And2Headings = displayedHeadings.filter(h => h.level <= BASE_HEADING_LEVEL + 1);
 
-    // Find level 2 headings (components, props, etc.)
     const parentHeadings = level1And2Headings.filter(h => h.level === BASE_HEADING_LEVEL + 1);
 
-    // Group children under their parents
     for (const parent of parentHeadings) {
       const parentIndex = displayedHeadings.findIndex(h => h.slug === parent.slug);
       if (parentIndex === -1) {
         continue;
       }
 
-      // Find all child headings that follow this parent until the next parent
       const childHeadings: Heading[] = [];
       let i = parentIndex + 1;
 
@@ -241,9 +236,7 @@ export const TableOfContents = forwardRef<
       </CALLOUT>
 
       {isVersionsPath && groupedHeadings ? (
-        // Render using collapsible groups for /versions/ pages
         <>
-          {/* First render any headings that come before the first group */}
           {displayedHeadings
             .slice(
               0,
@@ -264,8 +257,6 @@ export const TableOfContents = forwardRef<
                 />
               );
             })}
-
-          {/* Then render the grouped headings */}
           {groupedHeadings.map(group => {
             const isParentActive = group.parent.slug === activeSlug;
             const isGroupExpanded = !!expandedGroups[group.parent.slug];
@@ -321,22 +312,25 @@ export const TableOfContents = forwardRef<
             );
           })}
 
-          {/* Finally render any headings that come after the last group */}
           {(() => {
+            if (groupedHeadings.length === 0) {
+              return null;
+            }
+
+            const lastGroup = groupedHeadings.at(-1)!;
             const lastGroupIndex = displayedHeadings.findIndex(
-              h => groupedHeadings.length > 0 && groupedHeadings.at(-1).parent.slug === h.slug
+              h => h.slug === lastGroup.parent.slug
             );
 
             if (lastGroupIndex === -1) {
               return null;
             }
 
-            // Find where the last group's children end
             let lastChildIndex = lastGroupIndex;
-            const lastGroup = groupedHeadings.at(-1);
+
             if (lastGroup.children.length > 0) {
-              const lastChildSlug = lastGroup.children.at(-1).slug;
-              lastChildIndex = displayedHeadings.findIndex(h => h.slug === lastChildSlug);
+              const lastChild = lastGroup.children.at(-1)!;
+              lastChildIndex = displayedHeadings.findIndex(h => h.slug === lastChild.slug);
             }
 
             return displayedHeadings.slice(lastChildIndex + 1).map(heading => {

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -12,7 +12,7 @@ import {
   useImperativeHandle,
   useEffect,
 } from 'react';
-import { useRouter } from 'next/router';
+import { useRouter } from 'next/compat/router';
 
 import { isVersionedPath } from '~/common/routes';
 
@@ -43,7 +43,7 @@ export const TableOfContents = forwardRef<
   HeadingManagerProps & TableOfContentsProps
 >(({ headingManager: { headings }, contentRef, selfRef, maxNestingDepth = 4 }, ref) => {
   const router = useRouter();
-  const isVersioned = isVersionedPath(router.pathname);
+  const isVersioned = isVersionedPath(router?.pathname ?? '');
   const [activeSlug, setActiveSlug] = useState<string | null>(null);
   const [showScrollTop, setShowScrollTop] = useState(false);
   const [reducedMotion, setReducedMotion] = useState(false);

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -272,7 +272,7 @@ export const TableOfContents = forwardRef<
                 <div
                   className="group flex cursor-pointer items-center"
                   onClick={() => toggleGroup(group.parent.slug)}>
-                  <div className="flex size-[2] items-center justify-center">
+                  <div className="flex h-full items-center justify-center self-start pt-[5px]">
                     {isGroupExpanded ? (
                       <ChevronDownIcon className="icon-xs text-icon-secondary" />
                     ) : (
@@ -298,7 +298,7 @@ export const TableOfContents = forwardRef<
                   group.children.map(child => {
                     const isChildActive = child.slug === activeSlug;
                     return (
-                      <div className="ml-4" key={child.slug}>
+                      <div className="ml-3" key={child.slug}>
                         <TableOfContentsLink
                           key={child.slug}
                           heading={child}

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -1,4 +1,4 @@
-import { Button, mergeClasses } from '@expo/styleguide';
+import { Button, ButtonBase, mergeClasses } from '@expo/styleguide';
 import { ArrowCircleUpIcon } from '@expo/styleguide-icons/outline/ArrowCircleUpIcon';
 import { ChevronDownIcon } from '@expo/styleguide-icons/outline/ChevronDownIcon';
 import { LayoutAlt03Icon } from '@expo/styleguide-icons/outline/LayoutAlt03Icon';
@@ -12,6 +12,7 @@ import {
   useRef,
   useImperativeHandle,
   useEffect,
+  SyntheticEvent,
 } from 'react';
 
 import { BASE_HEADING_LEVEL, Heading } from '~/common/headingManager';
@@ -166,7 +167,7 @@ export const TableOfContents = forwardRef<
     }
   }
 
-  const toggleH3 = (slug: string, event: MouseEvent) => {
+  const toggleH3 = (slug: string, event: SyntheticEvent) => {
     event.preventDefault();
     event.stopPropagation();
     setCollapsedH3s(prev => {
@@ -226,21 +227,31 @@ export const TableOfContents = forwardRef<
           key={heading.slug}
           className={mergeClasses(
             'flex items-center',
-            currentH3 && heading.level > BASE_HEADING_LEVEL + 2 && 'ml-0'
+            currentH3 && heading.level > BASE_HEADING_LEVEL + 2 && 'ml-0',
+            hasChildren && isVersioned && '-ml-2'
           )}>
           {hasChildren && isVersioned && (
-            <div
+            <ButtonBase
               onClick={event => {
                 toggleH3(heading.slug, event);
               }}
-              className="flex h-full cursor-pointer items-center justify-center self-start pt-[4px] hover:opacity-70">
+              onKeyDown={event => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  toggleH3(heading.slug, event);
+                }
+              }}
+              aria-expanded={!collapsedH3s.has(heading.slug)}
+              aria-controls={`toc-section-${heading.slug}`}
+              className="-mr-2 flex h-full cursor-pointer items-center justify-center self-start pt-0.5 hocus:opacity-75"
+              aria-label={`${collapsedH3s.has(heading.slug) ? 'Expand' : 'Collapse'} section ${heading.title}`}>
               <ChevronDownIcon
                 className={mergeClasses(
-                  'icon-xs -mr-2 text-icon-secondary transition-transform',
+                  'icon-sm text-icon-secondary transition-transform',
                   collapsedH3s.has(heading.slug) ? '-rotate-90' : 'rotate-0'
                 )}
               />
-            </div>
+            </ButtonBase>
           )}
           <TableOfContentsLink
             heading={heading}
@@ -276,7 +287,7 @@ export const TableOfContents = forwardRef<
           <ArrowCircleUpIcon className="icon-sm text-icon-secondary" aria-label="Scroll to top" />
         </Button>
       </CALLOUT>
-      {renderTOC()}
+      <div role="tree">{renderTOC()}</div>
     </nav>
   );
 });

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -1,8 +1,8 @@
 import { Button, mergeClasses } from '@expo/styleguide';
 import { ArrowCircleUpIcon } from '@expo/styleguide-icons/outline/ArrowCircleUpIcon';
-import { LayoutAlt03Icon } from '@expo/styleguide-icons/outline/LayoutAlt03Icon';
 import { ChevronDownIcon } from '@expo/styleguide-icons/outline/ChevronDownIcon';
 import { ChevronRightIcon } from '@expo/styleguide-icons/outline/ChevronRightIcon';
+import { LayoutAlt03Icon } from '@expo/styleguide-icons/outline/LayoutAlt03Icon';
 import { useRouter } from 'next/router';
 import {
   PropsWithChildren,
@@ -178,7 +178,9 @@ export const TableOfContents = forwardRef<
 
   // Group headings for versions pages
   const groupedHeadings = useMemo(() => {
-    if (!isVersionsPath) return null;
+    if (!isVersionsPath) {
+      return null;
+    }
 
     const groups: GroupedHeading[] = [];
     const level1And2Headings = displayedHeadings.filter(h => h.level <= BASE_HEADING_LEVEL + 1);
@@ -189,7 +191,9 @@ export const TableOfContents = forwardRef<
     // Group children under their parents
     for (const parent of parentHeadings) {
       const parentIndex = displayedHeadings.findIndex(h => h.slug === parent.slug);
-      if (parentIndex === -1) continue;
+      if (parentIndex === -1) {
+        continue;
+      }
 
       // Find all child headings that follow this parent until the next parent
       const childHeadings: Heading[] = [];
@@ -265,14 +269,15 @@ export const TableOfContents = forwardRef<
           {groupedHeadings.map(group => {
             const isParentActive = group.parent.slug === activeSlug;
             const isGroupExpanded = !!expandedGroups[group.parent.slug];
-            const hasActiveChild = group.children.some(child => child.slug === activeSlug);
 
             return (
               <div key={group.parent.slug}>
                 <div
                   className="group flex cursor-pointer items-center"
-                  onClick={() => toggleGroup(group.parent.slug)}>
-                  <div className="flex h-full items-center justify-center self-start pt-[5px]">
+                  onClick={() => {
+                    toggleGroup(group.parent.slug);
+                  }}>
+                  <div className="flex h-full items-center justify-center self-start pt-[4px]">
                     {isGroupExpanded ? (
                       <ChevronDownIcon className="icon-xs text-icon-secondary" />
                     ) : (
@@ -319,18 +324,18 @@ export const TableOfContents = forwardRef<
           {/* Finally render any headings that come after the last group */}
           {(() => {
             const lastGroupIndex = displayedHeadings.findIndex(
-              h =>
-                groupedHeadings.length > 0 &&
-                groupedHeadings[groupedHeadings.length - 1].parent.slug === h.slug
+              h => groupedHeadings.length > 0 && groupedHeadings.at(-1).parent.slug === h.slug
             );
 
-            if (lastGroupIndex === -1) return null;
+            if (lastGroupIndex === -1) {
+              return null;
+            }
 
             // Find where the last group's children end
             let lastChildIndex = lastGroupIndex;
-            const lastGroup = groupedHeadings[groupedHeadings.length - 1];
+            const lastGroup = groupedHeadings.at(-1);
             if (lastGroup.children.length > 0) {
-              const lastChildSlug = lastGroup.children[lastGroup.children.length - 1].slug;
+              const lastChildSlug = lastGroup.children.at(-1).slug;
               lastChildIndex = displayedHeadings.findIndex(h => h.slug === lastChildSlug);
             }
 

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -1,7 +1,6 @@
 import { Button, mergeClasses } from '@expo/styleguide';
 import { ArrowCircleUpIcon } from '@expo/styleguide-icons/outline/ArrowCircleUpIcon';
 import { ChevronDownIcon } from '@expo/styleguide-icons/outline/ChevronDownIcon';
-import { ChevronRightIcon } from '@expo/styleguide-icons/outline/ChevronRightIcon';
 import { LayoutAlt03Icon } from '@expo/styleguide-icons/outline/LayoutAlt03Icon';
 import { useRouter } from 'next/compat/router';
 import {
@@ -303,11 +302,12 @@ export const TableOfContents = forwardRef<
                     toggleGroup(group.parent.slug);
                   }}>
                   <div className="flex h-full items-center justify-center self-start pt-[4px]">
-                    {isGroupExpanded ? (
-                      <ChevronDownIcon className="icon-xs text-icon-secondary" />
-                    ) : (
-                      <ChevronRightIcon className="icon-xs text-icon-secondary" />
-                    )}
+                    <ChevronDownIcon
+                      className={mergeClasses(
+                        'icon-xs text-icon-secondary transition-transform duration-150',
+                        !isGroupExpanded && '-rotate-90'
+                      )}
+                    />
                   </div>
                   <div className="w-full">
                     <TableOfContentsLink

--- a/docs/ui/components/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
+++ b/docs/ui/components/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
@@ -60,42 +60,54 @@ exports[`TableOfContents correctly matches snapshot 1`] = `
         </span>
       </button>
     </p>
-    <a
-      class="mb-1.5 flex items-center justify-between truncate !text-pretty focus-visible:relative focus-visible:z-10"
-      data-state="closed"
-      href="#base-level-heading"
+    <div
+      class="flex items-center"
     >
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full !text-secondary hocus:!text-link"
-        data-text="true"
+      <a
+        class="mb-1.5 flex items-center justify-between truncate !text-pretty focus-visible:relative focus-visible:z-10"
+        data-state="closed"
+        href="#base-level-heading"
       >
-        Base level heading
-      </p>
-    </a>
-    <a
-      class="mb-1.5 flex items-center justify-between truncate !text-pretty pl-3 focus-visible:relative focus-visible:z-10"
-      data-state="closed"
-      href="#level-3-subheading"
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full !text-secondary hocus:!text-link"
+          data-text="true"
+        >
+          Base level heading
+        </p>
+      </a>
+    </div>
+    <div
+      class="flex items-center"
     >
-      <p
-        class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full !text-secondary hocus:!text-link"
-        data-text="true"
+      <a
+        class="mb-1.5 flex items-center justify-between truncate !text-pretty pl-3 focus-visible:relative focus-visible:z-10"
+        data-state="closed"
+        href="#level-3-subheading"
       >
-        Level 3 subheading
-      </p>
-    </a>
-    <a
-      class="mb-1.5 flex items-center justify-between truncate !text-pretty pl-3 focus-visible:relative focus-visible:z-10"
-      data-state="closed"
-      href="#code-heading-depth-1"
+        <p
+          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full !text-secondary hocus:!text-link"
+          data-text="true"
+        >
+          Level 3 subheading
+        </p>
+      </a>
+    </div>
+    <div
+      class="flex items-center"
     >
-      <code
-        class="leading-[1.6154] text-default w-full !text-secondary hocus:!text-link truncate !text-2xs"
-        data-text="true"
+      <a
+        class="mb-1.5 flex items-center justify-between truncate !text-pretty pl-3 focus-visible:relative focus-visible:z-10"
+        data-state="closed"
+        href="#code-heading-depth-1"
       >
-        Code heading depth 1
-      </code>
-    </a>
+        <code
+          class="leading-[1.6154] text-default w-full !text-secondary hocus:!text-link truncate !text-2xs"
+          data-text="true"
+        >
+          Code heading depth 1
+        </code>
+      </a>
+    </div>
   </nav>
 </div>
 `;

--- a/docs/ui/components/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
+++ b/docs/ui/components/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
@@ -61,52 +61,56 @@ exports[`TableOfContents correctly matches snapshot 1`] = `
       </button>
     </p>
     <div
-      class="flex items-center"
+      role="tree"
     >
-      <a
-        class="mb-1.5 flex items-center justify-between truncate !text-pretty focus-visible:relative focus-visible:z-10"
-        data-state="closed"
-        href="#base-level-heading"
+      <div
+        class="flex items-center"
       >
-        <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full !text-secondary hocus:!text-link"
-          data-text="true"
+        <a
+          class="mb-1.5 flex items-center justify-between truncate !text-pretty focus-visible:relative focus-visible:z-10"
+          data-state="closed"
+          href="#base-level-heading"
         >
-          Base level heading
-        </p>
-      </a>
-    </div>
-    <div
-      class="flex items-center"
-    >
-      <a
-        class="mb-1.5 flex items-center justify-between truncate !text-pretty pl-3 focus-visible:relative focus-visible:z-10"
-        data-state="closed"
-        href="#level-3-subheading"
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full !text-secondary hocus:!text-link"
+            data-text="true"
+          >
+            Base level heading
+          </p>
+        </a>
+      </div>
+      <div
+        class="flex items-center"
       >
-        <p
-          class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full !text-secondary hocus:!text-link"
-          data-text="true"
+        <a
+          class="mb-1.5 flex items-center justify-between truncate !text-pretty pl-3 focus-visible:relative focus-visible:z-10"
+          data-state="closed"
+          href="#level-3-subheading"
         >
-          Level 3 subheading
-        </p>
-      </a>
-    </div>
-    <div
-      class="flex items-center"
-    >
-      <a
-        class="mb-1.5 flex items-center justify-between truncate !text-pretty pl-3 focus-visible:relative focus-visible:z-10"
-        data-state="closed"
-        href="#code-heading-depth-1"
+          <p
+            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full !text-secondary hocus:!text-link"
+            data-text="true"
+          >
+            Level 3 subheading
+          </p>
+        </a>
+      </div>
+      <div
+        class="flex items-center"
       >
-        <code
-          class="leading-[1.6154] text-default w-full !text-secondary hocus:!text-link truncate !text-2xs"
-          data-text="true"
+        <a
+          class="mb-1.5 flex items-center justify-between truncate !text-pretty pl-3 focus-visible:relative focus-visible:z-10"
+          data-state="closed"
+          href="#code-heading-depth-1"
         >
-          Code heading depth 1
-        </code>
-      </a>
+          <code
+            class="leading-[1.6154] text-default w-full !text-secondary hocus:!text-link truncate !text-2xs"
+            data-text="true"
+          >
+            Code heading depth 1
+          </code>
+        </a>
+      </div>
     </div>
   </nav>
 </div>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15427

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update `TableOfContents` component to allow collapsing third-level nested items and support grouped headings for versioned paths. The position of the icon and the rotation follow the same pattern that we have in the main sidebar.  These changes improve the usability of the `TableOfContents` component for Reference docs with nested headings.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview:


## Preview

https://github.com/user-attachments/assets/80291280-eae2-4acd-952c-99c769e9978a




# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
