### PR TITLE
feat(eslint): use react/recommended

### DIFF
--- a/packages/eslint-config-expo/CHANGELOG.md
+++ b/packages/eslint-config-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- use `react/recommended` plugin. ([#36265](https://github.com/expo/expo/pull/36265) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/eslint-config-expo/flat/utils/react.js
+++ b/packages/eslint-config-expo/flat/utils/react.js
@@ -23,26 +23,13 @@ module.exports = [
     },
 
     rules: {
+      ...pluginReact.configs.recommended.rules,
       ...pluginReactHooks.configs.recommended.rules,
-      'react/display-name': 'warn',
-      'react/jsx-no-duplicate-props': 'error',
-      'react/jsx-no-undef': 'error',
-      'react/jsx-uses-react': 'warn',
-      'react/jsx-uses-vars': 'warn',
-      'react/no-danger-with-children': 'warn',
-      'react/no-deprecated': 'warn',
-      'react/no-direct-mutation-state': 'warn',
-
-      'react/no-string-refs': [
-        'warn',
-        {
-          noTemplateLiterals: true,
-        },
-      ],
-
-      'react/no-this-in-sfc': 'warn',
       'react/no-unknown-property': 'warn',
-      'react/require-render-return': 'warn',
+      'react/react-in-jsx-scope': 'off',
+      'react/prop-types': 'off',
+      'react/jsx-no-target-blank': 'off',
+      'react/no-this-in-sfc': 'warn',
     },
   },
 ];


### PR DESCRIPTION
# Why

- React Native apps need these defaults more than React DOM. We should be enabling rules like [react/no-unescaped-entities](https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unescaped-entities.md) exist to prevent breaking JSX and rendering unwrapped text, but we have it disabled and ship unescaped characters in many places.
- Rules like mutating state should absolutely be errors and not warnings. There's little wiggle room for the rules of React to be broken in React Native as error handling is more fragile.

