### PR TITLE
feat(expo): [RFC] Add improved error messages for React DOM elements on native.

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### 🎉 New features
 
+- Add shims for React 19 meta tags on native.
+- Add improved error messages for React DOM elements on native.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### 🎉 New features
 
-- Add shims for React 19 meta tags on native.
-- Add improved error messages for React DOM elements on native.
+- Add shims for React 19 meta tags on native. ([#36279](https://github.com/expo/expo/pull/36279) by [@EvanBacon](https://github.com/EvanBacon))
+- Add improved error messages for React DOM elements on native. ([#36279](https://github.com/expo/expo/pull/36279) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/src/Expo.fx.tsx
+++ b/packages/expo/src/Expo.fx.tsx
@@ -1,5 +1,6 @@
 // load expo-asset immediately to set a custom `source` transformer in React Native
 import './winter';
+import './react-meta-tags';
 import 'expo-asset';
 
 import Constants from 'expo-constants';

--- a/packages/expo/src/react-meta-tags.native.tsx
+++ b/packages/expo/src/react-meta-tags.native.tsx
@@ -1,0 +1,70 @@
+// Shim for supporting React 19 meta tags on native.
+import * as ReactNativeViewConfigRegistry from 'react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
+
+for (const key of ['title', 'link', 'meta', 'style', 'script']) {
+  ReactNativeViewConfigRegistry.register(key, () => {
+    const config = ReactNativeViewConfigRegistry.get('RCTVirtualText');
+    return {
+      ...config,
+      // Modify to make nothing render
+      validAttributes: {
+        ...config.validAttributes,
+        // Add any custom attributes you want to support
+        // For example, if you want to support a custom attribute called "title"
+        children: {
+          process: () => {
+            return null;
+          },
+        },
+      },
+    };
+  });
+}
+
+for (const key of [
+  'div',
+  'span',
+  'p',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'a',
+  'ul',
+  'ol',
+  'li',
+  'strong',
+  'em',
+  'b',
+  'i',
+  'br',
+  'hr',
+  'img',
+  'table',
+  'thead',
+  'tbody',
+  'tr',
+  'th',
+  'td',
+  'caption',
+  'form',
+  'input',
+  'button',
+  'select',
+  'option',
+  'textarea',
+  'label',
+  'fieldset',
+  'legend',
+  'details',
+  'summary',
+  'dialog',
+]) {
+  ReactNativeViewConfigRegistry.register(key, () => {
+    throw new Error(
+      `DOM element <${key} /> is not supported on native. Solutions include switching to a universal component like <View>, <Text>, or <ScrollView>. Alternatively, render web code in an Expo DOM component with the "use dom" directive.`
+    );
+  });
+}


### PR DESCRIPTION
# Why

- Hack React Native internals a bit to provide better error messages when users render a `<div>`, `<span>`, etc. on native platforms.

```
Warning: Invariant Violation: View config getter callback for component `div` must be a function (received `undefined`). Make sure to start component names with a capital letter.
```

Is now:

```
Warning: Error: DOM element <div /> is not supported on native. Solutions include switching to a universal component like <View>, <Text>, or <ScrollView>. Alternatively, render web code in an Expo DOM component with the "use dom" directive.
```

- This PR also experiments with adding fallbacks for `title, link, meta, style, script` tags which can be plainly rendered in React 19 for web but not on native. These still have a warning as wrapped text can only be added to views with a hardcoded list of names like `RCTText`.
