### PR TITLE
[ncl] fix bottom sheet animation

### DIFF
--- a/apps/native-component-list/src/screens/UI/BottomSheetScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/BottomSheetScreen.ios.tsx
@@ -1,20 +1,33 @@
 import { Button, BottomSheet } from '@expo/ui/swift-ui';
 import * as React from 'react';
 import { ScrollView, Text } from 'react-native';
-import Animated, { LinearTransition } from 'react-native-reanimated';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+
 export default function BottomSheetScreen() {
   const [isOpened, setIsOpened] = React.useState<boolean>(true);
-  const [height, setHeight] = React.useState<number>(100);
+  const height = useSharedValue(100);
+
+  const handleIncreaseHeight = () => {
+    height.value = height.value > 500 ? 100 : height.value + 100;
+  };
+
+  const animatedStyles = useAnimatedStyle(() => ({
+    height: withTiming(height.value, { duration: 3000 }),
+  }));
 
   return (
-    <ScrollView>
+    <ScrollView
+      contentContainerStyle={{
+        flex: 1,
+        justifyContent: 'flex-start',
+        alignItems: 'flex-start',
+        padding: 8,
+      }}>
       <Button onPress={() => setIsOpened((h) => !h)}>Toggle</Button>
       <Text>isOpened: {isOpened ? 'yes' : 'no'}</Text>
       <BottomSheet isOpened={isOpened} onIsOpenedChange={(e) => setIsOpened(e)}>
-        <Animated.View layout={LinearTransition.duration(3000)} style={{ height, padding: 20 }}>
-          <Button onPress={() => setHeight((h) => (h > 500 ? 100 : h + 100))}>
-            Increase height
-          </Button>
+        <Animated.View style={[{ padding: 20 }, animatedStyles]}>
+          <Button onPress={handleIncreaseHeight}>Increase height</Button>
         </Animated.View>
       </BottomSheet>
     </ScrollView>


### PR DESCRIPTION
# Why

the other regression since #35553

# How

- i don't not quite know the root cause tbh. it looks like that layout animation requires two nested UIViews to make it work. but since #35553, we remove one extra uiview and broke it.
- the other culprit may be since #35553, a UIView would be a direct UIViewRepresentable from swiftui children. it doesn't respect UIView intrinsic content size and controlled size by swiftui. the original `GeometryReader` doesn't well support layout animation height changes.
- rather than using layout animation, i just update it for classic reanimated animation.

# Test Plan

ncl + expo ui bottom sheet

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
