### PR TITLE
[docs] Update unit testing guide

### DIFF
--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -21,8 +21,6 @@ import { CODE } from '~/ui/components/Text';
 
 You will also use the [`jest-expo`](https://github.com/expo/expo/tree/main/packages/jest-expo) library, which is a Jest preset that mocks the native part of the Expo SDK and handles most of the configuration required for your Expo project.
 
-> **info** **Note:** While unit testing is a useful practice for library development, you might not need it for your app since unit tests on rendering aren't useful. See configuring [E2E tests with Maestro](/eas/workflows/reference/e2e-tests/) guide.
-
 ## Installation and configuration
 
 After creating your Expo project, follow the instructions below to install and configure `jest-expo` in your project:
@@ -147,7 +145,7 @@ To install it, run the following command:
 
 </Tabs>
 
-> **warning** **Deprecated:** For **SDK 52 and below**, if you are using the default Expo template, after installing this library, you can uninstall the `react-test-renderer` and `@types/react-test-renderer` from your project's dev dependencies. The `react-test-renderer` has been deprecated and will no longer be maintained in the React 19 and above. See [React's documentation for more information](https://react.dev/warnings/react-test-renderer).
+> **warning** **Deprecated:** `@testing-library/react-native` replaces the deprecated `react-test-renderer` because `react-test-renderer` does not support React 19 and above. Remove the deprecated library from your project if you are currently using it. See [React's documentation for more information](https://react.dev/warnings/react-test-renderer).
 
 ## Unit test
 
@@ -249,6 +247,8 @@ Alternatively, you can have multiple **\_\_tests\_\_** sub-directories for diffe
 It's all about preferences, and it is up to you to decide how you want to organize your project directory.
 
 ## Snapshot test
+
+> **info** **Note:** While unit testing is a useful practice for library development, you might not need it for your app since unit tests on rendering aren't useful. See configuring [E2E tests with Maestro](/eas/workflows/reference/e2e-tests/) guide.
 
 A [snapshot test](https://jestjs.io/docs/en/snapshot-testing) is used to make sure that UI stays consistent, especially when a project is working with global styles that are potentially shared across components.
 

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -21,13 +21,11 @@ import { CODE } from '~/ui/components/Text';
 
 You will also use the [`jest-expo`](https://github.com/expo/expo/tree/main/packages/jest-expo) library, which is a Jest preset that mocks the native part of the Expo SDK and handles most of the configuration required for your Expo project.
 
+> **info** **Note:** While unit testing is a useful practice for library development, you might not need it for your app since unit tests on rendering aren't useful. You can look into E2E testing with [Maestro](/eas/workflows/reference/e2e-tests/) for your app.
+
 ## Installation and configuration
 
-If you have created your project using the [default Expo template](/get-started/create-a-project/), you can skip this section. The `jest-expo` and other required dev dependencies are already installed and configured.
-
-<Collapsible summary={<>Manual installation instructions for <CODE>jest-expo</CODE></>}>
-
-If you have created your project using [different template](/more/create-expo/#--template), follow the instructions below to install and configure `jest-expo` in your project.
+After creating your Expo project, follow the instructions below to install and configure `jest-expo` in your project:
 
 <Step label="1">
 
@@ -71,7 +69,19 @@ Open **package.json**, add a script for running tests, and add the preset for us
 
 </Step>
 
-</Collapsible>
+<Step label="3">
+
+In **package.json**, add `jest-expo` as a preset so that a base for Jest's configuration is set up:
+
+```json package.json
+{
+  "jest": {
+    "preset": "jest-expo"
+  }
+}
+```
+
+</Step>
 
 <Collapsible summary={<>Additional configuration for using <CODE>transformIgnorePatterns</CODE></>}>
 

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -21,7 +21,7 @@ import { CODE } from '~/ui/components/Text';
 
 You will also use the [`jest-expo`](https://github.com/expo/expo/tree/main/packages/jest-expo) library, which is a Jest preset that mocks the native part of the Expo SDK and handles most of the configuration required for your Expo project.
 
-> **info** **Note:** While unit testing is a useful practice for library development, you might not need it for your app since unit tests on rendering aren't useful. You can look into E2E testing with [Maestro](/eas/workflows/reference/e2e-tests/) for your app.
+> **info** **Note:** While unit testing is a useful practice for library development, you might not need it for your app since unit tests on rendering aren't useful. See configuring [E2E tests with Maestro](/eas/workflows/reference/e2e-tests/) for your app.
 
 ## Installation and configuration
 

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -21,7 +21,7 @@ import { CODE } from '~/ui/components/Text';
 
 You will also use the [`jest-expo`](https://github.com/expo/expo/tree/main/packages/jest-expo) library, which is a Jest preset that mocks the native part of the Expo SDK and handles most of the configuration required for your Expo project.
 
-> **info** **Note:** While unit testing is a useful practice for library development, you might not need it for your app since unit tests on rendering aren't useful. See configuring [E2E tests with Maestro](/eas/workflows/reference/e2e-tests/) for your app.
+> **info** **Note:** While unit testing is a useful practice for library development, you might not need it for your app since unit tests on rendering aren't useful. See configuring [E2E tests with Maestro](/eas/workflows/reference/e2e-tests/) guide.
 
 ## Installation and configuration
 

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -248,7 +248,7 @@ It's all about preferences, and it is up to you to decide how you want to organi
 
 ## Snapshot test
 
-> **info** **Note:** While unit testing is a useful practice for library development, you might not need it for your app since unit tests on rendering aren't useful. See configuring [E2E tests with Maestro](/eas/workflows/reference/e2e-tests/) guide.
+> **info** **Note:** For UI testing, we recommend end-to-end tests instead of snapshot unit tests. See the [E2E tests with Maestro](/eas/workflows/reference/e2e-tests/) guide.
 
 A [snapshot test](https://jestjs.io/docs/en/snapshot-testing) is used to make sure that UI stays consistent, especially when a project is working with global styles that are potentially shared across components.
 

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -147,7 +147,7 @@ To install it, run the following command:
 
 </Tabs>
 
-> **warning** **Deprecated:** If you are using the default Expo template, after installing this library, you can uninstall the `react-test-renderer` and `@types/react-test-renderer` from your project's dev dependencies. The `react-test-renderer` has been deprecated and will no longer be maintained in the future. See [React's documentation for more information](https://react.dev/warnings/react-test-renderer).
+> **warning** **Deprecated:** For **SDK 52 and below**, if you are using the default Expo template, after installing this library, you can uninstall the `react-test-renderer` and `@types/react-test-renderer` from your project's dev dependencies. The `react-test-renderer` has been deprecated and will no longer be maintained in the React 19 and above. See [React's documentation for more information](https://react.dev/warnings/react-test-renderer).
 
 ## Unit test
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #36291 to account for Jest removal changes from default template.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add a note in the introduction to explain that unit testing isn't a requitement for most apps and developers can consider using E2E test. It also includes a link to the Maestro guide.
- Update `react-test-renderer` callout to mention that the library is not maintained from React 19
- Update Jest installation and configuration section to include steps in the main flow and also add a step about setting `jest-expo` as a preset in the package.json file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See: /develop/unit-testing/

## Preview

![CleanShot 2025-04-22 at 00 48 30](https://github.com/user-attachments/assets/3418f567-48da-4e1d-820d-fcf241c4ee07)


![CleanShot 2025-04-22 at 00 46 25](https://github.com/user-attachments/assets/26e695ca-5ce4-4373-8aca-80b6d6864c2c)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
