### PR TITLE
fix: check name is not empty, fix `CUICatalog: Invalid asset name supplied: ''`

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Check name is not empty, fix `CUICatalog: Invalid asset name supplied: ''` error in iOS.
+
 ### 💡 Others
 
 ## 2.1.4 — 2025-04-14

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Check name is not empty, fix `CUICatalog: Invalid asset name supplied: ''` error in iOS.
+- Check name is not empty, fix `CUICatalog: Invalid asset name supplied: ''` error in iOS. ([#36294](https://github.com/expo/expo/pull/36294) by [@Innei](https://github.com/Innei))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Check name is not empty, fix `CUICatalog: Invalid asset name supplied: ''` error in iOS. ([#36294](https://github.com/expo/expo/pull/36294) by [@Innei](https://github.com/Innei))
+- Fixed `CUICatalog: Invalid asset name supplied: ''` error on iOS when the path is empty. ([#36294](https://github.com/expo/expo/pull/36294) by [@Innei](https://github.com/Innei))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -244,7 +244,7 @@ public final class ImageView: ExpoView {
       return nil
     }()
 
-    if let path, let local = UIImage(named: path) {
+    if let path, !path.isEmpty, let local = UIImage(named: path) {
       renderSourceImage(local)
       return true
     }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix many error print in Xcode console.

```
CUICatalog: Invalid asset name supplied: ''
```

# How

<!--
How did you build this feature or fix this bug and why?
-->

To solve console error

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
