### PR TITLE
[core][iOS] Do not add hostingController when parent is UINavigationController

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed adding SwiftUI views to navigation header ([#36305](https://github.com/expo/expo/pull/36305) by [@jakex7](https://github.com/jakex7))
+
 ### 💡 Others
 
 ## 2.3.6 — 2025-04-21

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -198,6 +198,8 @@ extension ExpoSwiftUI {
       if window != nil, let parentController = reactViewController() {
         #if !os(macOS)
         if parentController as? UINavigationController == nil {
+          // Swift automatically adds the hostingController in the correct place when the parentController
+          // is UINavigationController, since it's children are supposed to be only screens
           parentController.addChild(hostingController)
         }
         #else

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -196,7 +196,9 @@ extension ExpoSwiftUI {
       super.didMoveToWindow()
 
       if window != nil, let parentController = reactViewController() {
-        parentController.addChild(hostingController)
+        if (parentController as? UINavigationController == nil) {
+          parentController.addChild(hostingController)
+        }
         addSubview(hostingController.view)
         #if os(iOS) || os(tvOS)
         hostingController.didMove(toParent: parentController)

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -196,9 +196,13 @@ extension ExpoSwiftUI {
       super.didMoveToWindow()
 
       if window != nil, let parentController = reactViewController() {
+        #if !os(macOS)
         if parentController as? UINavigationController == nil {
           parentController.addChild(hostingController)
         }
+        #else
+        parentController.addChild(hostingController)
+        #endif
         addSubview(hostingController.view)
         #if os(iOS) || os(tvOS)
         hostingController.didMove(toParent: parentController)

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -196,7 +196,7 @@ extension ExpoSwiftUI {
       super.didMoveToWindow()
 
       if window != nil, let parentController = reactViewController() {
-        if (parentController as? UINavigationController == nil) {
+        if parentController as? UINavigationController == nil {
           parentController.addChild(hostingController)
         }
         addSubview(hostingController.view)


### PR DESCRIPTION
# Why

We should not add hostingController to UINavigationController because NavigationController's children are supposed to be screens. Swift handles such a case by adding it itself.

# How

Don't add hostingController when nearest controller is UINavigationController.

> [!NOTE]
> Direct children of the header that are SwiftUI elements must explicitly declare their size, as `AutoSizingStack` currently doesn't work with `react-native-screens`. At the moment, RNS header elements cannot be resized after the initial render when SwiftUI elements doesn't have their size set yet.

Example usage:
```tsx
<Stack.Navigator
  screenOptions={{
    headerRight: () => {
      return <Switch value={true} onValueChange={() => {}} style={{ width: 60, height: 30 }} />;
    },
  }}>
```
```tsx
<Stack.Navigator
  screenOptions={{
    headerRight: () => {
      return (
        <ContextMenu style={{ width: 24, height: 24 }}>
          <ContextMenu.Items>
            <Button systemImage="star">Item 1</Button>
            <Button systemImage="heart">Item 2</Button>
          </ContextMenu.Items>
          <ContextMenu.Trigger>
            <SymbolView name="person.crop.circle.badge.xmark" size={24} />
          </ContextMenu.Trigger>
        </ContextMenu>
      );
    },
  }}>
```

https://github.com/user-attachments/assets/a3f1fb60-933e-4907-870c-4d0c186ad95c


![image](https://github.com/user-attachments/assets/85216ed0-3e12-4574-aa2b-e3ac165e221b)

# Test Plan

Bare Expo 

```tsx
import { Switch } from '@expo/ui/swift-ui';
import { createNativeStackNavigator } from '@react-navigation/native-stack';
import React from 'react';
import { Text } from 'react-native';

const HomeScreen = () => <Text>Home</Text>;
const ProfileScreen = () => <Text>Profile</Text>;

const Stack = createNativeStackNavigator();

export default function Main() {
  return (
    <Stack.Navigator
      screenOptions={{
        headerRight: () => {
          return (
            <Switch
              value={true}
              onValueChange={() => {}}
              style={{ width: 50, height: 30 }}
            />
          );
        },
      }}>
      <Stack.Screen name="Home" component={HomeScreen} />
      <Stack.Screen name="Profile" component={ProfileScreen} />
    </Stack.Navigator>
  );
}
```