### PR TITLE
[docs] Add missing `extends` properties in `tsconfig.json` samples

### DIFF
--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -88,6 +88,7 @@ The default configuration in **tsconfig.json** is user-friendly and encourages a
 
 ```json tsconfig.json
 {
+  "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true
   }
@@ -106,6 +107,7 @@ For example, to import `Button` component from **src/components/Button.tsx** usi
 
 ```json tsconfig.json
 {
+  "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
@@ -151,6 +153,7 @@ To enable absolute imports from a project's root directory, define [`compilerOpt
 
 ```json tsconfig.json
 {
+  "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "baseUrl": "./"
   }

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -80,7 +80,7 @@ To type check your project's files run `tsc` command within the root of your pro
 
 ### Add base configuration with tsconfig.json
 
-A project's **tsconfig.json** should extend the `expo/tsconfig.base` by default. You can automatically generate a **tsconfig.json** file by running the command:
+A project's **tsconfig.json** should extend `expo/tsconfig.base` by default. You can automatically generate a **tsconfig.json** file by running the command:
 
 <Terminal cmd={['$ npx expo customize tsconfig.json']} />
 


### PR DESCRIPTION
# Why

We're stating:
> A project's **tsconfig.json** should extend `expo/tsconfig.base` by default

But then go on to show `tsconfig.json` examples that don't contain this property. If a user isn't reading carefully and copies the examples, they'll be missing this crucial addition. The preset contains everything a user needs to add to make a config valid, so by simply adding this to the samples, all the samples are immediately copyable.

## Side-note

I've noticed this section below the changes: https://docs.expo.dev/guides/typescript/#typescript-for-projects-config-files

I think we should discourage this and potentially alter our `expo/tsconfig.base`, since it currently excludes these files. If a user wishes to type check these files, it's much less error prone for them to use `checkJs: true` or `// @ts-check` comments.

Changing configuration to TypeScript files could introduce a lot of testing burden for us, and I'm not sure if we ever check that this setup is valid and works across SDK versions. `ts-node` has a lot of gotchas, and we're basically telling a user here to transpile their configs with `ts-node` with the `tsconfig.json` that's meant for their app, which can lead to problems.

Unrelated to this PR, but worth noting here, while I'm editing this file :v:

# How

- Add missing `extends: 'expo/tsconfig.base` to all `tsconfig.json` examples on TypeScript page