### PR TITLE
feat(cli): Add support for custom remote build cache providers

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add support for custom remote build cache providers ([#36314](https://github.com/expo/expo/pull/36314) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 - Fix support for using build variants with remote build cache ([#36165](https://github.com/expo/expo/pull/36165) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/@expo/cli/src/run/android/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/resolveOptions-test.ts
@@ -14,11 +14,19 @@ jest.mock('../resolveDevice', () => ({
   })),
 }));
 
+const fixture = {
+  ...rnFixture,
+  'package.json': JSON.stringify({}),
+  'node_modules/expo/package.json': JSON.stringify({
+    version: '53.0.0',
+  }),
+};
+
 describe(resolveOptionsAsync, () => {
   afterEach(() => vol.reset());
 
   it(`resolves default options`, async () => {
-    vol.fromJSON(rnFixture, '/');
+    vol.fromJSON(fixture, '/');
 
     expect(await resolveOptionsAsync('/', {})).toEqual({
       apkVariantDirectory: '/android/app/build/outputs/apk/debug',
@@ -43,7 +51,7 @@ describe(resolveOptionsAsync, () => {
     });
   });
   it(`resolves complex options`, async () => {
-    vol.fromJSON(rnFixture, '/');
+    vol.fromJSON(fixture, '/');
 
     expect(
       await resolveOptionsAsync('/', {

--- a/packages/@expo/cli/src/run/android/resolveOptions.ts
+++ b/packages/@expo/cli/src/run/android/resolveOptions.ts
@@ -1,7 +1,11 @@
+import { getConfig } from '@expo/config';
+
 import { resolveDeviceAsync } from './resolveDevice';
 import { GradleProps, resolveGradlePropsAsync } from './resolveGradlePropsAsync';
 import { LaunchProps, resolveLaunchPropsAsync } from './resolveLaunchProps';
 import { AndroidDeviceManager } from '../../start/platforms/android/AndroidDeviceManager';
+import { resolveRemoteBuildCacheProvider } from '../../utils/remote-build-cache-providers';
+import { RemoteBuildCacheProvider } from '../../utils/remote-build-cache-providers/types';
 import { BundlerProps, resolveBundlerPropsAsync } from '../resolveBundlerProps';
 
 export type Options = {
@@ -25,6 +29,7 @@ export type ResolvedOptions = GradleProps &
     install: boolean;
     architectures?: string;
     appId?: string;
+    buildCacheProvider?: RemoteBuildCacheProvider;
   };
 
 export async function resolveOptionsAsync(
@@ -33,6 +38,12 @@ export async function resolveOptionsAsync(
 ): Promise<ResolvedOptions> {
   // Resolve the device before the gradle props because we need the device to be running to get the ABI.
   const device = await resolveDeviceAsync(options.device);
+
+  const projectConfig = getConfig(projectRoot);
+  const buildCacheProvider = resolveRemoteBuildCacheProvider(
+    projectConfig.exp.experiments?.remoteBuildCache?.provider,
+    projectRoot
+  );
 
   return {
     ...(await resolveBundlerPropsAsync(projectRoot, options)),
@@ -44,5 +55,6 @@ export async function resolveOptionsAsync(
     device,
     buildCache: !!options.buildCache,
     install: !!options.install,
+    buildCacheProvider,
   };
 }

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -12,14 +12,14 @@ import { assembleAsync, installAsync } from '../../start/platforms/android/gradl
 import { CommandError } from '../../utils/errors';
 import { setNodeEnv } from '../../utils/nodeEnv';
 import { ensurePortAvailabilityAsync } from '../../utils/port';
-import { getSchemesForAndroidAsync } from '../../utils/scheme';
-import { ensureNativeProjectAsync } from '../ensureNativeProject';
-import { logProjectLogsLocation } from '../hints';
 import {
   resolveRemoteBuildCache,
   resolveRemoteBuildCacheProvider,
   uploadRemoteBuildCache,
-} from '../remoteBuildCache';
+} from '../../utils/remote-build-cache-providers';
+import { getSchemesForAndroidAsync } from '../../utils/scheme';
+import { ensureNativeProjectAsync } from '../ensureNativeProject';
+import { logProjectLogsLocation } from '../hints';
 import { startBundlerAsync } from '../startBundler';
 
 const debug = require('debug')('expo:run:android');

--- a/packages/@expo/cli/src/run/ios/XcodeBuild.types.ts
+++ b/packages/@expo/cli/src/run/ios/XcodeBuild.types.ts
@@ -1,5 +1,5 @@
 import { OSType } from '../../start/platforms/ios/simctl';
-import { RemoteBuildCacheProvider } from '../remoteBuildCache';
+import { RemoteBuildCacheProvider } from '../../utils/remote-build-cache-providers/types';
 import { BundlerProps } from '../resolveBundlerProps';
 
 export type XcodeConfiguration = 'Debug' | 'Release';

--- a/packages/@expo/cli/src/run/ios/XcodeBuild.types.ts
+++ b/packages/@expo/cli/src/run/ios/XcodeBuild.types.ts
@@ -1,4 +1,5 @@
 import { OSType } from '../../start/platforms/ios/simctl';
+import { RemoteBuildCacheProvider } from '../remoteBuildCache';
 import { BundlerProps } from '../resolveBundlerProps';
 
 export type XcodeConfiguration = 'Debug' | 'Release';
@@ -43,6 +44,7 @@ export type BuildProps = {
   /** Should use derived data for builds. */
   buildCache: boolean;
   scheme: string;
+  buildCacheProvider?: RemoteBuildCacheProvider;
 
   /** Options that were used to create the eager bundle in release builds. */
   eagerBundleOptions?: string;

--- a/packages/@expo/cli/src/run/ios/options/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/run/ios/options/__tests__/resolveOptions-test.ts
@@ -14,11 +14,13 @@ jest.mock('../resolveDevice', () => ({
   })),
 }));
 
+const fixture = { ...rnFixture, 'package.json': JSON.stringify({}) };
+
 describe(resolveOptionsAsync, () => {
   afterEach(() => vol.reset());
 
   it(`resolves default options`, async () => {
-    vol.fromJSON(rnFixture, '/');
+    vol.fromJSON(fixture, '/');
 
     expect(await resolveOptionsAsync('/', {})).toEqual({
       buildCache: true,
@@ -34,7 +36,7 @@ describe(resolveOptionsAsync, () => {
     });
   });
   it(`resolves complex options`, async () => {
-    vol.fromJSON(rnFixture, '/');
+    vol.fromJSON(fixture, '/');
 
     jest.mocked(isSimulatorDevice).mockImplementationOnce(() => false);
 

--- a/packages/@expo/cli/src/run/ios/options/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/run/ios/options/__tests__/resolveOptions-test.ts
@@ -14,7 +14,13 @@ jest.mock('../resolveDevice', () => ({
   })),
 }));
 
-const fixture = { ...rnFixture, 'package.json': JSON.stringify({}) };
+const fixture = {
+  ...rnFixture,
+  'package.json': JSON.stringify({}),
+  'node_modules/expo/package.json': JSON.stringify({
+    version: '53.0.0',
+  }),
+};
 
 describe(resolveOptionsAsync, () => {
   afterEach(() => vol.reset());

--- a/packages/@expo/cli/src/run/ios/options/resolveOptions.ts
+++ b/packages/@expo/cli/src/run/ios/options/resolveOptions.ts
@@ -1,8 +1,11 @@
+import { getConfig } from '@expo/config';
+
 import { isSimulatorDevice, resolveDeviceAsync } from './resolveDevice';
 import { resolveNativeSchemePropsAsync } from './resolveNativeScheme';
 import { resolveXcodeProject } from './resolveXcodeProject';
 import { isOSType } from '../../../start/platforms/ios/simctl';
 import { profile } from '../../../utils/profile';
+import { resolveRemoteBuildCacheProvider } from '../../remoteBuildCache';
 import { resolveBundlerPropsAsync } from '../../resolveBundlerProps';
 import { BuildProps, Options } from '../XcodeBuild.types';
 
@@ -38,6 +41,12 @@ export async function resolveOptionsAsync(
 
   const isSimulator = isSimulatorDevice(device);
 
+  const projectConfig = getConfig(projectRoot);
+  const buildCacheProvider = resolveRemoteBuildCacheProvider(
+    projectConfig.exp.experiments?.remoteBuildCache?.provider,
+    projectRoot
+  );
+
   // This optimization skips resetting the Metro cache needlessly.
   // The cache is reset in `../node_modules/react-native/scripts/react-native-xcode.sh` when the
   // project is running in Debug and built onto a physical device. It seems that this is done because
@@ -55,5 +64,6 @@ export async function resolveOptionsAsync(
     shouldSkipInitialBundling,
     buildCache: options.buildCache !== false,
     scheme,
+    buildCacheProvider,
   };
 }

--- a/packages/@expo/cli/src/run/ios/options/resolveOptions.ts
+++ b/packages/@expo/cli/src/run/ios/options/resolveOptions.ts
@@ -5,7 +5,7 @@ import { resolveNativeSchemePropsAsync } from './resolveNativeScheme';
 import { resolveXcodeProject } from './resolveXcodeProject';
 import { isOSType } from '../../../start/platforms/ios/simctl';
 import { profile } from '../../../utils/profile';
-import { resolveRemoteBuildCacheProvider } from '../../remoteBuildCache';
+import { resolveRemoteBuildCacheProvider } from '../../../utils/remote-build-cache-providers';
 import { resolveBundlerPropsAsync } from '../../resolveBundlerProps';
 import { BuildProps, Options } from '../XcodeBuild.types';
 

--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -4,25 +4,28 @@ import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
 
-import * as Log from '../../log';
-import { AppleAppIdResolver } from '../../start/platforms/ios/AppleAppIdResolver';
-import { maybePromptToSyncPodsAsync } from '../../utils/cocoapods';
-import { setNodeEnv } from '../../utils/nodeEnv';
-import { ensurePortAvailabilityAsync } from '../../utils/port';
-import { profile } from '../../utils/profile';
-import { getSchemesForIosAsync } from '../../utils/scheme';
-import { ensureNativeProjectAsync } from '../ensureNativeProject';
-import { logProjectLogsLocation } from '../hints';
-import { uploadRemoteBuildCache, resolveRemoteBuildCache } from '../remoteBuildCache';
-import { startBundlerAsync } from '../startBundler';
 import * as XcodeBuild from './XcodeBuild';
 import { Options } from './XcodeBuild.types';
 import { getLaunchInfoForBinaryAsync, launchAppAsync } from './launchApp';
 import { resolveOptionsAsync } from './options/resolveOptions';
 import { getValidBinaryPathAsync } from './validateExternalBinary';
 import { exportEagerAsync } from '../../export/embed/exportEager';
+import * as Log from '../../log';
+import { AppleAppIdResolver } from '../../start/platforms/ios/AppleAppIdResolver';
 import { getContainerPathAsync, simctlAsync } from '../../start/platforms/ios/simctl';
+import { maybePromptToSyncPodsAsync } from '../../utils/cocoapods';
 import { CommandError } from '../../utils/errors';
+import { setNodeEnv } from '../../utils/nodeEnv';
+import { ensurePortAvailabilityAsync } from '../../utils/port';
+import { profile } from '../../utils/profile';
+import {
+  resolveRemoteBuildCache,
+  uploadRemoteBuildCache,
+} from '../../utils/remote-build-cache-providers';
+import { getSchemesForIosAsync } from '../../utils/scheme';
+import { ensureNativeProjectAsync } from '../ensureNativeProject';
+import { logProjectLogsLocation } from '../hints';
+import { startBundlerAsync } from '../startBundler';
 
 const debug = require('debug')('expo:run:ios');
 
@@ -52,11 +55,6 @@ export async function runIosAsync(projectRoot: string, options: Options) {
     if (localPath) {
       options.binary = localPath;
     }
-  }
-
-  let x = 1;
-  if (x > 0) {
-    return;
   }
 
   if (options.rebundle) {

--- a/packages/@expo/cli/src/run/remoteBuildCache.ts
+++ b/packages/@expo/cli/src/run/remoteBuildCache.ts
@@ -1,81 +1,163 @@
 import { ExpoConfig } from '@expo/config';
 import { ModPlatform } from '@expo/config-plugins';
+import fs from 'fs';
+import resolveFrom from 'resolve-from';
 
 import { type Options as AndroidRunOptions } from './android/resolveOptions';
 import { type Options as IosRunOptions } from './ios/XcodeBuild.types';
-import {
-  calculateEASFingerprintHashAsync,
-  resolveEASRemoteBuildCache,
-  uploadEASRemoteBuildCache,
-} from '../utils/remote-build-cache-providers/eas';
+import { EASRemoteBuildCacheProvider } from '../utils/remote-build-cache-providers/eas';
+
 const debug = require('debug')('expo:run:remote-build') as typeof console.log;
 
-export async function resolveRemoteBuildCache(
-  projectRoot: string,
-  {
-    platform,
-    provider,
-    runOptions,
-  }: {
-    platform: ModPlatform;
-    provider?: Required<Required<ExpoConfig>['experiments']>['remoteBuildCache']['provider'];
-    runOptions: AndroidRunOptions | IosRunOptions;
-  }
-): Promise<string | null> {
-  const fingerprintHash = await calculateFingerprintHashAsync(projectRoot, platform, provider);
-  if (!fingerprintHash) {
-    return null;
-  }
+export type ResolveRemoteBuildCacheProps = {
+  projectRoot: string;
+  platform: ModPlatform;
+  runOptions: AndroidRunOptions | IosRunOptions;
+  fingerprintHash: string;
+};
+export type UploadRemoteBuildCacheProps = {
+  projectRoot: string;
+  buildPath: string;
+  runOptions: AndroidRunOptions | IosRunOptions;
+  fingerprintHash: string;
+  platform: ModPlatform;
+};
+export type CalculateFingerprintHashProps = {
+  projectRoot: string;
+  platform: ModPlatform;
+  runOptions: AndroidRunOptions | IosRunOptions;
+};
 
-  if (provider === 'eas') {
-    return await resolveEASRemoteBuildCache({ platform, fingerprintHash, projectRoot, runOptions });
-  }
+export type RemoteBuildCacheProvider<T = any> = {
+  plugin: RemoteBuildCachePlugin<T>;
+  options: T;
+};
 
-  return null;
-}
+export type RemoteBuildCachePlugin<T = any> = {
+  resolveRemoteBuildCache(props: ResolveRemoteBuildCacheProps, options: T): Promise<string | null>;
+  uploadRemoteBuildCache(props: UploadRemoteBuildCacheProps, options: T): Promise<string | null>;
+  calculateFingerprintHash?: (
+    props: CalculateFingerprintHashProps,
+    options: T
+  ) => Promise<string | null>;
+};
 
-export async function uploadRemoteBuildCache(
-  projectRoot: string,
-  {
-    platform,
-    provider,
-    buildPath,
-  }: {
-    platform: ModPlatform;
-    provider?: Required<Required<ExpoConfig>['experiments']>['remoteBuildCache']['provider'];
-    buildPath?: string;
-  }
-): Promise<void> {
-  const fingerprintHash = await calculateFingerprintHashAsync(projectRoot, platform, provider);
-  if (!fingerprintHash) {
+// Default plugin entry file name.
+export const pluginFileName = 'buildCacheProvider.plugin.js';
+
+export const resolveRemoteBuildCacheProvider = (
+  provider:
+    | Required<Required<ExpoConfig>['experiments']>['remoteBuildCache']['provider']
+    | undefined,
+  projectRoot: string
+): RemoteBuildCacheProvider | undefined => {
+  if (!provider) {
     return;
   }
 
   if (provider === 'eas') {
-    await uploadEASRemoteBuildCache({
+    return { plugin: EASRemoteBuildCacheProvider, options: {} };
+  }
+
+  if (typeof provider === 'object' && typeof provider.plugin === 'function') {
+    return provider as RemoteBuildCacheProvider;
+  }
+
+  if (typeof provider === 'object' && typeof provider.plugin === 'string') {
+    const plugin = resolvePluginFunction(projectRoot, provider.plugin);
+
+    return { plugin, options: provider.options };
+  }
+
+  throw new Error('Invalid remote build cache provider');
+};
+
+export async function resolveRemoteBuildCache({
+  projectRoot,
+  platform,
+  provider,
+  runOptions,
+}: {
+  projectRoot: string;
+  platform: ModPlatform;
+  provider: RemoteBuildCacheProvider;
+  runOptions: AndroidRunOptions | IosRunOptions;
+}): Promise<string | null> {
+  const fingerprintHash = await calculateFingerprintHashAsync({
+    projectRoot,
+    platform,
+    provider,
+    runOptions,
+  });
+  if (!fingerprintHash) {
+    return null;
+  }
+
+  await provider.plugin.resolveRemoteBuildCache(
+    { fingerprintHash, platform, runOptions, projectRoot },
+    provider.options
+  );
+
+  return null;
+}
+
+export async function uploadRemoteBuildCache({
+  projectRoot,
+  platform,
+  provider,
+  buildPath,
+  runOptions,
+}: {
+  projectRoot: string;
+  platform: ModPlatform;
+  provider: RemoteBuildCacheProvider;
+  buildPath: string;
+  runOptions: AndroidRunOptions | IosRunOptions;
+}): Promise<void> {
+  const fingerprintHash = await calculateFingerprintHashAsync({
+    projectRoot,
+    platform,
+    provider,
+    runOptions,
+  });
+  if (!fingerprintHash) {
+    debug('No fingerprint hash found, skipping upload');
+    return;
+  }
+
+  await provider.plugin.uploadRemoteBuildCache(
+    {
       projectRoot,
       platform,
       fingerprintHash,
       buildPath,
-    });
-  }
+      runOptions,
+    },
+    provider.options
+  );
 }
 
-async function calculateFingerprintHashAsync(
-  projectRoot: string,
-  platform: ModPlatform,
-  provider?: Required<Required<ExpoConfig>['experiments']>['remoteBuildCache']['provider']
-): Promise<string | null> {
-  if (provider === 'eas') {
-    const easFingerprintHash = await calculateEASFingerprintHashAsync({ projectRoot, platform });
-    if (easFingerprintHash) {
-      return easFingerprintHash;
-    }
+async function calculateFingerprintHashAsync({
+  projectRoot,
+  platform,
+  provider,
+  runOptions,
+}: {
+  projectRoot: string;
+  platform: ModPlatform;
+  provider: RemoteBuildCacheProvider;
+  runOptions: AndroidRunOptions | IosRunOptions;
+}): Promise<string | null> {
+  if (provider.plugin.calculateFingerprintHash) {
+    return await provider.plugin.calculateFingerprintHash(
+      { projectRoot, platform, runOptions },
+      provider.options
+    );
   }
 
   const Fingerprint = importFingerprintForDev(projectRoot);
   if (!Fingerprint) {
-    debug('@expo/fingerprint is not installed in the project, skip checking for remote builds');
+    debug('@expo/fingerprint is not installed in the project, unable to calculate fingerprint');
     return null;
   }
   const fingerprint = await Fingerprint.createFingerprintAsync(projectRoot);
@@ -88,5 +170,104 @@ function importFingerprintForDev(projectRoot: string): null | typeof import('@ex
     return require(require.resolve('@expo/fingerprint', { paths: [projectRoot] }));
   } catch {
     return null;
+  }
+}
+
+// Resolve the module function and assert type
+export function resolvePluginFunction(
+  projectRoot: string,
+  pluginReference: string
+): RemoteBuildCachePlugin {
+  const { filePath: pluginFile } = resolvePluginForModule(projectRoot, pluginReference);
+
+  try {
+    let plugin = require(pluginFile);
+
+    if (plugin?.default != null) {
+      plugin = plugin.default;
+    }
+
+    if (typeof plugin !== 'function') {
+      throw new Error(`The provider plugin "${pluginReference}" must export a function.`);
+    }
+    return plugin;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      // Add error linking to the docs of how create a valid provider plugin
+    }
+    throw error;
+  }
+}
+
+/**
+ * Resolve the provider plugin from a node module or package.
+ * If the module or package does not include a provider plugin, this function throws.
+ * The resolution is done in following order:
+ *   1. Is the reference a relative file path or an import specifier with file path? e.g. `./file.js`, `pkg/file.js` or `@org/pkg/file.js`?
+ *     - Resolve the provider plugin as-is
+ *   2. If the reference a module? e.g. `expo-font`
+ *     - Resolve the root `app.plugin.js` file within the module, e.g. `expo-font/app.plugin.js`
+ *   3. Does the module have a valid provider plugin in the `main` field?
+ *     - Resolve the `main` entry point as provider plugin
+ */
+function resolvePluginForModule(
+  projectRoot: string,
+  pluginReference: string
+): { filePath: string } {
+  if (moduleNameIsDirectFileReference(pluginReference)) {
+    // Only resolve `./file.js`, `package/file.js`, `@org/package/file.js`
+    const pluginScriptFile = resolveFrom.silent(projectRoot, pluginReference);
+    if (pluginScriptFile) {
+      return {
+        filePath: pluginScriptFile,
+      };
+    }
+  } else if (moduleNameIsPackageReference(pluginReference)) {
+    // Only resolve `package -> package/app.plugin.js`, `@org/package -> @org/package/app.plugin.js`
+    const pluginPackageFile = resolveFrom.silent(
+      projectRoot,
+      `${pluginReference}/${pluginFileName}`
+    );
+    if (pluginPackageFile && fileExists(pluginPackageFile)) {
+      return { filePath: pluginPackageFile };
+    }
+    // Try to resole the `main` entry as config plugin
+    const packageMainEntry = resolveFrom.silent(projectRoot, pluginReference);
+    if (packageMainEntry) {
+      return { filePath: packageMainEntry };
+    }
+  }
+
+  throw new Error(
+    `Failed to resolve provider plugin for module "${pluginReference}" relative to "${projectRoot}". Do you have node modules installed?`
+  );
+}
+
+function moduleNameIsDirectFileReference(name: string): boolean {
+  // Check if path is a file. Matches lines starting with: . / ~/
+  if (name.match(/^(\.|~\/|\/)/g)) {
+    return true;
+  }
+
+  const slashCount = name.split('/')?.length;
+  // Orgs (like @expo/config ) should have more than one slash to be a direct file.
+  if (name.startsWith('@')) {
+    return slashCount > 2;
+  }
+
+  // Regular packages should be considered direct reference if they have more than one slash.
+  return slashCount > 1;
+}
+
+function moduleNameIsPackageReference(name: string): boolean {
+  const slashCount = name.split('/')?.length;
+  return name.startsWith('@') ? slashCount === 2 : slashCount === 1;
+}
+
+export function fileExists(file: string): boolean {
+  try {
+    return fs.statSync(file).isFile();
+  } catch {
+    return false;
   }
 }

--- a/packages/@expo/cli/src/utils/remote-build-cache-providers/eas.ts
+++ b/packages/@expo/cli/src/utils/remote-build-cache-providers/eas.ts
@@ -5,10 +5,8 @@ import fs from 'fs';
 import path from 'path';
 
 import { isDevClientBuild } from './helpers';
+import { CalculateFingerprintHashProps, RemoteBuildCachePlugin, RunOptions } from './types';
 import { Log } from '../../log';
-import { type Options as AndroidRunOptions } from '../../run/android/resolveOptions';
-import { type Options as IosRunOptions } from '../../run/ios/XcodeBuild.types';
-import { CalculateFingerprintHashProps, RemoteBuildCachePlugin } from '../../run/remoteBuildCache';
 import { isSpawnResultError } from '../../start/platforms/ios/xcrun';
 
 const debug = require('debug')('expo:eas-remote-build-cache') as typeof console.log;
@@ -22,7 +20,7 @@ export async function resolveEASRemoteBuildCache({
   projectRoot: string;
   platform: ModPlatform;
   fingerprintHash: string;
-  runOptions: AndroidRunOptions | IosRunOptions;
+  runOptions: RunOptions;
 }): Promise<string | null> {
   const easJsonPath = path.join(projectRoot, 'eas.json');
   if (!fs.existsSync(easJsonPath)) {
@@ -75,7 +73,7 @@ export async function uploadEASRemoteBuildCache({
   buildPath,
 }: {
   projectRoot: string;
-  runOptions: AndroidRunOptions | IosRunOptions;
+  runOptions: RunOptions;
   platform: ModPlatform;
   fingerprintHash: string;
   buildPath?: string;

--- a/packages/@expo/cli/src/utils/remote-build-cache-providers/eas.ts
+++ b/packages/@expo/cli/src/utils/remote-build-cache-providers/eas.ts
@@ -8,6 +8,7 @@ import { isDevClientBuild } from './helpers';
 import { Log } from '../../log';
 import { type Options as AndroidRunOptions } from '../../run/android/resolveOptions';
 import { type Options as IosRunOptions } from '../../run/ios/XcodeBuild.types';
+import { CalculateFingerprintHashProps, RemoteBuildCachePlugin } from '../../run/remoteBuildCache';
 import { isSpawnResultError } from '../../start/platforms/ios/xcrun';
 
 const debug = require('debug')('expo:eas-remote-build-cache') as typeof console.log;
@@ -74,14 +75,15 @@ export async function uploadEASRemoteBuildCache({
   buildPath,
 }: {
   projectRoot: string;
+  runOptions: AndroidRunOptions | IosRunOptions;
   platform: ModPlatform;
   fingerprintHash: string;
   buildPath?: string;
-}): Promise<void> {
+}) {
   const easJsonPath = path.join(projectRoot, 'eas.json');
   if (!fs.existsSync(easJsonPath)) {
-    debug('eas.json not found, skip checking for remote builds');
-    return;
+    debug('eas.json not found, skip uploading builds');
+    return null;
   }
 
   try {
@@ -106,18 +108,17 @@ export async function uploadEASRemoteBuildCache({
     // }
     const json = JSON.parse(results.stdout.trim());
     Log.log(chalk`{whiteBright \u203A} {bold Build successfully uploaded: ${json?.url}}`);
+    return json?.url;
   } catch (error) {
     debug('eas-cli error:', error);
   }
+  return null;
 }
 
 export async function calculateEASFingerprintHashAsync({
   projectRoot,
   platform,
-}: {
-  projectRoot: string;
-  platform: ModPlatform;
-}): Promise<string | null> {
+}: CalculateFingerprintHashProps): Promise<string | null> {
   // prefer using `eas fingerprint:generate` because it automatically upload sources
   try {
     const results = await spawnAsync(
@@ -137,3 +138,9 @@ export async function calculateEASFingerprintHashAsync({
   }
   return null;
 }
+
+export const EASRemoteBuildCacheProvider: RemoteBuildCachePlugin = {
+  resolveRemoteBuildCache: resolveEASRemoteBuildCache,
+  uploadRemoteBuildCache: uploadEASRemoteBuildCache,
+  calculateFingerprintHash: calculateEASFingerprintHashAsync,
+};

--- a/packages/@expo/cli/src/utils/remote-build-cache-providers/helpers.ts
+++ b/packages/@expo/cli/src/utils/remote-build-cache-providers/helpers.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+
 import { type Options as AndroidRunOptions } from '../../run/android/resolveOptions';
 import { type Options as IosRunOptions } from '../../run/ios/XcodeBuild.types';
 import { hasDirectDevClientDependency } from '../../start/detectDevClient';
@@ -21,4 +23,33 @@ export function isDevClientBuild({
   }
 
   return true;
+}
+
+export function moduleNameIsDirectFileReference(name: string): boolean {
+  // Check if path is a file. Matches lines starting with: . / ~/
+  if (name.match(/^(\.|~\/|\/)/g)) {
+    return true;
+  }
+
+  const slashCount = name.split('/')?.length;
+  // Orgs (like @expo/config ) should have more than one slash to be a direct file.
+  if (name.startsWith('@')) {
+    return slashCount > 2;
+  }
+
+  // Regular packages should be considered direct reference if they have more than one slash.
+  return slashCount > 1;
+}
+
+export function moduleNameIsPackageReference(name: string): boolean {
+  const slashCount = name.split('/')?.length;
+  return name.startsWith('@') ? slashCount === 2 : slashCount === 1;
+}
+
+export function fileExists(file: string): boolean {
+  try {
+    return fs.statSync(file).isFile();
+  } catch {
+    return false;
+  }
 }

--- a/packages/@expo/cli/src/utils/remote-build-cache-providers/helpers.ts
+++ b/packages/@expo/cli/src/utils/remote-build-cache-providers/helpers.ts
@@ -1,14 +1,13 @@
 import fs from 'fs';
 
-import { type Options as AndroidRunOptions } from '../../run/android/resolveOptions';
-import { type Options as IosRunOptions } from '../../run/ios/XcodeBuild.types';
+import { RunOptions } from './types';
 import { hasDirectDevClientDependency } from '../../start/detectDevClient';
 
 export function isDevClientBuild({
   runOptions,
   projectRoot,
 }: {
-  runOptions: AndroidRunOptions | IosRunOptions;
+  runOptions: RunOptions;
   projectRoot: string;
 }) {
   if (!hasDirectDevClientDependency(projectRoot)) {

--- a/packages/@expo/cli/src/utils/remote-build-cache-providers/index.ts
+++ b/packages/@expo/cli/src/utils/remote-build-cache-providers/index.ts
@@ -1,49 +1,14 @@
 import { ExpoConfig } from '@expo/config';
 import { ModPlatform } from '@expo/config-plugins';
-import fs from 'fs';
 import resolveFrom from 'resolve-from';
 
-import { type Options as AndroidRunOptions } from './android/resolveOptions';
-import { type Options as IosRunOptions } from './ios/XcodeBuild.types';
-import { EASRemoteBuildCacheProvider } from '../utils/remote-build-cache-providers/eas';
+import { EASRemoteBuildCacheProvider } from './eas';
+import { moduleNameIsDirectFileReference, moduleNameIsPackageReference } from './helpers';
+import { RemoteBuildCachePlugin, RemoteBuildCacheProvider } from './types';
+import { type Options as AndroidRunOptions } from '../../run/android/resolveOptions';
+import { type Options as IosRunOptions } from '../../run/ios/XcodeBuild.types';
 
 const debug = require('debug')('expo:run:remote-build') as typeof console.log;
-
-export type ResolveRemoteBuildCacheProps = {
-  projectRoot: string;
-  platform: ModPlatform;
-  runOptions: AndroidRunOptions | IosRunOptions;
-  fingerprintHash: string;
-};
-export type UploadRemoteBuildCacheProps = {
-  projectRoot: string;
-  buildPath: string;
-  runOptions: AndroidRunOptions | IosRunOptions;
-  fingerprintHash: string;
-  platform: ModPlatform;
-};
-export type CalculateFingerprintHashProps = {
-  projectRoot: string;
-  platform: ModPlatform;
-  runOptions: AndroidRunOptions | IosRunOptions;
-};
-
-export type RemoteBuildCacheProvider<T = any> = {
-  plugin: RemoteBuildCachePlugin<T>;
-  options: T;
-};
-
-export type RemoteBuildCachePlugin<T = any> = {
-  resolveRemoteBuildCache(props: ResolveRemoteBuildCacheProps, options: T): Promise<string | null>;
-  uploadRemoteBuildCache(props: UploadRemoteBuildCacheProps, options: T): Promise<string | null>;
-  calculateFingerprintHash?: (
-    props: CalculateFingerprintHashProps,
-    options: T
-  ) => Promise<string | null>;
-};
-
-// Default plugin entry file name.
-export const pluginFileName = 'buildCacheProvider.plugin.js';
 
 export const resolveRemoteBuildCacheProvider = (
   provider:
@@ -93,12 +58,10 @@ export async function resolveRemoteBuildCache({
     return null;
   }
 
-  await provider.plugin.resolveRemoteBuildCache(
+  return await provider.plugin.resolveRemoteBuildCache(
     { fingerprintHash, platform, runOptions, projectRoot },
     provider.options
   );
-
-  return null;
 }
 
 export async function uploadRemoteBuildCache({
@@ -173,16 +136,44 @@ function importFingerprintForDev(projectRoot: string): null | typeof import('@ex
   }
 }
 
+/**
+ * Resolve the provider plugin from a node module or package.
+ * If the module or package does not include a provider plugin, this function throws.
+ * The resolution is done in following order:
+ *   1. Is the reference a relative file path or an import specifier with file path? e.g. `./file.js`, `pkg/file.js` or `@org/pkg/file.js`?
+ *     - Resolve the provider plugin as-is
+ *   2. Does the module have a valid provider plugin in the `main` field?
+ *     - Resolve the `main` entry point as provider plugin
+ */
+function resolvePluginFilePathForModule(projectRoot: string, pluginReference: string) {
+  if (moduleNameIsDirectFileReference(pluginReference)) {
+    // Only resolve `./file.js`, `package/file.js`, `@org/package/file.js`
+    const pluginScriptFile = resolveFrom.silent(projectRoot, pluginReference);
+    if (pluginScriptFile) {
+      return pluginScriptFile;
+    }
+  } else if (moduleNameIsPackageReference(pluginReference)) {
+    // Try to resole the `main` entry as config plugin
+    const packageMainEntry = resolveFrom.silent(projectRoot, pluginReference);
+    if (packageMainEntry) {
+      return packageMainEntry;
+    }
+  }
+
+  throw new Error(
+    `Failed to resolve provider plugin for module "${pluginReference}" relative to "${projectRoot}". Do you have node modules installed?`
+  );
+}
+
 // Resolve the module function and assert type
 export function resolvePluginFunction(
   projectRoot: string,
   pluginReference: string
 ): RemoteBuildCachePlugin {
-  const { filePath: pluginFile } = resolvePluginForModule(projectRoot, pluginReference);
+  const pluginFile = resolvePluginFilePathForModule(projectRoot, pluginReference);
 
   try {
     let plugin = require(pluginFile);
-
     if (plugin?.default != null) {
       plugin = plugin.default;
     }
@@ -196,78 +187,5 @@ export function resolvePluginFunction(
       // Add error linking to the docs of how create a valid provider plugin
     }
     throw error;
-  }
-}
-
-/**
- * Resolve the provider plugin from a node module or package.
- * If the module or package does not include a provider plugin, this function throws.
- * The resolution is done in following order:
- *   1. Is the reference a relative file path or an import specifier with file path? e.g. `./file.js`, `pkg/file.js` or `@org/pkg/file.js`?
- *     - Resolve the provider plugin as-is
- *   2. If the reference a module? e.g. `expo-font`
- *     - Resolve the root `app.plugin.js` file within the module, e.g. `expo-font/app.plugin.js`
- *   3. Does the module have a valid provider plugin in the `main` field?
- *     - Resolve the `main` entry point as provider plugin
- */
-function resolvePluginForModule(
-  projectRoot: string,
-  pluginReference: string
-): { filePath: string } {
-  if (moduleNameIsDirectFileReference(pluginReference)) {
-    // Only resolve `./file.js`, `package/file.js`, `@org/package/file.js`
-    const pluginScriptFile = resolveFrom.silent(projectRoot, pluginReference);
-    if (pluginScriptFile) {
-      return {
-        filePath: pluginScriptFile,
-      };
-    }
-  } else if (moduleNameIsPackageReference(pluginReference)) {
-    // Only resolve `package -> package/app.plugin.js`, `@org/package -> @org/package/app.plugin.js`
-    const pluginPackageFile = resolveFrom.silent(
-      projectRoot,
-      `${pluginReference}/${pluginFileName}`
-    );
-    if (pluginPackageFile && fileExists(pluginPackageFile)) {
-      return { filePath: pluginPackageFile };
-    }
-    // Try to resole the `main` entry as config plugin
-    const packageMainEntry = resolveFrom.silent(projectRoot, pluginReference);
-    if (packageMainEntry) {
-      return { filePath: packageMainEntry };
-    }
-  }
-
-  throw new Error(
-    `Failed to resolve provider plugin for module "${pluginReference}" relative to "${projectRoot}". Do you have node modules installed?`
-  );
-}
-
-function moduleNameIsDirectFileReference(name: string): boolean {
-  // Check if path is a file. Matches lines starting with: . / ~/
-  if (name.match(/^(\.|~\/|\/)/g)) {
-    return true;
-  }
-
-  const slashCount = name.split('/')?.length;
-  // Orgs (like @expo/config ) should have more than one slash to be a direct file.
-  if (name.startsWith('@')) {
-    return slashCount > 2;
-  }
-
-  // Regular packages should be considered direct reference if they have more than one slash.
-  return slashCount > 1;
-}
-
-function moduleNameIsPackageReference(name: string): boolean {
-  const slashCount = name.split('/')?.length;
-  return name.startsWith('@') ? slashCount === 2 : slashCount === 1;
-}
-
-export function fileExists(file: string): boolean {
-  try {
-    return fs.statSync(file).isFile();
-  } catch {
-    return false;
   }
 }

--- a/packages/@expo/cli/src/utils/remote-build-cache-providers/index.ts
+++ b/packages/@expo/cli/src/utils/remote-build-cache-providers/index.ts
@@ -4,9 +4,7 @@ import resolveFrom from 'resolve-from';
 
 import { EASRemoteBuildCacheProvider } from './eas';
 import { moduleNameIsDirectFileReference, moduleNameIsPackageReference } from './helpers';
-import { RemoteBuildCachePlugin, RemoteBuildCacheProvider } from './types';
-import { type Options as AndroidRunOptions } from '../../run/android/resolveOptions';
-import { type Options as IosRunOptions } from '../../run/ios/XcodeBuild.types';
+import { RemoteBuildCachePlugin, RemoteBuildCacheProvider, RunOptions } from './types';
 
 const debug = require('debug')('expo:run:remote-build') as typeof console.log;
 
@@ -46,7 +44,7 @@ export async function resolveRemoteBuildCache({
   projectRoot: string;
   platform: ModPlatform;
   provider: RemoteBuildCacheProvider;
-  runOptions: AndroidRunOptions | IosRunOptions;
+  runOptions: RunOptions;
 }): Promise<string | null> {
   const fingerprintHash = await calculateFingerprintHashAsync({
     projectRoot,
@@ -75,7 +73,7 @@ export async function uploadRemoteBuildCache({
   platform: ModPlatform;
   provider: RemoteBuildCacheProvider;
   buildPath: string;
-  runOptions: AndroidRunOptions | IosRunOptions;
+  runOptions: RunOptions;
 }): Promise<void> {
   const fingerprintHash = await calculateFingerprintHashAsync({
     projectRoot,
@@ -109,7 +107,7 @@ async function calculateFingerprintHashAsync({
   projectRoot: string;
   platform: ModPlatform;
   provider: RemoteBuildCacheProvider;
-  runOptions: AndroidRunOptions | IosRunOptions;
+  runOptions: RunOptions;
 }): Promise<string | null> {
   if (provider.plugin.calculateFingerprintHash) {
     return await provider.plugin.calculateFingerprintHash(

--- a/packages/@expo/cli/src/utils/remote-build-cache-providers/index.ts
+++ b/packages/@expo/cli/src/utils/remote-build-cache-providers/index.ts
@@ -1,5 +1,4 @@
-import { ExpoConfig } from '@expo/config';
-import { ModPlatform } from '@expo/config-plugins';
+import { ExpoConfig, Platform } from '@expo/config';
 import resolveFrom from 'resolve-from';
 
 import { EASRemoteBuildCacheProvider } from './eas';
@@ -42,7 +41,7 @@ export async function resolveRemoteBuildCache({
   runOptions,
 }: {
   projectRoot: string;
-  platform: ModPlatform;
+  platform: Omit<Platform, 'web'>;
   provider: RemoteBuildCacheProvider;
   runOptions: RunOptions;
 }): Promise<string | null> {
@@ -70,7 +69,7 @@ export async function uploadRemoteBuildCache({
   runOptions,
 }: {
   projectRoot: string;
-  platform: ModPlatform;
+  platform: Omit<Platform, 'web'>;
   provider: RemoteBuildCacheProvider;
   buildPath: string;
   runOptions: RunOptions;
@@ -105,7 +104,7 @@ async function calculateFingerprintHashAsync({
   runOptions,
 }: {
   projectRoot: string;
-  platform: ModPlatform;
+  platform: Omit<Platform, 'web'>;
   provider: RemoteBuildCacheProvider;
   runOptions: RunOptions;
 }): Promise<string | null> {

--- a/packages/@expo/cli/src/utils/remote-build-cache-providers/index.ts
+++ b/packages/@expo/cli/src/utils/remote-build-cache-providers/index.ts
@@ -176,8 +176,15 @@ export function resolvePluginFunction(
       plugin = plugin.default;
     }
 
-    if (typeof plugin !== 'function') {
-      throw new Error(`The provider plugin "${pluginReference}" must export a function.`);
+    if (
+      typeof plugin !== 'object' ||
+      typeof plugin.resolveRemoteBuildCache !== 'function' ||
+      typeof plugin.uploadRemoteBuildCache !== 'function'
+    ) {
+      throw new Error(`
+        The provider plugin "${pluginReference}" must export an object containing
+        the resolveRemoteBuildCache and uploadRemoteBuildCache functions.
+      `);
     }
     return plugin;
   } catch (error) {

--- a/packages/@expo/cli/src/utils/remote-build-cache-providers/types.ts
+++ b/packages/@expo/cli/src/utils/remote-build-cache-providers/types.ts
@@ -1,4 +1,4 @@
-import { ModPlatform } from '@expo/config-plugins';
+import { Platform } from '@expo/config';
 
 import { type Options as AndroidRunOptions } from '../../run/android/resolveOptions';
 import { type Options as IosRunOptions } from '../../run/ios/XcodeBuild.types';
@@ -7,7 +7,7 @@ export type RunOptions = AndroidRunOptions | IosRunOptions;
 
 export type ResolveRemoteBuildCacheProps = {
   projectRoot: string;
-  platform: ModPlatform;
+  platform: Omit<Platform, 'web'>;
   runOptions: RunOptions;
   fingerprintHash: string;
 };
@@ -16,11 +16,11 @@ export type UploadRemoteBuildCacheProps = {
   buildPath: string;
   runOptions: RunOptions;
   fingerprintHash: string;
-  platform: ModPlatform;
+  platform: Omit<Platform, 'web'>;
 };
 export type CalculateFingerprintHashProps = {
   projectRoot: string;
-  platform: ModPlatform;
+  platform: Omit<Platform, 'web'>;
   runOptions: RunOptions;
 };
 

--- a/packages/@expo/cli/src/utils/remote-build-cache-providers/types.ts
+++ b/packages/@expo/cli/src/utils/remote-build-cache-providers/types.ts
@@ -3,23 +3,25 @@ import { ModPlatform } from '@expo/config-plugins';
 import { type Options as AndroidRunOptions } from '../../run/android/resolveOptions';
 import { type Options as IosRunOptions } from '../../run/ios/XcodeBuild.types';
 
+export type RunOptions = AndroidRunOptions | IosRunOptions;
+
 export type ResolveRemoteBuildCacheProps = {
   projectRoot: string;
   platform: ModPlatform;
-  runOptions: AndroidRunOptions | IosRunOptions;
+  runOptions: RunOptions;
   fingerprintHash: string;
 };
 export type UploadRemoteBuildCacheProps = {
   projectRoot: string;
   buildPath: string;
-  runOptions: AndroidRunOptions | IosRunOptions;
+  runOptions: RunOptions;
   fingerprintHash: string;
   platform: ModPlatform;
 };
 export type CalculateFingerprintHashProps = {
   projectRoot: string;
   platform: ModPlatform;
-  runOptions: AndroidRunOptions | IosRunOptions;
+  runOptions: RunOptions;
 };
 
 export type RemoteBuildCacheProvider<T = any> = {

--- a/packages/@expo/cli/src/utils/remote-build-cache-providers/types.ts
+++ b/packages/@expo/cli/src/utils/remote-build-cache-providers/types.ts
@@ -1,0 +1,37 @@
+import { ModPlatform } from '@expo/config-plugins';
+
+import { type Options as AndroidRunOptions } from '../../run/android/resolveOptions';
+import { type Options as IosRunOptions } from '../../run/ios/XcodeBuild.types';
+
+export type ResolveRemoteBuildCacheProps = {
+  projectRoot: string;
+  platform: ModPlatform;
+  runOptions: AndroidRunOptions | IosRunOptions;
+  fingerprintHash: string;
+};
+export type UploadRemoteBuildCacheProps = {
+  projectRoot: string;
+  buildPath: string;
+  runOptions: AndroidRunOptions | IosRunOptions;
+  fingerprintHash: string;
+  platform: ModPlatform;
+};
+export type CalculateFingerprintHashProps = {
+  projectRoot: string;
+  platform: ModPlatform;
+  runOptions: AndroidRunOptions | IosRunOptions;
+};
+
+export type RemoteBuildCacheProvider<T = any> = {
+  plugin: RemoteBuildCachePlugin<T>;
+  options: T;
+};
+
+export type RemoteBuildCachePlugin<T = any> = {
+  resolveRemoteBuildCache(props: ResolveRemoteBuildCacheProps, options: T): Promise<string | null>;
+  uploadRemoteBuildCache(props: UploadRemoteBuildCacheProps, options: T): Promise<string | null>;
+  calculateFingerprintHash?: (
+    props: CalculateFingerprintHashProps,
+    options: T
+  ) => Promise<string | null>;
+};

--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -291,7 +291,10 @@ export interface ExpoConfig {
             /**
              * Service provider for remote builds.
              */
-            provider?: 'eas';
+            provider: 'eas' | {
+                plugin: string | object;
+                options: any;
+            };
         };
     };
     /**

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -295,7 +295,7 @@ export interface ExpoConfig {
       /**
        * Service provider for remote builds.
        */
-      provider?: 'eas';
+      provider: 'eas' | { plugin: string | object; options: any };
     };
   };
   /**


### PR DESCRIPTION
# Why

As specified in https://github.com/expo/expo/pull/36029, we should add support for custom build cache providers. 

# How

Add support for custom remote build cache providers through provider plugins. Similar to config-plugins, users can pass in a module name or the path to a file that implements a provider plugin. 
e.g.

app.json
```json
{
  "expo": {
    "experiments": {
      "remoteBuildCache": {
        "provider": {
          "plugin": "./buildCacheProviderPlugin.js",
          "options": {
            "url": ""
          }
        }
      }
    }
  }
}
```

For a provider plugin to be valid, it must export an object that implements two functions:

```ts
  resolveRemoteBuildCache(props: ResolveRemoteBuildCacheProps, options: T): Promise<string | null>;
  uploadRemoteBuildCache(props: UploadRemoteBuildCacheProps, options: T): Promise<string | null>;

```

Additionally, users can customise the fingerprint generation by providing their own implementation of `calculateFingerprintHash`

```ts
calculateFingerprintHash?: (
    props: CalculateFingerprintHashProps,
    options: T
) => Promise<string | null>;
```

### Follow-ups
- [ ] Move the EAS cache provider implementation to a separate repo.
- [ ] Add a custom provider example to expo/examples
- [ ] Add docs
- [ ] Improve tests

# Test Plan

Run `nexpo run:android` and `nexpo run:ios`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
