### PR TITLE
[expo-go] Add expo-audio

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -3,6 +3,7 @@ package versioned.host.exp.exponent
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import expo.modules.application.ApplicationModule
 import expo.modules.asset.AssetModule
+import expo.modules.audio.AudioModule
 import expo.modules.av.AVModule
 import expo.modules.av.AVPackage
 import expo.modules.av.video.VideoViewModule
@@ -27,6 +28,7 @@ import expo.modules.fetch.ExpoFetchModule
 import expo.modules.filesystem.FileSystemModule
 import expo.modules.filesystem.FileSystemPackage
 import expo.modules.font.FontLoaderModule
+import expo.modules.font.FontUtilsModule
 import expo.modules.gl.GLObjectManagerModule
 import expo.modules.gl.GLViewModule
 import expo.modules.haptics.HapticsModule
@@ -119,6 +121,7 @@ object ExperiencePackagePicker : ModulesProvider {
 
   @OptIn(UnstableReactNativeAPI::class)
   override fun getModulesList(): List<Class<out Module>> = listOf(
+    AudioModule::class.java,
     AVModule::class.java,
     ApplicationModule::class.java,
     // Sensors
@@ -155,6 +158,7 @@ object ExperiencePackagePicker : ModulesProvider {
     DocumentPickerModule::class.java,
     EASClientModule::class.java,
     ExpoFetchModule::class.java,
+    FontUtilsModule::class.java,
     ExpoLinkingModule::class.java,
     FileSystemModule::class.java,
     FontLoaderModule::class.java,

--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -57,7 +57,6 @@ target 'Expo Go' do
       'expo-network-addons',
       'expo-insights',
       'expo-splash-screen',
-      'expo-audio',
       '@expo/ui'
     ],
     includeTests: true,

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -62,6 +62,8 @@ PODS:
     - ExpoModulesCore
   - ExpoAsset (11.1.2):
     - ExpoModulesCore
+  - ExpoAudio (0.4.2):
+    - ExpoModulesCore
   - ExpoBackgroundFetch (13.1.3):
     - ExpoModulesCore
   - ExpoBackgroundTask (0.2.4):
@@ -2853,6 +2855,7 @@ DEPENDENCIES:
   - Expo (from `../../../packages/expo`)
   - ExpoAppleAuthentication (from `../../../packages/expo-apple-authentication/ios`)
   - ExpoAsset (from `../../../packages/expo-asset/ios`)
+  - ExpoAudio (from `../../../packages/expo-audio/ios`)
   - ExpoBackgroundFetch (from `../../../packages/expo-background-fetch/ios`)
   - ExpoBackgroundTask (from `../../../packages/expo-background-task/ios`)
   - ExpoBattery (from `../../../packages/expo-battery/ios`)
@@ -3089,6 +3092,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-apple-authentication/ios"
   ExpoAsset:
     :path: "../../../packages/expo-asset/ios"
+  ExpoAudio:
+    :path: "../../../packages/expo-audio/ios"
   ExpoBackgroundFetch:
     :path: "../../../packages/expo-background-fetch/ios"
   ExpoBackgroundTask:
@@ -3400,6 +3405,7 @@ SPEC CHECKSUMS:
   Expo: 8968cac151cfad8835644eda4c58cecd72e841db
   ExpoAppleAuthentication: b1b48e4b0b84699f2c38b7210a3c9b0fef4b301f
   ExpoAsset: 6ed36a13e3817a85b0991032ac44d69bb41297c6
+  ExpoAudio: a19999a254a62b9ce8b4243386af300474c159fd
   ExpoBackgroundFetch: a902c5ec702bb7cbd76c2e60445b438c9d68e201
   ExpoBackgroundTask: 16fa0d74878f99a01a39b7aa2bbe8d2267b19256
   ExpoBattery: b5ca5288f89d7d8478ca131b3f95e95d921d0faf
@@ -3586,6 +3592,6 @@ SPEC CHECKSUMS:
   Yoga: d15f5aa644c466e917569ac43b19cbf17975239a
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: a281d730cb159bd3316f12fe0fa826633ca90be1
+PODFILE CHECKSUM: b43e8fd68aecb83928c36a03bb11448210e1072a
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
# Why
Closes ENG-15543

# How
Add `expo-audio` to expo go. 
Expo go was crashing on android because we hadn't added the `FontUtilsModule` so I've added that

# Test Plan
The NCL example works correctly running in expo go

