### PR TITLE
[expo-go][ios] hide empty errors in cli

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/Views/EXErrorView.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/EXErrorView.m
@@ -138,7 +138,14 @@
   }
   
   // Send error to cli/packager
-  [EXPackagerLogHelper logError:[NSString stringWithFormat:@"%@\n\n%@\n\nHow to fix this error:\n\n%@", errorHeader, [errorDetail stringByReplacingOccurrencesOfString:@"**" withString:@""], errorFixInstructions] withBundleUrl:_appRecord.appLoader.manifestUrl];
+  if (errorHeader != nil && errorDetail != nil) {
+    NSString* cleanedDetails = [errorDetail stringByReplacingOccurrencesOfString:@"**" withString:@""];
+    if (errorFixInstructions != nil) {
+      [EXPackagerLogHelper logError:[NSString stringWithFormat:@"%@\n\n%@\n\nHow to fix this error:\n\n%@", errorHeader, cleanedDetails, errorFixInstructions] withBundleUrl:_appRecord.appLoader.manifestUrl];
+    } else {
+      [EXPackagerLogHelper logError:[NSString stringWithFormat:@"%@\n\n%@", errorHeader, cleanedDetails] withBundleUrl:_appRecord.appLoader.manifestUrl];
+    }
+  }
 
   [self _resetUIState];
 }


### PR DESCRIPTION
# Why

When sending errors to the CLI from `EXErrorView`, we didn't check if the error texts was empty.

# How

This commit fixes this by adding nil tests before sending data to the CLI.

# Test Plan

- Start Expo-Go on iOS
- Add the line `const not_working = require('./a-file-that-doesnt-exist.mp3');` to the file `./index.js` 
- Open native-components-list example in Expo Go
- Observe that an error is displayed and the app won't start
- (NULL) is not printed in the console, only the error.
 
# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
