### PR TITLE
[module-scripts] move `tsconfig.node` in, from monorepo root

### DIFF
--- a/packages/@expo/cli/src/utils/telemetry/clients/FetchClient.ts
+++ b/packages/@expo/cli/src/utils/telemetry/clients/FetchClient.ts
@@ -2,13 +2,15 @@ import { Buffer } from 'node:buffer';
 import { URL } from 'node:url';
 import { Agent, RetryAgent, type RequestInfo, type RequestInit } from 'undici';
 
-import { fetch } from '../../../utils/fetch';
+import { fetch } from '../../fetch';
 import { TelemetryClient, TelemetryClientStrategy, TelemetryRecordInternal } from '../types';
 import { TELEMETRY_ENDPOINT, TELEMETRY_TARGET } from '../utils/constants';
 
+type Fetch = typeof fetch;
+
 type FetchClientOptions = {
   /** The fetch method for sending events, should handle retries and timeouts */
-  fetch?: typeof fetch;
+  fetch?: Fetch;
   /** The endpoint for recorded events */
   url?: string;
   /** The telemetry target for all events */
@@ -24,7 +26,7 @@ export class FetchClient implements TelemetryClient {
   /** This client should be used for long-running commands */
   readonly strategy: TelemetryClientStrategy = 'instant';
   /** The fetch instance used to transport telemetry to the backend */
-  private fetch: typeof fetch;
+  private fetch: Fetch;
   /** The endpoint to send events to */
   private url: string;
   /** Additional headers to send with every event */

--- a/packages/@expo/cli/tsconfig.json
+++ b/packages/@expo/cli/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src", "./ts-declarations"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__typetests__/*"],
   "compilerOptions": {

--- a/packages/@expo/config-plugins/tsconfig.json
+++ b/packages/@expo/config-plugins/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/@expo/config-types/tsconfig.json
+++ b/packages/@expo/config-types/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/@expo/config/tsconfig.json
+++ b/packages/@expo/config/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/@expo/dom-webview/scripts/tsconfig.json
+++ b/packages/@expo/dom-webview/scripts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../../tsconfig.node.json",
+  "extends": "expo-module-scripts/tsconfig.node",
   "compilerOptions": {
     "noEmit": true
   },

--- a/packages/@expo/env/tsconfig.json
+++ b/packages/@expo/env/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/@expo/fingerprint/tsconfig.json
+++ b/packages/@expo/fingerprint/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "compilerOptions": {
     "allowJs": true,
     "outDir": "./build",

--- a/packages/@expo/image-utils/tsconfig.json
+++ b/packages/@expo/image-utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "compilerOptions": {
     "outDir": "./build",

--- a/packages/@expo/json-file/tsconfig.json
+++ b/packages/@expo/json-file/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/@expo/metro-config/tsconfig.json
+++ b/packages/@expo/metro-config/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/@expo/osascript/tsconfig.json
+++ b/packages/@expo/osascript/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/@expo/package-manager/tsconfig.json
+++ b/packages/@expo/package-manager/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/@expo/pkcs12/tsconfig.json
+++ b/packages/@expo/pkcs12/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/@expo/plist/tsconfig.json
+++ b/packages/@expo/plist/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/@expo/prebuild-config/tsconfig.json
+++ b/packages/@expo/prebuild-config/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/@expo/schemer/tsconfig.json
+++ b/packages/@expo/schemer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/@expo/server/tsconfig.json
+++ b/packages/@expo/server/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*", "install.d.ts", "install.js"],
   "compilerOptions": {

--- a/packages/babel-preset-expo/tsconfig.json
+++ b/packages/babel-preset-expo/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/create-expo/tsconfig.json
+++ b/packages/create-expo/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/create-expo/tsconfig.json
+++ b/packages/create-expo/tsconfig.json
@@ -1,15 +1,13 @@
 {
-  "extends": "expo-module-scripts/tsconfig.node",
+  "extends": "../expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {
     "outDir": "build",
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
     "module": "preserve",
     "moduleResolution": "bundler",
     "declaration": false,
-    "composite": false,
+    "composite": false
   }
 }

--- a/packages/eslint-plugin-expo/tsconfig.json
+++ b/packages/eslint-plugin-expo/tsconfig.json
@@ -5,8 +5,6 @@
   "compilerOptions": {
     "outDir": "build",
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
     "declaration": false,
     "composite": false
   }

--- a/packages/eslint-plugin-expo/tsconfig.json
+++ b/packages/eslint-plugin-expo/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__tests__/*"],
   "compilerOptions": {

--- a/packages/expo-doctor/tsconfig.json
+++ b/packages/expo-doctor/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/expo-doctor/tsconfig.json
+++ b/packages/expo-doctor/tsconfig.json
@@ -1,11 +1,10 @@
 {
-  "extends": "expo-module-scripts/tsconfig.node",
+  "extends": "../expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {
     "outDir": "./build",
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true,
     "typeRoots": [
       "ts-declarations",
       "../../expo-module-scripts/ts-declarations",

--- a/packages/expo-env-info/tsconfig.json
+++ b/packages/expo-env-info/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": [
     "src/**/*.ts"
   ],

--- a/packages/expo-env-info/tsconfig.json
+++ b/packages/expo-env-info/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "expo-module-scripts/tsconfig.node",
+  "extends": "../expo-module-scripts/tsconfig.node",
   "include": [
     "src/**/*.ts"
   ],

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add TS config base for Node apps. ([#36322](https://github.com/expo/expo/pull/36322) by [@Simek]
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-module-scripts/tsconfig.node.json
+++ b/packages/expo-module-scripts/tsconfig.node.json
@@ -1,6 +1,9 @@
 {
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
+    "target": "ES2020",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "esModuleInterop": true,
     "declaration": true,
     "strict": true,

--- a/packages/expo-module-scripts/tsconfig.node.json
+++ b/packages/expo-module-scripts/tsconfig.node.json
@@ -1,6 +1,5 @@
 {
   "extends": "@tsconfig/node18/tsconfig.json",
-
   "compilerOptions": {
     "esModuleInterop": true,
     "declaration": true,

--- a/packages/expo-module-scripts/tsconfig.node.json
+++ b/packages/expo-module-scripts/tsconfig.node.json
@@ -1,12 +1,13 @@
 {
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "Node16",
     "moduleResolution": "Node16",
     "esModuleInterop": true,
     "declaration": true,
     "strict": true,
+    "useDefineForClassFields": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "allowSyntheticDefaultImports": true,

--- a/packages/expo-test-runner/tsconfig.json
+++ b/packages/expo-test-runner/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["./src"],
-  "extends": "../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "compilerOptions": {
     "outDir": "./build",
     "paths": {},

--- a/packages/expo-updates/e2e/tsconfig.json
+++ b/packages/expo-updates/e2e/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "../../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./fixtures", "./setup"]
 }

--- a/packages/install-expo-modules/tsconfig.json
+++ b/packages/install-expo-modules/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "expo-module-scripts/tsconfig.node",
+  "extends": "../expo-module-scripts/tsconfig.node",
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src"

--- a/packages/install-expo-modules/tsconfig.json
+++ b/packages/install-expo-modules/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src"

--- a/packages/jest-expo/tsconfig.json
+++ b/packages/jest-expo/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/patch-project/tsconfig.json
+++ b/packages/patch-project/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "compilerOptions": {
     "allowJs": true,
     "outDir": "./build",

--- a/packages/pod-install/tsconfig.json
+++ b/packages/pod-install/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "expo-module-scripts/tsconfig.node",
+  "extends": "../expo-module-scripts/tsconfig.node",
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src",

--- a/packages/pod-install/tsconfig.json
+++ b/packages/pod-install/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src",

--- a/packages/uri-scheme/tsconfig.json
+++ b/packages/uri-scheme/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.node",
+  "extends": "expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {

--- a/packages/uri-scheme/tsconfig.json
+++ b/packages/uri-scheme/tsconfig.json
@@ -1,11 +1,11 @@
 {
-  "extends": "expo-module-scripts/tsconfig.node",
+  "extends": "../expo-module-scripts/tsconfig.node",
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"],
   "compilerOptions": {
     "resolveJsonModule": true,
     "rootDir": "src",
     "declaration": false,
-    "composite": false,
-  },
+    "composite": false
+  }
 }


### PR DESCRIPTION
# Why

During work on `expo-module-scripts` conversion for Windows compatibility I have spotted that some packages refers to TS custom config located in the monorepo root.

Refs:
* #36296

# How

Move custom `tsconfig.node` from monorepo root to the `expo-module-scripts`, where all other custom configs for monorepo packages resides. Besides config collocation in one place, we can also now avoid using relative paths in config (EDIT: not in all cases, since we use `ncc` compiler for some packages, and it cannot correctly resolve extend config, when referring by package name, instead of path) .

# Test Plan

Affected packages build as expected after the changes.