### PR TITLE
fix(cli): limit prebuild renaming operations to files and not folders

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Exclude directories from prebuild "magic string" renaming operations. ([#36325](https://github.com/expo/expo/pull/36325) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 0.24.3 — 2025-04-21

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -292,6 +292,6 @@ it('runs `npx expo prebuild --platform ios` after building Android', async () =>
     templateTarball.relativePath,
   ]);
 
-  // Ensure there was no errors
+  // Ensure there are no errors
   expect(command).toMatchObject({ stderr: '' });
 });

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -257,7 +257,8 @@ itNotWindows('runs `npx expo prebuild --template <github-url>`', async () => {
 });
 
 // Regression test for https://github.com/expo/expo/issues/36289
-it('runs `npx expo prebuild --platform ios` after building Android', async () => {
+// This tests contains assertions related to ios files, making it incompatible with Windows
+itNotWindows('runs `npx expo prebuild --platform ios` after building Android', async () => {
   const projectRoot = await setupTestProjectWithOptionsAsync(
     'regression-expo-36289',
     'with-blank',

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -293,5 +293,7 @@ it('runs `npx expo prebuild --platform ios` after building Android', async () =>
   ]);
 
   // Ensure there are no errors
-  expect(command).toMatchObject({ stderr: '' });
+  expect(command).not.toMatchObject({
+    stderr: expect.stringContaining('Failed to read template file'),
+  });
 });

--- a/packages/@expo/cli/src/prebuild/renameTemplateAppName.ts
+++ b/packages/@expo/cli/src/prebuild/renameTemplateAppName.ts
@@ -104,6 +104,9 @@ export async function getTemplateFilesToRenameAsync({
     // Prevent climbing out of the template directory in case a template
     // includes a symlink to an external directory.
     follow: false,
+    // Do not match on directories, only files
+    // Without this patterns like `android/**/*.gradle` actually match the folder `android/.gradle`
+    nodir: true,
   });
 }
 


### PR DESCRIPTION
# Why

Fixes #36289
Fixes ENG-15406

# How

Prebuild has special logic to rename certain files using the template "magic strings". This is happening in [`renameTemplateAppName.ts`](https://github.com/expo/expo/blob/main/packages/%40expo/cli/src/prebuild/renameTemplateAppName.ts). The unfortunate thing here is that `android/**/*.gradle` also matches the temporary folder `android/.gradle`, which can't have any of this logic applied because its a folder.

![image](https://github.com/user-attachments/assets/ab32b3fb-6fab-4a51-ba8f-de48576160d4)

This limits the glob to only match on files to avoid accidentally reading folders as files.

# Test Plan

See modified test case to trigger the `android/.gradle` folder issue.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
