### PR TITLE
[docs] fix new lint warnings after migration to flat config

### DIFF
--- a/docs/common/utilities.ts
+++ b/docs/common/utilities.ts
@@ -1,12 +1,12 @@
 import GithubSlugger from 'github-slugger';
-import React from 'react';
+import { ReactNode, ReactElement } from 'react';
 
 import versions from '~/public/static/constants/versions.json';
 
 const { BETA_VERSION, LATEST_VERSION } = versions;
 
-function hasChildren(node: React.ReactNode): node is React.ReactElement {
-  return (node as React.ReactElement)?.props?.children !== undefined;
+function hasChildren(node: ReactNode): node is ReactElement {
+  return (node as ReactElement)?.props?.children !== undefined;
 }
 
 /**
@@ -14,9 +14,9 @@ function hasChildren(node: React.ReactNode): node is React.ReactElement {
  * This is needed, because sometimes we receive pure string node,
  * but sometimes (e.g. when using styled text), we receive whole object (React.Element)
  *
- * @param {React.ReactNode} node React Node object to stringify
+ * @param node React Node object to stringify
  */
-export const toString = (node: React.ReactNode): string => {
+export const toString = (node: ReactNode): string => {
   if (typeof node === 'string') {
     return node;
   } else if (Array.isArray(node)) {
@@ -28,7 +28,7 @@ export const toString = (node: React.ReactNode): string => {
   }
 };
 
-export const generateSlug = (slugger: GithubSlugger, node: React.ReactNode, length = 7): string => {
+export const generateSlug = (slugger: GithubSlugger, node: ReactNode, length = 7): string => {
   const stringToSlug = toString(node).split(' ').splice(0, length).join('-');
 
   // NOTE(jim): This will strip out commas from stringToSlug
@@ -77,15 +77,6 @@ export const pathStartsWith = (name: string, path: string) => {
   return path.startsWith(`/${name}`);
 };
 
-export const chunkArray = (array: any[], chunkSize: number) => {
-  return array.reduce((acc, _, i) => {
-    if (i % chunkSize === 0) {
-      acc.push(array.slice(i, i + chunkSize));
-    }
-    return acc;
-  }, []);
-};
-
 export function listMissingHashLinkTargets(apiName?: string) {
   const contentLinks = document.querySelectorAll<HTMLAnchorElement>(
     `div.size-full.overflow-x-hidden.overflow-y-auto a`
@@ -124,6 +115,10 @@ export function versionToText(version: string): string {
   return formatSdkVersion(version);
 }
 
-function formatSdkVersion(version: string): string {
+export function formatSdkVersion(version: string): string {
   return version.includes('v') ? `SDK ${version.substring(1, 3)}` : `SDK ${version}`;
+}
+
+export function capitalize(str: string) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
 }

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -2,9 +2,9 @@ import { mergeClasses } from '@expo/styleguide';
 import { breakpoints } from '@expo/styleguide-base';
 import { useRouter } from 'next/compat/router';
 import { useEffect, useState, createRef, type PropsWithChildren, useRef } from 'react';
+
 import { InlineHelp } from 'ui/components/InlineHelp';
 import { PageHeader } from 'ui/components/PageHeader';
-
 import * as RoutesUtils from '~/common/routes';
 import { appendSectionToRoute, isRouteActive } from '~/common/routes';
 import { versionToText } from '~/common/utilities';

--- a/docs/components/plugins/api/APISectionDeprecationNote.tsx
+++ b/docs/components/plugins/api/APISectionDeprecationNote.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 import ReactMarkdown from 'react-markdown';
-import { InlineHelp } from 'ui/components/InlineHelp';
 
+import { InlineHelp } from '~/ui/components/InlineHelp';
 import { BOLD } from '~/ui/components/Text';
 
 import { CommentData } from './APIDataTypes';

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -2,6 +2,7 @@ import { mergeClasses } from '@expo/styleguide';
 import { CornerDownRightIcon } from '@expo/styleguide-icons/outline/CornerDownRightIcon';
 
 import { APIBoxHeader } from '~/components/plugins/api/components/APIBoxHeader';
+import { APIMethodParamRows } from '~/components/plugins/api/components/APIMethodParamRows';
 import { H2 } from '~/ui/components/Text';
 
 import {
@@ -11,13 +12,7 @@ import {
   PropData,
 } from './APIDataTypes';
 import { APISectionDeprecationNote } from './APISectionDeprecationNote';
-import {
-  getMethodName,
-  renderParams,
-  resolveTypeName,
-  getTagData,
-  getAllTagData,
-} from './APISectionUtils';
+import { getMethodName, resolveTypeName, getTagData, getAllTagData } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
 import { APIDataType } from './components/APIDataType';
 import { ELEMENT_SPACING, STYLES_APIBOX, STYLES_APIBOX_NESTED, STYLES_SECONDARY } from './styles';
@@ -100,7 +95,7 @@ export const renderMethod = (
         />
         {parameters && parameters.length > 0 && (
           <>
-            {renderParams(parameters, sdkVersion)}
+            <APIMethodParamRows parameters={parameters} sdkVersion={sdkVersion} />
             <br />
           </>
         )}

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -21,7 +21,6 @@ import {
   parseCommentContent,
   getCommentOrSignatureComment,
   getTagData,
-  renderParams,
   renderDefaultValue,
   renderIndexSignature,
   getCommentContent,
@@ -30,6 +29,7 @@ import {
 } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
 import { APIDataType } from './components/APIDataType';
+import { APIMethodParamRows } from './components/APIMethodParamRows';
 import { APIParamsTableHeadRow } from './components/APIParamsTableHeadRow';
 import { APITypeOrSignatureType } from './components/APITypeOrSignatureType';
 import { ELEMENT_SPACING, STYLES_APIBOX, STYLES_SECONDARY, VERTICAL_SPACING } from './styles';
@@ -177,7 +177,9 @@ const renderType = (
         {signature ? (
           <div key={`type-definition-signature-${signature.name}`}>
             <APICommentTextBlock comment={signature.comment} />
-            {signature.parameters && renderParams(signature.parameters, sdkVersion)}
+            {signature.parameters && (
+              <APIMethodParamRows parameters={signature.parameters} sdkVersion={sdkVersion} />
+            )}
           </div>
         ) : null}
         {signature?.type && (

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -41,9 +41,7 @@ import {
   replaceableTypes,
   sdkVersionHardcodedTypeLinks,
 } from './APIStaticData';
-import { APIParamRow } from './components/APIParamRow';
-import { APIParamsTableHeadRow } from './components/APIParamsTableHeadRow';
-import { ELEMENT_SPACING, STYLES_OPTIONAL, STYLES_SECONDARY, VERTICAL_SPACING } from './styles';
+import { ELEMENT_SPACING, STYLES_OPTIONAL, STYLES_SECONDARY } from './styles';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -402,25 +400,6 @@ export const resolveTypeName = (
 
 export const parseParamName = (name: string) => (name.startsWith('__') ? name.substr(2) : name);
 
-export const renderParams = (parameters: MethodParamData[], sdkVersion: string) => {
-  const hasDescription = Boolean(parameters.some(param => param.comment));
-  return (
-    <Table containerClassName={mergeClasses(VERTICAL_SPACING, 'mt-0.5')}>
-      <APIParamsTableHeadRow hasDescription={hasDescription} mainCellLabel="Parameter" />
-      <tbody>
-        {parameters?.map(param => (
-          <APIParamRow
-            key={param.name}
-            param={param}
-            sdkVersion={sdkVersion}
-            showDescription={hasDescription}
-          />
-        ))}
-      </tbody>
-    </Table>
-  );
-};
-
 export const listParams = (parameters: MethodParamData[]) =>
   parameters
     ? parameters
@@ -529,8 +508,6 @@ export const getMethodName = (
 
   return methodName;
 };
-
-export const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
 
 export const getCommentContent = (content: CommentContentData[]) => {
   return content

--- a/docs/components/plugins/api/components/APICommentTextBlock.tsx
+++ b/docs/components/plugins/api/components/APICommentTextBlock.tsx
@@ -5,8 +5,8 @@ import ReactMarkdown from 'react-markdown';
 import { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkSupsub from 'remark-supersub';
-import { InlineHelp } from 'ui/components/InlineHelp';
 
+import { InlineHelp } from '~/ui/components/InlineHelp';
 import { Tag } from '~/ui/components/Tag/Tag';
 import { CALLOUT } from '~/ui/components/Text';
 

--- a/docs/components/plugins/api/components/APIMethodParamRows.tsx
+++ b/docs/components/plugins/api/components/APIMethodParamRows.tsx
@@ -1,0 +1,32 @@
+import { mergeClasses } from '@expo/styleguide';
+
+import { MethodParamData } from '~/components/plugins/api/APIDataTypes';
+import { VERTICAL_SPACING } from '~/components/plugins/api/styles';
+import { Table } from '~/ui/components/Table';
+
+import { APIParamRow } from './APIParamRow';
+import { APIParamsTableHeadRow } from './APIParamsTableHeadRow';
+
+type Props = {
+  parameters: MethodParamData[];
+  sdkVersion: string;
+};
+
+export function APIMethodParamRows({ parameters, sdkVersion }: Props) {
+  const hasDescription = Boolean(parameters.some(param => param.comment));
+  return (
+    <Table containerClassName={mergeClasses(VERTICAL_SPACING, 'mt-0.5')}>
+      <APIParamsTableHeadRow hasDescription={hasDescription} mainCellLabel="Parameter" />
+      <tbody>
+        {parameters?.map(param => (
+          <APIParamRow
+            key={param.name}
+            param={param}
+            sdkVersion={sdkVersion}
+            showDescription={hasDescription}
+          />
+        ))}
+      </tbody>
+    </Table>
+  );
+}

--- a/docs/components/plugins/permissions/AndroidPermissions.tsx
+++ b/docs/components/plugins/permissions/AndroidPermissions.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
 import { useMemo } from 'react';
-import { InlineHelp } from 'ui/components/InlineHelp';
 
+import { InlineHelp } from 'ui/components/InlineHelp';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import { CODE, P, createPermalinkedComponent } from '~/ui/components/Text';
 

--- a/docs/eslint.config.mjs
+++ b/docs/eslint.config.mjs
@@ -18,25 +18,25 @@ const CORE_RULES = {
   'prettier/prettier': 'error',
   'no-void': ['warn', { allowAsStatement: true }],
   'no-return-await': 'off',
-  // 'import/order': [
-  //   'error',
-  //   {
-  //     groups: [['external', 'builtin'], 'internal', ['parent', 'sibling']],
-  //     'newlines-between': 'always',
-  //     alphabetize: {
-  //       order: 'asc',
-  //     },
-  //     pathGroups: [
-  //       {
-  //         pattern: '~/**',
-  //         group: 'internal',
-  //       },
-  //     ],
-  //   },
-  // ],
+  'import/order': [
+    'error',
+    {
+      groups: [['external', 'builtin'], 'internal', ['parent', 'sibling']],
+      'newlines-between': 'always',
+      alphabetize: {
+        order: 'asc',
+      },
+      pathGroups: [
+        {
+          pattern: '~/**',
+          group: 'internal',
+        },
+      ],
+    },
+  ],
   curly: 'warn',
   eqeqeq: ['error', 'always', { null: 'ignore' }],
-  // 'import/no-cycle': ['error', { maxDepth: '∞' }],
+  'import/no-cycle': ['error', { maxDepth: '∞' }],
   'lodash/import-scope': [2, 'method'],
   'unicorn/new-for-builtins': 'warn',
   'unicorn/no-useless-spread': 'warn',
@@ -64,17 +64,17 @@ const CORE_RULES = {
 
 export default defineConfig([
   globalIgnores([
+    '**/.cache',
     '**/.next/',
     '**/.swc/',
     '**/.yarn/',
-    'types/global.d.ts',
-    '**/.cache',
     '**/.vale',
-    '**/out',
     '**/node_modules',
-    'pages/versions/latest',
+    '**/out',
     '**/public',
+    'pages/versions/latest',
     'scripts/generate-llms/talks.js',
+    'types/global.d.ts',
     'README.md',
     'next-env.d.ts',
   ]),
@@ -84,11 +84,6 @@ export default defineConfig([
 
   // Overrides needed to make flat config rules work
   {
-    rules: {
-      'import/order': 'off', // TODO (Kadi): enable and fix issues
-      'import/no-cycle': 'off', // TODO (Kadi): enable and fix issues
-      'import/no-named-as-default': 'off', // TODO (Kadi): for LightboxImage
-    },
     settings: {
       'import/resolver': {
         typescript: { project: './tsconfig.json' },

--- a/docs/pages/workflow/android-studio-emulator.mdx
+++ b/docs/pages/workflow/android-studio-emulator.mdx
@@ -6,7 +6,6 @@ description: Learn how to set up the Android Emulator to test your app on a virt
 import AndroidEmulatorInstructions from 'scenes/get-started/set-up-your-environment/instructions/_androidEmulatorInstructions.mdx';
 import AndroidStudioEnvironmentInstructions from 'scenes/get-started/set-up-your-environment/instructions/_androidStudioEnvironmentInstructions.mdx';
 import AndroidStudioInstructions from 'scenes/get-started/set-up-your-environment/instructions/_androidStudioInstructions.mdx';
-
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 

--- a/docs/pages/workflow/customizing.mdx
+++ b/docs/pages/workflow/customizing.mdx
@@ -31,7 +31,7 @@ When using [development builds](/develop/development-builds/introduction/), usin
 You can now use the library in your application code.
 
 <Collapsible summary="Key concepts and development workflow">
-    
+
 [The development overview](/workflow/overview/) provides details on key concepts for developing an app with Expo and the flow of the core development loop.
 
 </Collapsible>
@@ -67,7 +67,7 @@ The Expo Modules API allows you to write Swift and Kotlin to add new capabilitie
 
 ### Creating a local module
 
-If you intend to use your native module in a single app (you can always change your mind later), we recommend [using a "local" Expo module](/modules/get-started/#creating-the-local-expo-module) to write custom native code. Local Expo Modules function similarly to [Expo Modules](/modules/overview) used by library developers and within the Expo SDK, like `expo-camera`, but they are not published on npm. Instead, you create them directly inside your project.
+If you intend to use your native module in a single app (you can always change your mind later), we recommend [using a "local" Expo module](/modules/get-started/#creating-the-local-expo-module) to write custom native code. Local Expo Modules function similarly to [Expo Modules](/modules/overview) used by library developers and within the Expo SDK, like `expo-camera`, but they are not published on npm. Instead, you create them directly inside your project.
 
 Creating a local module scaffolds a Swift and Kotlin module inside the `modules` directory in your project, and these modules are automatically linked to your app.
 

--- a/docs/pages/workflow/ios-simulator.mdx
+++ b/docs/pages/workflow/ios-simulator.mdx
@@ -4,8 +4,8 @@ description: Learn how you can install the iOS Simulator on your Mac and use it 
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
-import XcodeInstructions from 'scenes/get-started/set-up-your-environment/instructions/_xcodeInstructions.mdx';
 
+import XcodeInstructions from 'scenes/get-started/set-up-your-environment/instructions/_xcodeInstructions.mdx';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';

--- a/docs/providers/page-api-version.tsx
+++ b/docs/providers/page-api-version.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/compat/router';
 import { createContext, PropsWithChildren, useCallback, useContext } from 'react';
 
-import { isVersionedPath } from '~/common/routes';
+import { pathStartsWith } from '~/common/utilities';
 import navigation from '~/public/static/constants/navigation.json';
 
 export const PageApiVersionContext = createContext({
@@ -50,7 +50,7 @@ export function usePageApiVersion() {
  * This only accepts pathname without hashes or query strings.
  */
 export function getVersionFromPath(path: string): PageApiVersionContextType['version'] | null {
-  return isVersionedPath(path)
+  return pathStartsWith('versions', path)
     ? (path.split('/', 3).pop()! as PageApiVersionContextType['version'])
     : null;
 }

--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalDevelopmentBuild.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalDevelopmentBuild.mdx
@@ -1,7 +1,7 @@
-import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
-
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+
+import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
 
 ## Set up an Android device with a development build
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalDevelopmentBuildLocal.mdx
@@ -1,9 +1,9 @@
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
 import AndroidStudioEnvironmentInstructions from './_androidStudioEnvironmentInstructions.mdx';
 import AndroidStudioInstructions from './_androidStudioInstructions.mdx';
 import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
-
-import { Terminal } from '~/ui/components/Snippet';
-import { Step } from '~/ui/components/Step';
 
 ## Set up an Android device with a development build
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidSimulatedDevelopmentBuild.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidSimulatedDevelopmentBuild.mdx
@@ -1,9 +1,9 @@
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
 import AndroidEmulatorInstructions from './_androidEmulatorInstructions.mdx';
 import AndroidStudioInstructions from './_androidStudioInstructions.mdx';
 import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
-
-import { Terminal } from '~/ui/components/Snippet';
-import { Step } from '~/ui/components/Step';
 
 ## Set up an Android Emulator with a development build
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidSimulatedDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidSimulatedDevelopmentBuildLocal.mdx
@@ -1,10 +1,10 @@
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
 import AndroidEmulatorInstructions from './_androidEmulatorInstructions.mdx';
 import AndroidStudioEnvironmentInstructions from './_androidStudioEnvironmentInstructions.mdx';
 import AndroidStudioInstructions from './_androidStudioInstructions.mdx';
 import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
-
-import { Terminal } from '~/ui/components/Snippet';
-import { Step } from '~/ui/components/Step';
 
 ## Set up an Android Emulator with a development build
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuild.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuild.mdx
@@ -1,7 +1,7 @@
-import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
-
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+
+import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
 
 ## Set up an iOS device with a development build
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -1,8 +1,8 @@
-import XcodeInstructions from './_xcodeInstructions.mdx';
-import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
-
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+
+import XcodeInstructions from './_xcodeInstructions.mdx';
+import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
 
 ## Set up an iOS device with a development build
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosSimulatedDevelopmentBuild.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosSimulatedDevelopmentBuild.mdx
@@ -1,8 +1,8 @@
-import XcodeInstructions from './_xcodeInstructions.mdx';
-import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
-
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+
+import XcodeInstructions from './_xcodeInstructions.mdx';
+import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
 
 ## Set up an iOS Simulator with a development build
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosSimulatedDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosSimulatedDevelopmentBuildLocal.mdx
@@ -1,8 +1,8 @@
-import XcodeInstructions from './_xcodeInstructions.mdx';
-import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
-
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+
+import XcodeInstructions from './_xcodeInstructions.mdx';
+import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
 
 ## Set up an iOS Simulator with a development build
 

--- a/docs/scripts/fetch-versions-schema.js
+++ b/docs/scripts/fetch-versions-schema.js
@@ -1,12 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { inc } from 'semver';
 
 import { VERSIONS, LATEST_VERSION, BETA_VERSION } from '../constants/versions.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const projectRoot = path.resolve(__dirname, '..');
+const projectRoot = path.resolve(import.meta.dirname, '..');
 
 export async function getSchemaAsync(sdkVersion, isUnversioned = false) {
   const response = await fetch(

--- a/docs/scripts/generate-llms/compileTalks.js
+++ b/docs/scripts/generate-llms/compileTalks.js
@@ -1,10 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const projectRoot = path.resolve(__dirname, '../..');
+const projectRoot = path.resolve(import.meta.dirname, '../..');
 
 const inputFile = path.join(projectRoot, 'public/static/talks.ts');
 const outputFile = path.join(projectRoot, 'scripts/generate-llms/talks.js');

--- a/docs/scripts/generate-static-resources.js
+++ b/docs/scripts/generate-static-resources.js
@@ -1,12 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import navigation from '../constants/navigation.js';
 import * as versions from '../constants/versions.js';
 
-const dirname = path.dirname(fileURLToPath(import.meta.url));
-const basePath = path.join(dirname, '../', 'public', 'static', 'constants');
+const basePath = path.join(import.meta.dirname, '../', 'public', 'static', 'constants');
 
 function writeResource(filename, data) {
   const filePath = path.join(basePath, filename);

--- a/docs/ui/components/ContentSpotlight/LightboxImage.tsx
+++ b/docs/ui/components/ContentSpotlight/LightboxImage.tsx
@@ -1,5 +1,5 @@
 import { ImgHTMLAttributes, useState } from 'react';
-import Lightbox from 'yet-another-react-lightbox';
+import { Lightbox } from 'yet-another-react-lightbox';
 import Zoom from 'yet-another-react-lightbox/plugins/zoom';
 
 import 'yet-another-react-lightbox/styles.css';

--- a/docs/ui/components/Footer/FeedbackDialog.tsx
+++ b/docs/ui/components/Footer/FeedbackDialog.tsx
@@ -3,8 +3,8 @@ import { CheckIcon } from '@expo/styleguide-icons/outline/CheckIcon';
 import { XIcon } from '@expo/styleguide-icons/outline/XIcon';
 import * as Dialog from '@radix-ui/react-dialog';
 import { useState } from 'react';
-import { InlineHelp } from 'ui/components/InlineHelp';
 
+import { InlineHelp } from 'ui/components/InlineHelp';
 import { Input, Textarea } from '~/ui/components/Form';
 import { CALLOUT, LABEL, RawH2 } from '~/ui/components/Text';
 

--- a/docs/ui/components/Layout/Layout.tsx
+++ b/docs/ui/components/Layout/Layout.tsx
@@ -2,8 +2,9 @@ import { mergeClasses } from '@expo/styleguide';
 import { type PropsWithChildren, type ReactNode } from 'react';
 
 import { Header } from '~/ui/components/Header';
-import { LayoutScroll } from '~/ui/components/Layout';
 import { Sidebar } from '~/ui/components/Sidebar/Sidebar';
+
+import { LayoutScroll } from './LayoutScroll';
 
 type LayoutProps = PropsWithChildren<{
   /**

--- a/docs/ui/components/Markdown/index.tsx
+++ b/docs/ui/components/Markdown/index.tsx
@@ -1,6 +1,6 @@
 import type { ComponentType, PropsWithChildren } from 'react';
-import { InlineHelp } from 'ui/components/InlineHelp';
 
+import { InlineHelp } from 'ui/components/InlineHelp';
 import { Code as PrismCodeBlock } from '~/components/base/code';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import { H1, H2, H3, H4, H5, A, CODE, P, BOLD, UL, OL, LI, KBD, DEL } from '~/ui/components/Text';

--- a/docs/ui/components/PrereleaseNotice.tsx
+++ b/docs/ui/components/PrereleaseNotice.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren } from 'react';
-import { InlineHelp } from 'ui/components/InlineHelp';
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { InlineHelp } from '~/ui/components/InlineHelp';
 import { A, CODE } from '~/ui/components/Text';
 
 export default function PrereleaseNotice({ children }: PropsWithChildren) {

--- a/docs/ui/components/RedirectNotification.tsx
+++ b/docs/ui/components/RedirectNotification.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/compat/router';
 import { useEffect, useState, PropsWithChildren } from 'react';
-import { InlineHelp } from 'ui/components/InlineHelp';
+
+import { InlineHelp } from '~/ui/components/InlineHelp';
 
 type Props = PropsWithChildren<{
   showForQuery?: string;

--- a/docs/ui/components/TableOfContents/TableOfContents.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContents.tsx
@@ -16,8 +16,9 @@ import { BASE_HEADING_LEVEL, Heading } from '~/common/headingManager';
 import { prefersReducedMotion } from '~/common/window';
 import { HeadingManagerProps, HeadingsContext } from '~/common/withHeadingManager';
 import { ScrollContainer } from '~/components/ScrollContainer';
-import { TableOfContentsLink } from '~/ui/components/TableOfContents';
 import { CALLOUT } from '~/ui/components/Text';
+
+import { TableOfContentsLink } from './TableOfContentsLink';
 
 const UPPER_SCROLL_LIMIT_FACTOR = 1 / 4;
 const LOWER_SCROLL_LIMIT_FACTOR = 3 / 4;

--- a/docs/ui/components/Tag/helpers.ts
+++ b/docs/ui/components/Tag/helpers.ts
@@ -1,4 +1,4 @@
-import { capitalize } from '~/components/plugins/api/APISectionUtils';
+import { capitalize } from '~/common/utilities';
 import { PlatformName } from '~/types/common';
 
 export function getPlatformName(text: string): PlatformName {

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -443,7 +443,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.1.2, @eslint-community/eslint-utils@npm:^4.5.0":
+"@eslint-community/eslint-utils@npm:^4.1.2, @eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0, @eslint-community/eslint-utils@npm:^4.5.0":
   version: 4.6.0
   resolution: "@eslint-community/eslint-utils@npm:4.6.0"
   dependencies:
@@ -451,17 +451,6 @@ __metadata:
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
   checksum: 10c0/a64131c1b43021e3a84267f6011fd678a936718097c9be169c37a40ada2c7016bec7d6685ecc88112737d57733f36837bb90d9425ad48d2e2aa351d999d32443
-  languageName: node
-  linkType: hard
-
-"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
-  version: 4.4.1
-  resolution: "@eslint-community/eslint-utils@npm:4.4.1"
-  dependencies:
-    eslint-visitor-keys: "npm:^3.4.3"
-  peerDependencies:
-    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  checksum: 10c0/2aa0ac2fc50ff3f234408b10900ed4f1a0b19352f21346ad4cc3d83a1271481bdda11097baa45d484dd564c895e0762a27a8240be7a256b3ad47129e96528252
   languageName: node
   linkType: hard
 
@@ -2780,14 +2769,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:^1.0.0":
-  version: 1.0.6
-  resolution: "@types/estree@npm:1.0.6"
-  checksum: 10c0/cdfd751f6f9065442cd40957c07fd80361c962869aa853c1c2fd03e101af8b9389d8ff4955a43a6fcfa223dd387a089937f95be0f3eec21ca527039fd2d9859a
-  languageName: node
-  linkType: hard
-
-"@types/estree@npm:^1.0.6":
+"@types/estree@npm:*, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.6":
   version: 1.0.7
   resolution: "@types/estree@npm:1.0.7"
   checksum: 10c0/be815254316882f7c40847336cd484c3bc1c3e34f710d197160d455dc9d6d050ffbf4c3bc76585dba86f737f020ab20bdb137ebe0e9116b0c86c7c0342221b8c
@@ -4804,17 +4786,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.15.0":
-  version: 5.18.0
-  resolution: "enhanced-resolve@npm:5.18.0"
-  dependencies:
-    graceful-fs: "npm:^4.2.4"
-    tapable: "npm:^2.2.0"
-  checksum: 10c0/5fcc264a6040754ab5b349628cac2bb5f89cee475cbe340804e657a5b9565f70e6aafb338d5895554eb0ced9f66c50f38a255274a0591dcb64ee17c549c459ce
-  languageName: node
-  linkType: hard
-
-"enhanced-resolve@npm:^5.17.1":
+"enhanced-resolve@npm:^5.15.0, enhanced-resolve@npm:^5.17.1":
   version: 5.18.1
   resolution: "enhanced-resolve@npm:5.18.1"
   dependencies:
@@ -6265,16 +6237,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-tsconfig@npm:^4.7.5":
-  version: 4.8.1
-  resolution: "get-tsconfig@npm:4.8.1"
-  dependencies:
-    resolve-pkg-maps: "npm:^1.0.0"
-  checksum: 10c0/536ee85d202f604f4b5fb6be81bcd6e6d9a96846811e83e9acc6de4a04fb49506edea0e1b8cf1d5ee7af33e469916ec2809d4c5445ab8ae015a7a51fbd1572f9
-  languageName: node
-  linkType: hard
-
-"get-tsconfig@npm:^4.8.1":
+"get-tsconfig@npm:^4.7.5, get-tsconfig@npm:^4.8.1":
   version: 4.10.0
   resolution: "get-tsconfig@npm:4.10.0"
   dependencies:
@@ -6375,17 +6338,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^15.11.0":
+"globals@npm:^15.11.0, globals@npm:^15.9.0":
   version: 15.15.0
   resolution: "globals@npm:15.15.0"
   checksum: 10c0/f9ae80996392ca71316495a39bec88ac43ae3525a438b5626cd9d5ce9d5500d0a98a266409605f8cd7241c7acf57c354a48111ea02a767ba4f374b806d6861fe
-  languageName: node
-  linkType: hard
-
-"globals@npm:^15.9.0":
-  version: 15.14.0
-  resolution: "globals@npm:15.14.0"
-  checksum: 10c0/039deb8648bd373b7940c15df9f96ab7508fe92b31bbd39cbd1c1a740bd26db12457aa3e5d211553b234f30e9b1db2fee3683012f543a01a6942c9062857facb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Why

Follow up on `eslint-config-universe` upgrade, see:
* Stacked on #36200

# How

Address new lint warnings appearing after migration to flat config.

# Test Plan

All lint check and tests are passing. Docs app works locally as expected, including Lighbox presentation.
