### PR TITLE
[ios][expo] Remove moduleName and initialProps

### DIFF
--- a/apps/bare-expo/ios/AppDelegate.swift
+++ b/apps/bare-expo/ios/AppDelegate.swift
@@ -15,8 +15,6 @@ public class AppDelegate: ExpoAppDelegate {
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
 
-    window = UIWindow(frame: UIScreen.main.bounds)
-
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 

--- a/apps/bare-expo/ios/AppDelegate.swift
+++ b/apps/bare-expo/ios/AppDelegate.swift
@@ -50,6 +50,7 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
   override func sourceURL(for bridge: RCTBridge) -> URL? {
+    // needed to return the correct URL for expo-dev-client. 
     bridge.bundleURL ?? bundleURL()
   }
 

--- a/apps/bare-expo/ios/AppDelegate.swift
+++ b/apps/bare-expo/ios/AppDelegate.swift
@@ -15,6 +15,14 @@ public class AppDelegate: ExpoAppDelegate {
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
 
+#if os(iOS) || os(tvOS)
+    window = UIWindow(frame: UIScreen.main.bounds)
+    reactNativeFactory?.startReactNative(
+      withModuleName: "main",
+      in: window,
+      launchOptions: launchOptions)
+#endif
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 

--- a/apps/bare-expo/ios/AppDelegate.swift
+++ b/apps/bare-expo/ios/AppDelegate.swift
@@ -50,7 +50,7 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
   override func sourceURL(for bridge: RCTBridge) -> URL? {
-    // needed to return the correct URL for expo-dev-client. 
+    // needed to return the correct URL for expo-dev-client.
     bridge.bundleURL ?? bundleURL()
   }
 

--- a/apps/bare-expo/ios/AppDelegate.swift
+++ b/apps/bare-expo/ios/AppDelegate.swift
@@ -8,15 +8,14 @@ public class AppDelegate: ExpoAppDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    self.moduleName = "main"
-    self.initialProps = [:]
-
     let delegate = ReactNativeDelegate()
     let factory = ExpoReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
 
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
+
+    window = UIWindow(frame: UIScreen.main.bounds)
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/apps/bare-expo/ios/AppDelegate.swift
+++ b/apps/bare-expo/ios/AppDelegate.swift
@@ -48,4 +48,16 @@ public class AppDelegate: ExpoAppDelegate {
 
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
+
+  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+    bridge.bundleURL ?? bundleURL()
+  }
+
+  open override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
 }

--- a/apps/bare-expo/ios/AppDelegate.swift
+++ b/apps/bare-expo/ios/AppDelegate.swift
@@ -49,11 +49,11 @@ public class AppDelegate: ExpoAppDelegate {
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
-  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+  override func sourceURL(for bridge: RCTBridge) -> URL? {
     bridge.bundleURL ?? bundleURL()
   }
 
-  open override func bundleURL() -> URL? {
+  override func bundleURL() -> URL? {
 #if DEBUG
     return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
 #else

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3597,8 +3597,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   BenchmarkingModule: a97859cac8efb2f5411b2052e61841b349813a4a
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EASClient: 2d9d3631681fc426f9c4ade4d7cf6fc2d19baa46
   EXApplication: 11b2bbe282966309a86145fc642090b6e5b356cc
   EXAV: 796c01cfbe714ce51fb0712636780b3b6feb1248
@@ -3676,7 +3676,7 @@ SPEC CHECKSUMS:
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: abbac80c6f89e71a8c55c7e92ec015c8a9496753
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: c32f2e405098bc1ebe30630a051ddce6f21d3c2e
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f

--- a/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
+++ b/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
@@ -11,6 +11,14 @@ public class AppDelegate: ExpoAppDelegate {
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
 
+#if os(iOS) || os(tvOS)
+    window = UIWindow(frame: UIScreen.main.bounds)
+    reactNativeFactory?.startReactNative(
+      withModuleName: "main",
+      in: window,
+      launchOptions: launchOptions)
+#endif
+
     return super.applicationDidFinishLaunching(notification)
   }
 }

--- a/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
+++ b/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
@@ -27,7 +27,7 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
   override func sourceURL(for bridge: RCTBridge) -> URL? {
-    // needed to return the correct URL for expo-dev-client. 
+    // needed to return the correct URL for expo-dev-client.
     bridge.bundleURL ?? bundleURL()
   }
 

--- a/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
+++ b/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
@@ -27,6 +27,7 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
   override func sourceURL(for bridge: RCTBridge) -> URL? {
+    // needed to return the correct URL for expo-dev-client. 
     bridge.bundleURL ?? bundleURL()
   }
 

--- a/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
+++ b/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
@@ -25,4 +25,16 @@ public class AppDelegate: ExpoAppDelegate {
 
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
+
+  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+    bridge.bundleURL ?? bundleURL()
+  }
+
+  open override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
 }

--- a/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
+++ b/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
@@ -11,8 +11,6 @@ public class AppDelegate: ExpoAppDelegate {
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
 
-    window = UIWindow(frame: UIScreen.main.bounds)
-
     return super.applicationDidFinishLaunching(notification)
   }
 }

--- a/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
+++ b/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
@@ -26,11 +26,11 @@ public class AppDelegate: ExpoAppDelegate {
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
-  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+  override func sourceURL(for bridge: RCTBridge) -> URL? {
     bridge.bundleURL ?? bundleURL()
   }
 
-  open override func bundleURL() -> URL? {
+  override func bundleURL() -> URL? {
 #if DEBUG
     return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
 #else

--- a/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
+++ b/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
@@ -4,15 +4,14 @@ import ReactAppDependencyProvider
 
 public class AppDelegate: ExpoAppDelegate {
   public override func applicationDidFinishLaunching(_ notification: Notification) {
-    self.moduleName = "main"
-    self.initialProps = [:]
-
     let delegate = ReactNativeDelegate()
     let factory = ExpoReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
 
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
+    
+    window = UIWindow(frame: UIScreen.main.bounds)
 
     return super.applicationDidFinishLaunching(notification)
   }

--- a/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
+++ b/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
@@ -10,7 +10,7 @@ public class AppDelegate: ExpoAppDelegate {
 
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
-    
+
     window = UIWindow(frame: UIScreen.main.bounds)
 
     return super.applicationDidFinishLaunching(notification)

--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -50,11 +50,12 @@ class AppDelegate: ExpoAppDelegate {
 }
 
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
-  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+
+  override func sourceURL(for bridge: RCTBridge) -> URL? {
     bridge.bundleURL ?? bundleURL()
   }
 
-  open override func bundleURL() -> URL? {
+  override func bundleURL() -> URL? {
 #if DEBUG
     return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
 #else

--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -16,8 +16,6 @@ class AppDelegate: ExpoAppDelegate {
 
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
-    // Tell `ExpoAppDelegate` to skip calling the React Native instance setup from `RCTAppDelegate`.
-    automaticallyLoadReactNativeWindow = false
 
     FirebaseApp.configure()
 

--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -49,4 +49,16 @@ class AppDelegate: ExpoAppDelegate {
   }
 }
 
-class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {}
+class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
+  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+    bridge.bundleURL ?? bundleURL()
+  }
+
+  open override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
+}

--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -10,17 +10,14 @@ class AppDelegate: ExpoAppDelegate {
   var rootViewController: EXRootViewController?
 
   override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-    self.moduleName = "main"
-    self.initialProps = [:]
-
     let delegate = ReactNativeDelegate()
     let factory = ExpoGoReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
 
-    self.reactNativeFactoryDelegate = delegate
-    self.reactNativeFactory = factory
+    reactNativeFactoryDelegate = delegate
+    reactNativeFactory = factory
     // Tell `ExpoAppDelegate` to skip calling the React Native instance setup from `RCTAppDelegate`.
-    self.automaticallyLoadReactNativeWindow = false
+    automaticallyLoadReactNativeWindow = false
 
     FirebaseApp.configure()
 

--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -50,7 +50,6 @@ class AppDelegate: ExpoAppDelegate {
 }
 
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
-
   override func sourceURL(for bridge: RCTBridge) -> URL? {
     bridge.bundleURL ?? bundleURL()
   }

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3391,9 +3391,9 @@ EXTERNAL SOURCES:
     :path: "../../../react-native-lab/react-native/packages/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
+  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EASClient: 2d9d3631681fc426f9c4ade4d7cf6fc2d19baa46
   EXApplication: 11b2bbe282966309a86145fc642090b6e5b356cc
   EXAV: 796c01cfbe714ce51fb0712636780b3b6feb1248
@@ -3472,13 +3472,13 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 85bdce8babed7814816496bb6f082bc05b0a45e1
   FirebaseSessions: f5c6bfeb66a7202deaf33352017bb6365e395820
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: b8d74dbf752f98968ebe3e98c8d913153915dbbb
+  hermes-engine: 41babe300c4747d49b17f5fd368e227380c258eb
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
@@ -3491,7 +3491,7 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
+  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 0ada4fb1e5c5637bff940dc40b94e2d3bf96b0ab
   RCTRequired: 76ca80ff10acb3834ed0dacba9645645009578a2
   RCTTypeSafety: 01b27f48153eb2d222c0ad4737fe291e9549946a

--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -57,11 +57,11 @@ public class AppDelegate: ExpoAppDelegate {
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
-  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+  override func sourceURL(for bridge: RCTBridge) -> URL? {
     bridge.bundleURL ?? bundleURL()
   }
 
-  open override func bundleURL() -> URL? {
+  override func bundleURL() -> URL? {
 #if DEBUG
     return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
 #else
@@ -129,11 +129,11 @@ GMSServices.provideAPIKey("mykey")
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
-  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+  override func sourceURL(for bridge: RCTBridge) -> URL? {
     bridge.bundleURL ?? bundleURL()
   }
 
-  open override func bundleURL() -> URL? {
+  override func bundleURL() -> URL? {
 #if DEBUG
     return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
 #else
@@ -201,11 +201,11 @@ GMSServices.provideAPIKey("mykey")
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
-  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+  override func sourceURL(for bridge: RCTBridge) -> URL? {
     bridge.bundleURL ?? bundleURL()
   }
 
-  open override func bundleURL() -> URL? {
+  override func bundleURL() -> URL? {
 #if DEBUG
     return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
 #else

--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -23,7 +23,13 @@ public class AppDelegate: ExpoAppDelegate {
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
 
+#if os(iOS) || os(tvOS)
     window = UIWindow(frame: UIScreen.main.bounds)
+    reactNativeFactory?.startReactNative(
+      withModuleName: "main",
+      in: window,
+      launchOptions: launchOptions)
+#endif
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
@@ -72,7 +78,13 @@ public class AppDelegate: ExpoAppDelegate {
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
 
+#if os(iOS) || os(tvOS)
     window = UIWindow(frame: UIScreen.main.bounds)
+    reactNativeFactory?.startReactNative(
+      withModuleName: "main",
+      in: window,
+      launchOptions: launchOptions)
+#endif
 
 // @generated begin react-native-maps-init - expo prebuild (DO NOT MODIFY) sync-d167568d212e7a4ec24615c397330e087bc93758
 #if canImport(GoogleMaps)
@@ -126,7 +138,13 @@ public class AppDelegate: ExpoAppDelegate {
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
 
+#if os(iOS) || os(tvOS)
     window = UIWindow(frame: UIScreen.main.bounds)
+    reactNativeFactory?.startReactNative(
+      withModuleName: "main",
+      in: window,
+      launchOptions: launchOptions)
+#endif
 
 // @generated begin react-native-maps-init - expo prebuild (DO NOT MODIFY) sync-d167568d212e7a4ec24615c397330e087bc93758
 #if canImport(GoogleMaps)

--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -16,15 +16,14 @@ public class AppDelegate: ExpoAppDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    self.moduleName = "main"
-    self.initialProps = [:]
-
     let delegate = ReactNativeDelegate()
     let factory = ExpoReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
 
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
+
+    window = UIWindow(frame: UIScreen.main.bounds)
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
@@ -66,15 +65,14 @@ public class AppDelegate: ExpoAppDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    self.moduleName = "main"
-    self.initialProps = [:]
-
     let delegate = ReactNativeDelegate()
     let factory = ExpoReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
 
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
+
+    window = UIWindow(frame: UIScreen.main.bounds)
 
 // @generated begin react-native-maps-init - expo prebuild (DO NOT MODIFY) sync-d167568d212e7a4ec24615c397330e087bc93758
 #if canImport(GoogleMaps)
@@ -121,15 +119,14 @@ public class AppDelegate: ExpoAppDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    self.moduleName = "main"
-    self.initialProps = [:]
-
     let delegate = ReactNativeDelegate()
     let factory = ExpoReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
 
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
+
+    window = UIWindow(frame: UIScreen.main.bounds)
 
 // @generated begin react-native-maps-init - expo prebuild (DO NOT MODIFY) sync-d167568d212e7a4ec24615c397330e087bc93758
 #if canImport(GoogleMaps)

--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -56,6 +56,18 @@ public class AppDelegate: ExpoAppDelegate {
 
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
+
+  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+    bridge.bundleURL ?? bundleURL()
+  }
+
+  open override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
 }
 "
 `;
@@ -116,6 +128,18 @@ GMSServices.provideAPIKey("mykey")
 
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
+
+  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+    bridge.bundleURL ?? bundleURL()
+  }
+
+  open override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
 }
 "
 `;
@@ -176,6 +200,18 @@ GMSServices.provideAPIKey("mykey")
 
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
+
+  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+    bridge.bundleURL ?? bundleURL()
+  }
+
+  open override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
 }
 "
 `;

--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -58,6 +58,7 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
   override func sourceURL(for bridge: RCTBridge) -> URL? {
+    // needed to return the correct URL for expo-dev-client.
     bridge.bundleURL ?? bundleURL()
   }
 
@@ -130,6 +131,7 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
   override func sourceURL(for bridge: RCTBridge) -> URL? {
+    // needed to return the correct URL for expo-dev-client.
     bridge.bundleURL ?? bundleURL()
   }
 
@@ -202,6 +204,7 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
   override func sourceURL(for bridge: RCTBridge) -> URL? {
+    // needed to return the correct URL for expo-dev-client.
     bridge.bundleURL ?? bundleURL()
   }
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Remove `moduleName` and `initialProps` from the `AppDelegate`.
+
 ## 53.0.0-preview.11 — 2025-04-23
 
 ### 🎉 New features

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [iOS] Remove `moduleName` and `initialProps` from the `AppDelegate`.
+- [iOS] Remove `moduleName` and `initialProps` from the `AppDelegate`. ([#36338](https://github.com/expo/expo/pull/36338) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 53.0.0-preview.11 — 2025-04-23
 

--- a/packages/expo/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -20,22 +20,6 @@
   return self;
 }
 
-- (void)setModuleName:(NSString * _Nullable)moduleName {
-  _expoAppDelegate.moduleName = [moduleName copy];
-}
-
-- (NSString*) moduleName {
-  return _expoAppDelegate.moduleName;
-}
-
-- (void)setInitialProps:(NSDictionary * _Nullable)initialProps {
-  _expoAppDelegate.initialProps = initialProps;
-}
-
-- (NSDictionary*) initialProps {
-  return _expoAppDelegate.initialProps;
-}
-
 // This needs to be implemented, otherwise forwarding won't be called.
 // When the app starts, `UIApplication` uses it to check beforehand
 // which `UIApplicationDelegate` selectors are implemented.

--- a/packages/expo/ios/AppDelegates/EXReactRootViewFactory.h
+++ b/packages/expo/ios/AppDelegates/EXReactRootViewFactory.h
@@ -25,8 +25,8 @@ NS_SWIFT_NAME(ExpoReactRootViewFactory)
  Calls super `viewWithModuleName:initialProperties:launchOptions:` from `RCTRootViewFactory`.
  */
 - (UIView *)superViewWithModuleName:(NSString *)moduleName
-                  initialProperties:(NSDictionary *)initialProperties
-                      launchOptions:(NSDictionary *)launchOptions;
+                  initialProperties:(nullable NSDictionary *)initialProperties
+                      launchOptions:(nullable NSDictionary *)launchOptions;
 
 @end
 

--- a/packages/expo/ios/AppDelegates/EXReactRootViewFactory.mm
+++ b/packages/expo/ios/AppDelegates/EXReactRootViewFactory.mm
@@ -41,8 +41,8 @@
 }
 
 - (UIView *)superViewWithModuleName:(NSString *)moduleName
-                  initialProperties:(NSDictionary *)initialProperties
-                      launchOptions:(NSDictionary *)launchOptions
+                  initialProperties:(nullable NSDictionary *)initialProperties
+                      launchOptions:(nullable NSDictionary *)launchOptions
 {
   return [super viewWithModuleName:moduleName initialProperties:initialProperties launchOptions:launchOptions];
 }

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -44,7 +44,7 @@ open class ExpoAppDelegate: NSObject, ReactNativeFactoryProvider, UIApplicationD
         backing: .buffered,
         defer: false)
 
-      window.title = moduleName
+      window.title = defaultModuleName
       window.autorecalculatesKeyViewLoop = true
 
       let rootViewController = NSViewController()

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -16,22 +16,19 @@ import ReactAppDependencyProvider
 open class ExpoAppDelegate: NSObject, ReactNativeFactoryProvider, UIApplicationDelegate {
   @objc public var reactNativeFactory: RCTReactNativeFactory?
   @objc public var reactNativeFactoryDelegate: ExpoReactNativeFactoryDelegate?
+  private let defaultModuleName = "main"
+  private let defaultInitialProps = [AnyHashable: Any]()
 
   /// The window object, used to render the UIViewControllers
   public var window: UIWindow?
-
-  /// From RCTAppDelegate
-  @objc public var moduleName: String = ""
-  @objc public var initialProps: [AnyHashable: Any]?
 
   /// If `automaticallyLoadReactNativeWindow` is set to `true`, the React Native window will be loaded automatically.
   public var automaticallyLoadReactNativeWindow = true
 
   func loadReactNativeWindow(launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
 #if os(iOS) || os(tvOS)
-    window = UIWindow(frame: UIScreen.main.bounds)
     reactNativeFactory?.startReactNative(
-      withModuleName: self.moduleName,
+      withModuleName: defaultModuleName,
       in: window,
       launchOptions: launchOptions)
 #elseif os(macOS)
@@ -87,22 +84,19 @@ open class ExpoAppDelegate: NSObject, ReactNativeFactoryProvider, UIApplicationD
       }
     }
 
-    self.moduleName = moduleName ?? ""
-    self.initialProps = initialProps
-
     let rootView: UIView
     if let factory = rootViewFactory as? ExpoReactRootViewFactory {
       // When calling `recreateRootViewWithBundleURL:` from `EXReactRootViewFactory`,
       // we don't want to loop the ReactDelegate again. Otherwise, it will be an infinite loop.
       rootView = factory.superView(
-        withModuleName: self.moduleName as String,
-        initialProperties: self.initialProps ?? [:],
+        withModuleName: moduleName ?? defaultModuleName,
+        initialProperties: initialProps ?? defaultInitialProps,
         launchOptions: launchOptions ?? [:]
       )
     } else {
       rootView = rootViewFactory.view(
-        withModuleName: self.moduleName as String,
-        initialProperties: self.initialProps,
+        withModuleName: moduleName ?? defaultModuleName,
+        initialProperties: initialProps ?? defaultInitialProps,
         launchOptions: launchOptions
       )
     }

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -33,8 +33,8 @@ open class ExpoAppDelegate: NSObject, ReactNativeFactoryProvider, UIApplicationD
       launchOptions: launchOptions)
 #elseif os(macOS)
     if let rootView = reactNativeFactory?.rootViewFactory.view(
-      withModuleName: self.moduleName as String,
-      initialProperties: self.initialProps,
+      withModuleName: defaultModuleName,
+      initialProperties: defaultInitialProps,
       launchOptions: launchOptions
     ) {
       let frame = NSRect(x: 0, y: 0, width: 1280, height: 720)

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -90,13 +90,13 @@ open class ExpoAppDelegate: NSObject, ReactNativeFactoryProvider, UIApplicationD
       // we don't want to loop the ReactDelegate again. Otherwise, it will be an infinite loop.
       rootView = factory.superView(
         withModuleName: moduleName ?? defaultModuleName,
-        initialProperties: initialProps ?? defaultInitialProps,
+        initialProperties: initialProps,
         launchOptions: launchOptions ?? [:]
       )
     } else {
       rootView = rootViewFactory.view(
         withModuleName: moduleName ?? defaultModuleName,
-        initialProperties: initialProps ?? defaultInitialProps,
+        initialProperties: initialProps,
         launchOptions: launchOptions
       )
     }

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -27,6 +27,7 @@ open class ExpoAppDelegate: NSObject, ReactNativeFactoryProvider, UIApplicationD
 
   func loadReactNativeWindow(launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
 #if os(iOS) || os(tvOS)
+    window = UIWindow(frame: UIScreen.main.bounds)
     reactNativeFactory?.startReactNative(
       withModuleName: defaultModuleName,
       in: window,

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -22,17 +22,8 @@ open class ExpoAppDelegate: NSObject, ReactNativeFactoryProvider, UIApplicationD
   /// The window object, used to render the UIViewControllers
   public var window: UIWindow?
 
-  /// If `automaticallyLoadReactNativeWindow` is set to `true`, the React Native window will be loaded automatically.
-  public var automaticallyLoadReactNativeWindow = true
-
-  func loadReactNativeWindow(launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
-#if os(iOS) || os(tvOS)
-    window = UIWindow(frame: UIScreen.main.bounds)
-    reactNativeFactory?.startReactNative(
-      withModuleName: defaultModuleName,
-      in: window,
-      launchOptions: launchOptions)
-#elseif os(macOS)
+  func loadMacOSWindow(launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
+#if os(macOS)
     if let rootView = reactNativeFactory?.rootViewFactory.view(
       withModuleName: defaultModuleName,
       initialProperties: defaultInitialProps,
@@ -132,9 +123,7 @@ open class ExpoAppDelegate: NSObject, ReactNativeFactoryProvider, UIApplicationD
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    if automaticallyLoadReactNativeWindow {
-      loadReactNativeWindow(launchOptions: launchOptions)
-    }
+    loadMacOSWindow(launchOptions: launchOptions)
 
     ExpoAppDelegateSubscriberRepository.subscribers.forEach { subscriber in
       // Subscriber result is ignored as it doesn't matter if any subscriber handled the incoming URL – we always return `true` anyway.

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -123,8 +123,6 @@ open class ExpoAppDelegate: NSObject, ReactNativeFactoryProvider, UIApplicationD
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    loadMacOSWindow(launchOptions: launchOptions)
-
     ExpoAppDelegateSubscriberRepository.subscribers.forEach { subscriber in
       // Subscriber result is ignored as it doesn't matter if any subscriber handled the incoming URL – we always return `true` anyway.
       _ = subscriber.application?(application, didFinishLaunchingWithOptions: launchOptions)
@@ -145,10 +143,8 @@ open class ExpoAppDelegate: NSObject, ReactNativeFactoryProvider, UIApplicationD
   }
 
   open func applicationDidFinishLaunching(_ notification: Notification) {
-    if automaticallyLoadReactNativeWindow {
-      let launchOptions = notification.userInfo as? [String: Any]
-      loadReactNativeWindow(launchOptions: launchOptions)
-    }
+    let launchOptions = notification.userInfo as? [String: Any]
+    loadMacOSWindow(launchOptions: launchOptions)
 
     ExpoAppDelegateSubscriberRepository
       .subscribers

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactoryDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactoryDelegate.swift
@@ -1,20 +1,7 @@
 import React_RCTAppDelegate
 
-@objc(EXExpoReactNativeFactoryDelegate)
 open class ExpoReactNativeFactoryDelegate: RCTDefaultReactNativeFactoryDelegate {
   open override func customize(_ rootView: UIView) {
     ExpoAppDelegateSubscriberRepository.subscribers.forEach { $0.customizeRootView?(rootView) }
-  }
-
-  open override func sourceURL(for bridge: RCTBridge) -> URL? {
-    bridge.bundleURL ?? bundleURL()
-  }
-
-  open override func bundleURL() -> URL? {
-#if DEBUG
-    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
-#else
-    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
-#endif
   }
 }

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
@@ -15,8 +15,6 @@ public class AppDelegate: ExpoAppDelegate {
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
 
-    window = UIWindow(frame: UIScreen.main.bounds)
-
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
@@ -50,6 +50,7 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
   override func sourceURL(for bridge: RCTBridge) -> URL? {
+    // needed to return the correct URL for expo-dev-client. 
     bridge.bundleURL ?? bundleURL()
   }
 

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
@@ -15,6 +15,14 @@ public class AppDelegate: ExpoAppDelegate {
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
 
+#if os(iOS) || os(tvOS)
+    window = UIWindow(frame: UIScreen.main.bounds)
+    reactNativeFactory?.startReactNative(
+      withModuleName: "main",
+      in: window,
+      launchOptions: launchOptions)
+#endif
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
@@ -50,7 +50,7 @@ class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
   override func sourceURL(for bridge: RCTBridge) -> URL? {
-    // needed to return the correct URL for expo-dev-client. 
+    // needed to return the correct URL for expo-dev-client.
     bridge.bundleURL ?? bundleURL()
   }
 

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
@@ -8,15 +8,14 @@ public class AppDelegate: ExpoAppDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    self.moduleName = "main"
-    self.initialProps = [:]
-
     let delegate = ReactNativeDelegate()
     let factory = ExpoReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
 
     reactNativeFactoryDelegate = delegate
     reactNativeFactory = factory
+
+    window = UIWindow(frame: UIScreen.main.bounds)
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
@@ -48,4 +48,16 @@ public class AppDelegate: ExpoAppDelegate {
 
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
+
+  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+    bridge.bundleURL ?? bundleURL()
+  }
+
+  open override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
 }

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
@@ -49,11 +49,11 @@ public class AppDelegate: ExpoAppDelegate {
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
   // Extension point for config-plugins
 
-  open override func sourceURL(for bridge: RCTBridge) -> URL? {
+  override func sourceURL(for bridge: RCTBridge) -> URL? {
     bridge.bundleURL ?? bundleURL()
   }
 
-  open override func bundleURL() -> URL? {
+  override func bundleURL() -> URL? {
 #if DEBUG
     return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
 #else


### PR DESCRIPTION
# Why
Drops `moduleName` and `initialProps` from the `AppDelegate`. These are not necessary.

# How
Remove from the template and the `ExpoAppDelegate`

# Test Plan
Bare-expo ✅
Expo go ✅

