### PR TITLE
[docs] add "important" InlineHelp theme, and alpha page state flag

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -745,6 +745,7 @@ function makePage(file) {
     // TODO(cedric): refactor href into url
     href: url,
     isNew: data.isNew ?? undefined,
+    isAlpha: data.isAlpha ?? undefined,
     isDeprecated: data.isDeprecated ?? undefined,
     inExpoGo: data.inExpoGo ?? undefined,
   };

--- a/docs/pages/versions/unversioned/sdk/maps.mdx
+++ b/docs/pages/versions/unversioned/sdk/maps.mdx
@@ -17,7 +17,7 @@ import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 
-> **important** Expo Maps is currently in alpha and subject to breaking changes. It is not available in the Expo Go app &mdash; use [development builds](/develop/development-builds/introduction/) to try it out.
+> **important** **This library is currently in alpha and will frequently experience breaking changes.** It is not available in the Expo Go app &ndash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/maps.mdx
+++ b/docs/pages/versions/unversioned/sdk/maps.mdx
@@ -1,12 +1,11 @@
 ---
 title: Maps
-sidebar_title: Maps (expo-maps)
 description: A library that provides access to Google Maps on Android and Apple Maps on iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-maps'
 packageName: 'expo-maps'
 platforms: ['ios', 'android']
 iconUrl: '/static/images/packages/expo-maps.png'
-isNew: true
+isAlpha: true
 ---
 
 import APISection from '~/components/plugins/APISection';
@@ -18,7 +17,7 @@ import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 
-> **warning** **Expo Maps is currently in alpha and subject to breaking changes. It is not available in the Expo Go app.**
+> **important** Expo Maps is currently in alpha and subject to breaking changes. It is not available in the Expo Go app &mdash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui.mdx
@@ -13,7 +13,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **important** This library is currently in alpha, and it will frequently experience breaking changes. It is not available in the Expo Go app &mdash; use [development builds](/develop/development-builds/introduction/) to try it out.
+> **important** **This library is currently in alpha and will frequently experience breaking changes.** It is not available in the Expo Go app &ndash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 `@expo/ui` is a set of native input components that allows you to build fully native interfaces with SwiftUI and Jetpack Compose. It aims to provide the commonly used features and components that a typical app will need.
 

--- a/docs/pages/versions/unversioned/sdk/ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui.mdx
@@ -5,7 +5,7 @@ description: A set of components that allow you to build UIs directly with Swift
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['android', 'ios']
-isNew: true
+isAlpha: true
 ---
 
 {/* import APISection from '~/components/plugins/APISection'; */}
@@ -13,7 +13,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **warning** This library is currently in alpha, and it will frequently experience breaking changes. It is unavailable in the Expo Go app &mdash; use [development builds](/develop/development-builds/introduction/) to try it out.
+> **important** This library is currently in alpha, and it will frequently experience breaking changes. It is not available in the Expo Go app &mdash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 `@expo/ui` is a set of native input components that allows you to build fully native interfaces with SwiftUI and Jetpack Compose. It aims to provide the commonly used features and components that a typical app will need.
 

--- a/docs/pages/versions/v52.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/maps.mdx
@@ -17,7 +17,7 @@ import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 
-> **important** Expo Maps is currently in alpha and subject to breaking changes. It is not available in the Expo Go app &mdash; use [development builds](/develop/development-builds/introduction/) to try it out.
+> **important** **This library is currently in alpha and will frequently experience breaking changes.** It is not available in the Expo Go app &ndash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 ## Installation
 

--- a/docs/pages/versions/v52.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/maps.mdx
@@ -1,12 +1,11 @@
 ---
 title: Maps
-sidebar_title: Maps (expo-maps)
 description: A library that provides access to Google Maps on Android and Apple Maps on iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-maps'
 packageName: 'expo-maps'
 platforms: ['ios', 'android']
 iconUrl: '/static/images/packages/expo-maps.png'
-isNew: true
+isAlpha: true
 ---
 
 import APISection from '~/components/plugins/APISection';
@@ -18,7 +17,7 @@ import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 
-> **warning** **Expo Maps is currently in alpha and subject to breaking changes. It is not available in the Expo Go app.**
+> **important** Expo Maps is currently in alpha and subject to breaking changes. It is not available in the Expo Go app &mdash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 ## Installation
 

--- a/docs/pages/versions/v53.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/maps.mdx
@@ -17,7 +17,7 @@ import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 
-> **important** Expo Maps is currently in alpha and subject to breaking changes. It is not available in the Expo Go app &mdash; use [development builds](/develop/development-builds/introduction/) to try it out.
+> **important** **This library is currently in alpha and will frequently experience breaking changes.** It is not available in the Expo Go app &ndash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 ## Installation
 

--- a/docs/pages/versions/v53.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/maps.mdx
@@ -1,12 +1,11 @@
 ---
 title: Maps
-sidebar_title: Maps (expo-maps)
 description: A library that provides access to Google Maps on Android and Apple Maps on iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-53/packages/expo-maps'
 packageName: 'expo-maps'
 platforms: ['ios', 'android']
 iconUrl: '/static/images/packages/expo-maps.png'
-isNew: true
+isAlpha: true
 ---
 
 import APISection from '~/components/plugins/APISection';
@@ -18,7 +17,7 @@ import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
 
-> **warning** **Expo Maps is currently in alpha and subject to breaking changes. It is not available in the Expo Go app.**
+> **important** Expo Maps is currently in alpha and subject to breaking changes. It is not available in the Expo Go app &mdash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 ## Installation
 

--- a/docs/pages/versions/v53.0.0/sdk/ui.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/ui.mdx
@@ -13,7 +13,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **important** This library is currently in alpha, and it will frequently experience breaking changes. It is not available in the Expo Go app &mdash; use [development builds](/develop/development-builds/introduction/) to try it out.
+> **important** **This library is currently in alpha and will frequently experience breaking changes.** It is not available in the Expo Go app &ndash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 `@expo/ui` is a set of native input components that allows you to build fully native interfaces with SwiftUI and Jetpack Compose. It aims to provide the commonly used features and components that a typical app will need.
 

--- a/docs/pages/versions/v53.0.0/sdk/ui.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/ui.mdx
@@ -5,7 +5,7 @@ description: A set of components that allow you to build UIs directly with Swift
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-53/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['android', 'ios']
-isNew: true
+isAlpha: true
 ---
 
 {/* import APISection from '~/components/plugins/APISection'; */}
@@ -13,7 +13,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **warning** This library is currently in alpha, and it will frequently experience breaking changes. It is unavailable in the Expo Go app &mdash; use [development builds](/develop/development-builds/introduction/) to try it out.
+> **important** This library is currently in alpha, and it will frequently experience breaking changes. It is not available in the Expo Go app &mdash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 `@expo/ui` is a set of native input components that allows you to build fully native interfaces with SwiftUI and Jetpack Compose. It aims to provide the commonly used features and components that a typical app will need.
 

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -45,6 +45,7 @@ export type NavigationRoute = {
   sidebarTitle?: string;
   weight?: number;
   isNew?: boolean;
+  isAlpha?: boolean;
   isDeprecated?: boolean;
   inExpoGo?: boolean;
   children?: NavigationRouteWithSection[];

--- a/docs/ui/components/InlineHelp/index.tsx
+++ b/docs/ui/components/InlineHelp/index.tsx
@@ -1,4 +1,5 @@
 import { mergeClasses } from '@expo/styleguide';
+import { AlertCircleSolidIcon } from '@expo/styleguide-icons/solid/AlertCircleSolidIcon';
 import { AlertTriangleSolidIcon } from '@expo/styleguide-icons/solid/AlertTriangleSolidIcon';
 import { InfoCircleSolidIcon } from '@expo/styleguide-icons/solid/InfoCircleSolidIcon';
 import { XSquareSolidIcon } from '@expo/styleguide-icons/solid/XSquareSolidIcon';
@@ -11,7 +12,7 @@ import {
   type ReactNode,
 } from 'react';
 
-type CalloutType = 'default' | 'warning' | 'error' | 'info' | 'info-light';
+type CalloutType = 'default' | 'important' | 'warning' | 'error' | 'info' | 'info-light';
 
 type Props = PropsWithChildren<{
   type?: CalloutType;
@@ -40,7 +41,9 @@ export const InlineHelp = ({ type = 'default', size = 'md', icon, children, clas
   const contentChildren = Children.toArray(isValidElement(content) && content?.props?.children);
 
   const extractedType = extractType(contentChildren);
-  const finalType = ['warning', 'error', 'info'].includes(extractedType) ? extractedType : type;
+  const finalType = ['warning', 'error', 'info', 'important'].includes(extractedType)
+    ? extractedType
+    : type;
   const Icon = icon ?? getCalloutIcon(finalType);
 
   return (
@@ -89,6 +92,13 @@ function getCalloutColor(type: CalloutType) {
         `selection:bg-palette-yellow5 dark:selection:bg-palette-yellow6`,
         `dark:[&_code]:border-palette-yellow6 dark:[&_code]:bg-palette-yellow5`
       );
+    case 'important':
+      return mergeClasses(
+        'border-palette-purple7 bg-palette-purple3',
+        `[&_code]:border-palette-purple5 [&_code]:bg-palette-purple4`,
+        `selection:bg-palette-purple5 dark:selection:bg-palette-purple6`,
+        `dark:[&_code]:border-palette-purple6 dark:[&_code]:bg-palette-purple5`
+      );
     case 'error':
       return mergeClasses(
         'border-danger bg-danger',
@@ -99,7 +109,7 @@ function getCalloutColor(type: CalloutType) {
       return mergeClasses(
         'border-info bg-info',
         `[&_code]:border-palette-blue5 [&_code]:bg-palette-blue4`,
-        `dark:selection:bg-palette-yellow6`
+        `dark:selection:bg-palette-blue6`
       );
     case 'info-light':
       return mergeClasses('bg-default');
@@ -112,6 +122,8 @@ function getCalloutIcon(type: CalloutType): (props: HTMLAttributes<SVGSVGElement
   switch (type) {
     case 'warning':
       return AlertTriangleSolidIcon;
+    case 'important':
+      return AlertCircleSolidIcon;
     case 'error':
       return XSquareSolidIcon;
     default:
@@ -123,6 +135,8 @@ function getCalloutIconColor(type: CalloutType) {
   switch (type) {
     case 'warning':
       return 'text-warning';
+    case 'important':
+      return 'text-palette-purple11';
     case 'error':
       return 'text-danger';
     case 'info':

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -78,12 +78,23 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
       {info.isNew && (
         <div
           className={mergeClasses(
-            '-mt-px ml-2 inline-flex h-[17px] items-center rounded-full border border-palette-blue10 px-[5px] text-[11px] font-semibold leading-none text-palette-white',
+            '-mt-px ml-2 inline-flex h-[17px] items-center rounded-full border border-palette-blue10 px-[5px] text-[10px] font-semibold leading-none text-palette-white',
             isSelected
               ? 'bg-palette-blue10 text-palette-white dark:text-palette-black'
               : 'border-palette-blue10 bg-none text-palette-blue10 dark:border-palette-blue9 dark:text-palette-blue9'
           )}>
           NEW
+        </div>
+      )}
+      {info.isAlpha && (
+        <div
+          className={mergeClasses(
+            '-mt-px ml-2 inline-flex h-[17px] items-center rounded-full border border-palette-purple10 px-[5px] text-[10px] font-semibold leading-none text-palette-white',
+            isSelected
+              ? 'bg-palette-purple10 text-palette-white dark:text-palette-black'
+              : 'border-palette-purple10 bg-none text-palette-purple11 dark:border-palette-purple9 dark:text-palette-purple10'
+          )}>
+          ALPHA
         </div>
       )}
       {isExternal && (


### PR DESCRIPTION
# Why

We have decided that we need to put more attention, and more clearly mark some packages in early development process which differs for regular new packages included in latest SDK release.

# How

Add new "important" `InlineHelp` theme, and an alpha page state flag and sidebar badge matching the callout color scheme.

Make few small tweaks to phrasing and wording of callouts on the alpha package pages.

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks and tests are passing.

# Preview

![Screenshot 2025-04-23 at 19 19 28](https://github.com/user-attachments/assets/2dbfb130-bacd-464e-8417-fedd74527c7e)

![Screenshot 2025-04-23 at 19 20 06](https://github.com/user-attachments/assets/2f6b7e74-8367-4732-9c67-ca70dab22c81)
