### PR TITLE
Update docs to be React 19-first

### DIFF
--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -6,6 +6,7 @@ description: Learn about rendering React DOM components in Expo native apps usin
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
 > **info** Available in **SDK 52 and above**.
 
@@ -187,10 +188,10 @@ You can use the `useDOMImperativeHandle` hook inside a DOM component to accept r
 import { useRef } from 'react';
 import { Button, View } from 'react-native';
 
-import MyComponent, { type MyRef } from './my-component';
+import MyComponent, { type DOMRef } from './my-component';
 
 export default function App() {
-  const ref = useRef<MyRef>(null);
+  const ref = useRef<DOMRef>(null);
 
   return (
     <View style={{ flex: 1 }}>
@@ -205,6 +206,48 @@ export default function App() {
   );
 }
 ```
+
+<Tabs>
+
+<Tab label="SDK 53 and above">
+
+In Expo SDK 53 and above we use React 19. This means that the `ref` prop is passed to the component as a prop, and you can use it directly in the component.
+
+```tsx my-component.tsx (web)
+'use dom';
+
+import { useDOMImperativeHandle, type DOMImperativeFactory } from 'expo/dom';
+import { Ref, useRef } from 'react';
+
+export interface DOMRef extends DOMImperativeFactory {
+  focus: () => void;
+}
+
+export default function MyComponent(props: {
+  ref: Ref<DOMRef>;
+  dom?: import('expo/dom').DOMProps;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useDOMImperativeHandle(
+    props.ref,
+    () => ({
+      focus: () => {
+        inputRef.current?.focus();
+      },
+    }),
+    []
+  );
+
+  return <input ref={inputRef} />;
+}
+```
+
+</Tab>
+
+<Tab label="SDK 52 and below">
+
+In Expo SDK 52 and below (React 18), use the legacy `forwardRef` function to access the `ref` handle.
 
 ```tsx my-component.tsx (web)
 'use dom';
@@ -232,6 +275,10 @@ export default forwardRef<MyRef, object>(function MyComponent(props, ref) {
   return <input ref={inputRef} />;
 });
 ```
+
+</Tab>
+
+</Tabs>
 
 React is meant to have a unilateral data flow, so the concept of using callbacks to go back up the tree is not idiomatic. Expect the behavior to be flakey and possibly phased out in the future with newer versions of React. The preferred way to send data back up the tree is to use native actions, which update the state and then pass it back to the DOM component.
 

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -211,7 +211,7 @@ export default function App() {
 
 <Tab label="SDK 53 and above">
 
-In Expo SDK 53 and above we use React 19. This means that the `ref` prop is passed to the component as a prop, and you can use it directly in the component.
+Expo SDK 53 and above use React 19. This means that the `ref` prop is passed to the component as a prop, and you can use it directly in the component.
 
 ```tsx my-component.tsx (web)
 'use dom';

--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -53,7 +53,7 @@ To follow the above example, set up a [React Context provider](https://react.dev
 This provider uses a mock implementation. You can replace it with your own [authentication provider](/guides/authentication/).
 
 ```tsx ctx.tsx
-import { useContext, createContext, type PropsWithChildren } from 'react';
+import { use, createContext, type PropsWithChildren } from 'react';
 import { useStorageState } from './useStorageState';
 
 const AuthContext = createContext<{
@@ -70,11 +70,9 @@ const AuthContext = createContext<{
 
 // This hook can be used to access the user info.
 export function useSession() {
-  const value = useContext(AuthContext);
-  if (process.env.NODE_ENV !== 'production') {
-    if (!value) {
-      throw new Error('useSession must be wrapped in a <SessionProvider />');
-    }
+  const value = use(AuthContext);
+  if (!value) {
+    throw new Error('useSession must be wrapped in a <SessionProvider />');
   }
 
   return value;
@@ -84,7 +82,7 @@ export function SessionProvider({ children }: PropsWithChildren) {
   const [[isLoading, session], setSession] = useStorageState('session');
 
   return (
-    <AuthContext.Provider
+    <AuthContext
       value={{
         signIn: () => {
           // Perform sign-in logic here
@@ -97,7 +95,7 @@ export function SessionProvider({ children }: PropsWithChildren) {
         isLoading,
       }}>
       {children}
-    </AuthContext.Provider>
+    </AuthContext>
   );
 }
 ```

--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -6,7 +6,6 @@ sidebar_title: Custom tabs
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
-import { Tabs, Tab } from '~/ui/components/Tabs';
 
 > **warning** Experimentally available in SDK 52 and above. For the React Navigation styled tabs layout that are commonly used in native apps, see [Tabs](/router/advanced/tabs/).
 

--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -6,6 +6,7 @@ sidebar_title: Custom tabs
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
 > **warning** Experimentally available in SDK 52 and above. For the React Navigation styled tabs layout that are commonly used in native apps, see [Tabs](/router/advanced/tabs/).
 
@@ -206,34 +207,41 @@ type Icon = ComponentProps<typeof FontAwesome>['name'];
 
 export type TabButtonProps = TabTriggerSlotProps & {
   icon?: Icon;
+  ref: Ref<View>;
 };
 
-export const TabButton = forwardRef(
-  ({ icon, children, isFocused, ...props }: TabButtonProps, ref: Ref<View>) => {
-    return (
-      <Pressable
-        ref={ref}
-        {...props}
-        style={[
-          {
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            flexDirection: 'column',
-            gap: 5,
-            padding: 10,
-          },
-          isFocused ? { backgroundColor: 'white' } : undefined,
-        ]}>
-        <FontAwesome name={icon} />
-        <Text style={[{ fontSize: 16 }, isFocused ? { color: 'white' } : undefined]}>
-          {children}
-        </Text>
-      </Pressable>
-    );
-  }
-);
+export function TabButton({ icon, children, isFocused, ...props }: TabButtonProps) {
+  return (
+    <Pressable
+      {...props}
+      style={[
+        {
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          flexDirection: 'column',
+          gap: 5,
+          padding: 10,
+        },
+        isFocused ? { backgroundColor: 'white' } : undefined,
+      ]}>
+      <FontAwesome name={icon} />
+      <Text style={[{ fontSize: 16 }, isFocused ? { color: 'white' } : undefined]}>{children}</Text>
+    </Pressable>
+  );
+}
 ```
+
+<Collapsible summary="Expo SDK 52 / React 18 and below">
+
+In Expo SDK 52 and below (React 18), use the legacy `forwardRef` function to access the `ref` handle.
+
+```diff
+- export function TabButton({ ref }) {
++ export const TabButton = forwardRef((props: TabButtonProps, ref: Ref<View>) => {
+```
+
+</Collapsible>
 
 ### Hooks
 


### PR DESCRIPTION
# Why

- Update DOM components to use ref prop instead of forwardRef -> add fallback instructions.
- Update expo-router/ui to use ref prop and add note about forwardRef.
- Update authentication context guide to use React 19 context. No fallback because it's an easier fix and just a mild guide.
