### PR TITLE
feat(eslint-config-expo): Disallow `require()` for source files and continue to allow for assets.

### DIFF
--- a/packages/eslint-config-expo/CHANGELOG.md
+++ b/packages/eslint-config-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Disallow `require()` for source files and continue to allow for assets.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/eslint-config-expo/CHANGELOG.md
+++ b/packages/eslint-config-expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Disallow `require()` for source files and continue to allow for assets.
+- Disallow `require()` for source files and continue to allow for assets. ([#36346](https://github.com/expo/expo/pull/36346) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/eslint-config-expo/flat/utils/typescript.js
+++ b/packages/eslint-config-expo/flat/utils/typescript.js
@@ -80,6 +80,20 @@ module.exports = [
       'no-useless-constructor': 'off',
       '@typescript-eslint/no-useless-constructor': 'warn',
       'no-undef': 'off',
+
+      // Prevent use of CJS `require` syntax unless importing assets to align with Metro behavior.
+      '@typescript-eslint/no-require-imports': [
+        'warn',
+        {
+          // Allow supported asset extensions:
+          // https://github.com/facebook/metro/blob/9e1a6da5a7cd71bb9243f45644efe655870e5fff/packages/metro-config/src/defaults/defaults.js#L18-L53
+          // https://github.com/expo/expo/blob/c774cfaa7898098411fc7e09dcb409b7cb5064f9/packages/%40expo/metro-config/src/ExpoMetroConfig.ts#L247-L254
+          // Includes json which can be imported both as source and asset.
+          allow: [
+            '\\.(aac|aiff|avif|bmp|caf|db|gif|heic|html|jpeg|jpg|json|m4a|m4v|mov|mp3|mp4|mpeg|mpg|otf|pdf|png|psd|svg|ttf|wav|webm|webp|xml|yaml|yml|zip)$',
+          ],
+        },
+      ],
     },
   },
 ];

--- a/packages/eslint-config-expo/utils/typescript.js
+++ b/packages/eslint-config-expo/utils/typescript.js
@@ -46,6 +46,20 @@ module.exports = {
         // The typescript-eslint FAQ recommends turning off "no-undef" in favor of letting tsc check for
         // undefined variables, including types
         'no-undef': 'off',
+
+        // Prevent use of CJS `require` syntax unless importing assets to align with Metro behavior.
+        '@typescript-eslint/no-require-imports': [
+          'warn',
+          {
+            // Allow supported asset extensions:
+            // https://github.com/facebook/metro/blob/9e1a6da5a7cd71bb9243f45644efe655870e5fff/packages/metro-config/src/defaults/defaults.js#L18-L53
+            // https://github.com/expo/expo/blob/c774cfaa7898098411fc7e09dcb409b7cb5064f9/packages/%40expo/metro-config/src/ExpoMetroConfig.ts#L247-L254
+            // Includes json which can be imported both as source and asset.
+            allow: [
+              '\\.(aac|aiff|avif|bmp|caf|db|gif|heic|html|jpeg|jpg|json|m4a|m4v|mov|mp3|mp4|mpeg|mpg|otf|pdf|png|psd|svg|ttf|wav|webm|webp|xml|yaml|yml|zip)$',
+            ],
+          },
+        ],
       },
       settings: {
         'import/extensions': allExtensions,


### PR DESCRIPTION
# Why

- Devs should be using import/export syntax whenever possible. Doing so enables us to better support more modern features such as tree shaking and API routes.
- React Native encourages the use of `require()` for assets, e.g. `require('./image.png')` so we need to still allow this until we have a better solution.

# How

- I added a warning on require syntax and allowed file extensions from all assets in the existing asset extensions system. This won't account for new assets, but they can just use import to get around this.

