### PR TITLE
[docs] Fix a typo in layout.mdx

### DIFF
--- a/docs/pages/router/basics/layout.mdx
+++ b/docs/pages/router/basics/layout.mdx
@@ -66,7 +66,7 @@ You can implement a stack navigator in your root layout, as shown above, or in a
   ]}
 />
 
-If you want everything inside of the **apps/products** directory to be arranged in a stack relationship, inside the **\_layout.tsx** file, return a `Stack` component:
+If you want everything inside of the **app/products** directory to be arranged in a stack relationship, inside the **\_layout.tsx** file, return a `Stack` component:
 
 ```tsx app/products/_layout.tsx
 import { Stack } from 'expo-router';


### PR DESCRIPTION
# Why

Fix an issue which causes confusion in reading docs for layout.mdx.

# How

Modified a line in `docs/pages/router/basics/layout.mdx` which previously `**apps/products**` into ` **app/products**` for the base directory in the topic is `app/` not `apps/`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
