### PR TITLE
[maps][ui] Use `coreFeatures` field to indicate usage of swiftui and compose

### DIFF
--- a/packages/expo-maps/expo-module.config.json
+++ b/packages/expo-maps/expo-module.config.json
@@ -1,5 +1,6 @@
 {
   "platforms": ["apple", "android"],
+  "coreFeatures": ["swiftui", "compose"],
   "apple": {
     "modules": ["MapsModule", "AppleMapsModule"]
   },

--- a/packages/expo-ui/expo-module.config.json
+++ b/packages/expo-ui/expo-module.config.json
@@ -1,5 +1,6 @@
 {
   "platforms": ["apple", "android"],
+  "coreFeatures": ["swiftui", "compose"],
   "apple": {
     "modules": ["ExpoUIModule"]
   },


### PR DESCRIPTION
# Why

Starts using `coreFeatures` field to indicate usage of swiftui and compose.
Used by https://github.com/expo/expo/pull/36353.

# Test Plan

- bare-expo ✅ 