### PR TITLE
[template] add notification delegates to AppDelegate.swift

### DIFF
--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
@@ -39,6 +39,22 @@ public class AppDelegate: ExpoAppDelegate {
     let result = RCTLinkingManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
     return super.application(application, continue: userActivity, restorationHandler: restorationHandler) || result
   }
+
+  // Explicitly define remote notification delegates to ensure compatibility with third-party libraries and config plugins
+  public override func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    super.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+  }
+  public override func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: any Error) {
+    super.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+  }
+  public override func application(
+    _ application: UIApplication,
+    didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+    fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+  ) {
+    super.application(application, didReceiveRemoteNotification: userInfo, fetchCompletionHandler: completionHandler)
+  }
+  // end Explicitly define remote notification delegates
 }
 
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-template-bare-minimum",
-  "description": "This bare project template includes a minimal setup for using unimodules with React Native.",
+  "description": "This bare project template includes a minimal setup for using Expo with React Native.",
   "license": "0BSD",
   "version": "53.0.14",
   "main": "index.js",


### PR DESCRIPTION
# Why

Previously (https://github.com/expo/expo/commit/1306ca9dc8e8f2c29fde374caea685f2293a6a31) the Obj-C app delegate contained notification-related methods. Keeping them in the template is desirable because 3rd party depends on these methods being present ([example](https://github.com/intercom/intercom-react-native/blob/095b38fc0c7d53587b3ffbcd59141b087774b0c2/src/expo-plugins/withPushNotifications.ts#L26)).

This does not guarantee that 3rd party integrations will work (they will still need to do some work to ensure Swift compatibility), but it makes the migration to Swift AppDelegate less disruptive.

# How

add back notification delegate functions to Swift AppDelegate

# Test Plan

tried to prebuild from locally-created template (`tar -czvf expo-template-bare-minimum.tar.gz expo-template-bare-minimum`, `npx expo prebuild --clean -p ios --template path-to/expo-template-bare-minimum.tar.gz`) but ended up having a bunch of unexpected files:

```
expo/apps/notification-tester/ios/notificationtester $ tree . -a
.
├── ._AppDelegate.swift
├── ._Images.xcassets
├── ._Info.plist
├── ._notificationtester-Bridging-Header.h
├── ._SplashScreen.storyboard
├── ._Supporting
├── AppDelegate.swift
├── bells_sound.wav
├── Images.xcassets
│   ├── ._AppIcon.appiconset
│   ├── ._Contents.json
│   ├── AppIcon.appiconset
│   │   ├── ._Contents.json
│   │   ├── App-Icon-1024x1024@1x.png
│   │   └── Contents.json
│   ├── Contents.json
│   ├── SplashScreenBackground.colorset
│   │   └── Contents.json
│   └── SplashScreenLogo.imageset
│       ├── Contents.json
│       ├── image.png
│       ├── image@2x.png
│       └── image@3x.png
├── Info.plist
├── notificationtester-Bridging-Header.h
├── notificationtester.entitlements
├── pop_sound.wav
├── SplashScreen.storyboard
└── Supporting
    ├── ._Expo.plist
    └── Expo.plist

6 directories, 26 files
```
That being said, the AppDelegate is updated as expected.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
