### PR TITLE
[fetch] make exceptions final to support Swift 6

### DIFF
--- a/packages/expo/ios/Fetch/FetchExceptions.swift
+++ b/packages/expo/ios/Fetch/FetchExceptions.swift
@@ -2,13 +2,13 @@
 
 import ExpoModulesCore
 
-internal class FetchUnknownException: Exception {
+internal final class FetchUnknownException: Exception {
   override var reason: String {
     "Unknown error"
   }
 }
 
-internal class FetchRequestCanceledException: Exception {
+internal final class FetchRequestCanceledException: Exception {
   override var reason: String {
     "Fetch request has been canceled"
   }


### PR DESCRIPTION
# Why

to fix `Non-final class 'FetchRequestCanceledException' cannot conform to 'Sendable'; use '@unchecked Sendable'; this is an error in the Swift 6 language mode`

# How

make classes final 

# Test Plan

green CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)