### PR TITLE
[dev-launcher][android] Enable edge-to-edge

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - [iOS] Remove usage of deprecated `SFAuthenticationSession` for user login. ([#36395](https://github.com/expo/expo/pull/36395) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] enable edge-to-edge
+- [Android] Enable edge-to-edge. ([#36363](https://github.com/expo/expo/pull/36363) by [@behenate](https://github.com/behenate))
 
 ## 5.1.5 — 2025-04-23
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [iOS] Remove usage of deprecated `SFAuthenticationSession` for user login. ([#36395](https://github.com/expo/expo/pull/36395) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] enable edge-to-edge
 
 ## 5.1.5 — 2025-04-23
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherActivity.kt
@@ -6,6 +6,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.WindowCompat
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactInstanceEventListener
@@ -51,6 +52,8 @@ class DevLauncherActivity : ReactActivity(), ReactInstanceEventListener, DevLaun
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    // Enables edge-to-edge
+    WindowCompat.setDecorFitsSystemWindows(window, false)
     super.onCreate(savedInstanceState)
 
     contentView = findViewById(android.R.id.content) ?: return

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/errors/DevLauncherErrorActivity.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/errors/DevLauncherErrorActivity.kt
@@ -4,6 +4,11 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.widget.LinearLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.fragment.app.FragmentActivity
 import com.facebook.react.ReactActivity
 import expo.modules.devlauncher.databinding.ErrorFragmentBinding
@@ -21,11 +26,27 @@ class DevLauncherErrorActivity :
   private val adapter = DevLauncherStackAdapter(this, null)
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    // Enables edge-to-edge
+    WindowCompat.setDecorFitsSystemWindows(window, false)
     super.onCreate(savedInstanceState)
 
     binding = ErrorFragmentBinding.inflate(layoutInflater)
     binding.homeButton.setOnClickListener { this.launchHome() }
     binding.reloadButton.setOnClickListener { this.reload() }
+
+    // Set footer padding to avoid the navigation bar
+    ViewCompat.setOnApplyWindowInsetsListener(binding.errorFooterContent) { view, windowInsets ->
+      val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+      view.updatePadding(bottom = insets.bottom)
+      WindowInsetsCompat.CONSUMED
+    }
+
+    // Set title padding to account for status bar
+    ViewCompat.setOnApplyWindowInsetsListener(binding.errorTitle) { view, windowInsets ->
+      val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+      view.updatePadding(top = insets.top)
+      WindowInsetsCompat.CONSUMED
+    }
 
     synchronized(DevLauncherErrorActivity) {
       val error = currentError

--- a/packages/expo-dev-launcher/android/src/main/res/layout/error_fragment.xml
+++ b/packages/expo-dev-launcher/android/src/main/res/layout/error_fragment.xml
@@ -20,6 +20,7 @@
     android:weightSum="1">
 
     <TextView
+      android:id="@+id/error_title"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:tag="DevLauncherErrorScreen"
@@ -62,6 +63,7 @@
     android:layout_alignParentBottom="true">
 
     <LinearLayout
+      android:id="@+id/error_footer_content"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:background="@color/dev_launcher_white"

--- a/packages/expo-dev-launcher/android/src/main/res/values/styles.xml
+++ b/packages/expo-dev-launcher/android/src/main/res/values/styles.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
   <style name="Theme.DevLauncher.LauncherActivity" parent="Theme.AppCompat.Light.NoActionBar">
+    <item name="android:navigationBarColor">@android:color/transparent</item>
+    <item name="android:statusBarColor">@android:color/transparent</item>
+    <item name="android:windowLightStatusBar">true</item>
+    <item name="android:enforceNavigationBarContrast" tools:targetApi="q">false</item>
+    <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">true</item>
+
     <item name="android:windowContentOverlay">@null</item>
     <item name="android:windowNoTitle">true</item>
     <item name="android:windowIsFloating">false</item>
@@ -9,7 +15,12 @@
   </style>
 
   <style name="Theme.DevLauncher.ErrorActivity" parent="Theme.AppCompat.Light.NoActionBar">
+    <item name="android:navigationBarColor">@android:color/transparent</item>
     <item name="android:statusBarColor">@android:color/transparent</item>
+    <item name="android:windowLightStatusBar">true</item>
+    <item name="android:enforceNavigationBarContrast" tools:targetApi="q">false</item>
+    <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">true</item>
+
     <item name="colorPrimary">@color/dev_launcher_primary</item>
     <item name="colorPrimaryDark">@color/dev_launcher_colorPrimaryDark</item>
     <item name="colorAccent">@color/dev_launcher_colorAccentDark</item>


### PR DESCRIPTION
# Why

Since we are enabling edge-to-edge by default for new projects `expo-dev-launcher` should also have it enabled.

# How

Enable by running `WindowCompat.setDecorFitsSystemWindows(window, false)` in the dev launcher and dev launcher errors activities. Dev launcher worked well with edge-to-edge right away, while the error activity needed some padding adjustments.

# Test Plan

Tested in BareExpo on Android
