### PR TITLE
[docs] Update compatibility tables in SDK 53 reference

### DIFF
--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -87,7 +87,6 @@ Before each Expo SDK release, we publish beta versions of the `expo` package and
 | 53.0.0           | 0.79                 | 0.20.0                   |
 | 52.0.0           | 0.76                 | 0.19.13                  |
 | 51.0.0           | 0.74                 | 0.19.10                  |
-| 50.0.0           | 0.73                 | 0.19.6                   |
 
 ### Additional information
 
@@ -129,6 +128,5 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 | 53.0.0           | 7+              | 35                  | 15.1+       | 16.0+         |
 | 52.0.0           | 7+              | 35                  | 15.1+       | 16.0+         |
 | 51.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
-| 50.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
 
 When deciding whether to upgrade your Expo SDK version, consider both Expo's SDK version and app store submission requirements, as described in the above table. Google Play Store and Apple App Store periodically increase their minimum required OS versions and API levels, which are required for new app submissions. Expo has no control over the app store requirements, and you should check [Google](https://developer.android.com/studio/build) and [Apple](https://developer.apple.com/news/upcoming-requirements/) for the current store submission requirements.

--- a/docs/pages/versions/v53.0.0/index.mdx
+++ b/docs/pages/versions/v53.0.0/index.mdx
@@ -87,7 +87,6 @@ Before each Expo SDK release, we publish beta versions of the `expo` package and
 | 53.0.0           | 0.79                 | 0.20.0                   |
 | 52.0.0           | 0.76                 | 0.19.13                  |
 | 51.0.0           | 0.74                 | 0.19.10                  |
-| 50.0.0           | 0.73                 | 0.19.6                   |
 
 ### Additional information
 
@@ -129,6 +128,5 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 | 53.0.0           | 7+              | 35                  | 15.1+       | 16.0+         |
 | 52.0.0           | 7+              | 35                  | 15.1+       | 16.0+         |
 | 51.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
-| 50.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
 
 When deciding whether to upgrade your Expo SDK version, consider both Expo's SDK version and app store submission requirements, as described in the above table. Google Play Store and Apple App Store periodically increase their minimum required OS versions and API levels, which are required for new app submissions. Expo has no control over the app store requirements, and you should check [Google](https://developer.android.com/studio/build) and [Apple](https://developer.apple.com/news/upcoming-requirements/) for the current store submission requirements.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Remove the SDK 50 reference in the compatibility tables for the SDK 53 reference index.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update index file for SDK 53 and unversioned.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-04-24 at 18 54 11](https://github.com/user-attachments/assets/fd3684df-b130-49e9-a88c-d4c49f495d93)

![CleanShot 2025-04-24 at 18 54 27](https://github.com/user-attachments/assets/10b4c0c0-3d75-4cae-b8ca-5c3d4f1d0aad)



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
