### PR TITLE
[expo-go] Add FontUtilsModule to home

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
@@ -27,6 +27,7 @@ import expo.modules.easclient.EASClientModule
 import expo.modules.filesystem.FileSystemModule
 import expo.modules.filesystem.FileSystemPackage
 import expo.modules.font.FontLoaderModule
+import expo.modules.font.FontUtilsModule
 import expo.modules.haptics.HapticsModule
 import expo.modules.keepawake.KeepAwakeModule
 import expo.modules.keepawake.KeepAwakePackage
@@ -175,6 +176,7 @@ open class HomeActivity : BaseExperienceActivity() {
         EASClientModule::class.java,
         FileSystemModule::class.java,
         FontLoaderModule::class.java,
+        FontUtilsModule::class.java,
         HapticsModule::class.java,
         KeepAwakeModule::class.java,
         LinearGradientModule::class.java,


### PR DESCRIPTION
# Why
Fixes crash on expo go

# How
The FontUtilsModule also needs to be added to the HomeActivity

# Test Plan
Expo go. Couldn't reliably repro locally but this will likely to solve the problem
