### PR TITLE
[media-library][updates] prevent pulling react submodule from umbrella header

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed build error from **AppDelegate.swift** integration. ([#36368](https://github.com/expo/expo/pull/36368) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 17.1.3 — 2025-04-21

--- a/packages/expo-media-library/ios/MediaLibraryImageLoader.h
+++ b/packages/expo-media-library/ios/MediaLibraryImageLoader.h
@@ -1,11 +1,9 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#if __has_include(<React/RCTImageURLLoader.h>)
+#pragma once
 
-#import <React/RCTImageURLLoader.h>
+#import <Foundation/Foundation.h>
 
-@interface MediaLibraryImageLoader : NSObject <RCTImageURLLoader>
+@interface MediaLibraryImageLoader : NSObject
 
 @end
-
-#endif

--- a/packages/expo-media-library/ios/MediaLibraryImageLoader.m
+++ b/packages/expo-media-library/ios/MediaLibraryImageLoader.m
@@ -10,7 +10,12 @@
 #import <React/RCTDefines.h>
 #import <React/RCTUtils.h>
 #import <React/RCTBridgeModule.h>
+#import <React/RCTImageURLLoader.h>
 #import <ExpoMediaLibrary/MediaLibraryImageLoader.h>
+
+@interface MediaLibraryImageLoader () <RCTImageURLLoader>
+
+@end
 
 @implementation MediaLibraryImageLoader
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed build error from **AppDelegate.swift** integration. ([#36368](https://github.com/expo/expo/pull/36368) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.28.6 — 2025-04-22

--- a/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesMultipartStreamReader.h
+++ b/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesMultipartStreamReader.h
@@ -1,9 +1,10 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import <React/RCTMultipartStreamReader.h>
 
 NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^EXMultipartCallback)(NSDictionary * _Nullable headers, NSData * _Nullable content, BOOL done);
 
 /**
  * Fork of {@link RCTMultipartStreamReader} that doesn't necessarily
@@ -12,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXUpdatesMultipartStreamReader : NSObject
 
 - (instancetype)initWithInputStream:(NSInputStream *)stream boundary:(NSString *)boundary;
-- (BOOL)readAllPartsWithCompletionCallback:(RCTMultipartCallback)callback;
+- (BOOL)readAllPartsWithCompletionCallback:(EXMultipartCallback)callback;
 
 @end
 

--- a/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesMultipartStreamReader.m
+++ b/packages/expo-updates/ios/EXUpdates/Multipart/EXUpdatesMultipartStreamReader.m
@@ -35,7 +35,7 @@
   return headers;
 }
 
-- (void)emitChunk:(NSData *)data headers:(NSDictionary *)headers callback:(RCTMultipartCallback)callback done:(BOOL)done
+- (void)emitChunk:(NSData *)data headers:(NSDictionary *)headers callback:(EXMultipartCallback)callback done:(BOOL)done
 {
   NSData *marker = [CRLF CRLF dataUsingEncoding:NSUTF8StringEncoding];
   NSRange range = [data rangeOfData:marker options:0 range:NSMakeRange(0, data.length)];
@@ -54,7 +54,7 @@
   }
 }
 
-- (BOOL)readAllPartsWithCompletionCallback:(RCTMultipartCallback)callback
+- (BOOL)readAllPartsWithCompletionCallback:(EXMultipartCallback)callback
 {
   NSInteger chunkStart = 0;
   NSInteger bytesSeen = 0;

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/EXDeferredRCTRootView.h
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/EXDeferredRCTRootView.h
@@ -1,6 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <React/RCTRootView.h>
+#import <ExpoModulesCore/ExpoModulesCore.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/EXDeferredRCTRootView.m
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/EXDeferredRCTRootView.m
@@ -1,6 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import <EXUpdates/EXDeferredRCTRootView.h>
+#import <React/RCTBridge.h>
 
 @interface EXNoopUIView : UIView
 


### PR DESCRIPTION
# Why

fixes AppDelegate.swift build error when accessing RCTBridge, e.g. adding this

```swift
class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
  override func sourceURL(for bridge: RCTBridge) -> URL? {
    self.bundleURL()
  }

  override func bundleURL() -> URL? {
    #if DEBUG
    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
    #else
    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
    #endif
  }
}
```

# How

React-Core pod doesn't well support submodule import. we should not import submodule and pull from header. it will lead into ambigious React import.

- [media-library] move import into implementation
- [updates] move import into implementation and replace `RCTMultipartCallback` with our own `EXMultipartCallback` type

# Test Plan

adding the code in bare-expo AppDelegate.swift and build should pass

```swift
class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
  override func sourceURL(for bridge: RCTBridge) -> URL? {
    self.bundleURL()
  }

  override func bundleURL() -> URL? {
    #if DEBUG
    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
    #else
    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
    #endif
  }
}
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
