### PR TITLE
[android][sensors] Fix error when sending events

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix throwing an error inside `getOrientation` when the `currentActivity` is not available.
+
 ### 💡 Others
 
 ## 14.1.2 — 2025-04-14

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix throwing an error inside `getOrientation` when the `currentActivity` is not available.
+- [Android] Fix throwing an error inside `getOrientation` when the `currentActivity` is not available. ([#36369](https://github.com/expo/expo/pull/36369) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
+++ b/packages/expo-sensors/android/src/main/java/expo/modules/sensors/modules/DeviceMotionModule.kt
@@ -17,6 +17,7 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.sensors.SensorSubscription
 import java.lang.ref.WeakReference
 import android.Manifest
+import android.util.Log
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.kotlin.Promise
 
@@ -261,7 +262,13 @@ class DeviceMotionModule : Module(), SensorEventListener2 {
   private fun getOrientation(): Int {
     val windowManager = appContext.reactContext?.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
     val rotation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      appContext.throwingActivity.display?.rotation
+      val activity = appContext.currentActivity
+      if (activity == null) {
+        Log.e(TAG, "[expo-sensors]: The currentActivity is no longer available")
+        0
+      } else {
+        activity.display?.rotation
+      }
     } else {
       @Suppress("DEPRECATION")
       windowManager?.defaultDisplay?.rotation
@@ -277,5 +284,9 @@ class DeviceMotionModule : Module(), SensorEventListener2 {
       }
     }
     return 0
+  }
+
+  companion object {
+    val TAG = DeviceMotionModule::class.simpleName
   }
 }


### PR DESCRIPTION
# Why
Closes #36285

# How
`getOrientation` is called in a event handler. Throwing here will be uncaught and cause a crash so instead we log an error and return `0` as the result

# Test Plan
bare-expo
