### PR TITLE
[eslint-*] align peer dependency ranges

### DIFF
--- a/packages/eslint-config-expo/package.json
+++ b/packages/eslint-config-expo/package.json
@@ -47,11 +47,11 @@
   },
   "devDependencies": {
     "eslint": "^9.18.0",
+    "eslint8": "npm:eslint@^8.57.1",
     "eslint-plugin-prettier": "^5.2.1",
-    "prettier": "^3.4.2",
-    "eslint8": "npm:eslint@^8.57.1"
+    "prettier": "^3.4.2"
   },
   "peerDependencies": {
-    "eslint": "^8 || ^9"
+    "eslint": ">=8.10"
   }
 }

--- a/packages/eslint-config-universe/package.json
+++ b/packages/eslint-config-universe/package.json
@@ -62,8 +62,8 @@
   "devDependencies": {
     "@expo/spawn-async": "^1.7.2",
     "eslint": "^9.24.0",
+    "eslint8": "npm:eslint@^8.57.1",
     "jest": "^29.7.0",
-    "prettier": "^3.5.3",
-    "eslint8": "npm:eslint@^8.57.1"
+    "prettier": "^3.5.3"
   }
 }

--- a/packages/eslint-plugin-expo/package.json
+++ b/packages/eslint-plugin-expo/package.json
@@ -41,7 +41,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "eslint": ">=8 <9"
+    "eslint": ">=8.10"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
# Why

Looks like we miss updating peer dependency range for the `eslint-plugin-expo` package with recent refactors of configs.

# How

Align peer dependency ranges across all ESLint related packages in monorepo.

# Test Plan

There are no peer dependency related warnings when setting up v9 lint stack in Expo app.
