### PR TITLE
[docs] mostly visual tweaks for `InlineHelp` component

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -240,11 +240,11 @@ button.
 not appear on the screen.
       </p>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <svg
-          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          class="translate-z shrink-0 select-none icon-xs mt-[3px] text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -1336,11 +1336,11 @@ This should come from the user field of an
       
 
       <blockquote
-        class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
+        class="flex rounded-md border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <svg
-          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-default"
+          class="translate-z shrink-0 select-none icon-xs mt-[3px] text-icon-default"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -3043,11 +3043,11 @@ After calling this function, the listener will no longer receive any events from
 which contains all of the pertinent user and credential information.
       </p>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <svg
-          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          class="translate-z shrink-0 select-none icon-xs mt-[3px] text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -3974,11 +3974,11 @@ may be
         A value to specify the style for formatting a name.
       </p>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <svg
-          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          class="translate-z shrink-0 select-none icon-xs mt-[3px] text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -4164,11 +4164,11 @@ for more details.
 You must include the ID string of the user whose credentials you'd like to refresh.
       </p>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <svg
-          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          class="translate-z shrink-0 select-none icon-xs mt-[3px] text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -4495,11 +4495,11 @@ OAuth 2.0 protocol
 None of these options are required.
       </p>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <svg
-          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          class="translate-z shrink-0 select-none icon-xs mt-[3px] text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -4846,11 +4846,11 @@ OAuth 2.0 protocol
 You must include the ID string of the user to sign out.
       </p>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <svg
-          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          class="translate-z shrink-0 select-none icon-xs mt-[3px] text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -5740,11 +5740,11 @@ OAuth 2.0 protocol
         .
       </p>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <svg
-          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          class="translate-z shrink-0 select-none icon-xs mt-[3px] text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -6433,11 +6433,11 @@ for more details.
       
 
       <blockquote
-        class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
+        class="flex rounded-md border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <svg
-          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-default"
+          class="translate-z shrink-0 select-none icon-xs mt-[3px] text-icon-default"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -6478,11 +6478,11 @@ You will still need to handle null values for any fields you request.
         </div>
       </blockquote>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <svg
-          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          class="translate-z shrink-0 select-none icon-xs mt-[3px] text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -6722,11 +6722,11 @@ for more details.
         An enum whose values specify the system's best guess for how likely the current user is a real person.
       </p>
       <blockquote
-        class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
         <svg
-          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          class="translate-z shrink-0 select-none icon-xs mt-[3px] text-icon-secondary"
           fill="none"
           role="img"
           stroke="currentColor"
@@ -7484,11 +7484,11 @@ exports[`APISection expo-pedometer 1`] = `
           
 
           <blockquote
-            class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
+            class="flex rounded-md border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
             data-testid="callout-container"
           >
             <svg
-              class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-default"
+              class="translate-z shrink-0 select-none icon-xs mt-[3px] text-icon-default"
               fill="none"
               role="img"
               stroke="currentColor"
@@ -8025,11 +8025,11 @@ provided with a single argument that is
           
 
           <blockquote
-            class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
+            class="flex rounded-md border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
             data-testid="callout-container"
           >
             <svg
-              class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-default"
+              class="translate-z shrink-0 select-none icon-xs mt-[3px] text-icon-default"
               fill="none"
               role="img"
               stroke="currentColor"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -243,27 +243,31 @@ not appear on the screen.
         class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
-        <div
-          class="select-none mt-1"
+        <svg
+          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          fill="none"
+          role="img"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          <svg
-            class="translate-z shrink-0 icon-xs text-icon-secondary"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
+          <g
+            id="info-circle-duotone-icon"
           >
-            <g
-              id="info-circle-solid-icon"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                fill-rule="evenodd"
-                id="Solid"
-              />
-            </g>
-          </svg>
-        </div>
+            <path
+              d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+              fill="currentColor"
+              id="Fill"
+              opacity="0.12"
+            />
+            <path
+              d="M12 16V12M12 8H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+              id="Icon"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
         <div
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
@@ -1335,27 +1339,31 @@ This should come from the user field of an
         class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
-        <div
-          class="select-none mt-1"
+        <svg
+          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-default"
+          fill="none"
+          role="img"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          <svg
-            class="translate-z shrink-0 icon-xs text-icon-default"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
+          <g
+            id="info-circle-duotone-icon"
           >
-            <g
-              id="info-circle-solid-icon"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                fill-rule="evenodd"
-                id="Solid"
-              />
-            </g>
-          </svg>
-        </div>
+            <path
+              d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+              fill="currentColor"
+              id="Fill"
+              opacity="0.12"
+            />
+            <path
+              d="M12 16V12M12 8H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+              id="Icon"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
         <div
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
@@ -3038,27 +3046,31 @@ which contains all of the pertinent user and credential information.
         class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
-        <div
-          class="select-none mt-1"
+        <svg
+          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          fill="none"
+          role="img"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          <svg
-            class="translate-z shrink-0 icon-xs text-icon-secondary"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
+          <g
+            id="info-circle-duotone-icon"
           >
-            <g
-              id="info-circle-solid-icon"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                fill-rule="evenodd"
-                id="Solid"
-              />
-            </g>
-          </svg>
-        </div>
+            <path
+              d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+              fill="currentColor"
+              id="Fill"
+              opacity="0.12"
+            />
+            <path
+              d="M12 16V12M12 8H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+              id="Icon"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
         <div
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
@@ -3965,27 +3977,31 @@ may be
         class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
-        <div
-          class="select-none mt-1"
+        <svg
+          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          fill="none"
+          role="img"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          <svg
-            class="translate-z shrink-0 icon-xs text-icon-secondary"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
+          <g
+            id="info-circle-duotone-icon"
           >
-            <g
-              id="info-circle-solid-icon"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                fill-rule="evenodd"
-                id="Solid"
-              />
-            </g>
-          </svg>
-        </div>
+            <path
+              d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+              fill="currentColor"
+              id="Fill"
+              opacity="0.12"
+            />
+            <path
+              d="M12 16V12M12 8H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+              id="Icon"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
         <div
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
@@ -4151,27 +4167,31 @@ You must include the ID string of the user whose credentials you'd like to refre
         class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
-        <div
-          class="select-none mt-1"
+        <svg
+          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          fill="none"
+          role="img"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          <svg
-            class="translate-z shrink-0 icon-xs text-icon-secondary"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
+          <g
+            id="info-circle-duotone-icon"
           >
-            <g
-              id="info-circle-solid-icon"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                fill-rule="evenodd"
-                id="Solid"
-              />
-            </g>
-          </svg>
-        </div>
+            <path
+              d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+              fill="currentColor"
+              id="Fill"
+              opacity="0.12"
+            />
+            <path
+              d="M12 16V12M12 8H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+              id="Icon"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
         <div
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
@@ -4478,27 +4498,31 @@ None of these options are required.
         class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
-        <div
-          class="select-none mt-1"
+        <svg
+          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          fill="none"
+          role="img"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          <svg
-            class="translate-z shrink-0 icon-xs text-icon-secondary"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
+          <g
+            id="info-circle-duotone-icon"
           >
-            <g
-              id="info-circle-solid-icon"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                fill-rule="evenodd"
-                id="Solid"
-              />
-            </g>
-          </svg>
-        </div>
+            <path
+              d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+              fill="currentColor"
+              id="Fill"
+              opacity="0.12"
+            />
+            <path
+              d="M12 16V12M12 8H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+              id="Icon"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
         <div
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
@@ -4825,27 +4849,31 @@ You must include the ID string of the user to sign out.
         class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
-        <div
-          class="select-none mt-1"
+        <svg
+          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          fill="none"
+          role="img"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          <svg
-            class="translate-z shrink-0 icon-xs text-icon-secondary"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
+          <g
+            id="info-circle-duotone-icon"
           >
-            <g
-              id="info-circle-solid-icon"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                fill-rule="evenodd"
-                id="Solid"
-              />
-            </g>
-          </svg>
-        </div>
+            <path
+              d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+              fill="currentColor"
+              id="Fill"
+              opacity="0.12"
+            />
+            <path
+              d="M12 16V12M12 8H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+              id="Icon"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
         <div
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
@@ -5715,27 +5743,31 @@ OAuth 2.0 protocol
         class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
-        <div
-          class="select-none mt-1"
+        <svg
+          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          fill="none"
+          role="img"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          <svg
-            class="translate-z shrink-0 icon-xs text-icon-secondary"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
+          <g
+            id="info-circle-duotone-icon"
           >
-            <g
-              id="info-circle-solid-icon"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                fill-rule="evenodd"
-                id="Solid"
-              />
-            </g>
-          </svg>
-        </div>
+            <path
+              d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+              fill="currentColor"
+              id="Fill"
+              opacity="0.12"
+            />
+            <path
+              d="M12 16V12M12 8H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+              id="Icon"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
         <div
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
@@ -6404,27 +6436,31 @@ for more details.
         class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
-        <div
-          class="select-none mt-1"
+        <svg
+          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-default"
+          fill="none"
+          role="img"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          <svg
-            class="translate-z shrink-0 icon-xs text-icon-default"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
+          <g
+            id="info-circle-duotone-icon"
           >
-            <g
-              id="info-circle-solid-icon"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                fill-rule="evenodd"
-                id="Solid"
-              />
-            </g>
-          </svg>
-        </div>
+            <path
+              d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+              fill="currentColor"
+              id="Fill"
+              opacity="0.12"
+            />
+            <path
+              d="M12 16V12M12 8H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+              id="Icon"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
         <div
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
@@ -6445,27 +6481,31 @@ You will still need to handle null values for any fields you request.
         class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
-        <div
-          class="select-none mt-1"
+        <svg
+          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          fill="none"
+          role="img"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          <svg
-            class="translate-z shrink-0 icon-xs text-icon-secondary"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
+          <g
+            id="info-circle-duotone-icon"
           >
-            <g
-              id="info-circle-solid-icon"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                fill-rule="evenodd"
-                id="Solid"
-              />
-            </g>
-          </svg>
-        </div>
+            <path
+              d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+              fill="currentColor"
+              id="Fill"
+              opacity="0.12"
+            />
+            <path
+              d="M12 16V12M12 8H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+              id="Icon"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
         <div
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
@@ -6685,27 +6725,31 @@ for more details.
         class="mb-4 flex gap-2 rounded-md border border-default px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
         data-testid="callout-container"
       >
-        <div
-          class="select-none mt-1"
+        <svg
+          class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-secondary"
+          fill="none"
+          role="img"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
         >
-          <svg
-            class="translate-z shrink-0 icon-xs text-icon-secondary"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
+          <g
+            id="info-circle-duotone-icon"
           >
-            <g
-              id="info-circle-solid-icon"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                fill-rule="evenodd"
-                id="Solid"
-              />
-            </g>
-          </svg>
-        </div>
+            <path
+              d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+              fill="currentColor"
+              id="Fill"
+              opacity="0.12"
+            />
+            <path
+              d="M12 16V12M12 8H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+              id="Icon"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </g>
+        </svg>
         <div
           class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
         >
@@ -7443,27 +7487,31 @@ exports[`APISection expo-pedometer 1`] = `
             class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
             data-testid="callout-container"
           >
-            <div
-              class="select-none mt-1"
+            <svg
+              class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-default"
+              fill="none"
+              role="img"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
             >
-              <svg
-                class="translate-z shrink-0 icon-xs text-icon-default"
-                fill="currentColor"
-                role="img"
-                viewBox="0 0 24 24"
+              <g
+                id="info-circle-duotone-icon"
               >
-                <g
-                  id="info-circle-solid-icon"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                    fill-rule="evenodd"
-                    id="Solid"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+                  fill="currentColor"
+                  id="Fill"
+                  opacity="0.12"
+                />
+                <path
+                  d="M12 16V12M12 8H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+                  id="Icon"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </g>
+            </svg>
             <div
               class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
             >
@@ -7980,27 +8028,31 @@ provided with a single argument that is
             class="flex gap-2 rounded-md border border-default bg-subtle px-3 py-2.5 [&_code]:bg-element [&_p]:!mb-0 shadow-none mb-2.5 [table_&]:last:mb-0"
             data-testid="callout-container"
           >
-            <div
-              class="select-none mt-1"
+            <svg
+              class="translate-z shrink-0 mt-1 select-none icon-xs text-icon-default"
+              fill="none"
+              role="img"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
             >
-              <svg
-                class="translate-z shrink-0 icon-xs text-icon-default"
-                fill="currentColor"
-                role="img"
-                viewBox="0 0 24 24"
+              <g
+                id="info-circle-duotone-icon"
               >
-                <g
-                  id="info-circle-solid-icon"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M12 1C5.92487 1 1 5.92487 1 12C1 18.0751 5.92487 23 12 23C18.0751 23 23 18.0751 23 12C23 5.92487 18.0751 1 12 1ZM12 7C11.4477 7 11 7.44772 11 8C11 8.55228 11.4477 9 12 9H12.01C12.5623 9 13.01 8.55228 13.01 8C13.01 7.44772 12.5623 7 12.01 7H12ZM13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12V16C11 16.5523 11.4477 17 12 17C12.5523 17 13 16.5523 13 16V12Z"
-                    fill-rule="evenodd"
-                    id="Solid"
-                  />
-                </g>
-              </svg>
-            </div>
+                <path
+                  d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
+                  fill="currentColor"
+                  id="Fill"
+                  opacity="0.12"
+                />
+                <path
+                  d="M12 16V12M12 8H12.01M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+                  id="Icon"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </g>
+            </svg>
             <div
               class="w-full text-default last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
             >

--- a/docs/pages/versions/unversioned/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem-next.mdx
@@ -12,9 +12,9 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 > **info** The `next` version of the FileSystem API is included in the `expo-file-system` library. It can be used alongside the previous API, and offers a simplified, object oriented way of performing filesystem operations.
 
-`expo-file-system/next` provides access to the file system stored locally on the device. It can also download files from the network.
+> **important** To provide quicker updates, `expo-file-system/next` is currently unsupported in Expo Go and Snack. To use it, create a [development build](/develop/development-builds/create-a-build/).
 
-> **info** To provide quicker updates, `expo-file-system/next` is currently unsupported in Expo Go and Snack. To use it, create a [development build](/develop/development-builds/create-a-build/).
+`expo-file-system/next` provides access to the file system stored locally on the device. It can also download files from the network.
 
 ## Installation
 

--- a/docs/pages/versions/v52.0.0/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/filesystem-next.mdx
@@ -13,9 +13,9 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 > **info** The `next` version of the FileSystem API is included in the `expo-file-system` library. It can be used alongside the previous API, and offers a simplified, object oriented way of performing filesystem operations.
 
-`expo-file-system/next` provides access to the file system stored locally on the device. It can also download files from the network.
+> **important** To provide quicker updates, `expo-file-system/next` is currently unsupported in Expo Go and Snack. To use it, create a [development build](/develop/development-builds/create-a-build/).
 
-> **info** To provide quicker updates, `expo-file-system/next` is currently unsupported in Expo Go and Snack. To use it, create a [development build](/develop/development-builds/create-a-build/).
+`expo-file-system/next` provides access to the file system stored locally on the device. It can also download files from the network.
 
 ## Installation
 

--- a/docs/pages/versions/v53.0.0/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/filesystem-next.mdx
@@ -12,9 +12,9 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 > **info** The `next` version of the FileSystem API is included in the `expo-file-system` library. It can be used alongside the previous API, and offers a simplified, object oriented way of performing filesystem operations.
 
-`expo-file-system/next` provides access to the file system stored locally on the device. It can also download files from the network.
+> **important** To provide quicker updates, `expo-file-system/next` is currently unsupported in Expo Go and Snack. To use it, create a [development build](/develop/development-builds/create-a-build/).
 
-> **info** To provide quicker updates, `expo-file-system/next` is currently unsupported in Expo Go and Snack. To use it, create a [development build](/develop/development-builds/create-a-build/).
+`expo-file-system/next` provides access to the file system stored locally on the device. It can also download files from the network.
 
 ## Installation
 

--- a/docs/ui/components/InlineHelp/InlineHelp.test.tsx
+++ b/docs/ui/components/InlineHelp/InlineHelp.test.tsx
@@ -5,12 +5,6 @@ import ReactMarkdown from 'react-markdown';
 import { InlineHelp } from '.';
 
 describe(InlineHelp, () => {
-  it('renders inline help with icon emoji', () => {
-    render(<InlineHelp icon="🎨">Hello</InlineHelp>);
-    expect(screen.getByText('🎨')).toBeInTheDocument();
-    expect(screen.getByText('Hello')).toBeInTheDocument();
-  });
-
   it('renders inline help with icon component', () => {
     render(<InlineHelp icon={CheckCircleSolidIcon}>Hello</InlineHelp>);
     expect(screen.getByRole('img')).toBeInTheDocument();
@@ -43,6 +37,11 @@ describe(InlineHelp, () => {
   it('renders inline help with error style from error type', () => {
     render(<InlineHelp type="error">Hello</InlineHelp>);
     expect(screen.getByTestId('callout-container')).toHaveClass('bg-danger');
+  });
+
+  it('renders inline help with important style from important type', () => {
+    render(<InlineHelp type="important">Hello</InlineHelp>);
+    expect(screen.getByTestId('callout-container')).toHaveClass('bg-palette-purple3');
   });
 
   it('renders inline help with info style from info type', () => {

--- a/docs/ui/components/InlineHelp/index.tsx
+++ b/docs/ui/components/InlineHelp/index.tsx
@@ -1,8 +1,8 @@
 import { mergeClasses } from '@expo/styleguide';
-import { AlertCircleSolidIcon } from '@expo/styleguide-icons/solid/AlertCircleSolidIcon';
-import { AlertTriangleSolidIcon } from '@expo/styleguide-icons/solid/AlertTriangleSolidIcon';
-import { InfoCircleSolidIcon } from '@expo/styleguide-icons/solid/InfoCircleSolidIcon';
-import { XSquareSolidIcon } from '@expo/styleguide-icons/solid/XSquareSolidIcon';
+import { AlertCircleDuotoneIcon } from '@expo/styleguide-icons/duotone/AlertCircleDuotoneIcon';
+import { AlertTriangleDuotoneIcon } from '@expo/styleguide-icons/duotone/AlertTriangleDuotoneIcon';
+import { InfoCircleDuotoneIcon } from '@expo/styleguide-icons/duotone/InfoCircleDuotoneIcon';
+import { XSquareDuotoneIcon } from '@expo/styleguide-icons/duotone/XSquareDuotoneIcon';
 import {
   Children,
   HTMLAttributes,
@@ -17,7 +17,7 @@ type CalloutType = 'default' | 'important' | 'warning' | 'error' | 'info' | 'inf
 type Props = PropsWithChildren<{
   type?: CalloutType;
   className?: string;
-  icon?: ComponentType<HTMLAttributes<SVGSVGElement>> | string;
+  icon?: ComponentType<HTMLAttributes<SVGSVGElement>>;
   size?: 'sm' | 'md';
 }>;
 
@@ -49,8 +49,8 @@ export const InlineHelp = ({ type = 'default', size = 'md', icon, children, clas
   return (
     <blockquote
       className={mergeClasses(
-        'mb-4 flex gap-2 rounded-md border border-default bg-subtle px-4 py-3 shadow-xs',
-        size === 'sm' && 'px-3 py-2.5',
+        'mb-4 flex gap-2.5 rounded-md border border-default bg-subtle py-3 pl-3.5 pr-4 shadow-xs',
+        size === 'sm' && 'gap-2 px-3 py-2.5',
         '[table_&]:last:mb-0',
         '[&_code]:bg-element',
         getCalloutColor(finalType),
@@ -59,18 +59,13 @@ export const InlineHelp = ({ type = 'default', size = 'md', icon, children, clas
         className
       )}
       data-testid="callout-container">
-      <div className={mergeClasses('mt-1 select-none', size === 'sm' && 'mt-1')}>
-        {typeof icon === 'string' ? (
-          icon
-        ) : (
-          <Icon
-            className={mergeClasses(
-              size === 'sm' ? 'icon-xs' : 'icon-sm',
-              getCalloutIconColor(finalType)
-            )}
-          />
+      <Icon
+        className={mergeClasses(
+          'mt-1 select-none',
+          size === 'sm' ? 'icon-xs mt-[3px]' : 'icon-sm',
+          getCalloutIconColor(finalType)
         )}
-      </div>
+      />
       <div
         className={mergeClasses(
           'w-full leading-normal text-default',
@@ -121,13 +116,13 @@ function getCalloutColor(type: CalloutType) {
 function getCalloutIcon(type: CalloutType): (props: HTMLAttributes<SVGSVGElement>) => JSX.Element {
   switch (type) {
     case 'warning':
-      return AlertTriangleSolidIcon;
+      return AlertTriangleDuotoneIcon;
     case 'important':
-      return AlertCircleSolidIcon;
+      return AlertCircleDuotoneIcon;
     case 'error':
-      return XSquareSolidIcon;
+      return XSquareDuotoneIcon;
     default:
-      return InfoCircleSolidIcon;
+      return InfoCircleDuotoneIcon;
   }
 }
 


### PR DESCRIPTION
# Why

When adding new "important" theme I have spotted that we can simplify and tweak a bit appearance of `InlineHelp` component.

# How

Summary of changes:
* InlineHelp: switch to duotone icon variants
* InlineHelp: tweaks to spacing in few places
* InlineHelp: remove ability to pass emoji as icon, simplify DOM
* update InlineHelp tests
* reorder callouts on FileSystem (next) pages 

# Test Plan

The changes have been reviewed by running docs app locally. All lint checks are passing.

# Preview

![Screenshot 2025-04-24 at 22 53 14](https://github.com/user-attachments/assets/46d62586-cf46-469b-8b05-56a03f64c7d3)
![Screenshot 2025-04-24 at 23 04 09](https://github.com/user-attachments/assets/02584707-d413-4cfa-9267-e7719e251f50)
![Screenshot 2025-04-24 at 22 38 58](https://github.com/user-attachments/assets/713b3b67-e971-4c73-87c6-537a20204baf)
![Screenshot 2025-04-24 at 22 47 02](https://github.com/user-attachments/assets/651356df-d8fd-4bdd-8753-f87028df8fd2)
