### PR TITLE
feat(babel): enable import meta in server

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Always enable `import.meta` polyfill for server bundles.
+- Always enable `import.meta` polyfill for server bundles. ([#36380](https://github.com/expo/expo/pull/36380) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Always enable `import.meta` polyfill for server bundles.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/babel-preset-expo/README.md
+++ b/packages/babel-preset-expo/README.md
@@ -150,7 +150,7 @@ Changes the engine preset in `@react-native/babel-preset` based on the JavaScrip
 
 ### `unstable_transformImportMeta`
 
-Enable that transform that converts `import.meta` to `globalThis.__ExpoImportMetaRegistry`, defaults to `false`.
+Enable that transform that converts `import.meta` to `globalThis.__ExpoImportMetaRegistry`, defaults to `false` in client bundles and `true` for server bundles.
 
 > **Note:** Use this option at your own risk. If the JavaScript engine supports `import.meta` natively, this transformation may interfere with the native implementation.
 

--- a/packages/babel-preset-expo/build/index.d.ts
+++ b/packages/babel-preset-expo/build/index.d.ts
@@ -72,7 +72,7 @@ type BabelPresetExpoPlatformOptions = {
      *
      * > **Note:** Use this option at your own risk. If the JavaScript engine supports `import.meta` natively, this transformation may interfere with the native implementation.
      *
-     * @default `false`
+     * @default `false` on client and `true` on server.
      */
     unstable_transformImportMeta?: boolean;
 };

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -181,7 +181,8 @@ function babelPresetExpo(api, options = {}) {
     if (platformOptions.disableImportExportTransform) {
         extraPlugins.push([require('./detect-dynamic-exports').detectDynamicExports]);
     }
-    extraPlugins.push((0, import_meta_transform_plugin_1.expoImportMetaTransformPluginFactory)(platformOptions.unstable_transformImportMeta === true));
+    const polyfillImportMeta = platformOptions.unstable_transformImportMeta ?? isServerEnv;
+    extraPlugins.push((0, import_meta_transform_plugin_1.expoImportMetaTransformPluginFactory)(polyfillImportMeta === true));
     return {
         presets: [
             (() => {

--- a/packages/babel-preset-expo/src/__tests__/import-meta-transform-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/import-meta-transform-plugin.test.ts
@@ -45,21 +45,30 @@ it(`should throw an error when trying to transform import.meta by default for na
     );
   });
 });
+it(`should not transform import.meta by default for web platforms`, () => {
+  const options = {
+    ...DEF_OPTIONS,
+    caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'web', isDev: true }),
+  };
 
-it(`should not transform import.meta by default for web and server platforms`, () => {
-  ['web', 'server'].forEach((platform) => {
-    const options = {
-      ...DEF_OPTIONS,
-      caller: getCaller({
-        name: 'metro',
-        engine: 'hermes',
-        platform: 'web',
-        isDev: true,
-        isServer: platform === 'server',
-      }),
-    };
+  const sourceCode = `var url = import.meta.url;`;
+  expect(babel.transform(sourceCode, options).code).toEqual(`var url = import.meta.url;`);
+});
 
-    const sourceCode = `var url = import.meta.url;`;
-    expect(babel.transform(sourceCode, options)!.code).toEqual(sourceCode);
-  });
+it(`should transform import.meta by default for server bundles`, () => {
+  const options = {
+    ...DEF_OPTIONS,
+    caller: getCaller({
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'web',
+      isDev: true,
+      isServer: true,
+    }),
+  };
+
+  const sourceCode = `var url = import.meta.url;`;
+  expect(babel.transform(sourceCode, options)!.code).toEqual(
+    `var url = globalThis.__ExpoImportMetaRegistry.url;`
+  );
 });

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -106,7 +106,7 @@ type BabelPresetExpoPlatformOptions = {
    *
    * > **Note:** Use this option at your own risk. If the JavaScript engine supports `import.meta` natively, this transformation may interfere with the native implementation.
    *
-   * @default `false`
+   * @default `false` on client and `true` on server.
    */
   unstable_transformImportMeta?: boolean;
 };
@@ -328,9 +328,10 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
   if (platformOptions.disableImportExportTransform) {
     extraPlugins.push([require('./detect-dynamic-exports').detectDynamicExports]);
   }
-  extraPlugins.push(
-    expoImportMetaTransformPluginFactory(platformOptions.unstable_transformImportMeta === true)
-  );
+
+  const polyfillImportMeta = platformOptions.unstable_transformImportMeta ?? isServerEnv;
+
+  extraPlugins.push(expoImportMetaTransformPluginFactory(polyfillImportMeta === true));
 
   return {
     presets: [


### PR DESCRIPTION
# Why

- After further consideration, I think it's probably fine if we enable import.meta in the server. It's better if code continues to work and we phase out require / module.exports.

# Test Plan

- Update tests