### PR TITLE
[docs] update hover effects and polish few components

### DIFF
--- a/docs/ui/components/BoxLink/index.tsx
+++ b/docs/ui/components/BoxLink/index.tsx
@@ -1,12 +1,13 @@
+import { LinkBase, mergeClasses } from '@expo/styleguide';
 import { ArrowRightIcon } from '@expo/styleguide-icons/outline/ArrowRightIcon';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons/outline/ArrowUpRightIcon';
 import type { AnchorHTMLAttributes, ComponentType, HTMLAttributes, ReactNode } from 'react';
 
-import { A, DEMI, CALLOUT } from '~/ui/components/Text';
+import { DEMI, CALLOUT } from '~/ui/components/Text';
 
 type BoxLinkProps = AnchorHTMLAttributes<HTMLLinkElement> & {
   title: string;
-  description: ReactNode;
+  description?: ReactNode;
   testID?: string;
   Icon?: ComponentType<HTMLAttributes<SVGSVGElement>>;
   imageUrl?: string;
@@ -16,25 +17,27 @@ export function BoxLink({ title, description, href, testID, Icon, imageUrl }: Bo
   const isExternal = Boolean(href?.startsWith('http'));
   const ArrowIcon = isExternal ? ArrowUpRightIcon : ArrowRightIcon;
   return (
-    <A
+    <LinkBase
       href={href}
-      className="mb-3 flex flex-row justify-between rounded-md border border-solid border-default px-4 py-3 hocus:shadow-xs"
+      className={mergeClasses(
+        'group mb-3 flex flex-row justify-between rounded-md border border-solid border-default px-4 py-3 transition',
+        'hocus:bg-subtle hocus:shadow-xs'
+      )}
       data-testid={testID}
-      openInNewTab={isExternal}
-      isStyled>
+      openInNewTab={isExternal}>
       <div className="flex flex-row gap-4">
         {Icon && (
-          <div className="flex h-9 min-w-[36px] items-center justify-center self-center rounded-md bg-element">
+          <div className="flex h-9 min-w-[36px] items-center justify-center self-center rounded-md bg-element transition group-hover:bg-hover">
             <Icon className="icon-lg text-icon-default" />
           </div>
         )}
         {imageUrl && <img className="!h-9 !w-9 self-center" src={imageUrl} alt="Icon" />}
-        <div>
+        <div className="flex flex-col self-center">
           <DEMI>{title}</DEMI>
-          <CALLOUT theme="secondary">{description}</CALLOUT>
+          {description && <CALLOUT theme="secondary">{description}</CALLOUT>}
         </div>
       </div>
       <ArrowIcon className="ml-3 min-w-[20px] content-end self-center text-icon-secondary" />
-    </A>
+    </LinkBase>
   );
 }

--- a/docs/ui/components/Footer/PageVote.tsx
+++ b/docs/ui/components/Footer/PageVote.tsx
@@ -1,4 +1,6 @@
 import { Button, mergeClasses } from '@expo/styleguide';
+import { ThumbsDownDuotoneIcon } from '@expo/styleguide-icons/duotone/ThumbsDownDuotoneIcon';
+import { ThumbsUpDuotoneIcon } from '@expo/styleguide-icons/duotone/ThumbsUpDuotoneIcon';
 import { ThumbsDownIcon } from '@expo/styleguide-icons/outline/ThumbsDownIcon';
 import { ThumbsUpIcon } from '@expo/styleguide-icons/outline/ThumbsUpIcon';
 import { useState } from 'react';
@@ -28,8 +30,13 @@ export const PageVote = () => {
               theme="secondary"
               size="xs"
               aria-label="Vote up"
-              className="mx-1 min-w-[40px] text-center"
-              leftSlot={<ThumbsUpIcon className="icon-sm" />}
+              className="group mx-1 min-w-[40px] text-center"
+              leftSlot={
+                <>
+                  <ThumbsUpIcon className="icon-sm group-hover:hidden group-focus-visible:hidden" />
+                  <ThumbsUpDuotoneIcon className="icon-sm hidden text-icon-success group-hover:flex group-focus-visible:flex" />
+                </>
+              }
               onClick={() => {
                 reportPageVote({ status: true });
                 setUserVoted(true);
@@ -39,8 +46,13 @@ export const PageVote = () => {
               theme="secondary"
               size="xs"
               aria-label="Vote down"
-              className="mx-1 min-w-[40px] text-center"
-              leftSlot={<ThumbsDownIcon className="icon-sm" />}
+              className="group mx-1 min-w-[40px] text-center"
+              leftSlot={
+                <>
+                  <ThumbsDownIcon className="icon-sm group-hover:hidden group-focus-visible:hidden" />
+                  <ThumbsDownDuotoneIcon className="icon-sm hidden text-icon-danger group-hover:flex group-focus-visible:flex" />
+                </>
+              }
               onClick={() => {
                 reportPageVote({ status: false });
                 setUserVoted(true);

--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { Button, mergeClasses } from '@expo/styleguide';
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+import { Star01DuotoneIcon } from '@expo/styleguide-icons/duotone/Star01DuotoneIcon';
 import { Menu01Icon } from '@expo/styleguide-icons/outline/Menu01Icon';
 import { Star01Icon } from '@expo/styleguide-icons/outline/Star01Icon';
 import { type ReactNode } from 'react';
@@ -49,8 +50,13 @@ export const Header = ({
           <Button
             openInNewTab
             theme="quaternary"
-            className={mergeClasses('px-2 text-secondary', 'max-lg-gutters:hidden')}
-            leftSlot={<Star01Icon className="icon-sm" />}
+            className={mergeClasses('group px-2 text-secondary', 'max-lg-gutters:hidden')}
+            leftSlot={
+              <>
+                <Star01Icon className="icon-sm group-hover:hidden group-focus-visible:hidden" />
+                <Star01DuotoneIcon className="icon-sm hidden text-icon-warning group-hover:flex group-focus-visible:flex" />
+              </>
+            }
             href="https://github.com/expo/expo">
             Star Us on GitHub
           </Button>

--- a/docs/ui/components/Prerequisites/index.tsx
+++ b/docs/ui/components/Prerequisites/index.tsx
@@ -90,7 +90,7 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
               onClick={() => {
                 detailsRef?.current?.setAttribute('open', '');
               }}
-              className="ml-auto inline rounded-md p-1 hocus:bg-element"
+              className="ml-1 inline rounded-md p-1 hocus:bg-element"
               aria-label="Permalink">
               <PermalinkIcon className="icon-sm invisible inline-flex group-hover:visible group-focus-visible:visible" />
             </LinkBase>

--- a/docs/ui/components/ProgressTracker/index.tsx
+++ b/docs/ui/components/ProgressTracker/index.tsx
@@ -1,9 +1,9 @@
-import { ArrowRightIcon } from '@expo/styleguide-icons/outline/ArrowRightIcon';
+import { mergeClasses } from '@expo/styleguide';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
-import React from 'react';
 
 import { useTutorialChapterCompletion } from '~/providers/TutorialChapterCompletionProvider';
-import { P, A, DEMI } from '~/ui/components/Text';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { P } from '~/ui/components/Text';
 
 import { SuccessCheckmark } from './SuccessCheckmark';
 import { Chapter } from './TutorialData';
@@ -91,19 +91,22 @@ export function ProgressTracker({
 
   return (
     <>
-      <div className="mx-auto mt-6 max-h-96 w-full rounded-md border border-solid border-default bg-subtle p-3">
-        <div className="flex items-center justify-center pt-2">
-          <SuccessCheckmark />
-        </div>
-        <div className="flex flex-col items-center justify-center">
-          <p className="mt-6 flex items-center text-center font-semibold text-default heading-lg">
-            <BookOpen02Icon className="mr-2 size-6" /> {currentChapter.title}
+      <div className="mx-auto flex w-full flex-col gap-4 rounded-lg border-2 border-palette-gray4 px-4 py-5">
+        <SuccessCheckmark
+          size="sm"
+          className={mergeClasses(
+            'mx-auto flex items-center justify-center grayscale transition duration-300',
+            currentChapter.completed && 'border-palette-green5 grayscale-0'
+          )}
+        />
+        <div className="flex flex-col items-center justify-center gap-2">
+          <p className="flex items-center text-center font-semibold text-default heading-lg">
+            <BookOpen02Icon className="mr-2 size-6 text-icon-secondary max-md-gutters:hidden" />{' '}
+            {currentChapter.title}
           </p>
-          <div className="mt-2 flex max-w-lg items-center justify-center leading-7">
-            <p className="pb-2 text-center text-default">{summary}</p>
-          </div>
+          <p className="max-w-[60ch] pb-2 text-center leading-normal text-secondary">{summary}</p>
         </div>
-        <div className="mt-4 flex items-center justify-center">
+        <div className="flex items-center justify-center">
           <Checkbox
             id={`chapter-${currentChapterIndex}`}
             checked={currentChapter.completed}
@@ -118,20 +121,7 @@ export function ProgressTracker({
       </div>
       <>
         <P className="my-4">{nextChapterDescription}</P>
-        <A
-          href={nextChapterLink}
-          className="mb-3 flex flex-row justify-between rounded-md border border-solid border-default px-4 py-3 hocus:shadow-xs"
-          isStyled>
-          <div className="flex flex-row items-center gap-4">
-            <div className="flex h-9 min-w-[36px] items-center justify-center self-center rounded-md bg-element">
-              <BookOpen02Icon className="icon-lg text-icon-default" />
-            </div>
-            <div>
-              <DEMI>Next: {nextChapterTitle}</DEMI>
-            </div>
-          </div>
-          <ArrowRightIcon className="ml-3 min-w-[20px] content-end self-center text-icon-secondary" />
-        </A>
+        <BoxLink href={nextChapterLink} title={`Next: ${nextChapterTitle}`} Icon={BookOpen02Icon} />
       </>
     </>
   );

--- a/docs/ui/components/Search/Search.tsx
+++ b/docs/ui/components/Search/Search.tsx
@@ -39,7 +39,10 @@ export const Search = () => {
           },
         ]}
       />
-      <CommandMenuTrigger setOpen={setOpen} className="mb-2.5" />
+      <CommandMenuTrigger
+        setOpen={setOpen}
+        className="mb-2.5 hocus:bg-element hocus:dark:bg-subtle"
+      />
     </>
   );
 };

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -63,7 +63,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
             <SidebarTitle Icon={Icon}>{title}</SidebarTitle>
             <div className="flex flex-row items-center pb-1">
               <CircularProgressBar progress={progressPercentage} />{' '}
-              <p className="ml-2 text-sm text-secondary">{`${completedChaptersCount} of ${totalChapters}`}</p>
+              <p className="ml-2 text-xs text-tertiary">{`${completedChaptersCount} of ${totalChapters}`}</p>
             </div>
           </div>
         )}
@@ -121,7 +121,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
             <SidebarTitle Icon={Icon}>{title}</SidebarTitle>
             <div className="flex flex-row items-center pb-1">
               <CircularProgressBar progress={progressPercentageForGetStarted} />{' '}
-              <p className="ml-2 text-sm text-secondary">{`${completedGetStartedChaptersCount} of ${totalGetStartedChapters}`}</p>
+              <p className="ml-2 text-xs text-tertiary">{`${completedGetStartedChaptersCount} of ${totalGetStartedChapters}`}</p>
             </div>
           </div>
         )}

--- a/docs/ui/components/VideoBoxLink/index.tsx
+++ b/docs/ui/components/VideoBoxLink/index.tsx
@@ -1,9 +1,9 @@
-import { mergeClasses } from '@expo/styleguide';
+import { LinkBase, mergeClasses } from '@expo/styleguide';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons/outline/ArrowUpRightIcon';
 import { PlaySolidIcon } from '@expo/styleguide-icons/solid/PlaySolidIcon';
 import { type ReactNode } from 'react';
 
-import { A, CALLOUT, LABEL } from '~/ui/components/Text';
+import { CALLOUT, LABEL } from '~/ui/components/Text';
 
 type VideoBoxLinkProps = {
   title: string;
@@ -15,26 +15,25 @@ type VideoBoxLinkProps = {
 
 export function VideoBoxLink({ title, description, videoId, time, className }: VideoBoxLinkProps) {
   return (
-    <A
+    <LinkBase
       openInNewTab
       href={`https://www.youtube.com/watch?v=${videoId}${time ? `&t=${time}` : ''}`}
       className={mergeClasses(
-        'relative flex items-stretch overflow-hidden rounded-lg border border-default bg-default shadow-xs transition',
-        'hocus:shadow-sm',
+        'group relative flex items-stretch overflow-hidden rounded-lg border border-default bg-default shadow-xs transition',
+        'hocus:bg-subtle hocus:shadow-sm',
         'max-sm-gutters:flex-col',
         '[&+hr]:!mt-6',
         className
       )}
-      isStyled
       aria-label={`Watch video: ${title} (opens in new tab)`}>
       <div
         className={mergeClasses(
-          'relative flex max-w-[200px] items-center justify-center border-r border-secondary bg-element',
+          'relative flex max-w-[200px] items-center justify-center overflow-hidden border-r border-secondary bg-element',
           'max-sm-gutters:max-w-full max-sm-gutters:border-b max-sm-gutters:border-r-0'
         )}>
         <img
           src={`https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`}
-          className="aspect-video"
+          className="aspect-video transition duration-300 group-hover:scale-105 group-focus-visible:scale-105"
           alt={title}
           aria-label={`Video thumbnail for ${title}`}
         />
@@ -45,7 +44,7 @@ export function VideoBoxLink({ title, description, videoId, time, className }: V
           <PlaySolidIcon className="icon-lg ml-0.5 text-palette-white" />
         </div>
       </div>
-      <div className="flex flex-col justify-center gap-1 bg-default px-4 py-2">
+      <div className="flex flex-col justify-center gap-1 px-4 py-2">
         <LABEL className="flex items-center gap-1.5 leading-normal">{title}</LABEL>
         {description && (
           <CALLOUT theme="secondary" className="flex items-center gap-2">
@@ -57,6 +56,6 @@ export function VideoBoxLink({ title, description, videoId, time, className }: V
         className="icon-md my-auto ml-auto mr-4 shrink-0 text-icon-secondary max-sm-gutters:hidden"
         aria-hidden="true"
       />
-    </A>
+    </LinkBase>
   );
 }


### PR DESCRIPTION
# Why

Spotted that not all hover effects match across the docs site.

# How

Align hover effects of few components, add icon tint on hover for few buttons, tweak few components appearance.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

https://github.com/user-attachments/assets/6169223d-e80d-4048-8dff-d5fde667847f

![Screenshot 2025-04-25 at 11 30 14](https://github.com/user-attachments/assets/6ed4452a-d92d-4ddf-b5ca-fe9dd132a271)
![Screenshot 2025-04-25 at 00 08 16](https://github.com/user-attachments/assets/de4afa64-00ce-4f85-b1b4-76454d3adf8a)
![Screenshot 2025-04-25 at 00 08 12](https://github.com/user-attachments/assets/ac03e5f3-deb7-4bd6-a5e5-c5957ad32255)
![Screenshot 2025-04-25 at 11 32 09](https://github.com/user-attachments/assets/a01c8df8-2520-4d0e-a12d-dae1722d90ec)
