### PR TITLE
[docs] removed unnecessary check in example

### DIFF
--- a/docs/pages/eas-update/download-updates.mdx
+++ b/docs/pages/eas-update/download-updates.mdx
@@ -67,12 +67,9 @@ export const setupBackgroundUpdates = async () => {
     return Promise.resolve();
   });
 
-  const isRegistered = await TaskManager.isTaskRegisteredAsync(BACKGROUND_TASK_NAME);
-  if (!isRegistered) {
-    await BackgroundTask.registerTaskAsync(BACKGROUND_TASK_NAME, {
-      minimumInterval: 60 * 24,
-    });
-  }
+  await BackgroundTask.registerTaskAsync(BACKGROUND_TASK_NAME, {
+    minimumInterval: 60 * 24,
+  });
 };
 
 setupBackgroundUpdates();


### PR DESCRIPTION
# Why

There should be no need to check if a task is registered, a test for this was added in #35734

# How

Removed check in example.

Before:
<img width="687" alt="image" src="https://github.com/user-attachments/assets/8baa553c-dbd1-403a-9363-8a5927984ff1" />

After:
<img width="697" alt="image" src="https://github.com/user-attachments/assets/aaaf6d97-a291-4585-b759-ba7440734e81" />

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
