### PR TITLE
[dev-launcher] Drop deprecated auth method

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3597,8 +3597,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   BenchmarkingModule: a97859cac8efb2f5411b2052e61841b349813a4a
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EASClient: 2d9d3631681fc426f9c4ade4d7cf6fc2d19baa46
   EXApplication: 11b2bbe282966309a86145fc642090b6e5b356cc
   EXAV: 796c01cfbe714ce51fb0712636780b3b6feb1248
@@ -3676,7 +3676,7 @@ SPEC CHECKSUMS:
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: abbac80c6f89e71a8c55c7e92ec015c8a9496753
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: c32f2e405098bc1ebe30630a051ddce6f21d3c2e
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3391,9 +3391,9 @@ EXTERNAL SOURCES:
     :path: "../../../react-native-lab/react-native/packages/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
+  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EASClient: 2d9d3631681fc426f9c4ade4d7cf6fc2d19baa46
   EXApplication: 11b2bbe282966309a86145fc642090b6e5b356cc
   EXAV: 796c01cfbe714ce51fb0712636780b3b6feb1248
@@ -3472,13 +3472,13 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 85bdce8babed7814816496bb6f082bc05b0a45e1
   FirebaseSessions: f5c6bfeb66a7202deaf33352017bb6365e395820
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: b8d74dbf752f98968ebe3e98c8d913153915dbbb
+  hermes-engine: 41babe300c4747d49b17f5fd368e227380c258eb
   JKBigInteger: 5c72131974815e969c0782c41e3452f1bbe5619f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Remove usage of deprecated `SFAuthenticationSession` for user login.
+
 ## 5.1.5 — 2025-04-23
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [iOS] Remove usage of deprecated `SFAuthenticationSession` for user login.
+- [iOS] Remove usage of deprecated `SFAuthenticationSession` for user login. ([#36395](https://github.com/expo/expo/pull/36395) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 5.1.5 — 2025-04-23
 

--- a/packages/expo-dev-launcher/ios/DevLauncherAuth.swift
+++ b/packages/expo-dev-launcher/ios/DevLauncherAuth.swift
@@ -33,7 +33,7 @@ public class DevLauncherAuth: Module {
         }
         self?.flowDidFinish()
       }
-      
+
       // With ASWebAuthenticationSession, all that is required for the callbackURLScheme is the scheme defined in CFBundleURLSchemes.
       // ://auth is not necessary.
       let scheme = getAuthScheme()
@@ -56,12 +56,12 @@ public class DevLauncherAuth: Module {
       return UserDefaults.standard.string(forKey: "expo-session-secret")
     }
   }
-  
+
   private func getAuthScheme() -> String {
     guard let urlTypes = Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes") as? [[String: Any]] else {
       return DEV_LAUNCHER_DEFAULT_SCHEME
     }
-    
+
     return urlTypes.compactMap { urlType in
       (urlType["CFBundleURLSchemes"] as? [String])?.first
     }.first ?? DEV_LAUNCHER_DEFAULT_SCHEME

--- a/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
@@ -14,16 +14,13 @@ public class EXDevLauncherUrl: NSObject {
   @objc
   public init(_ url: URL) {
     self.queryParams = EXDevLauncherURLHelper.getQueryParamsForUrl(url)
-    self.url = url
 
-    if EXDevLauncherURLHelper.isDevLauncherURL(url) {
-      if let urlParam = self.queryParams["url"] {
-        if let urlFromParam = URL.init(string: urlParam) {
-          self.url = EXDevLauncherURLHelper.replaceEXPScheme(urlFromParam, to: "http")
-        }
-      }
+    if EXDevLauncherURLHelper.isDevLauncherURL(url),
+      let urlParam = queryParams["url"],
+      let urlFromParam = URL(string: urlParam) {
+      self.url = EXDevLauncherURLHelper.replaceEXPScheme(urlFromParam, to: "http")
     } else {
-      self.url = EXDevLauncherURLHelper.replaceEXPScheme(self.url, to: "http")
+      self.url = EXDevLauncherURLHelper.replaceEXPScheme(url, to: "http")
     }
 
     super.init()
@@ -39,48 +36,53 @@ public class EXDevLauncherURLHelper: NSObject {
 
   @objc
   public static func hasUrlQueryParam(_ url: URL) -> Bool {
-    var hasUrlQueryParam = false
-
-    let components = URLComponents.init(url: url, resolvingAgainstBaseURL: false)
-
-    if (components?.queryItems?.contains(where: {
-      $0.name == "url" && $0.value != nil
-    })) ?? false {
-      hasUrlQueryParam = true
+    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+    let queryItems = components.queryItems else {
+      return false
     }
 
-    return hasUrlQueryParam
+    return queryItems.contains { $0.name == "url" && $0.value != nil }
   }
 
   @objc
   public static func disableOnboardingPopupIfNeeded(_ url: URL) {
-    let components = URLComponents.init(url: url, resolvingAgainstBaseURL: false)
+    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+    let queryItems = components.queryItems else {
+      return
+    }
 
-    if (components?.queryItems?.contains(where: {
+    let shouldDisable = queryItems.contains {
       $0.name == "disableOnboarding" && ($0.value ?? "") == "1"
-    })) ?? false {
+    }
+
+    if shouldDisable {
       DevMenuPreferences.isOnboardingFinished = true
     }
   }
 
   @objc
   public static func replaceEXPScheme(_ url: URL, to scheme: String) -> URL {
-    var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-    if components?.scheme == "exp" {
-      components?.scheme = scheme
+    guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+    components.scheme == "exp" else {
+      return url
     }
-    return components?.url ?? url
+
+    components.scheme = scheme
+    return components.url ?? url
   }
 
   @objc
   public static func getQueryParamsForUrl(_ url: URL) -> [String: String] {
-    let components = URLComponents.init(url: url, resolvingAgainstBaseURL: false)
-    var dict: [String: String] = [:]
-
-    for parameter in components?.queryItems ?? [] {
-      dict[parameter.name] = parameter.value?.removingPercentEncoding ?? ""
+    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+    let queryItems = components.queryItems else {
+      return [:]
     }
 
-    return dict
+    var params: [String: String] = [:]
+    for item in queryItems {
+      params[item.name] = item.value?.removingPercentEncoding ?? ""
+    }
+
+    return params
   }
 }


### PR DESCRIPTION
# Why
`SFAuthenticationSession` is deprecated so we should drop it's usage.

# How
Switch to using `ASWebAuthenticationSession`. Note, with `ASWebAuthenticationSession` we no longer need the `callbackURLScheme` to be something like `bareexpo://auth`. The scheme defined in `CFBundleURLSchemes` is enough. Passing anything with special characters will crash the app.

# Test Plan
Bare-expo. Logging in works as expected.
