### PR TITLE
[docs] Fix typo in sitemap.mdx

### DIFF
--- a/docs/pages/router/reference/sitemap.mdx
+++ b/docs/pages/router/reference/sitemap.mdx
@@ -44,7 +44,7 @@ In SDK 52 and above, the sitemap can be removed by adding `sitemap: false` to th
 }
 ```
 
-In SDK 51 and below, the sitemap can be removed by creating an empty **\_sitemap** file insdide the **app** directory:
+In SDK 51 and below, the sitemap can be removed by creating an empty **\_sitemap** file inside the **app** directory:
 
 ```tsx app/_sitemap.tsx
 export default function Sitemap() {


### PR DESCRIPTION
# Why

Fix typo in sitemap.mdx

# How

Change 'insdide' with 'inside'.

# Test Plan

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
