### PR TITLE
[docs] Adds workflows examples in context

### DIFF
--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -93,6 +93,38 @@ By default, the `eas build` command will wait for your build to complete, but yo
 
 If you are a member of an organization and your build is on its behalf, you will find the build details on [the build dashboard for that account](https://expo.dev/accounts/[account]/builds).
 
+## Create builds automatically
+
+You can automatically create builds on commits to specific branches with [EAS Workflows](/eas/workflows/get-started/). First, you'll need to [configure your project](/eas/workflows/get-started/#configure-your-project), add a file named **.eas/workflows/create-builds.yml** at the root of your project, then add the following workflow configuration:
+
+```yaml .eas/workflows/create-builds.yml
+name: Create builds
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  build_android:
+    name: Build Android app
+    type: build
+    params:
+      platform: android
+      profile: production
+  build_ios:
+    name: Build iOS app
+    type: build
+    params:
+      platform: ios
+      profile: production
+```
+
+The workflow above will create Android and iOS builds on every commit to your project's `main` branch. You can also run this workflow manually with the following EAS CLI command:
+
+<Terminal cmd={['$ eas workflow:run create-builds.yml']} />
+
+Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples).
+
 ## Production builds locally
 
 To create a production build locally, see the following React Native guides for more information on the necessary steps for Android and iOS.

--- a/docs/pages/deploy/send-over-the-air-updates.mdx
+++ b/docs/pages/deploy/send-over-the-air-updates.mdx
@@ -48,7 +48,7 @@ jobs:
 
 The workflow above will send an over-the-air update for the `production` update channel on every commit to your project's `main` branch. You can also run this workflow manually with the following EAS CLI command:
 
-<Terminal cmd={['$ eas workflow:run send_updates.yml']} />
+<Terminal cmd={['$ eas workflow:run send-updates.yml']} />
 
 Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples).
 

--- a/docs/pages/deploy/send-over-the-air-updates.mdx
+++ b/docs/pages/deploy/send-over-the-air-updates.mdx
@@ -29,7 +29,7 @@ You can verify the update works by force closing the app and reopening it two ti
 
 ## Send updates automatically
 
-You can automatically send updates automatically with [EAS Workflows](/eas/workflows/get-started/). First, you'll need to [configure your project](/eas/workflows/get-started/#configure-your-project), add a file named **.eas/workflows/send-updates.yml** at the root of your project, then add the following workflow configuration:
+You can automatically send updates with [EAS Workflows](/eas/workflows/get-started/). First, you'll need to [configure your project](/eas/workflows/get-started/#configure-your-project), add a file named **.eas/workflows/send-updates.yml** at the root of your project, then add the following workflow configuration:
 
 ```yaml .eas/workflows/send-updates.yml
 name: Send updates

--- a/docs/pages/deploy/send-over-the-air-updates.mdx
+++ b/docs/pages/deploy/send-over-the-air-updates.mdx
@@ -27,6 +27,31 @@ This command will create an update and make it available to builds of your app t
 
 You can verify the update works by force closing the app and reopening it two times. The update should be applied on the second launch.
 
+## Send updates automatically
+
+You can automatically send updates automatically with [EAS Workflows](/eas/workflows/get-started/). First, you'll need to [configure your project](/eas/workflows/get-started/#configure-your-project), add a file named **.eas/workflows/send-updates.yml** at the root of your project, then add the following workflow configuration:
+
+```yaml .eas/workflows/send-updates.yml
+name: Send updates
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  send_updates:
+    name: Send updates
+    type: update
+    params:
+      channel: production
+```
+
+The workflow above will send an over-the-air update for the `production` update channel on every commit to your project's `main` branch. You can also run this workflow manually with the following EAS CLI command:
+
+<Terminal cmd={['$ eas workflow:run send_updates.yml']} />
+
+Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples).
+
 ## Learn more
 
 You can learn how to [rollout an update](/eas-update/rollouts/), [optimize assets](/eas-update/optimize-assets/), and more with our [update guides](/eas-update/introduction/).

--- a/docs/pages/deploy/submit-to-app-stores.mdx
+++ b/docs/pages/deploy/submit-to-app-stores.mdx
@@ -114,6 +114,50 @@ Run the following command to submit a build to the Google Play Store:
 
 The command will lead you step by step through the process of submitting the app.
 
+## Build and submit automatically
+
+You can automatically create builds and submit them to the app stores with [EAS Workflows](/eas/workflows/get-started/). First, you'll need to [configure your project](/eas/workflows/get-started/#configure-your-project), add a file named **.eas/workflows/build-and-submit.yml** at the root of your project, then add the following workflow configuration:
+
+```yaml .eas/workflows/build-and-submit.yml
+name: Build and submit
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  build_android:
+    name: Build Android app
+    type: build
+    params:
+      platform: android
+      profile: production
+  build_ios:
+    name: Build iOS app
+    type: build
+    params:
+      platform: ios
+      profile: production
+  submit_android:
+    name: Submit Android
+    type: submit
+    needs: [build_android]
+    params:
+      build_id: ${{ needs.build_android.outputs.build_id }}
+  submit_ios:
+    name: Submit iOS
+    type: submit
+    needs: [build_ios]
+    params:
+      build_id: ${{ needs.build_ios.outputs.build_id }}
+```
+
+The workflow above will create Android and iOS builds on every commit to your project's `main` branch, then submit them to the Google Play and Apple App Store respectively. You can also run this workflow manually with the following EAS CLI command:
+
+<Terminal cmd={['$ eas workflow:run build-and-submit.yml']} />
+
+Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples).
+
 ## Manual submission to app stores
 
 You can also submit your app manually to the Google Play Store and Apple App Store.

--- a/docs/pages/deploy/web.mdx
+++ b/docs/pages/deploy/web.mdx
@@ -40,6 +40,31 @@ To create a production deployment, run the following [EAS CLI](/develop/tools/#e
 
 Once your deployment is complete, the EAS CLI will output a production URL to access your deployed app.
 
+## Deploy automatically
+
+You can automatically deploy your app to the web with [EAS Workflows](/eas/workflows/get-started/). First, you'll need to [configure your project](/eas/workflows/get-started/#configure-your-project), add a file named **.eas/workflows/deploy-web.yml** at the root of your project, then add the following workflow configuration:
+
+```yaml .eas/workflows/deploy-web.yml
+name: Deploy web
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  deploy_web:
+    name: Deploy web
+    type: deploy
+    params:
+      prod: true
+```
+
+The workflow above will create a web deployment on every commit to your project's `main` branch. You can also run this workflow manually with the following EAS CLI command:
+
+<Terminal cmd={['$ eas workflow:run deploy-web.yml']} />
+
+Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples).
+
 ## Learn more
 
 You can learn more about setting up [deployment aliases](/eas/hosting/deployments-and-aliases/), using a [custom domain](/eas/hosting/custom-domain/), or [deploying an API Route](/router/reference/api-routes/#deployment).

--- a/docs/pages/review/share-previews-with-your-team.mdx
+++ b/docs/pages/review/share-previews-with-your-team.mdx
@@ -41,6 +41,31 @@ Share the **EAS dashboard** link with a reviewer. After opening the link, they c
   src="/static/images/eas-update/preview-updates-qr-code.png"
 />
 
+## Create previews automatically
+
+You can automatically create previews on every commit with [EAS Workflows](/eas/workflows/get-started/). First, you'll need to [configure your project](/eas/workflows/get-started/#configure-your-project), add a file named **.eas/workflows/publish-preview-update.yml** at the root of your project, then add the following workflow configuration:
+
+```yaml .eas/workflows/publish-preview-update.yml
+name: Publish preview update
+
+on:
+  push:
+    branches: ['*']
+
+jobs:
+  publish_preview_update:
+    name: Publish preview update
+    type: update
+    params:
+      branch: ${{ github.ref_name || 'test' }}
+```
+
+The workflow above will publish an update on every commit to every branch. You can also run this workflow manually with the following EAS CLI command:
+
+<Terminal cmd={['$ eas workflow:run publish-preview-update.yml']} />
+
+Learn more about common patterns with the [workflows examples guide](/eas/workflows/examples).
+
 ## Learn more
 
 <BoxLink


### PR DESCRIPTION
# Why

I'd like to make it more obvious how you can automate building, submitting, and updating your app with workflows, by adding examples to docs on the home page. This should help save developers time and also raise awareness that there are convenient ways to use EAS to boost their productivity. Also, all of the workflows listed in these docs are available to run for free on free accounts up to 100min/month.

# How

Adds workflows examples to:

- /deploy/build-a-project
- /deploy/send-over-the-air-updates
- /deploy/submit-to-app-stores
- /deploy/web
- /review/share-previews-with-your-team

# Test Plan

Make sure the changes read well and make sense.