### PR TITLE
[notifications][iOS] fix Expo Go support for categories

### DIFF
--- a/apps/expo-go/ios/ExpoNotificationServiceExtension/NotificationService.swift
+++ b/apps/expo-go/ios/ExpoNotificationServiceExtension/NotificationService.swift
@@ -9,20 +9,19 @@
  * to trigger this handler.
  */
 
-// TODO: rework the new Swift Notification code for ExpoGo
-
-/*
 import UserNotifications
 
 class NotificationService: UNNotificationServiceExtension {
   override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
     if let bestAttemptContent = request.content.mutableCopy() as? UNMutableNotificationContent {
       // Modify notification content here...
-      if !request.content.categoryIdentifier.isEmpty && (request.content.userInfo["experienceId"]) != nil {
-        bestAttemptContent.categoryIdentifier = EXScopedNotificationsUtils.scopedIdentifier(fromId: request.content.categoryIdentifier, forExperience: request.content.userInfo["experienceId"] as! String)
+      if !request.content.categoryIdentifier.isEmpty, let experienceId = request.content.userInfo["experienceId"] as? String {
+        bestAttemptContent.categoryIdentifier = EXScopedNotificationsUtils.scopedIdentifier(
+          fromId: request.content.categoryIdentifier,
+          forExperience: experienceId
+        )
       }
       contentHandler(bestAttemptContent)
     }
   }
 }
- */

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsSchedulerModule.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/Notifications/ExpoGoNotificationsSchedulerModule.swift
@@ -21,8 +21,26 @@ public final class ExpoGoNotificationsSchedulerModule: SchedulerModule {
     contentInput: [String: Any],
     triggerInput: [String: Any]?
   ) throws -> UNNotificationRequest? {
+    var mutableContentInput = contentInput
+
+    if var data = mutableContentInput["data"] as? [String: Any] {
+      data["experienceId"] = scopeKey
+      data["scopeKey"] = scopeKey
+      mutableContentInput["data"] = data
+    } else {
+      mutableContentInput["data"] = [
+        "experienceId": scopeKey,
+        "scopeKey": scopeKey
+      ]
+    }
+
+    if let categoryIdentifier = mutableContentInput["categoryIdentifier"] as? String {
+      let scopedCategoryIdentifier = EXScopedNotificationsUtils.scopedIdentifier(fromId: categoryIdentifier, forExperience: scopeKey)
+      mutableContentInput["categoryIdentifier"] = scopedCategoryIdentifier
+    }
+
     let scopedIdentifier = EXScopedNotificationsUtils.scopedIdentifier(fromId: identifier, forExperience: scopeKey)
-    return try super.buildNotificationRequest(identifier: scopedIdentifier, contentInput: contentInput, triggerInput: triggerInput)
+    return try super.buildNotificationRequest(identifier: scopedIdentifier, contentInput: mutableContentInput, triggerInput: triggerInput)
   }
 
   override public func serializedNotificationRequests(_ requests: [UNNotificationRequest]) -> [[String: Any]] {


### PR DESCRIPTION
# Why

notification categories would not work in Expo Go. The code that ensured their support in Push (Remote) notifications was previously commented out with a TODO note to rework it.
For Local notifications, it didn't work because the category id wasn't scoped.

# How

- Removed the TODO comment and uncommented the Swift code for the `NotificationService` class
- Improved the conditional check in the Extension for `experienceId` using optional binding instead of force unwrapping
- added back category scoping for local notifications in Expo Go

# Test Plan

- expo go NCL - tested on device with local notifications as well as push notifications

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)