### PR TITLE
[github][docs] Upgrade Vale dependency version

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -54,7 +54,7 @@ jobs:
       - name: 💬 Lint Docs website content
         uses: errata-ai/vale-action@reviewdog
         with:
-          version: 3.11.1
+          version: 3.11.2
           reporter: github-pr-check
           files: 'docs/pages'
           vale_flags: '--config=./docs/.vale.ini'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,7 @@ jobs:
       - name: 💬 Lint Docs website content
         uses: errata-ai/vale-action@reviewdog
         with:
-          version: 3.11.1
+          version: 3.11.2
           reporter: github-pr-check
           files: 'docs/pages'
           vale_flags: '--config=./docs/.vale.ini'

--- a/docs/package.json
+++ b/docs/package.json
@@ -89,7 +89,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@types/semver": "^7.7.0",
-    "@vvago/vale": "3.11.1",
+    "@vvago/vale": "3.11.2",
     "acorn": "^8.14.1",
     "autoprefixer": "^10.4.21",
     "axios": "^1.8.4",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3228,9 +3228,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vvago/vale@npm:3.11.1":
-  version: 3.11.1
-  resolution: "@vvago/vale@npm:3.11.1"
+"@vvago/vale@npm:3.11.2":
+  version: 3.11.2
+  resolution: "@vvago/vale@npm:3.11.2"
   dependencies:
     axios: "npm:^1.4.0"
     rimraf: "npm:^5.0.0"
@@ -3238,7 +3238,7 @@ __metadata:
     unzipper: "npm:^0.10.14"
   bin:
     vale: bin/vale
-  checksum: 10c0/3a2249cac3d97ea7cceeade5a8ca389246f25c1dc1fc5cb88e1dbe6771e9b0fbc41f76ac2bc32afe5e40647ca774aed5fcf5f3042714559cd402cd0c1e8165db
+  checksum: 10c0/8bd12e484183851c43022b2b45f2ef63bea64d7411bf8c60f42d5068824c678bc0a27e9b8b42bf5cf4b1fb0c80522667a75781063910c2335e0a0dfff6f95ea7
   languageName: node
   linkType: hard
 
@@ -5752,7 +5752,7 @@ __metadata:
     "@types/react": "npm:^18.3.12"
     "@types/react-dom": "npm:^18.3.1"
     "@types/semver": "npm:^7.7.0"
-    "@vvago/vale": "npm:3.11.1"
+    "@vvago/vale": "npm:3.11.2"
     acorn: "npm:^8.14.1"
     autoprefixer: "npm:^10.4.21"
     axios: "npm:^1.8.4"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Vale CLI released 3.11.2 with improved error messages for scopes included in the CLI (such as front matter). This PR upgrades both the dependency version and the version for Vale CLI in the GitHub Actions for Docs PR and Deployment.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Upgrade Lint Docs Website content action in `docs.yml` and `docs-pr.yml`.
- Upgrade `@vvago/vale` devDependency in `docs/` repo.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Running `yarn run lint-prose` should work as expected locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
