### PR TITLE
[ios][core] Remove warning from runOnQueue

### DIFF
--- a/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
@@ -9,6 +9,7 @@ internal protocol AnyAsyncFunctionDefinition: AnyFunctionDefinition {
   /**
    Specifies on which queue the function should run.
    */
+  @discardableResult
   func runOnQueue(_ queue: DispatchQueue?) -> Self
 }
 


### PR DESCRIPTION
# Why
Removes the warning when we use `runOnQueue` internally

# How
Add `@discardableResult`

# Test Plan
Xcode, warning is silenced