### PR TITLE
[docs Update link app config guide into a BoxLink

### DIFF
--- a/docs/pages/versions/unversioned/config/app.mdx
+++ b/docs/pages/versions/unversioned/config/app.mdx
@@ -14,7 +14,7 @@ The following is a list of properties that are available for you under the `"exp
 
 <BoxLink
   title="Configuration with app config"
-  description="For general information on app configuration, such as the differences between various ap config files and using them dynamically."
+  description="For general information on app configuration, such as the differences between various app config files and how to use them dynamically."
   href="/workflow/configuration/"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/versions/unversioned/config/app.mdx
+++ b/docs/pages/versions/unversioned/config/app.mdx
@@ -4,12 +4,20 @@ description: A reference of available properties in Expo app config.
 maxHeadingDepth: 5
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import schema from '~/public/static/schemas/unversioned/app-config-schema.json';
 import AppConfigSchemaTable from '~/ui/components/AppConfigSchemaTable';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 The following is a list of properties that are available for you under the `"expo"` key in **app.json** or **app.config.json**. These properties can be passed to the top level object of **app.config.js** or **app.config.ts**.
 
-For more general information on app configuration, such as the differences between the various app configuration files, see [Configuration with app config](/workflow/configuration/).
+<BoxLink
+  title="Configuration with app config"
+  description="For general information on app configuration, such as the differences between various ap config files and using them dynamically."
+  href="/workflow/configuration/"
+  Icon={BookOpen02Icon}
+/>
 
 ## Properties
 

--- a/docs/pages/versions/unversioned/config/app.mdx
+++ b/docs/pages/versions/unversioned/config/app.mdx
@@ -14,7 +14,7 @@ The following is a list of properties that are available for you under the `"exp
 
 <BoxLink
   title="Configuration with app config"
-  description="For general information on app configuration, such as the differences between various app config files and how to use them dynamically."
+  description="For information on app configuration, the differences between various app config files, and how to use them dynamically."
   href="/workflow/configuration/"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/versions/v51.0.0/config/app.mdx
+++ b/docs/pages/versions/v51.0.0/config/app.mdx
@@ -4,12 +4,20 @@ description: A reference of available properties in Expo app config.
 maxHeadingDepth: 5
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import schema from '~/public/static/schemas/v51.0.0/app-config-schema.json';
 import AppConfigSchemaTable from '~/ui/components/AppConfigSchemaTable';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 The following is a list of properties that are available for you under the `"expo"` key in **app.json** or **app.config.json**. These properties can be passed to the top level object of **app.config.js** or **app.config.ts**.
 
-For more general information on app configuration, such as the differences between the various app configuration files, see [Configuration with app config](/workflow/configuration/).
+<BoxLink
+  title="Configuration with app config"
+  description="For general information on app configuration, such as the differences between various ap config files and using them dynamically."
+  href="/workflow/configuration/"
+  Icon={BookOpen02Icon}
+/>
 
 ## Properties
 

--- a/docs/pages/versions/v51.0.0/config/app.mdx
+++ b/docs/pages/versions/v51.0.0/config/app.mdx
@@ -14,7 +14,7 @@ The following is a list of properties that are available for you under the `"exp
 
 <BoxLink
   title="Configuration with app config"
-  description="For general information on app configuration, such as the differences between various ap config files and using them dynamically."
+  description="For general information on app configuration, such as the differences between various app config files and how to use them dynamically."
   href="/workflow/configuration/"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/versions/v51.0.0/config/app.mdx
+++ b/docs/pages/versions/v51.0.0/config/app.mdx
@@ -14,7 +14,7 @@ The following is a list of properties that are available for you under the `"exp
 
 <BoxLink
   title="Configuration with app config"
-  description="For general information on app configuration, such as the differences between various app config files and how to use them dynamically."
+  description="For information on app configuration, the differences between various app config files, and how to use them dynamically."
   href="/workflow/configuration/"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/versions/v52.0.0/config/app.mdx
+++ b/docs/pages/versions/v52.0.0/config/app.mdx
@@ -14,7 +14,7 @@ The following is a list of properties that are available for you under the `"exp
 
 <BoxLink
   title="Configuration with app config"
-  description="For general information on app configuration, such as the differences between various app config files and how to use them dynamically."
+  description="For information on app configuration, the differences between various app config files, and how to use them dynamically."
   Icon={BookOpen02Icon}
 />
 

--- a/docs/pages/versions/v52.0.0/config/app.mdx
+++ b/docs/pages/versions/v52.0.0/config/app.mdx
@@ -14,8 +14,7 @@ The following is a list of properties that are available for you under the `"exp
 
 <BoxLink
   title="Configuration with app config"
-  description="For general information on app configuration, such as the differences between various ap config files and using them dynamically."
-  href="/workflow/configuration/"
+  description="For general information on app configuration, such as the differences between various app config files and how to use them dynamically."
   Icon={BookOpen02Icon}
 />
 

--- a/docs/pages/versions/v52.0.0/config/app.mdx
+++ b/docs/pages/versions/v52.0.0/config/app.mdx
@@ -4,12 +4,20 @@ description: A reference of available properties in Expo app config.
 maxHeadingDepth: 5
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import schema from '~/public/static/schemas/unversioned/app-config-schema.json';
 import AppConfigSchemaTable from '~/ui/components/AppConfigSchemaTable';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 The following is a list of properties that are available for you under the `"expo"` key in **app.json** or **app.config.json**. These properties can be passed to the top level object of **app.config.js** or **app.config.ts**.
 
-For more general information on app configuration, such as the differences between the various app configuration files, see [Configuration with app config](/workflow/configuration/).
+<BoxLink
+  title="Configuration with app config"
+  description="For general information on app configuration, such as the differences between various ap config files and using them dynamically."
+  href="/workflow/configuration/"
+  Icon={BookOpen02Icon}
+/>
 
 ## Properties
 

--- a/docs/pages/versions/v53.0.0/config/app.mdx
+++ b/docs/pages/versions/v53.0.0/config/app.mdx
@@ -14,7 +14,7 @@ The following is a list of properties that are available for you under the `"exp
 
 <BoxLink
   title="Configuration with app config"
-  description="For general information on app configuration, such as the differences between various app config files and how to use them dynamically."
+  description="For information on app configuration, the differences between various app config files, and how to use them dynamically."
   Icon={BookOpen02Icon}
 />
 

--- a/docs/pages/versions/v53.0.0/config/app.mdx
+++ b/docs/pages/versions/v53.0.0/config/app.mdx
@@ -14,8 +14,7 @@ The following is a list of properties that are available for you under the `"exp
 
 <BoxLink
   title="Configuration with app config"
-  description="For general information on app configuration, such as the differences between various ap config files and using them dynamically."
-  href="/workflow/configuration/"
+  description="For general information on app configuration, such as the differences between various app config files and how to use them dynamically."
   Icon={BookOpen02Icon}
 />
 

--- a/docs/pages/versions/v53.0.0/config/app.mdx
+++ b/docs/pages/versions/v53.0.0/config/app.mdx
@@ -4,12 +4,20 @@ description: A reference of available properties in Expo app config.
 maxHeadingDepth: 5
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import schema from '~/public/static/schemas/unversioned/app-config-schema.json';
 import AppConfigSchemaTable from '~/ui/components/AppConfigSchemaTable';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 The following is a list of properties that are available for you under the `"expo"` key in **app.json** or **app.config.json**. These properties can be passed to the top level object of **app.config.js** or **app.config.ts**.
 
-For more general information on app configuration, such as the differences between the various app configuration files, see [Configuration with app config](/workflow/configuration/).
+<BoxLink
+  title="Configuration with app config"
+  description="For general information on app configuration, such as the differences between various ap config files and using them dynamically."
+  href="/workflow/configuration/"
+  Icon={BookOpen02Icon}
+/>
 
 ## Properties
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on feedback from @brentvatne. We missed updating the link to the app config guide to a BoxLink.

# How

<!--
How did you build this feature or fix this bug and why?
-->

In app config reference page, update the link to app config guide to a BoxLink. Changes backported to SDK 53, 52, & 51.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-04-28 at 17 50 01@2x](https://github.com/user-attachments/assets/1140e3e3-1a01-4e2b-b510-3f9d6c44f27c)



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
