### PR TITLE
[docs] APIReference: improve literal types parsing and rendering

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -8744,7 +8744,12 @@ After calling this function, the listener will no longer receive any events from
       >
         Literal Type: 
       </span>
-      multiple types
+      <code
+        class="text-default text-[13px] font-normal leading-[130%] tracking-[-0.003rem] inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5"
+        data-text="true"
+      >
+        union
+      </code>
     </p>
     <div
       class="px-4 [table_&]:!mb-0 [table_&]:px-0"

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -123,8 +123,11 @@ export const renderProp = (
   const extractedSignatures = signatures ?? type?.declaration?.signatures;
   const extractedComment = getCommentOrSignatureComment(comment, extractedSignatures);
   const platforms = getAllTagData('platform', extractedComment);
+
   const isLiteralType =
     type?.type && ['literal', 'templateLiteral', 'union', 'tuple'].includes(type.type);
+  const definedLiteralGeneric =
+    isLiteralType && type?.types ? defineLiteralType(type.types) : undefined;
 
   return (
     <div
@@ -141,7 +144,7 @@ export const renderProp = (
       <div className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING, 'mb-2.5')}>
         {flags?.isOptional && <>Optional&emsp;&bull;&emsp;</>}
         {flags?.isReadonly && <>Read Only&emsp;&bull;&emsp;</>}
-        {type?.types && isLiteralType && <>Literal type: {defineLiteralType(type.types)}</>}
+        {definedLiteralGeneric && <>Literal type: {definedLiteralGeneric}</>}
         {!isLiteralType && (
           <>
             Type:{' '}

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -524,7 +524,7 @@ export const getCommentContent = (content: CommentContentData[]) => {
 const getMonospaceHeader = (
   element: ComponentType<any>,
   baseNestingLevel: number,
-  className: string | undefined = undefined
+  className?: string
 ) => {
   return createPermalinkedComponent(element, {
     baseNestingLevel,
@@ -536,7 +536,7 @@ const getMonospaceHeader = (
 export function getCodeHeadingWithBaseNestingLevel(
   baseNestingLevel: number,
   Element: ComponentType<any>,
-  className: string | undefined = undefined
+  className?: string
 ) {
   return getMonospaceHeader(Element, baseNestingLevel, className);
 }
@@ -575,12 +575,17 @@ export function defineLiteralType(types: TypeDefinitionData[]) {
           return td.head;
         } else if ('value' in td) {
           return td.value && typeof td.value;
+        } else if ('name' in td) {
+          return td.name;
         }
       })
     )
   );
-  if (uniqueTypes.length === 1 && uniqueTypes.filter(Boolean).length === 1) {
+  if (uniqueTypes.length === 1) {
     return <CODE>{uniqueTypes[0]}</CODE>;
+  }
+  if (uniqueTypes.filter(Boolean).every(type => typeof type === 'string')) {
+    return <CODE>union</CODE>;
   }
   return null;
 }


### PR DESCRIPTION
# Why

Fixes ENG-15617

# How

Improve literal types parsing and how we render information about multiple type literals in API reference docs.

# Test Plan

The changes have been review by running docs app locally.

# Preview

![Screenshot 2025-04-28 at 15 09 39](https://github.com/user-attachments/assets/f4e84e6c-7639-49f5-a213-6fe21d30fc92)

![Screenshot 2025-04-28 at 15 21 13](https://github.com/user-attachments/assets/098d180f-4485-4263-9201-8496d612d747)
