### PR TITLE
[core][Android] Add trait system

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventsDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/EventsDefinition.kt
@@ -1,3 +1,11 @@
 package expo.modules.kotlin.events
 
-class EventsDefinition(val names: Array<out String>)
+class EventsDefinition(val names: Array<String>) {
+  operator fun plus(other: EventsDefinition?): EventsDefinition {
+    if (other == null) {
+      return this
+    }
+
+    return EventsDefinition(names + other.names)
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -162,7 +162,7 @@ open class InternalModuleDefinitionBuilder(
   }
 
   inline fun Class(name: String, body: ClassComponentBuilder<Unit>.() -> Unit = {}) {
-    val clazzBuilder = ClassComponentBuilder(name, Unit::class, toAnyType<Unit>())
+    val clazzBuilder = ClassComponentBuilder(requireNotNull(module).appContext, name, Unit::class, toAnyType<Unit>())
     body.invoke(clazzBuilder)
     classData.add(clazzBuilder.buildClass())
   }
@@ -172,7 +172,7 @@ open class InternalModuleDefinitionBuilder(
     sharedObjectClass: KClass<SharedObjectType> = SharedObjectType::class,
     body: ClassComponentBuilder<SharedObjectType>.() -> Unit = {}
   ) {
-    val clazzBuilder = ClassComponentBuilder(name, sharedObjectClass, toAnyType<SharedObjectType>())
+    val clazzBuilder = ClassComponentBuilder(requireNotNull(module).appContext, name, sharedObjectClass, toAnyType<SharedObjectType>())
     body.invoke(clazzBuilder)
     classData.add(clazzBuilder.buildClass())
   }
@@ -181,7 +181,7 @@ open class InternalModuleDefinitionBuilder(
     sharedObjectClass: KClass<SharedObjectType> = SharedObjectType::class,
     body: ClassComponentBuilder<SharedObjectType>.() -> Unit = {}
   ) {
-    val clazzBuilder = ClassComponentBuilder(sharedObjectClass.java.simpleName, sharedObjectClass, toAnyType<SharedObjectType>())
+    val clazzBuilder = ClassComponentBuilder(requireNotNull(module).appContext, sharedObjectClass.java.simpleName, sharedObjectClass, toAnyType<SharedObjectType>())
     body.invoke(clazzBuilder)
     classData.add(clazzBuilder.buildClass())
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -437,7 +437,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
    * Defines event names that this module can send to JavaScript.
    */
   fun Events(vararg events: String) {
-    eventsDefinition = EventsDefinition(events)
+    eventsDefinition = EventsDefinition(events.asList().toTypedArray())
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionData.kt
@@ -15,4 +15,19 @@ class ObjectDefinitionData(
 ) {
   val functions
     get() = ConcatIterator(syncFunctions.values.iterator(), asyncFunctions.values.iterator())
+
+  operator fun plus(other: ObjectDefinitionData?): ObjectDefinitionData {
+    if (other == null) {
+      return this
+    }
+
+    return ObjectDefinitionData(
+      legacyConstantsProvider = { legacyConstantsProvider() + other.legacyConstantsProvider() },
+      syncFunctions = syncFunctions + other.syncFunctions,
+      asyncFunctions = asyncFunctions + other.asyncFunctions,
+      eventsDefinition = eventsDefinition?.plus(other.eventsDefinition),
+      properties = properties + other.properties,
+      constants = constants + other.constants
+    )
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/traits/SavableTrait.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/traits/SavableTrait.kt
@@ -1,0 +1,51 @@
+package expo.modules.kotlin.traits
+
+import android.graphics.Bitmap
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.objects.ObjectDefinitionBuilder
+import expo.modules.kotlin.objects.ObjectDefinitionData
+import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.sharedobjects.SharedRef
+import java.io.File
+import java.util.UUID
+import kotlin.reflect.KClass
+
+class SavableTrait<InputType> @PublishedApi internal constructor(
+  val exportImpl: (AppContext) -> ObjectDefinitionData
+) : Trait<InputType> {
+  override fun export(appContext: AppContext) = exportImpl(appContext)
+
+  companion object {
+    data class SavableBitmapOptions(
+      val compression: Int = 100
+    ) : Record
+
+    @PublishedApi
+    internal inline fun <reified InputType, reified OptionType> createImplementation(
+      appContext: AppContext,
+      crossinline saveToFile: (file: File, input: InputType, options: OptionType) -> Unit
+    ): ObjectDefinitionData {
+      return ObjectDefinitionBuilder().apply {
+        AsyncFunction("saveAsync") { input: InputType, options: OptionType ->
+          val outputFile = File(appContext.cacheDirectory, UUID.randomUUID().toString())
+          outputFile.createNewFile()
+
+          saveToFile(outputFile, input, options)
+        }
+      }.buildObject()
+    }
+
+    inline fun <reified T : SharedRef<Bitmap>> create(klass: KClass<T> = T::class) = SavableTrait<T>(
+      exportImpl = { appContext ->
+        createImplementation<T, SavableBitmapOptions>(appContext) { file, input, options ->
+          input.appContext
+          input.ref.compress(
+            Bitmap.CompressFormat.PNG,
+            options.compression,
+            file.outputStream()
+          )
+        }
+      }
+    )
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/traits/SavableTrait.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/traits/SavableTrait.kt
@@ -27,11 +27,11 @@ class SavableTrait<InputType> @PublishedApi internal constructor(
       appContext: AppContext,
       crossinline saveToFile: (file: File, input: InputType, options: OptionType) -> Unit
     ): ObjectDefinitionData {
-      val appContextWeekRef = appContext.weak()
+      val appContextWeakRef = appContext.weak()
 
       return ObjectDefinitionBuilder().apply {
         AsyncFunction("saveAsync") { input: InputType, options: OptionType ->
-          val context = appContextWeekRef.get() ?: throw Exceptions.AppContextLost()
+          val context = appContextWeakRef.get() ?: throw Exceptions.AppContextLost()
           val outputFile = File(context.cacheDirectory, UUID.randomUUID().toString())
           outputFile.createNewFile()
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/traits/Trait.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/traits/Trait.kt
@@ -1,0 +1,8 @@
+package expo.modules.kotlin.traits
+
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.objects.ObjectDefinitionData
+
+interface Trait<InputType> {
+  fun export(appContext: AppContext): ObjectDefinitionData
+}


### PR DESCRIPTION
# Why

Introduces a trait system for modules on Android. This is a proof of concept and is not yet finished. I wanted to gather options before spending more time refining this approach.
# How

I have added a simple trait system for classes, which should serve as an effective replacement for inheritance. Currently, we have multiple image classes scattered across different packages, and we lack an easy way to export the same set of functions from them. I believe the trait system will integrate nicely with our current module infrastructure. This pull request is just a proof of concept, and we can refine and optimize this approach further.

Usage:

```kotlin
Class<ImageRef>("Image") {
	UseTrait(SavableTrait.create<ImageRef>())
}
``` 
