### PR TITLE
[docs] app delegate subscribers update

### DIFF
--- a/docs/pages/config-plugins/development-and-debugging.mdx
+++ b/docs/pages/config-plugins/development-and-debugging.mdx
@@ -488,42 +488,32 @@ Generally, you should only interact with the Gradle file via Expo [Autolinking][
 
 ### iOS AppDelegate
 
-Some modules may need to add delegate methods to the project AppDelegate, this can be done dangerously via the `withAppDelegate` mod,
-or it can be done safely by adding support for unimodules AppDelegate proxy to the native module.
-The unimodules AppDelegate proxy can swizzle function calls to native modules in a safe and reliable way.
-If the language of the project AppDelegate changes from Objective-C to Swift, the swizzler will continue to work, whereas a regex would possibly fail.
+Some modules may need to add delegate methods to the project AppDelegate. This can be done safely by using [AppDelegate subscribers](/modules/appdelegate-subscribers/) or dangerously via the `withAppDelegate` mod (_strongly discouraged_).
+Using AppDelegate subscribers allows native Expo modules to react to important events in a safe and reliable way.
 
-Here are some examples of the AppDelegate proxy in action:
+Below are some examples of the AppDelegate subscribers in action. Additionally, you will find many examples in community repositories on GitHub. A good, minimal example is [here](https://github.com/bamlab/react-native-app-security/blob/c1a861cbd348f404ec18ffae90d1c9bdc66bc00d/ios/RNASAppLifecyleDelegate.swift).
 
-- `expo-app-auth` -- [**EXAppAuthAppDelegate.m**](https://github.com/expo/expo/blob/bd7bc03ee10d89487eac25351a455bd9db155b8c/packages/expo-app-auth/ios/EXAppAuth/EXAppAuthAppDelegate.m) (openURL)
-- `expo-notifications` -- [**EXPushTokenManager.m**](https://github.com/expo/expo/blob/bd469e421856f348d539b1b57325890147935dbc/packages/expo-notifications/ios/EXNotifications/PushToken/EXPushTokenManager.m) (didRegisterForRemoteNotificationsWithDeviceToken, didFailToRegisterForRemoteNotificationsWithError)
-- `expo-facebook` -- [**EXFacebookAppDelegate.m**](https://github.com/expo/expo/blob/e0bb254c889734f2ec6c7b688167f013587ed201/packages/expo-facebook/ios/EXFacebook/EXFacebookAppDelegate.m) (openURL)
-- `expo-file-system` -- [**EXSessionHandler.m**](https://github.com/expo/expo/blob/e0bb254c889734f2ec6c7b688167f013587ed201/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionHandler.m) (handleEventsForBackgroundURLSession)
-
-Currently, the only known way to add support for the AppDelegate proxy to a native module, without converting that module to a unimodule,
-is to create a wrapper package: [example](https://github.com/expo/expo/pull/5165).
-
-We plan to improve this in the future.
+- `expo-linking` -- [**LinkingAppDelegateSubscriber.swift**](https://github.com/expo/expo/blob/b4ca25a4319d7148258ebd5121d1df40a3b1333e/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift#L14) (openURL)
+- `expo-notifications` -- [**NotificationsAppDelegateSubscriber.swift**](https://github.com/expo/expo/blob/bd469e421856f348d539b1b57325890147935dbc/packages/expo-notifications/ios/EXNotifications/PushToken/EXPushTokenManager.m) (didRegisterForRemoteNotificationsWithDeviceToken, didFailToRegisterForRemoteNotificationsWithError, didReceiveRemoteNotification)
 
 ### iOS CocoaPods Podfile
 
-The `ios/Podfile` can be customized dangerously with regex, or statically via JSON:
+The `ios/Podfile` can be customized dangerously with regex, or statically via JSON. See how the `podfile_properties` variable below is used to customize the Podfile.
 
 ```ruby Podfile
 require 'json'
 
 # @info Import a JSON file and parse it in Ruby #
-podfileConfig = JSON.parse(File.read(File.join(__dir__, 'podfile.config.json')))
+podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}
 # @end #
 
-platform :ios, '11.0'
+platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
 
 target 'yolo27' do
-  use_unimodules!
-  config = use_native_modules!
-  use_react_native!(:path => config["reactNativePath"])
+  use_expo_modules!
+  # ...
 
-  # podfileConfig['version']
+  # podfile_properties['your_property']
 end
 ```
 

--- a/docs/pages/config-plugins/development-and-debugging.mdx
+++ b/docs/pages/config-plugins/development-and-debugging.mdx
@@ -491,14 +491,14 @@ Generally, you should only interact with the Gradle file via Expo [Autolinking][
 Some modules may need to add delegate methods to the project AppDelegate. This can be done safely by using [AppDelegate subscribers](/modules/appdelegate-subscribers/) or dangerously via the `withAppDelegate` mod (_strongly discouraged_).
 Using AppDelegate subscribers allows native Expo modules to react to important events in a safe and reliable way.
 
-Below are some examples of the AppDelegate subscribers in action. Additionally, you will find many examples in community repositories on GitHub. A good, minimal example is [here](https://github.com/bamlab/react-native-app-security/blob/c1a861cbd348f404ec18ffae90d1c9bdc66bc00d/ios/RNASAppLifecyleDelegate.swift).
+Below are some examples of the AppDelegate subscribers in action. Additionally, you will find many examples in community repositories on GitHub ([one such example](https://github.com/bamlab/react-native-app-security/blob/c1a861cbd348f404ec18ffae90d1c9bdc66bc00d/ios/RNASAppLifecyleDelegate.swift)).
 
-- `expo-linking` -- [**LinkingAppDelegateSubscriber.swift**](https://github.com/expo/expo/blob/b4ca25a4319d7148258ebd5121d1df40a3b1333e/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift#L14) (openURL)
-- `expo-notifications` -- [**NotificationsAppDelegateSubscriber.swift**](https://github.com/expo/expo/blob/bd469e421856f348d539b1b57325890147935dbc/packages/expo-notifications/ios/EXNotifications/PushToken/EXPushTokenManager.m) (didRegisterForRemoteNotificationsWithDeviceToken, didFailToRegisterForRemoteNotificationsWithError, didReceiveRemoteNotification)
+- `expo-linking`: [**LinkingAppDelegateSubscriber.swift**](https://github.com/expo/expo/blob/b4ca25a4319d7148258ebd5121d1df40a3b1333e/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift#L14) (openURL)
+- `expo-notifications`: [**NotificationsAppDelegateSubscriber.swift**](https://github.com/expo/expo/blob/bd469e421856f348d539b1b57325890147935dbc/packages/expo-notifications/ios/EXNotifications/PushToken/EXPushTokenManager.m) (didRegisterForRemoteNotificationsWithDeviceToken, didFailToRegisterForRemoteNotificationsWithError, didReceiveRemoteNotification)
 
 ### iOS CocoaPods Podfile
 
-The `ios/Podfile` can be customized dangerously with regex, or statically via JSON. See how the `podfile_properties` variable below is used to customize the Podfile.
+The **Podfile** can be customized with a regular expression (this is considered dangerous because these types of changes do not compose well and multiple changes are likely to collide), but it's more reliable to instead set configuration values in JSON file called **Podfile.properties.json**. See how `podfile_properties` is used to customize the **Podfile** below:
 
 ```ruby Podfile
 require 'json'

--- a/docs/pages/modules/existing-library.mdx
+++ b/docs/pages/modules/existing-library.mdx
@@ -108,7 +108,7 @@ Then, add your classes to Android and/or iOS `modules` in the [**expo-module.con
 
 ```json expo-module.config.json
 {
-  "ios": {
+  "apple": {
     "modules": ["MyModule"]
   },
   "android": {
@@ -133,3 +133,11 @@ export default requireNativeModule('MyModule');
 </Step>
 
 Now that the class is set up and linked, you can start to implement its functionality. See the [native module API](/modules/module-api/) reference page and links to [examples](/modules/module-api/#examples) from simple to moderately complex real-world modules to understand how to use the API.
+
+## Subscribing to application events
+
+// how to set up an expo module in your existing react native library to hook into appdelegate subscribers on ios and app lifecycler listeners on android
+
+https://github.com/bamlab/react-native-app-security/blob/main/ios/RNASAppLifecyleDelegate.swift
+
+For simple scenarios, it's also possible to integrate AppDelegate subscribers into native modules that are not Expo Modules ([example](https://github.com/react-native-google-signin/google-signin/blob/master/expo-module.config.json)).

--- a/docs/pages/modules/existing-library.mdx
+++ b/docs/pages/modules/existing-library.mdx
@@ -108,7 +108,7 @@ Then, add your classes to Android and/or iOS `modules` in the [**expo-module.con
 
 ```json expo-module.config.json
 {
-  "apple": {
+  "ios": {
     "modules": ["MyModule"]
   },
   "android": {
@@ -133,11 +133,3 @@ export default requireNativeModule('MyModule');
 </Step>
 
 Now that the class is set up and linked, you can start to implement its functionality. See the [native module API](/modules/module-api/) reference page and links to [examples](/modules/module-api/#examples) from simple to moderately complex real-world modules to understand how to use the API.
-
-## Subscribing to application events
-
-// how to set up an expo module in your existing react native library to hook into appdelegate subscribers on ios and app lifecycler listeners on android
-
-https://github.com/bamlab/react-native-app-security/blob/main/ios/RNASAppLifecyleDelegate.swift
-
-For simple scenarios, it's also possible to integrate AppDelegate subscribers into native modules that are not Expo Modules ([example](https://github.com/react-native-google-signin/google-signin/blob/master/expo-module.config.json)).


### PR DESCRIPTION
# Why

This PR updates the documentation to recommend using AppDelegate subscribers instead of `withAppDelegate` mod for iOS modules. 

Next PR will add a new section on subscribing to application events in existing React Native libraries.

# How

- Updated the iOS AppDelegate section in the development-and-debugging.mdx file to recommend using AppDelegate subscribers
- Replaced outdated examples with newer ones using Swift
- Updated references from `use_unimodules!` to `use_expo_modules!` and some more podspec changes


# Test Plan



# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)