### PR TITLE
[docs] update Unicorn ESLint plugin, new rules

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -78,11 +78,11 @@ function getVersionFromPath(path: string) {
 }
 
 // Filter unversioned and latest out, so we end up with v34, etc.
-const supportedVersions = versions.VERSIONS.filter(v => v.match(/^v/));
+const supportedVersions = new Set(versions.VERSIONS.filter(v => v.match(/^v/)));
 
 // Return true if the version is still included in documentation
 function isVersionDocumented(path: string) {
-  return supportedVersions.includes(getVersionFromPath(path));
+  return supportedVersions.has(getVersionFromPath(path));
 }
 
 function pathIncludesHtmlExtension(path: string) {

--- a/docs/common/sentry-utilities.ts
+++ b/docs/common/sentry-utilities.ts
@@ -6,7 +6,7 @@ import { ErrorEvent } from '@sentry/react';
  */
 
 // These exact error messages may be different depending on the browser!
-const ERRORS_TO_DISCARD = [
+const ERRORS_TO_DISCARD = new Set([
   // Filter out errors from extensions
   'chrome-extension://',
   'moz-extension://',
@@ -15,7 +15,7 @@ const ERRORS_TO_DISCARD = [
   "undefined is not an object (evaluating 'window.__pad.performLoop')",
   // This error appears in Firefox related to local storage and flooded our Sentry bandwidth
   'SecurityError: The operation is insecure.',
-];
+]);
 
 const REPORTED_ERRORS_KEY = 'sentry:reportedErrors';
 const TIMESTAMP_KEY = 'sentry:errorReportingInit';
@@ -36,7 +36,7 @@ export function preprocessSentryError(event: ErrorEvent) {
   }
 
   // Discard any errors that we know we do not care about
-  if (ERRORS_TO_DISCARD.includes(message)) {
+  if (ERRORS_TO_DISCARD.has(message)) {
     return null;
   }
 

--- a/docs/common/utilities.ts
+++ b/docs/common/utilities.ts
@@ -53,7 +53,7 @@ export const getUserFacingVersionString = (
   latestVersion?: string,
   betaVersion?: string
 ): string => {
-  const versionString = `SDK ${version?.substring(1, 3)}`;
+  const versionString = `SDK ${version?.slice(1, 3)}`;
 
   if (version === 'latest') {
     return latestVersion ? `${getUserFacingVersionString(latestVersion)} (Latest)` : 'Latest';
@@ -87,14 +87,14 @@ export function listMissingHashLinkTargets(apiName?: string) {
       if (link.hostname !== 'localhost' || !link.href.startsWith(link.baseURI.split('#')[0])) {
         return '';
       }
-      return link.hash.substring(1);
+      return link.hash.slice(1);
     })
     .filter(hash => hash !== '');
 
-  const availableIDs = Array.from(document.querySelectorAll('*[id]')).map(link => link.id);
-  const missingEntries = wantedHashes.filter(hash => !availableIDs.includes(hash));
+  const availableIDs = new Set(Array.from(document.querySelectorAll('*[id]')).map(link => link.id));
+  const missingEntries = wantedHashes.filter(hash => !availableIDs.has(hash));
 
-  if (missingEntries.length) {
+  if (missingEntries.length > 0) {
     /* eslint-disable no-console */
     console.group(`🚨 The following links targets are missing in the ${apiName} API reference:`);
     console.table(missingEntries);
@@ -116,7 +116,7 @@ export function versionToText(version: string): string {
 }
 
 export function formatSdkVersion(version: string): string {
-  return version.includes('v') ? `SDK ${version.substring(1, 3)}` : `SDK ${version}`;
+  return version.includes('v') ? `SDK ${version.slice(1, 3)}` : `SDK ${version}`;
 }
 
 export function capitalize(str: string) {

--- a/docs/components/plugins/api/APISectionDeprecationNote.tsx
+++ b/docs/components/plugins/api/APISectionDeprecationNote.tsx
@@ -38,7 +38,7 @@ export const APISectionDeprecationNote = ({ comment, className, sticky = false }
           sticky && 'mb-0 rounded-b-none rounded-t-lg px-4 shadow-none max-md-gutters:px-4',
           className
         )}>
-        {content.length ? (
+        {content.length > 0 ? (
           <ReactMarkdown components={mdComponents}>{`**Deprecated** ${content}`}</ReactMarkdown>
         ) : (
           <BOLD>Deprecated</BOLD>

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -115,7 +115,7 @@ const renderInterface = (
 ): JSX.Element | null => {
   const interfaceChildren = children?.filter(child => !child?.inheritedFrom) || [];
 
-  if (!interfaceChildren.length) {
+  if (interfaceChildren.length === 0) {
     return null;
   }
 

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -57,7 +57,7 @@ const renderInheritedProps = (
   const inheritedData = data?.type?.types ?? data?.extendedTypes ?? [];
   const inheritedProps =
     inheritedData.filter((ip: TypeDefinitionData) => ip.type === 'reference') ?? [];
-  if (inheritedProps.length) {
+  if (inheritedProps.length > 0) {
     return (
       <div className={mergeClasses('border-t border-palette-gray4 px-4 py-3')}>
         {exposeInSidebar ? <H3>Inherited Props</H3> : <H4>Inherited Props</H4>}
@@ -139,7 +139,7 @@ export const renderProp = (
         comment={extractedComment}
         baseNestingLevel={baseNestingLevel}
         deprecated={Boolean(getTagData('deprecated', extractedComment))}
-        platforms={platforms.length ? platforms : parentPlatforms}
+        platforms={platforms.length > 0 ? platforms : parentPlatforms}
       />
       <div className={mergeClasses(STYLES_SECONDARY, VERTICAL_SPACING, 'mb-2.5')}>
         {flags?.isOptional && <>Optional&emsp;&bull;&emsp;</>}

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -221,7 +221,7 @@ const renderType = (
     );
     const propObjectDefinitions = propTypes.filter(type => !propMethodDefinitions.includes(type));
 
-    if (propTypes.length) {
+    if (propTypes.length > 0) {
       return (
         <div key={`prop-type-definition-${name}`} className={STYLES_APIBOX}>
           <APISectionDeprecationNote comment={comment} sticky />
@@ -265,7 +265,7 @@ const renderType = (
           )}
         </div>
       );
-    } else if (literalTypes.length) {
+    } else if (literalTypes.length > 0) {
       const acceptedLiteralTypes = defineLiteralType(literalTypes);
       return (
         <div key={`type-definition-${name}`} className={STYLES_APIBOX}>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -398,7 +398,7 @@ export const resolveTypeName = (
   }
 };
 
-export const parseParamName = (name: string) => (name.startsWith('__') ? name.substr(2) : name);
+export const parseParamName = (name: string) => (name.startsWith('__') ? name.slice(2) : name);
 
 export const listParams = (parameters: MethodParamData[]) =>
   parameters
@@ -453,7 +453,7 @@ export const getAllTagData = (tagName: string, comment?: CommentData) =>
           tag,
           content: [
             {
-              text: tag.substring(1),
+              text: tag.slice(1),
               tag,
             } as CommentContentData,
           ],
@@ -471,7 +471,7 @@ export const getAllTagData = (tagName: string, comment?: CommentData) =>
       }
       return tag;
     })
-    .filter(tag => tag.tag.substring(1) === tagName);
+    .filter(tag => tag.tag.slice(1) === tagName);
 
 export const getTagNamesList = (comment?: CommentData) =>
   comment && [

--- a/docs/components/plugins/api/components/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/components/APISectionPlatformTags.tsx
@@ -40,7 +40,7 @@ export const APISectionPlatformTags = ({
         ? defaultPlatforms?.map(platform => platform.replace('*', ''))
         : [];
 
-  if (!experimentalData.length && !platformNames?.length) {
+  if (experimentalData.length === 0 && !platformNames?.length) {
     return null;
   }
 

--- a/docs/eslint.config.mjs
+++ b/docs/eslint.config.mjs
@@ -7,7 +7,7 @@ import lodash from 'eslint-plugin-lodash';
 import * as mdx from 'eslint-plugin-mdx';
 import tailwind from 'eslint-plugin-tailwindcss';
 import testingLibrary from 'eslint-plugin-testing-library';
-import unicorn from 'eslint-plugin-unicorn';
+import unicorn from 'eslint-plugin-unicorn'; // eslint-disable-line
 
 const TAILWIND_DEFAULTS = {
   callees: ['mergeClasses'],
@@ -38,16 +38,21 @@ const CORE_RULES = {
   eqeqeq: ['error', 'always', { null: 'ignore' }],
   'import/no-cycle': ['error', { maxDepth: '∞' }],
   'lodash/import-scope': [2, 'method'],
+  'unicorn/better-regex': 'warn',
+  'unicorn/consistent-date-clone': 'warn',
+  'unicorn/explicit-length-check': 'warn',
   'unicorn/new-for-builtins': 'warn',
   'unicorn/no-useless-spread': 'warn',
+  'unicorn/no-unnecessary-array-splice-count': 'warn',
   'unicorn/prefer-array-some': 'warn',
   'unicorn/prefer-at': 'warn',
+  'unicorn/prefer-date-now': 'warn',
+  'unicorn/prefer-set-has': 'warn',
   'unicorn/prefer-includes': 'warn',
   'unicorn/prefer-regexp-test': 'warn',
-  'unicorn/throw-new-error': 'warn',
   'unicorn/prefer-node-protocol': 'warn',
-  'unicorn/prefer-date-now': 'warn',
-  'unicorn/better-regex': 'warn',
+  'unicorn/prefer-string-slice': 'warn',
+  'unicorn/throw-new-error': 'warn',
   'unicorn/prevent-abbreviations': [
     'warn',
     {

--- a/docs/mdx-plugins/remark-code-title.js
+++ b/docs/mdx-plugins/remark-code-title.js
@@ -5,7 +5,7 @@ import { visit } from 'unist-util-visit';
  */
 export default function remarkLinkRewrite() {
   return (tree, file) => {
-    if (!file.cwd || !file.history || !file.history.length) {
+    if (!file.cwd || !file.history || file.history.length === 0) {
       return;
     }
 

--- a/docs/mdx-plugins/remark-link-rewrite.js
+++ b/docs/mdx-plugins/remark-link-rewrite.js
@@ -35,7 +35,7 @@ export default function remarkLinkRewrite(options) {
    */
   return (tree, file) => {
     // we can't rewrite files without knowing where the file exists
-    if (!file.cwd || !file.history || !file.history.length) {
+    if (!file.cwd || !file.history || file.history.length === 0) {
       return;
     }
     // index references should be ignored, it's handled by Next

--- a/docs/package.json
+++ b/docs/package.json
@@ -100,7 +100,7 @@
     "eslint-plugin-mdx": "^3.4.1",
     "eslint-plugin-tailwindcss": "^3.18.0",
     "eslint-plugin-testing-library": "^7.1.1",
-    "eslint-plugin-unicorn": "^56.0.1",
+    "eslint-plugin-unicorn": "^59.0.0",
     "fs-extra": "^11.3.0",
     "http-server": "^14.1.1",
     "jest": "^29.7.0",

--- a/docs/scripts/create-sitemap.js
+++ b/docs/scripts/create-sitemap.js
@@ -2,10 +2,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { SitemapStream } from 'sitemap';
 
-const IGNORED_PAGES = [
+const IGNORED_PAGES = new Set([
   '/404', // We don't want to add the 404 error page as sitemap entry
   '/versions', // Skip the redirect to latest, use `/versions/latest` instead
-];
+]);
 
 /**
  * Create a sitemap for crawlers like Algolia Docsearch.
@@ -28,9 +28,7 @@ export default function createSitemap({ pathMap, domain, output, pathsPriority, 
 
   // Get a list of URLs from the pathMap that we can use in the sitemap
   const urls = Object.keys(pathMap)
-    .filter(
-      url => !IGNORED_PAGES.includes(url) && !pathsHidden.some(hidden => url.startsWith(hidden))
-    )
+    .filter(url => !IGNORED_PAGES.has(url) && !pathsHidden.some(hidden => url.startsWith(hidden)))
     .map(pathWithTrailingSlash)
     .sort((a, b) => pathSortedByPriority(a, b, pathsPriority));
 

--- a/docs/scripts/generate-llms/llms-txt.js
+++ b/docs/scripts/generate-llms/llms-txt.js
@@ -21,7 +21,7 @@ function generateSectionMarkdown(section) {
   content += section.items.map(generateItemMarkdown).join('');
 
   section.groups.forEach(group => {
-    if (group.items.length) {
+    if (group.items.length > 0) {
       content += `\n### ${group.title}\n`;
       content += group.items.map(generateItemMarkdown).join('');
     }
@@ -41,9 +41,9 @@ function generateFullMarkdown({ title, description, sections }) {
   const filteredSections = sections.filter(section => {
     if (
       section.title === 'React Native' &&
-      !section.items.length &&
-      !section.groups.length &&
-      !section.sections.length
+      section.items.length === 0 &&
+      section.groups.length === 0 &&
+      section.sections.length === 0
     ) {
       return false;
     }

--- a/docs/scripts/generate-llms/utils.js
+++ b/docs/scripts/generate-llms/utils.js
@@ -41,7 +41,7 @@ function processGroup(group) {
     .map(processPage)
     .filter(Boolean);
 
-  return items.length ? { title: group.name, items } : null;
+  return items.length > 0 ? { title: group.name, items } : null;
 }
 
 export function processSection(node) {
@@ -235,7 +235,7 @@ export function generateSectionMarkdown(section) {
   content += section.items.map(generateItemMarkdown).join('');
 
   section.groups.forEach(group => {
-    if (group.items.length) {
+    if (group.items.length > 0) {
       content += `# ${group.title}\n\n`;
       content += group.items.map(generateItemMarkdown).join('');
     }

--- a/docs/ui/components/Authentication/GridItem.tsx
+++ b/docs/ui/components/Authentication/GridItem.tsx
@@ -26,7 +26,7 @@ export const GridItem = ({
     isStyled>
     <Icon title={title} image={image} />
     <RawH4 className="!mt-1 text-center">{title}</RawH4>
-    {(protocol || []).length && (
+    {(protocol || []).length > 0 && (
       <CALLOUT
         theme="secondary"
         className={mergeClasses(

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -47,7 +47,7 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
     useEffect(() => {
       if (router?.asPath) {
         const splitUrl = router.asPath.split('#');
-        const hash = splitUrl.length ? splitUrl[1] : undefined;
+        const hash = splitUrl.length > 0 ? splitUrl[1] : undefined;
         if (hash && hash === heading.current.slug) {
           detailsRef?.current?.setAttribute('open', '');
         }

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -69,7 +69,7 @@ function generateStructure(files: FileTreeProps['files'] = []): FileObject[] {
 function renderStructure(structure: FileObject[], level = 0): ReactNode {
   return structure.map(({ name, note, files }, index) => {
     const FileIcon = getIconForFile(name);
-    return files.length ? (
+    return files.length > 0 ? (
       <div key={name + '_' + index} className="mt-1 flex flex-col rounded-sm pl-2 pt-1">
         <div className="flex items-center">
           {' '.repeat(level)}

--- a/docs/ui/components/Footer/FeedbackDialog.tsx
+++ b/docs/ui/components/Footer/FeedbackDialog.tsx
@@ -31,7 +31,7 @@ export const FeedbackDialog = ({ pathname }: Props) => {
       },
       body: JSON.stringify({
         feedback,
-        email: email.length ? email : undefined,
+        email: email.length > 0 ? email : undefined,
         url: pathname,
       }),
     })

--- a/docs/ui/components/Footer/NewsletterSignUp.tsx
+++ b/docs/ui/components/Footer/NewsletterSignUp.tsx
@@ -72,7 +72,7 @@ export const NewsletterSignUp = () => {
             size="xs"
             theme={userSignedUp ? 'quaternary' : 'secondary'}
             className="absolute right-2.5 top-2 min-w-[68px]"
-            disabled={userSignedUp || !email.length}
+            disabled={userSignedUp || email.length === 0}
             onClick={signUp}>
             {userSignedUp ? 'Done!' : 'Sign Up'}
           </Button>

--- a/docs/ui/components/Navigation/Navigation.tsx
+++ b/docs/ui/components/Navigation/Navigation.tsx
@@ -43,7 +43,7 @@ function navigationRenderer(
   const Component = renderers[route.type];
   const routeKey = `${route.type}-${route.name}`;
   const isActive = activeRoutes[route.type] === route;
-  const hasChildren = route.type !== 'page' && route.children.length;
+  const hasChildren = route.type !== 'page' && route.children.length > 0;
   return (
     <Component key={routeKey} route={route} isActive={isActive}>
       {hasChildren && route.children.map(nested => navigationRenderer(nested, activeRoutes))}

--- a/docs/ui/components/Prerequisites/index.tsx
+++ b/docs/ui/components/Prerequisites/index.tsx
@@ -40,7 +40,7 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
     useEffect(() => {
       if (router?.asPath) {
         const splitUrl = router.asPath.split('#');
-        const hash = splitUrl.length ? splitUrl[1] : undefined;
+        const hash = splitUrl.length > 0 ? splitUrl[1] : undefined;
         if (hash && hash === heading.current.slug) {
           detailsRef?.current?.setAttribute('open', '');
         }

--- a/docs/ui/components/Snippet/blocks/DiffBlock.tsx
+++ b/docs/ui/components/Snippet/blocks/DiffBlock.tsx
@@ -69,7 +69,7 @@ export const DiffBlock = ({
   }: RenderLine) => {
     // older SDK template-bare-minimum files (e.g, 46) generate a diff with no hunks and no paths
     // one example of this was a change to gradle-wrapper.jar
-    if (!hunks.length) {
+    if (hunks.length === 0) {
       return null;
     }
     return (

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -78,7 +78,7 @@ function cmdMapper(line: string, index: number) {
           className="whitespace-pre !border-none !bg-transparent text-default"
           dangerouslySetInnerHTML={{
             __html: Prism.highlight(
-              line.substring(1).trim(),
+              line.slice(1).trim(),
               Prism.languages['bash'],
               'bash' as Language
             ),

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -35,7 +35,7 @@ export const Table = ({
         '[&_blockquote_code]:px-1 [&_blockquote_code]:py-0',
         className
       )}>
-      {headers.length ? (
+      {headers.length > 0 ? (
         <>
           <TableHeaders headers={headers} headersAlign={headersAlign} />
           <tbody>{children}</tbody>

--- a/docs/ui/components/TableOfContents/TableOfContentsLink.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContentsLink.tsx
@@ -79,7 +79,7 @@ function trimCodedTitle(str: string) {
   if (!str.includes('...')) {
     const dotIdx = str.indexOf('.');
     if (dotIdx > 0) {
-      str = str.substring(dotIdx + 1);
+      str = str.slice(Math.max(0, dotIdx + 1));
     }
   }
 
@@ -87,7 +87,7 @@ function trimCodedTitle(str: string) {
 
   const parIdx = str.indexOf('(');
   if (parIdx > 0) {
-    str = str.substring(0, parIdx + 1) + ')';
+    str = str.slice(0, Math.max(0, parIdx + 1)) + ')';
   }
 
   return str;

--- a/docs/ui/components/Tabs/Tabs.tsx
+++ b/docs/ui/components/Tabs/Tabs.tsx
@@ -43,7 +43,7 @@ const InnerTabs = ({
   const tabTitles = tabs ?? generateTabLabels(children);
 
   const layoutId = useMemo(
-    () => tabTitles.reduce((acc, tab) => acc + tab, `${Math.random().toString(36).substring(5)}-`),
+    () => tabTitles.reduce((acc, tab) => acc + tab, `${Math.random().toString(36).slice(5)}-`),
     []
   );
 

--- a/docs/ui/components/Tag/Tag.tsx
+++ b/docs/ui/components/Tag/Tag.tsx
@@ -5,7 +5,7 @@ import { StatusTag } from './StatusTag';
 import { TagProps } from './types';
 
 export const Tag = ({ name, ...rest }: TagProps) => {
-  if (getPlatformName(name).length) {
+  if (getPlatformName(name).length > 0) {
     return <PlatformTag platform={name} {...rest} />;
   } else {
     return <StatusTag status={name} {...rest} />;

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -10,8 +10,8 @@ export { AnchorContext } from './AnchorContext';
 
 const isDev = process.env.NODE_ENV === 'development';
 
-const CRAWLABLE_HEADINGS = ['h1', 'h2', 'h3', 'h4', 'h5'];
-const CRAWLABLE_TEXT = ['span', 'p', 'li', 'blockquote', 'code', 'pre'];
+const CRAWLABLE_HEADINGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5']);
+const CRAWLABLE_TEXT = new Set(['span', 'p', 'li', 'blockquote', 'code', 'pre']);
 
 type PermalinkedComponentProps = PropsWithChildren<
   { level?: number; id?: string } & AdditionalProps & TextComponentProps
@@ -79,8 +79,8 @@ export function createTextComponent(Element: TextElement, textClassName?: string
           className
         )}
         data-testid={testID}
-        data-heading={(crawlable && CRAWLABLE_HEADINGS.includes(TextElementTag)) || undefined}
-        data-text={(crawlable && CRAWLABLE_TEXT.includes(TextElementTag)) || undefined}
+        data-heading={(crawlable && CRAWLABLE_HEADINGS.has(TextElementTag)) || undefined}
+        data-text={(crawlable && CRAWLABLE_TEXT.has(TextElementTag)) || undefined}
         {...rest}
       />
     );

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -144,7 +144,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.24.7, @babel/helper-validator-identifier@npm:^7.25.9":
+"@babel/helper-validator-identifier@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/helper-validator-identifier@npm:7.25.9"
   checksum: 10c0/4fc6f830177b7b7e887ad3277ddb3b91d81e6c4a24151540d9d1023e8dc6b1c0505f0f0628ae653601eb4388a8db45c1c14b2c07a9173837aef7e4116456259d
@@ -443,14 +443,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.1.2, @eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0, @eslint-community/eslint-utils@npm:^4.5.0":
-  version: 4.6.0
-  resolution: "@eslint-community/eslint-utils@npm:4.6.0"
+"@eslint-community/eslint-utils@npm:^4.1.2, @eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0, @eslint-community/eslint-utils@npm:^4.5.0, @eslint-community/eslint-utils@npm:^4.5.1":
+  version: 4.6.1
+  resolution: "@eslint-community/eslint-utils@npm:4.6.1"
   dependencies:
     eslint-visitor-keys: "npm:^3.4.3"
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  checksum: 10c0/a64131c1b43021e3a84267f6011fd678a936718097c9be169c37a40ada2c7016bec7d6685ecc88112737d57733f36837bb90d9425ad48d2e2aa351d999d32443
+  checksum: 10c0/cdeb6f8fc33a83726357d7f736075cdbd6e79dc7ac4b00b15680f1111d0f33bda583e7fafa5937245a058cc66302dc47568bba57b251302dc74964d8e87f56d7
   languageName: node
   linkType: hard
 
@@ -2979,13 +2979,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/normalize-package-data@npm:^2.4.0":
-  version: 2.4.4
-  resolution: "@types/normalize-package-data@npm:2.4.4"
-  checksum: 10c0/aef7bb9b015883d6f4119c423dd28c4bdc17b0e8a0ccf112c78b4fe0e91fbc4af7c6204b04bba0e199a57d2f3fbbd5b4a14bf8739bf9d2a39b2a0aad545e0f86
-  languageName: node
-  linkType: hard
-
 "@types/nprogress@npm:^0.2.3":
   version: 0.2.3
   resolution: "@types/nprogress@npm:0.2.3"
@@ -3788,7 +3781,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.24.0, browserslist@npm:^4.24.2, browserslist@npm:^4.24.4":
+"browserslist@npm:^4.24.0, browserslist@npm:^4.24.4":
   version: 4.24.4
   resolution: "browserslist@npm:4.24.4"
   dependencies:
@@ -3832,10 +3825,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"builtin-modules@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "builtin-modules@npm:3.3.0"
-  checksum: 10c0/2cb3448b4f7306dc853632a4fcddc95e8d4e4b9868c139400027b71938fc6806d4ff44007deffb362ac85724bd40c2c6452fb6a0aa4531650eeddb98d8e5ee8a
+"builtin-modules@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "builtin-modules@npm:5.0.0"
+  checksum: 10c0/bee8e74d1b949133c66a30b2e7982b3bdfe70d09f72bc4425ac9811d01d6f2f11abbe66c47aa9c977800a255155cac5a8068e0714cd2dc31867762fb309fd065
   languageName: node
   linkType: hard
 
@@ -4086,10 +4079,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:^4.0.0":
-  version: 4.1.0
-  resolution: "ci-info@npm:4.1.0"
-  checksum: 10c0/0f969ce32a974c542bc8abe4454b220d9d9323bb9415054c92a900faa5fdda0bb222eda68c490127c1d78503510d46b6aca614ecaba5a60515b8ac7e170119e6
+"ci-info@npm:^4.0.0, ci-info@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "ci-info@npm:4.2.0"
+  checksum: 10c0/37a2f4b6a213a5cf835890eb0241f0d5b022f6cfefde58a69e9af8e3a0e71e06d6ad7754b0d4efb9cd2613e58a7a33996d71b56b0d04242722e86666f3f3d058
   languageName: node
   linkType: hard
 
@@ -4266,12 +4259,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-compat@npm:^3.38.1":
-  version: 3.39.0
-  resolution: "core-js-compat@npm:3.39.0"
+"core-js-compat@npm:^3.41.0":
+  version: 3.41.0
+  resolution: "core-js-compat@npm:3.41.0"
   dependencies:
-    browserslist: "npm:^4.24.2"
-  checksum: 10c0/880579a3dab235e3b6350f1e324269c600753b48e891ea859331618d5051e68b7a95db6a03ad2f3cc7df4397318c25a5bc7740562ad39e94f56568638d09d414
+    browserslist: "npm:^4.24.4"
+  checksum: 10c0/92d2c748d3dd1c4e3b6cee6b6683b9212db9bc0a6574d933781210daf3baaeb76334ed4636eb8935b45802aa8d9235ab604c9a262694e02a2fa17ad0f6976829
   languageName: node
   linkType: hard
 
@@ -5413,29 +5406,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-unicorn@npm:^56.0.1":
-  version: 56.0.1
-  resolution: "eslint-plugin-unicorn@npm:56.0.1"
+"eslint-plugin-unicorn@npm:^59.0.0":
+  version: 59.0.0
+  resolution: "eslint-plugin-unicorn@npm:59.0.0"
   dependencies:
-    "@babel/helper-validator-identifier": "npm:^7.24.7"
-    "@eslint-community/eslint-utils": "npm:^4.4.0"
-    ci-info: "npm:^4.0.0"
+    "@babel/helper-validator-identifier": "npm:^7.25.9"
+    "@eslint-community/eslint-utils": "npm:^4.5.1"
+    "@eslint/plugin-kit": "npm:^0.2.7"
+    ci-info: "npm:^4.2.0"
     clean-regexp: "npm:^1.0.0"
-    core-js-compat: "npm:^3.38.1"
+    core-js-compat: "npm:^3.41.0"
     esquery: "npm:^1.6.0"
-    globals: "npm:^15.9.0"
-    indent-string: "npm:^4.0.0"
-    is-builtin-module: "npm:^3.2.1"
-    jsesc: "npm:^3.0.2"
+    find-up-simple: "npm:^1.0.1"
+    globals: "npm:^16.0.0"
+    indent-string: "npm:^5.0.0"
+    is-builtin-module: "npm:^5.0.0"
+    jsesc: "npm:^3.1.0"
     pluralize: "npm:^8.0.0"
-    read-pkg-up: "npm:^7.0.1"
     regexp-tree: "npm:^0.1.27"
-    regjsparser: "npm:^0.10.0"
-    semver: "npm:^7.6.3"
-    strip-indent: "npm:^3.0.0"
+    regjsparser: "npm:^0.12.0"
+    semver: "npm:^7.7.1"
+    strip-indent: "npm:^4.0.0"
   peerDependencies:
-    eslint: ">=8.56.0"
-  checksum: 10c0/3b853ecde6ab597b12e28b962ba6ad7d3594f7f066d90135db2d3366ac13361c72500119163e13e1c38ca6fbdd331b1cc31dce9e8673880bff050fe51d6c64db
+    eslint: ">=9.22.0"
+  checksum: 10c0/2d2d4b8632bdd0f47a819300f03134b881c81bcbf4374f112a8800ba64ce40cd3a084cb118dbb07011841a3af3722b418be0fbbb871cb85409e0d95812e28151
   languageName: node
   linkType: hard
 
@@ -5766,7 +5760,7 @@ __metadata:
     eslint-plugin-mdx: "npm:^3.4.1"
     eslint-plugin-tailwindcss: "npm:^3.18.0"
     eslint-plugin-testing-library: "npm:^7.1.1"
-    eslint-plugin-unicorn: "npm:^56.0.1"
+    eslint-plugin-unicorn: "npm:^59.0.0"
     framer-motion: "npm:^12.7.4"
     front-matter: "npm:^4.0.2"
     fs-extra: "npm:^11.3.0"
@@ -5928,6 +5922,13 @@ __metadata:
   dependencies:
     to-regex-range: "npm:^5.0.1"
   checksum: 10c0/b75b691bbe065472f38824f694c2f7449d7f5004aa950426a2c28f0306c60db9b880c0b0e4ed819997ffb882d1da02cfcfc819bddc94d71627f5269682edf018
+  languageName: node
+  linkType: hard
+
+"find-up-simple@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "find-up-simple@npm:1.0.1"
+  checksum: 10c0/ad34de157b7db925d50ff78302fefb28e309f3bc947c93ffca0f9b0bccf9cf1a2dc57d805d5c94ec9fc60f4838f5dbdfd2a48ecd77c23015fa44c6dd5f60bc40
   languageName: node
   linkType: hard
 
@@ -6338,7 +6339,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^15.11.0, globals@npm:^15.9.0":
+"globals@npm:^15.11.0":
   version: 15.15.0
   resolution: "globals@npm:15.15.0"
   checksum: 10c0/f9ae80996392ca71316495a39bec88ac43ae3525a438b5626cd9d5ce9d5500d0a98a266409605f8cd7241c7acf57c354a48111ea02a767ba4f374b806d6861fe
@@ -6549,13 +6550,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hosted-git-info@npm:^2.1.4":
-  version: 2.8.9
-  resolution: "hosted-git-info@npm:2.8.9"
-  checksum: 10c0/317cbc6b1bbbe23c2a40ae23f3dafe9fa349ce42a89a36f930e3f9c0530c179a3882d2ef1e4141a4c3674d6faaea862138ec55b43ad6f75e387fda2483a13c70
-  languageName: node
-  linkType: hard
-
 "hosted-git-info@npm:^7.0.0":
   version: 7.0.2
   resolution: "hosted-git-info@npm:7.0.2"
@@ -6762,6 +6756,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"indent-string@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "indent-string@npm:5.0.0"
+  checksum: 10c0/8ee77b57d92e71745e133f6f444d6fa3ed503ad0e1bcd7e80c8da08b42375c07117128d670589725ed07b1978065803fa86318c309ba45415b7fe13e7f170220
+  languageName: node
+  linkType: hard
+
 "inflight@npm:^1.0.4":
   version: 1.0.6
   resolution: "inflight@npm:1.0.6"
@@ -6903,12 +6904,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-builtin-module@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "is-builtin-module@npm:3.2.1"
+"is-builtin-module@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "is-builtin-module@npm:5.0.0"
   dependencies:
-    builtin-modules: "npm:^3.3.0"
-  checksum: 10c0/5a66937a03f3b18803381518f0ef679752ac18cdb7dd53b5e23ee8df8d440558737bd8dcc04d2aae555909d2ecb4a81b5c0d334d119402584b61e6a003e31af1
+    builtin-modules: "npm:^5.0.0"
+  checksum: 10c0/9561cdb92f7548df9403fa501f7d456bc90b9f49b547ce8935c5333b2316ea9ec3cbee3b972f2a98f041a9e2534a27465307fc45155a8ba793d9fdc9b7008aae
   languageName: node
   linkType: hard
 
@@ -7847,7 +7848,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsesc@npm:^3.0.2":
+"jsesc@npm:^3.0.2, jsesc@npm:^3.1.0":
   version: 3.1.0
   resolution: "jsesc@npm:3.1.0"
   bin:
@@ -7856,12 +7857,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsesc@npm:~0.5.0":
-  version: 0.5.0
-  resolution: "jsesc@npm:0.5.0"
+"jsesc@npm:~3.0.2":
+  version: 3.0.2
+  resolution: "jsesc@npm:3.0.2"
   bin:
     jsesc: bin/jsesc
-  checksum: 10c0/f93792440ae1d80f091b65f8ceddf8e55c4bb7f1a09dee5dcbdb0db5612c55c0f6045625aa6b7e8edb2e0a4feabd80ee48616dbe2d37055573a84db3d24f96d9
+  checksum: 10c0/ef22148f9e793180b14d8a145ee6f9f60f301abf443288117b4b6c53d0ecd58354898dc506ccbb553a5f7827965cd38bc5fb726575aae93c5e8915e2de8290e1
   languageName: node
   linkType: hard
 
@@ -9136,7 +9137,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"min-indent@npm:^1.0.0":
+"min-indent@npm:^1.0.0, min-indent@npm:^1.0.1":
   version: 1.0.1
   resolution: "min-indent@npm:1.0.1"
   checksum: 10c0/7e207bd5c20401b292de291f02913230cb1163abca162044f7db1d951fa245b174dc00869d40dd9a9f32a885ad6a5f3e767ee104cf278f399cb4e92d3f582d5c
@@ -9491,18 +9492,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-package-data@npm:^2.5.0":
-  version: 2.5.0
-  resolution: "normalize-package-data@npm:2.5.0"
-  dependencies:
-    hosted-git-info: "npm:^2.1.4"
-    resolve: "npm:^1.10.0"
-    semver: "npm:2 || 3 || 4 || 5"
-    validate-npm-package-license: "npm:^3.0.1"
-  checksum: 10c0/357cb1646deb42f8eb4c7d42c4edf0eec312f3628c2ef98501963cc4bbe7277021b2b1d977f982b2edce78f5a1014613ce9cf38085c3df2d76730481357ca504
-  languageName: node
-  linkType: hard
-
 "normalize-package-data@npm:^6.0.0":
   version: 6.0.2
   resolution: "normalize-package-data@npm:6.0.2"
@@ -9822,7 +9811,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-json@npm:^5.0.0, parse-json@npm:^5.2.0":
+"parse-json@npm:^5.2.0":
   version: 5.2.0
   resolution: "parse-json@npm:5.2.0"
   dependencies:
@@ -10657,29 +10646,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"read-pkg-up@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "read-pkg-up@npm:7.0.1"
-  dependencies:
-    find-up: "npm:^4.1.0"
-    read-pkg: "npm:^5.2.0"
-    type-fest: "npm:^0.8.1"
-  checksum: 10c0/82b3ac9fd7c6ca1bdc1d7253eb1091a98ff3d195ee0a45386582ce3e69f90266163c34121e6a0a02f1630073a6c0585f7880b3865efcae9c452fa667f02ca385
-  languageName: node
-  linkType: hard
-
-"read-pkg@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "read-pkg@npm:5.2.0"
-  dependencies:
-    "@types/normalize-package-data": "npm:^2.4.0"
-    normalize-package-data: "npm:^2.5.0"
-    parse-json: "npm:^5.0.0"
-    type-fest: "npm:^0.6.0"
-  checksum: 10c0/b51a17d4b51418e777029e3a7694c9bd6c578a5ab99db544764a0b0f2c7c0f58f8a6bc101f86a6fceb8ba6d237d67c89acf6170f6b98695d0420ddc86cf109fb
-  languageName: node
-  linkType: hard
-
 "readable-stream@npm:^2.0.2, readable-stream@npm:~2.3.6":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
@@ -10826,14 +10792,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regjsparser@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "regjsparser@npm:0.10.0"
+"regjsparser@npm:^0.12.0":
+  version: 0.12.0
+  resolution: "regjsparser@npm:0.12.0"
   dependencies:
-    jsesc: "npm:~0.5.0"
+    jsesc: "npm:~3.0.2"
   bin:
     regjsparser: bin/parser
-  checksum: 10c0/0f0508c142eddbceae55dab9715e714305c19e1e130db53168e8fa5f9f7ff9a4901f674cf6f71e04a0973b2f883882ba05808c80778b2d52b053d925050010f4
+  checksum: 10c0/99d3e4e10c8c7732eb7aa843b8da2fd8b647fe144d3711b480e4647dc3bff4b1e96691ccf17f3ace24aa866a50b064236177cb25e6e4fbbb18285d99edaed83b
   languageName: node
   linkType: hard
 
@@ -11063,7 +11029,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.7, resolve@npm:^1.10.0, resolve@npm:^1.10.1, resolve@npm:^1.20.0, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
+"resolve@npm:^1.1.7, resolve@npm:^1.10.1, resolve@npm:^1.20.0, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
   version: 1.22.10
   resolution: "resolve@npm:1.22.10"
   dependencies:
@@ -11089,7 +11055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
   version: 1.22.10
   resolution: "resolve@patch:resolve@npm%3A1.22.10#optional!builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
   dependencies:
@@ -11274,15 +11240,6 @@ __metadata:
   version: 3.0.1
   resolution: "secure-compare@npm:3.0.1"
   checksum: 10c0/af3102f3f555d917c8ffff7a5f6f00f70195708f4faf82d48794485c9f3cb365cee0dd4da6b4e53e8964f172970bce6069b6101ba3ce8c309bff54f460d1f650
-  languageName: node
-  linkType: hard
-
-"semver@npm:2 || 3 || 4 || 5":
-  version: 5.7.2
-  resolution: "semver@npm:5.7.2"
-  bin:
-    semver: bin/semver
-  checksum: 10c0/e4cf10f86f168db772ae95d86ba65b3fd6c5967c94d97c708ccb463b778c2ee53b914cd7167620950fc07faf5a564e6efe903836639e512a1aa15fbc9667fa25
   languageName: node
   linkType: hard
 
@@ -11917,6 +11874,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-indent@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "strip-indent@npm:4.0.0"
+  dependencies:
+    min-indent: "npm:^1.0.1"
+  checksum: 10c0/6b1fb4e22056867f5c9e7a6f3f45922d9a2436cac758607d58aeaac0d3b16ec40b1c43317de7900f1b8dd7a4107352fa47fb960f2c23566538c51e8585c8870e
+  languageName: node
+  linkType: hard
+
 "strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
@@ -12319,20 +12285,6 @@ __metadata:
   version: 0.21.3
   resolution: "type-fest@npm:0.21.3"
   checksum: 10c0/902bd57bfa30d51d4779b641c2bc403cdf1371fb9c91d3c058b0133694fcfdb817aef07a47f40faf79039eecbaa39ee9d3c532deff244f3a19ce68cea71a61e8
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "type-fest@npm:0.6.0"
-  checksum: 10c0/0c585c26416fce9ecb5691873a1301b5aff54673c7999b6f925691ed01f5b9232db408cdbb0bd003d19f5ae284322523f44092d1f81ca0a48f11f7cf0be8cd38
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^0.8.1":
-  version: 0.8.1
-  resolution: "type-fest@npm:0.8.1"
-  checksum: 10c0/dffbb99329da2aa840f506d376c863bd55f5636f4741ad6e65e82f5ce47e6914108f44f340a0b74009b0cb5d09d6752ae83203e53e98b1192cf80ecee5651636
   languageName: node
   linkType: hard
 
@@ -12835,7 +12787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"validate-npm-package-license@npm:^3.0.1, validate-npm-package-license@npm:^3.0.4":
+"validate-npm-package-license@npm:^3.0.4":
   version: 3.0.4
   resolution: "validate-npm-package-license@npm:3.0.4"
   dependencies:


### PR DESCRIPTION
# Why

With migration to ESlint v9 and flat config, we are unblocked on `eslint-plugin-unicorn` upgrade.

# How

Update Unicorn ESLint plugin, add few new rules to our set, fix new warnings.

# Test Plan

All lint checks and tests are passing. Docs app is running locally as expected.
