### PR TITLE
[expo-media-library] Fixed assets change event listener.

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `medialibraryassetschangeevent` listener not capturing assets changes.
 - Fixed build error from **AppDelegate.swift** integration. ([#36368](https://github.com/expo/expo/pull/36368) by [@kudo](https://github.com/kudo))
 
 ## 17.1.3 — 2025-04-21

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `medialibraryassetschangeevent` listener not capturing assets changes.
+- Fixed `medialibraryassetschangeevent` listener not capturing assets changes. ([#36459](https://github.com/expo/expo/pull/36459) by [@aleqsio](https://github.com/aleqsio))
 - Fixed build error from **AppDelegate.swift** integration. ([#36368](https://github.com/expo/expo/pull/36368) by [@kudo](https://github.com/kudo))
 
 ## 17.1.3 — 2025-04-21

--- a/packages/expo-media-library/ios/MediaLibraryModule.swift
+++ b/packages/expo-media-library/ios/MediaLibraryModule.swift
@@ -530,12 +530,6 @@ public class MediaLibraryModule: Module, PhotoLibraryObserverHandler {
           var insertedAssets = [[String: Any?]?]()
           var deletedAssets = [[String: Any?]?]()
           var updatedAssets = [[String: Any?]?]()
-          let body: [String: Any] = [
-            "hasIncrementalChanges": true,
-            "insertedAssets": insertedAssets,
-            "deletedAssets": deletedAssets,
-            "updatedAssets": updatedAssets
-          ]
 
           for asset in changeDetails.insertedObjects {
             insertedAssets.append(exportAsset(asset: asset))
@@ -548,6 +542,13 @@ public class MediaLibraryModule: Module, PhotoLibraryObserverHandler {
           for asset in changeDetails.changedObjects {
             updatedAssets.append(exportAsset(asset: asset))
           }
+
+          let body: [String: Any] = [
+            "hasIncrementalChanges": true,
+            "insertedAssets": insertedAssets,
+            "deletedAssets": deletedAssets,
+            "updatedAssets": updatedAssets
+          ]
 
           sendEvent("mediaLibraryDidChange", body)
           return


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/29890.

# How

Reordered dict creation so it's no longer empty.

# Test Plan

Tested repro linked in the issue.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
