### PR TITLE
Change sample `babel.config.js` for React Compiler to reflect options available in `v19.1.0-rc.1`

### DIFF
--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -167,7 +167,7 @@ module.exports = function (api) {
         {
           'react-compiler': {
             // Passed directly to the React Compiler Babel plugin.
-            compilationMode: 'strict',
+            compilationMode: 'all',
             panicThreshold: 'all_errors',
           },
           web: {


### PR DESCRIPTION
# Why

If someone were to copy the sample config from Expo Docs as is , they would get an error upon running or building the app.

# How

`compilationMode: 'strict'` is no longer a valid option of `babel-plugin-react-compiler`. Available values are `infer`, `syntax`, `annotation`, `all`. [See here](https://github.com/facebook/react/blob/0038c501a307e5ddc0cb80027e55740ddda09520/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts#L144).

# Test Plan

Started testing React Compiler on a personal project. Followed steps from Expo Docs and the extended babel config was what caused an error.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
