### PR TITLE
[launcher][Android] Fix appIcon

### DIFF
--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -193,8 +193,8 @@ class DevLauncherInternalModule : Module(), DevLauncherKoinComponent {
     val packageManager = context.packageManager
     val packageName = context.packageName
     val applicationInfo = packageManager.getApplicationInfo(packageName, 0)
-//    TODO - figure out how to get resId for AdaptiveIconDrawable icons
-    return "" + applicationInfo.icon
+    val appIconResId = applicationInfo.icon
+    return "android.resource://$packageName/$appIconResId"
   }
 
   private fun sanitizeUrlString(url: String): Uri {


### PR DESCRIPTION
# Why

* `getApplicationIconUri` should return a valid uri instead of resource id as string.
* Image URI can be Android asset since react-native@0.79. However, we shouldn't rely on react-native's fallback to resources and instead provide the correct uri to the asset.

In fact, this issue does not occur starting from react-native 0.79 but I still think that given the above we should change it

# How

By making correct android resource uri to app icon resource.

Resolves ENG-11498

# Test Plan

App icon in dev-launcher (SDK 53) should render correctly.

<img width="333" alt="image" src="https://github.com/user-attachments/assets/50bd3dd4-6ba0-48f9-958f-28edea3d7ec3" />

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
