### PR TITLE
[docs] Fix missing link in BoxLink

### DIFF
--- a/docs/pages/versions/v52.0.0/config/app.mdx
+++ b/docs/pages/versions/v52.0.0/config/app.mdx
@@ -15,6 +15,7 @@ The following is a list of properties that are available for you under the `"exp
 <BoxLink
   title="Configuration with app config"
   description="For information on app configuration, the differences between various app config files, and how to use them dynamically."
+  href="/workflow/configuration/"
   Icon={BookOpen02Icon}
 />
 

--- a/docs/pages/versions/v53.0.0/config/app.mdx
+++ b/docs/pages/versions/v53.0.0/config/app.mdx
@@ -15,6 +15,7 @@ The following is a list of properties that are available for you under the `"exp
 <BoxLink
   title="Configuration with app config"
   description="For information on app configuration, the differences between various app config files, and how to use them dynamically."
+  href="/workflow/configuration/"
   Icon={BookOpen02Icon}
 />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

 Fix missing link in BoxLink in app config reference for SDK 52 and 53.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Running docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
