### PR TITLE
[docs] Update Install Expo modules manual instructions for SDK 53

### DIFF
--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -124,16 +124,15 @@ fi
 `"$NODE_BINARY" --print "require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'"`
 ```
 
-And add support the `"main"` field in **package.json** by making the following change to **AppDelegate.mm**:
+And add support the `"main"` field in **package.json** by making the following change to **AppDelegate.swift**:
 
-```diff AppDelegate.mm
- - (NSURL *)getBundleURL
- {
+```diff AppDelegate.swift
+   override func bundleURL() -> URL? {
  #if DEBUG
--  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
-+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@".expo/.virtual-metro-entry"];
+-    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
++    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
  #else
-   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+     Bundle.main.url(forResource: "main", withExtension: "jsbundle")
  #endif
 ```
 

--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -38,7 +38,7 @@ To install and use Expo modules, the easiest way to get up and running is with t
 
 ## Manual installation
 
-The following instructions apply to installing the latest version of Expo modules in React Native 0.76. For previous versions, check the [native upgrade helper](/bare/upgrade) to see how these files are customized.
+The following instructions apply to installing the latest version of Expo modules in React Native 0.79. For previous versions, check the [native upgrade helper](/bare/upgrade) to see how these files are customized.
 
 <InstallSection packageName="expo" cmd={['$ npm install expo']} hideBareInstructions />
 
@@ -52,7 +52,7 @@ Once installation is complete, apply the changes from the following diffs to con
 
 <DiffBlock source="/static/diffs/expo-ios.diff" />
 
-Optionally, you can also add additional delegate methods to your **AppDelegate.mm**. Some libraries may require them, so unless you have a good reason to leave them out, it is recommended to add them. [See delegate methods in AppDelegate.mm](https://github.com/expo/expo/blob/sdk-52/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.mm#L33-L60).
+Optionally, you can also add additional delegate methods to your **AppDelegate.swift**. Some libraries may require them, so unless you have a good reason to leave them out, it is recommended to add them. [See delegate methods in AppDelegate.swift](https://github.com/expo/expo/blob/sdk-53/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift#L24-L42).
 
 Save all of your changes and update your iOS Deployment Target in Xcode to `iOS 15.1`:
 

--- a/docs/public/static/diffs/expo-android.diff
+++ b/docs/public/static/diffs/expo-android.diff
@@ -89,7 +89,6 @@ index 8762b63..1e69c41 100644
 +expoAutolinking.useExpoModules()
 +expoAutolinking.useExpoVersionCatalog()
 +includeBuild(expoAutolinking.reactNativeGradlePlugin)
- /**
 diff --git a/android/build.gradle b/android/build.gradle
 index 9766946..6ee6b73 100644
 --- a/android/build.gradle

--- a/docs/public/static/diffs/expo-android.diff
+++ b/docs/public/static/diffs/expo-android.diff
@@ -1,53 +1,42 @@
 diff --git a/android/app/src/main/java/com/myapp/MainActivity.kt b/android/app/src/main/java/com/myapp/MainActivity.kt
-index cb23b47..13beb08 100644
+index 1789e54..b6ac31d 100644
 --- a/android/app/src/main/java/com/myapp/MainActivity.kt
 +++ b/android/app/src/main/java/com/myapp/MainActivity.kt
 @@ -1,4 +1,5 @@
  package com.myapp
 +import expo.modules.ReactActivityDelegateWrapper
+
  import com.facebook.react.ReactActivity
  import com.facebook.react.ReactActivityDelegate
- import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
-@@ -18,5 +18,5 @@ class MainActivity : ReactActivity() {
+@@ -18,5 +19,5 @@ class MainActivity : ReactActivity() {
     * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
     */
    override fun createReactActivityDelegate(): ReactActivityDelegate =
 -      DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
 +      ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled))
  }
-diff --git a/android/app/src/main/java/com/myapp/MainApplication.kt b/android/app/src/main/java/com/titoz/MainApplication.kt
-index 9fdd6df..2a521ff 100644
+diff --git a/android/app/src/main/java/com/myapp/MainApplication.kt b/android/app/src/main/java/com/myapp/MainApplication.kt
+index 6f58c28..24e3a00 100644
 --- a/android/app/src/main/java/com/myapp/MainApplication.kt
 +++ b/android/app/src/main/java/com/myapp/MainApplication.kt
-@@ -1,5 +1,8 @@
+@@ -1,4 +1,7 @@
  package com.myapp
 +import android.content.res.Configuration
 +import expo.modules.ApplicationLifecycleDispatcher
 +import expo.modules.ReactNativeHostWrapper
+
  import android.app.Application
  import com.facebook.react.PackageList
- import com.facebook.react.ReactApplication
-@@ -15,12 +18,13 @@ import com.facebook.soloader.SoLoader
+@@ -15,7 +18,7 @@ import com.facebook.soloader.SoLoader
  class MainApplication : Application(), ReactApplication {
 
    override val reactNativeHost: ReactNativeHost =
 -      object : DefaultReactNativeHost(this) {
--        override fun getPackages(): List<ReactPackage> =
--            PackageList(this).packages.apply {
--              // Packages that cannot be autolinked yet can be added manually here, for example:
--              // add(MyReactNativePackage())
--            }
 +      ReactNativeHostWrapper(this, object : DefaultReactNativeHost(this) {
-+        override fun getPackages(): List<ReactPackage> {
-+            val packages = PackageList(this).packages
-+            // Packages that cannot be autolinked yet can be added manually here, for example:
-+            // packages.add(new MyReactNativePackage());
-+            return packages
-+        }
-
-         override fun getJSMainModuleName(): String = "index"
-
-@@ -28,10 +32,10 @@ class MainApplication : Application(), ReactApplication {
+         override fun getPackages(): List<ReactPackage> =
+             PackageList(this).packages.apply {
+               // Packages that cannot be autolinked yet can be added manually here, for example:
+@@ -28,10 +31,10 @@ class MainApplication : Application(), ReactApplication {
 
          override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
          override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
@@ -60,7 +49,7 @@ index 9fdd6df..2a521ff 100644
 
    override fun onCreate() {
      super.onCreate()
-@@ -40,5 +44,10 @@ class MainApplication : Application(), ReactApplication {
+@@ -40,5 +43,11 @@ class MainApplication : Application(), ReactApplication {
        // If you opted-in for the New Architecture, we load the native entry point for this app.
        load()
      }
@@ -73,13 +62,40 @@ index 9fdd6df..2a521ff 100644
    }
  }
 diff --git a/android/settings.gradle b/android/settings.gradle
-index dd91c04..6b7789d 100644
+index 8762b63..1e69c41 100644
 --- a/android/settings.gradle
 +++ b/android/settings.gradle
-@@ -4,3 +4,6 @@ extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autoli
+@@ -1,6 +1,20 @@
+-pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
+-plugins { id("com.facebook.react.settings") }
+-extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
++pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin")
++  def expoPluginsPath = new File(
++    providers.exec {
++      workingDir(rootDir)
++      commandLine("node", "--print", "require.resolve('expo-modules-autolinking/package.json', { paths: [require.resolve('expo/package.json')] })")
++    }.standardOutput.asText.get().trim(),
++    "../android/expo-gradle-plugin"
++  ).absolutePath
++  includeBuild(expoPluginsPath)
++}
++plugins { id("com.facebook.react.settings")
++id("expo-autolinking-settings")
++}
++extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand(expoAutolinking.rnConfigCommand) }
  rootProject.name = 'myapp'
  include ':app'
  includeBuild('../node_modules/@react-native/gradle-plugin')
-+
-+apply from: new File(["node", "--print", "require.resolve('expo/package.json')"].execute(null, rootDir).text.trim(), "../scripts/autolinking.gradle")
-+useExpoModules()
++expoAutolinking.useExpoModules()
++expoAutolinking.useExpoVersionCatalog()
++includeBuild(expoAutolinking.reactNativeGradlePlugin)
+ /**
+diff --git a/android/build.gradle b/android/build.gradle
+index 9766946..6ee6b73 100644
+--- a/android/build.gradle
++++ b/android/build.gradle
+@@ -19,3 +19,4 @@ buildscript {
+ }
+
+ apply plugin: "com.facebook.react.rootproject"
++apply plugin: "expo-root-project"

--- a/docs/public/static/diffs/expo-ios.diff
+++ b/docs/public/static/diffs/expo-ios.diff
@@ -1,18 +1,68 @@
-diff --git a/ios/myapp/AppDelegate.h b/ios/myapp/AppDelegate.h
-index 5d28082..a7ebb51 100644
---- a/ios/myapp/AppDelegate.h
-+++ b/ios/myapp/AppDelegate.h
-@@ -1,6 +1,7 @@
- #import <RCTAppDelegate.h>
-+#import <Expo/Expo.h>
- #import <UIKit/UIKit.h>
+diff --git a/ios/myapp/AppDelegate.swift b/ios/myapp/AppDelegate.swift
+index d06a6a8..16f3098 100644
+--- a/ios/myapp/AppDelegate.swift
++++ b/ios/myapp/AppDelegate.swift
+@@ -1,48 +1,27 @@
+ import UIKit
++import Expo
+ import React
+ import React_RCTAppDelegate
+ import ReactAppDependencyProvider
 
--@interface AppDelegate : RCTAppDelegate
-+@interface AppDelegate : EXAppDelegateWrapper
+ @main
+-class AppDelegate: UIResponder, UIApplicationDelegate {
+-  var window: UIWindow?
++class AppDelegate: ExpoAppDelegate {
 
- @end
+-  var reactNativeDelegate: ReactNativeDelegate?
+-  var reactNativeFactory: RCTReactNativeFactory?
+-
+-  func application(
++  override func application(
+     _ application: UIApplication,
+     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+   ) -> Bool {
+-    let delegate = ReactNativeDelegate()
+-    let factory = RCTReactNativeFactory(delegate: delegate)
+-    delegate.dependencyProvider = RCTAppDependencyProvider()
+-
+-    reactNativeDelegate = delegate
+-    reactNativeFactory = factory
+-
+-    window = UIWindow(frame: UIScreen.main.bounds)
+-
+-    factory.startReactNative(
+-      withModuleName: "myapp",
+-      in: window,
+-      launchOptions: launchOptions
+-    )
+-
+-    return true
+-  }
+-}
+-
+-class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
+-  override func sourceURL(for bridge: RCTBridge) -> URL? {
+-    self.bundleURL()
++    self.moduleName = "myapp"
++    self.initialProps = [:]
++    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+   }
+
+   override func bundleURL() -> URL? {
+ #if DEBUG
+-    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
++    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
+ #else
+-    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
++    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+ #endif
+   }
+ }
++
+
 diff --git a/ios/Podfile b/ios/Podfile
-index 6bb6b6f..8c3834c 100644
+index f7583bb..626c42d 100644
 --- a/ios/Podfile
 +++ b/ios/Podfile
 @@ -1,3 +1,4 @@
@@ -20,18 +70,29 @@ index 6bb6b6f..8c3834c 100644
  # Resolve react_native_pods.rb with node to allow for hoisting
  require Pod::Executable.execute_command('node', ['-p',
    'require.resolve(
-@@ -15,6 +16,14 @@ if linkage != nil
+@@ -15,7 +16,24 @@ if linkage != nil
  end
 
  target 'myapp' do
+-  config = use_native_modules!
 +  use_expo_modules!
-+  post_integrate do |installer|
-+    begin
-+      expo_patch_react_imports!(installer)
-+    rescue => e
-+      Pod::UI.warn e
-+    end
++
++  if ENV['EXPO_USE_COMMUNITY_AUTOLINKING'] == '1'
++    config_command = ['node', '-e', "process.argv=['', '', 'config'];require('@react-native-community/cli').run()"];
++  else
++    config_command = [
++      'node',
++      '--no-warnings',
++      '--eval',
++      'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
++      'react-native-config',
++      '--json',
++      '--platform',
++      'ios'
++    ]
 +  end
-   config = use_native_modules!
++
++  config = use_native_modules!(config_command)
 
    use_react_native!(
+     :path => config[:reactNativePath],

--- a/docs/public/static/diffs/expo-ios.diff
+++ b/docs/public/static/diffs/expo-ios.diff
@@ -1,8 +1,8 @@
 diff --git a/ios/myapp/AppDelegate.swift b/ios/myapp/AppDelegate.swift
-index d06a6a8..16f3098 100644
+index d06a6a8..15a0034 100644
 --- a/ios/myapp/AppDelegate.swift
 +++ b/ios/myapp/AppDelegate.swift
-@@ -1,48 +1,27 @@
+@@ -1,25 +1,27 @@
  import UIKit
 +import Expo
  import React
@@ -11,55 +11,44 @@ index d06a6a8..16f3098 100644
 
  @main
 -class AppDelegate: UIResponder, UIApplicationDelegate {
--  var window: UIWindow?
 +class AppDelegate: ExpoAppDelegate {
+   var window: UIWindow?
 
--  var reactNativeDelegate: ReactNativeDelegate?
--  var reactNativeFactory: RCTReactNativeFactory?
--
+   var reactNativeDelegate: ReactNativeDelegate?
+   var reactNativeFactory: RCTReactNativeFactory?
+
 -  func application(
 +  override func application(
      _ application: UIApplication,
      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
    ) -> Bool {
--    let delegate = ReactNativeDelegate()
+     let delegate = ReactNativeDelegate()
 -    let factory = RCTReactNativeFactory(delegate: delegate)
--    delegate.dependencyProvider = RCTAppDependencyProvider()
--
--    reactNativeDelegate = delegate
--    reactNativeFactory = factory
--
--    window = UIWindow(frame: UIScreen.main.bounds)
--
--    factory.startReactNative(
--      withModuleName: "myapp",
--      in: window,
--      launchOptions: launchOptions
--    )
--
++    let factory = ExpoReactNativeFactory(delegate: delegate)
+     delegate.dependencyProvider = RCTAppDependencyProvider()
+
+     reactNativeDelegate = delegate
+     reactNativeFactory = factory
++    bindReactNativeFactory(factory)
+
+     window = UIWindow(frame: UIScreen.main.bounds)
+
+@@ -29,18 +31,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
+       launchOptions: launchOptions
+     )
+
 -    return true
--  }
--}
--
--class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
--  override func sourceURL(for bridge: RCTBridge) -> URL? {
--    self.bundleURL()
-+    self.moduleName = "myapp"
-+    self.initialProps = [:]
 +    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
    }
-
-   override func bundleURL() -> URL? {
- #if DEBUG
--    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
-+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
- #else
--    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
-+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
- #endif
-   }
  }
-+
+
+-class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
++class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
+   override func sourceURL(for bridge: RCTBridge) -> URL? {
+-    self.bundleURL()
++    // needed to return the correct URL for expo-dev-client.
++    bridge.bundleURL ?? bundleURL()
+   }
 
 diff --git a/ios/Podfile b/ios/Podfile
 index f7583bb..626c42d 100644

--- a/docs/ui/components/Snippet/DiffBlock.test.tsx
+++ b/docs/ui/components/Snippet/DiffBlock.test.tsx
@@ -12,10 +12,10 @@ const DIFF_PATH = '/static/diffs/expo-ios.diff';
 const DIFF_CONTENT = fs.readFileSync(path.join(dirname, '../../../public', DIFF_PATH)).toString();
 
 const validateDiffContent = (screen: Screen) => {
-  expect(screen.getByText('ios/myapp/AppDelegate.h')).toBeInTheDocument();
+  expect(screen.getByText('ios/myapp/AppDelegate.swift')).toBeInTheDocument();
   expect(screen.getByText('ios/Podfile')).toBeInTheDocument();
-  expect(screen.getByText('#import <UIKit/UIKit.h>')).toBeInTheDocument();
-  expect(screen.getByText('#import <Expo/Expo.h>')).toBeInTheDocument();
+  expect(screen.getByText('import UIKit')).toBeInTheDocument();
+  expect(screen.getByText('import Expo')).toBeInTheDocument();
 };
 
 describe(DiffBlock, () => {
@@ -28,7 +28,7 @@ describe(DiffBlock, () => {
 
     render(<DiffBlock source={DIFF_PATH} />);
 
-    await screen.findByText('ios/myapp/AppDelegate.h');
+    await screen.findByText('ios/myapp/AppDelegate.swift');
 
     validateDiffContent(screen);
   });


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Update Manual Instructions for Android and iOS to install expo-modules.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Run `npx install-expo-modules@latest` in a existing React Native project and update patch changes in `expo-android.diff` and `expo-ios.diff` files. Also, update instruction for iOS app delegate methods to be applied in `AppDelegate.swift` file from SDK 53 bare minimum tempalte.
- Update React Native version mentioned to 0.79.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Running docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
