### PR TITLE
[android][updates] Update proguard rules

### DIFF
--- a/packages/expo-updates/android/proguard-rules.pro
+++ b/packages/expo-updates/android/proguard-rules.pro
@@ -3,5 +3,5 @@
 }
 
 -keepclassmembers class com.facebook.react.devsupport.ReleaseDevSupportManager {
-  private final com.facebook.react.bridge.DefaultJSExceptionHandler defaultJSExceptionHandler;
+  private final com.facebook.react.bridge.JSExceptionHandler defaultJSExceptionHandler;
 }


### PR DESCRIPTION
# Why
With react native 0.79 the class name we need to keep in updates `ErrorRecovery` is the `JSExceptionHandler` instead of the  `DefaultJSExceptionHandler`

# How
Update proguard rules

# Test Plan
Bare-expo in release mode on the old arch

