### PR TITLE
fix(cli): Fix remote build cache providers types

### DIFF
--- a/packages/@expo/cli/src/utils/remote-build-cache-providers/index.ts
+++ b/packages/@expo/cli/src/utils/remote-build-cache-providers/index.ts
@@ -25,10 +25,6 @@ export const resolveRemoteBuildCacheProvider = (
     return { plugin: EASRemoteBuildCacheProvider, options: {} };
   }
 
-  if (typeof provider === 'object' && typeof provider.plugin === 'function') {
-    return provider as RemoteBuildCacheProvider;
-  }
-
   if (typeof provider === 'object' && typeof provider.plugin === 'string') {
     const plugin = resolvePluginFunction(projectRoot, provider.plugin);
 

--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -291,9 +291,11 @@ export interface ExpoConfig {
             /**
              * Service provider for remote builds.
              */
-            provider: 'eas' | {
-                plugin: string | object;
-                options: any;
+            provider?: 'eas' | {
+                plugin: string;
+                options?: {
+                    [k: string]: any;
+                };
             };
         };
     };

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -295,7 +295,14 @@ export interface ExpoConfig {
       /**
        * Service provider for remote builds.
        */
-      provider: 'eas' | { plugin: string | object; options: any };
+      provider?:
+        | 'eas'
+        | {
+            plugin: string;
+            options?: {
+              [k: string]: any;
+            };
+          };
     };
   };
   /**


### PR DESCRIPTION
# Why

We should simplify app.json and not support implementing functions directly. Users should instead pass in a path to a provider plugin

# How

Fix remote build cache providers types

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
