### PR TITLE
[create-expo-module][sdk-53] update devDependencies in template

### DIFF
--- a/packages/expo-module-template/$package.json
+++ b/packages/expo-module-template/$package.json
@@ -30,7 +30,7 @@
   "homepage": "<%- repo %>#readme",
   "dependencies": {},
   "devDependencies": {
-    "@types/react": "~18.3.12",
+    "@types/react": "~19.0.0",
     "expo-module-scripts": "^4.1.5",
     "expo": "~53.0.0",
     "react-native": "0.79.1"

--- a/packages/expo-module-template/$package.json
+++ b/packages/expo-module-template/$package.json
@@ -32,8 +32,8 @@
   "devDependencies": {
     "@types/react": "~18.3.12",
     "expo-module-scripts": "^4.1.5",
-    "expo": "~52.0.0",
-    "react-native": "0.76.0"
+    "expo": "~53.0.0",
+    "react-native": "0.79.1"
   },
   "peerDependencies": {
     "expo": "*",


### PR DESCRIPTION
# Why

Should be updated for SDK 53

# How

Bump versions

Maybe this can be automated in the future during `et publish-packages`

# Test Plan

There's not really a way to test the template because the create-expo-module command can only pull from NPM

# Checklist
- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
