### PR TITLE
[ios][calendar] Fix expo-calendar not returning day of the week on recurrence rule

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix event recurrence rules returning `dayOfTheWeek` as `undefined`. ([#36482](https://github.com/expo/expo/pull/36482) by [@ouwargui](https://github.com/ouwargui))
+
 ### 💡 Others
 
 ## 14.1.3 — 2025-04-25

--- a/packages/expo-calendar/ios/Conversions/Conversions.swift
+++ b/packages/expo-calendar/ios/Conversions/Conversions.swift
@@ -147,7 +147,7 @@ func serializeCalendar(item: EKCalendarItem, with formatter: DateFormatter) -> [
     if let daysOfTheWeek = rule.daysOfTheWeek {
       recurrenceRule["daysOfTheWeek"] = daysOfTheWeek.map({ day in
         [
-          "dayOfTheWeek": day.dayOfTheWeek,
+          "dayOfTheWeek": day.dayOfTheWeek.rawValue,
           "weekNumber": day.weekNumber
         ]
       })


### PR DESCRIPTION
# Why

When fetching events using `getEventsAsync` on iOS, the `dayOfTheWeek` property inside the `recurrenceRule.daysOfTheWeek` array is coming back as `undefined` instead of the expected numeric enum value (1 for Sunday, 2 for Monday, etc).

Closes #35888

# How

The issue lies in the native iOS serialization code. Specifically, in how the `EKRecurrenceDayOfWeek` object's `dayOfTheWeek` property (which is an `EKWeekday` enum) is being converted into the dictionary sent back to JavaScript. The code is attempting to serialize the enum type itself rather than its underlying integer value.

# Test Plan

Tested manually by using bare-expo app Calendar API. I would like to add automated tests, let me know if it's ok.


https://github.com/user-attachments/assets/599035ae-4c6c-4719-af31-5bb0db75a0b5


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
