### PR TITLE
docs: update example cli on splash-screen

### DIFF
--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -195,7 +195,7 @@ SplashScreen.setOptions({
 });
 ```
 
-If you prefer to use custom animation, see the [`with-splash-screen`](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
+If you prefer to use custom animation, see the [`with-splash-screen`](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen. You can initialize a new project from this example by running `npx create-expo-app --example with-splash-screen`.
 
 ## API
 


### PR DESCRIPTION
# Why

using 
```
npx create-react-native-app -t with-splash-screen
```
does not sparks joy

![CleanShot 2025-04-30 at 11 36 42](https://github.com/user-attachments/assets/5e56b28e-b6e8-4225-bb7b-33c1d070f568)

```
❯ npx create-react-native-app -t with-splash-screen

⚠️ This tool does not initialize new React Native projects.

It's recommended to use a framework to build apps with React Native, for example:

  Expo:
    npx create-expo-app

  React Native Community template:
    npx @react-native-community/cli init

Learn more: https://reactnative.dev/docs/environment-setup
```

# How

we should use

```
npx create-expo-app --example with-splash-screen
```

# Test Plan

tested on my laptop 

![CleanShot 2025-04-30 at 11 34 58](https://github.com/user-attachments/assets/26064ce9-4a80-41b6-a2ca-14eab33a6232)
