### PR TITLE
[eslint-config-expo] Disallow var

### DIFF
--- a/packages/eslint-config-expo/CHANGELOG.md
+++ b/packages/eslint-config-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `no-var` rule to disallow `var`. ([#36488](https://github.com/expo/expo/pull/36488) by [@kadikraman](https://github.com/kadikraman))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/eslint-config-expo/__tests__/__snapshots__/rules-flat-test.js.snap
+++ b/packages/eslint-config-expo/__tests__/__snapshots__/rules-flat-test.js.snap
@@ -1,5 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lints custom rules: fixtures/rule-no-var.js 1`] = `
+{
+  "errorCount": 1,
+  "fatalErrorCount": 0,
+  "fixableErrorCount": 1,
+  "fixableWarningCount": 0,
+  "messages": [
+    {
+      "column": 1,
+      "endColumn": 30,
+      "endLine": 3,
+      "fix": {
+        "range": [
+          58,
+          61,
+        ],
+        "text": "let",
+      },
+      "line": 3,
+      "message": "Unexpected var, use let or const instead.",
+      "messageId": "unexpectedVar",
+      "nodeType": "VariableDeclaration",
+      "ruleId": "no-var",
+      "severity": 2,
+    },
+  ],
+  "source": "const constAllowed = "Hello!";
+let letAllowed = "Hello!";
+var varNotAllowed = "Hello!";
+
+console.log(constAllowed, letAllowed, varNotAllowed);
+",
+  "suppressedMessages": [],
+  "usedDeprecatedRules": [],
+  "warningCount": 0,
+}
+`;
+
+exports[`lints custom rules: fixtures/rule-no-var.ts 1`] = `
+{
+  "errorCount": 1,
+  "fatalErrorCount": 0,
+  "fixableErrorCount": 1,
+  "fixableWarningCount": 0,
+  "messages": [
+    {
+      "column": 1,
+      "endColumn": 30,
+      "endLine": 3,
+      "fix": {
+        "range": [
+          58,
+          61,
+        ],
+        "text": "let",
+      },
+      "line": 3,
+      "message": "Unexpected var, use let or const instead.",
+      "messageId": "unexpectedVar",
+      "nodeType": "VariableDeclaration",
+      "ruleId": "no-var",
+      "severity": 2,
+    },
+  ],
+  "source": "const constAllowed = "Hello!";
+let letAllowed = "Hello!";
+var varNotAllowed = "Hello!";
+
+console.log(constAllowed, letAllowed, varNotAllowed);
+",
+  "suppressedMessages": [],
+  "usedDeprecatedRules": [],
+  "warningCount": 0,
+}
+`;
+
 exports[`lints custom rules: fixtures/rule-require.js 1`] = `
 {
   "errorCount": 0,

--- a/packages/eslint-config-expo/__tests__/__snapshots__/rules-test.js.snap
+++ b/packages/eslint-config-expo/__tests__/__snapshots__/rules-test.js.snap
@@ -1,5 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lints custom rules: fixtures/rule-no-var.js 1`] = `
+{
+  "errorCount": 1,
+  "fatalErrorCount": 0,
+  "fixableErrorCount": 1,
+  "fixableWarningCount": 0,
+  "messages": [
+    {
+      "column": 1,
+      "endColumn": 30,
+      "endLine": 3,
+      "fix": {
+        "range": [
+          58,
+          61,
+        ],
+        "text": "let",
+      },
+      "line": 3,
+      "message": "Unexpected var, use let or const instead.",
+      "messageId": "unexpectedVar",
+      "nodeType": "VariableDeclaration",
+      "ruleId": "no-var",
+      "severity": 2,
+    },
+  ],
+  "source": "const constAllowed = "Hello!";
+let letAllowed = "Hello!";
+var varNotAllowed = "Hello!";
+
+console.log(constAllowed, letAllowed, varNotAllowed);
+",
+  "suppressedMessages": [],
+  "usedDeprecatedRules": [],
+  "warningCount": 0,
+}
+`;
+
+exports[`lints custom rules: fixtures/rule-no-var.ts 1`] = `
+{
+  "errorCount": 1,
+  "fatalErrorCount": 0,
+  "fixableErrorCount": 1,
+  "fixableWarningCount": 0,
+  "messages": [
+    {
+      "column": 1,
+      "endColumn": 30,
+      "endLine": 3,
+      "fix": {
+        "range": [
+          58,
+          61,
+        ],
+        "text": "let",
+      },
+      "line": 3,
+      "message": "Unexpected var, use let or const instead.",
+      "messageId": "unexpectedVar",
+      "nodeType": "VariableDeclaration",
+      "ruleId": "no-var",
+      "severity": 2,
+    },
+  ],
+  "source": "const constAllowed = "Hello!";
+let letAllowed = "Hello!";
+var varNotAllowed = "Hello!";
+
+console.log(constAllowed, letAllowed, varNotAllowed);
+",
+  "suppressedMessages": [],
+  "usedDeprecatedRules": [],
+  "warningCount": 0,
+}
+`;
+
 exports[`lints custom rules: fixtures/rule-require.js 1`] = `
 {
   "errorCount": 0,

--- a/packages/eslint-config-expo/__tests__/fixtures/rule-no-var.js
+++ b/packages/eslint-config-expo/__tests__/fixtures/rule-no-var.js
@@ -1,0 +1,5 @@
+const constAllowed = "Hello!";
+let letAllowed = "Hello!";
+var varNotAllowed = "Hello!";
+
+console.log(constAllowed, letAllowed, varNotAllowed);

--- a/packages/eslint-config-expo/__tests__/fixtures/rule-no-var.ts
+++ b/packages/eslint-config-expo/__tests__/fixtures/rule-no-var.ts
@@ -1,0 +1,5 @@
+const constAllowed = "Hello!";
+let letAllowed = "Hello!";
+var varNotAllowed = "Hello!";
+
+console.log(constAllowed, letAllowed, varNotAllowed);

--- a/packages/eslint-config-expo/flat/utils/core.js
+++ b/packages/eslint-config-expo/flat/utils/core.js
@@ -84,6 +84,7 @@ module.exports = [
       'valid-typeof': 'error',
       'import/first': 'warn',
       'import/default': 'off',
+      'no-var': 'error',
     },
   },
   {

--- a/packages/eslint-config-expo/utils/core.js
+++ b/packages/eslint-config-expo/utils/core.js
@@ -48,6 +48,7 @@ module.exports = {
     'valid-typeof': 'error',
     'import/first': 'warn', //keep
     'import/default': 'off',
+    'no-var': 'error',
   },
   settings: {
     'import/extensions': jsExtensions,


### PR DESCRIPTION
# Why

It is a good practice to avoid using var in JavaScript in favour of `let` and `const`, because var has several problematic behaviors that can lead to bugs and unpredictable code:
- `var` is function scoped, not block scoped
- `var` is hoisted in a confusing way ("hoisted" to the top of their function or script, but their initialization is not)
- `var` allows redecleration

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Enable the `no-var` [rule](https://eslint.org/docs/latest/rules/no-var).

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Add a snapshot tests that verifies this rule for:
- `.js` with old config
- `.ts` legacy config
- `.js` flat config
- `.ts` flat config

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
