### PR TITLE
[docs] Document how to use remote build cache providers

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -181,7 +181,11 @@ export const general = [
     ),
     makeGroup(
       'Compile locally',
-      [makePage('guides/local-app-development.mdx'), makePage('guides/local-app-production.mdx')],
+      [
+        makePage('guides/local-app-development.mdx'),
+        makePage('guides/local-app-production.mdx'),
+        makePage('guides/cache-builds-remotely.mdx'),
+      ],
       {
         expanded: false,
       }

--- a/docs/pages/guides/cache-builds-remotely.mdx
+++ b/docs/pages/guides/cache-builds-remotely.mdx
@@ -132,7 +132,7 @@ At the root of your project, run `npm run build provider` to start the TypeScrip
 }
 ```
 
-When you run the `npx expo run` command inside your **example** directory, you should see your plugin’s console statements in the logs.
+When you run the `npx expo run` command inside your **example** directory, you should see your plugin's console statements in the logs.
 
 <Terminal cmd={['$ cd example', '$ npx expo run:ios']} />
 

--- a/docs/pages/guides/cache-builds-remotely.mdx
+++ b/docs/pages/guides/cache-builds-remotely.mdx
@@ -5,6 +5,7 @@ description: Accelerate local development by caching and reusing builds from a r
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 
 Remote build caching is an experimental feature that speeds up `npx expo run:[android|ios]` by caching builds remotely, based on the project [fingerprint](/versions/latest/sdk/fingerprint/).
 When you run `npx expo run:[android|ios]`, it checks if a build with a matching fingerprint exists, then downloads and launches it rather than compiling it again. Otherwise, the project is compiled as usual and then the resulting binary is uploaded to the remote cache for future runs.
@@ -73,13 +74,14 @@ type CalculateFingerprintHashProps = {
 };
 ```
 
-A reference implementation using Github Releases to cache builds can be found at in the [Remote Build Cache Provider Example](https://github.com/expo/examples/tree/master/with-github-remote-build-cache-provider)
+A reference implementation using GitHub Releases to cache builds can be found at in the [Remote Build Cache Provider Example](https://github.com/expo/examples/tree/master/with-github-remote-build-cache-provider)
 
 ## Creating a custom remote build provider
 
 Start by creating a **provider** directory for writing the provider plugin in TypeScript and add a **provider.plugin.js** file in the project root, which will be the plugin's entry point.
 
-### Create a provider/tsconfig.json file
+<Step label="1">
+### Create a `provider/tsconfig.json` file
 
 ```json provider/tsconfig.json
 {
@@ -93,7 +95,10 @@ Start by creating a **provider** directory for writing the provider plugin in Ty
 }
 ```
 
-### Create a provider/src/index.ts file for your plugin
+</Step>
+
+<Step label="2">
+### Create a `provider/src/index.ts` file for your plugin
 
 ```ts provider/src/index.ts
 import { RemoteBuildCachePlugin } from '@expo/config';
@@ -112,14 +117,27 @@ const plugin: RemoteBuildCachePlugin {
 export default plugin;
 ```
 
-### Create an provider.plugin.js file in the root directory
+</Step>
+
+<Step label="3">
+### Create an `provider.plugin.js` file in the root directory
 
 ```js provider.plugin.js
 // This file configures the entry file for your plugin.
 module.exports = require('./provider/build');
 ```
 
-At the root of your project, run `npm run build provider` to start the TypeScript compiler in watch mode. Next, configure your example project to use your plugin by adding the following line to the **example/app.json** file:
+</Step>
+
+<Step label="4">
+### Build your provider plugin
+
+At the root of your project, run `npm run build provider` to start the TypeScript compiler in watch mode.
+
+</Step>
+
+<Step label="5">
+### Configure your example project to use your plugin by adding the following line to the `example/app.json` file:
 
 ```json example/app.json
 {
@@ -134,11 +152,19 @@ At the root of your project, run `npm run build provider` to start the TypeScrip
 }
 ```
 
+</Step>
+
+<Step label="6">
+### Test your provider
 When you run the `npx expo run` command inside your **example** directory, you should see your plugin's console statements in the logs.
 
 <Terminal cmd={['$ cd example', '$ npx expo run:ios']} />
 
-### Pass custom options
+That's it! You now have a remote build cache provider to speed up your builds.
+
+</Step>
+
+### Passing custom options
 
 To inject custom options to your plugin you can use the `options` field and it will be forwarded as the second parameter of your custom functions. To do so modify the `remoteBuildCache` field in **example/app.json** as shown below:
 
@@ -157,5 +183,3 @@ To inject custom options to your plugin you can use the `options` field and it w
   }
 }
 ```
-
-That's it! You now have a remote build cache provider to speed up your builds.

--- a/docs/pages/guides/cache-builds-remotely.mdx
+++ b/docs/pages/guides/cache-builds-remotely.mdx
@@ -6,16 +6,16 @@ description: Accelerate local development by caching and reusing builds from a r
 
 import { Terminal } from '~/ui/components/Snippet';
 
-Remote build caching is an experimental feature that speeds up `npx expo run:[ios|android]` by caching builds remotely, based on the project [fingerprint](/versions/latest/sdk/fingerprint/).
-When you run `npx expo run:[ios|android]`, it checks if a build with a matching fingerprint exists, then downloads and launches it rather than compiling it again. Otherwise, the project is compiled as usual and then the resulting binary is uploaded to the remote cache for future runs,
+Remote build caching is an experimental feature that speeds up `npx expo run:[android|ios]` by caching builds remotely, based on the project [fingerprint](/versions/latest/sdk/fingerprint/).
+When you run `npx expo run:[android|ios]`, it checks if a build with a matching fingerprint exists, then downloads and launches it rather than compiling it again. Otherwise, the project is compiled as usual and then the resulting binary is uploaded to the remote cache for future runs.
 
 ## Using EAS as a remote build provider
 
-To use the EAS remote build provider plugin start by installing the `eas-build-cache-provider` package as a developer dependency:
+To use the EAS remote build provider plugin, start by installing the `eas-build-cache-provider` package as a developer dependency:
 
 <Terminal cmd={['$ npx expo install eas-build-cache-provider']} />
 
-Then update your **app.json** to
+Then, update your **app.json** to include the `remoteBuildCache` property and its provider under `experiments`:
 
 ```json app.json
 {
@@ -77,7 +77,7 @@ A reference implementation using Github Releases to cache builds can be found at
 
 ## Creating a custom remote build provider
 
-Start by creating a **provider** directory for writing the provider plugin in TypeScript and add an **provider.plugin.js** file in the project root, which will be the plugin's entry point.
+Start by creating a **provider** directory for writing the provider plugin in TypeScript and add a **provider.plugin.js** file in the project root, which will be the plugin's entry point.
 
 ### Create a provider/tsconfig.json file
 

--- a/docs/pages/guides/cache-builds-remotely.mdx
+++ b/docs/pages/guides/cache-builds-remotely.mdx
@@ -30,8 +30,6 @@ Then update your **app.json** to
 }
 ```
 
-## Creating a custom remote build provider
-
 You can roll your own cache provider by exporting a plugin that implements the following methods:
 
 ```ts
@@ -74,6 +72,10 @@ type CalculateFingerprintHashProps = {
   runOptions: RunOptions;
 };
 ```
+
+A reference implementation using Github Releases to cache builds can be found at in the [Remote Build Cache Provider Example](https://github.com/expo/examples/tree/master/with-github-remote-build-cache-provider)
+
+## Creating a custom remote build provider
 
 Start by creating a **provider** directory for writing the provider plugin in TypeScript and add an **provider.plugin.js** file in the project root, which will be the plugin's entry point.
 

--- a/docs/pages/guides/cache-builds-remotely.mdx
+++ b/docs/pages/guides/cache-builds-remotely.mdx
@@ -1,0 +1,159 @@
+---
+title: Use remote build cache providers
+sidebar_title: Cache builds remotely
+description: Accelerate local development by caching and reusing builds from a remote provider.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+Remote build cache is an experimental feature that allow users to search for a build with a matching fingerprint on a remote server when running `npx expo run:[ios|android]`.
+If a cached build exists, it downloads and launches it rather than compiling locally. Otherwise, it proceeds with a local build as usual and then uploads the resulting binary to the remote cache for future runs.
+
+## Using EAS as a remote build provider
+
+To use the EAS remote build provider plugin start by installing the `eas-build-cache-provider` package as a developer dependency:
+
+<Terminal cmd={['$ npx expo install eas-build-cache-provider']} />
+
+Then update your **app.json** to
+
+```json app.json
+{
+  "expo": {
+    ...
+    "experiments": {
+      "remoteBuildCache": {
+        "provider": "eas-build-cache-provider"
+      }
+    }
+  }
+}
+```
+
+## Creating a custom remote build provider
+
+You can roll your own cache provider by exporting a plugin that implements the following methods:
+
+```ts
+type RemoteBuildCachePlugin<T = any> = {
+  /**
+   * Try to fetch an existing build. Return its URL or null if missing.
+   */
+  resolveRemoteBuildCache(props: ResolveRemoteBuildCacheProps, options: T): Promise<string | null>;
+
+  /**
+   * Upload a new build binary. Return its URL or null on failure.
+   */
+  uploadRemoteBuildCache(props: UploadRemoteBuildCacheProps, options: T): Promise<string | null>;
+
+  /**
+   * (Optional) Customize the fingerprint hash algorithm.
+   */
+  calculateFingerprintHash?: (
+    props: CalculateFingerprintHashProps,
+    options: T
+  ) => Promise<string | null>;
+};
+
+type ResolveRemoteBuildCacheProps = {
+  projectRoot: string;
+  platform: 'android' | 'ios';
+  runOptions: RunOptions;
+  fingerprintHash: string;
+};
+type UploadRemoteBuildCacheProps = {
+  projectRoot: string;
+  buildPath: string;
+  runOptions: RunOptions;
+  fingerprintHash: string;
+  platform: 'android' | 'ios';
+};
+type CalculateFingerprintHashProps = {
+  projectRoot: string;
+  platform: 'android' | 'ios';
+  runOptions: RunOptions;
+};
+```
+
+Start by creating a **provider** directory for writing the provider plugin in TypeScript and add an **provider.plugin.js** file in the project root, which will be the plugin's entry point.
+
+### Create a provider/tsconfig.json file
+
+```json provider/tsconfig.json
+{
+  "extends": "expo-module-scripts/tsconfig.plugin",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+}
+```
+
+### Create a provider/src/index.ts file for your plugin
+
+```ts provider/src/index.ts
+import { RemoteBuildCachePlugin } from '@expo/config';
+
+const plugin: RemoteBuildCachePlugin {
+  resolveRemoteBuildCache: () => {
+    console.log('Searching for remote builds...')
+    return null;
+  },
+  uploadRemoteBuildCache: () => {
+    console.log('Uploading build to remote...')
+    return null;
+  },,
+};
+
+export default plugin;
+```
+
+### Create an provider.plugin.js file in the root directory
+
+```js provider.plugin.js
+// This file configures the entry file for your plugin.
+module.exports = require('./provider/build');
+```
+
+At the root of your project, run `npm run build provider` to start the TypeScript compiler in watch mode. Next, configure your example project to use your plugin by adding the following line to the **example/app.json** file:
+
+```json example/app.json
+{
+  "expo": {
+    ...
+    "experiments": {
+      "remoteBuildCache": {
+        "provider": "./provider.plugin.js"
+      }
+    }
+  }
+}
+```
+
+When you run the `npx expo run` command inside your **example** directory, you should see your plugin’s console statements in the logs.
+
+<Terminal cmd={['$ cd example', '$ npx expo run:ios']} />
+
+### Pass custom options
+
+To inject custom options to your plugin you can use the `options` field and it will be forwarded as the second parameter of your custom functions. To do so modify the `remoteBuildCache` field in **example/app.json** as shown below:
+
+```json example/app.json
+{
+  "expo": {
+    ...
+    "experiments": {
+      "remoteBuildCache": {
+        "provider": "./provider.plugin.js",
+        "options": {
+          "myCustomKey": "XXX-XXX-XXX"
+        }
+      }
+    }
+  }
+}
+```
+
+That's it! You now have a remote build cache provider to speed up your builds.

--- a/docs/pages/guides/cache-builds-remotely.mdx
+++ b/docs/pages/guides/cache-builds-remotely.mdx
@@ -6,8 +6,8 @@ description: Accelerate local development by caching and reusing builds from a r
 
 import { Terminal } from '~/ui/components/Snippet';
 
-Remote build cache is an experimental feature that allow users to search for a build with a matching fingerprint on a remote server when running `npx expo run:[ios|android]`.
-If a cached build exists, it downloads and launches it rather than compiling locally. Otherwise, it proceeds with a local build as usual and then uploads the resulting binary to the remote cache for future runs.
+Remote build caching is an experimental feature that speeds up `npx expo run:[ios|android]` by caching builds remotely, based on the project [fingerprint](/versions/latest/sdk/fingerprint/).
+When you run `npx expo run:[ios|android]`, it checks if a build with a matching fingerprint exists, then downloads and launches it rather than compiling it again. Otherwise, the project is compiled as usual and then the resulting binary is uploaded to the remote cache for future runs,
 
 ## Using EAS as a remote build provider
 


### PR DESCRIPTION
# Why

We should document how to implement custom remote build cache providers

# How

Adds a guide on how to use and create a custom remote build cache providers

# Test Plan

Run docs locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
