### PR TITLE
chore(cli): test latest LTS Node version `18 -> 20`

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -52,7 +52,7 @@ jobs:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -116,7 +116,7 @@ jobs:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -176,7 +176,7 @@ jobs:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -261,7 +261,7 @@ jobs:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
# Why

[Node 18 is EOL today! 🎉](https://nodejs.org/en/about/previous-releases#looking-for-the-latest-release-of-a-version-branch)  This updates the CLI action to start testing on Node 20.

# How

- Bumped versions in GitHub workflow

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
