### PR TITLE
[docs] Remove and update info that referenced SDK 50

### DIFF
--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -85,8 +85,6 @@ You'll be prompted to select an Expo username. This will be the username for you
 
 ### Expo CLI
 
-> Available with SDK 50 and above. For previous versions, the Expo CLI will use your SSO account after logging in via the EAS CLI.
-
 When using the Expo CLI, you can run the following command to log in to your Expo account.
 
 <Terminal cmd={['$ npx expo login --sso']} />

--- a/docs/pages/debugging/create-devtools-plugins.mdx
+++ b/docs/pages/debugging/create-devtools-plugins.mdx
@@ -7,8 +7,6 @@ import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **warning** Dev Tools plugins are compatible with SDK 50 and above.
-
 > **Tip**: Check out the [Expo DevTools Plugins](https://github.com/expo/dev-plugins) for complete examples.
 
 You can create a dev tools plugin, whether that's for inspecting aspects of a common framework or library or something specific to your custom code. This guide will walk you through creating a dev tools plugin.

--- a/docs/pages/debugging/devtools-plugins.mdx
+++ b/docs/pages/debugging/devtools-plugins.mdx
@@ -6,8 +6,6 @@ description: Learn about using dev tools plugins to inspect and debug your Expo 
 import { Terminal } from '~/ui/components/Snippet';
 import { Tab, Tabs } from '~/ui/components/Tabs';
 
-> **warning** Available from SDK 50 and above.
-
 Dev tools plugins are available in your local development environment to help you debug your app. They consist of a small amount of code you add to a project that enables two-way communication between the app and an external Chrome window. This setup provides display tools to inspect the app, trigger certain behaviors for testing, and more.
 
 Dev tools plugins are similar to Flipper plugins that are available in Development builds and Expo Go, and do not require adding native modules or config plugins to your project.

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -55,7 +55,6 @@ The `expo-font` config plugin allows embedding one or more font files in your pr
 However, this method also has some limitations:
 
 - Doesn't work with Expo Go since this method requires [creating a development build](/develop/development-builds/create-a-build/).
-- Only available for SDK 50 and above.
 
 To embed a font in a project, follow the steps below:
 

--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -9,9 +9,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 import { CODE } from '~/ui/components/Text';
 
-> **info** Available for SDK 50 and above ([`expo-updates`](/versions/latest/sdk/updates/) >= 0.23.0).
-
-SDK 50 added the experimental **asset selection feature**, which allows the developer to specify that only certain assets should be included in updates. This can greatly reduce the number of assets that need to be uploaded to and downloaded from the updates server. This feature will work with the EAS Update server or any custom server that complies with the [`expo-updates` protocol](/technical-specs/expo-updates-1).
+Experimental **asset selection feature** allows the developer to specify that only certain assets should be included in updates. This can greatly reduce the number of assets that need to be uploaded to and downloaded from the updates server. This feature will work with the EAS Update server or any custom server that complies with the [`expo-updates` protocol](/technical-specs/expo-updates-1).
 
 SDK 52 launched this feature to general availability.
 

--- a/docs/pages/eas-update/optimize-assets.mdx
+++ b/docs/pages/eas-update/optimize-assets.mdx
@@ -7,7 +7,7 @@ description: Learn how EAS Update downloads assets and how to optimize them for 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **info** For SDK 50 and above, the new [asset selection feature](/eas-update/asset-selection) can greatly reduce the total number and size of downloaded assets.
+> **info** The new [asset selection feature](/eas-update/asset-selection) can greatly reduce the total number and size of downloaded assets.
 
 When an app finds a new update, it downloads a manifest and then downloads any new or updated assets so that it can run the update. The process is as follows:
 

--- a/docs/pages/guides/apple-privacy.mdx
+++ b/docs/pages/guides/apple-privacy.mdx
@@ -41,7 +41,7 @@ You can include an iOS privacy manifest by using the `privacyManifests` field un
 }
 ```
 
-> Available with SDK 50 and above. Make sure you have updated your Expo SDK libraries to the latest versions for your SDK version using `npx expo install --fix`. For SDK versions below 50, use the [`expo-privacy-manifest-polyfill-plugin`](https://www.npmjs.com/package/expo-privacy-manifest-polyfill-plugin).
+Make sure you have updated your Expo SDK libraries to the latest versions for your SDK version using `npx expo install --fix`.
 
 <ConfigReactNative>
 

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -11,7 +11,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **Warning** TV development is available only in SDK 50 and above. Not all Expo features and SDK libraries are available on TV. For more details, check the [See which libraries are supported](#see-which-libraries-are-supported).
+> **Warning** Not all Expo features and SDK libraries are available on TV. For more details, check the [See which libraries are supported](#see-which-libraries-are-supported).
 
 React Native is supported on Android TV and Apple TV through the [React Native TV project](https://github.com/react-native-tvos/react-native-tvos). This technology extends beyond TV, offering a comprehensive core repo fork with support for phone and TV targets, including Hermes and Fabric.
 

--- a/docs/pages/guides/customizing-metro.mdx
+++ b/docs/pages/guides/customizing-metro.mdx
@@ -135,7 +135,7 @@ This technique can be used with Expo Router to automatically split the bundle ba
 
 ## Web support
 
-Expo CLI has support for bundling websites using Metro. This is the same bundler used for native apps, and it is designed to be universal across platforms. It is the recommended bundler for web projects in Expo SDK 50 and greater.
+Expo CLI has support for bundling websites using Metro. This is the same bundler used for native apps, and it is designed to be universal across platforms. It is the recommended bundler for web projects.
 
 ### Expo webpack versus Expo Metro
 

--- a/docs/pages/guides/in-app-purchases.mdx
+++ b/docs/pages/guides/in-app-purchases.mdx
@@ -8,13 +8,7 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import RedirectNotification from '~/ui/components/RedirectNotification';
 import { CODE } from '~/ui/components/Text';
-
-<RedirectNotification>
-  The `expo-in-app-purchases` library has been removed from SDK 50 onwards. If you are using this
-  library, you will need to migrate to a third-party library as mentioned below.
-</RedirectNotification>
 
 In-app purchases (IAP) are transactions within a mobile or desktop application where users can buy digital goods or additional features. This guide provides a list of popular libraries and tutorials for implementing IAP in your Expo app.
 

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -256,7 +256,7 @@ As mentioned earlier, using monorepos is not for everyone. You take on increased
 
 ### Multiple React Native versions within the monorepo
 
-Expo SDK 50 and higher has improved support for more complete **node_modules** patterns, such as isolated modules. Unfortunately, React Native can still cause issues when installing multiple versions inside a single monorepo. Because of that, it's recommended to only use a single version of React Native.
+Expo SDK has improved support for more complete **node_modules** patterns, such as isolated modules. Unfortunately, React Native can still cause issues when installing multiple versions inside a single monorepo. Because of that, it's recommended to only use a single version of React Native.
 
 You can check if your monorepo has multiple React Native versions and why they are installed through the package manager you use.
 

--- a/docs/pages/guides/publishing-websites.mdx
+++ b/docs/pages/guides/publishing-websites.mdx
@@ -301,7 +301,7 @@ In case you want to change the header for hosting add the following config for `
 
 [GitHub Pages](https://pages.github.com/) allows you to publish a website directly from a GitHub repository.
 
-> **warning** GitHub Pages deployment requires Expo SDK 50 or higher, and uses experimental `baseUrl` functionality that may not work as intended.
+> **warning** GitHub Pages deployment uses experimental `baseUrl` functionality that may not work as intended.
 
 <Step label="1">
 

--- a/docs/pages/guides/tree-shaking.mdx
+++ b/docs/pages/guides/tree-shaking.mdx
@@ -91,7 +91,7 @@ To improve speed, Expo CLI only performs code elimination in production builds. 
 
 ## Custom code removal
 
-With Expo SDK 50, `EXPO_PUBLIC_` environment variables are inlined before the minification process. This means they can be used to remove code from the production bundle. For example:
+`EXPO_PUBLIC_` environment variables are inlined before the minification process. This means they can be used to remove code from the production bundle. For example:
 
 <Step label="1">
 

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -117,7 +117,7 @@ For example, to import `Button` component from **src/components/Button.tsx** usi
 }
 ```
 
-<Collapsible summary="Disable path aliases for SDK 50 and above">
+<Collapsible summary="Disable path aliases">
 
 `tsconfigPaths` is enabled by default which allows you to set path aliases. You can disable it by setting `tsconfigPaths` to `false` in the project's [app config](/workflow/configuration/):
 

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -6,9 +6,7 @@ description: A guide on configuring ESLint and Prettier to format Expo apps.
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
-import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 [ESLint](https://eslint.org/) is a JavaScript linter that helps you find and fix errors in your code. It's a great tool to help you write better code and catch mistakes before they make it to production. In conjunction, you can use [Prettier](https://prettier.io/docs/en/), a code formatter that ensures all the code files follow a consistent styling.
@@ -19,75 +17,17 @@ This guide provides steps to set up and configure ESLint and Prettier.
 
 ### Setup
 
+> **info** From **SDK 53** onwards, the created ESLint config file uses the [Flat config](https://eslint.org/blog/2022/08/new-config-system-part-2/) format. However, legacy config is also supported.
+
 To set up ESLint in your Expo project, you can use the Expo CLI to install the necessary dependencies. Running this command also creates a **eslint.config.js** file at the root of your project which extends configuration from [`eslint-config-expo`](https://github.com/expo/expo/tree/main/packages/eslint-config-expo).
 
 <Terminal cmd={['# Install and configure ESLint', '$ npx expo lint']} />
-
-> **info** From **SDK 53** onwards, the created ESLint config file will use the [Flat config](https://eslint.org/blog/2022/08/new-config-system-part-2/) format. However, legacy config will also be supported.
-
-<Collapsible summary="Setup instructions for SDK 50 and below">
-
-<Step label="1">
-
-Install ESLint, and [`eslint-config-expo`](https://github.com/expo/expo/tree/main/packages/eslint-config-expo) in your project.
-
-<Tabs>
-
-<Tab label="macOS/Linux">
-
-<Terminal cmd={['$ npx expo install eslint@8 eslint-config-expo --dev']} />
-
-</Tab>
-
-<Tab label="Windows">
-
-<Terminal cmd={['$ npx expo install eslint@8 eslint-config-expo "--" --dev']} />
-
-</Tab>
-
-</Tabs>
-
-</Step>
-
-<Step label="2">
-
-Create an ESLint configuration file called **.eslintrc.js** at the root of your project. The configuration in **.eslintrc.js** extends [`eslint-config-expo`](https://github.com/expo/expo/tree/main/packages/eslint-config-expo).
-
-```js .eslintrc.js
-module.exports = {
-  extends: 'expo',
-};
-```
-
-</Step>
-
-<Step label="3">
-
-Add a `script` to your **package.json** to run ESLint.
-
-```json package.json
-{
-  "scripts": {
-    "lint": "expo lint"
-  }
-}
-```
-
-You can replace the `.` with specific directories or files to lint. For example, if you use Expo Router, you can use the `eslint app` command to lint only your routes inside the **app** directory.
-
-</Step>
-
-</Collapsible>
 
 ### Usage
 
 > **info** **Recommended:** If you're using VS Code, install the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) to lint your code as you type.
 
 You can lint your code manually from the command line with the `npx expo lint` script:
-
-<Tabs>
-
-<Tab label="For SDK 51 and above">
 
 <Terminal
   cmd={[
@@ -109,16 +49,6 @@ Running the above command will run the `lint` script from **package.json**.
     '✖ 1 problem (0 errors, 1 warning)',
   ]}
 />
-
-</Tab>
-
-<Tab label="For SDK 50 and below">
-
-<Terminal cmd={['$ npm run lint']} />
-
-</Tab>
-
-</Tabs>
 
 ### Environment configuration
 

--- a/docs/pages/modules/additional-platform-support.mdx
+++ b/docs/pages/modules/additional-platform-support.mdx
@@ -13,7 +13,7 @@ Currently, only **macOS** and **tvOS** platforms are supported. This guide will 
 
 ## Use the `"apple"` platform in `expo-module.config.json`
 
-To provide seamless support for other Apple platforms, Expo SDK 50 introduced a universal `"apple"` platform to instruct the [autolinking](/modules/autolinking/) that the module may support any of the Apple platform and whether to link the module in the specific CocoaPods target is moved off to the podspec. If you have used `"ios"` before, you can safely replace it:
+To provide seamless support for other Apple platforms, Expo SDK introduced a universal `"apple"` platform to instruct the [autolinking](/modules/autolinking/) that the module may support any of the Apple platform and whether to link the module in the specific CocoaPods target is moved off to the podspec. If you have used `"ios"` before, you can safely replace it:
 
 ```diff expo-module.config.json
 {

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -260,11 +260,11 @@ The following options are provided:
 - `--max-workers <number>`: Maximum number of tasks to allow the bundler to spawn. Setting this to `0` will run all transpilation on the same process, meaning you can easily debug Babel transpilation.
 - `-c, --clear`: Clear the bundler cache before exporting.
 - `--no-minify`: Skip minifying JavaScript and CSS assets.
-- `--no-bytecode`: Skip generating Hermes bytecode for native platforms (SDK 50 and above). Only use this for analyzing bundle sizes and never ship UTF-8 bundles to native platforms as this will lead to drastically longer startup times.
+- `--no-bytecode`: Skip generating Hermes bytecode for native platforms. Only use this for analyzing bundle sizes and never ship UTF-8 bundles to native platforms as this will lead to drastically longer startup times.
 
 #### Hosting with sub-paths
 
-> Experimental functionality. Available from SDK 50.
+> Experimental functionality.
 
 You can configure the prefix for static assets by setting the `experiments.baseUrl` field in your [app config](/workflow/configuration/):
 

--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -146,8 +146,6 @@ module.exports = function (api) {
 };
 ```
 
-If you're upgrading from a version of Expo Router that is older than v3, remove the `plugins: ['expo-router/babel']`. `expo-router/babel` was merged in `babel-preset-expo` in SDK 50 (Expo Router v3).
-
 </Step>
 
 <Step label="5">

--- a/docs/pages/router/migrate/from-expo-webpack.mdx
+++ b/docs/pages/router/migrate/from-expo-webpack.mdx
@@ -103,11 +103,11 @@ Due to limitations on native, hosting with fake HTTPS is not currently supported
 
 The [`expo-constants`](/versions/latest/sdk/constants/) library can be used to access the **app.json** in-app. Behind the scenes, this is accomplished by setting `process.env.APP_MANIFEST` with the stringified contents of the **app.json** file.
 
-In Expo Router, this is done using Babel with the `expo-router/babel` in SDK 49 and lower and `babel-preset-expo` in SDK 50 and higher. If you modify the **app.json**, restart the Babel cache with `npx expo start --clear` to see the updates.
+In Expo Router, this is done using Babel with the `babel-preset-expo`. If you modify the **app.json**, restart the Babel cache with `npx expo start --clear` to see the updates.
 
 ## Base path and subpath hosting
 
-> Experimental functionality. It will be available from SDK 50.
+> **important** Experimental functionality.
 
 In `@expo/webpack-config`, you could bundle your website to be hosted from a subpath by using the `PUBLIC_URL` environment variable or the `homepage` field in the project's **package.json**:
 

--- a/docs/pages/router/reference/async-routes.mdx
+++ b/docs/pages/router/reference/async-routes.mdx
@@ -32,7 +32,7 @@ For those familiar with advanced bundling techniques, the async routes feature i
 
 Enable the feature by setting the `asyncRoutes` option in the Expo Router config plugin of your [app config](/versions/latest/config/app/):
 
-    > SDK 50 and above supports production bundle splitting. Set `asyncRoutes` to `true` to enable it.
+    > Set `asyncRoutes` to `true` to enable production bundle splitting.
 
     ```json app.json
     {

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -389,8 +389,6 @@ Expo's Metro config injects build settings that can be used in the client bundle
 
 ## Bundle splitting
 
-> This feature is web-only in SDK 50 and above.
-
 Expo CLI automatically splits web bundles into multiple chunks based on async imports in production. This feature requires `@expo/metro-runtime` to be installed and imported somewhere in the entry bundle (available by default in Expo Router).
 
 Shared dependencies of async bundles are merged into a single chunk to reduce the number of requests. For example, if you have two async bundles that import `lodash`, then the library is merged into a single initial chunk.
@@ -669,7 +667,7 @@ In your **ios/&lt;Project&gt;.xcodeproj/project.pbxproj** file, replace the foll
 
 #### "Start Packager" script
 
-Remove the **"Start Packager"** script in SDK 50 and higher. The dev server must be started with `npx expo` before/after running the app.
+Remove the **"Start Packager"** script. The dev server must be started with `npx expo` before/after running the app.
 
 ```diff Start Packager
 -    FD10A7F022414F080027D42C /* Start Packager */ = {

--- a/docs/pages/versions/v53.0.0/config/metro.mdx
+++ b/docs/pages/versions/v53.0.0/config/metro.mdx
@@ -389,8 +389,6 @@ Expo's Metro config injects build settings that can be used in the client bundle
 
 ## Bundle splitting
 
-> This feature is web-only in SDK 50 and above.
-
 Expo CLI automatically splits web bundles into multiple chunks based on async imports in production. This feature requires `@expo/metro-runtime` to be installed and imported somewhere in the entry bundle (available by default in Expo Router).
 
 Shared dependencies of async bundles are merged into a single chunk to reduce the number of requests. For example, if you have two async bundles that import `lodash`, then the library is merged into a single initial chunk.
@@ -669,7 +667,7 @@ In your **ios/&lt;Project&gt;.xcodeproj/project.pbxproj** file, replace the foll
 
 #### "Start Packager" script
 
-Remove the **"Start Packager"** script in SDK 50 and higher. The dev server must be started with `npx expo` before/after running the app.
+Remove the **"Start Packager"** script. The dev server must be started with `npx expo` before/after running the app.
 
 ```diff Start Packager
 -    FD10A7F022414F080027D42C /* Start Packager */ = {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #36493

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove and update info that referenced SDK 50 from multiple defaults. Any feature released in SDK 50 is now available in SDK 53.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
