### PR TITLE
[core][Android] Fix `extraMavenRepos` not applied on gradle subprojects

### DIFF
--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
@@ -112,11 +112,18 @@ class SettingsManager(
     }
 
     settings.gradle.beforeRootProject { rootProject: Project ->
-      config.allPlugins.forEach(rootProject::linkBuildDependence)
-      config.extraDependencies.forEach { mavenConfig ->
+      val extraDependency = config.extraDependencies
+      extraDependency.forEach { mavenConfig ->
         rootProject.logger.quiet("Adding extra maven repository: ${mavenConfig.url}")
-        rootProject.linkMavenRepository(mavenConfig)
+
       }
+      rootProject.allprojects { project ->
+        extraDependency.forEach { mavenConfig ->
+          project.linkMavenRepository(mavenConfig)
+        }
+      }
+
+      config.allPlugins.forEach(rootProject::linkBuildDependence)
 
       // Adds maven repositories for all projects that are using the publication.
       // It most likely means that we will add "https://maven.pkg.github.com/expo/expo" to the repositories.

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/ProjectExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/ProjectExtension.kt
@@ -37,7 +37,7 @@ internal fun Project.linkMavenRepository(mavenRepo: MavenRepo) {
   val (url, credentials, authentication) = mavenRepo
 
   repositories.maven { maven ->
-    maven.url = URI.create(url)
+    maven.setUrl(url)
     maven.applyCredentials(credentials)
     maven.applyAuthentication(authentication)
   }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `extraMavenRepos` not applied on Gradle subprojects.
+- Fixed `extraMavenRepos` not applied on Gradle subprojects. ([#36500](https://github.com/expo/expo/pull/36500) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `extraMavenRepos` not applied on Gradle subprojects.
+
 ### 💡 Others
 
 ## 2.3.11 — 2025-04-28


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/36229 

# How

Make sure to apply `extraDependency` to all projects. It's a temporary fix as it isn't an intended use case. Packages should be self-contained. Defining repositories that need to be used to resolve package-specific dependencies should be part of the package. 

# Test Plan

- https://github.com/janwiebe-jump/sdk-53-extramavenrepos?rgh-link-date=2025-04-17T13:15:51.000Z ✅ 