### PR TITLE
fix(cli): lookup absolute asset paths correctly in the ssr manifest for server components

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -52,7 +52,7 @@ jobs:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -116,7 +116,7 @@ jobs:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -176,7 +176,7 @@ jobs:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -261,7 +261,7 @@ jobs:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Lookup absolute asset paths correctly when used as server components.
+
 ### 💡 Others
 
 ## 0.24.6 — 2025-04-28

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Lookup absolute asset paths correctly when used as server components.
+- Lookup absolute asset paths correctly when used as server components. ([#36501](https://github.com/expo/expo/pull/36501) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/e2e/__tests__/export-dom-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-dom-test.ts
@@ -263,7 +263,8 @@ describe('Export DOM Components', () => {
     const outputFilesWithoutMap = outputFiles.filter(
       (file) => !(file.startsWith('www.bundle/') && file.endsWith('.map'))
     );
-    expect(outputFilesWithoutMap).toEqual([
+
+    const expectedItemsUnsorted = [
       expect.stringMatching(/_expo\/static\/js\/ios\/AppEntry-[\w\d]+\.hbc$/),
       expect.stringMatching(/_expo\/static\/js\/ios\/AppEntry-[\w\d]+\.hbc\.map$/),
       'assetmap.json',
@@ -280,7 +281,9 @@ describe('Export DOM Components', () => {
       expect.stringMatching(/^www\.bundle\/[\w\d]{32}\.html$/),
       expect.stringMatching(/^www\.bundle\/[\w\d]{32}\.js$/),
       expect.stringMatching(/^www\.bundle\/[\w\d]{32}\.css$/),
-    ]);
+    ];
+    expect(outputFilesWithoutMap).toEqual(expect.arrayContaining(expectedItemsUnsorted));
+    expect(outputFilesWithoutMap).toHaveLength(expectedItemsUnsorted.length);
   });
 });
 

--- a/packages/@expo/cli/src/start/server/metro/createServerComponentsMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/createServerComponentsMiddleware.ts
@@ -366,10 +366,10 @@ export function createServerComponentsMiddleware(
     );
 
     return (file: string, isServer: boolean) => {
-      const filePath = path.join(
-        projectRoot,
-        file.startsWith('file://') ? fileURLToFilePath(file) : file
-      );
+      // NOTE(cedric): assets are being passed as absolute file paths
+      const filePath = path.isAbsolute(file)
+        ? file
+        : path.join(projectRoot, file.startsWith('file://') ? fileURLToFilePath(file) : file);
 
       if (isExporting) {
         assert(context.ssrManifest, 'SSR manifest must exist when exporting');


### PR DESCRIPTION
# Why

See #36497

When upgrading to Node 20, I noticed the [Windows CI tests were failing due to something blocking the process](https://github.com/expo/expo/actions/runs/14761169900/job/41441959043?pr=36497). Turns out that there was an actual assertion error being invoked, without it being visible on macos/linux.

<img width="1796" alt="image" src="https://github.com/user-attachments/assets/1fdf3219-bec4-40c6-acb9-ac06a45e6c99" />


# How

It seems that assets are passed as absolute paths, which may be unexpected. Because of that, it tries to append the project root to an absolute path. This removes that part.

# Test Plan

See `yarn test:e2e e2e/__tests__/export/export-embed-rsc.test.ts`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
