### PR TITLE
[expo] Update new arch check for new default

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Update new arch check in Expo Go to account for new default behavior of `newArchEnabled` (now `true` when not specified in SDK 53).
+
 ### 💡 Others
 
 ## 53.0.4 — 2025-04-30

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Update new arch check in Expo Go to account for new default behavior of `newArchEnabled` (now `true` when not specified in SDK 53).
+- Update new arch check in Expo Go to account for new default behavior of `newArchEnabled` (now `true` when not specified in SDK 53). ([#36506](https://github.com/expo/expo/pull/36506) by [@brentvatne](https://github.com/brentvatne))
 
 ### 💡 Others
 

--- a/packages/expo/src/Expo.fx.tsx
+++ b/packages/expo/src/Expo.fx.tsx
@@ -21,11 +21,12 @@ if (isRunningInExpoGo()) {
 // but your builds will have the New Architecture disabled.
 if (__DEV__ && isRunningInExpoGo() && process.env.NODE_ENV === 'development') {
   (['android', 'ios'] as const).forEach((platform) => {
-    const isNewArchEnabledForPlatform = Constants.expoConfig?.[platform]?.newArchEnabled;
-    const isNewArchEnabledAtRoot = Constants.expoConfig?.newArchEnabled;
+    const newArchPlatformConfig = Constants.expoConfig?.[platform]?.newArchEnabled;
+    const newArchRootConfig = Constants.expoConfig?.newArchEnabled;
+
     const isNewArchExplicitlyDisabled =
-      isNewArchEnabledForPlatform === false ||
-      (isNewArchEnabledForPlatform === undefined && isNewArchEnabledAtRoot === false);
+      newArchPlatformConfig === false ||
+      (newArchPlatformConfig === undefined && newArchRootConfig === false);
 
     if (Platform.OS === platform && isNewArchExplicitlyDisabled) {
       // Wrap it in rAF to show the warning after the React Native DevTools message

--- a/packages/expo/src/Expo.fx.tsx
+++ b/packages/expo/src/Expo.fx.tsx
@@ -21,15 +21,17 @@ if (isRunningInExpoGo()) {
 // but your builds will have the New Architecture disabled.
 if (__DEV__ && isRunningInExpoGo() && process.env.NODE_ENV === 'development') {
   (['android', 'ios'] as const).forEach((platform) => {
-    if (
-      Platform.OS === platform &&
-      Constants.expoConfig?.[platform]?.newArchEnabled !== true &&
-      Constants.expoConfig?.newArchEnabled !== true
-    ) {
+    const isNewArchEnabledForPlatform = Constants.expoConfig?.[platform]?.newArchEnabled;
+    const isNewArchEnabledAtRoot = Constants.expoConfig?.newArchEnabled;
+    const isNewArchExplicitlyDisabled =
+      isNewArchEnabledForPlatform === false ||
+      (isNewArchEnabledForPlatform === undefined && isNewArchEnabledAtRoot === false);
+
+    if (Platform.OS === platform && isNewArchExplicitlyDisabled) {
       // Wrap it in rAF to show the warning after the React Native DevTools message
       requestAnimationFrame(() => {
         console.warn(
-          `🚨 React Native's New Architecture is always enabled in Expo Go, but it is not explicitly enabled in your project's app config. This may lead to unexpected behavior when creating a production or development build. Set "newArchEnabled": true in your app.json.\nLearn more: https://docs.expo.dev/guides/new-architecture/`
+          `🚨 React Native's New Architecture is always enabled in Expo Go, but it is explicitly disabled in your project's app config. This may lead to unexpected behavior when creating a production or development build. Remove "newArchEnabled": false from your app.json.\nLearn more: https://docs.expo.dev/guides/new-architecture/`
         );
       });
     }


### PR DESCRIPTION
# Why

If you leave `newArchEnabled` blank in app config, you're warned in Expo Go right now. But in SDK 53, `newArchEnabled` defaults to true -- so this is actually fine.