### PR TITLE
[cli]: Fix E2E export-dom-test output order

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/export-dom-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-dom-test.ts
@@ -263,7 +263,7 @@ describe('Export DOM Components', () => {
     const outputFilesWithoutMap = outputFiles.filter(
       (file) => !(file.startsWith('www.bundle/') && file.endsWith('.map'))
     );
-    expect(outputFilesWithoutMap).toEqual([
+    expect(outputFilesWithoutMap.sort()).toEqual([
       expect.stringMatching(/_expo\/static\/js\/ios\/AppEntry-[\w\d]+\.hbc$/),
       expect.stringMatching(/_expo\/static\/js\/ios\/AppEntry-[\w\d]+\.hbc\.map$/),
       'assetmap.json',
@@ -277,8 +277,8 @@ describe('Export DOM Components', () => {
 
       'metadata.json',
 
-      expect.stringMatching(/^www\.bundle\/[\w\d]{32}\.html$/),
       expect.stringMatching(/^www\.bundle\/[\w\d]{32}\.js$/),
+      expect.stringMatching(/^www\.bundle\/[\w\d]{32}\.html$/),
       expect.stringMatching(/^www\.bundle\/[\w\d]{32}\.css$/),
     ]);
   });


### PR DESCRIPTION
# Why

I'm unsure the direct cause, but on `main` this E2E test is failing simply due to the order of assertions.

This is reproducible with `CI=true yarn test:e2e`, which disables the local e2e cache & forcing a yarn install before each test

# How

Updated the test to sort the files for a guaranteed order