### PR TITLE
Docs: Fix wrong import path for Expo Router's `Stack`.

### DIFF
--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -31,7 +31,7 @@ This file structure produces a layout where the `index` route is the first route
 You can use the **app/\_layout.tsx** file to define your app's `Stack` navigator with these two routes:
 
 ```tsx app/_layout.tsx
-import { Stack } from 'expo-router/stack';
+import { Stack } from 'expo-router';
 
 export default function Layout() {
   return <Stack />;


### PR DESCRIPTION
# Why

Broken

# How

I did this by hand.

# Test Plan

Test in prod.

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
