### PR TITLE
[expo-go] Splashscreen fallback on older devices

### DIFF
--- a/apps/expo-go/android/app/src/main/res/layout/splash_screen_view.xml
+++ b/apps/expo-go/android/app/src/main/res/layout/splash_screen_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/splashLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="150dp"
+        android:layout_height="150dp"
+        android:layout_gravity="center"
+        android:src="@drawable/splashscreen_image"
+        android:contentDescription="splash image" />
+</FrameLayout>

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
@@ -3,11 +3,13 @@ package host.exp.exponent.experience
 
 import android.content.Intent
 import android.content.res.Configuration
+import android.os.Build
 import android.os.Bundle
 import android.os.Debug
 import android.view.View
 import android.view.ViewTreeObserver
 import android.view.animation.AccelerateInterpolator
+import android.window.SplashScreenView
 import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
@@ -3,13 +3,11 @@ package host.exp.exponent.experience
 
 import android.content.Intent
 import android.content.res.Configuration
-import android.os.Build
 import android.os.Bundle
 import android.os.Debug
 import android.view.View
 import android.view.ViewTreeObserver
 import android.view.animation.AccelerateInterpolator
-import android.window.SplashScreenView
 import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
@@ -135,7 +135,7 @@ class ExponentPackage : ReactPackage {
         nativeModules.addAll(SvgPackage().getReactModuleInfoProvider().getReactModuleInfos().map { SvgPackage().getModule(it.value.name, reactContext)!! })
         nativeModules.addAll(MapsPackage().createNativeModules(reactContext))
         nativeModules.addAll(RNDateTimePickerPackage().getReactModuleInfoProvider().getReactModuleInfos().map { RNDateTimePickerPackage().getModule(it.value.name, reactContext)!! })
-        nativeModules.addAll(stripePackage.createNativeModules(reactContext))
+        nativeModules.addAll(stripePackage.getReactModuleInfoProvider().getReactModuleInfos().map { stripePackage.getModule(it.value.name, reactContext)!! })
         nativeModules.addAll(skiaPackage.createNativeModules(reactContext))
 
         // Call to create native modules has to be at the bottom --


### PR DESCRIPTION
# Why
Closes  #36521
On older devices we need to provide a fallback layout `splash_screen_view` or the app will crash. I can't find where this is documented and didn't come across it during the `expo-splash-screen` work.

Also had to change how the stripe module is initialised to get the app to build. It was updated in #36478 but had been building fine 🤔
 
# How
Add the `splash_screen_view` layout file to be used on devices before api 31.

# Test Plan
Tested on apis 27, 28, 29 and 30. The view is used correctly

