### PR TITLE
[docs] Fix import statement in code example in Tabs

### DIFF
--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -42,7 +42,7 @@ This file structure produces a layout with a tab bar at the bottom of the screen
 You can use the **app/\_layout.tsx** file to define your app's root layout:
 
 ```tsx app/_layout.tsx
-import { Stack } from 'expo-router/stack';
+import { Stack } from 'expo-router';
 
 export default function Layout() {
   return (


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #36518

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix import statement in Tabs code example to import `Stack` from `expo-router` library.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
