### PR TITLE
[default template] Increate bottom tab padding on iOS

### DIFF
--- a/templates/expo-template-default/components/ui/TabBarBackground.ios.tsx
+++ b/templates/expo-template-default/components/ui/TabBarBackground.ios.tsx
@@ -1,7 +1,6 @@
 import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { BlurView } from 'expo-blur';
 import { StyleSheet } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function BlurTabBarBackground() {
   return (
@@ -16,7 +15,5 @@ export default function BlurTabBarBackground() {
 }
 
 export function useBottomTabOverflow() {
-  const tabHeight = useBottomTabBarHeight();
-  const { bottom } = useSafeAreaInsets();
-  return tabHeight - bottom;
+  return useBottomTabBarHeight();
 }


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/36427

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

On iOS, `useBottomTabOverflow` subtracts the inset height from the overflow. As far as I can tell, the overflow should just be the height of the bottom tabs.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

1. creating a project using the default template
2. add this change
3. open a collapsible on the `explore` tab
4. verifying that there is sufficient spacing between the text and the bottom tab bar

| Before      | After |
| ----------- | ----------- |
| <img width="568" alt="Screenshot 2025-05-01 at 13 56 45" src="https://github.com/user-attachments/assets/1a458b40-dd46-4504-b7b3-a1c0705041f9" />       | <img width="568" alt="Screenshot 2025-05-01 at 13 57 45" src="https://github.com/user-attachments/assets/b8d09e5d-0425-4329-9eda-1b4e0c54e83a" />     | 





<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
