### PR TITLE
Improve error format when `npx expo export` (native) fails.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Improve error format when `npx expo export` (native) fails.
+- Improve error format when `npx expo export` (native) fails. ([#36533](https://github.com/expo/expo/pull/36533) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Improve error format when `npx expo export` (native) fails.
+
 ### 💡 Others
 
 ## 0.24.9 — 2025-04-30

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '@expo/config';
 import type { Platform } from '@expo/config';
+import { SerialAsset } from '@expo/metro-config/build/serializer/serializerAssets';
 import assert from 'assert';
 import chalk from 'chalk';
 import fs from 'fs';
@@ -39,7 +40,6 @@ import { createTemplateHtmlFromExpoConfigAsync } from '../start/server/webTempla
 import { env } from '../utils/env';
 import { CommandError } from '../utils/errors';
 import { setNodeEnv } from '../utils/nodeEnv';
-import { SerialAsset } from '@expo/metro-config/build/serializer/serializerAssets';
 
 export async function exportAppAsync(
   projectRoot: string,

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -24,6 +24,7 @@ import {
   BundleOutput,
   getFilesFromSerialAssets,
   persistMetroFilesAsync,
+  BundleAssetWithFileHashes,
 } from './saveAssets';
 import { createAssetMap } from './writeContents';
 import * as Log from '../log';
@@ -38,6 +39,7 @@ import { createTemplateHtmlFromExpoConfigAsync } from '../start/server/webTempla
 import { env } from '../utils/env';
 import { CommandError } from '../utils/errors';
 import { setNodeEnv } from '../utils/nodeEnv';
+import { SerialAsset } from '@expo/metro-config/build/serializer/serializerAssets';
 
 export async function exportAppAsync(
   projectRoot: string,
@@ -167,26 +169,43 @@ export async function exportAppAsync(
             await assertEngineMismatchAsync(projectRoot, exp, platform);
           }
 
-          // Run metro bundler and create the JS bundles/source maps.
-          const bundle = await devServer.nativeExportBundleAsync(
-            exp,
-            {
-              platform,
-              splitChunks:
-                !env.EXPO_NO_BUNDLE_SPLITTING &&
-                ((devServer.isReactServerComponentsEnabled && !bytecode) || platform === 'web'),
-              mainModuleName: getEntryWithServerRoot(projectRoot, {
+          let bundle: {
+            artifacts: SerialAsset[];
+            assets: readonly BundleAssetWithFileHashes[];
+            files?: ExportAssetMap;
+          };
+
+          try {
+            // Run metro bundler and create the JS bundles/source maps.
+            bundle = await devServer.nativeExportBundleAsync(
+              exp,
+              {
                 platform,
-                pkg: projectConfig.pkg,
-              }),
-              mode: dev ? 'development' : 'production',
-              engine: isHermes ? 'hermes' : undefined,
-              serializerIncludeMaps: sourceMaps,
-              bytecode: bytecode && isHermes,
-              reactCompiler: !!exp.experiments?.reactCompiler,
-            },
-            files
-          );
+                splitChunks:
+                  !env.EXPO_NO_BUNDLE_SPLITTING &&
+                  ((devServer.isReactServerComponentsEnabled && !bytecode) || platform === 'web'),
+                mainModuleName: getEntryWithServerRoot(projectRoot, {
+                  platform,
+                  pkg: projectConfig.pkg,
+                }),
+                mode: dev ? 'development' : 'production',
+                engine: isHermes ? 'hermes' : undefined,
+                serializerIncludeMaps: sourceMaps,
+                bytecode: bytecode && isHermes,
+                reactCompiler: !!exp.experiments?.reactCompiler,
+              },
+              files
+            );
+          } catch (error) {
+            Log.log('');
+            if (error instanceof Error) {
+              Log.exception(error);
+            } else {
+              Log.error('Failed to bundle the app');
+              Log.log(error as any);
+            }
+            process.exit(1);
+          }
 
           bundles[platform] = bundle;
 

--- a/packages/@expo/cli/src/export/exportAsync.ts
+++ b/packages/@expo/cli/src/export/exportAsync.ts
@@ -7,8 +7,8 @@ import * as Log from '../log';
 import { waitUntilAtlasExportIsReadyAsync } from '../start/server/metro/debugging/attachAtlas';
 import { FileNotifier } from '../utils/FileNotifier';
 import { ensureDirectoryAsync, removeAsync } from '../utils/dir';
-import { ensureProcessExitsAfterDelay } from '../utils/exit';
 import { CommandError } from '../utils/errors';
+import { ensureProcessExitsAfterDelay } from '../utils/exit';
 
 export async function exportAsync(projectRoot: string, options: Options) {
   // Ensure the output directory is created

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -1530,42 +1530,54 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       let delta: DeltaResult;
       let revision: GraphRevision;
 
-      // TODO: Some bug in Metro/RSC causes this to break when changing imports in server components.
-      // We should resolve the bug because it results in ~6x faster bundling to reuse the graph revision.
-      if (transformOptions.customTransformOptions?.environment === 'react-server') {
-        const props = await this.metro.getBundler().initializeGraph(
-          // NOTE: Using absolute path instead of relative input path is a breaking change.
-          // entryFile,
-          resolvedEntryFilePath,
+      try {
+        // TODO: Some bug in Metro/RSC causes this to break when changing imports in server components.
+        // We should resolve the bug because it results in ~6x faster bundling to reuse the graph revision.
+        if (transformOptions.customTransformOptions?.environment === 'react-server') {
+          const props = await this.metro.getBundler().initializeGraph(
+            // NOTE: Using absolute path instead of relative input path is a breaking change.
+            // entryFile,
+            resolvedEntryFilePath,
 
-          transformOptions,
-          resolverOptions,
-          {
-            onProgress,
-            shallow: graphOptions.shallow,
-            lazy: graphOptions.lazy,
+            transformOptions,
+            resolverOptions,
+            {
+              onProgress,
+              shallow: graphOptions.shallow,
+              lazy: graphOptions.lazy,
+            }
+          );
+          delta = props.delta;
+          revision = props.revision;
+        } else {
+          const props = await (revPromise != null
+            ? this.metro.getBundler().updateGraph(await revPromise, false)
+            : this.metro.getBundler().initializeGraph(
+                // NOTE: Using absolute path instead of relative input path is a breaking change.
+                // entryFile,
+                resolvedEntryFilePath,
+
+                transformOptions,
+                resolverOptions,
+                {
+                  onProgress,
+                  shallow: graphOptions.shallow,
+                  lazy: graphOptions.lazy,
+                }
+              ));
+          delta = props.delta;
+          revision = props.revision;
+        }
+      } catch (error) {
+        if (error instanceof Error) {
+          // Space out build failures.
+          const cause = error.cause as undefined | { _expoImportStack?: string };
+          if (cause && '_expoImportStack' in cause) {
+            error.message += '\n\n' + cause._expoImportStack;
           }
-        );
-        delta = props.delta;
-        revision = props.revision;
-      } else {
-        const props = await (revPromise != null
-          ? this.metro.getBundler().updateGraph(await revPromise, false)
-          : this.metro.getBundler().initializeGraph(
-              // NOTE: Using absolute path instead of relative input path is a breaking change.
-              // entryFile,
-              resolvedEntryFilePath,
+        }
 
-              transformOptions,
-              resolverOptions,
-              {
-                onProgress,
-                shallow: graphOptions.shallow,
-                lazy: graphOptions.lazy,
-              }
-            ));
-        delta = props.delta;
-        revision = props.revision;
+        throw error;
       }
 
       bundlePerfLogger?.annotate({


### PR DESCRIPTION
# Why

![image](https://github.com/user-attachments/assets/bcdb25ee-9e38-42a8-96a0-3b1974194a68)

