### PR TITLE
[docs] Fix initialization command for Splash Screen example

### DIFF
--- a/docs/pages/versions/v51.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/splash-screen.mdx
@@ -97,7 +97,7 @@ See how to configure the native projects in the [installation instructions in th
 
 ### Animating the splash screen
 
-See the [with-splash-screen](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen, such as a fade out. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
+See the [with-splash-screen](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen, such as a fade out. You can initialize a new project from this example by running `npx create-expo-app --example with-splash-screen`.
 
 ## API
 

--- a/docs/pages/versions/v52.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/splash-screen.mdx
@@ -193,7 +193,7 @@ SplashScreen.setOptions({
 });
 ```
 
-If you prefer to use custom animation, see the [`with-splash-screen`](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
+If you prefer to use custom animation, see the [`with-splash-screen`](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen. You can initialize a new project from this example by running `npx create-expo-app --example with-splash-screen`.
 
 ## API
 

--- a/docs/pages/versions/v53.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/splash-screen.mdx
@@ -195,7 +195,7 @@ SplashScreen.setOptions({
 });
 ```
 
-If you prefer to use custom animation, see the [`with-splash-screen`](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
+If you prefer to use custom animation, see the [`with-splash-screen`](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen. You can initialize a new project from this example by running `npx create-expo-app --example with-splash-screen`.
 
 ## API
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #36487

# How

<!--
How did you build this feature or fix this bug and why?
-->
Fix initialization command for Splash Screen example to use `--example` with `create-expo-app` and replace `create-react-native-app` reference in versioned docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
