### PR TITLE
[docs] Update callout in ESLint guide

### DIFF
--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -17,7 +17,7 @@ This guide provides steps to set up and configure ESLint and Prettier.
 
 ### Setup
 
-> **info** From **SDK 53** onwards, the created ESLint config file uses the [Flat config](https://eslint.org/blog/2022/08/new-config-system-part-2/) format and also supports legacy config. **For SDK 52 and below**, the created ESLint config file uses legacy config and does not support Flat config.
+> **info** **From SDK 53 onwards**, the created ESLint config file uses the [Flat config](https://eslint.org/blog/2022/08/new-config-system-part-2/) format. It also supports legacy config. **For SDK 52 and below**, the created ESLint config file uses legacy config and does not support Flat config.
 
 To set up ESLint in your Expo project, you can use the Expo CLI to install the necessary dependencies. Running this command also creates a **eslint.config.js** file at the root of your project which extends configuration from [`eslint-config-expo`](https://github.com/expo/expo/tree/main/packages/eslint-config-expo).
 

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -17,7 +17,7 @@ This guide provides steps to set up and configure ESLint and Prettier.
 
 ### Setup
 
-> **info** **From SDK 53 onwards**, the created ESLint config file uses the [Flat config](https://eslint.org/blog/2022/08/new-config-system-part-2/) format. It also supports legacy config. **For SDK 52 and below**, the created ESLint config file uses legacy config and does not support Flat config.
+> **info** **From SDK 53 onwards**, the default ESLint config file uses the [Flat config](https://eslint.org/blog/2022/08/new-config-system-part-2/) format. It also supports legacy config. **For SDK 52 and below**, the default ESLint config file uses legacy config and does not support Flat config.
 
 To set up ESLint in your Expo project, you can use the Expo CLI to install the necessary dependencies. Running this command also creates a **eslint.config.js** file at the root of your project which extends configuration from [`eslint-config-expo`](https://github.com/expo/expo/tree/main/packages/eslint-config-expo).
 

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -17,7 +17,7 @@ This guide provides steps to set up and configure ESLint and Prettier.
 
 ### Setup
 
-> **info** From **SDK 53** onwards, the created ESLint config file uses the [Flat config](https://eslint.org/blog/2022/08/new-config-system-part-2/) format. However, legacy config is also supported.
+> **info** From **SDK 53** onwards, the created ESLint config file uses the [Flat config](https://eslint.org/blog/2022/08/new-config-system-part-2/) format and also supports legacy config. **For SDK 52 and below**, the created ESLint config file uses legacy config and does not support Flat config.
 
 To set up ESLint in your Expo project, you can use the Expo CLI to install the necessary dependencies. Running this command also creates a **eslint.config.js** file at the root of your project which extends configuration from [`eslint-config-expo`](https://github.com/expo/expo/tree/main/packages/eslint-config-expo).
 
@@ -125,6 +125,7 @@ To integrate Prettier with ESlint, update your **.eslintrc.js**:
 ```js .eslintrc.js
 module.exports = {
   extends: ['expo', 'prettier'],
+  ignorePatterns: ['/dist/*'],
   plugins: ['prettier'],
   rules: {
     'prettier/prettier': 'error',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

In #36424, I noticed that developers might run into confusion about Flat config support vs legacy config support. To make the message a bit clearer, let's update the callout in the setup section about which SDK versions range supports legacy config.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update the callout in ESLint guide to explain that for SDK 52 and below, projects running `npx expo lint` only use and support legacy config.
- Update example under Prettier > Legacy config to include missing `ignorePatterns` statement which is included in the default ESLint config when configuring lint tool inside the SDK 52 project.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

![CleanShot 2025-05-02 at 00 29 15](https://github.com/user-attachments/assets/aa60b8d5-57dd-4f2f-80c3-656fd3335cbd)


![CleanShot 2025-05-02 at 00 24 42](https://github.com/user-attachments/assets/abf9c51f-02cd-4606-825c-0014d3c3ba1d)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
