### PR TITLE
[gha] bump sdk branch for expo.new template sync workflow

### DIFF
--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -3,7 +3,7 @@ name: Sync App Template Repository
 on:
   workflow_dispatch: {}
   push:
-    branches: [sdk-52]
+    branches: [sdk-53]
     paths:
       - .github/workflows/sync-template.yml
       - templates/expo-template-default/**


### PR DESCRIPTION
# Why

To start generating repositories with the latest SDK version from expo.new, we need to synchronize the template repo from the sdk-53 branch.

# How

I edited the workflow to point to the new branch.

# Test Plan

When merged, updates to the template repo should trigger the workflow that syncs template changes to https://github.com/expo/expo-template-default