### PR TITLE
 [fingerprint] Fix test on Windows

### DIFF
--- a/packages/@expo/fingerprint/e2e/__tests__/default-ignore-paths-test.ts
+++ b/packages/@expo/fingerprint/e2e/__tests__/default-ignore-paths-test.ts
@@ -51,11 +51,11 @@ describe('default template ignore paths', () => {
         continue;
       }
       const { filePath } = source;
-      const nodeModulesIndex = filePath.indexOf('node_modules/');
+      const nodeModulesIndex = filePath.indexOf('node_modules' + path.sep);
       if (nodeModulesIndex < 0) {
         continue;
       }
-      const moduleName = filePath.split('/')[1];
+      const moduleName = filePath.split(path.sep)[1];
 
       // Heuristic to check if it's a native module
       // We ignore expo modules first and then check react-native- prefix.


### PR DESCRIPTION
Some change in the last day has made the fingerprint test on Windows more restrictive about path separators.  @brentvatne found the fix!
