### PR TITLE
[CI] Do not run EAS workflows on push (for now)

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
@@ -1,14 +1,16 @@
 name: TV compile test
 
 on:
-  push:
-    branches:
-      - main
+# For now, disable this workflow on push
+# Reenable once full paths support is ready for both push and pull_request
+#  push:
+#    branches:
+#      - main
   pull_request:
     branches:
       - main
   schedule:
-    - cron: '0 22 * * SUN' # 22:00 UTC every Sunday
+    - cron: '0 17 * * SUN' # 22:00 UTC every Sunday
 
 jobs:
   check_paths:

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
@@ -1,10 +1,11 @@
 name: Updates E2E (bricking measures disabled)
 
 on:
-  push:
-    branches:
-      - main
-      - sdk-*
+# For now, disable this workflow on push
+# Reenable once full paths support is ready for both push and pull_request
+#  push:
+#    branches:
+#      - main
   pull_request:
     branches:
       - main

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
@@ -1,10 +1,11 @@
 name: Updates E2E (CLI)
 
 on:
-  push:
-    branches:
-      - main
-      - sdk-*
+# For now, disable this workflow on push
+# Reenable once full paths support is ready for both push and pull_request
+#  push:
+#    branches:
+#      - main
   pull_request:
     branches:
       - main

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
@@ -1,14 +1,16 @@
 name: Updates E2E (custom init)
 
 on:
-  push:
-    branches:
-      - main
+# For now, disable this workflow on push
+# Reenable once full paths support is ready for both push and pull_request
+#  push:
+#    branches:
+#      - main
   pull_request:
     branches:
       - main
   schedule:
-    - cron: '0 20 * * SUN' # 22:00 UTC every Sunday
+    - cron: '0 19 * * SUN' # 22:00 UTC every Sunday
 
 jobs:
   check_paths:

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
@@ -1,15 +1,16 @@
 name: Updates E2E (disabled)
 
 on:
-  push:
-    branches:
-      - main
-      - sdk-*
+# For now, disable this workflow on push
+# Reenable once full paths support is ready for both push and pull_request
+#  push:
+#    branches:
+#      - main
   pull_request:
     branches:
       - main
   schedule:
-    - cron: '0 18 * * SUN' # 18:00 UTC every Sunday
+    - cron: '0 19 * * SUN' # 18:00 UTC every Sunday
 
 jobs:
   check_paths:

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
@@ -1,9 +1,11 @@
 name: Updates E2E (enabled)
 
 on:
-  push:
-    branches:
-      - main
+# For now, disable this workflow on push
+# Reenable once full paths support is ready for both push and pull_request
+#  push:
+#    branches:
+#      - main
   pull_request:
     branches:
       - main

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
@@ -1,15 +1,16 @@
 name: Updates E2E (error recovery)
 
 on:
-  push:
-    branches:
-      - main
-      - sdk-*
+# For now, disable this workflow on push
+# Reenable once full paths support is ready for both push and pull_request
+#  push:
+#    branches:
+#      - main
   pull_request:
     branches:
       - main
   schedule:
-    - cron: '0 22 * * SUN' # 18:00 UTC every Sunday
+    - cron: '0 20 * * SUN' # 18:00 UTC every Sunday
 
 jobs:
   check_paths:

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
@@ -1,15 +1,16 @@
 name: Updates E2E (fingerprint)
 
 on:
-  push:
-    branches:
-      - main
-      - sdk-*
+# For now, disable this workflow on push
+# Reenable once full paths support is ready for both push and pull_request
+#  push:
+#    branches:
+#      - main
   pull_request:
     branches:
       - main
   schedule:
-    - cron: '0 22 * * SUN' # 20:00 UTC every Sunday
+    - cron: '0 21 * * SUN' # 20:00 UTC every Sunday
 
 jobs:
   check_paths:

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-old-arch.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-old-arch.yml
@@ -1,14 +1,16 @@
 name: Updates E2E (old arch)
 
 on:
-  push:
-    branches:
-      - main
+# For now, disable this workflow on push
+# Reenable once full paths support is ready for both push and pull_request
+#  push:
+#    branches:
+#      - main
   pull_request:
     branches:
       - main
   schedule:
-    - cron: '0 20 * * SUN' # 22:00 UTC every Sunday
+    - cron: '0 22 * * SUN' # 22:00 UTC every Sunday
 
 jobs:
   check_paths:

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
@@ -1,15 +1,16 @@
 name: Updates E2E (startup)
 
 on:
-  push:
-    branches:
-      - main
-      - sdk-*
+# For now, disable this workflow on push
+# Reenable once full paths support is ready for both push and pull_request
+#  push:
+#    branches:
+#      - main
   pull_request:
     branches:
       - main
   schedule:
-    - cron: '0 22 * * SUN' # 20:00 UTC every Sunday
+    - cron: '0 23 * * SUN' # 20:00 UTC every Sunday
 
 jobs:
   check_paths:


### PR DESCRIPTION
To reduce the resource contention for workflows on CI, we temporarily disable running the workflows immediately on push. They will still run on a cron schedule, and on pull requests.

This change will be reverted when we add top-level paths checks to the workflows.
