### PR TITLE
Update overview.mdx

### DIFF
--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -88,7 +88,7 @@ This contains your React components and most, if not all, of your application lo
 
 <Collapsible summary="2. The native projects">
 
-Android and Xcode projects that bundle the JavaScript app, serve as the launchpad for the JavaScript app on each platform. They also handle the rendering of native components and provide the means to access platform-specific functionalities and integrate with any installed native libraries. App configuration, such as the name (as it appears on the home screen), icon, required permissions, associated domains, supported orientations, and so on, is configured in the native project.
+Android and Xcode projects that bundle the JavaScript app, serve as the launchpad for the JavaScript app on each platform. They also handle the rendering of native components and provide the means to access platform-specific functionalities and integrate with any installed native libraries. App configuration, such as the name (as it appears on the home screen), icon, required permissions, associated domains, supported orientations, and so on, are configured in the native project.
 
 </Collapsible>
 


### PR DESCRIPTION
Proper tense of is/are used in the sentence:

"App configuration, such as the name (as it appears on the home screen), icon, required permissions, associated domains, supported orientations, and so on, is configured in the native project."

"App configuration, *such as* the name ... [plural and singular items] *are* configured in the native project." is the correct use of English grammar here.

### Source for Usage
[Purdue, Subject-Verb Agreement](https://owl.purdue.edu/owl/general_writing/grammar/subject_verb_agreement.html)