### PR TITLE
[docs] document notifications error no valid "aps-environment" entitlement

### DIFF
--- a/docs/pages/push-notifications/faq.mdx
+++ b/docs/pages/push-notifications/faq.mdx
@@ -107,9 +107,9 @@ Setting the priority to `high` gives your notification the greatest likelihood t
 
 When your push notification credentials have expired, run `eas credentials`, choose iOS and a build profile, then remove your push notification key and generate a new one.
 
-### Error no valid aps-environment entitlement string found for application
+### No valid aps-environment entitlement string found error for iOS
 
-This error occurs if you haven't set up a push notification key for your project. To check, go to the [Project Credentials page](https://expo.dev/accounts/[account]/projects/[project]/credentials/ios).
+This error occurs if you haven't set up a push notification key for your iOS project. To check, go to the [Project Credentials page](https://expo.dev/accounts/[account]/projects/[project]/credentials/ios).
 
 To generate a new push notification key, trigger a new build by running:
 
@@ -117,7 +117,7 @@ To generate a new push notification key, trigger a new build by running:
 eas build --profile [profile] --platform ios
 ```
 
-For a visual guide, see the [Expo Notifications with EAS video at minute 35:20](https://youtu.be/BCCjGtKtBjE?t=2123).
+For a visual guide, see the [Expo Notifications with EAS video](https://youtu.be/BCCjGtKtBjE?t=2123).
 
 ### Error message when sending a notification
 

--- a/docs/pages/push-notifications/faq.mdx
+++ b/docs/pages/push-notifications/faq.mdx
@@ -4,6 +4,7 @@ sidebar_title: Troubleshooting and FAQ
 description: A collection of common questions about Expo push notification service.
 ---
 
+import { Terminal } from '~/ui/components/Snippet';
 import { Collapsible } from '~/ui/components/Collapsible';
 
 A collection of common issues and FAQs when setting up push notifications with the `expo-notifications` library and Expo push notification service.
@@ -113,9 +114,7 @@ This error occurs if you haven't set up a push notification key for your iOS pro
 
 To generate a new push notification key, trigger a new build by running:
 
-```bash
-eas build --profile [profile] --platform ios
-```
+<Terminal cmd={['eas build --profile [profile] --platform ios']} />
 
 For a visual guide, see the [Expo Notifications with EAS video](https://youtu.be/BCCjGtKtBjE?t=2123).
 

--- a/docs/pages/push-notifications/faq.mdx
+++ b/docs/pages/push-notifications/faq.mdx
@@ -4,8 +4,8 @@ sidebar_title: Troubleshooting and FAQ
 description: A collection of common questions about Expo push notification service.
 ---
 
-import { Terminal } from '~/ui/components/Snippet';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
 
 A collection of common issues and FAQs when setting up push notifications with the `expo-notifications` library and Expo push notification service.
 

--- a/docs/pages/push-notifications/faq.mdx
+++ b/docs/pages/push-notifications/faq.mdx
@@ -107,6 +107,18 @@ Setting the priority to `high` gives your notification the greatest likelihood t
 
 When your push notification credentials have expired, run `eas credentials`, choose iOS and a build profile, then remove your push notification key and generate a new one.
 
+### Error no valid aps-environment entitlement string found for application
+
+This error occurs if you haven't set up a push notification key for your project. To check, go to the [Project Credentials page](https://expo.dev/accounts/[account]/projects/[project]/credentials/ios).
+
+To generate a new push notification key, trigger a new build by running:
+
+```bash
+eas build --profile [profile] --platform ios
+```
+
+For a visual guide, see the [Expo Notifications with EAS video at minute 35:20](https://youtu.be/BCCjGtKtBjE?t=2123).
+
 ### Error message when sending a notification
 
 Check the `details` property of the returned push ticket or receipt for more information. [Read this](/push-notifications/sending-notifications/#errors) for common error code responses and their associated solutions.


### PR DESCRIPTION
# Why

[ENG-15670 Hello I'm getting this error: `LOG expoPushToken Error: no valid "aps-environment" entitlement s...](https://linear.app/expo/issue/ENG-15670/hello-im-getting-this-error-log-expopushtoken-error-no-valid-aps)

# How

Update Notifications FAQs doc

# Test Plan

Ran locally, tested links.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
