### PR TITLE
chore(cli): Update to `lan-network@^0.1.5` for local VPN network IP changes

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Update to `lan-network@^0.1.5` for VPN network local IP changes ([#36572](https://github.com/expo/expo/pull/36572) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 0.24.10 — 2025-05-01

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -74,7 +74,7 @@
     "getenv": "^1.0.0",
     "glob": "^10.4.2",
     "minimatch": "^9.0.0",
-    "lan-network": "^0.1.4",
+    "lan-network": "^0.1.5",
     "node-forge": "^1.3.1",
     "npm-package-arg": "^11.0.0",
     "ora": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10557,10 +10557,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lan-network@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/lan-network/-/lan-network-0.1.4.tgz#e55742ec279f1c622911b9f61f9ace869344c750"
-  integrity sha512-9EzcRaFzlj3nSwcn2VOdxm30uHBBCgkX8/xzhSIlZXvQ1N1QV2cSwSrL+4bJC/WI+3k1f9SNJuPt4/F/9Au6hQ==
+lan-network@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/lan-network/-/lan-network-0.1.5.tgz#e781889b7bd4dbedd9126fff3ceddd809a83c3ff"
+  integrity sha512-CV3k7l8jW0Z1b+G41tB7JInVyJEKQzh/YPl2v9uXpZMusp0aa+rh3OqG77xWuX7+eVBa8PsdTuMznTAssF4qwg==
 
 lazy-cache@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
# Why

See: https://github.com/kitten/lan-network/pull/7
Resolves #36526

This disregards internal networks (now also detected by zeroed MAC addresses for interfaces) when probing network connections, and instead uses the fallback method for detecting LAN IPs by sorting network interfaces by preference.

We attempted to enable VPNs to be detectable and usable for the Expo CLI internal IP detection, however, this can result in false positives when a non-LAN VPN is in use, i.e. a VPN that's not intended for both the Expo Go and Expo CLI devices.

For the above, `REACT_NATIVE_PACKAGER_HOSTNAME` should again be used instead.
`lan-network` now disregards VPNs.

# How

- Update to `lan-network@^0.1.5`

# Test Plan

- Tested by installing ProtonVPN on macOS and connecting
  - `npx lan-network` can be used to test this quickly, as before