### PR TITLE
Add recommended react-native-bootsplash version for SDK 53

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -111,5 +111,5 @@
   "@shopify/react-native-skia": "v2.0.0-next.2",
   "@shopify/flash-list": "1.7.6",
   "@sentry/react-native": "~6.10.0",
-  "react-native-bootsplash": "~6.3.7"
+  "react-native-bootsplash": "^6.3.7"
 }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -110,5 +110,6 @@
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "v2.0.0-next.2",
   "@shopify/flash-list": "1.7.6",
-  "@sentry/react-native": "~6.10.0"
+  "@sentry/react-native": "~6.10.0",
+  "react-native-bootsplash": "~6.3.7"
 }


### PR DESCRIPTION
# Why

SDK 53 came with some breaking changes for Bootsplash (mainly due to the iOS AppDelegate getting migrated to Swift).
Currently `--fix` will not update `react-native-bootsplash` to the new version when installed.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Add `react-native-bootsplash` to the bundled native modules list.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
