### PR TITLE
[android][location] Add explicit service location type

### DIFF
--- a/packages/expo-location/android/src/main/AndroidManifest.xml
+++ b/packages/expo-location/android/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
   <application>
     <service


### PR DESCRIPTION
# Why
It is now mandatory to specify the foreground service type

# How
Add to expo locations manifest

# Test Plan
n/a

