### PR TITLE
[expo-go] Add location service to manifest

### DIFF
--- a/packages/expo-location/android/src/main/AndroidManifest.xml
+++ b/packages/expo-location/android/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
   <application>
     <service

--- a/packages/expo-location/android/src/main/AndroidManifest.xml
+++ b/packages/expo-location/android/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
   <application>
     <service

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -40,6 +40,7 @@
     <!-- END OPTIONAL PERMISSIONS -->
 
     <uses-permission android:name="android.permission.WRITE_CONTACTS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
     <uses-feature
         android:glEsVersion="0x00020000"


### PR DESCRIPTION
# Why
Google is detecting we use a location service but it's not declared in the manifest

# How
Add the declaration

# Test Plan
n/a
