### PR TITLE
[jest-expo] Add ExpoFontUtils mock

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Add ExpoFontUtils mock
+- Add ExpoFontUtils mock ([#36585](https://github.com/expo/expo/pull/36585) by [@brentvatne](https://github.com/brentvatne))
 
 ### 💡 Others
 

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add ExpoFontUtils mock
+
 ### 💡 Others
 
 ## 53.0.3 — 2025-05-01

--- a/packages/jest-expo/src/preset/expoModules.js
+++ b/packages/jest-expo/src/preset/expoModules.js
@@ -328,6 +328,9 @@ module.exports = {
           { name: 'loadAsync', argumentsCount: 2, key: 'loadAsync' },
           { name: 'getLoadedFonts', argumentsCount: 0, key: 'getLoadedFonts' },
         ],
+        ExpoFontUtils: [
+          { name: 'renderToImageAsync', argumentsCount: 2, key: 'renderToImageAsync' },
+        ],
         ExpoGo: [],
         ExpoHaptics: [
           { name: 'impactAsync', argumentsCount: 1, key: 'impactAsync' },


### PR DESCRIPTION
# Why

Fixes #36575

# How

Manually added this for now, because mock generator is having issues in Expo Go. @aleqsio can follow up with getting mock generator fixed.