### PR TITLE
[docs][tailwind] Fix `expo install` command

### DIFF
--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -48,7 +48,7 @@ Install `tailwindcss` and its required peer dependencies. Then, the run initiali
 <Terminal
   cmd={[
     '# Install Tailwind and its peer dependencies',
-    '$ npx expo install tailwindcss@3 postcss autoprefixer --dev',
+    '$ npx expo install tailwindcss@3 postcss autoprefixer -- --dev',
     '',
     '# Create a Tailwind config file',
     '$ npx tailwindcss init -p',
@@ -134,7 +134,7 @@ Install `tailwindcss` and its required peer dependencies:
 <Terminal
   cmd={[
     '# Install Tailwind and its peer dependencies',
-    '$ npx expo install tailwindcss @tailwindcss/postcss postcss --dev',
+    '$ npx expo install tailwindcss @tailwindcss/postcss postcss -- --dev',
   ]}
 />
 


### PR DESCRIPTION
The install command was missing the "--" before the "--dev" at the end of the command.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The install command was missing the "--" before the "--dev" at the end of the command. When trying to run the current command on the page, this error is raised:
```
CommandError: Unexpected: --dev
Did you mean: npx expo install tailwindcss @tailwindcss/postcss postcss -- --dev
```

# How

<!--
How did you build this feature or fix this bug and why?
-->

I added the "--" missing in at the end of the command.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Running the command with the "--" before the "--dev" runs the install command as intended without issues.
