### PR TITLE
fix(cli): Fix typo in CLI error message

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 💡 Others
 
+- fix typo in CLI error message when `expo-router` is not installed. ([#36608](https://github.com/expo/expo/pull/36608) by [@abraj](https://github.com/abraj))
 - Bump to `@expo/metro@~54.0.0` ([#39800](https://github.com/expo/expo/pull/39800) by [@kitten](https://github.com/kitten))
 
 ### ⚠️ Notices
@@ -268,7 +269,6 @@ _This version does not introduce any user-facing changes._
 ### 🐛 Bug fixes
 
 - Improve error format when `npx expo export` (native) fails. ([#36533](https://github.com/expo/expo/pull/36533) by [@EvanBacon](https://github.com/EvanBacon))
-- Fix typo in CLI error message when `expo-router` is not installed. ([#36608](https://github.com/expo/expo/pull/36608) by [@abraj](https://github.com/abraj))
 
 ## 0.24.9 — 2025-04-30
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -268,6 +268,7 @@ _This version does not introduce any user-facing changes._
 ### 🐛 Bug fixes
 
 - Improve error format when `npx expo export` (native) fails. ([#36533](https://github.com/expo/expo/pull/36533) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix typo in CLI error message when `expo-router` is not installed. ([#36608](https://github.com/expo/expo/pull/36608) by [@abraj](https://github.com/abraj))
 
 ## 0.24.9 — 2025-04-30
 

--- a/packages/@expo/cli/src/start/server/metro/createServerRouteMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/createServerRouteMiddleware.ts
@@ -41,7 +41,7 @@ export function createRouteHandlerMiddleware(
 ) {
   if (!resolveFrom.silent(projectRoot, 'expo-router')) {
     throw new CommandError(
-      `static and server rendering requires the expo-router package to be installed in your project. Either install the expo-router package or change 'web.output' to 'static' in your app.json.`
+      `static and server rendering requires the expo-router package to be installed in your project. Either install the expo-router package or change 'web.output' to 'single' in your app.json.`
     );
   }
 


### PR DESCRIPTION
# Why

### Fix typo in error message:   
> static and server rendering requires the expo-router package to be installed in your project. Either install the expo-router package or change 'web.output' to **'static'** in your app.json.

**`static`** should be changed to **`single`**

# How

When `expo-router` is not installed, the only valid config in `app.json` for [`web.output`](https://docs.expo.dev/versions/latest/config/app/#output) should be `single`.

# Test Plan

### `app.json`
<img width="420" alt="Screenshot 2568-05-04 at 2 21 57 AM" src="https://github.com/user-attachments/assets/42806f1c-572f-4b57-b72d-b4ecbabefc98" />

### Error message on `expo start`
<img width="1087" alt="Screenshot 2568-05-04 at 2 22 57 AM" src="https://github.com/user-attachments/assets/f4607608-fae6-4067-af23-4d4b1a81217e" />

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
