### PR TITLE
[docs] Replace deprecated shouldShowAlert in Notifications reference example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -64,9 +64,10 @@ import Constants from 'expo-constants';
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
-    shouldShowAlert: true,
     shouldPlaySound: false,
     shouldSetBadge: false,
+    shouldShowBanner: true,
+    shouldShowList: true,
   }),
 });
 
@@ -203,9 +204,10 @@ import * as Notifications from 'expo-notifications';
 // to show the alert
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
-    shouldShowAlert: true,
     shouldPlaySound: false,
     shouldSetBadge: false,
+    shouldShowBanner: true,
+    shouldShowList: true,
   }),
 });
 


### PR DESCRIPTION
# Why

I had a TypeScript error when upgrading to Expo 53.

```
util/push-notifications.ts:12:35 - error TS2322: Type 'Promise<{ shouldShowAlert: true; shouldPlaySound: false; shouldSetBadge: false; }>' is not assignable to type 'Promise<NotificationBehavior>'.
  Type '{ shouldShowAlert: true; shouldPlaySound: false; shouldSetBadge: false; }' is missing the following properties from type 'NotificationBehavior': shouldShowBanner, shouldShowList

 12   handleNotification: async () => ({
                                      ~~
 13     shouldShowAlert: true,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~
... 
 15     shouldSetBadge: false,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~
 16   }),
    ~~~~
```

According to these very docs, `shouldShowAlert` is deprecated:

```
Deprecated instead, specify shouldShowBanner and / or shouldShowList
```

I've updated the examples in the docs to reflect this by replacing `shouldShowAlert` with the new `shouldShowBanner` and `shouldShowList.`

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
