### PR TITLE
Update file tree on notation.mdx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🐛 Bug fixes
 
+- Update file tree on notation.mdx ([#36626](https://github.com/expo/expo/pull/36626) by [@abraj](https://github.com/abraj))
+
 ## 53.0.0 — 2025-04-30
 
 ### 📚 3rd party library updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🐛 Bug fixes
 
-- Update file tree on notation.mdx ([#36626](https://github.com/expo/expo/pull/36626) by [@abraj](https://github.com/abraj))
-
 ## 53.0.0 — 2025-04-30
 
 ### 📚 3rd party library updates

--- a/docs/pages/router/basics/notation.mdx
+++ b/docs/pages/router/basics/notation.mdx
@@ -62,7 +62,7 @@ Consider the following project file structure to identify the different types of
     ['app/(tabs)/\profile.tsx'],
     ['app/_layout.tsx'],
     ['app/users/[userId].tsx'],
-    ['app/users/+not-found.tsx'],
+    ['app/+not-found.tsx'],
     ['app/about.tsx'],
   ]}
 />


### PR DESCRIPTION
# Why

As per the description on the [docs](https://docs.expo.dev/router/basics/notation/#route-notation-applied):
> **+not-found.tsx** is a special route that will be displayed if the user navigates to a route that doesn't exist in your app.

it is imperative that the file **+not-found.tsx** should be at the root, i.e. directly inside the `app` directory instead of inside the `app/users` directory.
.
# How

`app/users/+not-found.tsx` should be updated to `app/+not-found.tsx` in accordance with the description on the docs page.

# Test Plan

**Before:**  
<img width="270" alt="Screenshot 2568-05-05 at 9 28 20 AM" src="https://github.com/user-attachments/assets/ba56b15e-b3d0-40b5-8796-5131f2f5365a" />

**After:**  
<img width="270" alt="Screenshot 2568-05-05 at 9 41 08 AM" src="https://github.com/user-attachments/assets/4c4733a4-74d7-4042-89db-2f201cbf2914" />

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
