### PR TITLE
[docs] yarn dev requires specific version of node

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ Our docs are made with [Next.js](https://github.com/vercel/next.js). They're loc
 
 **TL;DR:**
 
-Note: Running docs yarn commands requires a specific version of Node. You can find this version under the `volta` section in ./docs/package.json.
+Note: Running docs yarn commands requires a specific version of Node. You can find this version under the `volta` section in [./docs/package.json](./docs/package.json).
 
 1. Navigate to the **docs** directory and run `yarn`.
 2. Start the project with `yarn dev` (make sure you don't have another server running on port `3002`). Note: Requires Node `22.13.1` or higher. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ Our docs are made with [Next.js](https://github.com/vercel/next.js). They're loc
 **TL;DR:**
 
 1. Navigate to the **docs** directory and run `yarn`.
-2. Start the project with `yarn dev` (make sure you don't have another server running on port `3002`).
+2. Start the project with `yarn dev` (make sure you don't have another server running on port `3002`). Requires Node 20.x.
 3. Navigate to the docs you want to edit: `cd docs/pages/`.
 4. If you update an older version, ensure the relevant changes are copied into `docs/pages/versions/unversioned/` for API docs.
 5. Package API docs are generated from sources. To regenerate the docs, run `et generate-docs-api-data -p <package-name>` (for the next SDK version) or `et generate-docs-api-data -p <package-name> -s <number>` (for a specific SDK version).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,8 +150,10 @@ Our docs are made with [Next.js](https://github.com/vercel/next.js). They're loc
 
 **TL;DR:**
 
+Note: Running docs yarn commands requires a specific version of Node. You can find this version under the `volta` section in ./docs/package.json.
+
 1. Navigate to the **docs** directory and run `yarn`.
-2. Start the project with `yarn dev` (make sure you don't have another server running on port `3002`). Requires Node 20.x.
+2. Start the project with `yarn dev` (make sure you don't have another server running on port `3002`). Note: Requires Node `22.13.1` or higher. 
 3. Navigate to the docs you want to edit: `cd docs/pages/`.
 4. If you update an older version, ensure the relevant changes are copied into `docs/pages/versions/unversioned/` for API docs.
 5. Package API docs are generated from sources. To regenerate the docs, run `et generate-docs-api-data -p <package-name>` (for the next SDK version) or `et generate-docs-api-data -p <package-name> -s <number>` (for a specific SDK version).


### PR DESCRIPTION
# Why

```
❯ cd docs && yarn dev
node:internal/modules/esm/resolve:303
  return new ERR_PACKAGE_PATH_NOT_EXPORTED(
         ^

Error: No "exports" main defined in /Users/norsegaud/expo/docs/node_modules/estree-walker/package.json
    at exportsNotFound (node:internal/modules/esm/resolve:303:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:593:13)
    at resolveExports (node:internal/modules/cjs/loader:589:36)
    at Module._findPath (node:internal/modules/cjs/loader:666:31)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1128:27)
    at /Users/norsegaud/expo/docs/node_modules/next/dist/server/require-hook.js:55:36
    at Module._load (node:internal/modules/cjs/loader:983:27)
    at Module.require (node:internal/modules/cjs/loader:1230:19)
    at mod.require (/Users/norsegaud/expo/docs/node_modules/next/dist/server/require-hook.js:65:28)
    at require (node:internal/modules/helpers:179:18) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}

Node.js v21.7.3
```

# How

Mention Node 20.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [N/A] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [N/A] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
