### PR TITLE
[docs] Update `setNotificationHandler` method examples

### DIFF
--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -69,9 +69,10 @@ import Constants from 'expo-constants';
 /* @info This handler determines how your app handles notifications that come in while the app is foregrounded. */
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
-    shouldShowAlert: true,
     shouldPlaySound: true,
     shouldSetBadge: true,
+    shouldShowBanner: true,
+    shouldShowList: true,
   }),
 });
 /* @end */

--- a/docs/pages/push-notifications/receiving-notifications.mdx
+++ b/docs/pages/push-notifications/receiving-notifications.mdx
@@ -223,16 +223,18 @@ For more information on these objects, see [`Notification`](/versions/latest/sdk
 
 To handle the behavior when notifications are received when your app is **foregrounded**, use [`Notifications.setNotificationHandler`](/versions/latest/sdk/notifications/#handling-incoming-notifications-when-the-app-is) with the `handleNotification()` callback to set the following options:
 
-- `shouldShowAlert`
 - `shouldPlaySound`
 - `shouldSetBadge`
+- `shouldShowBanner`
+- `shouldShowList`
 
 ```jsx
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
-    shouldShowAlert: true,
     shouldPlaySound: false,
     shouldSetBadge: false,
+    shouldShowBanner: true,
+    shouldShowList: true,
   }),
 });
 ```

--- a/docs/pages/versions/v53.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/notifications.mdx
@@ -64,9 +64,10 @@ import Constants from 'expo-constants';
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
-    shouldShowAlert: true,
     shouldPlaySound: false,
     shouldSetBadge: false,
+    shouldShowBanner: true,
+    shouldShowList: true,
   }),
 });
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

In `setNotificationHandler`, two new properties (`shouldShowBanner` and `shouldShowList`) are introduced which aren't optional (as per the current docs here: https://docs.expo.dev/versions/latest/sdk/notifications/#notificationbehavior).

As per #36617, developers are running into TypeScript error.

This PR updates `setNotificationHandler` examples to include these properties.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Backport changes from #36617 to SDK 53 Notifications reference
- Update examples when `setNotificationHandler` method is used in Push notifications section and remove the deprecated `shouldShowAlert` method

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
