### PR TITLE
[docs]  Add missing router import in login component example in Common navigation patterns guide

### DIFF
--- a/docs/pages/router/basics/common-navigation-patterns.mdx
+++ b/docs/pages/router/basics/common-navigation-patterns.mdx
@@ -4,7 +4,7 @@ description: Apply Expo Router basics to real-life navigation patterns you could
 sidebar_title: Common patterns
 ---
 
-import { DocsLogo } from '@expo/styleguide';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
@@ -79,7 +79,7 @@ You can also nest tabs inside of an outer stack navigator. That is often more us
   title="Nested navigators"
   description="Learn more about how to use nested navigators in your Expo Router app."
   href="/router/advanced/nesting-navigators/"
-  Icon={DocsLogo}
+  Icon={BookOpen02Icon}
 />
 
 ## One screen, two tabs: sharing routes
@@ -131,7 +131,7 @@ When you're already focused on a tab and navigating to a user, you will stay in 
   title="Shared routes"
   description="Learn more about how distinct routes can share the same URL in Expo Router."
   href="/router/advanced/shared-routes/"
-  Icon={DocsLogo}
+  Icon={BookOpen02Icon}
 />
 
 ## Authenticated users only protecting routes
@@ -202,7 +202,7 @@ This will cause **app/(logged-in)/\_layout.tsx** to re-render again. This time, 
   title="Expo Router authentication"
   description="Follow an in-depth guide for implementing authentication using protected routes."
   href="/router/advanced/authentication/"
-  Icon={DocsLogo}
+  Icon={BookOpen02Icon}
 />
 
 ## Sometimes the best route isn't a route at all
@@ -231,5 +231,5 @@ export default function Layout() {
   title="Modals in Expo Router"
   description="Learn multiple patterns for displaying modals in Expo Router, including using a modal inside of a layout file."
   href="/router/advanced/modals/"
-  Icon={DocsLogo}
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/router/basics/common-navigation-patterns.mdx
+++ b/docs/pages/router/basics/common-navigation-patterns.mdx
@@ -179,6 +179,8 @@ import { Button } from 'react-native';
 import { useRouter } from 'expo-router';
 
 export default function Login() {
+  const router = useRouter();
+
   return (
     <View>
       {/* login form */}
@@ -197,8 +199,8 @@ export default function Login() {
 This will cause **app/(logged-in)/\_layout.tsx** to re-render again. This time, the authentication check will pass, and the app will proceed to the default route.
 
 <BoxLink
-  title="Expo Router Authentication Guide"
-  description="Follow an in-depth example of implementing authentication using protected routes."
+  title="Expo Router authentication"
+  description="Follow an in-depth guide for implementing authentication using protected routes."
   href="/router/advanced/authentication/"
   Icon={DocsLogo}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15677

# How

<!--
How did you build this feature or fix this bug and why?
-->

In Common navigation patterns guide

- Add missing router import in login component example
  - Fix authentication guide verbiage on BoxLink in the same section
- Fix BoxLink icons usage on this page. Previously, it was using SDK reference icon on BoxLinks.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-05-05 at 17 45 32@2x](https://github.com/user-attachments/assets/27471cd7-2224-4a8b-88dc-80e7ae6bb0f1)

![CleanShot 2025-05-05 at 17 45 26@2x](https://github.com/user-attachments/assets/bb2044d4-6db3-4788-a3c6-1c510269f42e)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
