### PR TITLE
Fixes for docs

### DIFF
--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -66,7 +66,7 @@ Library authors can extend the app config by using [Expo Config plugins](/config
 
 ## Dynamic configuration
 
-For more customization, you can use the JavaScript (**app.config.js**) or [TypeScript](#using-typescript-for-configuration-appconfigts-instead-of) (**app.config.ts**). These configs have the following properties:
+For more customization, you can use the JavaScript (**app.config.js**) or [TypeScript](#using-typescript-for-configuration-appconfigts-instead-of-appconfigjs) (**app.config.ts**). These configs have the following properties:
 
 - Comments, variables, and single quotes.
 - ESM import syntax (the `import` keyword) is not supported, except when using [TypeScript with `ts-node`](/guides/typescript/#appconfigjs). JS files that are compatible with your current version of Node.js can be imported with `require()`.

--- a/docs/pages/workflow/continuous-native-generation.mdx
+++ b/docs/pages/workflow/continuous-native-generation.mdx
@@ -160,7 +160,7 @@ No, CNG is a versatile pattern that can be applied to any native project. While 
 
 </Collapsible>
 
-<Collapsible summary="How does community uses CNG?">
+<Collapsible summary="How does community use CNG?">
 
 Here are a few community examples of difficult native features converted into simple configuration files, which have allowed developers to build more powerful apps without compromising on iteration speed:
 


### PR DESCRIPTION
# Why

- Grammatical  typo on [`configuration.mdx`](https://docs.expo.dev/workflow/continuous-native-generation/#cng):  _How does community **uses** CNG?_

-  Incorrect URL fragment exists in broken link on [`continuous-native-generation.mdx`](https://docs.expo.dev/workflow/configuration/#dynamic-configuration)

![Screenshot 2568-05-05 at 11 50 32 PM](https://github.com/user-attachments/assets/053b6f00-35bd-42b3-8a6c-fc8cca949b52)

# How

- Fix grammatical  typo on `configuration.mdx`
- Fix URL fragment in broken link on `continuous-native-generation.mdx`

# Test Plan

**Before:**
<img width="837" alt="Screenshot 2568-05-05 at 11 39 59 PM" src="https://github.com/user-attachments/assets/cdb152cd-8198-4779-baa0-c623ab14ab85" />

**After:**
<img width="837" alt="Screenshot 2568-05-05 at 11 39 20 PM" src="https://github.com/user-attachments/assets/74258c96-7627-4e38-96b6-3d3111aff510" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
