### PR TITLE
[autolinking][Android] Fix `build-properties` properties don't apply

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed project properties were not being resolved correctly.
+- [Android] Fixed project properties were not being resolved correctly. ([#36666](https://github.com/expo/expo/pull/36666) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed project properties were not being resolved correctly.
+
 ### 💡 Others
 
 ## 2.1.9 — 2025-04-30

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoRootProjectPlugin.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoRootProjectPlugin.kt
@@ -14,7 +14,7 @@ import kotlin.jvm.optionals.getOrNull
 class ExpoRootProjectPlugin : Plugin<Project> {
   override fun apply(rootProject: Project) {
     val versionCatalogs = rootProject.extensions.getByType(VersionCatalogsExtension::class.java)
-    val libs = versionCatalogs.find("libs")
+    val libs = versionCatalogs.find("expoLibs")
 
     with(rootProject) {
       defineDefaultProperties(libs)


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/36461.

# How

The version catalog name weren't from settings plugin weren't alight with autolinking plugin.

# Test Plan

- https://github.com/bjtrounson/expo-build-properties-dont-apply-reprod ✅ 
