### PR TITLE
[ios][screen-orientation] Fix listener in split view on ipad

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix the app becoming unresponsive when the orientation listener is used in `Split View` on iPad.
+- [iOS] Fix the app becoming unresponsive when the orientation listener is used in `Split View` on iPad. ([#36667](https://github.com/expo/expo/pull/36667) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix the app becoming unresponsive when the orientation listener is used in `Split View` on iPad.
+
 ### 💡 Others
 
 ## 8.1.5 — 2025-04-30


### PR DESCRIPTION
# Why
Closes #36621
When used in a `Split View` on iPad, when the app is moved to the background we try to emit an event even though we shouldn't. When this happens the JS thread becomes blocked and never recovers. This is because `OnStopObserving` is not called when the app moves to the background so `shouldEmitEvents` remains `true`.

# How
We should register and unregister the controller when the app moves to and from the background. This prevents the listener from ever being called when it shouldn't be. I also fixed an issue where the sizeClasses were not being returned as serializable values and always ended up undefined.

# Test Plan
Bare-expo and the provided repro using an ipad. The module works as expected when run normally or in a split view.

