### PR TITLE
[sqlite] improve sync api on web

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Avoided synchronous API calls for `kv-store`. ([#36669](https://github.com/expo/expo/pull/36669) by [@kudo](https://github.com/kudo))
+- Improved synchronous APIs on web. ([#36670](https://github.com/expo/expo/pull/36670) by [@kudo](https://github.com/kudo))
 
 ## 15.2.9 — 2025-04-30
 


### PR DESCRIPTION
# Why

improve sync api support on web, though it's still very flaky

# How

- fixed returned value turned as error from a successful undefined result, e.g. `openDatabase` doesn't return anything.
- try to use `Atomics.pause` to block main thread when possible

# Test Plan

sqlite test-suite on web

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
