### PR TITLE
[sqlite] fix reentrant issue for statement.executeAsync

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed parallel issue for `Statement.executeAsync`. ([#36674](https://github.com/expo/expo/pull/36674) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Avoided synchronous API calls for `kv-store`. ([#36669](https://github.com/expo/expo/pull/36669) by [@kudo](https://github.com/kudo))

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
@@ -367,44 +367,49 @@ class SQLiteModule : Module() {
   private fun run(statement: NativeStatement, database: NativeDatabase, bindParams: Map<String, Any>, bindBlobParams: Map<String, ByteArray>, shouldPassAsArray: Boolean): Map<String, Any> {
     maybeThrowForClosedDatabase(database)
     maybeThrowForFinalizedStatement(statement)
-    statement.ref.sqlite3_reset()
-    statement.ref.sqlite3_clear_bindings()
-    for ((key, param) in bindParams) {
-      val index = getBindParamIndex(statement, key, shouldPassAsArray)
-      if (index > 0) {
-        // expo-modules-core AnyTypeConverter casts JavaScript Number to Kotlin Double,
-        // here to cast as Long if the value is an integer.
-        val normalizedParam =
-          if (param is Double && param.toDouble() % 1.0 == 0.0) {
-            param.toLong()
-          } else {
-            param
-          }
-        statement.ref.bindStatementParam(index, normalizedParam)
-      }
-    }
-    for ((key, param) in bindBlobParams) {
-      val index = getBindParamIndex(statement, key, shouldPassAsArray)
-      if (index > 0) {
-        statement.ref.bindStatementParam(index, param)
-      }
-    }
 
-    val ret = statement.ref.sqlite3_step()
-    if (ret != NativeDatabaseBinding.SQLITE_ROW && ret != NativeDatabaseBinding.SQLITE_DONE) {
-      throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
-    }
-    val firstRowValues: SQLiteColumnValues =
-      if (ret == NativeDatabaseBinding.SQLITE_ROW) {
-        statement.ref.getColumnValues()
-      } else {
-        arrayListOf()
+    // The statement with parameter bindings is stateful,
+    // we have to guard with a critical section for thread safety.
+    synchronized(statement) {
+      statement.ref.sqlite3_reset()
+      statement.ref.sqlite3_clear_bindings()
+      for ((key, param) in bindParams) {
+        val index = getBindParamIndex(statement, key, shouldPassAsArray)
+        if (index > 0) {
+          // expo-modules-core AnyTypeConverter casts JavaScript Number to Kotlin Double,
+          // here to cast as Long if the value is an integer.
+          val normalizedParam =
+            if (param is Double && param.toDouble() % 1.0 == 0.0) {
+              param.toLong()
+            } else {
+              param
+            }
+          statement.ref.bindStatementParam(index, normalizedParam)
+        }
       }
-    return mapOf(
-      "lastInsertRowId" to database.ref.sqlite3_last_insert_rowid().toInt(),
-      "changes" to database.ref.sqlite3_changes(),
-      "firstRowValues" to firstRowValues
-    )
+      for ((key, param) in bindBlobParams) {
+        val index = getBindParamIndex(statement, key, shouldPassAsArray)
+        if (index > 0) {
+          statement.ref.bindStatementParam(index, param)
+        }
+      }
+
+      val ret = statement.ref.sqlite3_step()
+      if (ret != NativeDatabaseBinding.SQLITE_ROW && ret != NativeDatabaseBinding.SQLITE_DONE) {
+        throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
+      }
+      val firstRowValues: SQLiteColumnValues =
+        if (ret == NativeDatabaseBinding.SQLITE_ROW) {
+          statement.ref.getColumnValues()
+        } else {
+          arrayListOf()
+        }
+      return mapOf(
+        "lastInsertRowId" to database.ref.sqlite3_last_insert_rowid().toInt(),
+        "changes" to database.ref.sqlite3_changes(),
+        "firstRowValues" to firstRowValues
+      )
+    }
   }
 
   @Throws(AccessClosedResourceException::class, InvalidConvertibleException::class, SQLiteErrorException::class)

--- a/packages/expo-sqlite/ios/NativeStatement.swift
+++ b/packages/expo-sqlite/ios/NativeStatement.swift
@@ -6,7 +6,7 @@ final class NativeStatement: SharedObject, Equatable {
   var pointer: OpaquePointer?
   var isFinalized = false
   var extraPointer: OpaquePointer?
-  internal let lock = NSLock()
+  internal let lock = DispatchSemaphore(value: 1)
 
   // MARK: - Equatable
 

--- a/packages/expo-sqlite/ios/NativeStatement.swift
+++ b/packages/expo-sqlite/ios/NativeStatement.swift
@@ -6,6 +6,7 @@ final class NativeStatement: SharedObject, Equatable {
   var pointer: OpaquePointer?
   var isFinalized = false
   var extraPointer: OpaquePointer?
+  internal let lock = NSLock()
 
   // MARK: - Equatable
 

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -371,6 +371,11 @@ public final class SQLiteModule: Module {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
 
+    // The statement with parameter bindings is stateful,
+    // we have to guard with a critical section for thread safety.
+    statement.lock.lock()
+    defer { statement.lock.unlock() }
+
     exsqlite3_reset(statement.pointer)
     exsqlite3_clear_bindings(statement.pointer)
     for (key, param) in bindParams {

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -373,8 +373,10 @@ public final class SQLiteModule: Module {
 
     // The statement with parameter bindings is stateful,
     // we have to guard with a critical section for thread safety.
-    statement.lock.lock()
-    defer { statement.lock.unlock() }
+    statement.lock.wait()
+    defer {
+      statement.lock.signal()
+    }
 
     exsqlite3_reset(statement.pointer)
     exsqlite3_clear_bindings(statement.pointer)


### PR DESCRIPTION
# Why

fixes #36307

# How

since #35896, the async tasks would be exeucted in parallel. however, the `statement.executeAsync` is stateful because it store parameter bindings. we have to pretect the relevant code with a lock

# Test Plan

tested repro from https://github.com/GiyoMoon/expo-sqlite-promise-resolve-bug

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
