### PR TITLE
[updates][Android] Fix errors when `configuration-cache` is enabled

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed errors when `configuration-cache` is enabled.
+- [Android] Fixed errors when `configuration-cache` is enabled. ([#36678](https://github.com/expo/expo/pull/36678) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed errors when `configuration-cache` is enabled.
+
 ### 💡 Others
 
 ## 0.28.12 — 2025-05-01


### PR DESCRIPTION
# Why

Fixes errors when `configuration-cache` is enabled.

# How

When the configuration cache is enabled, we can't use `Task.project` property. Replaces `project.exec` with `ExecOperations`.

# Test Plan

- bare-expo ✅ 
