### PR TITLE
[docs] Remove SDK 50 references

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -27,7 +27,6 @@ When selecting an image for the build you can use the full name provided below o
 - The `sdk-53` alias will be assigned to the image best suited for SDK 53 builds.
 - The `sdk-52` alias will be assigned to the image best suited for SDK 52 builds.
 - The `sdk-51` alias will be assigned to the image best suited for SDK 51 builds.
-- The `sdk-50` alias will be assigned to the image best suited for SDK 50 builds.
 - SDK aliases will be updated with every new SDK release.
 - The `latest` alias will be updated with every new image release.
 

--- a/docs/pages/distribution/app-size.mdx
+++ b/docs/pages/distribution/app-size.mdx
@@ -42,9 +42,9 @@ Typically, what app developers care about the "download size" on the Play Store 
 
 The only truly accurate way to see what your final app size will be shipped to users is to upload your app to the stores and download it on a physical device. Google Play also provides a reliable estimate for the expected download size on your developer dashboard. You can find this under the **App size** page in **Android vitals** on the [Google Play Developer Console](https://play.google.com/console/). For more information, see [Optimize your app’s size and stay within Google Play app size limits](https://support.google.com/googleplay/android-developer/answer/9859372?hl=en).
 
-<Collapsible summary="Why did my APK size increase after upgrading to React Native 0.73?">
+<Collapsible summary="Why did my APK size increase after upgrading to React Native 0.73 and above?">
 
-React Native 0.73, which is used in Expo SDK 50, bumped the Android `minSdkVersion` to `23`. This had the side effect of changing the default value of [`extractNativeLibs`](https://developer.android.com/guide/topics/manifest/application-element#extractNativeLibs`) to `false`.
+React Native 0.73 bumped the Android `minSdkVersion` to `23`. This had the side effect of changing the default value of [`extractNativeLibs`](https://developer.android.com/guide/topics/manifest/application-element#extractNativeLibs`) to `false`.
 
 > If set to `false`, your native libraries are stored uncompressed in the APK. Although your APK might be larger, your application loads faster because the libraries load directly from the APK at runtime.
 

--- a/docs/pages/router/reference/async-routes.mdx
+++ b/docs/pages/router/reference/async-routes.mdx
@@ -83,8 +83,6 @@ Then, when you are about to start your project, you can use the `--clear` flag t
 
 ## Static rendering
 
-> Bundle splitting with static rendering is only supported in SDK 50 and above.
-
 Static rendering is supported in production web apps by rendering all Suspense boundaries synchronously in Node.js, then linking all of async chunks together in the HTML based on all the selected routes for a given HTML file. This ensures you don't encounter a waterfall of loading states on server navigations. Subsequent navigations will recursively load any missing chunks.
 
 To ensure a consistent first render, all layout routes leading up to the leaf route for a URL will be included in the initial server response.

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -7,7 +7,6 @@ import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { Tabs, Tab } from '~/ui/components/Tabs';
 
 To enable Search Engine Optimization (SEO) on the web you must statically render your app. This guide will walk you through the process of statically rendering your Expo Router app.
 
@@ -54,55 +53,8 @@ You can also learn more about [customizing Metro](/guides/customizing-metro/) .
 </Step>
 
 <Step label="3">
-Ensure Fast Refresh is configured.
 
-<Tabs>
-
-<Tab label="Expo Router v3">
-
-Expo Router requires at least `react-refresh@0.14.0`. This is available in SDK 50 and above. Ensure you **do not** have any overrides or resolutions for `react-refresh` in your **package.json**.
-
-</Tab>
-
-<Tab label="Expo Router v2">
-
-Expo Router requires at least `react-refresh@0.14.0`. React Native hasn't upgraded as of SDK 49 and Expo Router v2, so you need to force upgrade your `react-refresh` version by setting a Yarn resolution or npm override.
-
-<Tabs>
-
-<Tab label="npm">
-
-```json package.json
-{
-  /* @hide ... */
-  /* @end */
-  "overrides": {
-    "react-refresh": "~0.14.0"
-  }
-}
-```
-
-</Tab>
-
-<Tab label="Yarn">
-
-```json package.json
-{
-  /* @hide ... */
-  /* @end */
-  "resolutions": {
-    "react-refresh": "~0.14.0"
-  }
-}
-```
-
-</Tab>
-
-</Tabs>
-
-</Tab>
-
-</Tabs>
+Ensure Fast Refresh is configured. Expo Router requires at least `react-refresh@0.14.0`. Ensure you **do not** have any overrides or resolutions for `react-refresh` in your **package.json**.
 
 </Step>
 
@@ -326,8 +278,6 @@ export default function Page() {
 
 ## Fonts
 
-> Font optimization is available in SDK 50 and above.
-
 Expo Font has automatic static optimization for font loading in Expo Router. When you load a font with `expo-font`, Expo CLI will automatically extract the font resource and embed it in the page's HTML, enabling preloading, faster hydration, and reduced layout shift.
 
 The following snippet will load Inter into the namespace and statically optimize on web:
@@ -371,7 +321,7 @@ This generates the following static HTML:
 - Static font optimization requires the font to be loaded synchronously. If the font isn't statically optimized, it could be because it was loaded inside a `useEffect`, deferred component, or async function.
 - Static optimization is only supported with `Font.loadAsync` and `Font.useFonts` from `expo-font`. Wrapper functions are supported as long as the wrappers are synchronous.
 
-## FAQ
+## Common questions
 
 ### How do I add a custom server?
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #36498

Remove SDK 50 references in multiple docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
