### PR TITLE
[docs] Fix formatting issues in protected routes guide

### DIFF
--- a/docs/pages/router/advanced/protected.mdx
+++ b/docs/pages/router/advanced/protected.mdx
@@ -1,11 +1,11 @@
 ---
 title: Protected routes
-description: Learn how to make screens inaccessible to client-side navigation
+description: Learn how to make screens inaccessible to client-side navigation.
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
 
-> **warning** Protected screens are available in SDK 53 and above.
+> **warning** Protected routes are available in SDK 53 and above.
 
 Protected screens allow you to prevent users from accessing certain routes using client-side navigation. If a user tries to navigate to a protected screen, or if a screen becomes protected while it is active, they will be redirected to the anchor route (usually the index screen) or the first available screen in the stack.
 
@@ -36,7 +36,7 @@ export function AppLayout() {
       <Stack.Protected guard={isLoggedIn}>
         <Stack.Screen name="private" />
       </Stack.Protected>
-      {/* Expo Router includes all routes by default. Adding Stack.Protected creates exceptions for these screens */}
+      {/* Expo Router includes all routes by default. Adding Stack.Protected creates exceptions for these screens. */}
     </Stack>
   );
 }
@@ -48,7 +48,7 @@ Additionally, if the user is on `/private/page` and the `guard` condition change
 
 When a screen's **guard** is changed from **true** to **false**, all it's history entries will be removed from the navigation history.
 
-## Multiple Protected Screens
+## Multiple protected screens
 
 In Expo Router, a screen can **only exist in one active route group at a time**.
 
@@ -72,7 +72,7 @@ export function AppLayout() {
 }
 ```
 
-## Nesting Protected Screens
+## Nesting protected screens
 
 Protected screens can be nested to define hierarchical access control logic.
 
@@ -137,8 +137,8 @@ export function AppLayout() {
 }
 ```
 
-Here, because the **index** screen is protected and the **protected** is **false**, the router redirects to the first available screen — **login**.
+Here, because the **index** screen is protected and the **protected** is **false**, the router redirects to the first available screen &mdash; **login**.
 
-## Static Rendering Considerations
+## Static rendering considerations
 
 Protected screens are evaluated on the client side only. During static site generation, no HTML files are created for protected routes. However, if users know the URLs of these routes, they can still request the corresponding HTML or JavaScript files directly. Protected screens are not a replacement for server-side authentication or access control.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While going through this doc, I found formatting inconsistencies such as using title case in headings, missing periods, etc.. Also, the callout uses the term "Protected screens" but the page title uses "Protected routes". 

This PR resolves these issues.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Running the docs app locally and visiting the guide.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
