### PR TITLE
[default-template] Update MAPPING object type in IconSymbol component

### DIFF
--- a/templates/expo-template-default/components/ui/IconSymbol.tsx
+++ b/templates/expo-template-default/components/ui/IconSymbol.tsx
@@ -18,7 +18,7 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
-} as IconMapping;
+} satisfies Partial<IconMapping>;
 
 /**
  * An icon component that uses native SF Symbols on iOS, and Material Icons on Android and web.


### PR DESCRIPTION
# Why

Replaced as with satisfies for the MAPPING object to enable proper type inference and ensure compile-time checks for unmapped icons.

# How

"as" was replaced with "satisfies" to improve type safety.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
