### PR TITLE
[android][core] Fix `getSharedObjectId` on devices running android 7

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `getSharedObjectId` for devices running android 7 and below.
+- [Android] Fix `getSharedObjectId` for devices running android 7 and below. ([#36693](https://github.com/expo/expo/pull/36693) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `getSharedObjectId` for devices running android 7 and below.
+
 ### 💡 Others
 
 ## 2.3.12 — 2025-04-30

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -21,7 +21,7 @@ open class SharedObject(runtimeContext: RuntimeContext? = null) {
 
   // Used by JNI
   @DoNotStrip
-  private fun getSharedObjectId(): Int {
+  fun getSharedObjectId(): Int {
     return sharedObjectId.value
   }
 


### PR DESCRIPTION
# Why
Closes #34690
On api 25 and below, private methods cannot be called from JNI causing the app to crash. We can revert this when we drop support for 24 and 25

# How
Remove `private` from `getSharedObjectId` 

# Test Plan
Bare-expo and the provided repro running on android 7.

