### PR TITLE
[notifications] showcase image attachments in notification-tester

### DIFF
--- a/apps/native-component-list/src/api/registerForPushNotificationsAsync.ts
+++ b/apps/native-component-list/src/api/registerForPushNotificationsAsync.ts
@@ -5,7 +5,9 @@ import * as Notifications from 'expo-notifications';
 // own server or use the local notification API if you want to notify this user.
 const PUSH_ENDPOINT = 'https://exp.host/--/api/v2/push/send';
 
-export default async function registerForPushNotificationsAsync() {
+export default async function registerForPushNotificationsAsync(
+  payloadOverride?: Record<string, any>
+) {
   // this method assumes the user has already granted permission
   // to receive remote notifications.
 
@@ -29,6 +31,7 @@ export default async function registerForPushNotificationsAsync() {
         body: 'Native Component List is registered for push notifications.',
         data: { example: 'sample data' },
         categoryId: 'welcome',
+        ...payloadOverride,
       },
     ]),
   });

--- a/apps/native-component-list/src/screens/NotificationScreen.tsx
+++ b/apps/native-component-list/src/screens/NotificationScreen.tsx
@@ -95,6 +95,19 @@ export default class NotificationScreen extends React.Component<
         )}
         <ListButton onPress={this._sendNotificationAsync} title="Send me a push notification" />
         <ListButton
+          onPress={async () => {
+            const permission = await this._obtainRemoteNotifPermissionsAsync();
+            if (permission.status === 'granted') {
+              registerForPushNotificationsAsync({
+                richContent: {
+                  image: 'https://picsum.photos/200/300',
+                },
+              });
+            }
+          }}
+          title="Send me a push notification with an image"
+        />
+        <ListButton
           onPress={this._unregisterForNotificationsAsync}
           title="Unregister for push notifications"
         />

--- a/apps/notification-tester/app.json
+++ b/apps/notification-tester/app.json
@@ -9,6 +9,7 @@
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
+      "appleTeamId": "your-apple-team-id",
       "supportsTablet": true,
       "bundleIdentifier": "com.vonovak.microfoam"
     },
@@ -32,7 +33,12 @@
           "icon": "./assets/images/icon.png",
           "color": "#232323",
           "defaultChannel": "defaultExpoChannel",
-          "sounds": ["./assets/pop_sound.wav", "./assets/bells_sound.wav"],
+          "sounds": [
+            "./assets/pop_sound.wav",
+            "./assets/bells_sound.wav",
+            "./assets/pop_sound.wav",
+            "./assets/bells_sound.wav"
+          ],
           "enableBackgroundRemoteNotifications": true
         }
       ],
@@ -44,7 +50,8 @@
           "resizeMode": "contain",
           "backgroundColor": "#ffffff"
         }
-      ]
+      ],
+      "@bacons/apple-targets"
     ],
     "runtimeVersion": "be975abaed5ef1ab51b8eff6c95f384a8700debe",
     "owner": "brents",

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -16,6 +16,7 @@
     "preset": "jest-expo"
   },
   "dependencies": {
+    "@bacons/apple-targets": "latest",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/native": "^7.1.6",
     "expo": "~53.0.0-preview.7",

--- a/apps/notification-tester/scripts/prebuild-ios.sh
+++ b/apps/notification-tester/scripts/prebuild-ios.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-EXPO_NO_GIT_STATUS=1 npx expo prebuild --clean -p ios --template expo-template-bare-minimum@sdk-53
+EXPO_NO_GIT_STATUS=1 EXPO_DEBUG=1 npx expo prebuild --clean -p ios --template expo-template-bare-minimum@sdk-53

--- a/apps/notification-tester/targets/notification-service/Info.plist
+++ b/apps/notification-tester/targets/notification-service/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSExtension</key>
+    <dict>
+      <key>NSExtensionAttributes</key>
+      <dict>
+        <key>NSExtensionActivationRule</key>
+        <string>TRUEPREDICATE</string>
+      </dict>
+      <key>NSExtensionPrincipalClass</key>
+      <string>$(PRODUCT_MODULE_NAME).NotificationService</string>
+      <key>NSExtensionPointIdentifier</key>
+      <string>com.apple.usernotifications.service</string>
+    </dict>
+  </dict>
+</plist>

--- a/apps/notification-tester/targets/notification-service/NotificationService.swift
+++ b/apps/notification-tester/targets/notification-service/NotificationService.swift
@@ -1,0 +1,75 @@
+import UserNotifications
+
+class NotificationService: UNNotificationServiceExtension {
+  var contentHandler: ((UNNotificationContent) -> Void)?
+  var bestAttemptContent: UNMutableNotificationContent?
+
+  override func didReceive(
+    _ request: UNNotificationRequest,
+    withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void
+  ) {
+    self.contentHandler = contentHandler
+    bestAttemptContent =
+      (request.content.mutableCopy() as? UNMutableNotificationContent)
+
+    if let bestAttemptContent = bestAttemptContent {
+      if let userInfo = request.content.userInfo["body"] as? [String: Any],
+        let richContent = userInfo["_richContent"] as? [String: Any],
+        let imageUrlString = richContent["image"] as? String,
+        let imageUrl = URL(string: imageUrlString) {
+        downloadAndAttachImage(url: imageUrl, to: bestAttemptContent) { content in
+          contentHandler(content)
+        }
+      } else {
+        contentHandler(bestAttemptContent)
+      }
+    }
+  }
+
+  private func downloadAndAttachImage(
+    url: URL,
+    to content: UNMutableNotificationContent,
+    completion: @escaping (UNNotificationContent) -> Void
+  ) {
+    let task = URLSession.shared.downloadTask(with: url) { temporaryFileLocation, _, error in
+      guard let temporaryFileLocation = temporaryFileLocation else {
+        completion(content)
+        return
+      }
+
+      let fileManager = FileManager.default
+      let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+      let targetFileName = temporaryFileLocation.lastPathComponent + ".jpg"
+      let targetUrl = tempDirectory.appendingPathComponent(targetFileName)
+
+      try? fileManager.removeItem(at: targetUrl)
+
+      do {
+        try fileManager.moveItem(at: temporaryFileLocation, to: targetUrl)
+
+        let attachment = try UNNotificationAttachment(
+          identifier: "image",
+          url: targetUrl,
+          options: nil
+        )
+
+        content.attachments = [attachment]
+      } catch {
+        print("Error processing attachment: \(error.localizedDescription)")
+      }
+
+      completion(content)
+    }
+
+    task.resume()
+  }
+
+  override func serviceExtensionTimeWillExpire() {
+    // Called just before the extension will be terminated by the system.
+    // Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
+    if let contentHandler = contentHandler,
+      let bestAttemptContent = bestAttemptContent {
+      contentHandler(bestAttemptContent)
+    }
+  }
+}

--- a/apps/notification-tester/targets/notification-service/expo-target.config.js
+++ b/apps/notification-tester/targets/notification-service/expo-target.config.js
@@ -1,0 +1,5 @@
+/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: "notification-service",
+  entitlements: { /* Add entitlements */ },
+});

--- a/apps/notification-tester/targets/notification-service/generated.entitlements
+++ b/apps/notification-tester/targets/notification-service/generated.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict/>
+</plist>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
