### PR TITLE
[android][core] Fix getSharedObjectId on devices running android 7

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `getSharedObjectId` for devices running android 7 and below.
+
 ### 💡 Others
 
 ## 2.3.12 — 2025-04-30

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `getSharedObjectId` for devices running android 7 and below.
+- [Android] Fix `getSharedObjectId` for devices running android 7 and below. ([#36698](https://github.com/expo/expo/pull/36698) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/cpp/JSharedObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSharedObject.cpp
@@ -5,7 +5,7 @@
 namespace expo {
 
 int JSharedObject::getId() noexcept {
-  static const auto method = getClass()->getMethod<int()>("getSharedObjectId");
+  static const auto method = javaClassStatic()->getMethod<int()>("getSharedObjectId");
   return method(self());
 }
 


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/34690.
It appears that the `getMethod` function does not locate private methods when `getClass` returns a class that inherits from a base class where the method is defined. However, we can retrieve the method ID by querying the base class. This ID should be consistent across all derived classes.

# Test Plan

- https://github.com/mrakesh0608/expo-image-manipulator-crash-android-8?rgh-link-date=2025-02-05T13:07:13.000Z ✅ 