### PR TITLE
[background-task] simplification of enqueuing tasks

### DIFF
--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Simplified how workers are started and stopped. Removed battery constaint on Android.
+- Simplified how workers are started and stopped. Removed battery constaint on Android. ([#36705](https://github.com/expo/expo/pull/36705) by [@chrfalch](https://github.com/chrfalch))
 
 ## 0.2.6 — 2025-04-30
 

--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Simplified how workers are started and stopped. Removed battery constaint on Android. ([#36705](https://github.com/expo/expo/pull/36705) by [@chrfalch](https://github.com/chrfalch))
+- Simplified how workers are started and stopped. Removed battery constraint on Android. ([#36705](https://github.com/expo/expo/pull/36705) by [@chrfalch](https://github.com/chrfalch))
 
 ## 0.2.6 — 2025-04-30
 

--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Simplified how workers are started and stopped. Removed battery constaint on Android.
+
 ## 0.2.6 — 2025-04-30
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskConsumer.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskConsumer.kt
@@ -37,13 +37,13 @@ class BackgroundTaskConsumer(context: Context?, taskManagerUtils: TaskManagerUti
     this.task = task
 
     val intervalMinutes = getIntervalMinutes()
-    BackgroundTaskScheduler.registerTask(intervalMinutes)
+    BackgroundTaskScheduler.registerTask(context, intervalMinutes)
   }
 
   override fun didUnregister() {
     Log.d(TAG, "didUnregister: ${task?.name}")
     this.task = null
-    BackgroundTaskScheduler.unregisterTask()
+    BackgroundTaskScheduler.unregisterTask(context)
   }
 
   private fun getIntervalMinutes(): Long {

--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskModule.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskModule.kt
@@ -6,7 +6,6 @@ import expo.modules.interfaces.taskManager.TaskManagerInterface
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
-import kotlinx.coroutines.runBlocking
 
 class BackgroundTaskModule : Module() {
   companion object {
@@ -37,7 +36,7 @@ class BackgroundTaskModule : Module() {
     }
 
     AsyncFunction("registerTaskAsync") { taskName: String, options: Map<String, Any?> ->
-      Log.d(TAG, "registerTaskAsync: $taskName")
+      Log.d(TAG, "registerTaskAsync: $taskName with options $options")
       taskManager.registerTask(taskName, BackgroundTaskConsumer::class.java, options)
     }
 
@@ -46,21 +45,12 @@ class BackgroundTaskModule : Module() {
       taskManager.unregisterTask(taskName, BackgroundTaskConsumer::class.java)
     }
 
-    OnActivityEntersBackground {
-      appContext.reactContext?.let {
-        runBlocking {
-          val appScopeKey = it.packageName
-          BackgroundTaskScheduler.scheduleWorker(it, appScopeKey)
-        }
-      } ?: throw MissingContextException()
+    OnActivityEntersForeground {
+      BackgroundTaskScheduler.inForeground = true
     }
 
-    OnActivityEntersForeground {
-      appContext.reactContext?.let {
-        runBlocking {
-          BackgroundTaskScheduler.stopWorker(it)
-        }
-      } ?: throw MissingContextException()
+    OnActivityEntersBackground {
+      BackgroundTaskScheduler.inForeground = false
     }
   }
 }

--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.time.Duration
 import java.util.concurrent.TimeUnit
@@ -39,25 +40,45 @@ object BackgroundTaskScheduler {
   // Interval
   private var intervalMinutes: Long = DEFAULT_INTERVAL_MINUTES
 
+  // Tracks whether in foreground
+  private var _inForeground: Boolean = false
+  var inForeground: Boolean
+    get() = _inForeground
+    set(value) {
+      _inForeground = value
+    }
+
   /**
    * Call when a task is registered
    */
-  fun registerTask(intervalMinutes: Long) {
+  fun registerTask(context: Context, intervalMinutes: Long) {
     numberOfRegisteredTasksOfThisType += 1
     this.intervalMinutes = intervalMinutes
+
+    if (numberOfRegisteredTasksOfThisType == 1) {
+      runBlocking {
+        scheduleWorker(context, context.packageName)
+      }
+    }
   }
 
   /**
    * Call when a task is unregistered
    */
-  fun unregisterTask() {
+  fun unregisterTask(context: Context) {
     numberOfRegisteredTasksOfThisType -= 1
+
+    if (numberOfRegisteredTasksOfThisType == 0) {
+      runBlocking {
+        stopWorker(context)
+      }
+    }
   }
 
   /**
    * Schedules the worker task to run. The worker should run periodically.
    */
-  suspend fun scheduleWorker(context: Context, appScopeKey: String, cancelExisting: Boolean = true): Boolean {
+  private suspend fun scheduleWorker(context: Context, appScopeKey: String, cancelExisting: Boolean = true, overriddenIntervalMinutes: Long = intervalMinutes): Boolean {
     if (numberOfRegisteredTasksOfThisType == 0) {
       Log.d(TAG, "Will not enqueue worker. No registered tasks to run.")
       return false
@@ -68,14 +89,13 @@ object BackgroundTaskScheduler {
       stopWorker(context)
     }
 
-    Log.d(TAG, "Enqueuing worker with identifier $WORKER_IDENTIFIER")
+    Log.d(TAG, "Enqueuing worker with identifier $WORKER_IDENTIFIER and '$overriddenIntervalMinutes' minutes delay.")
 
     // Build the work request
     val data = Data.Builder()
       .putString("appScopeKey", appScopeKey)
       .build()
     val constraints = Constraints.Builder()
-      .setRequiresBatteryNotLow(true)
       .setRequiredNetworkType(NetworkType.CONNECTED)
       .build()
 
@@ -95,7 +115,7 @@ object BackgroundTaskScheduler {
         .setConstraints(constraints)
 
       // Add minimum interval here as well so that the work doesn't start immediately
-      builder.setInitialDelay(Duration.ofMinutes(intervalMinutes))
+      builder.setInitialDelay(Duration.ofMinutes(overriddenIntervalMinutes))
 
       // Create work request
       val workRequest = builder.build()
@@ -144,7 +164,7 @@ object BackgroundTaskScheduler {
   /**
    * Cancels the worker task
    */
-  suspend fun stopWorker(context: Context): Boolean {
+  private suspend fun stopWorker(context: Context): Boolean {
     if (!isWorkerRunning(context)) {
       return false
     }
@@ -173,7 +193,7 @@ object BackgroundTaskScheduler {
   /**
    * Runs tasks with the given appScopeKey
    */
-  suspend fun runTasks(context: Context, appScopeKey: String): Boolean {
+  suspend fun runTasks(context: Context, appScopeKey: String) {
     // Get task service
     val taskService = TaskServiceProviderHelper.getTaskServiceImpl(context)
       ?: throw MissingTaskServiceException()
@@ -185,22 +205,42 @@ object BackgroundTaskScheduler {
     Log.d(TAG, "runTasks: number of consumers ${consumers.size}")
 
     if (consumers.isEmpty()) {
-      return false
+      return
+    }
+
+    // Make sure we're in the background before running a task
+    if (_inForeground) {
+      // Schedule task in an hour (or at least minimumInterval) - the app is foregrounded and
+      // we don't want to run anything to avoid performance issues.
+      Log.d(TAG, "runTasks: App is in the foreground")
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        scheduleWorker(context, appScopeKey, false, 60L.coerceAtMost(intervalMinutes))
+        Log.d(TAG, "runTasks: Scheduled new worker in $intervalMinutes minutes")
+      }
+      return
     }
 
     val tasks = consumers.filterIsInstance<BackgroundTaskConsumer>()
       .map { bgTaskConsumer ->
         Log.d(TAG, "runTasks: executing tasks for consumer of type ${bgTaskConsumer.taskType()}")
         val taskCompletion = CompletableDeferred<Unit>()
-        bgTaskConsumer.executeTask {
-          Log.d(TAG, "Task successfully finished")
-          taskCompletion.complete(Unit)
+        try {
+          bgTaskConsumer.executeTask {
+            Log.d(TAG, "Task successfully finished")
+            taskCompletion.complete(Unit)
+          }
+        } catch (e: Exception) {
+          Log.e(TAG, "Task failed: ${e.message}")
         }
         taskCompletion
       }
     // Await all tasks to complete
     tasks.awaitAll()
-    return true
+
+    // Schedule next task
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      scheduleWorker(context, appScopeKey, false)
+    }
   }
 
   /**

--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
@@ -41,12 +41,7 @@ object BackgroundTaskScheduler {
   private var intervalMinutes: Long = DEFAULT_INTERVAL_MINUTES
 
   // Tracks whether in foreground
-  private var _inForeground: Boolean = false
-  var inForeground: Boolean
-    get() = _inForeground
-    set(value) {
-      _inForeground = value
-    }
+  var inForeground: Boolean = false
 
   /**
    * Call when a task is registered

--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
@@ -204,7 +204,7 @@ object BackgroundTaskScheduler {
     }
 
     // Make sure we're in the background before running a task
-    if (_inForeground) {
+    if (inForeground) {
       // Schedule task in an hour (or at least minimumInterval) - the app is foregrounded and
       // we don't want to run anything to avoid performance issues.
       Log.d(TAG, "runTasks: App is in the foreground")

--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskWork.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskWork.kt
@@ -1,7 +1,6 @@
 package expo.modules.backgroundtask
 
 import android.content.Context
-import android.os.Build
 import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.Data
@@ -25,12 +24,6 @@ class BackgroundTaskWork(context: Context, params: WorkerParameters) : Coroutine
       // Run tasks async using the task service. This call will return when the task has finished
       // ie. When JS task executor has notified the task manager that it is done.
       BackgroundTaskScheduler.runTasks(applicationContext, appScopeKey)
-      // If we are on a newer Android version we're using a One time request and need to spawn new
-      // requests for each run (and also ask to not try to cancel the work, since we're already
-      // finishing the work item when this function returns.
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        BackgroundTaskScheduler.scheduleWorker(applicationContext, appScopeKey, false)
-      }
     } catch (e: Exception) {
       // Wrap exception in Data:
       val outputData = Data.Builder()

--- a/packages/expo-background-task/ios/BackgroundTaskModule.swift
+++ b/packages/expo-background-task/ios/BackgroundTaskModule.swift
@@ -56,23 +56,5 @@ public class BackgroundTaskModule: Module {
       return BackgroundTaskScheduler.supportsBackgroundTasks() ?
         BackgroundTaskStatus.available : .restricted
     }
-
-    OnAppEntersBackground {
-      Task {
-        // Try start worker when app enters background
-        do {
-          try await BackgroundTaskScheduler.tryScheduleWorker()
-        } catch {
-          log.error("Could not schedule the worker: \(error.localizedDescription)")
-        }
-      }
-    }
-
-    OnAppEntersForeground {
-      Task {
-        // When entering foreground we'll stop the worker
-        await BackgroundTaskScheduler.stopWorker()
-      }
-    }
   }
 }

--- a/packages/expo-background-task/ios/BackgroundTaskScheduler.swift
+++ b/packages/expo-background-task/ios/BackgroundTaskScheduler.swift
@@ -21,6 +21,12 @@ public class BackgroundTaskScheduler {
       intervalSeconds = Double(minutes) * 60
     }
     numberOfRegisteredTasksOfThisType += 1
+
+    if numberOfRegisteredTasksOfThisType == 1 {
+      Task {
+        try await tryScheduleWorker()
+      }
+    }
   }
 
   /**
@@ -28,6 +34,11 @@ public class BackgroundTaskScheduler {
    */
   public static func didUnregisterTask() {
     numberOfRegisteredTasksOfThisType -= 1
+    if numberOfRegisteredTasksOfThisType == 0 {
+      Task {
+        await stopWorker()
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
# Why

Tasks are only run in the background on  iOS so we don't need to wait with enqueuing workers until the app is backgrounded.

# How

This commit fixes this by simplifying when app workers are enqueued:

- Enqueue worker for the first task registered
- Stop worker for the last task registered.
- Removed battery constraint on Android (this is false by default)
- Added rescheduling after 15-60 mins (depending on minimumInterval) if app is foregrounded when task starts on Android

Closes ENG-15665

# Test Plan

Test in BareExpo

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
