### PR TITLE
Export correct variable

### DIFF
--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -125,7 +125,7 @@ const config = getDefaultConfig(__dirname);
 config.resolver.sourceExts.push('cjs');
 config.resolver.unstable_enablePackageExports = false;
 
-module.exports = defaultConfig;
+module.exports = config;
 ```
 
 </Step>


### PR DESCRIPTION
Just a small fix in the docs where it exported `defaultConfig` instead of `config`