### PR TITLE
Update using-firebase.mdx

### DIFF
--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -125,7 +125,7 @@ const config = getDefaultConfig(__dirname);
 config.resolver.sourceExts.push('cjs');
 config.resolver.unstable_enablePackageExports = false;
 
-module.exports = defaultConfig;
+module.exports = config;
 ```
 
 </Step>


### PR DESCRIPTION
Corrected a variable name in the Metro configuration example.

# Why
The documentation incorrectly used defaultConfig when exporting the Metro config, but that variable was never declared in the code. This leads to a runtime error when developers copy and use the snippet as-is. The correct variable name, as defined earlier in the example, is config.

This change improves the accuracy of the documentation and prevents confusion or errors for users following the guide.


# How
I replaced:
```
module.exports = defaultConfig;
```
with:
```
module.exports = config;
```

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
