### PR TITLE
[core] fix network inspector for xhr upload progress

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix `getSharedObjectId` for devices running android 7 and below. ([#36698](https://github.com/expo/expo/pull/36698) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fixed missing upload progress from `XMLHttpRequest` when network inspector is enabled. ([#36715](https://github.com/expo/expo/pull/36715) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/DevTools/ExpoRequestInterceptorProtocol.swift
+++ b/packages/expo-modules-core/ios/DevTools/ExpoRequestInterceptorProtocol.swift
@@ -167,7 +167,7 @@ public final class ExpoRequestInterceptorProtocol: URLProtocol, URLSessionDataDe
     guard let task = self.task else {
       return
     }
-    if let delegate = task.delegate {
+    if #available(iOS 15.0, tvOS 15.0, macOS 12.0, *), let delegate = task.delegate {
       // For the case if the task has a dedicated delegate than the default delegate from its URLSession
       delegate.urlSession?(session, task: task, didSendBodyData: bytesSent, totalBytesSent: totalBytesSent, totalBytesExpectedToSend: totalBytesExpectedToSend)
       return

--- a/packages/expo-modules-core/ios/DevTools/ExpoRequestInterceptorProtocol.swift
+++ b/packages/expo-modules-core/ios/DevTools/ExpoRequestInterceptorProtocol.swift
@@ -149,6 +149,36 @@ public final class ExpoRequestInterceptorProtocol: URLProtocol, URLSessionDataDe
     client?.urlProtocol(self, didReceive: challengeWithSender)
   }
 
+  public func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didSendBodyData bytesSent: Int64,
+    totalBytesSent: Int64,
+    totalBytesExpectedToSend: Int64
+  ) {
+    // swiftlint:disable line_length
+    // Apple does not support sending upload progress from URLProtocol back to URLProtocolClient.
+    // > Similarly, there is no way for your NSURLProtocol subclass to call the NSURLConnection delegate's -connection:needNewBodyStream: or -connection:didSendBodyData:totalBytesWritten:totalBytesExpectedToWrite: methods (<rdar://problem/9226155> and <rdar://problem/9226157>).  The latter is not a serious concern--it just means that your clients don't get upload progress--but the former is a real issue.  If you're in a situation where you might need a second copy of a request body, you will need your own logic to make that copy, including the case where the body is a stream.
+    // See: https://developer.apple.com/library/archive/samplecode/CustomHTTPProtocol/Listings/Read_Me_About_CustomHTTPProtocol_txt.html
+    //
+    // Workaround to get the original task's URLSessionDelegate through the internal property and send upload process
+    // Fixes https://github.com/expo/expo/issues/28269
+    // swiftlint:enable line_length
+    guard let task = self.task else {
+      return
+    }
+    if let delegate = task.delegate {
+      // For the case if the task has a dedicated delegate than the default delegate from its URLSession
+      delegate.urlSession?(session, task: task, didSendBodyData: bytesSent, totalBytesSent: totalBytesSent, totalBytesExpectedToSend: totalBytesExpectedToSend)
+      return
+    }
+    guard let session = task.value(forKey: "session") as? URLSession,
+      let delegate = session.delegate as? URLSessionTaskDelegate else {
+      return
+    }
+    delegate.urlSession?(session, task: task, didSendBodyData: bytesSent, totalBytesSent: totalBytesSent, totalBytesExpectedToSend: totalBytesExpectedToSend)
+  }
+
   /**
    Data structure to save the response for redirection
    */

--- a/packages/expo-modules-core/ios/DevTools/URLSessionSessionDelegateProxy.swift
+++ b/packages/expo-modules-core/ios/DevTools/URLSessionSessionDelegateProxy.swift
@@ -100,4 +100,21 @@ public final class URLSessionSessionDelegateProxy: NSObject, URLSessionDataDeleg
       completionHandler(.performDefaultHandling, nil)
     }
   }
+
+  public func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didSendBodyData bytesSent: Int64,
+    totalBytesSent: Int64,
+    totalBytesExpectedToSend: Int64
+  ) {
+    if let delegate = getDelegate(task: task) {
+      delegate.urlSession?(
+        session,
+        task: task,
+        didSendBodyData: bytesSent,
+        totalBytesSent: totalBytesSent,
+        totalBytesExpectedToSend: totalBytesExpectedToSend)
+    }
+  }
 }


### PR DESCRIPTION
# Why

fixes #28269

# How

- it's an apple's limitation that to ignore the upload progress for intercepted requests using `URLProtocol`
  - referenced from the [doc](https://developer.apple.com/library/archive/samplecode/CustomHTTPProtocol/Listings/Read_Me_About_CustomHTTPProtocol_txt.html)
  > Similarly, there is no way for your NSURLProtocol subclass to call the NSURLConnection delegate's -connection:needNewBodyStream: or -connection:didSendBodyData:totalBytesWritten:totalBytesExpectedToWrite: methods (<rdar://problem/9226155> and <rdar://problem/9226157>).  The latter is not a serious concern--it just means that your clients don't get upload progress--but the former is a real issue.  If you're in a situation where you might need a second copy of a request body, you will need your own logic to make that copy, including the case where the body is a stream.

- this pr tries to use an internal property to get the original `URLSessionTask -> URLSession -> URLSessionDelegate` and send the `connection:didSendBodyData:totalBytesWritten:totalBytesExpectedToWrite:` back to [react-native](https://github.com/facebook/react-native/blob/84253c4e2008460f18ea5d64f77a4b9ba634f12c/packages/react-native/Libraries/Network/RCTHTTPRequestHandler.mm#L119-L131)
- dev-client is debug-only and should be fine for the internal property
- expo-go on release build works as well. let's see if it passes the review.

# Test Plan

test repro from https://github.com/expo/expo/issues/28269#issuecomment-2845041078

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
