### PR TITLE
[android][updates] Prevent initialize call in onWillCreateReactInstance

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [Android] Prevent `initialize` from being called when using custom init.
+
 ## 0.28.12 — 2025-05-01
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- [Android] Prevent `initialize` from being called when using custom init.
+- [Android] Prevent `initialize` from being called when using custom init. ([#36718](https://github.com/expo/expo/pull/36718) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.28.12 — 2025-05-01
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -35,7 +35,9 @@ class UpdatesPackage : Package {
       }
 
       override fun onWillCreateReactInstance(useDeveloperSupport: Boolean) {
-        UpdatesController.initialize(context)
+        if (!isUsingCustomInit) {
+          UpdatesController.initialize(context)
+        }
       }
 
       override fun onDidCreateDevSupportManager(devSupportManager: DevSupportManager) {


### PR DESCRIPTION
# Why
Some packages like [this one](https://dev.dengage.com/reference/react-native#create-dengagemanager-instance) may require the user to access the `reactInstanceManager` in `onCreate`, this leads to `onWillCreateReactInstance` getting called and updates initialising even when controlling init themselves. 

# How
Check if the user is controlling initialisation and prevent the call in `onWillCreateReactInstance`

# Test Plan
Bare expo. Updates behaves as normal. 

