### PR TITLE
[docs] Update router authenication guide for SDK 53

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -254,6 +254,7 @@ export const general = [
       makePage('router/advanced/tabs.mdx'),
       makePage('router/advanced/drawer.mdx'),
       makePage('router/advanced/authentication.mdx'),
+      makePage('router/advanced/authentication-rewrites.mdx'),
       makePage('router/advanced/nesting-navigators.mdx'),
       makePage('router/advanced/modals.mdx'),
       makePage('router/advanced/shared-routes.mdx'),

--- a/docs/pages/router/advanced/authentication-rewrites.mdx
+++ b/docs/pages/router/advanced/authentication-rewrites.mdx
@@ -1,10 +1,10 @@
 ---
-title: Authentication in Expo Router
-sidebar_title: Authentication
+title: Authentication in Expo Router using redirects
+sidebar_title: Authentication (redirects)
 description: How to implement authentication and protect routes with Expo Router.
 ---
 
-> This guide requires SDK 53. For the previous version of this guide see [Authentication (redirects)](/router/advanced/authentication-rewrites/)
+> SDK 53 introduced [Protected routes](/router/advanced/protected/), a more powerful method of handling authentication. Please follow this guide if using SDK >53.
 
 import { Lock01Icon } from '@expo/styleguide-icons/outline/Lock01Icon';
 import { LockUnlocked01Icon } from '@expo/styleguide-icons/outline/LockUnlocked01Icon';
@@ -14,28 +14,35 @@ import { FileTree } from '~/ui/components/FileTree';
 import { Step } from '~/ui/components/Step';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
+<VideoBoxLink
+  videoId="yNaOaR2kIa0"
+  title="Building an Auth Flow with Expo Router"
+  description="Learn how to implement an auth flow in your Expo Router project."
+  className="mb-6"
+/>
+
 With Expo Router, all routes are always defined and accessible. You can use runtime logic to redirect users away from specific screens depending on whether they are authenticated. There are two different techniques for authenticating users within routes. This guide provides an example that demonstrates the functionality of standard native apps.
 
-## Using Protected Routes
+## Using React Context and Route Groups
 
-[Protected routes](/router/advanced/protected/) allow you to prevent users from accessing certain routes using client-side navigation. If a user tries to navigate to a protected screen, or if a screen becomes protected while it is active, they will be redirected to the anchor route (usually the index screen) or the first available screen in the stack. Consider the following project structure that has a `/sign-in` route that is always accessible and a `(app)` group that requires authentication:
+It's common to restrict specific routes to users who are not authenticated. This is achievable in an organized way by using React Context and Route Groups. Consider the following project structure that has a `/sign-in` route that is always accessible and a `(app)` group that requires authentication:
 
 <FileTree
   files={[
-    ['app/_layout.tsx', <span>Controls what is protected</span>],
+    'app/_layout.tsx',
     [
       'app/sign-in.tsx',
       <span>
         Always accessible <LockUnlocked01Icon className="mb-1 inline" />
       </span>,
     ],
+    ['app/(app)/_layout.tsx', <span>Protects child routes</span>],
     [
-      'app/(app)/_layout.tsx',
+      'app/(app)/index.tsx',
       <span>
         Requires authorization <Lock01Icon className="mb-1 inline" />
       </span>,
     ],
-    ['app/(app)/index.tsx', <span>Should be protected by the (app)/_layout</span>],
   ]}
 />
 
@@ -115,15 +122,11 @@ function useAsyncState<T>(
 }
 
 export async function setStorageItemAsync(key: string, value: string | null) {
-  if (Platform.OS === 'web') {
-    try {
-      if (value === null) {
-        localStorage.removeItem(key);
-      } else {
-        localStorage.setItem(key, value);
-      }
-    } catch (e) {
-      console.error('Local storage is unavailable:', e);
+  if (process.env.EXPO_OS === 'web') {
+    if (value === null) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, value);
     }
   } else {
     if (value == null) {
@@ -174,20 +177,19 @@ export function useStorageState(key: string): UseStateHook<string> {
 
 <Step label="2">
 
-Create a **SplashScreenController** to manage the splash screen. Because loading the authentication is asynchronous we can keep the splash screen visible until the authentication has loaded.
+Use the `SessionProvider` in the root layout to provide the authentication context to the entire app. It's imperative that the `<Slot />` is mounted before any navigation events are triggered. Otherwise, a runtime error will be thrown.
 
-```tsx splash.tsx
-import { SplashScreen } from 'expo-router';
-import { useSession } from './ctx';
+```tsx app/_layout.tsx
+import { Slot } from 'expo-router';
+import { SessionProvider } from '../ctx';
 
-export function SplashScreenController() {
-  const { isLoading } = useSession();
-
-  if (!isLoading) {
-    SplashScreen.hideAsync();
-  }
-
-  return null;
+export default function Root() {
+  // Set up the auth context and render our layout inside of it.
+  return (
+    <SessionProvider>
+      <Slot />
+    </SessionProvider>
+  );
 }
 ```
 
@@ -195,26 +197,32 @@ export function SplashScreenController() {
 
 <Step label="3">
 
-Use the **SessionProvider** in the root layout to provide the authentication context to the entire app. Ensure the **SplashScreenController** is inside the **SessionProvider**
+Create a nested [layout route](/router/basics/layout/) that checks whether users are authenticated before rendering the child route components. This layout route redirects users to the sign-in screen if they are not authenticated.
 
-```tsx app/_layout.tsx
-import { Slot } from 'expo-router';
-import { SessionProvider } from '../ctx';
-import { SplashScreenController } form '../splash'
+```tsx app/(app)/_layout.tsx|collapseHeight=400
+import { Text } from 'react-native';
+import { Redirect, Stack } from 'expo-router';
 
-export default function Root() {
-  // Set up the auth context and render our layout inside of it.
-  return (
-    <SessionProvider>
-      <SplashScreenController />
-      <RootNavigator />
-    </SessionProvider>
-  );
-}
+import { useSession } from '../../ctx';
 
-// Separate this into a new component so it can access the SessionProvider context later
-function RootNavigator() {
-  return <Stack />
+export default function AppLayout() {
+  const { session, isLoading } = useSession();
+
+  // You can keep the splash screen open, or render a loading screen like we do here.
+  if (isLoading) {
+    return <Text>Loading...</Text>;
+  }
+
+  // Only require authentication within the (app) group's layout as users
+  // need to be able to access the (auth) group and sign in again.
+  if (!session) {
+    // On web, static rendering will stop here as the user is not authenticated
+    // in the headless Node process that the pages are rendered in.
+    return <Redirect href="/sign-in" />;
+  }
+
+  // This layout can be deferred because it's not the root layout.
+  return <Stack />;
 }
 ```
 
@@ -252,32 +260,6 @@ export default function SignIn() {
 
 <Step label="5">
 
-Now we can modify the `<RootNavigator />` to protect routes based on our SessionProvider.
-
-```tsx app/_layout.tsx|collapseHeight=400
-/* Keep the code the same above, just edit the RootNavigator */
-
-function RootNavigator() {
-  const { session } = useSession();
-
-  return (
-    <Stack>
-      <Stack.Protected guard={session}>
-        <Stack.Screen name="(app)" />
-      </Stack.Protected>
-
-      <Stack.Protected guard={!session}>
-        <Stack.Screen name="sign-in" />
-      </Stack.Protected>
-    </Stack>
-  );
-}
-```
-
-</Step>
-
-<Step label="6">
-
 Implement an authenticated screen that lets users sign out.
 
 ```tsx app/(app)/index.tsx|collapseHeight=480
@@ -303,7 +285,11 @@ export default function Index() {
 
 </Step>
 
-You now have an app that will present the splash screen until the initial authentication state has loaded and will redirects to the sign-in screen if the user is not authenticated. If a user visits a deep link to any routes with the authentication check, they'll be redirected to the sign-in screen.
+You now have an app that can present a loading state while it checks the initial authentication state and redirects to the sign-in screen if the user is not authenticated. If a user visits a deep link to any routes with the authentication check, they'll be redirected to the sign-in screen.
+
+## Alternative loading states
+
+With Expo Router, something must be rendered to the screen while loading the initial auth state. In the example above, the app layout renders a loading message. Alternatively, you can make the `index` route a loading state and move the initial route to something such as `/home`, which is similar to how X works.
 
 ## Modals and per-route authentication
 
@@ -328,7 +314,7 @@ Another common pattern is to render a sign-in modal over the top of the app. Thi
 import { Stack } from 'expo-router';
 
 export const unstable_settings = {
-  initialRouteName: '(root)',
+  anchor: '(root)',
 };
 
 export default function AppLayout() {
@@ -346,16 +332,70 @@ export default function AppLayout() {
 }
 ```
 
-## More information
+## Navigating without navigation
 
-For more information, read the [Protected routes documentation](/router/advanced/protected/) to learn more patterns
+You may encounter the following error when the app attempts to perform navigation without a navigator mounted in the [root layout](/router/basics/layout/#root-layout).
 
-<VideoBoxLink
-  videoId="XCTaMu0qnFY"
-  title="How to use Protected Routes in Expo Router V5 for smooth auth"
-  description="Learn how to use Protected Routes in Expo Router V5 to create an authentication flow"
-  className="mb-6"
+```text
+Error: Attempted to navigate before mounting the Root Layout component. Ensure the Root Layout component is rendering a Slot, or other navigator on the first render.
+```
+
+To fix this, add a group and move conditional logic down a level.
+
+### Before
+
+<FileTree files={['app/_layout.tsx', 'app/about.tsx']} />
+
+```tsx app/_layout.tsx
+export default function RootLayout() {
+  React.useEffect(() => {
+    // This navigation event will trigger the error above.
+    router.push('/about');
+  }, []);
+
+  // This conditional statement creates a problem since the root layout's
+  // content (the Slot) must be mounted before any navigation events occur.
+  if (isLoading) {
+    return <Text>Loading...</Text>;
+  }
+
+  return <Slot />;
+}
+```
+
+### After
+
+<FileTree
+  files={[
+    ['app/_layout.tsx', ''],
+    ['app/(app)/_layout.tsx', 'Move conditional logic down a level'],
+    'app/(app)/about.tsx',
+  ]}
 />
+
+```tsx app/_layout.tsx
+export default function RootLayout() {
+  return <Slot />;
+}
+```
+
+```tsx app/(app)/_layout.tsx
+export default function RootLayout() {
+  React.useEffect(() => {
+    router.push('/about');
+  }, []);
+
+  // It is OK to defer rendering this nested layout's content. We couldn't
+  // defer rendering the root layout's content since a navigation event (the
+  // redirect) would have been triggered before the root layout's content had
+  // been mounted.
+  if (isLoading) {
+    return <Text>Loading...</Text>;
+  }
+
+  return <Slot />;
+}
+```
 
 ## Middleware
 


### PR DESCRIPTION
# Why

Add a new version of the authentication guide for SDK 53 that uses Protected Routes