### PR TITLE
[tsconfig] respect react-native type export condition

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- respect `react-native` type export conditions ([#36728](https://github.com/expo/expo/pull/36728) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 ## 53.0.8 — 2025-05-06

--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -10,7 +10,7 @@
     "module": "preserve",
     "moduleDetection": "force",
     "moduleResolution": "bundler",
-	"customConditions": ["react-native"],
+    "customConditions": ["react-native"],
     "noEmit": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,

--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -10,6 +10,7 @@
     "module": "preserve",
     "moduleDetection": "force",
     "moduleResolution": "bundler",
+	"customConditions": ["react-native"],
     "noEmit": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,


### PR DESCRIPTION
# Why

Packages can choose to specify `react-native` export condition which will be respected by Metro bundler. It could look like this: https://callstack.github.io/react-native-builder-bob/esm#alternative-approach

Along with the JS code come the types that TS will use for type checking and show to the user. Types, too, can be specified under the `react-native` export condition, but our tsconfig currently ignores those - it will pick the types from the `import` or `require` conditions, based on what syntax is used.

That could lead to a discrepancy.

https://www.typescriptlang.org/tsconfig/#customConditions

# How

Add `react-native` to `customConditions` in the TypeScript configuration to ensure correct type resolution for those packages that specify the `react-native.types` export condition.

React Native core has been shipping this for a while now: https://www.npmjs.com/package/@react-native/typescript-config/v/0.74.89?activeTab=code

# Test Plan

- Verified locally that TypeScript resolves imports from packages that use the `react-native.types` export condition in their package.json exports field


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)