### PR TITLE
Replace `removeNotificationSubscription` to `remove()`

### DIFF
--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -172,10 +172,8 @@ export default function App() {
     });
 
     return () => {
-      notificationListener.current &&
-        Notifications.removeNotificationSubscription(notificationListener.current);
-      responseListener.current &&
-        Notifications.removeNotificationSubscription(responseListener.current);
+      notificationListener.current?.remove();
+      responseListener.current?.remove();
     };
   }, []);
 

--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -153,8 +153,6 @@ export default function App() {
   const [notification, setNotification] = useState<Notifications.Notification | undefined>(
     undefined
   );
-  const notificationListener = useRef<Notifications.EventSubscription>();
-  const responseListener = useRef<Notifications.EventSubscription>();
 
   useEffect(() => {
     /* @info Gets the push token and displays it in the UI, or in case of an error, displays the error message. */
@@ -163,17 +161,17 @@ export default function App() {
       .catch((error: any) => setExpoPushToken(`${error}`));
     /* @end */
 
-    notificationListener.current = Notifications.addNotificationReceivedListener(notification => {
+    const notificationListener = Notifications.addNotificationReceivedListener(notification => {
       setNotification(notification);
     });
 
-    responseListener.current = Notifications.addNotificationResponseReceivedListener(response => {
+    const responseListener = Notifications.addNotificationResponseReceivedListener(response => {
       console.log(response);
     });
 
     return () => {
-      notificationListener.current?.remove();
-      responseListener.current?.remove();
+      notificationListener.remove();
+      responseListener.remove();
     };
   }, []);
 


### PR DESCRIPTION
# Why

The removeNotificationSubscription function has been deprecated, as noted in the documentation. Instead, it is recommended to call remove() directly on the subscription object. I noticed this while reviewing the official Expo documentation, which clearly marks removeNotificationSubscription as deprecated and advises using the .remove() method instead.

# How

I replaced the usage of Notifications.removeNotificationSubscription(...) with direct calls to .remove() on the subscription objects (notificationListener.current?.remove() and responseListener.current?.remove()). This change aligns with the current API recommendation and avoids usage of deprecated functions.

# Test Plan

I tested this change in a local Expo project. After registering and removing notification listeners, no deprecation warnings appeared in the console, and the cleanup behavior worked as expected when unmounting the component. This confirms the subscriptions are properly removed using the .remove() method.
# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
