### PR TITLE
[ios][updates] Update deferred root view constraints

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,10 +9,9 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed errors when `configuration-cache` is enabled. ([#36678](https://github.com/expo/expo/pull/36678) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Update the constraints of the deferred root view. ([#36744](https://github.com/expo/expo/pull/36744) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
-
-- [iOS] Update the constraints of the deferred root view.
 
 ## 0.28.12 — 2025-05-01
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [iOS] Update the constraints of the deferred root view.
+
 ## 0.28.12 — 2025-05-01
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -45,12 +45,15 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     if let view = createSplashScreenview(), let rootView = self.deferredRootView {
       view.translatesAutoresizingMaskIntoConstraints = false
       // The deferredRootView needs to be dark mode aware so we set the color to be the same as the splashscreen background.
-      rootView.backgroundColor = UIColor(named: "SplashScreenBackground") ?? .white
+      let backgroundColor = view.backgroundColor ?? UIColor(named: "SplashScreenBackground")
+      rootView.backgroundColor = backgroundColor ?? .white
       rootView.addSubview(view)
 
       NSLayoutConstraint.activate([
-        view.centerXAnchor.constraint(equalTo: rootView.centerXAnchor),
-        view.centerYAnchor.constraint(equalTo: rootView.centerYAnchor)
+        view.leadingAnchor.constraint(equalTo: rootView.leadingAnchor),
+        view.trailingAnchor.constraint(equalTo: rootView.trailingAnchor),
+        view.topAnchor.constraint(equalTo: rootView.topAnchor),
+        view.bottomAnchor.constraint(equalTo: rootView.bottomAnchor)
       ])
     }
     return self.deferredRootView


### PR DESCRIPTION
# Why
Closes #35410

# How
Update the root views layout constraints to match how the splashscreen is constrained.

# Test Plan
Fix was confirmed https://github.com/expo/expo/issues/35410#issuecomment-2850753697