### PR TITLE
Fix: Add missing shouldShowAlert in setNotificationHandler to resolve compile error

### DIFF
--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -69,10 +69,9 @@ import Constants from 'expo-constants';
 /* @info This handler determines how your app handles notifications that come in while the app is foregrounded. */
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
+    shouldShowAlert: true,
     shouldPlaySound: true,
     shouldSetBadge: true,
-    shouldShowBanner: true,
-    shouldShowList: true,
   }),
 });
 /* @end */


### PR DESCRIPTION
# Why

A TypeScript compilation error occurred because shouldShowAlert was missing in the object returned by handleNotification. This property is required in the return type of the NotificationHandler.

I initially used:
```tsx
Notifications.setNotificationHandler({
  handleNotification: async () => ({
    shouldPlaySound: true,
    shouldSetBadge: true,
    shouldShowBanner: true,
    shouldShowList: true,
  }),
});
```

However, shouldShowBanner and shouldShowList are not recognized properties, and the required shouldShowAlert was missing — causing the error.

# How

I updated the handleNotification return value to include the required shouldShowAlert field and removed unsupported properties:
```tsx
Notifications.setNotificationHandler({
  handleNotification: async () => ({
    shouldShowAlert: true,
    shouldPlaySound: true,
    shouldSetBadge: true,
  }),
});
```

# Test Plan

Tested locally in an Expo app. The app compiles without error, and the notification handler behaves as expected.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
