### PR TITLE
chore(cli): Update to `lan-network@^0.1.6` for Windows fixes

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Update to `lan-network@^0.1.5` for VPN network local IP changes ([#36572](https://github.com/expo/expo/pull/36572) by [@kitten](https://github.com/kitten))
+- Update to `lan-network@^0.1.6` for VPN network local IP changes and Windows fixes ([#36747](https://github.com/expo/expo/pull/36747) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -74,7 +74,7 @@
     "getenv": "^1.0.0",
     "glob": "^10.4.2",
     "minimatch": "^9.0.0",
-    "lan-network": "^0.1.5",
+    "lan-network": "^0.1.6",
     "node-forge": "^1.3.1",
     "npm-package-arg": "^11.0.0",
     "ora": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10562,10 +10562,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lan-network@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/lan-network/-/lan-network-0.1.5.tgz#e781889b7bd4dbedd9126fff3ceddd809a83c3ff"
-  integrity sha512-CV3k7l8jW0Z1b+G41tB7JInVyJEKQzh/YPl2v9uXpZMusp0aa+rh3OqG77xWuX7+eVBa8PsdTuMznTAssF4qwg==
+lan-network@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/lan-network/-/lan-network-0.1.6.tgz#098375edbb996bb6ca0cc597eff03ce45f1a2787"
+  integrity sha512-0qPYjNoD89v+bfhkIqFBYGBAof1xhxLqjX8bkNN1kQdP81UHpZw5TDXgEjwB+X2iCFGQmzF8TRmvg4vQcykyDA==
 
 lazy-cache@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
# Why

See: https://github.com/kitten/lan-network/pull/9
Resolves #36710
Follow-up to #36572

This disregards Windows virtual interfaces and `vEthernet` named interfaces.
It also switches around the IP that's used for probing.

# How

- Update to `lan-network@^0.1.6`

# Test Plan

- Tested manually on Windows 11 with WSL installed 
  - `npx lan-network` can be used to test this quickly, as before