### PR TITLE
[go] bump skia to v2.0.0-next.4

### DIFF
--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -39,7 +39,7 @@
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/stack": "^7.2.10",
     "@shopify/flash-list": "1.7.6",
-    "@shopify/react-native-skia": "v2.0.0-next.2",
+    "@shopify/react-native-skia": "v2.0.0-next.4",
     "@stripe/stripe-react-native": "0.45.0",
     "date-fns": "^2.28.0",
     "dedent": "^0.7.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -51,7 +51,7 @@
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/stack": "^7.2.10",
     "@shopify/flash-list": "1.7.6",
-    "@shopify/react-native-skia": "v2.0.0-next.2",
+    "@shopify/react-native-skia": "v2.0.0-next.4",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.9",
     "expo": "~53.0.8",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -108,7 +108,7 @@
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~5.1.3",
   "unimodules-image-loader-interface": "~6.1.0",
-  "@shopify/react-native-skia": "v2.0.0-next.2",
+  "@shopify/react-native-skia": "v2.0.0-next.4",
   "@shopify/flash-list": "1.7.6",
   "@sentry/react-native": "~6.10.0",
   "react-native-bootsplash": "^6.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,10 +3265,10 @@
     recyclerlistview "4.2.3"
     tslib "2.8.1"
 
-"@shopify/react-native-skia@v2.0.0-next.2":
-  version "2.0.0-next.2"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-2.0.0-next.2.tgz#4e749d268f18d548f89e912f9e47bc99e6b815e2"
-  integrity sha512-Ht62iLPqTd8ufctR85Jkvpb+KtVn+DGIdtzXOj+PsCY6NubxWtoOVINr2H2dzjroMFJ+WZyyJ6fEoyuHe0ObRg==
+"@shopify/react-native-skia@v2.0.0-next.4":
+  version "2.0.0-next.4"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-2.0.0-next.4.tgz#eb3e142d9e5cccbc248c3bb232cecd82224758c4"
+  integrity sha512-NzvdgryRz6tkKMHgCChCKa3wXfN9TZhlV0/LrfIU/wKLC1uKgGXkoZgNz7Is0wwdhtao1JJJJ81fqHCGHgzk9g==
   dependencies:
     canvaskit-wasm "0.40.0"
     react-reconciler "0.31.0"


### PR DESCRIPTION
# Why

v2.0.0-next.4 comes with react 19 fixes.

# How

according to William, this new version doesn't have native changes. we can just bump the version without releasing new expo-go.

# Test Plan

current released expo-go + ncl + skia

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
