### PR TITLE
[docs] include maximum Xcode version for SDK 51

### DIFF
--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -127,6 +127,6 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 | ---------------- | --------------- | ------------------- | ----------- | ------------- |
 | 53.0.0           | 7+              | 35                  | 15.1+       | 16.0+         |
 | 52.0.0           | 7+              | 35                  | 15.1+       | 16.0+         |
-| 51.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
+| 51.0.0           | 6+              | 34                  | 13.4+       | 15.4 - 16.2   |
 
 When deciding whether to upgrade your Expo SDK version, consider both Expo's SDK version and app store submission requirements, as described in the above table. Google Play Store and Apple App Store periodically increase their minimum required OS versions and API levels, which are required for new app submissions. Expo has no control over the app store requirements, and you should check [Google](https://developer.android.com/studio/build) and [Apple](https://developer.apple.com/news/upcoming-requirements/) for the current store submission requirements.

--- a/docs/pages/versions/v51.0.0/index.mdx
+++ b/docs/pages/versions/v51.0.0/index.mdx
@@ -99,7 +99,7 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version | Xcode version |
 | ---------------- | --------------- | ------------------- | ----------- | ------------- |
-| 51.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
+| 51.0.0           | 6+              | 34                  | 13.4+       | 15.4 - 16.2   |
 | 50.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
 | 49.0.0           | 5+              | 33                  | 13+         | 15.4          |
 

--- a/docs/pages/versions/v52.0.0/index.mdx
+++ b/docs/pages/versions/v52.0.0/index.mdx
@@ -118,7 +118,7 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version | Xcode version |
 | ---------------- | --------------- | ------------------- | ----------- | ------------- |
 | 52.0.0           | 7+              | 35                  | 15.1+       | 16.0+         |
-| 51.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
+| 51.0.0           | 6+              | 34                  | 13.4+       | 15.4 - 16.2   |
 | 50.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
 
 When deciding whether to upgrade your Expo SDK version, consider both Expo's SDK version and app store submission requirements, as described in the above table. Google Play Store and Apple App Store periodically increase their minimum required OS versions and API levels, which are required for new app submissions. Expo has no control over the app store requirements, and you should check [Google](https://developer.android.com/studio/build) and [Apple](https://developer.apple.com/news/upcoming-requirements/) for the current store submission requirements.

--- a/docs/pages/versions/v53.0.0/index.mdx
+++ b/docs/pages/versions/v53.0.0/index.mdx
@@ -127,6 +127,6 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 | ---------------- | --------------- | ------------------- | ----------- | ------------- |
 | 53.0.0           | 7+              | 35                  | 15.1+       | 16.0+         |
 | 52.0.0           | 7+              | 35                  | 15.1+       | 16.0+         |
-| 51.0.0           | 6+              | 34                  | 13.4+       | 15.4          |
+| 51.0.0           | 6+              | 34                  | 13.4+       | 15.4 - 16.2   |
 
 When deciding whether to upgrade your Expo SDK version, consider both Expo's SDK version and app store submission requirements, as described in the above table. Google Play Store and Apple App Store periodically increase their minimum required OS versions and API levels, which are required for new app submissions. Expo has no control over the app store requirements, and you should check [Google](https://developer.android.com/studio/build) and [Apple](https://developer.apple.com/news/upcoming-requirements/) for the current store submission requirements.


### PR DESCRIPTION
# Why

SDK 51 doesn't support XCode 16.3. The doctor warning links to this table through an fyi article, so this table should reflect that information.

# How

Changed the XCode version to be a range for SDK 51. Arguably, because _Apple_ doesn't support 15.x anymore, we could also change this to say 16.0 - 16.2. That being said, 'app store submission requirements' are mentioned separately, so 15.4 - 16.2 is probably more correct in this context.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
