### PR TITLE
fix(cli): Fix build cache providers types

### DIFF
--- a/packages/@expo/cli/src/utils/build-cache-providers/index.ts
+++ b/packages/@expo/cli/src/utils/build-cache-providers/index.ts
@@ -81,7 +81,7 @@ export async function resolveBuildCache({
     return null;
   }
 
-  if (provider.plugin.resolveRemoteBuildCache) {
+  if ('resolveRemoteBuildCache' in provider.plugin) {
     Log.warn('The resolveRemoteBuildCache function is deprecated. Use resolveBuildCache instead.');
     return await provider.plugin.resolveRemoteBuildCache(
       { fingerprintHash, platform, runOptions, projectRoot },
@@ -118,7 +118,7 @@ export async function uploadBuildCache({
     return;
   }
 
-  if (provider.plugin.uploadRemoteBuildCache) {
+  if ('uploadRemoteBuildCache' in provider.plugin) {
     Log.warn('The uploadRemoteBuildCache function is deprecated. Use uploadBuildCache instead.');
     await provider.plugin.uploadRemoteBuildCache(
       {


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/36752 tests did not catch this 
# How

Use `in` operator to check for the deprecated plugin functions to ensure types are detected correctly 
 
# Test Plan

yarn tsc inside @expo/cli 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
