### PR TITLE
noop non-fabric renderer when new architecture is enabled.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- noop non-fabric renderer when new architecture is enabled. ([#36757](https://github.com/expo/expo/pull/36757) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 🐛 Bug fixes
 
 - Update to `lan-network@^0.1.6` for VPN network local IP changes and Windows fixes ([#36747](https://github.com/expo/expo/pull/36747) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -165,6 +165,10 @@ export async function loadMetroConfigAsync(
     isNamedRequiresEnabled: env.EXPO_USE_METRO_REQUIRE,
     isReactServerComponentsEnabled: !!exp.experiments?.reactServerComponentRoutes,
     getMetroBundler,
+    isFabricEnabled: {
+      ios: exp.ios?.newArchEnabled ?? exp.newArchEnabled ?? true,
+      android: exp.android?.newArchEnabled ?? exp.newArchEnabled ?? true,
+    },
   });
 
   return {

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- noop non-fabric renderer when new architecture is enabled.
+
 ### 🐛 Bug fixes
 
 - respect `react-native` type export conditions ([#36728](https://github.com/expo/expo/pull/36728) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- noop non-fabric renderer when new architecture is enabled.
+- noop non-fabric renderer when new architecture is enabled. ([#36757](https://github.com/expo/expo/pull/36757) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 


### PR DESCRIPTION
# Why

- Each renderer is very heavy, we currently bundle two of them. We can speed up bundling and reduce the bundle size a lot (~320kb).

