### PR TITLE
[build-properties] [sdk52] Allow setting kotlin gradle plugin version

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Also set the version of the kotlin gradle plugin when specifying kotlinVersion. ([#29401](https://github.com/expo/expo/pull/36763) by [@janicduplessis](https://github.com/janicduplessis))
+
 ## 0.13.2 — 2025-01-10
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-build-properties/build/android.d.ts
+++ b/packages/expo-build-properties/build/android.d.ts
@@ -20,3 +20,8 @@ export declare const withAndroidPurgeProguardRulesOnce: ConfigPlugin;
 export declare function updateAndroidProguardRules(contents: string, newProguardRules: string | null, updateMode: 'append' | 'overwrite'): string;
 export declare const withAndroidCleartextTraffic: ConfigPlugin<PluginConfigType>;
 export declare const withAndroidQueries: ConfigPlugin<PluginConfigType>;
+/**
+ * This plugin is used to set the `kotlinVersion` in the `build.gradle` file for the
+ * kotlin gradle plugin.
+ */
+export declare const withAndroidKotlinGradlePluginVersion: ConfigPlugin<PluginConfigType>;

--- a/packages/expo-build-properties/build/android.js
+++ b/packages/expo-build-properties/build/android.js
@@ -220,17 +220,14 @@ const withAndroidKotlinGradlePluginVersion = (config, props) => {
     if (props.android?.kotlinVersion == null) {
         return config;
     }
-    return (0, config_plugins_1.withDangerousMod)(config, [
-        'android',
-        async (config) => {
-            const buildGradlePath = path_1.default.join(config.modRequest.platformProjectRoot, 'build.gradle');
-            const contents = await fs_1.default.promises.readFile(buildGradlePath, 'utf8');
-            const newContents = contents.replace("classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')", 'classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")');
-            if (contents !== newContents) {
-                await fs_1.default.promises.writeFile(buildGradlePath, newContents);
-            }
-            return config;
-        },
-    ]);
+    return (0, config_plugins_1.withProjectBuildGradle)(config, async (config) => {
+        if (config.modResults.language === 'groovy') {
+            config.modResults.contents = config.modResults.contents.replace("classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')", 'classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")');
+        }
+        else {
+            config_plugins_1.WarningAggregator.addWarningAndroid('withAndroidKotlinGradlePluginVersion', `Cannot automatically configure project build.gradle if it's not groovy`);
+        }
+        return config;
+    });
 };
 exports.withAndroidKotlinGradlePluginVersion = withAndroidKotlinGradlePluginVersion;

--- a/packages/expo-build-properties/build/android.js
+++ b/packages/expo-build-properties/build/android.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.withAndroidQueries = exports.withAndroidCleartextTraffic = exports.updateAndroidProguardRules = exports.withAndroidPurgeProguardRulesOnce = exports.withAndroidProguardRules = exports.withAndroidBuildProperties = void 0;
+exports.withAndroidKotlinGradlePluginVersion = exports.withAndroidQueries = exports.withAndroidCleartextTraffic = exports.updateAndroidProguardRules = exports.withAndroidPurgeProguardRulesOnce = exports.withAndroidProguardRules = exports.withAndroidBuildProperties = void 0;
 const config_plugins_1 = require("expo/config-plugins");
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
@@ -212,3 +212,25 @@ const withAndroidQueries = (config, props) => {
     });
 };
 exports.withAndroidQueries = withAndroidQueries;
+/**
+ * This plugin is used to set the `kotlinVersion` in the `build.gradle` file for the
+ * kotlin gradle plugin.
+ */
+const withAndroidKotlinGradlePluginVersion = (config, props) => {
+    if (props.android?.kotlinVersion == null) {
+        return config;
+    }
+    return (0, config_plugins_1.withDangerousMod)(config, [
+        'android',
+        async (config) => {
+            const buildGradlePath = path_1.default.join(config.modRequest.platformProjectRoot, 'build.gradle');
+            const contents = await fs_1.default.promises.readFile(buildGradlePath, 'utf8');
+            const newContents = contents.replace("classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')", 'classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")');
+            if (contents !== newContents) {
+                await fs_1.default.promises.writeFile(buildGradlePath, newContents);
+            }
+            return config;
+        },
+    ]);
+};
+exports.withAndroidKotlinGradlePluginVersion = withAndroidKotlinGradlePluginVersion;

--- a/packages/expo-build-properties/build/withBuildProperties.js
+++ b/packages/expo-build-properties/build/withBuildProperties.js
@@ -22,6 +22,7 @@ const withBuildProperties = (config, props) => {
     //
     // plugins order matter: the later one would run first
     config = (0, android_1.withAndroidPurgeProguardRulesOnce)(config);
+    config = (0, android_1.withAndroidKotlinGradlePluginVersion)(config, pluginConfig);
     config = (0, ios_1.withIosBuildProperties)(config, pluginConfig);
     config = (0, ios_1.withIosDeploymentTarget)(config, pluginConfig);
     return config;

--- a/packages/expo-build-properties/src/android.ts
+++ b/packages/expo-build-properties/src/android.ts
@@ -261,3 +261,31 @@ export const withAndroidQueries: ConfigPlugin<PluginConfigType> = (config, props
     return config;
   });
 };
+
+/**
+ * This plugin is used to set the `kotlinVersion` in the `build.gradle` file for the
+ * kotlin gradle plugin.
+ */
+export const withAndroidKotlinGradlePluginVersion: ConfigPlugin<PluginConfigType> = (
+  config,
+  props
+) => {
+  if (props.android?.kotlinVersion == null) {
+    return config;
+  }
+  return withDangerousMod(config, [
+    'android',
+    async (config) => {
+      const buildGradlePath = path.join(config.modRequest.platformProjectRoot, 'build.gradle');
+      const contents = await fs.promises.readFile(buildGradlePath, 'utf8');
+      const newContents = contents.replace(
+        "classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')",
+        'classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")'
+      );
+      if (contents !== newContents) {
+        await fs.promises.writeFile(buildGradlePath, newContents);
+      }
+      return config;
+    },
+  ]);
+};

--- a/packages/expo-build-properties/src/withBuildProperties.ts
+++ b/packages/expo-build-properties/src/withBuildProperties.ts
@@ -6,6 +6,7 @@ import {
   withAndroidPurgeProguardRulesOnce,
   withAndroidCleartextTraffic,
   withAndroidQueries,
+  withAndroidKotlinGradlePluginVersion,
 } from './android';
 import { withIosBuildProperties, withIosDeploymentTarget } from './ios';
 import { PluginConfigType, validateConfig } from './pluginConfig';
@@ -30,6 +31,7 @@ export const withBuildProperties: ConfigPlugin<PluginConfigType> = (config, prop
   //
   // plugins order matter: the later one would run first
   config = withAndroidPurgeProguardRulesOnce(config);
+  config = withAndroidKotlinGradlePluginVersion(config, pluginConfig);
 
   config = withIosBuildProperties(config, pluginConfig);
   config = withIosDeploymentTarget(config, pluginConfig);


### PR DESCRIPTION
# Why

It is currently not possible to use kotlin 2+ with expo sdk 52. This fixes it. We currently have a hard requirement of kotlin 2+ for the android stripe sdk so we need to support it in the react-native sdk. A lot of users are still on expo 52 so it would be good to support it.

Note that this must only be used for sdk 52, in sdk 53 the kotlin version is no longer specified the same way and is not compatible with this.

# How

This passes the kotlin version explicitly to the kotlin gradle plugin. This allows overriding what the react-native gradle plugin sets.

# Test Plan

Tested using this repo https://github.com/janicduplessis/stripe-expo-sdk-52

- Apply this change locally in node_modules
- Delete android folder
- Run `yarn android`
- Check that it builds and that changes are applied properly in build.gradle.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
