### PR TITLE
fix(babel-preset-expo): Disable `minifyTypeofWindow` for web targets temporarily

### DIFF
--- a/docs/pages/guides/tree-shaking.mdx
+++ b/docs/pages/guides/tree-shaking.mdx
@@ -138,9 +138,10 @@ The above code snippet is then minified, which removes the unused conditional:
 
 It's common to use `typeof window === 'undefined'` to conditionally enable or disable code for server and client environments.
 
-`babel-preset-expo` automatically transforms `typeof window === 'undefined'` to `true` when bundling for server environments and `false` when bundling for websites. The check remains unchanged when bundling for native client environments to support apps that polyfill `window`. This transform runs in both development and production but only removes conditional requires in production.
+`babel-preset-expo` will transform `typeof window === 'undefined'` to `true` when when bundling for server environments. By default, this check remains unchanged when bundling for web client environments. This transform runs in both development and production but only removes conditional requires in production.
 
-You can configure `babel-preset-expo` to skip the transform by passing `{ preserveTypeofWindow: false }`.
+You can configure `babel-preset-expo` to enable this transform by passing `{ minifyTypeofWindow: true }`.
+By default, this transform remains disabled even for web environments since web workers won't have a `window` global.
 
 <Step label="1">
 
@@ -162,15 +163,7 @@ if (true) {
 }
 ```
 
-Bundling client code for web browsers will change `typeof window` to `false`:
-
-```js Post babel-preset-expo
-if (false) {
-  console.log('Hello on the server!');
-}
-```
-
-Bundling client code for native apps will leave `typeof window` in place:
+Bundling client code for web or native apps will not replace `typeof window` unless `minifyTypeOfWindow: true` is set:
 
 ```js Post babel-preset-expo
 if (typeof window === 'undefined') {
@@ -182,13 +175,16 @@ if (typeof window === 'undefined') {
 
 <Step label="3">
 
-The above code snippet is then minified, which removes the unused conditional:
+For server environments, the above code snippet is then minified which removes the unused conditional:
 
 ```js Post minifier (server)
 console.log('Hello on the server!');
 ```
 
-```js Post minifier (client websites)
+```js Post minifier (client)
+if (typeof window === 'undefined') {
+  console.log('Hello on the server!');
+}
 // Empty file
 ```
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Disable `minifyTypeofWindow` for Web to prevent breaking Web Worker targets ([#36773](https://github.com/expo/expo/pull/36773) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 13.1.11 — 2025-05-01

--- a/packages/babel-preset-expo/README.md
+++ b/packages/babel-preset-expo/README.md
@@ -33,7 +33,7 @@ Settings to pass to `babel-plugin-react-compiler`. Set as `false` to disable the
 
 ### `minifyTypeofWindow`
 
-Set `minifyTypeofWindow: false` to preserve the `typeof window` check in your code, e.g. `if (typeof window === 'undefined')` -> `if (true)` in servers. This is useful when you're using libraries that mock the window object on native or in the server.
+Set `minifyTypeofWindow: true` to transform `typeof window` checks in your code, e.g. `if (typeof window === 'object')` -> `if (true)` in clients. This is useful when you're using libraries that mock the window object on native or in the server.
 
 ```js
 [
@@ -47,7 +47,7 @@ Set `minifyTypeofWindow: false` to preserve the `typeof window` check in your co
 ];
 ```
 
-Defaults to `false` for server environments and web, `true` for native platforms to support legacy browser polyfills.
+Defaults to `true` for server environments, and `false` for client environments to support legacy browser polyfills and web workers.
 
 ### `reanimated`
 

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -117,7 +117,9 @@ function babelPresetExpo(api, options = {}) {
         'process.env.EXPO_SERVER': !!isServerEnv,
     };
     // `typeof window` is left in place for native + client environments.
-    const minifyTypeofWindow = (platformOptions.minifyTypeofWindow ?? isServerEnv) || platform === 'web';
+    // NOTE(@kitten): We're temporarily disabling this default optimization for Web targets due to Web Workers
+    // We're currently not passing metadata to indicate we're transforming for a Web Worker to disable this automatically
+    const minifyTypeofWindow = platformOptions.minifyTypeofWindow ?? isServerEnv;
     if (minifyTypeofWindow !== false) {
         // This nets out slightly faster in development when considering the cost of bundling server dependencies.
         inlines['typeof window'] = isServerEnv ? 'undefined' : 'object';

--- a/packages/babel-preset-expo/src/__tests__/platform-shaking.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/platform-shaking.test.ts
@@ -662,15 +662,16 @@ describe('SSR window check', () => {
     `;
 
     const res = babel.transform(src, options);
-    expect(res?.code).toMatch('if(true){');
+    expect(res?.code).toMatch("if(typeof window!=='undefined'){\nconsole.log('ssr.1');\n}");
 
-    // Code is fully minified away
-    expect((await minifyLikeMetroAsync(res!)).code).toBe(`console.log('ssr.1');`);
+    expect((await minifyLikeMetroAsync(res!)).code).toBe(
+      `'undefined'!=typeof window&&console.log('ssr.1');`
+    );
   });
-  it(`preserves typeof window usage in client bundles`, async () => {
+  it(`removes typeof window check in client bundles when minifyTypeOfWindow is enabled`, async () => {
     const options = {
       babelrc: false,
-      presets: [preset],
+      presets: [[preset, { minifyTypeofWindow: true }]],
       filename: 'unknown',
       // compact: true,
       // Make the snapshot easier to read
@@ -686,7 +687,7 @@ describe('SSR window check', () => {
     `;
 
     const res = babel.transform(src, options);
-    expect(res?.code).toMatch('if(true){');
+    expect(res?.code).toMatch("if(true){\nconsole.log('ssr.1');\n}");
 
     // Code is fully minified away
     expect((await minifyLikeMetroAsync(res!)).code).toBe(`console.log('ssr.1');`);

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -250,9 +250,9 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
   };
 
   // `typeof window` is left in place for native + client environments.
-  const minifyTypeofWindow =
-    (platformOptions.minifyTypeofWindow ?? isServerEnv) || platform === 'web';
-
+  // NOTE(@kitten): We're temporarily disabling this default optimization for Web targets due to Web Workers
+  // We're currently not passing metadata to indicate we're transforming for a Web Worker to disable this automatically
+  const minifyTypeofWindow = platformOptions.minifyTypeofWindow ?? isServerEnv;
   if (minifyTypeofWindow !== false) {
     // This nets out slightly faster in development when considering the cost of bundling server dependencies.
     inlines['typeof window'] = isServerEnv ? 'undefined' : 'object';


### PR DESCRIPTION
# Why

Resolves #36620

Due to `asyncType` being used to communicate whether we're bundling for a Web Worker, it's currently tricky to mark the transform step as being for Web Workers. It's also unclear whether passing this on somehow would break Metro's cache key for the affected files.

However, `minifyTypeofWindow` makes the incorrect assumption of `typeof window === 'object'` for web workers.

# How

Temporarily disable `minifyTypeofWindow` for all web targets to prevent this from becoming a problem, until we have a better solution.

# Test Plan

- Manually tested