### PR TITLE
[ios][image] Fix PhotoLibrary assets incorrect scaling

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix PhotoLibrary assets being scaled twice.
+- [iOS] Fix PhotoLibrary assets being scaled twice. ([#36776](https://github.com/expo/expo/pull/36776) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix PhotoLibrary assets being scaled twice.
+
 ### 💡 Others
 
 ## 2.1.7 — 2025-05-06

--- a/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
+++ b/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
@@ -107,12 +107,9 @@ private func requestAsset(
     }
   }
 
-  let screenScale = context?[ImageView.screenScaleKey] as? Double ?? UIScreen.main.scale
-  let targetSize = CGSize(width: Double(asset.pixelWidth) / screenScale, height: Double(asset.pixelHeight) / screenScale)
-
   return PHImageManager.default().requestImage(
     for: asset,
-    targetSize: targetSize,
+    targetSize: PHImageManagerMaximumSize,
     contentMode: .aspectFit,
     options: options,
     resultHandler: { image, info in


### PR DESCRIPTION
# Why
Closes #36739
When fetching assets from the `PhotosLibrary`, we scaled them as part of the fetch request. This causes an issue because when the image size is passed to `idealSize`, it is an already scaled size that is scaled even further.

# How
We should fetch the image at its full dimensions and then let `idealSize` do the correct scaling. 

# Test Plan
Using the provided repro, the blurred image is rendered at the correct resolution.

![Simulator Screenshot - iPhone 16 - 2025-05-09 at 13 57 30](https://github.com/user-attachments/assets/371c7af1-0718-40c6-aba3-3cc6d81c65d3)
