### PR TITLE
[expo-go] Fix pod install error

### DIFF
--- a/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
+++ b/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
@@ -4,6 +4,7 @@
 	classes = {
 	};
 	objectVersion = 70;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -449,6 +450,11 @@
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		2D1A6CC92D9B38910007E94A /* Notifications */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Notifications; sourceTree = "<group>"; };
+		2D1A6CC92D9B38910007E94A /* Notifications */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = Notifications;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1242,7 +1248,6 @@
 				};
 			};
 			buildConfigurationList = 78CEE2BB1ACD07D70095B124 /* Build configuration list for PBXProject "Exponent" */;
-			compatibilityVersion = "Xcode 12.0";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -1251,6 +1256,7 @@
 				Base,
 			);
 			mainGroup = 78CEE2B71ACD07D70095B124;
+			preferredProjectObjectVersion = 77;
 			productRefGroup = 78CEE2C11ACD07D70095B124 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";


### PR DESCRIPTION
# Why

Running `et pods` threw the following error for me:
```
### Error

ArgumentError - [Xcodeproj] Unable to find compatibility version string for object version `70`.
```

# How

Bumped project format to xcode 16. Interestingly, bumping to 16.3 also breaks for now with latest cocoapods.

<img width="194" alt="image" src="https://github.com/user-attachments/assets/8c7d2160-3c8e-4523-920b-79f2cfae6eb1" />


# Test Plan

Pods now install successfully.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
