### PR TITLE
[docs] add maps video to expo maps doc

### DIFF
--- a/docs/pages/versions/unversioned/sdk/maps.mdx
+++ b/docs/pages/versions/unversioned/sdk/maps.mdx
@@ -16,12 +16,16 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 > **important** **This library is currently in alpha and will frequently experience breaking changes.** It is not available in the Expo Go app &ndash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 ## Installation
 
 <APIInstallSection />
+
+<br />
+<VideoBoxLink videoId="jDCuaIQ9vd0" title="Watch: Expo Maps Deep Dive" />
 
 ## Configuration
 

--- a/docs/pages/versions/v52.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/maps.mdx
@@ -16,12 +16,16 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 > **important** **This library is currently in alpha and will frequently experience breaking changes.** It is not available in the Expo Go app &ndash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 ## Installation
 
 <APIInstallSection />
+
+<br />
+<VideoBoxLink videoId="jDCuaIQ9vd0" title="Watch: Expo Maps Deep Dive" />
 
 ## Configuration
 

--- a/docs/pages/versions/v53.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/maps.mdx
@@ -16,12 +16,16 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 > **important** **This library is currently in alpha and will frequently experience breaking changes.** It is not available in the Expo Go app &ndash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 ## Installation
 
 <APIInstallSection />
+
+<br />
+<VideoBoxLink videoId="jDCuaIQ9vd0" title="Watch: Expo Maps Deep Dive" />
 
 ## Configuration
 


### PR DESCRIPTION
# Why

[ENG-15732 Add maps video to the documentation](https://linear.app/expo/issue/ENG-15732/add-maps-video-to-the-documentation)

# How

Added using `VideoBoxLink` to sdk 52, 53 and unversioned

# Test Plan

Ran locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
