### PR TITLE
[docs] Update icons

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -30,7 +30,7 @@
     "@expo/styleguide": "^9.1.2",
     "@expo/styleguide-base": "^2.0.3",
     "@expo/styleguide-icons": "^2.2.2",
-    "@expo/styleguide-search-ui": "^2.3.4",
+    "@expo/styleguide-search-ui": "^2.3.6",
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/mdx": "^3.1.0",
     "@mdx-js/react": "^3.1.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@expo/styleguide": "^9.1.2",
     "@expo/styleguide-base": "^2.0.3",
-    "@expo/styleguide-icons": "^2.2.0",
+    "@expo/styleguide-icons": "^2.2.2",
     "@expo/styleguide-search-ui": "^2.3.4",
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/mdx": "^3.1.0",

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -5,7 +5,7 @@ description: Learn how to set up and configure the jest-expo library to write un
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
-import { Dataflow01Icon } from '@expo/styleguide-icons/outline/Dataflow01Icon';
+import { Dataflow03Icon } from '@expo/styleguide-icons/outline/Dataflow03Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -325,7 +325,7 @@ For more information, see [CLI Options](https://jestjs.io/docs/en/cli) in Jest d
   title="E2E tests with EAS Workflows"
   description="Learn how to set up and run E2E tests on EAS Workflows with Maestro."
   href="/eas/workflows/reference/e2e-tests/"
-  Icon={Dataflow01Icon}
+  Icon={Dataflow03Icon}
 />
 
 </TabsGroup>

--- a/docs/pages/eas/index.mdx
+++ b/docs/pages/eas/index.mdx
@@ -10,7 +10,7 @@ import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
 import { EasSubmitIcon } from '@expo/styleguide-icons/custom/EasSubmitIcon';
 import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 import { DataIcon } from '@expo/styleguide-icons/outline/DataIcon';
-import { Dataflow01Icon } from '@expo/styleguide-icons/outline/Dataflow01Icon';
+import { Dataflow03Icon } from '@expo/styleguide-icons/outline/Dataflow03Icon';
 import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
@@ -23,7 +23,7 @@ Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links
   title="EAS Workflows"
   description="Automate your development release workflows."
   href="/eas/workflows/get-started/"
-  Icon={Dataflow01Icon}
+  Icon={Dataflow03Icon}
 />
 
 <BoxLink

--- a/docs/pages/eas/workflows/automating-eas-cli.mdx
+++ b/docs/pages/eas/workflows/automating-eas-cli.mdx
@@ -3,7 +3,7 @@ title: Automating EAS CLI commands
 description: Learn how to automate sequences of EAS CLI commands with EAS Workflows.
 ---
 
-import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+import { Dataflow03Icon } from '@expo/styleguide-icons/outline/Dataflow03Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
@@ -122,5 +122,5 @@ Workflows are a powerful way to automate your development and release processes.
   href="/eas/workflows/examples"
   title="Workflow examples"
   description="Learn how to use workflows to create development builds, publish preview updates, and create production builds."
-  Icon={BookOpen02Icon}
+  Icon={Dataflow03Icon}
 />

--- a/docs/pages/eas/workflows/reference/e2e-tests.mdx
+++ b/docs/pages/eas/workflows/reference/e2e-tests.mdx
@@ -5,7 +5,7 @@ description: Learn how to set up and run E2E tests on EAS Workflows with Maestro
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
-import { Dataflow01Icon } from '@expo/styleguide-icons/outline/Dataflow01Icon';
+import { Dataflow03Icon } from '@expo/styleguide-icons/outline/Dataflow03Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
@@ -183,14 +183,14 @@ After the workflow starts, you can track its progress and view the results in th
   title="Syntax for EAS Workflows"
   description="Learn more about the syntax for EAS Workflows."
   href="/eas/workflows/syntax/"
-  Icon={Dataflow01Icon}
+  Icon={Dataflow03Icon}
 />
 
 <BoxLink
   title="Example CI/CD workflows"
   description="Learn more about example CI/CD workflows for EAS Workflows."
   href="/eas/workflows/examples/"
-  Icon={Dataflow01Icon}
+  Icon={Dataflow03Icon}
 />
 
 <BoxLink

--- a/docs/pages/monitoring/services.mdx
+++ b/docs/pages/monitoring/services.mdx
@@ -3,7 +3,10 @@ title: Monitoring services
 description: Learn how to monitor the usage of your Expo and React Native app after its release.
 ---
 
+import { LogrocketIcon } from '@expo/styleguide-icons/custom/LogrocketIcon';
+import { SentryIcon } from '@expo/styleguide-icons/custom/SentryIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+import { DataIcon } from '@expo/styleguide-icons/outline/DataIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
@@ -25,7 +28,7 @@ Get started with the following guide:
   title="EAS Insights"
   description="Learn how to use EAS Insights to monitor your app."
   href="/eas-insights/introduction/"
-  Icon={BookOpen02Icon}
+  Icon={DataIcon}
 />
 
 ## LogRocket
@@ -43,7 +46,7 @@ Get started with the following guide:
   title="Using LogRocket"
   description="Learn how to use LogRocket to monitor your app."
   href="/guides/using-logrocket/"
-  Icon={BookOpen02Icon}
+  Icon={LogrocketIcon}
 />
 
 ## Sentry
@@ -63,7 +66,7 @@ Get started with the following guide:
   title="Using Sentry"
   description="Learn how to use Sentry to monitor your app."
   href="/guides/using-sentry/"
-  Icon={BookOpen02Icon}
+  Icon={SentryIcon}
 />
 
 ## Vexo

--- a/docs/ui/components/Search/expoEntries.ts
+++ b/docs/ui/components/Search/expoEntries.ts
@@ -7,13 +7,13 @@ import { Smartphone01Icon } from '@expo/styleguide-icons/custom/Smartphone01Icon
 import { BracketsXIcon } from '@expo/styleguide-icons/outline/BracketsXIcon';
 import { Cube02Icon } from '@expo/styleguide-icons/outline/Cube02Icon';
 import { DataIcon } from '@expo/styleguide-icons/outline/DataIcon';
-import { Dataflow01Icon } from '@expo/styleguide-icons/outline/Dataflow01Icon';
 import { Dataflow03Icon } from '@expo/styleguide-icons/outline/Dataflow03Icon';
 import { FileSearch02Icon } from '@expo/styleguide-icons/outline/FileSearch02Icon';
 import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
 import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon';
 import { NotificationBoxIcon } from '@expo/styleguide-icons/outline/NotificationBoxIcon';
 import { Settings01Icon } from '@expo/styleguide-icons/outline/Settings01Icon';
+import { Tag03Icon } from '@expo/styleguide-icons/outline/Tag03Icon';
 import type { ComponentType, HTMLAttributes } from 'react';
 
 export type ExpoItemType = {
@@ -61,7 +61,7 @@ export const entries: ExpoItemType[] = [
   {
     label: 'Project Deployments',
     url: 'https://expo.dev/accounts/[account]/projects/[project]/deployments',
-    Icon: Dataflow03Icon,
+    Icon: Tag03Icon,
   },
   {
     label: 'Project Development Builds',
@@ -101,7 +101,7 @@ export const entries: ExpoItemType[] = [
   {
     label: 'Project Workflows',
     url: 'https://expo.dev/accounts/[account]/projects/[project]/workflows',
-    Icon: Dataflow01Icon,
+    Icon: Dataflow03Icon,
   },
   {
     label: 'Project Push Notifications',

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -9,7 +9,7 @@ import { CodeSquare01Icon } from '@expo/styleguide-icons/outline/CodeSquare01Ico
 import { CpuChip01Icon } from '@expo/styleguide-icons/outline/CpuChip01Icon';
 import { Cube01Icon } from '@expo/styleguide-icons/outline/Cube01Icon';
 import { DataIcon } from '@expo/styleguide-icons/outline/DataIcon';
-import { Dataflow01Icon } from '@expo/styleguide-icons/outline/Dataflow01Icon';
+import { Dataflow03Icon } from '@expo/styleguide-icons/outline/Dataflow03Icon';
 import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon';
 import { NotificationBoxIcon } from '@expo/styleguide-icons/outline/NotificationBoxIcon';
 import { PaletteIcon } from '@expo/styleguide-icons/outline/PaletteIcon';
@@ -212,7 +212,7 @@ function getIconElement(iconName?: string) {
     case 'EAS Insights':
       return DataIcon;
     case 'EAS Workflows':
-      return Dataflow01Icon;
+      return Dataflow03Icon;
     case 'EAS Hosting':
       return Cloud01Icon;
     case 'Expo Modules API':

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -569,6 +569,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@expo/styleguide-icons@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@expo/styleguide-icons@npm:2.2.2"
+  dependencies:
+    tailwind-merge: "npm:^2.5.4"
+  peerDependencies:
+    react: ">= 16"
+  checksum: 10c0/df24b2c7652f4237eb6db9301cb58dbbe81bb955e94f69469a0e6e2668b9312828283f8dbbc3ae9382ac00a7ea6142222af553f80ba6443ddfca08d240b70948
+  languageName: node
+  linkType: hard
+
 "@expo/styleguide-search-ui@npm:^2.3.4":
   version: 2.3.4
   resolution: "@expo/styleguide-search-ui@npm:2.3.4"
@@ -5719,7 +5730,7 @@ __metadata:
     "@expo/spawn-async": "npm:^1.7.2"
     "@expo/styleguide": "npm:^9.1.2"
     "@expo/styleguide-base": "npm:^2.0.3"
-    "@expo/styleguide-icons": "npm:^2.2.0"
+    "@expo/styleguide-icons": "npm:^2.2.2"
     "@expo/styleguide-search-ui": "npm:^2.3.4"
     "@mdx-js/loader": "npm:^3.1.0"
     "@mdx-js/mdx": "npm:^3.1.0"

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -558,17 +558,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/styleguide-icons@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@expo/styleguide-icons@npm:2.2.0"
-  dependencies:
-    tailwind-merge: "npm:^2.5.4"
-  peerDependencies:
-    react: ">= 16"
-  checksum: 10c0/058085af3264149e1f842e003df3813f377f2b88b3b36b97d0e08c9f00bb76fc2a2b4274861a4bff88c1cf0277f556ecc3eb5b2a8953b8af0eb0bcbfaab94ce7
-  languageName: node
-  linkType: hard
-
 "@expo/styleguide-icons@npm:^2.2.2":
   version: 2.2.2
   resolution: "@expo/styleguide-icons@npm:2.2.2"
@@ -580,12 +569,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/styleguide-search-ui@npm:^2.3.4":
-  version: 2.3.4
-  resolution: "@expo/styleguide-search-ui@npm:2.3.4"
+"@expo/styleguide-search-ui@npm:^2.3.6":
+  version: 2.3.6
+  resolution: "@expo/styleguide-search-ui@npm:2.3.6"
   dependencies:
     "@expo/styleguide": "npm:^9.1.2"
-    "@expo/styleguide-icons": "npm:^2.2.0"
+    "@expo/styleguide-icons": "npm:^2.2.2"
     "@sanity/client": "npm:^6.28.3"
     "@sanity/image-url": "npm:^1.1.0"
     cmdk: "npm:^0.2.1"
@@ -593,7 +582,7 @@ __metadata:
   peerDependencies:
     next: ">= 13"
     react: ">= 16"
-  checksum: 10c0/a435b89a12e2c19f39164cb510cc06be82f0fb80930db05abc36a162877b28ee0dace1225ccce7ed4fff69ac9ac5a5fbe95590b45c89e9ecf698698dd5fe742f
+  checksum: 10c0/23df44e28607a1c18f0a4cc7bbc1f36b0d9d3c871c7859e642044a37e990b33df379493d32d42b975b33986b1899a744ed0781e6c5b184e2e6c36a6dbdf4a939
   languageName: node
   linkType: hard
 
@@ -5731,7 +5720,7 @@ __metadata:
     "@expo/styleguide": "npm:^9.1.2"
     "@expo/styleguide-base": "npm:^2.0.3"
     "@expo/styleguide-icons": "npm:^2.2.2"
-    "@expo/styleguide-search-ui": "npm:^2.3.4"
+    "@expo/styleguide-search-ui": "npm:^2.3.6"
     "@mdx-js/loader": "npm:^3.1.0"
     "@mdx-js/mdx": "npm:^3.1.0"
     "@mdx-js/react": "npm:^3.1.0"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

With changes in the Expo dashboard, the icons for Workflows and Project deployments have changed. This PR fixes that.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Upgrade stylleguide icon and search-ui dependencies to latest version
- Update EAS Workflows icon everywhere
- Update Poject deployments icon in Search UI
- Fix Workflows icon in a boxlink
- Update icons for Boxlinks on Monitoring services page

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
