### PR TITLE
[docs] Update local images example in Expo Print

### DIFF
--- a/docs/pages/versions/unversioned/sdk/print.mdx
+++ b/docs/pages/versions/unversioned/sdk/print.mdx
@@ -122,7 +122,6 @@ import { Asset } from 'expo-asset';
 import { useImageManipulator } from 'expo-image-manipulator';
 import { printAsync } from 'expo-print';
 import { useEffect } from 'react';
-import { View } from 'react-native';
 
 const IMAGE = Asset.fromModule(require('@/assets/images/icon.png'));
 
@@ -153,7 +152,7 @@ export function ImageManipulatorExample() {
     generateAndPrint();
   }, [context]);
 
-  return <View />;
+  return <>{/* Render UI */}</>;
 }
 ```
 

--- a/docs/pages/versions/unversioned/sdk/print.mdx
+++ b/docs/pages/versions/unversioned/sdk/print.mdx
@@ -115,28 +115,45 @@ import * as Print from 'expo-print';
 
 ## Local images
 
-On iOS, printing from HTML source doesn't support local asset URLs (due to WKWebView limitations). Instead, images need to be converted to base64 and inlined into the HTML.
+On iOS, printing from HTML source doesn't support local asset URLs (due to `WKWebView` limitations). Instead, images need to be converted to base64 and inlined into the HTML.
 
-```js
+```tsx Example
 import { Asset } from 'expo-asset';
+import { useImageManipulator } from 'expo-image-manipulator';
 import { printAsync } from 'expo-print';
-import { manipulateAsync } from 'expo-image-manipulator';
+import { useEffect } from 'react';
+import { View } from 'react-native';
 
-async function generateHTML() {
-  const asset = Asset.fromModule(require('../../assets/logo.png'));
-  const image = await manipulateAsync(asset.localUri ?? asset.uri, [], { base64: true });
-  return `
-    <html>
-      <img
-        src="data:image/jpeg;base64,${image.base64}"
-        style="width: 90vw;" />
-    </html>
-  `;
-}
+const IMAGE = Asset.fromModule(require('@/assets/images/icon.png'));
 
-async function print() {
-  const html = await generateHTML();
-  await printAsync({ html });
+export function ImageManipulatorExample() {
+  const context = useImageManipulator(IMAGE.uri);
+
+  useEffect(() => {
+    async function generateAndPrint() {
+      try {
+        await IMAGE.downloadAsync();
+        const manipulatedImage = await context.renderAsync();
+        const result = await manipulatedImage.saveAsync({ base64: true });
+
+        const html = `
+          <html>
+            <img
+              src="data:image/png;base64,${result.base64}"
+              style="width: 90vw;" />
+          </html>
+        `;
+
+        await printAsync({ html });
+      } catch (error) {
+        console.error('Error:', error);
+      }
+    }
+
+    generateAndPrint();
+  }, [context]);
+
+  return <View />;
 }
 ```
 

--- a/docs/pages/versions/v52.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/print.mdx
@@ -122,7 +122,6 @@ import { Asset } from 'expo-asset';
 import { useImageManipulator } from 'expo-image-manipulator';
 import { printAsync } from 'expo-print';
 import { useEffect } from 'react';
-import { View } from 'react-native';
 
 const IMAGE = Asset.fromModule(require('@/assets/images/icon.png'));
 
@@ -153,7 +152,7 @@ export function ImageManipulatorExample() {
     generateAndPrint();
   }, [context]);
 
-  return <View />;
+  return <>{/* Render UI */}</>;
 }
 ```
 

--- a/docs/pages/versions/v52.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/print.mdx
@@ -115,28 +115,45 @@ import * as Print from 'expo-print';
 
 ## Local images
 
-On iOS, printing from HTML source doesn't support local asset URLs (due to WKWebView limitations). Instead, images need to be converted to base64 and inlined into the HTML.
+On iOS, printing from HTML source doesn't support local asset URLs (due to `WKWebView` limitations). Instead, images need to be converted to base64 and inlined into the HTML.
 
-```js
+```tsx Example
 import { Asset } from 'expo-asset';
+import { useImageManipulator } from 'expo-image-manipulator';
 import { printAsync } from 'expo-print';
-import { manipulateAsync } from 'expo-image-manipulator';
+import { useEffect } from 'react';
+import { View } from 'react-native';
 
-async function generateHTML() {
-  const asset = Asset.fromModule(require('../../assets/logo.png'));
-  const image = await manipulateAsync(asset.localUri ?? asset.uri, [], { base64: true });
-  return `
-    <html>
-      <img
-        src="data:image/jpeg;base64,${image.base64}"
-        style="width: 90vw;" />
-    </html>
-  `;
-}
+const IMAGE = Asset.fromModule(require('@/assets/images/icon.png'));
 
-async function print() {
-  const html = await generateHTML();
-  await printAsync({ html });
+export function ImageManipulatorExample() {
+  const context = useImageManipulator(IMAGE.uri);
+
+  useEffect(() => {
+    async function generateAndPrint() {
+      try {
+        await IMAGE.downloadAsync();
+        const manipulatedImage = await context.renderAsync();
+        const result = await manipulatedImage.saveAsync({ base64: true });
+
+        const html = `
+          <html>
+            <img
+              src="data:image/png;base64,${result.base64}"
+              style="width: 90vw;" />
+          </html>
+        `;
+
+        await printAsync({ html });
+      } catch (error) {
+        console.error('Error:', error);
+      }
+    }
+
+    generateAndPrint();
+  }, [context]);
+
+  return <View />;
 }
 ```
 

--- a/docs/pages/versions/v53.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/print.mdx
@@ -122,7 +122,6 @@ import { Asset } from 'expo-asset';
 import { useImageManipulator } from 'expo-image-manipulator';
 import { printAsync } from 'expo-print';
 import { useEffect } from 'react';
-import { View } from 'react-native';
 
 const IMAGE = Asset.fromModule(require('@/assets/images/icon.png'));
 
@@ -153,7 +152,7 @@ export function ImageManipulatorExample() {
     generateAndPrint();
   }, [context]);
 
-  return <View />;
+  return <>{/* Render UI */}</>;
 }
 ```
 

--- a/docs/pages/versions/v53.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/print.mdx
@@ -115,28 +115,45 @@ import * as Print from 'expo-print';
 
 ## Local images
 
-On iOS, printing from HTML source doesn't support local asset URLs (due to WKWebView limitations). Instead, images need to be converted to base64 and inlined into the HTML.
+On iOS, printing from HTML source doesn't support local asset URLs (due to `WKWebView` limitations). Instead, images need to be converted to base64 and inlined into the HTML.
 
-```js
+```tsx Example
 import { Asset } from 'expo-asset';
+import { useImageManipulator } from 'expo-image-manipulator';
 import { printAsync } from 'expo-print';
-import { manipulateAsync } from 'expo-image-manipulator';
+import { useEffect } from 'react';
+import { View } from 'react-native';
 
-async function generateHTML() {
-  const asset = Asset.fromModule(require('../../assets/logo.png'));
-  const image = await manipulateAsync(asset.localUri ?? asset.uri, [], { base64: true });
-  return `
-    <html>
-      <img
-        src="data:image/jpeg;base64,${image.base64}"
-        style="width: 90vw;" />
-    </html>
-  `;
-}
+const IMAGE = Asset.fromModule(require('@/assets/images/icon.png'));
 
-async function print() {
-  const html = await generateHTML();
-  await printAsync({ html });
+export function ImageManipulatorExample() {
+  const context = useImageManipulator(IMAGE.uri);
+
+  useEffect(() => {
+    async function generateAndPrint() {
+      try {
+        await IMAGE.downloadAsync();
+        const manipulatedImage = await context.renderAsync();
+        const result = await manipulatedImage.saveAsync({ base64: true });
+
+        const html = `
+          <html>
+            <img
+              src="data:image/png;base64,${result.base64}"
+              style="width: 90vw;" />
+          </html>
+        `;
+
+        await printAsync({ html });
+      } catch (error) {
+        console.error('Error:', error);
+      }
+    }
+
+    generateAndPrint();
+  }, [context]);
+
+  return <View />;
 }
 ```
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15415

# How

<!--
How did you build this feature or fix this bug and why?
-->

Since `manipulateAsync` is deprecated in the `expo-image-manipulator` library, update the code example for the Local Images section to use the `useImageManipulator` hook from the library in the Expo Print reference.

Changes applied to unversioned, SDK 53, and SDK 52.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-05-12 at 19 28 25](https://github.com/user-attachments/assets/ac0bd9eb-fe77-4632-ad63-565d3eabd727)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
