### PR TITLE
[go] Fix `isEdgeToEdge` in Expo Go

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
@@ -23,6 +23,7 @@ import com.swmansion.gesturehandler.RNGestureHandlerPackage
 import com.swmansion.gesturehandler.react.RNGestureHandlerModule
 import com.swmansion.rnscreens.RNScreensPackage
 import com.th3rdwave.safeareacontext.SafeAreaContextPackage
+import com.zoontek.rnedgetoedge.EdgeToEdgeModule
 import expo.modules.adapters.react.ReactModuleRegistryProvider
 import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.SingletonModule
@@ -130,6 +131,7 @@ class ExponentPackage : ReactPackage {
         nativeModules.add(RNGestureHandlerModule(reactContext))
         nativeModules.add(RNCWebViewModule(reactContext))
         nativeModules.add(NetInfoModule(reactContext))
+        nativeModules.add(EdgeToEdgeModule(reactContext))
         nativeModules.addAll(SvgPackage().getReactModuleInfoProvider().getReactModuleInfos().map { SvgPackage().getModule(it.value.name, reactContext)!! })
         nativeModules.addAll(MapsPackage().createNativeModules(reactContext))
         nativeModules.addAll(RNDateTimePickerPackage().getReactModuleInfoProvider().getReactModuleInfos().map { RNDateTimePickerPackage().getModule(it.value.name, reactContext)!! })

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -69,6 +69,7 @@
     "querystring": "^0.2.0",
     "react": "19.0.0",
     "react-native": "0.79.2",
+    "react-native-edge-to-edge": "1.6.0",
     "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-infinite-scroll-view": "^0.4.5",


### PR DESCRIPTION
# Why

`RNEdgeToEdge` package wasn't being registered in expo-go native modules list, which broke `isEdgeToEdge` method from `react-native-edge-to-edge`. Because of this `expo-status-bar` and `expo-navigation-bar` wouldn't use `SystemBars` implementation from `react-native-edge-to-edge` breaking the status and navigation bar (Expo Go is always edge-to-edge).

# How

Added the `react-native-edge-to-edge` as an dependency and added the edge-to-edge package to modules in `ExponentPackage.kt`

# Test Plan

Tested in Expo Go on Android

