### PR TITLE
[docs][expo-notifications] Additional APNs setup

### DIFF
--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -124,12 +124,40 @@ Communicating with APNs is a little more complicated than with FCM. Some librari
 
 ### Client APNs entitlement
 
-The steps below will only work if your iOS app has the APNs entitlement. There are two ways to ensure that this entitlement is added to your app:
+The steps below will only work if your iOS app has the APNs entitlement. For apps using [CNG](/workflow/continuous-native-generation/),
+the Expo config needs to be modified in one of two ways:
 
-- If the app includes the `expo-notifications` library, then the entitlement is added automatically in the Expo configuration.
-- If you are not using the `expo-notifications` library, then you should [add the `aps-environment` entitlement manually to the Expo configuration](/build-reference/ios-capabilities/#entitlements).
+- **Recommended**: Add the `expo-notifications` library to your app, and ensure that its plugin appears in the `plugins` array of your `app.json` or `app.config.js`:
 
-For apps using [CNG](/workflow/continuous-native-generation/), the prebuild step will automatically add the entitlement to the generated native iOS files.
+```json app.json
+{
+  "expo": {
+    /* @hide ... */ /* @end */
+    "plugins": [
+      /* @hide ... */ /* @end */
+      "expo-notifications"
+    ]
+  }
+}
+```
+
+- If you do not plan to use the `expo-notifications` library, then you should [add the `aps-environment` entitlement manually to the Expo configuration](/build-reference/ios-capabilities/#entitlements),
+as in the example below:
+
+```json app.json
+{
+  "expo": {
+    /* @hide ... */ /* @end */
+    "ios": {
+      /* @hide ... */ /* @end */
+      "entitlements": {
+        "aps-environment": "development"
+      }
+    }
+  }
+}
+```
+
 If you are not using CNG, then you should [add the push notification entitlement in Xcode](https://developer.apple.com/documentation/usernotifications/registering-your-app-with-apns).
 
 > **Note**: If you are upgrading an Expo app from a version before SDK 51, you should refer to [this FYI document](https://expo.fyi/apns-entitlement-sdk-51).

--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -122,6 +122,18 @@ Your FCM server key can be found by making sure you've followed the [configurati
 
 Communicating with APNs is a little more complicated than with FCM. Some libraries wrap all of this functionality into one or two function calls such as [`node-apn`](https://github.com/node-apn/node-apn). However, in the examples below, a minimum set of libraries are used.
 
+### Client APNs entitlement
+
+The steps below will only work if your iOS app has the APNs entitlement. There are two ways to ensure that this entitlement is added to your app:
+
+- If the app includes the `expo-notifications` package, then the entitlement is added automatically in the Expo configuration.
+- If you are not using the `expo-notifications` package, then you should [add the `apns-environment` entitlement manually to the Expo configuration](/build-reference/ios-capabilities/#entitlements).
+
+For apps using [CNG](/workflow/continuous-native-generation/), the prebuild step will automatically add the entitlement to the generated native iOS files.
+If you are not using CNG, then you should [add the push notification entitlement in Xcode](https://developer.apple.com/documentation/usernotifications/registering-your-app-with-apns).
+
+> **Note**: If you are upgrading an Expo app from a version prior to SDK 51, you should refer to [this FYI document](https://expo.fyi/apns-entitlement-sdk-51).
+
 ### Authorization
 
 Initially, before sending requests to APNS, you need permission to send notifications to your app. This is granted via a JSON web token which is generated using iOS developer credentials:

--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -126,13 +126,13 @@ Communicating with APNs is a little more complicated than with FCM. Some librari
 
 The steps below will only work if your iOS app has the APNs entitlement. There are two ways to ensure that this entitlement is added to your app:
 
-- If the app includes the `expo-notifications` package, then the entitlement is added automatically in the Expo configuration.
-- If you are not using the `expo-notifications` package, then you should [add the `apns-environment` entitlement manually to the Expo configuration](/build-reference/ios-capabilities/#entitlements).
+- If the app includes the `expo-notifications` library, then the entitlement is added automatically in the Expo configuration.
+- If you are not using the `expo-notifications` library, then you should [add the `aps-environment` entitlement manually to the Expo configuration](/build-reference/ios-capabilities/#entitlements).
 
 For apps using [CNG](/workflow/continuous-native-generation/), the prebuild step will automatically add the entitlement to the generated native iOS files.
 If you are not using CNG, then you should [add the push notification entitlement in Xcode](https://developer.apple.com/documentation/usernotifications/registering-your-app-with-apns).
 
-> **Note**: If you are upgrading an Expo app from a version prior to SDK 51, you should refer to [this FYI document](https://expo.fyi/apns-entitlement-sdk-51).
+> **Note**: If you are upgrading an Expo app from a version before SDK 51, you should refer to [this FYI document](https://expo.fyi/apns-entitlement-sdk-51).
 
 ### Authorization
 

--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -124,7 +124,7 @@ Communicating with APNs is a little more complicated than with FCM. Some librari
 
 ### Client APNs entitlement
 
-The steps below will only work if your iOS app has the APNs entitlement. For apps using [CNG](/workflow/continuous-native-generation/),
+Receiving push notifications only works if your iOS app has the APNs entitlement. For apps using [CNG](/workflow/continuous-native-generation/),
 the Expo config needs to be modified in one of two ways:
 
 - **Recommended**: Add the `expo-notifications` library to your app, and ensure that its plugin appears in the `plugins` array of your [app config](/workflow/configuration/):

--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -132,17 +132,13 @@ the Expo config needs to be modified in one of two ways:
 ```json app.json
 {
   "expo": {
-    /* @hide ... */ /* @end */
-    "plugins": [
-      /* @hide ... */ /* @end */
-      "expo-notifications"
-    ]
+    /* @hide ... */ /* @end */ "plugins": [/* @hide ... */ /* @end */ "expo-notifications"]
   }
 }
 ```
 
 - If you do not plan to use the `expo-notifications` library, then you should [add the `aps-environment` entitlement manually to the Expo configuration](/build-reference/ios-capabilities/#entitlements),
-as in the example below:
+  as in the example below:
 
 ```json app.json
 {

--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -127,7 +127,7 @@ Communicating with APNs is a little more complicated than with FCM. Some librari
 The steps below will only work if your iOS app has the APNs entitlement. For apps using [CNG](/workflow/continuous-native-generation/),
 the Expo config needs to be modified in one of two ways:
 
-- **Recommended**: Add the `expo-notifications` library to your app, and ensure that its plugin appears in the `plugins` array of your `app.json` or `app.config.js`:
+- **Recommended**: Add the `expo-notifications` library to your app, and ensure that its plugin appears in the `plugins` array of your [app config](/workflow/configuration/):
 
 ```json app.json
 {


### PR DESCRIPTION
# Why

Document the change in APNs entitlement configuration from SDK 51.

Fixes #36651 .

# How

Updated the doc on sending push notifications directly from APNs.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
