### PR TITLE
[expo] disable timeout for expo/fetch

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Disable default timeout for `expo/fetch` requests on iOS. ([#36838](https://github.com/expo/expo/pull/36838) by [@kudo](https://github.com/kudo))
+
 ## 53.0.9 — 2025-05-08
 
 ### 🐛 Bug fixes

--- a/packages/expo/ios/Fetch/ExpoURLSessionTask.swift
+++ b/packages/expo/ios/Fetch/ExpoURLSessionTask.swift
@@ -23,6 +23,7 @@ internal final class ExpoURLSessionTask: NSObject, URLSessionTaskDelegate, URLSe
   ) {
     var request = URLRequest(url: url)
     request.httpMethod = requestInit.method
+    request.timeoutInterval = 0
     if requestInit.credentials == .include {
       request.httpShouldHandleCookies = true
       if let cookies = HTTPCookieStorage.shared.cookies(for: url) {


### PR DESCRIPTION
# Why

fixes #35106

# How

- as react-native, disable the timeout for URLSession (which has 60s timeout by default)
  - https://github.com/facebook/react-native/blob/12b2b5610263cb145d1ade8eaf06d8a6e015b10e/packages/react-native/Libraries/Network/RCTNetworking.mm#L326
  - https://github.com/facebook/react-native/blob/12b2b5610263cb145d1ade8eaf06d8a6e015b10e/packages/react-native/Libraries/Network/XMLHttpRequest.js#L152
- on android, we used the `OkHttpClientProvider` from react-native which also [disable timeout](https://github.com/facebook/react-native/blob/12b2b5610263cb145d1ade8eaf06d8a6e015b10e/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpClientProvider.kt#L52-L54)

# Test Plan

```js
import { fetch } from 'expo/fetch';

async function fetchAsync() {
  const url = 'https://httpstat.us/200?sleep=120000';
  const start = Date.now();
  try {
    console.log('Fetching data...');
    const response = await fetch(url);
    const data = await response.json();
    console.log('data:', data);
  } catch (error) {
    console.error('Error fetching data:', error);
  } finally {
    const end = Date.now();
    console.log('Fetch took', end - start, 'ms');
  }
}

fetchAsync();
```

before:  `LOG  Fetch took 60621 ms`
after: `LOG  Fetch took 120774 ms`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
