### PR TITLE
Fix `requireOptionalNativeModule` throwing error if mock is missing.

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `requireOptionalNativeModule` throwing error if mock is missing.
+
 ### 💡 Others
 
 - Rework mock generation for expo modules. ([#36677](https://github.com/expo/expo/pull/36677) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `requireOptionalNativeModule` throwing error if mock is missing.
+- Fix `requireOptionalNativeModule` throwing error if mock is missing. ([#36839](https://github.com/expo/expo/pull/36839) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others
 

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -252,7 +252,8 @@ try {
       // Support auto-mocking of expo-modules that:
       // 1. have a mock in the `mocks` directory
       // 2. the native module (e.g. ExpoCrypto) name matches the package name (expo-crypto)
-      const nativeModuleMock = attemptLookup(name) ?? ExpoModulesCore.requireNativeModule(name);
+      const nativeModuleMock =
+        attemptLookup(name) ?? ExpoModulesCore.requireOptionalNativeModule(name);
       if (!nativeModuleMock) {
         return null;
       }


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/36784

# How

We wrap `requireMockModule` in checking if module is null and throwing if so for `requireNativeModule` mock anyways, so we should just make the `requireMockModule` method return null if module is not found.

# Test Plan

Run jest tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
