### PR TITLE
[sqlite] prevent maybeFinalizeAllStatements throwing exceptions

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Prevent `maybeFinalizeAllStatements` throwing exceptions. ([#36843](https://github.com/expo/expo/pull/36843) by [@kudo](https://github.com/kudo))
+
 ## 15.2.10 — 2025-05-08
 
 ### 🐛 Bug fixes

--- a/packages/expo-sqlite/android/src/main/cpp/NativeDatabaseBinding.cpp
+++ b/packages/expo-sqlite/android/src/main/cpp/NativeDatabaseBinding.cpp
@@ -51,18 +51,18 @@ void NativeDatabaseBinding::registerNatives() {
 
 int NativeDatabaseBinding::sqlite3_changes() { return ::exsqlite3_changes(db); }
 
-int NativeDatabaseBinding::sqlite3_finalize_all_statement() {
+void NativeDatabaseBinding::sqlite3_finalize_all_statement() {
   ::exsqlite3_stmt *stmt = ::exsqlite3_next_stmt(db, nullptr);
-  int result = SQLITE_OK;
   while (stmt) {
     ::exsqlite3_stmt *nextStmt = ::exsqlite3_next_stmt(db, stmt);
     int ret = ::exsqlite3_finalize(stmt);
     if (ret != SQLITE_OK) {
-      result = ret;
+      std::string error = convertSqlLiteErrorToSTLString();
+      __android_log_print(ANDROID_LOG_WARN, TAG, "sqlite3_finalize failed: %s",
+                          error.c_str());
     }
     stmt = nextStmt;
   }
-  return result;
 }
 
 int NativeDatabaseBinding::sqlite3_close() {
@@ -191,15 +191,19 @@ int NativeDatabaseBinding::sqlite3_backup(
   return result;
 }
 
-jni::local_ref<jni::JString>
-NativeDatabaseBinding::convertSqlLiteErrorToString() {
+std::string NativeDatabaseBinding::convertSqlLiteErrorToSTLString() {
   int code = exsqlite3_errcode(db);
   const char *message = exsqlite3_errmsg(db);
   std::string result("Error code ");
   result += code;
   result += ": ";
   result += message;
-  return jni::make_jstring(result);
+  return result;
+}
+
+jni::local_ref<jni::JString>
+NativeDatabaseBinding::convertSqlLiteErrorToString() {
+  return jni::make_jstring(convertSqlLiteErrorToSTLString());
 }
 
 // static

--- a/packages/expo-sqlite/android/src/main/cpp/NativeDatabaseBinding.h
+++ b/packages/expo-sqlite/android/src/main/cpp/NativeDatabaseBinding.h
@@ -21,7 +21,7 @@ public:
 
   // sqlite3 bindings
   int sqlite3_changes();
-  int sqlite3_finalize_all_statement();
+  void sqlite3_finalize_all_statement();
   int sqlite3_close();
   std::string sqlite3_db_filename(const std::string &databaseName);
   int sqlite3_enable_load_extension(int onoff);
@@ -56,6 +56,8 @@ private:
   explicit NativeDatabaseBinding(
       jni::alias_ref<NativeDatabaseBinding::jhybridobject> jThis)
       : javaPart_(jni::make_global(jThis)) {}
+
+  std::string convertSqlLiteErrorToSTLString();
 
 private:
   static jni::local_ref<jhybriddata>

--- a/packages/expo-sqlite/android/src/main/cpp/libsql/NativeDatabaseBinding.cpp
+++ b/packages/expo-sqlite/android/src/main/cpp/libsql/NativeDatabaseBinding.cpp
@@ -195,6 +195,11 @@ int NativeDatabaseBinding::libsql_sync() {
   return 0;
 }
 
+std::string NativeDatabaseBinding::convertSqlLiteErrorToSTLString() {
+  jni::throwNewJavaException(UnsupportedOperationException::create().get());
+  return nullptr;
+}
+
 jni::local_ref<jni::JString>
 NativeDatabaseBinding::convertSqlLiteErrorToString() {
   jni::throwNewJavaException(UnsupportedOperationException::create().get());

--- a/packages/expo-sqlite/android/src/main/cpp/libsql/NativeDatabaseBinding.h
+++ b/packages/expo-sqlite/android/src/main/cpp/libsql/NativeDatabaseBinding.h
@@ -59,6 +59,8 @@ private:
       jni::alias_ref<NativeDatabaseBinding::jhybridobject> jThis)
       : javaPart_(jni::make_global(jThis)) {}
 
+  std::string convertSqlLiteErrorToSTLString();
+
 private:
   static jni::local_ref<jhybriddata>
   initHybrid(jni::alias_ref<jhybridobject> jThis);

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabaseBinding.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabaseBinding.kt
@@ -44,7 +44,7 @@ internal class NativeDatabaseBinding : Closeable {
   // region sqlite3 bindings
 
   external fun sqlite3_changes(): Int
-  external fun sqlite3_finalize_all_statement(): Int
+  external fun sqlite3_finalize_all_statement()
   external fun sqlite3_close(): Int
   external fun sqlite3_db_filename(databaseName: String): String
   external fun sqlite3_enable_load_extension(onoff: Int): Int

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
@@ -579,9 +579,7 @@ class SQLiteModule : Module() {
     if (!database.openOptions.finalizeUnusedStatementsBeforeClosing) {
       return
     }
-    if (database.ref.sqlite3_finalize_all_statement() != NativeDatabaseBinding.SQLITE_OK) {
-      throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
-    }
+    database.ref.sqlite3_finalize_all_statement()
   }
 
   // endregion

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -694,17 +694,13 @@ public final class SQLiteModule: Module {
     if stmt == nil {
       return
     }
-    var result = SQLITE_OK
     while let currentStmt = stmt {
       let nextStmt = exsqlite3_next_stmt(database.pointer, currentStmt)
       let ret = exsqlite3_finalize(currentStmt)
       if ret != SQLITE_OK {
-        result = ret
+        ExpoModulesCore.log.warn("sqlite3_finalize failed: \(convertSqlLiteErrorToString(database))")
       }
       stmt = nextStmt
-    }
-    if result != SQLITE_OK {
-      throw SQLiteErrorException(convertSqlLiteErrorToString(database))
     }
   }
 


### PR DESCRIPTION
# Why

fixes #36821

# How

according to the doc, [`sqlite3_finalize`](https://www.sqlite.org/c3ref/finalize.html) returns error from previous evaluated statement error rather than finalizing error. this pr tries to log the error than throwing exception directly.

# Test Plan

- ci passed
- test repro from #36821

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
