### PR TITLE
[docs] Adds note about experimental maestro tests

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -645,7 +645,7 @@ This job outputs the following properties:
 
 Runs [Maestro](https://maestro.mobile.dev/) tests on a build.
 
-> **Note:** Maestro tests are experimental and may experience flakiness.
+> **important** Maestro tests are experimental and may experience flakiness.
 
 ```yaml
 jobs:

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -645,6 +645,8 @@ This job outputs the following properties:
 
 Runs [Maestro](https://maestro.mobile.dev/) tests on a build.
 
+> **Note:** Maestro tests are experimental and may experience flakiness.
+
 ```yaml
 jobs:
   my_job:


### PR DESCRIPTION
# Why

Maestro tests can be extra flakey on our service. I'd like to share with users that this job can be flakey to properly set expectations.

<img width="1140" alt="Screenshot 2025-05-13 at 8 37 11 AM" src="https://github.com/user-attachments/assets/09f630f9-11f3-42e1-8a02-e02f84be5554" />

# Test plan

Make sure the changes read well.