### PR TITLE
[dev-launcher][Android] Remove `testDebug` variant from npm package

### DIFF
--- a/packages/expo-dev-launcher/.npmignore
+++ b/packages/expo-dev-launcher/.npmignore
@@ -13,3 +13,6 @@ __rsc_tests__
 /babel.config.js
 /android/src/androidTest/
 /android/src/test/
+
+# Exclude testDebug variant
+/android/src/testDebug/

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Remove `testDebug` variant from npm package.
+
 ### 💡 Others
 
 ## 5.1.11 — 2025-05-01

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Remove `testDebug` variant from npm package.
+- [Android] Remove `testDebug` variant from npm package. ([#36845](https://github.com/expo/expo/pull/36845) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/34720.

# How

Removed `testDebug` variant from npm package.

