### PR TITLE
[sqlite] sync #36674 change to libsql code

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Prevent `maybeFinalizeAllStatements` throwing exceptions. ([#36843](https://github.com/expo/expo/pull/36843) by [@kudo](https://github.com/kudo))
+- Apply [#36674](https://github.com/expo/expo/pull/36674) change to **SQLiteModuleLibSQL.swift**. ([#36850](https://github.com/expo/expo/pull/36850) by [@kudo](https://github.com/kudo))
 
 ## 15.2.10 — 2025-05-08
 

--- a/packages/expo-sqlite/ios/SQLiteModuleLibSQL.swift
+++ b/packages/expo-sqlite/ios/SQLiteModuleLibSQL.swift
@@ -383,6 +383,13 @@ public final class SQLiteModule: Module {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
 
+    // The statement with parameter bindings is stateful,
+    // we have to guard with a critical section for thread safety.
+    statement.lock.wait()
+    defer {
+      statement.lock.signal()
+    }
+
     if let rows = statement.extraPointer {
       libsql_free_rows(rows)
       statement.extraPointer = nil


### PR DESCRIPTION
# Why

missing #36674 change to libsql's SQLiteModule 

# How

apply #36674 change to SQLiteModuleLibSQL.swift

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
