### PR TITLE
[docs] Improve steps in Babel config reference

### DIFF
--- a/docs/pages/versions/unversioned/config/babel.mdx
+++ b/docs/pages/versions/unversioned/config/babel.mdx
@@ -13,13 +13,11 @@ Each new Expo project created using `npx create-expo-app` configures Babel autom
 
 If your project requires a custom Babel configuration, you need to create the **babel.config.js** file in your project by following the steps below:
 
-1. Navigate to the root of your project, run the following command inside a terminal:
+1. Navigate to the root of your project and run the following command inside a terminal. This will generate a **babel.config.js** file in the root of your project.
 
-<Terminal cmd={['$ npx expo customize']} />
+<Terminal cmd={['$ npx expo customize babel.config.js']} />
 
-2. This command prompts generating different config files. Select **babel.config.js**.
-
-3. The **babel.config.js** file is created in the root of your project with the default configuration as shown below:
+2. The **babel.config.js** file contains the following default configuration:
 
 ```js babel.config.js
 module.exports = function (api) {
@@ -30,7 +28,7 @@ module.exports = function (api) {
 };
 ```
 
-4. If you make a change to the **babel.config.js** file, you need to restart the Metro bundler to apply the changes and use `--clear` option from Expo CLI to clear the Metro bundler cache:
+3. If you make a change to the **babel.config.js** file, you need to restart the Metro bundler to apply the changes and use `--clear` option from Expo CLI to clear the Metro bundler cache:
 
 <Terminal cmd={['$ npx expo start --clear']} />
 

--- a/docs/pages/versions/v52.0.0/config/babel.mdx
+++ b/docs/pages/versions/v52.0.0/config/babel.mdx
@@ -10,17 +10,11 @@ Babel is used as the JavaScript compiler to transform modern JavaScript (ES6+) i
 
 Each new Expo project created using `npx create-expo-app` configures Babel automatically and uses [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo) as the default preset. There is no need to create a **babel.config.js** file unless you need to customize the Babel configuration.
 
-## Create babel.config.js
+1. Navigate to the root of your project and run the following command inside a terminal. This will generate a **babel.config.js** file in the root of your project.
 
-If your project requires a custom Babel configuration, you need to create the **babel.config.js** file in your project by following the steps below:
+<Terminal cmd={['$ npx expo customize babel.config.js']} />
 
-1. Navigate to the root of your project, run the following command inside a terminal:
-
-<Terminal cmd={['$ npx expo customize']} />
-
-2. This command prompts generating different config files. Select **babel.config.js**.
-
-3. The **babel.config.js** file is created in the root of your project with the default configuration as shown below:
+2. The **babel.config.js** file contains the following default configuration:
 
 ```js babel.config.js
 module.exports = function (api) {
@@ -31,7 +25,7 @@ module.exports = function (api) {
 };
 ```
 
-4. If you make a change to the **babel.config.js** file, you need to restart the Metro bundler to apply the changes and use `--clear` option from Expo CLI to clear the Metro bundler cache:
+3. If you make a change to the **babel.config.js** file, you need to restart the Metro bundler to apply the changes and use `--clear` option from Expo CLI to clear the Metro bundler cache:
 
 <Terminal cmd={['$ npx expo start --clear']} />
 

--- a/docs/pages/versions/v53.0.0/config/babel.mdx
+++ b/docs/pages/versions/v53.0.0/config/babel.mdx
@@ -13,13 +13,11 @@ Each new Expo project created using `npx create-expo-app` configures Babel autom
 
 If your project requires a custom Babel configuration, you need to create the **babel.config.js** file in your project by following the steps below:
 
-1. Navigate to the root of your project, run the following command inside a terminal:
+1. Navigate to the root of your project and run the following command inside a terminal. This will generate a **babel.config.js** file in the root of your project.
 
-<Terminal cmd={['$ npx expo customize']} />
+<Terminal cmd={['$ npx expo customize babel.config.js']} />
 
-2. This command prompts generating different config files. Select **babel.config.js**.
-
-3. The **babel.config.js** file is created in the root of your project with the default configuration as shown below:
+2. The **babel.config.js** file contains the following default configuration:
 
 ```js babel.config.js
 module.exports = function (api) {
@@ -30,7 +28,7 @@ module.exports = function (api) {
 };
 ```
 
-4. If you make a change to the **babel.config.js** file, you need to restart the Metro bundler to apply the changes and use `--clear` option from Expo CLI to clear the Metro bundler cache:
+3. If you make a change to the **babel.config.js** file, you need to restart the Metro bundler to apply the changes and use `--clear` option from Expo CLI to clear the Metro bundler cache:
 
 <Terminal cmd={['$ npx expo start --clear']} />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-12275

# How

<!--
How did you build this feature or fix this bug and why?
-->

Improve steps to create a `babel.config.js` file directly with the command instead of following the interactive CLI option. It reduces the extra step. These changes are applied to Babel config references for unversioned, SDK 53, and SDK 52.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
