### PR TITLE
fix(expo-camera): Fix the scenario where switching apps results in the loss of the recording video by throwing an error

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- fix(expo-camera): Fix the scenario where switching apps results in the loss of the recording video by throwing an error ([#36854](https://github.com/expo/expo/pull/36854) by [@ladeira1](https://github.com/ladeira1))
+
 ### 💡 Others
 
 ## 16.1.6 — 2025-04-30

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- fix(expo-camera): Fix the scenario where switching apps results in the loss of the recording video by throwing an error ([#36854](https://github.com/expo/expo/pull/36854) by [@ladeira1](https://github.com/ladeira1))
+- [Android] Fix the scenario where switching apps results in the loss of the recording video by throwing an error. ([#36854](https://github.com/expo/expo/pull/36854) by [@ladeira1](https://github.com/ladeira1))
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -364,7 +364,8 @@ class ExpoCameraView(
               when (event.error) {
                 VideoRecordEvent.Finalize.ERROR_FILE_SIZE_LIMIT_REACHED,
                 VideoRecordEvent.Finalize.ERROR_DURATION_LIMIT_REACHED,
-                VideoRecordEvent.Finalize.ERROR_NONE -> {
+                VideoRecordEvent.Finalize.ERROR_NONE,
+                VideoRecordEvent.Finalize.ERROR_SOURCE_INACTIVE -> {
                   promise.resolve(
                     Bundle().apply {
                       putString("uri", event.outputResults.outputUri.toString())


### PR DESCRIPTION
# Why

<!--
-->

On some Android devices, when the app is sent to the background during an active recording session, an error is thrown.
This breaks the recording flow and causes the recorded video to be lost.

# How

<!--
-->
Handled VideoRecordEvent.Finalize.ERROR_SOURCE_INACTIVE as a non-fatal error by adding it to the list of ignored errors.
This allows the recording to finalize gracefully and return the video instead of failing.

# Test Plan

<!--
-->
Manually verified on affected Android devices by backgrounding the app mid-recording and confirming the video is returned successfully.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
