### PR TITLE
[notification-tester] modify device check

### DIFF
--- a/apps/notification-tester/scripts/prebuild-ios.sh
+++ b/apps/notification-tester/scripts/prebuild-ios.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-EXPO_NO_GIT_STATUS=1 npx expo prebuild --clean -p ios --template expo-template-bare-minimum@sdk-53
+EXPO_NO_GIT_STATUS=1 EXPO_DEBUG=1 npx expo prebuild --clean -p ios --template expo-template-bare-minimum@sdk-53

--- a/apps/notification-tester/src/Notifier.tsx
+++ b/apps/notification-tester/src/Notifier.tsx
@@ -50,6 +50,7 @@ export const Notifier = () => {
         importance: AndroidImportance.HIGH,
         sound: 'pop_sound.wav',
         enableVibrate: true,
+        showBadge: true,
         vibrationPattern: [0, 3000, 250, 250],
       })
         .then((value) => {

--- a/apps/notification-tester/src/registerForNotifications.ts
+++ b/apps/notification-tester/src/registerForNotifications.ts
@@ -5,45 +5,36 @@ import {
   getPermissionsAsync,
   requestPermissionsAsync,
 } from 'expo-notifications';
+import { Platform } from 'react-native';
 
 export async function registerForPushNotificationsAsync() {
-  // if (Platform.OS === 'android') {
-  //   await setNotificationChannelAsync('default', {
-  //     name: 'default',
-  //     importance: AndroidImportance.MAX,
-  //     vibrationPattern: [0, 250, 250, 250],
-  //     lightColor: '#FF231F7C',
-  //   });
-  // }
-
-  if (isDevice) {
-    const { status: existingStatus } = await getPermissionsAsync();
-    let finalStatus = existingStatus;
-    if (existingStatus !== 'granted') {
-      const { status } = await requestPermissionsAsync();
-      finalStatus = status;
-    }
-    if (finalStatus !== 'granted') {
-      alert('Failed to get push token permission!');
-      throw new Error('Failed to get push token permission!');
-    }
-    // Learn more about projectId:
-    // https://docs.expo.dev/push-notifications/push-notifications-setup/#configure-projectid
-    // Here we use EAS projectId
-    const projectId =
-      Constants?.expoConfig?.extra?.eas?.projectId ?? Constants?.easConfig?.projectId;
-    if (!projectId) {
-      throw new Error('Project ID not found');
-    }
-    const token = (
-      await getExpoPushTokenAsync({
-        projectId,
-      })
-    ).data;
-    console.log(token);
-    return token;
-  } else {
+  if (Platform.OS === 'ios' && !isDevice) {
     console.error('Must use physical device for Push Notifications');
-    return '';
+    return;
   }
+
+  const { status: existingStatus } = await getPermissionsAsync();
+  let finalStatus = existingStatus;
+  if (existingStatus !== 'granted') {
+    const { status } = await requestPermissionsAsync();
+    finalStatus = status;
+  }
+  if (finalStatus !== 'granted') {
+    alert('Failed to get push token permission!');
+    throw new Error('Failed to get push token permission!');
+  }
+  // Learn more about projectId:
+  // https://docs.expo.dev/push-notifications/push-notifications-setup/#configure-projectid
+  // Here we use EAS projectId
+  const projectId = Constants?.expoConfig?.extra?.eas?.projectId ?? Constants?.easConfig?.projectId;
+  if (!projectId) {
+    throw new Error('Project ID not found');
+  }
+  const token = (
+    await getExpoPushTokenAsync({
+      projectId,
+    })
+  ).data;
+  console.log(token);
+  return token;
 }


### PR DESCRIPTION
# Why

Android emulators with google play services can display push notifications

# How

relax the condition

# Test Plan

test locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
