### PR TITLE
[core][Android] Pass custom converters to all related components

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -13,6 +13,7 @@ import expo.modules.kotlin.sharedobjects.SharedObject
 import expo.modules.kotlin.sharedobjects.SharedRef
 import expo.modules.kotlin.traits.Trait
 import expo.modules.kotlin.types.AnyType
+import expo.modules.kotlin.types.TypeConverterProvider
 import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.types.toAnyType
 import expo.modules.kotlin.types.toArgsArray
@@ -24,8 +25,9 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   private val appContext: AppContext,
   val name: String,
   private val ownerClass: KClass<SharedObjectType>,
-  val ownerType: AnyType
-) : ObjectDefinitionBuilder() {
+  val ownerType: AnyType,
+  converters: TypeConverterProvider? = null
+) : ObjectDefinitionBuilder(converters) {
   var constructor: SyncFunctionComponent? = null
   val traits = mutableListOf<Trait<in SharedObjectType>>()
 
@@ -91,7 +93,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0> Constructor(
     crossinline body: (p0: P0) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0>(), toReturnType<Any>()) { (p0) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0>(converterProvider = converters), toReturnType<Any>()) { (p0) ->
       enforceType<P0>(p0)
       body(p0)
     }.also {
@@ -102,7 +104,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1> Constructor(
     crossinline body: (p0: P0, p1: P1) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0, P1>(), toReturnType<Any>()) { (p0, p1) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1>(converterProvider = converters), toReturnType<Any>()) { (p0, p1) ->
       enforceType<P0, P1>(p0, p1)
       body(p0, p1)
     }.also {
@@ -113,7 +115,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2>(), toReturnType<Any>()) { (p0, p1, p2) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2>(converterProvider = converters), toReturnType<Any>()) { (p0, p1, p2) ->
       enforceType<P0, P1, P2>(p0, p1, p2)
       body(p0, p1, p2)
     }.also {
@@ -124,7 +126,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3>(), toReturnType<Any>()) { (p0, p1, p2, p3) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3>(converterProvider = converters), toReturnType<Any>()) { (p0, p1, p2, p3) ->
       enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
       body(p0, p1, p2, p3)
     }.also {
@@ -135,7 +137,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3, reified P4> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4>(), toReturnType<Any>()) { (p0, p1, p2, p3, p4) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4>(converterProvider = converters), toReturnType<Any>()) { (p0, p1, p2, p3, p4) ->
       enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
       body(p0, p1, p2, p3, p4)
     }.also {
@@ -146,7 +148,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5>(), toReturnType<Any>()) { (p0, p1, p2, p3, p4, p5) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5>(converterProvider = converters), toReturnType<Any>()) { (p0, p1, p2, p3, p4, p5) ->
       enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
       body(p0, p1, p2, p3, p4, p5)
     }.also {
@@ -157,7 +159,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5, P6>(), toReturnType<Any>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5, P6>(converterProvider = converters), toReturnType<Any>()) { (p0, p1, p2, p3, p4, p5, p6) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
       body(p0, p1, p2, p3, p4, p5, p6)
     }.also {
@@ -168,7 +170,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> Constructor(
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> SharedObjectType
   ): SyncFunctionComponent {
-    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>(), toReturnType<Any>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+    return SyncFunctionComponent("constructor", toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>(converterProvider = converters), toReturnType<Any>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
       body(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionBuilder.kt
@@ -6,10 +6,14 @@ import expo.modules.kotlin.component6
 import expo.modules.kotlin.component7
 import expo.modules.kotlin.component8
 import expo.modules.kotlin.Promise
+import expo.modules.kotlin.types.TypeConverterProvider
 import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.types.toArgsArray
 
-class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
+class AsyncFunctionBuilder(
+  @PublishedApi internal val name: String,
+  @PublishedApi internal val converters: TypeConverterProvider? = null
+) {
   @PublishedApi
   internal var asyncFunctionComponent: BaseAsyncFunctionComponent? = null
 
@@ -20,7 +24,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0> SuspendBody(crossinline block: suspend (p0: P0) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, toArgsArray<P0>()) { (p0) ->
+    return SuspendFunctionComponent(name, toArgsArray<P0>(converterProvider = converters)) { (p0) ->
       enforceType<P0>(p0)
       block(p0)
     }.also {
@@ -29,7 +33,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0, reified P1> SuspendBody(crossinline block: suspend (p0: P0, p1: P1) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
+    return SuspendFunctionComponent(name, toArgsArray<P0, P1>(converterProvider = converters)) { (p0, p1) ->
       enforceType<P0, P1>(p0, p1)
       block(p0, p1)
     }.also {
@@ -38,7 +42,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
+    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2>(converterProvider = converters)) { (p0, p1, p2) ->
       enforceType<P0, P1, P2>(p0, p1, p2)
       block(p0, p1, p2)
     }.also {
@@ -47,7 +51,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
+    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3>(converterProvider = converters)) { (p0, p1, p2, p3) ->
       enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
       block(p0, p1, p2, p3)
     }.also {
@@ -56,7 +60,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
+    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>(converterProvider = converters)) { (p0, p1, p2, p3, p4) ->
       enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
       block(p0, p1, p2, p3, p4)
     }.also {
@@ -65,7 +69,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
+    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5) ->
       enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
       block(p0, p1, p2, p3, p4, p5)
     }.also {
@@ -74,7 +78,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5, p6) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
       block(p0, p1, p2, p3, p4, p5, p6)
     }.also {
@@ -83,7 +87,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R): SuspendFunctionComponent {
-    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+    return SuspendFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
       block(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {
@@ -108,7 +112,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
     return if (P0::class == Promise::class) {
       AsyncFunctionWithPromiseComponent(name, emptyArray()) { _, promise -> body(promise as P0) }
     } else {
-      createAsyncFunctionComponent(name, toArgsArray<P0>()) { (p0) ->
+      createAsyncFunctionComponent(name, toArgsArray<P0>(converterProvider = converters)) { (p0) ->
         enforceType<P0>(p0)
         body(p0)
       }
@@ -118,7 +122,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0, reified P1> AsyncBody(crossinline body: (p0: P0, p1: P1) -> R): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1>(converterProvider = converters)) { (p0, p1) ->
       enforceType<P0, P1>(p0, p1)
       body(p0, p1)
     }.also {
@@ -128,7 +132,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   @JvmName("AsyncFunctionWithPromise")
   inline fun <reified R, reified P0> AsyncBody(crossinline body: (p0: P0, p1: Promise) -> R): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0>()) { (p0), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0>(converterProvider = converters)) { (p0), promise ->
       enforceType<P0>(p0)
       body(p0, promise)
     }.also {
@@ -137,7 +141,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2) -> R): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2>(converterProvider = converters)) { (p0, p1, p2) ->
       enforceType<P0, P1, P2>(p0, p1, p2)
       body(p0, p1, p2)
     }.also {
@@ -147,7 +151,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   @JvmName("AsyncFunctionWithPromise")
   inline fun <reified R, reified P0, reified P1> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: Promise) -> R): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1>()) { (p0, p1), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1>(converterProvider = converters)) { (p0, p1), promise ->
       enforceType<P0, P1>(p0, p1)
       body(p0, p1, promise)
     }.also {
@@ -156,7 +160,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>(converterProvider = converters)) { (p0, p1, p2, p3) ->
       enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
       body(p0, p1, p2, p3)
     }.also {
@@ -166,7 +170,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   @JvmName("AsyncFunctionWithPromise")
   inline fun <reified R, reified P0, reified P1, reified P2> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: Promise) -> R): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2>(converterProvider = converters)) { (p0, p1, p2), promise ->
       enforceType<P0, P1, P2>(p0, p1, p2)
       body(p0, p1, p2, promise)
     }.also {
@@ -175,7 +179,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>(converterProvider = converters)) { (p0, p1, p2, p3, p4) ->
       enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
       body(p0, p1, p2, p3, p4)
     }.also {
@@ -185,7 +189,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   @JvmName("AsyncFunctionWithPromise")
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: Promise) -> R): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3>(converterProvider = converters)) { (p0, p1, p2, p3), promise ->
       enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
       body(p0, p1, p2, p3, promise)
     }.also {
@@ -194,7 +198,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5) ->
       enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
       body(p0, p1, p2, p3, p4, p5)
     }.also {
@@ -204,7 +208,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   @JvmName("AsyncFunctionWithPromise")
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: Promise) -> R): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4>(converterProvider = converters)) { (p0, p1, p2, p3, p4), promise ->
       enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
       body(p0, p1, p2, p3, p4, promise)
     }.also {
@@ -213,7 +217,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5, p6) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
       body(p0, p1, p2, p3, p4, p5, p6)
     }.also {
@@ -223,7 +227,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   @JvmName("AsyncFunctionWithPromise")
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: Promise) -> R): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5), promise ->
       enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
       body(p0, p1, p2, p3, p4, p5, promise)
     }.also {
@@ -232,7 +236,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
       body(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {
@@ -242,7 +246,7 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
 
   @JvmName("AsyncFunctionWithPromise")
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: Promise) -> R): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5, p6), promise ->
       enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
       body(p0, p1, p2, p3, p4, p5, p6, promise)
     }.also {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -17,6 +17,8 @@ import expo.modules.kotlin.events.OnActivityResultPayload
 import expo.modules.kotlin.objects.ObjectDefinitionBuilder
 import expo.modules.kotlin.sharedobjects.SharedObject
 import expo.modules.kotlin.types.LazyKType
+import expo.modules.kotlin.types.TypeConverterProvider
+import expo.modules.kotlin.types.mergeWithDefault
 import expo.modules.kotlin.types.toAnyType
 import expo.modules.kotlin.views.ModuleDefinitionBuilderWithCompose
 import expo.modules.kotlin.views.ViewDefinitionBuilder
@@ -33,9 +35,10 @@ class ModuleDefinitionBuilder(
 
 @DefinitionMarker
 open class InternalModuleDefinitionBuilder(
-  @PublishedApi internal val module: Module? = null
+  @PublishedApi internal val module: Module? = null,
+  converters: TypeConverterProvider? = module?.converters()?.mergeWithDefault()
 ) : ObjectDefinitionBuilder(
-  module?.converters()
+  converters
 ) {
   @PublishedApi
   internal var name: String? = null
@@ -88,7 +91,11 @@ open class InternalModuleDefinitionBuilder(
    * Creates the view manager definition that scopes other view-related definitions.
    */
   inline fun <reified T : View> View(viewClass: KClass<T>, body: ViewDefinitionBuilder<T>.() -> Unit) {
-    val viewDefinitionBuilder = ViewDefinitionBuilder(viewClass, LazyKType(classifier = T::class, kTypeProvider = { typeOf<T>() }))
+    val viewDefinitionBuilder = ViewDefinitionBuilder(
+      viewClass,
+      LazyKType(classifier = T::class, kTypeProvider = { typeOf<T>() }),
+      converters
+    )
 
     viewDefinitionBuilder.UseCSSProps()
 
@@ -161,7 +168,13 @@ open class InternalModuleDefinitionBuilder(
   }
 
   inline fun Class(name: String, body: ClassComponentBuilder<Unit>.() -> Unit = {}) {
-    val clazzBuilder = ClassComponentBuilder(requireNotNull(module).appContext, name, Unit::class, toAnyType<Unit>())
+    val clazzBuilder = ClassComponentBuilder(
+      requireNotNull(module).appContext,
+      name,
+      Unit::class,
+      toAnyType<Unit>(),
+      converters
+    )
     body.invoke(clazzBuilder)
     classData.add(clazzBuilder.buildClass())
   }
@@ -171,7 +184,13 @@ open class InternalModuleDefinitionBuilder(
     sharedObjectClass: KClass<SharedObjectType> = SharedObjectType::class,
     body: ClassComponentBuilder<SharedObjectType>.() -> Unit = {}
   ) {
-    val clazzBuilder = ClassComponentBuilder(requireNotNull(module).appContext, name, sharedObjectClass, toAnyType<SharedObjectType>())
+    val clazzBuilder = ClassComponentBuilder(
+      requireNotNull(module).appContext,
+      name,
+      sharedObjectClass,
+      toAnyType<SharedObjectType>(),
+      converters
+    )
     body.invoke(clazzBuilder)
     classData.add(clazzBuilder.buildClass())
   }
@@ -180,7 +199,13 @@ open class InternalModuleDefinitionBuilder(
     sharedObjectClass: KClass<SharedObjectType> = SharedObjectType::class,
     body: ClassComponentBuilder<SharedObjectType>.() -> Unit = {}
   ) {
-    val clazzBuilder = ClassComponentBuilder(requireNotNull(module).appContext, sharedObjectClass.java.simpleName, sharedObjectClass, toAnyType<SharedObjectType>())
+    val clazzBuilder = ClassComponentBuilder(
+      requireNotNull(module).appContext,
+      sharedObjectClass.java.simpleName,
+      sharedObjectClass,
+      toAnyType<SharedObjectType>(),
+      converters
+    )
     body.invoke(clazzBuilder)
     classData.add(clazzBuilder.buildClass())
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -22,7 +22,6 @@ import expo.modules.kotlin.modules.convertEnumToString
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.types.TypeConverterProvider
 import expo.modules.kotlin.types.enforceType
-import expo.modules.kotlin.types.mergeWithDefault
 import expo.modules.kotlin.types.toArgsArray
 import expo.modules.kotlin.types.toReturnType
 import kotlin.reflect.full.declaredMemberProperties

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -31,10 +31,9 @@ import kotlin.reflect.full.primaryConstructor
 /**
  * Base class for other definitions representing an object, such as `ModuleDefinition`.
  */
-open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = null) {
-  @PublishedApi
-  internal val converterProvider = customConverter.mergeWithDefault()
-
+open class ObjectDefinitionBuilder(
+  @PublishedApi internal val converters: TypeConverterProvider? = null
+) {
   private var legacyConstantsProvider = { emptyMap<String, Any?>() }
 
   @PublishedApi
@@ -126,7 +125,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0>(converterProvider = converterProvider), toReturnType<R>()) { (p0) ->
+    return SyncFunctionComponent(name, toArgsArray<P0>(converterProvider = converters), toReturnType<R>()) { (p0) ->
       enforceType<P0>(p0)
       body(p0)
     }.also {
@@ -138,7 +137,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1>(), toReturnType<R>()) { (p0, p1) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1>(converterProvider = converters), toReturnType<R>()) { (p0, p1) ->
       enforceType<P0, P1>(p0, p1)
       body(p0, p1)
     }.also {
@@ -150,7 +149,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2>(), toReturnType<R>()) { (p0, p1, p2) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2>(converterProvider = converters), toReturnType<R>()) { (p0, p1, p2) ->
       enforceType<P0, P1, P2>(p0, p1, p2)
       body(p0, p1, p2)
     }.also {
@@ -162,7 +161,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>(), toReturnType<R>()) { (p0, p1, p2, p3) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>(converterProvider = converters), toReturnType<R>()) { (p0, p1, p2, p3) ->
       enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
       body(p0, p1, p2, p3)
     }.also {
@@ -174,7 +173,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>(), toReturnType<R>()) { (p0, p1, p2, p3, p4) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>(converterProvider = converters), toReturnType<R>()) { (p0, p1, p2, p3, p4) ->
       enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
       body(p0, p1, p2, p3, p4)
     }.also {
@@ -186,7 +185,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>(), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>(converterProvider = converters), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5) ->
       enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
       body(p0, p1, p2, p3, p4, p5)
     }.also {
@@ -198,7 +197,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>(), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>(converterProvider = converters), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5, p6) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
       body(p0, p1, p2, p3, p4, p5, p6)
     }.also {
@@ -210,7 +209,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
   ): SyncFunctionComponent {
-    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>(), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>(converterProvider = converters), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
       body(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {
@@ -245,7 +244,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     return if (P0::class.java == Promise::class.java) {
       AsyncFunctionWithPromiseComponent(name, arrayOf()) { _, promise -> body(promise as P0) }
     } else {
-      createAsyncFunctionComponent(name, toArgsArray<P0>()) { (p0) ->
+      createAsyncFunctionComponent(name, toArgsArray<P0>(converterProvider = converters)) { (p0) ->
         enforceType<P0>(p0)
         body(p0)
       }
@@ -258,7 +257,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1) -> R
   ): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1>(converterProvider = converters)) { (p0, p1) ->
       enforceType<P0, P1>(p0, p1)
       body(p0, p1)
     }.also {
@@ -271,7 +270,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: Promise) -> R
   ): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0>()) { (p0), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0>(converterProvider = converters)) { (p0), promise ->
       enforceType<P0>(p0)
       body(p0, promise)
     }.also {
@@ -283,7 +282,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
   ): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2>(converterProvider = converters)) { (p0, p1, p2) ->
       enforceType<P0, P1, P2>(p0, p1, p2)
       body(p0, p1, p2)
     }.also {
@@ -296,7 +295,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: Promise) -> R
   ): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1>()) { (p0, p1), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1>(converterProvider = converters)) { (p0, p1), promise ->
       enforceType<P0, P1>(p0, p1)
       body(p0, p1, promise)
     }.also {
@@ -308,7 +307,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
   ): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>(converterProvider = converters)) { (p0, p1, p2, p3) ->
       enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
       body(p0, p1, p2, p3)
     }.also {
@@ -321,7 +320,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: Promise) -> R
   ): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2>(converterProvider = converters)) { (p0, p1, p2), promise ->
       enforceType<P0, P1, P2>(p0, p1, p2)
       body(p0, p1, p2, promise)
     }.also {
@@ -333,7 +332,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
   ): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>(converterProvider = converters)) { (p0, p1, p2, p3, p4) ->
       enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
       body(p0, p1, p2, p3, p4)
     }.also {
@@ -346,7 +345,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: Promise) -> R
   ): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3>(converterProvider = converters)) { (p0, p1, p2, p3), promise ->
       enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
       body(p0, p1, p2, p3, promise)
     }.also {
@@ -358,7 +357,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
   ): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5) ->
       enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
       body(p0, p1, p2, p3, p4, p5)
     }.also {
@@ -371,7 +370,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: Promise) -> R
   ): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4>(converterProvider = converters)) { (p0, p1, p2, p3, p4), promise ->
       enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
       body(p0, p1, p2, p3, p4, promise)
     }.also {
@@ -383,7 +382,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
   ): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5, p6) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
       body(p0, p1, p2, p3, p4, p5, p6)
     }.also {
@@ -396,7 +395,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: Promise) -> R
   ): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5), promise ->
       enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
       body(p0, p1, p2, p3, p4, p5, promise)
     }.also {
@@ -408,7 +407,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
   ): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
       body(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {
@@ -421,7 +420,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: Promise) -> R
   ): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5, p6), promise ->
       enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
       body(p0, p1, p2, p3, p4, p5, p6, promise)
     }.also {
@@ -431,7 +430,7 @@ open class ObjectDefinitionBuilder(customConverter: TypeConverterProvider? = nul
 
   fun AsyncFunction(
     name: String
-  ) = AsyncFunctionBuilder(name).also { asyncFunctionBuilders[name] = it }
+  ) = AsyncFunctionBuilder(name, converters).also { asyncFunctionBuilders[name] = it }
 
   /**
    * Defines event names that this module can send to JavaScript.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -19,6 +19,7 @@ import expo.modules.kotlin.functions.AsyncFunctionWithPromiseComponent
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.functions.createAsyncFunctionComponent
 import expo.modules.kotlin.modules.DefinitionMarker
+import expo.modules.kotlin.types.TypeConverterProvider
 import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.types.toAnyType
 import expo.modules.kotlin.types.toArgsArray
@@ -28,7 +29,8 @@ import kotlin.reflect.KType
 @DefinitionMarker
 class ViewDefinitionBuilder<T : View>(
   @PublishedApi internal val viewClass: KClass<T>,
-  @PublishedApi internal val viewType: KType
+  @PublishedApi internal val viewType: KType,
+  @PublishedApi internal val converters: TypeConverterProvider? = null
 ) {
   @PublishedApi
   internal var name = viewClass.simpleName
@@ -229,7 +231,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1) -> R
   ): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1>()) { (p0, p1) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1>(converterProvider = converters)) { (p0, p1) ->
       enforceType<P0, P1>(p0, p1)
       body(p0, p1)
     }.also {
@@ -242,7 +244,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: Promise) -> R
   ): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0>()) { (p0), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0>(converterProvider = converters)) { (p0), promise ->
       enforceType<P0>(p0)
       body(p0, promise)
     }.also {
@@ -254,7 +256,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2) -> R
   ): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2>(converterProvider = converters)) { (p0, p1, p2) ->
       enforceType<P0, P1, P2>(p0, p1, p2)
       body(p0, p1, p2)
     }.also {
@@ -267,7 +269,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: Promise) -> R
   ): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1>()) { (p0, p1), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1>(converterProvider = converters)) { (p0, p1), promise ->
       enforceType<P0, P1>(p0, p1)
       body(p0, p1, promise)
     }.also {
@@ -279,7 +281,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
   ): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>(converterProvider = converters)) { (p0, p1, p2, p3) ->
       enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
       body(p0, p1, p2, p3)
     }.also {
@@ -292,7 +294,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: Promise) -> R
   ): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2>()) { (p0, p1, p2), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2>(converterProvider = converters)) { (p0, p1, p2), promise ->
       enforceType<P0, P1, P2>(p0, p1, p2)
       body(p0, p1, p2, promise)
     }.also {
@@ -304,7 +306,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
   ): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>(converterProvider = converters)) { (p0, p1, p2, p3, p4) ->
       enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
       body(p0, p1, p2, p3, p4)
     }.also {
@@ -317,7 +319,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: Promise) -> R
   ): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3>()) { (p0, p1, p2, p3), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3>(converterProvider = converters)) { (p0, p1, p2, p3), promise ->
       enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
       body(p0, p1, p2, p3, promise)
     }.also {
@@ -329,7 +331,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
   ): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5) ->
       enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
       body(p0, p1, p2, p3, p4, p5)
     }.also {
@@ -342,7 +344,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: Promise) -> R
   ): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4>()) { (p0, p1, p2, p3, p4), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4>(converterProvider = converters)) { (p0, p1, p2, p3, p4), promise ->
       enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
       body(p0, p1, p2, p3, p4, promise)
     }.also {
@@ -354,7 +356,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
   ): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5, p6) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
       body(p0, p1, p2, p3, p4, p5, p6)
     }.also {
@@ -367,7 +369,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: Promise) -> R
   ): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>()) { (p0, p1, p2, p3, p4, p5), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5), promise ->
       enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
       body(p0, p1, p2, p3, p4, p5, promise)
     }.also {
@@ -379,7 +381,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
   ): AsyncFunctionComponent {
-    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
       enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
       body(p0, p1, p2, p3, p4, p5, p6, p7)
     }.also {
@@ -392,7 +394,7 @@ class ViewDefinitionBuilder<T : View>(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: Promise) -> R
   ): AsyncFunctionComponent {
-    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>()) { (p0, p1, p2, p3, p4, p5, p6), promise ->
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5, p6), promise ->
       enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
       body(p0, p1, p2, p3, p4, p5, p6, promise)
     }.also {
@@ -402,14 +404,14 @@ class ViewDefinitionBuilder<T : View>(
 
   fun AsyncFunction(
     name: String
-  ) = AsyncFunctionBuilder(name).also { functionBuilders[name] = it }
+  ) = AsyncFunctionBuilder(name, converters).also { functionBuilders[name] = it }
 
   private fun createViewFactory(): (Context, AppContext) -> View =
     viewFactory@{ context: Context, appContext: AppContext ->
       val fullConstructor = try {
         // Try to use constructor with two arguments
         viewClass.java.getConstructor(Context::class.java, AppContext::class.java)
-      } catch (e: NoSuchMethodException) {
+      } catch (_: NoSuchMethodException) {
         null
       }
 
@@ -424,7 +426,7 @@ class ViewDefinitionBuilder<T : View>(
       val contextConstructor = try {
         // Try to use constructor that use Android's context
         viewClass.java.getConstructor(Context::class.java)
-      } catch (e: NoSuchMethodException) {
+      } catch (_: NoSuchMethodException) {
         null
       }
 
@@ -439,15 +441,11 @@ class ViewDefinitionBuilder<T : View>(
       throw IllegalStateException("Didn't find a correct constructor for $viewClass")
     }
 
-  private fun handleFailureDuringViewCreation(context: Context, appContext: AppContext, e: Throwable): View {
-    Log.e("ExpoModulesCore", "Couldn't create view of type $viewClass", e)
+  private fun handleFailureDuringViewCreation(context: Context, appContext: AppContext, error: Throwable): View {
+    Log.e("ExpoModulesCore", "Couldn't create view of type $viewClass", error)
 
     appContext.errorManager?.reportExceptionToLogBox(
-      if (e is CodedException) {
-        e
-      } else {
-        UnexpectedException(e)
-      }
+      error as? CodedException ?: UnexpectedException(error)
     )
 
     return if (ViewGroup::class.java.isAssignableFrom(viewClass.java)) {


### PR DESCRIPTION
# Why

Passes custom converters to all related components.

# How

When I introduced this feature, I didn't pass custom converters to all components. Now, we can pass it everywhere, allowing us to start using it in our packages. 