### PR TITLE
[docs] Add searchRank to Image and Video

### DIFF
--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-image'
 packageName: 'expo-image'
 iconUrl: '/static/images/packages/expo-image.png'
 platforms: ['android', 'ios', 'tvos', 'web']
+searchRank: 10
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-image-picke
 packageName: 'expo-image-picker'
 iconUrl: '/static/images/packages/expo-image-picker.png'
 platforms: ['android', 'ios', 'web']
+searchRank: 8
 ---
 
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';

--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-video'
 packageName: 'expo-video'
 iconUrl: '/static/images/packages/expo-video.png'
 platforms: ['android', 'ios', 'web', 'tvos']
+searchRank: 10
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v53.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/image.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-53/packages/expo-image'
 packageName: 'expo-image'
 iconUrl: '/static/images/packages/expo-image.png'
 platforms: ['android', 'ios', 'tvos', 'web']
+searchRank: 10
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v53.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/imagepicker.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-53/packages/expo-image-pic
 packageName: 'expo-image-picker'
 iconUrl: '/static/images/packages/expo-image-picker.png'
 platforms: ['android', 'ios', 'web']
+searchRank: 8
 ---
 
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';

--- a/docs/pages/versions/v53.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/video.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-53/packages/expo-video'
 packageName: 'expo-video'
 iconUrl: '/static/images/packages/expo-video.png'
 platforms: ['android', 'ios', 'web', 'tvos']
+searchRank: 10
 ---
 
 import APISection from '~/components/plugins/APISection';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, searching "expo image" doesn't rank Expo Image page as the first item in the search UI.

![CleanShot 2025-05-14 at 17 28 03@2x](https://github.com/user-attachments/assets/d3e9390b-e005-4cd3-9461-820d49f7dddf)

Similarly, for the search term "video" shows deprecated Video from Expo AV.

![CleanShot 2025-05-14 at 17 36 40@2x](https://github.com/user-attachments/assets/e2fd69ec-25a5-4b72-b0f9-724f7b8ea373)


# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds `searchRank` attribute to Image, ImagePicker, and Expo Video.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

Test on "expo image" search term ran through Algolia crawler configuration in Algolia dashboard. Adding a higher search rank value to Expo Image fixes this issue.

![CleanShot 2025-05-14 at 18 08 41@2x](https://github.com/user-attachments/assets/102fad02-3c91-44bd-95bd-ca14aac5c2e1)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
