### PR TITLE
[image][iOS] Don't add transformers when unnecessary

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fix React Server Components support. ([#36801](https://github.com/expo/expo/pull/36801) by [@EvanBacon](https://github.com/EvanBacon))
 - [iOS] Fix PhotoLibrary assets being scaled twice. ([#36776](https://github.com/expo/expo/pull/36776) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Don't add transformers when unnecessary.
+- [iOS] Don't add transformers when unnecessary. ([#36884](https://github.com/expo/expo/pull/36884) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix React Server Components support. ([#36801](https://github.com/expo/expo/pull/36801) by [@EvanBacon](https://github.com/EvanBacon))
 - [iOS] Fix PhotoLibrary assets being scaled twice. ([#36776](https://github.com/expo/expo/pull/36776) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Don't add transformers when unnecessary.
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -332,7 +332,10 @@ public final class ImageView: ExpoView {
 
   // MARK: - Processing
 
-  private func createTransformPipeline() -> SDImagePipelineTransformer {
+  private func createTransformPipeline() -> SDImagePipelineTransformer? {
+    if blurRadius <= 0 {
+      return nil
+    }
     let transformers: [SDImageTransformer] = [
       SDImageBlurTransformer(radius: blurRadius)
     ]


### PR DESCRIPTION
# Why

Adding `SDImageTransformer` dispatches image loading to global queue which makes it way slower.

# How

Don't add `SDImageTransformer` when it's unnecessary (when there is no blur).

# Test Plan

### Before

Max time to completion handler: 4551.363110542297 ms

https://github.com/user-attachments/assets/5188b5cf-dcc5-415c-bfb3-a6a3b55a0c04

### After

Max time to completion handler: 46.04899883270264 ms

https://github.com/user-attachments/assets/9ee8ac15-b9b4-43c5-b453-31b586631c63

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
