### PR TITLE
[router][e2e] Upgrade SDK version to 53 in router e2e github workflow

### DIFF
--- a/.github/workflows/router-e2e.yml
+++ b/.github/workflows/router-e2e.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install latest Expo Go
         working-directory: bin
         run: |
-          ./expotools client-install -p ios -s 52.0.0
+          ./expotools client-install -p ios -s 53.0.0
 
       - name: Setup maestro env
         run: |


### PR DESCRIPTION
# Why

Old version of expo go was installed

# How

Upgrading version passed to client-install from 52 to 53.

# Test Plan

1. Automated CI test - pipeline success

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
