### PR TITLE
[docs] Fix slack examples with proper curly braces

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -947,7 +947,7 @@ jobs:
 #### `eas/send_slack_message`
 
 Sends a specified message to a configured [Slack webhook URL](https://api.slack.com/messaging/webhooks), which then posts it in the related Slack channel. The message can be specified as plaintext or as a [Slack Block Kit](https://api.slack.com/block-kit) message.
-With both cases, you can reference build job properties and [use other steps outputs](#jobsjob_idoutputs) in the message for dynamic evaluation. For example, `Build URL: ${{ eas.job.expoBuildUrl }}`, `Build finished with status: ${{ steps.run_fastlane.status_text }}`, `Build failed with error: ${{ steps.run_gradle.error_text }}`.
+With both cases, you can reference build job properties and [use other steps outputs](#jobsjob_idoutputs) in the message for dynamic evaluation. For example, `Build URL: ${ eas.job.expoBuildUrl }`, `Build finished with status: ${ steps.run_fastlane.status_text }`, `Build failed with error: ${ steps.run_gradle.error_text }`.
 Either "message" or "payload" has to be specified, but not both.
 
 ```yaml


### PR DESCRIPTION
# Why

In the Slack example docs for workflows, we show that you can write a message like `hello ${{ world }}`, however that is invalid code. Instead we should show `hello ${ world }`. This updates docs to reflect the correct syntax.

# Test Plan

Make sure the changes read well.