### PR TITLE
[splash] Fallback to old splash key if no config for platform

### DIFF
--- a/packages/expo-splash-screen/plugin/build/withSplashScreen.js
+++ b/packages/expo-splash-screen/plugin/build/withSplashScreen.js
@@ -5,33 +5,35 @@ const withIosSplashScreen_1 = require("@expo/prebuild-config/build/plugins/unver
 const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('expo-splash-screen/package.json');
 const withSplashScreen = (config, props) => {
-    if (!props) {
-        config = (0, withAndroidSplashScreen_1.withAndroidSplashScreen)(config, null);
-        config = (0, withIosSplashScreen_1.withIosSplashScreen)(config, null);
-        return config;
-    }
+    let android = null;
+    let ios = null;
     const resizeMode = props?.resizeMode || 'contain';
-    const { ios: iosProps, android: androidProps, ...otherProps } = props;
-    const android = {
-        ...otherProps,
-        ...androidProps,
-        resizeMode: androidProps?.resizeMode || resizeMode,
-        dark: {
-            ...otherProps?.dark,
-            ...androidProps?.dark,
-        },
-    };
-    const ios = {
-        ...otherProps,
-        ...iosProps,
-        resizeMode: iosProps?.resizeMode || (resizeMode === 'native' ? 'contain' : resizeMode),
-        dark: {
-            ...otherProps?.dark,
-            ...iosProps?.dark,
-        },
-    };
-    // Need to pass null here if we don't receive any props. This means that the plugin has not been used.
-    // This only happens on Android. On iOS, if you don't use the plugin, this function won't be called.
+    const { ios: iosProps, android: androidProps, ...otherProps } = props ?? {};
+    const usesLegacySplashConfigIOS = !props || (androidProps && !iosProps && Object.keys(otherProps).length === 0);
+    const usesLegacySplashConfigAndroid = !props || (iosProps && !androidProps && Object.keys(otherProps).length === 0);
+    android = usesLegacySplashConfigAndroid
+        ? null
+        : {
+            ...otherProps,
+            ...androidProps,
+            resizeMode: androidProps?.resizeMode || resizeMode,
+            dark: {
+                ...otherProps?.dark,
+                ...androidProps?.dark,
+            },
+        };
+    ios = usesLegacySplashConfigIOS
+        ? null
+        : {
+            ...otherProps,
+            ...iosProps,
+            resizeMode: iosProps?.resizeMode || (resizeMode === 'native' ? 'contain' : resizeMode),
+            dark: {
+                ...otherProps?.dark,
+                ...iosProps?.dark,
+            },
+        };
+    // Passing null here will result in the legacy splash config being used.
     config = (0, withAndroidSplashScreen_1.withAndroidSplashScreen)(config, android);
     config = (0, withIosSplashScreen_1.withIosSplashScreen)(config, ios);
     return config;


### PR DESCRIPTION
# Why

I expected this to only change the splash on Android:

```
    "plugins": [
      [
        "expo-splash-screen",
        {
          "android": {
            "image": "./assets/images/splash-icon.png",
            "imageWidth": 200,
            "resizeMode": "contain",
            "backgroundColor": "#ffffff"
          }
        }
      ]
    ],
```

And I assumed that on iOS this would be used:

```
    "splash": {
      "image": "./assets/images/splash.png"
    },
```

Unfortunately, it looks like we end up using blank values for the iOS splash config in this case. So I fixed that by falling back to the legacy behavior if there is no config provided for a particular platform.

# How

Pretty straightforward checks to ensure we pass null along to the platform specific config plugins if there is no config, which instructs those plugins to fall back to the legacy behavior.

# Test Plan

I verified that this resolved the issue above by using it in a project directly.