### PR TITLE
[media-library] use named argument for runActionWithPermissions

### DIFF
--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -152,7 +152,7 @@ class MediaLibraryModule : Module() {
               .execute()
           }
         }
-        runActionWithPermissions(assetsId, action, true)
+        runActionWithPermissions(assetsId, action, useDeletePermission = true)
       }
     }
 


### PR DESCRIPTION
# Why

follow up on https://github.com/expo/expo/pull/33211#discussion_r2089381616

# How

- Added a named parameter to the `runActionWithPermissions` function call to improve code readability and maintainability.

# Test Plan

- built locally

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)