### PR TITLE
[jest-expo] Fix platform preset babel detection

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unpublished
 
-- Fix JSX and TSX files throwing errors when using `jest-expo/SUB-PKG` imports.
+- Fix JSX and TSX files throwing errors when using `jest-expo/SUB-PKG` imports. ([#36903](https://github.com/expo/expo/pull/36903) by [@crutchcorn](https://github.com/crutchcorn))
 
 ### 🛠 Breaking changes
 

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Fix JSX and TSX files throwing errors when using `jest-expo/SUB-PKG` imports.
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features


### PR DESCRIPTION
# Why

While working on a web/native monorepo for Expo, I found the `jest-expo` preset was working just fine, but anytime I changed said import to `jest-expo/universal` or even `jest-expo/web` it would break on JSX/TSX files with the following:

````
 FAIL   Web  src/views/login/login.spec.web.tsx
  ● Test suite failed to run

    Jest encountered an unexpected token

    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.

    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.

    By default "node_modules" folder is ignored by transformers.

    Here's what you can do:
     • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/ecmascript-modules for how to enable it.
     • If you are trying to use TypeScript, see https://jestjs.io/docs/getting-started#using-typescript
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/configuration
    For information about custom transformations, see:
    https://jestjs.io/docs/code-transformation

    Details:

    /Users/crutchcorn/git/txfsn/tf-react-frontend/src/utils/testing-utils/setup.ts:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){import { server } from "./server";
                                                                                      ^^^^^^

    SyntaxError: Cannot use import statement outside a module

      at Runtime.createScriptFromCode (node_modules/jest-runtime/build/index.js:1505:14)
````

I figured I'd dive in a bit deeper and try to fix this, which this PR does.

# How

I fixed this bug by modifying the source code in `node_modules` using a debugger view and reading most of the Expo Jest source code.

It's worth mentioning, however, that this PR alone does not solve my needs despite it fixing the bugs present. See, for my testing needs I also need to change a few values from the preset:

````js
{
      setupFilesAfterEnv: ["./src/utils/testing-utils/setup.ts"],
      moduleNameMapper: {
        "\\.(css|less|scss|sss|styl)$":
          "<rootDir>/node_modules/jest-css-modules",
      },
      testEnvironment: "jest-fixed-jsdom"
}
````

And these settings are not applied when using the `jest-expo/universal` preset due to it leveraging `projects` to mark each configuration file individually.

This can be fairly easily worked around for now with:

````js
const { getWebPreset } = require("jest-expo/config/getPlatformPreset");
const { withWatchPlugins } = require("jest-expo/config/withWatchPlugins");

const webPreset = getWebPreset();

module.exports = withWatchPlugins({
  projects: [
    // Create a new project for each platform.
    {
      ...webPreset,
      transformIgnorePatterns: [
        "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg)",
      ],
      setupFilesAfterEnv: ["./src/utils/testing-utils/setup.ts"],
      moduleNameMapper: {
        ...webPreset.moduleNameMapper,
        "\\.(css|less|scss|sss|styl)$":
          "<rootDir>/node_modules/jest-css-modules",
      },
      testEnvironment: "jest-fixed-jsdom",
    },
  ],
});
````

> This assumes the Babel fix from this PR has been merged to work

But it would be even better if we could pass a `jestOverwriteConfig` or something similar to the `jest-expo/universal` themes, but it's unclear how that would work - since AFAIK there's no way to pass arguments to presets in Jest.

Instead, I can make a follow-up PR documenting this preset override behavior on the `README.md` and maybe even [this page on the Expo.dev site](https://docs.expo.dev/develop/unit-testing/) if that would be acceptable.

# Test Plan

I pulled this new plugin code into my project via a `node_modules` patch and found that it resolved the issues I was facing before.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
