### PR TITLE
[docs] change monospace font

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from '@expo/styleguide';
 import { MDXProvider } from '@mdx-js/react';
 import * as Sentry from '@sentry/react';
 import { AppProps } from 'next/app';
-import { Inter, Fira_Code } from 'next/font/google';
+import { Inter, JetBrains_Mono } from 'next/font/google';
 
 import { preprocessSentryError } from '~/common/sentry-utilities';
 import { useNProgress } from '~/common/useNProgress';
@@ -24,8 +24,7 @@ export const regularFont = Inter({
   display: 'swap',
   subsets: ['latin'],
 });
-export const monospaceFont = Fira_Code({
-  weight: ['400', '500'],
+export const monospaceFont = JetBrains_Mono({
   display: 'swap',
   subsets: ['latin'],
 });


### PR DESCRIPTION
# Why

We have decided to change the monospace font we use in Expo products and services.

# How

Switch monospace font from Fira Code to JetBrains Mono.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2025-05-15 at 14 37 59](https://github.com/user-attachments/assets/02e438c1-9cb9-4268-8977-7062cdf99dba)
