### PR TITLE
[docs] add Expo.plist annotation for Xcode users in eas-update docs

### DIFF
--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -146,7 +146,7 @@ Inside **ios/project-name/Supporting/Expo.plist**, you'll see the following addi
 
 The `EXUpdatesURL` value should contain your project's ID.
 
-> **info** If you use Xcode to create project builds, make sure that the `Expo.plist` file [is added to your Xcode project](https://developer.apple.com/documentation/xcode/managing-files-and-folders-in-your-xcode-project#Add-existing-files-and-folders-to-a-project). 
+> **info** If you use Xcode to create project builds, make sure that the `Expo.plist` file [is added to your Xcode project](https://developer.apple.com/documentation/xcode/managing-files-and-folders-in-your-xcode-project#Add-existing-files-and-folders-to-a-project).
 
 </Collapsible>
 
@@ -229,7 +229,7 @@ In **Expo.plist**, you'll need to add the following, replacing `your-channel-nam
 </dict>
 ```
 
-> **info** If you use Xcode to create project builds, make sure that the `Expo.plist` file [is added to your Xcode project](https://developer.apple.com/documentation/xcode/managing-files-and-folders-in-your-xcode-project#Add-existing-files-and-folders-to-a-project). 
+> **info** If you use Xcode to create project builds, make sure that the `Expo.plist` file [is added to your Xcode project](https://developer.apple.com/documentation/xcode/managing-files-and-folders-in-your-xcode-project#Add-existing-files-and-folders-to-a-project).
 
 </Collapsible>
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -146,6 +146,8 @@ Inside **ios/project-name/Supporting/Expo.plist**, you'll see the following addi
 
 The `EXUpdatesURL` value should contain your project's ID.
 
+> **info** If you use Xcode to create project builds, make sure that the `Expo.plist` file [is added to your Xcode project](https://developer.apple.com/documentation/xcode/managing-files-and-folders-in-your-xcode-project#Add-existing-files-and-folders-to-a-project). 
+
 </Collapsible>
 
 </Step>
@@ -226,6 +228,8 @@ In **Expo.plist**, you'll need to add the following, replacing `your-channel-nam
   <string>your-channel-name</string>
 </dict>
 ```
+
+> **info** If you use Xcode to create project builds, make sure that the `Expo.plist` file [is added to your Xcode project](https://developer.apple.com/documentation/xcode/managing-files-and-folders-in-your-xcode-project#Add-existing-files-and-folders-to-a-project). 
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
I was setting up `eas-updates` for bare react native app (not using `eas-build`). After I configured update channel, I created a build in Xcode and launched the app on the iOS simulator - it turned out that the app does not send any request for new updates - after debugging and searching the web for a solution, I stumbled upon [an issue](https://github.com/expo/expo/issues/31436), that had [a comment](https://github.com/expo/expo/issues/31436#issuecomment-2603173911) which was the key to resolve my problem.  The missing part was to reference the Expo.plist file in the xCode project, which made it accessible during the build process.

# How

<!--
How did you build this feature or fix this bug and why?
-->
Decided to add information about this in the `eas-update` docs sections, that mention `Expo.plist` file, to point people that use Xcode for creating iOS app builds that this step is crucial in order for the `eas-update` to work.

# Test Plan
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/6ef7653e-cc38-4e3c-b5c2-d066040a70bf" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/4dc2d27a-2c32-47df-9ff8-267259930318" />



<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
