### PR TITLE
revert: Revert "noop non-fabric renderer when new architecture is enabled." #36757

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 ### 🎉 New features
 
-- noop non-fabric renderer when new architecture is enabled. ([#36757](https://github.com/expo/expo/pull/36757) by [@EvanBacon](https://github.com/EvanBacon))
-
 ### 🐛 Bug fixes
 
 - remove extraneous log ([#36801](https://github.com/expo/expo/pull/36801) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -165,10 +165,6 @@ export async function loadMetroConfigAsync(
     isNamedRequiresEnabled: env.EXPO_USE_METRO_REQUIRE,
     isReactServerComponentsEnabled: !!exp.experiments?.reactServerComponentRoutes,
     getMetroBundler,
-    isFabricEnabled: {
-      ios: exp.ios?.newArchEnabled ?? exp.newArchEnabled ?? true,
-      android: exp.android?.newArchEnabled ?? exp.newArchEnabled ?? true,
-    },
   });
 
   return {

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -150,7 +150,6 @@ export function withExtendedResolver(
     isReactCanaryEnabled,
     isReactServerComponentsEnabled,
     getMetroBundler,
-    isFabricEnabled,
   }: {
     tsconfig: TsConfigPaths | null;
     isTsconfigPathsEnabled?: boolean;
@@ -158,7 +157,6 @@ export function withExtendedResolver(
     isExporting?: boolean;
     isReactCanaryEnabled?: boolean;
     isReactServerComponentsEnabled?: boolean;
-    isFabricEnabled: Record<string, boolean>;
     getMetroBundler: () => Bundler;
   }
 ) {
@@ -388,44 +386,14 @@ export function withExtendedResolver(
   ];
 
   const metroConfigWithCustomResolver = withMetroResolvers(config, [
-    // Mock out legacy react renderer when bundling for new architecture.
-    function requestNoopOldReactRenderer(
-      context: ResolutionContext,
-      moduleName: string,
-      platform: string | null
-    ) {
-      // Native-only pass.
-      if (
-        !platform ||
-        platform === 'web' ||
-        // Only when the current platform has fabric enabled.
-        !isFabricEnabled[platform] ||
-        // Ensure the request is coming from within the react-native package.
-        !context.originModulePath.match(/[\\/]node_modules[\\/]react-native[\\/]/)
-      ) {
-        return null;
-      }
-
-      // Check if fabric enabled for the given platform.
-      if (moduleName.match(/[\\/]ReactNativeRenderer-(prod|dev)/)) {
-        debug(`Noop old-arch module for fabric bundle: ${moduleName}`);
-        return {
-          type: 'empty',
-        };
-      }
-
-      return null;
-    },
-
+    // Mock out production react imports in development.
     function requestDevMockProdReact(
       context: ResolutionContext,
       moduleName: string,
       platform: string | null
     ) {
       // This resolution is dev-only to prevent bundling the production React packages in development.
-      if (!context.dev) {
-        return null;
-      }
+      if (!context.dev) return null;
 
       if (
         // Match react-native renderers.
@@ -837,7 +805,6 @@ export async function withMetroMultiPlatformAsync(
     isReactCanaryEnabled,
     isNamedRequiresEnabled,
     isReactServerComponentsEnabled,
-    isFabricEnabled,
     getMetroBundler,
   }: {
     config: ConfigT;
@@ -849,7 +816,6 @@ export async function withMetroMultiPlatformAsync(
     isReactCanaryEnabled: boolean;
     isReactServerComponentsEnabled: boolean;
     isNamedRequiresEnabled: boolean;
-    isFabricEnabled: Record<string, boolean>;
     getMetroBundler: () => Bundler;
   }
 ) {
@@ -921,7 +887,6 @@ export async function withMetroMultiPlatformAsync(
     isFastResolverEnabled,
     isReactCanaryEnabled,
     isReactServerComponentsEnabled,
-    isFabricEnabled,
     getMetroBundler,
   });
 }

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 ### 🎉 New features
 
-- noop non-fabric renderer when new architecture is enabled. ([#36757](https://github.com/expo/expo/pull/36757) by [@EvanBacon](https://github.com/EvanBacon))
-
 ### 🐛 Bug fixes
 
 ### 💡 Others


### PR DESCRIPTION
# Why

The PR #36757 removes the paper renderer from the bundler when using the new arch to save space. After testing for a bit we found that `react-native-gesture-handler` uses `findNodeHandle` which in turn causes it to import the paper renderer even though we're on the new arch. 

We decided to revert this one.

@EvanBacon 
@Kudo 

# How

This reverts commit 959e44addb78f7f6166ec2112888d024a66758f2.

# Test Plan

Tests green

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
