### PR TITLE
[core][Android] Improve custom type converters

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -188,6 +188,27 @@ class SingleTestContext(
 }
 
 internal inline fun withSingleModule(
+  module: Module,
+  numberOfReloads: Int = 1,
+  block: SingleTestContext.() -> Unit
+) {
+  withJSIInterop(
+    module,
+    numberOfReloads = numberOfReloads,
+    block = { methodQueue ->
+      val appContext = runtimeContextHolder.get()?.appContext ?: throw IllegalStateException("AppContext is not available")
+      val moduleList = appContext.registry.registry.toList()
+      if (moduleList.size != 1) {
+        throw IllegalStateException("Module list should contain only one module")
+      }
+      val (moduleName) = moduleList.first()
+      val testContext = SingleTestContext(moduleName, this, methodQueue)
+      block.invoke(testContext)
+    }
+  )
+}
+
+internal inline fun withSingleModule(
   crossinline definition: ModuleDefinitionBuilder.() -> Unit = {},
   numberOfReloads: Int = 1,
   block: SingleTestContext.() -> Unit

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/CustomTypeConvertersTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/CustomTypeConvertersTest.kt
@@ -1,0 +1,60 @@
+package expo.modules.kotlin.jni.types
+
+import com.google.common.truth.Truth
+import expo.modules.kotlin.jni.withSingleModule
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleConverters
+import expo.modules.kotlin.modules.ModuleDefinition
+import org.junit.Test
+
+class CustomTypeConvertersTest {
+  class CustomType
+
+  @Test
+  fun test() = withSingleModule(object : Module() {
+    override fun converters() = ModuleConverters {
+      TypeConverter(CustomType::class)
+        .from { number: Int ->
+          Truth.assertThat(number).isEqualTo(1234)
+          CustomType()
+        }
+        .from { string: String ->
+          Truth.assertThat("string").isEqualTo("string")
+          CustomType()
+        }
+        .from { listOfNumber: List<Int> ->
+          Truth.assertThat(listOfNumber).isEqualTo(listOf(1, 2, 3))
+          CustomType()
+        }
+    }
+
+    override fun definition() = ModuleDefinition {
+      Name("TestModule")
+      Function("convert") { type: CustomType ->
+        Truth.assertThat(type).isInstanceOf(CustomType::class.java)
+        true
+      }
+      Function("convertNullable") { type: CustomType? ->
+        Truth.assertThat(type).isNull()
+        true
+      }
+    }
+  }) {
+    Truth.assertThat(
+      call("convert", "1234").getBool()
+    ).isTrue()
+
+    Truth.assertThat(
+      call("convertNullable", "null")
+        .getBool()
+    ).isTrue()
+
+    Truth.assertThat(
+      call("convert", "'string'").getBool()
+    ).isTrue()
+
+    Truth.assertThat(
+      call("convert", "[1, 2, 3]").getBool()
+    ).isTrue()
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleConvertersBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleConvertersBuilder.kt
@@ -4,37 +4,41 @@ package expo.modules.kotlin.modules
 
 import expo.modules.kotlin.exception.MissingTypeConverter
 import expo.modules.kotlin.types.TypeConverter
-import expo.modules.kotlin.types.TypeConverterCollection
+import expo.modules.kotlin.types.TypeConverterComponent
 import expo.modules.kotlin.types.TypeConverterProvider
+import expo.modules.kotlin.types.lazyTypeOf
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
-import kotlin.reflect.typeOf
 
 class ModuleConvertersBuilder {
   @PublishedApi
-  internal var typeConverters: MutableMap<KClass<*>, TypeConverter<*>> = mutableMapOf()
+  internal var convertersComponent = mutableListOf<TypeConverterComponent<*>>()
 
-  inline fun <reified T : Any> TypeConverter(classifier: KClass<T>, body: () -> TypeConverter<T>) {
-    typeConverters[classifier] = body()
+  inline fun <reified T : Any> TypeConverter(classifier: KClass<T>): TypeConverterComponent<T> {
+    val converterComponent = TypeConverterComponent<T>(lazyTypeOf<T>(), lazyTypeOf<(T?)?>())
+    convertersComponent.add(converterComponent)
+    return converterComponent
   }
 
-  inline fun <reified T : Any> TypeConverter(classifier: KClass<T>): TypeConverterCollection<T> {
-    val converter = TypeConverterCollection<T>(typeOf<T>())
-    typeConverters[classifier] = converter
-    return converter
-  }
-
-  inline fun <reified T : Any, reified P0> TypeConverter(classifier: KClass<T>, crossinline body: (p0: P0) -> T): TypeConverterCollection<T> {
-    val converter = TypeConverterCollection<T>(typeOf<T>()).from<P0>(body)
-    typeConverters[classifier] = converter
-    return converter
+  inline fun <reified T : Any, reified P0 : Any> TypeConverter(
+    classifier: KClass<T>,
+    crossinline body: (p0: P0) -> T
+  ): TypeConverterComponent<T> {
+    return TypeConverter<T>(classifier).apply {
+      from<P0> { value ->
+        body(value)
+      }
+    }
   }
 
   fun buildTypeConverterProvider(): TypeConverterProvider {
+    val converterMap = convertersComponent
+      .map { it.build() }
+      .flatten()
+      .toMap()
     return object : TypeConverterProvider {
       override fun obtainTypeConverter(type: KType): TypeConverter<*> {
-        val classifier = type.classifier as? KClass<*>
-        val typeConverter = typeConverters[classifier]
+        val typeConverter = converterMap[type]
         if (typeConverter != null) {
           return typeConverter
         } else {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
@@ -145,6 +145,15 @@ object AnyTypeProvider {
   }
 }
 
+inline fun <reified T> lazyTypeOf() = { typeOf<T>() }.toLazyType<T>()
+
+inline fun <reified T> (() -> KType).toLazyType() =
+  LazyKType(
+    classifier = T::class,
+    isMarkedNullable = null is T,
+    kTypeProvider = this
+  )
+
 inline fun <reified T> (() -> KType).toAnyType(converterProvider: TypeConverterProvider? = null) =
   AnyType(
     LazyKType(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
@@ -98,7 +98,7 @@ class EitherTypeConverter<FirstType : Any, SecondType : Any>(
     )
   }
 
-  override fun getCppRequiredTypes(): ExpectedType = firstType + secondType
+  override fun getCppRequiredTypes(): ExpectedType = ExpectedType.merge(firstType, secondType)
 
   override fun isTrivial(): Boolean = false
 }
@@ -144,7 +144,7 @@ class EitherOfThreeTypeConverter<FirstType : Any, SecondType : Any, ThirdType : 
     )
   }
 
-  override fun getCppRequiredTypes(): ExpectedType = firstType + secondType + thirdType
+  override fun getCppRequiredTypes(): ExpectedType = ExpectedType.merge(firstType, secondType, thirdType)
 }
 
 @EitherType
@@ -194,5 +194,5 @@ class EitherOfFourTypeConverter<FirstType : Any, SecondType : Any, ThirdType : A
     )
   }
 
-  override fun getCppRequiredTypes(): ExpectedType = firstType + secondType + thirdType
+  override fun getCppRequiredTypes(): ExpectedType = ExpectedType.merge(firstType, secondType, thirdType, fourthType)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ExpoDynamic.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ExpoDynamic.kt
@@ -1,0 +1,57 @@
+package expo.modules.kotlin.types
+
+import com.facebook.react.bridge.Dynamic
+
+class ExpoDynamic(private val dynamic: Dynamic) {
+  enum class Type {
+    Boolean,
+    Number,
+    String,
+    Map,
+    Array
+  }
+
+  val type: Type
+    get() {
+      return when (dynamic.type) {
+        com.facebook.react.bridge.ReadableType.Null -> throw IllegalStateException("ExpoDynamic is null")
+        com.facebook.react.bridge.ReadableType.Boolean -> Type.Boolean
+        com.facebook.react.bridge.ReadableType.Number -> Type.Number
+        com.facebook.react.bridge.ReadableType.String -> Type.String
+        com.facebook.react.bridge.ReadableType.Map -> Type.Map
+        com.facebook.react.bridge.ReadableType.Array -> Type.Array
+      }
+    }
+
+  val isNull: Boolean
+    get() {
+      if (dynamic.isNull) {
+        throw IllegalStateException("ExpoDynamic is null")
+      }
+      return false
+    }
+
+  fun asArray(): List<Any?> {
+    return dynamic.asArray().toArrayList()
+  }
+
+  fun asBoolean(): Boolean {
+    return dynamic.asBoolean()
+  }
+
+  fun asDouble(): Double {
+    return dynamic.asDouble()
+  }
+
+  fun asInt(): Int {
+    return dynamic.asInt()
+  }
+
+  fun asMap(): Map<String, Any?> {
+    return dynamic.asMap().toHashMap()
+  }
+
+  fun asString(): String {
+    return dynamic.asString()
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterCollection.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterCollection.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin.types
 
+import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.MissingTypeConverter
 import expo.modules.kotlin.jni.ExpectedType
@@ -7,34 +8,74 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
-class TypeConverterCollection<Type : Any>(val type: KType) : TypeConverter<Type>() {
+class TypeConverterComponent<Type : Any>(val notNullableType: KType, val nullableType: KType) {
+  val nonNullableConverter = lazy { TypeConverterCollection<Type>(notNullableType, false) }
+  val nullableConverter = lazy { TypeConverterCollection<Type>(nullableType, true) }
+
+  inline fun <reified P0 : Any> from(crossinline body: (p0: P0) -> Type): TypeConverterComponent<Type> {
+    nonNullableConverter.value.from(body)
+    nullableConverter.value.from(body)
+    return this
+  }
+
+  fun build(): List<Pair<KType, TypeConverter<*>>> {
+    if (nonNullableConverter.isInitialized() && nullableConverter.isInitialized()) {
+      return listOf(
+        notNullableType to nonNullableConverter.value,
+        nullableType to nullableConverter.value
+      )
+    }
+
+    return emptyList()
+  }
+}
+
+class TypeConverterCollection<Type : Any>(
+  val type: KType,
+  isOptional: Boolean
+) : NullAwareTypeConverter<Type>(isOptional) {
   @PublishedApi
   internal var converters: MutableMap<KType, (Any?) -> Type> = mutableMapOf()
 
   inline fun <reified P0> from(crossinline body: (p0: P0) -> Type): TypeConverterCollection<Type> {
     converters[typeOf<P0>()] = { value ->
-      body(value as P0)
+      enforceType<P0>(value)
+      body(value)
     }
 
     return this
   }
 
-  override fun convert(value: Any?, context: AppContext?): Type {
-    val converter = converters.firstNotNullOfOrNull { (key, converter) ->
-      val kClass = key.classifier as? KClass<*>
-      if (kClass?.isInstance(value) == true) {
-        return@firstNotNullOfOrNull converter
+  override fun convertNonOptional(value: Any, context: AppContext?): Type {
+    val possibleConverters = converters
+      .map { (key, converter) -> key to converter }
+      .filter { (key, _) ->
+        val kClass = key.classifier as? KClass<*>
+        kClass?.isInstance(value) == true
       }
-      return@firstNotNullOfOrNull null
+
+    if (possibleConverters.isEmpty()) {
+      // We don't have a converter for Dynamic, but we can try to convert it to ExpoDynamic
+      // and see if we have a converter for that.
+      if (value is Dynamic) {
+        return convertNonOptional(ExpoDynamic(value), context)
+      }
+
+      throw MissingTypeConverter(type)
     }
-    converter ?: throw MissingTypeConverter(type)
-    return converter(value)
+
+    if (possibleConverters.size > 1) {
+      throw TypeCastException("Cannot cast '$value' to '$type'. Type converters conflict")
+    }
+
+    return possibleConverters.first().second.invoke(value)
   }
 
   override fun getCppRequiredTypes(): ExpectedType {
-    val possibleTypes = converters.keys.flatMap { key ->
-      ExpectedType.fromKType(key).getPossibleTypes().map { it }
-    }.toTypedArray()
-    return ExpectedType(*possibleTypes)
+    return ExpectedType.merge(
+      *converters.keys.map { key ->
+        ExpectedType.fromKType(key)
+      }.toTypedArray()
+    )
   }
 }


### PR DESCRIPTION
# Why

Improves custom type converters.

# How

- Added `ExpoDynamic` to not have to depend on react native when adding converters for props. 
- Handled `null` case.
- Improved type merging algorithm (can also improve either type) - for example, if we want to merge `List<Int>` and `List<String>` into a C++ type, we should get `List<Int | String>`. Before we merge it to `List<Int> | List<String`, which wasn't correct.

# Test Plan

- unit tests ✅ 
