### PR TITLE
[docs] Add `env` and `environment` to Fingerprint job

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -516,6 +516,10 @@ jobs:
     # @info #
     type: fingerprint
     # @end #
+    params:
+      environment: production | preview | development # optional, defaults to production
+      env: # optional
+        APP_VARIANT: staging # just an example
 ```
 
 > **warning** This job type only supports [CNG (managed)](/workflow/continuous-native-generation/) workflows. If you commit your **android** or **ios** directories, the fingerprint job won't work.


### PR DESCRIPTION
# Why

Missing docs on params available.

# How

Added docs following [implementation](https://github.com/expo/universe/blob/f0387cb61b716180f5ad61b8bca067f879c295f3/server/www/src/data/entities/workflow/job/WorkflowFingerprintJob.ts#L16-L20).

# Test Plan

CI should pass.