### PR TITLE
[docs][expo-router] update troubleshooting docs to include package.js…

### DIFF
--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -48,8 +48,8 @@ Then, update your app's main entry point in **package.json**:
 
 ```json package.json
 {
-  /* @hide ... */ /* @end */
   "main": "index.js"
+  /* @hide ... */ /* @end */
 }
 ```
 

--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -44,13 +44,12 @@ export function App() {
 registerRootComponent(App);
 ```
 
-You will need to also update your app's main entry point:
+Then, update your app's main entry point in **package.json**:
 
 ```json package.json
 {
-  ...
+  /* @hide ... */ /* @end */
   "main": "index.js"
-  ... 
 }
 ```
 

--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -44,6 +44,16 @@ export function App() {
 registerRootComponent(App);
 ```
 
+You will need to also update your app's main entry point:
+
+```json package.json
+{
+  ...
+  "main": "index.js"
+  ... 
+}
+```
+
 > Do not use this to change the root directory (**app**) as it won't account for usage in any other places.
 
 ## `require.context` not enabled


### PR DESCRIPTION
…on change

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Expo router Troubleshooting docs doesn't mention package.json change
https://docs.expo.dev/router/reference/troubleshooting/

# How

<!--
How did you build this feature or fix this bug and why?
-->
Updated the docs to include change

### Before
<img width="1112" alt="Screenshot 2025-05-16 at 6 31 24 PM" src="https://github.com/user-attachments/assets/93747341-0fe3-433a-858d-a950bdff2ee4" />

### After

<img width="1107" alt="Screenshot 2025-05-16 at 6 33 27 PM" src="https://github.com/user-attachments/assets/d7a7641e-429a-4166-bdb8-661573d51e0e" />



