### PR TITLE
[docs] Add npx testflight/web deployment info to the docs home page

### DIFF
--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -1,6 +1,8 @@
 import { RouterLogo, mergeClasses } from '@expo/styleguide';
+import { AppleIcon } from '@expo/styleguide-icons/custom/AppleIcon';
 import { PlanEnterpriseIcon } from '@expo/styleguide-icons/custom/PlanEnterpriseIcon';
 import { ArrowRightIcon } from '@expo/styleguide-icons/outline/ArrowRightIcon';
+import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 
 import { GridContainer, GridCell, HomeButton } from '~/ui/components/Home/components';
 import { QuickStartIcon, DevicesImage } from '~/ui/components/Home/resources';
@@ -37,6 +39,53 @@ export function QuickStart() {
               <CALLOUT theme="secondary">
                 Then continue{' '}
                 <A href="/get-started/set-up-your-environment">setting up your environment</A>.
+              </CALLOUT>
+            </div>
+          </div>
+        </GridCell>
+        <GridCell
+          className={mergeClasses(
+            'min-h-[250px] bg-element !bg-cell-quickstart-pattern bg-blend-multiply',
+            'max-md-gutters:min-h-[200px]'
+          )}>
+          <div
+            className={mergeClasses(
+              'absolute inset-0 size-full rounded-lg bg-gradient-to-b from-subtle from-15% to-[#21262d00]',
+              'dark:from-[#181a1b]'
+            )}
+          />
+          <div className="relative z-10 flex flex-col gap-4">
+            <RawH2 className="flex items-center gap-2 !font-bold">
+              <AppleIcon /> Deploy to TestFlight
+            </RawH2>
+            <div>
+              <Terminal cmd={['$ npx testflight']} />
+              <CALLOUT theme="secondary">
+                This is iOS only command that will upload your app to TestFlight.
+              </CALLOUT>
+            </div>
+          </div>
+        </GridCell>
+        <GridCell
+          className={mergeClasses(
+            'min-h-[250px] bg-element !bg-cell-quickstart-pattern bg-blend-multiply',
+            'max-md-gutters:min-h-[200px]'
+          )}>
+          <div
+            className={mergeClasses(
+              'absolute inset-0 size-full rounded-lg bg-gradient-to-b from-subtle from-15% to-[#21262d00]',
+              'dark:from-[#181a1b]'
+            )}
+          />
+          <div className="relative z-10 flex flex-col gap-4">
+            <RawH2 className="flex items-center gap-2 !font-bold">
+              <Cloud01Icon /> Deploy your web app
+            </RawH2>
+            <div>
+              <Terminal cmd={['$ npx eas-cli deploy']} />
+              <CALLOUT theme="secondary">
+                For prerequisites and complete instructions, see{' '}
+                <A href="/deploy/web/#export-your-web-project/">Deploy web apps</A>.
               </CALLOUT>
             </div>
           </div>

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -80,7 +80,7 @@ export function QuickStart() {
           />
           <div className="relative z-10 flex flex-col gap-4">
             <RawH2 className="flex items-center gap-2 !font-bold !text-palette-purple10">
-              <AppleAppStoreIcon className="text-palette-purple10" /> Deploy to TestFlight
+              <AppleAppStoreIcon className="icon-lg text-palette-purple10" /> Deploy to TestFlight
             </RawH2>
             <div>
               <Terminal cmd={['$ npx testflight']} />
@@ -104,8 +104,8 @@ export function QuickStart() {
           />
           <div className="relative z-10 flex flex-col gap-4">
             <RawH2 className="flex items-center gap-2 !font-bold !text-[#1e8a5f] dark:!text-[#4eca8c]">
-              <Cloud01DuotoneIcon className="text-[#1e8a5f] dark:text-[#4eca8c]" /> Deploy your web
-              app
+              <Cloud01DuotoneIcon className="icon-lg text-[#1e8a5f] dark:text-[#4eca8c]" /> Deploy
+              your web app
             </RawH2>
             <div>
               <Terminal cmd={['$ npx eas-cli deploy']} />

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -92,8 +92,8 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'min-h-[250px] border-[#c9e9d9] bg-[#f0f9f0] !bg-cell-quickstart-pattern bg-blend-multiply',
-            'dark:border-[#2a5240] dark:bg-[#1d392c] dark:!bg-cell-quickstart-pattern dark:bg-blend-multiply',
+            'min-h-[250px] border-palette-green6 bg-[#f0f9f0] !bg-cell-quickstart-pattern bg-blend-multiply',
+            'dark:border-palette-green7 dark:bg-[#1d392c] dark:!bg-cell-quickstart-pattern dark:bg-blend-multiply',
             'max-md-gutters:min-h-[200px]'
           )}>
           <div

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -45,53 +45,6 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'min-h-[250px] bg-element !bg-cell-quickstart-pattern bg-blend-multiply',
-            'max-md-gutters:min-h-[200px]'
-          )}>
-          <div
-            className={mergeClasses(
-              'absolute inset-0 size-full rounded-lg bg-gradient-to-b from-subtle from-15% to-[#21262d00]',
-              'dark:from-[#181a1b]'
-            )}
-          />
-          <div className="relative z-10 flex flex-col gap-4">
-            <RawH2 className="flex items-center gap-2 !font-bold">
-              <AppleIcon /> Deploy to TestFlight
-            </RawH2>
-            <div>
-              <Terminal cmd={['$ npx testflight']} />
-              <CALLOUT theme="secondary">
-                This is iOS only command that will upload your app to TestFlight.
-              </CALLOUT>
-            </div>
-          </div>
-        </GridCell>
-        <GridCell
-          className={mergeClasses(
-            'min-h-[250px] bg-element !bg-cell-quickstart-pattern bg-blend-multiply',
-            'max-md-gutters:min-h-[200px]'
-          )}>
-          <div
-            className={mergeClasses(
-              'absolute inset-0 size-full rounded-lg bg-gradient-to-b from-subtle from-15% to-[#21262d00]',
-              'dark:from-[#181a1b]'
-            )}
-          />
-          <div className="relative z-10 flex flex-col gap-4">
-            <RawH2 className="flex items-center gap-2 !font-bold">
-              <Cloud01Icon /> Deploy your web app
-            </RawH2>
-            <div>
-              <Terminal cmd={['$ npx eas-cli deploy']} />
-              <CALLOUT theme="secondary">
-                For prerequisites and complete instructions, see{' '}
-                <A href="/deploy/web/#export-your-web-project/">Deploy web apps</A>.
-              </CALLOUT>
-            </div>
-          </div>
-        </GridCell>
-        <GridCell
-          className={mergeClasses(
             'relative z-0 min-h-[250px] border-palette-blue6 bg-palette-blue4 !bg-cell-tutorial-pattern bg-blend-multiply',
             'dark:bg-palette-blue3',
             'max-md-gutters:min-h-[200px]'
@@ -112,6 +65,53 @@ export function QuickStart() {
             rightSlot={<ArrowRightIcon className="icon-md" />}>
             Start Tutorial
           </HomeButton>
+        </GridCell>
+        <GridCell
+          className={mergeClasses(
+            'min-h-[250px] bg-palette-purple4 !bg-cell-quickstart-pattern bg-blend-multiply',
+            'max-md-gutters:min-h-[200px]'
+          )}>
+          <div
+            className={mergeClasses(
+              'absolute inset-0 size-full rounded-lg bg-gradient-to-b from-palette-purple3 from-15% to-transparent',
+              'dark:from-palette-purple3'
+            )}
+          />
+          <div className="relative z-10 flex flex-col gap-4">
+            <RawH2 className="flex items-center gap-2 !font-bold !text-palette-purple10">
+              <AppleIcon className="text-palette-purple10" /> Deploy to TestFlight
+            </RawH2>
+            <div>
+              <Terminal cmd={['$ npx testflight']} />
+              <CALLOUT theme="secondary">
+                This is iOS only command that will upload your app to TestFlight.
+              </CALLOUT>
+            </div>
+          </div>
+        </GridCell>
+        <GridCell
+          className={mergeClasses(
+            'min-h-[250px] bg-[#f0f9f0] !bg-cell-quickstart-pattern bg-blend-multiply',
+            'max-md-gutters:min-h-[200px]'
+          )}>
+          <div
+            className={mergeClasses(
+              'absolute inset-0 size-full rounded-lg bg-gradient-to-b from-[#e8f5e8] from-15% to-transparent',
+              'dark:from-[#e8f5e8]'
+            )}
+          />
+          <div className="relative z-10 flex flex-col gap-4">
+            <RawH2 className="flex items-center gap-2 !font-bold !text-[#1e8a5f]">
+              <Cloud01Icon className="text-[#1e8a5f]" /> Deploy your web app
+            </RawH2>
+            <div>
+              <Terminal cmd={['$ npx eas-cli deploy']} />
+              <CALLOUT theme="secondary">
+                For prerequisites and complete instructions, see{' '}
+                <A href="/deploy/web/#export-your-web-project/">Deploy web apps</A>.
+              </CALLOUT>
+            </div>
+          </div>
         </GridCell>
         <GridCell
           className={mergeClasses(
@@ -144,30 +144,30 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'relative z-0 min-h-[172px] border-palette-purple6 bg-palette-purple3',
-            'selection:bg-palette-purple5',
+            'relative z-0 min-h-[172px] border-palette-orange6 bg-palette-orange3',
+            'selection:bg-palette-orange5',
             'max-md-gutters:min-h-[200px]'
           )}>
           <PlanEnterpriseIcon
             className={mergeClasses(
               'absolute -bottom-12 -left-20 size-[350px] rotate-[40deg] opacity-[0.12]',
-              'text-palette-purple7'
+              'text-palette-orange7'
             )}
           />
           <PlanEnterpriseIcon
             className={mergeClasses(
               'absolute bottom-6 right-6 size-[72px] rounded-xl border-[6px] p-2',
-              'border-palette-purple5 bg-palette-purple4 text-palette-purple8'
+              'border-palette-orange5 bg-palette-orange4 text-palette-orange8'
             )}
           />
-          <RawH2 className="relative z-10 max-w-[22ch] !text-lg !text-palette-purple11">
+          <RawH2 className="relative z-10 max-w-[22ch] !text-lg !text-palette-orange11">
             Speed up your development with Expo Application Services
           </RawH2>
           <HomeButton
-            className="border-palette-purple10 bg-palette-purple10 hocus:bg-palette-purple9 dark:text-palette-purple2"
+            className="border-palette-orange10 bg-palette-orange10 hocus:bg-palette-orange9 dark:text-palette-orange2"
             href="/tutorial/eas/introduction/"
             size="sm"
-            rightSlot={<ArrowRightIcon className="icon-md dark:text-palette-purple2" />}>
+            rightSlot={<ArrowRightIcon className="icon-md dark:text-palette-orange2" />}>
             <span className="max-sm-gutters:hidden">Start&nbsp;</span>EAS Tutorial
           </HomeButton>
         </GridCell>

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -1,8 +1,8 @@
 import { RouterLogo, mergeClasses } from '@expo/styleguide';
-import { AppleIcon } from '@expo/styleguide-icons/custom/AppleIcon';
+import { AppleAppStoreIcon } from '@expo/styleguide-icons/custom/AppleAppStoreIcon';
 import { PlanEnterpriseIcon } from '@expo/styleguide-icons/custom/PlanEnterpriseIcon';
+import { Cloud01DuotoneIcon } from '@expo/styleguide-icons/duotone/Cloud01DuotoneIcon';
 import { ArrowRightIcon } from '@expo/styleguide-icons/outline/ArrowRightIcon';
-import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 
 import { GridContainer, GridCell, HomeButton } from '~/ui/components/Home/components';
 import { QuickStartIcon, DevicesImage } from '~/ui/components/Home/resources';
@@ -68,18 +68,19 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'min-h-[250px] bg-palette-purple4 !bg-cell-quickstart-pattern bg-blend-multiply',
+            'min-h-[250px] border-palette-purple6 bg-palette-purple4 !bg-cell-quickstart-pattern bg-blend-multiply',
+            'dark:border-palette-purple7 dark:bg-palette-purple4',
             'max-md-gutters:min-h-[200px]'
           )}>
           <div
             className={mergeClasses(
               'absolute inset-0 size-full rounded-lg bg-gradient-to-b from-palette-purple3 from-15% to-transparent',
-              'dark:from-palette-purple3'
+              'dark:from-palette-purple3 dark:to-transparent'
             )}
           />
           <div className="relative z-10 flex flex-col gap-4">
             <RawH2 className="flex items-center gap-2 !font-bold !text-palette-purple10">
-              <AppleIcon className="text-palette-purple10" /> Deploy to TestFlight
+              <AppleAppStoreIcon className="text-palette-purple10" /> Deploy to TestFlight
             </RawH2>
             <div>
               <Terminal cmd={['$ npx testflight']} />
@@ -91,18 +92,20 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'min-h-[250px] bg-[#f0f9f0] !bg-cell-quickstart-pattern bg-blend-multiply',
+            'min-h-[250px] border-[#c9e9d9] bg-[#f0f9f0] !bg-cell-quickstart-pattern bg-blend-multiply',
+            'dark:border-[#2a5240] dark:bg-[#1d392c] dark:!bg-cell-quickstart-pattern dark:bg-blend-multiply',
             'max-md-gutters:min-h-[200px]'
           )}>
           <div
             className={mergeClasses(
               'absolute inset-0 size-full rounded-lg bg-gradient-to-b from-[#e8f5e8] from-15% to-transparent',
-              'dark:from-[#e8f5e8]'
+              'dark:from-[#1d392c] dark:to-transparent'
             )}
           />
           <div className="relative z-10 flex flex-col gap-4">
-            <RawH2 className="flex items-center gap-2 !font-bold !text-[#1e8a5f]">
-              <Cloud01Icon className="text-[#1e8a5f]" /> Deploy your web app
+            <RawH2 className="flex items-center gap-2 !font-bold !text-[#1e8a5f] dark:!text-[#4eca8c]">
+              <Cloud01DuotoneIcon className="text-[#1e8a5f] dark:text-[#4eca8c]" /> Deploy your web
+              app
             </RawH2>
             <div>
               <Terminal cmd={['$ npx eas-cli deploy']} />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15720

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add sections for `npx testflight` and `npx eas-cli deploy` commands on the docs Home page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview:

## Preview

![CleanShot 2025-05-23 at 03 31 22@2x](https://github.com/user-attachments/assets/e0f3b584-185d-4bab-9e36-08f4e9a1b40a)
![CleanShot 2025-05-23 at 03 31 17@2x](https://github.com/user-attachments/assets/ae004557-430b-40a3-9ce5-ef47a328ca36)



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
