### PR TITLE
[chore] add packageManager field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,6 @@
   },
   "devDependencies": {
     "ts-node": "^10.9.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
# Why

Add a `packageManager` field to `package.json` to specify the version of Yarn to use for this project. This is to support corepack.

# How

Added the `packageManager` field to `package.json`

# Test Plan

- yarn install works locally when corepack is enabled

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)