### PR TITLE
[android][audio] Update player on main thread when focus changes

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Correctly handle recording URL's and local assets in production. ([#36737](https://github.com/expo/expo/pull/36737) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Run player updates on the main thread in the `audioFocusChangeListener`.
 
 ## 0.4.4 — 2025-04-30
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Correctly handle recording URL's and local assets in production. ([#36737](https://github.com/expo/expo/pull/36737) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Run player updates on the main thread in the `audioFocusChangeListener`.
+- [Android] Run player updates on the main thread in the `audioFocusChangeListener`. ([#36957](https://github.com/expo/expo/pull/36957) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.4.4 — 2025-04-30
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -63,7 +63,9 @@ class AudioModule : Module() {
       AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
         focusAcquired = false
         players.values.forEach {
-          it.player.pause()
+          runOnMain {
+            it.player.pause()
+          }
         }
       }
 
@@ -71,7 +73,9 @@ class AudioModule : Module() {
         focusAcquired = false
         if (interruptionMode == InterruptionMode.DUCK_OTHERS) {
           players.values.forEach {
-            it.player.volume /= 2f
+            runOnMain {
+              it.player.volume /= 2f
+            }
           }
         }
       }
@@ -147,7 +151,7 @@ class AudioModule : Module() {
     AsyncFunction("setIsAudioActiveAsync") { enabled: Boolean ->
       audioEnabled = enabled
       if (!enabled) {
-        appContext.mainQueue.launch {
+        runOnMain {
           players.values.forEach {
             if (it.player.isPlaying) {
               it.player.pause()


### PR DESCRIPTION
# Why
Closes #36948

# How
Player updates need to run on the main thread. Updated the calls in the `audioFocusChangeListener` 

# Test Plan
Bare-expo

