### PR TITLE
typo: change to import instead of export while importing `Stack`

### DIFF
--- a/docs/pages/router/advanced/protected.mdx
+++ b/docs/pages/router/advanced/protected.mdx
@@ -22,7 +22,7 @@ Protected screens allow you to prevent users from accessing certain routes using
 />
 
 ```tsx app/_layout.tsx
-export { Stack } from 'expo-router';
+import { Stack } from 'expo-router';
 
 const isLoggedIn = false;
 
@@ -55,7 +55,7 @@ In Expo Router, a screen can **only exist in one active route group at a time**.
 You should only declare a screen only once, in the most appropriate group or stack. If a screen's availability depends on logic, wrap it in a conditional group instead of duplicating the screen.
 
 ```tsx app/_layout.tsx
-export { Stack } from 'expo-router';
+import { Stack } from 'expo-router';
 
 const isLoggedIn = true;
 const isAdmin = true;
@@ -77,7 +77,7 @@ export function AppLayout() {
 Protected screens can be nested to define hierarchical access control logic.
 
 ```tsx app/_layout.tsx
-export { Stack } from 'expo-router';
+import { Stack } from 'expo-router';
 
 const isLoggedIn = true;
 const isAdmin = true;
@@ -119,7 +119,7 @@ You can configure the navigator to fall back to a specific screen if access is d
 />
 
 ```tsx app/_layout.tsx
-export { Stack } from 'expo-router';
+import { Stack } from 'expo-router';
 
 const isLoggedIn = false;
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
