### PR TITLE
[expo-go] Add background color on splashscreen icon

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/legacy/SplashScreenView.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/legacy/SplashScreenView.kt
@@ -106,6 +106,7 @@ fun SplashScreenImage(
     modifier = Modifier
       .width(width)
       .height(height)
+      .background(Color.White)
       .shadow(4.dp, RoundedCornerShape(30.dp))
   )
 }


### PR DESCRIPTION
# Why
Closes #36944
Some icons may be smaller causing more of the shadow to be visible than we want.

# How
Add a white background to the icon so that it is always the full size.

# Test Plan
Expo go
