### PR TITLE
[docs] Adds pre-packaged job doc

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -395,10 +395,11 @@ export const eas = [
   makeSection('EAS Workflows', [
     makePage('eas/workflows/get-started.mdx'),
     makePage('eas/workflows/examples.mdx'),
+    makePage('eas/workflows/pre-packaged-jobs.mdx'),
     makePage('eas/workflows/syntax.mdx'),
     makePage('eas/workflows/automating-eas-cli.mdx'),
     makePage('eas/workflows/limitations.mdx'),
-    makeGroup('Reference', [makePage('eas/workflows/reference/e2e-tests.mdx')]),
+    makeGroup('More', [makePage('eas/workflows/reference/e2e-tests.mdx')]),
   ]),
   makeSection('EAS Build', [
     makePage('build/introduction.mdx'),

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -399,7 +399,7 @@ export const eas = [
     makePage('eas/workflows/syntax.mdx'),
     makePage('eas/workflows/automating-eas-cli.mdx'),
     makePage('eas/workflows/limitations.mdx'),
-    makeGroup('More', [makePage('eas/workflows/reference/e2e-tests.mdx')]),
+    makeGroup('Reference', [makePage('eas/workflows/reference/e2e-tests.mdx')]),
   ]),
   makeSection('EAS Build', [
     makePage('build/introduction.mdx'),

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -34,7 +34,7 @@ You can pass the following parameters into the `params` list:
 
 | Parameter | Type   | Description                                                            |
 | --------- | ------ | ---------------------------------------------------------------------- |
-| platform  | string | Required. The platform to build for. Can be either `android` or `ios`. |
+| platform  | string | **Required.** The platform to build for. Can be either `android` or `ios`. |
 | profile   | string | Optional. The build profile to use. Defaults to `production`.          |
 
 #### Outputs

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -139,7 +139,7 @@ jobs:
 
 <Collapsible summary="Build with different profiles">
 
-This workflow creates two different Android builds using different profiles - one for internal distribution and one for store submission.
+This workflow creates two different Android builds using different profiles - one for internal distribution and one for store submission using the development and production profiles.
 
 ```yaml .eas/workflows/build-profiles.yml
 name: Build with different profiles
@@ -149,19 +149,19 @@ on:
     branches: ['main']
 
 jobs:
-  build_android_internal:
-    name: Build Android Internal
+  build_android_development:
+    name: Build Android Development
     type: build
     params:
       platform: android
-      profile: internal
+      profile: development
 
-  build_android_store:
-    name: Build Android Store
+  build_android_production:
+    name: Build Android Production
     type: build
     params:
       platform: android
-      profile: store
+      profile: production
 ```
 
 </Collapsible>
@@ -211,6 +211,27 @@ jobs:
     type: deploy
     params:
       prod: true
+```
+
+</Collapsible>
+
+<Collapsible summary="Deploy to production only on merges to the `main` branch">
+
+This workflow deploys your application to production when you merge to the main branch, and makes a non-production deployment on all other branches.
+
+```yaml .eas/workflows/deploy.yml
+name: Deploy
+
+on:
+  push:
+    branches: ['*']
+
+jobs:
+  deploy:
+    name: Deploy
+    type: deploy
+    params:
+      prod: ${{ github.ref_name == 'main' }}
 ```
 
 </Collapsible>
@@ -487,9 +508,17 @@ This workflow submits an iOS build to the App Store using the production submit 
 name: Submit iOS Build
 
 jobs:
+  build_ios:
+    name: Build iOS
+    type: build
+    params:
+      platform: ios
+      profile: production
+
   submit:
     name: Submit to App Store
     type: submit
+    needs: [build_ios]
     params:
       build_id: ${{ needs.build_ios.outputs.build_id }}
       profile: production
@@ -505,9 +534,17 @@ This workflow submits an Android build to the Play Store using the production su
 name: Submit Android Build
 
 jobs:
+  build_android:
+    name: Build Android
+    type: build
+    params:
+      platform: android
+      profile: production
+
   submit:
     name: Submit to Play Store
     type: submit
+    needs: [build_android]
     params:
       build_id: ${{ needs.build_android.outputs.build_id }}
       profile: production
@@ -657,12 +694,12 @@ jobs:
 
 You can pass the following parameters into the `params` list:
 
-| Parameter | Type   | Description                                                            |
-| --------- | ------ | ---------------------------------------------------------------------- |
-| build_id  | string | Required. The ID of the build to test.                                 |
-| flow_path | string | Required. The path to the Maestro flow file(s) to run.                 |
-| shards    | number | Optional. The number of shards to split the tests into. Defaults to 1. |
-| retries   | number | Optional. The number of times to retry failed tests. Defaults to 1.    |
+| Parameter | Type   | Description                                                                             |
+| --------- | ------ | --------------------------------------------------------------------------------------- |
+| build_id  | string | Required. The ID of the build to test.                                                  |
+| flow_path | string | Required. The path to the Maestro flow file(s) to run.                                  |
+| shards    | number | Optional and experimental. The number of shards to split the tests into. Defaults to 1. |
+| retries   | number | Optional. The number of times to retry failed tests. Defaults to 1.                     |
 
 ### Examples
 
@@ -689,7 +726,7 @@ jobs:
 
 <Collapsible summary="Maestro test with sharding">
 
-This workflow runs Maestro tests on an Android emulator build with 4 shards and 2 retries for failed tests.
+This workflow runs Maestro tests on an Android emulator build with 3 shards and 2 retries for failed tests.
 
 ```yaml .eas/workflows/maestro-sharded.yml
 name: Sharded Maestro Test
@@ -699,10 +736,11 @@ jobs:
     name: Run Sharded Maestro Tests
     type: maestro
     environment: preview
+    runs_on: linux-large-nested-virtualization
     params:
       build_id: ${{ needs.build_android_emulator.outputs.build_id }}
       flow_path: ./maestro/flows
-      shards: 4
+      shards: 3
       retries: 2
 ```
 
@@ -755,7 +793,7 @@ jobs:
 
   notify_build:
     name: Notify Build Status
-    needs: build_ios
+    needs: [build_ios]
     type: slack
     params:
       webhook_url: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
@@ -781,7 +819,7 @@ jobs:
 
   notify_build:
     name: Notify Build Status
-    needs: build_android
+    needs: [build_android]
     type: slack
     params:
       webhook_url: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -237,7 +237,7 @@ jobs:
 
 Calculates a fingerprint of your project.
 
-> **Note** This job type only supports [CNG (managed)](/workflow/continuous-native-generation/) workflows. If you commit your **android** or **ios** directories, the fingerprint job won't work.
+> **Note:** This job type only supports [CNG (managed)](/workflow/continuous-native-generation/) workflows. If you commit your **android** or **ios** directories, the fingerprint job won't work.
 
 ### Syntax
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -670,7 +670,7 @@ Here are some practical examples of using the Maestro job:
 
 <Collapsible summary="Basic Maestro test">
 
-This workflow runs Maestro tests on an iOS simulator build using the default settings.
+This workflow runs Maestro tests on an iOS Simulator build using the default settings.
 
 ```yaml .eas/workflows/maestro-basic.yml
 name: Basic Maestro Test

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1,0 +1,968 @@
+---
+title: Pre-packaged jobs
+description: Learn how to set up and use pre-packaged jobs.
+---
+
+import { Collapsible } from '~/ui/components/Collapsible';
+
+Pre-packaged jobs are ready-to-use workflow jobs that help you automate common tasks like building, submitting, and testing your app. They provide a standardized way to handle these operations without having to write custom job configurations from scratch. This guide covers the available pre-packaged jobs and how to use them in your workflows.
+
+## Build
+
+Build your project into an Android or iOS app.
+
+### Syntax
+
+```yaml
+jobs:
+  build_app:
+    type: build
+    params:
+      platform: android | ios
+      profile: string
+```
+
+#### Parameters
+
+You can pass the following parameters into the `params` list:
+
+| Parameter | Type   | Description                                                            |
+| --------- | ------ | ---------------------------------------------------------------------- |
+| platform  | string | Required. The platform to build for. Can be either `android` or `ios`. |
+| profile   | string | Optional. The build profile to use. Defaults to `production`.          |
+
+#### Outputs
+
+You can reference the following outputs in subsequent jobs:
+
+| Output            | Type   | Description                                                 |
+| ----------------- | ------ | ----------------------------------------------------------- |
+| build_id          | string | The ID of the created build.                                |
+| app_build_version | string | The build version of the app.                               |
+| app_identifier    | string | The bundle identifier/package name of the app.              |
+| app_version       | string | The version of the app.                                     |
+| channel           | string | The update channel used for the build.                      |
+| distribution      | string | The distribution method used. Can be `internal` or `store`. |
+| fingerprint_hash  | string | The fingerprint hash of the build.                          |
+| git_commit_hash   | string | The git commit hash used for the build.                     |
+| platform          | string | The platform the build was created for.                     |
+| profile           | string | The build profile used.                                     |
+| runtime_version   | string | The runtime version used.                                   |
+| sdk_version       | string | The SDK version used.                                       |
+| simulator         | string | Whether the build is for simulator.                         |
+
+### Examples
+
+Here are some practical examples of using the build job:
+
+<Collapsible summary="Basic build for a specific platform">
+
+This workflow builds your iOS app whenever you push to the main branch.
+
+```yaml .eas/workflows/build-ios.yml
+name: Build iOS app
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  build_ios:
+    name: Build iOS
+    type: build
+    params:
+      platform: ios
+      profile: production
+```
+
+</Collapsible>
+
+<Collapsible summary="Build for both platforms in parallel">
+
+This workflow builds both Android and iOS apps in parallel when you push to the main branch.
+
+```yaml .eas/workflows/build-all.yml
+name: Build for all platforms
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  build_android:
+    name: Build Android
+    type: build
+    params:
+      platform: android
+      profile: production
+
+  build_ios:
+    name: Build iOS
+    type: build
+    params:
+      platform: ios
+      profile: production
+```
+
+</Collapsible>
+
+<Collapsible summary="Build with environment variables">
+
+This workflow builds your Android app with custom environment variables that can be used during the build process.
+
+```yaml .eas/workflows/build-with-env.yml
+name: Build with environment variables
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  build_android:
+    name: Build Android
+    type: build
+    env:
+      APP_ENV: production
+      API_URL: https://api.example.com
+    params:
+      platform: android
+      profile: production
+```
+
+</Collapsible>
+
+<Collapsible summary="Build with different profiles">
+
+This workflow creates two different Android builds using different profiles - one for internal distribution and one for store submission.
+
+```yaml .eas/workflows/build-profiles.yml
+name: Build with different profiles
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  build_android_internal:
+    name: Build Android Internal
+    type: build
+    params:
+      platform: android
+      profile: internal
+
+  build_android_store:
+    name: Build Android Store
+    type: build
+    params:
+      platform: android
+      profile: store
+```
+
+</Collapsible>
+
+## Deploy
+
+Deploy your application using EAS Hosting.
+
+### Syntax
+
+```yaml
+jobs:
+  deploy_web:
+    type: deploy
+    params:
+      alias: string
+      prod: boolean
+```
+
+#### Parameters
+
+You can pass the following parameters into the `params` list:
+
+| Parameter | Type    | Description                                |
+| --------- | ------- | ------------------------------------------ |
+| alias     | string  | Optional. The alias to deploy to.          |
+| prod      | boolean | Optional. Whether to deploy to production. |
+
+### Examples
+
+Here are some practical examples of using the deploy job:
+
+<Collapsible summary="Basic deployment to production">
+
+This workflow deploys your application to production using EAS Hosting.
+
+```yaml .eas/workflows/deploy-basic.yml
+name: Basic Deployment
+
+jobs:
+  deploy:
+    name: Deploy to Production
+    type: deploy
+    params:
+      prod: true
+```
+
+</Collapsible>
+
+<Collapsible summary="Deployment with custom alias">
+
+This workflow deploys your application to a custom alias in production.
+
+```yaml .eas/workflows/deploy-alias.yml
+name: Deployment with Alias
+
+jobs:
+  deploy:
+    name: Deploy with Alias
+    type: deploy
+    params:
+      alias: my-custom-alias
+      prod: true
+```
+
+</Collapsible>
+
+<Collapsible summary="Deployment to preview environment">
+
+This workflow deploys your application to a preview environment using a custom alias.
+
+```yaml .eas/workflows/deploy-preview.yml
+name: Preview Deployment
+
+jobs:
+  deploy:
+    name: Deploy to Preview
+    type: deploy
+    params:
+      alias: preview
+      prod: false
+```
+
+</Collapsible>
+
+<Collapsible summary="Multi-alias deployment">
+
+This workflow deploys your application to both staging and production environments using different aliases.
+
+```yaml .eas/workflows/deploy-multi-alias.yml
+name: Multi-alias Deployment
+
+jobs:
+  deploy_staging:
+    name: Deploy to Staging
+    type: deploy
+    params:
+      alias: staging
+      prod: false
+
+  deploy_production:
+    name: Deploy to Production
+    type: deploy
+    params:
+      alias: production
+      prod: true
+```
+
+</Collapsible>
+
+## Fingerprint
+
+Calculate fingerprint of Android and iOS builds.
+
+> **warning** This job type only supports [CNG (managed)](/workflow/continuous-native-generation/) workflows. If you commit your **android** or **ios** directories, the fingerprint job won't work.
+
+### Syntax
+
+```yaml
+jobs:
+  calculate_fingerprint:
+    type: fingerprint
+    params:
+      environment: production
+      env:
+        APP_VARIANT: staging
+```
+
+#### Parameters
+
+You can pass the following parameters into the `params` list:
+
+| Parameter   | Type   | Description                                                                                                   |
+| ----------- | ------ | ------------------------------------------------------------------------------------------------------------- |
+| environment | string | Optional. The environment to use. Can be `production`, `preview`, or `development`. Defaults to `production`. |
+| env         | object | Optional. Environment variables to use during fingerprint calculation.                                        |
+
+#### Outputs
+
+You can reference the following outputs in subsequent jobs:
+
+| Output                   | Type   | Description                       |
+| ------------------------ | ------ | --------------------------------- |
+| android_fingerprint_hash | string | The fingerprint hash for Android. |
+| ios_fingerprint_hash     | string | The fingerprint hash for iOS.     |
+
+### Examples
+
+Here are some practical examples of using the fingerprint job:
+
+<Collapsible summary="Basic fingerprint calculation">
+
+This workflow calculates fingerprints for both Android and iOS builds in the production environment.
+
+```yaml .eas/workflows/fingerprint-basic.yml
+name: Basic Fingerprint
+
+jobs:
+  fingerprint:
+    name: Calculate Fingerprints
+    type: fingerprint
+    params:
+      environment: production
+```
+
+</Collapsible>
+
+<Collapsible summary="Fingerprint with environment variables">
+
+This workflow calculates fingerprints with custom environment variables that can affect the build configuration.
+
+```yaml .eas/workflows/fingerprint-with-env.yml
+name: Fingerprint with Environment Variables
+
+jobs:
+  fingerprint:
+    name: Calculate Fingerprints
+    type: fingerprint
+    params:
+      environment: production
+      env:
+        APP_VARIANT: staging
+        API_URL: https://api.staging.example.com
+```
+
+</Collapsible>
+
+## Get Build
+
+Retrieve an existing build from EAS that matches the provided parameters.
+
+### Syntax
+
+```yaml
+jobs:
+  get_build:
+    type: get-build
+    params:
+      platform: ios
+      profile: production
+      distribution: store
+      channel: production
+      app_identifier: com.example.app
+      app_build_version: 1
+      app_version: 1.0.0
+      git_commit_hash: abc123
+      fingerprint_hash: def456
+      sdk_version: 49.0.0
+      runtime_version: 1.0.0
+      simulator: false
+```
+
+#### Parameters
+
+You can pass the following parameters into the `params` list:
+
+| Parameter         | Type    | Description                                                                    |
+| ----------------- | ------- | ------------------------------------------------------------------------------ |
+| platform          | string  | Optional. The platform to get the build for. Can be `ios` or `android`.        |
+| profile           | string  | Optional. The build profile to use.                                            |
+| distribution      | string  | Optional. The distribution method. Can be `store`, `internal`, or `simulator`. |
+| channel           | string  | Optional. The update channel.                                                  |
+| app_identifier    | string  | Optional. The bundle identifier/package name.                                  |
+| app_build_version | string  | Optional. The build version.                                                   |
+| app_version       | string  | Optional. The app version.                                                     |
+| git_commit_hash   | string  | Optional. The git commit hash.                                                 |
+| fingerprint_hash  | string  | Optional. The fingerprint hash.                                                |
+| sdk_version       | string  | Optional. The SDK version.                                                     |
+| runtime_version   | string  | Optional. The runtime version.                                                 |
+| simulator         | boolean | Optional. Whether to get a simulator build.                                    |
+
+#### Outputs
+
+You can reference the following outputs in subsequent jobs:
+
+| Output            | Type   | Description                                    |
+| ----------------- | ------ | ---------------------------------------------- |
+| build_id          | string | The ID of the retrieved build.                 |
+| app_build_version | string | The build version of the app.                  |
+| app_identifier    | string | The bundle identifier/package name of the app. |
+| app_version       | string | The version of the app.                        |
+| channel           | string | The update channel used for the build.         |
+| distribution      | string | The distribution method used.                  |
+| fingerprint_hash  | string | The fingerprint hash of the build.             |
+| git_commit_hash   | string | The git commit hash used for the build.        |
+| platform          | string | The platform the build was created for.        |
+| profile           | string | The build profile used.                        |
+| runtime_version   | string | The runtime version used.                      |
+| sdk_version       | string | The SDK version used.                          |
+| simulator         | string | Whether the build is for simulator.            |
+
+### Examples
+
+Here are some practical examples of using the get-build job:
+
+<Collapsible summary="Get latest production build">
+
+This workflow retrieves the latest production build for iOS from the store distribution channel.
+
+```yaml .eas/workflows/get-build-production.yml
+name: Get Production Build
+
+jobs:
+  get_build:
+    name: Get Latest Production Build
+    type: get-build
+    params:
+      platform: ios
+      profile: production
+      distribution: store
+      channel: production
+```
+
+</Collapsible>
+
+<Collapsible summary="Get build by version">
+
+This workflow retrieves a specific version of an Android build by its app version and build version.
+
+```yaml .eas/workflows/get-build-version.yml
+name: Get Build by Version
+
+jobs:
+  get_build:
+    name: Get Specific Version Build
+    type: get-build
+    params:
+      platform: android
+      app_identifier: com.example.app
+      app_version: 1.0.0
+      app_build_version: 42
+```
+
+</Collapsible>
+
+<Collapsible summary="Get simulator build">
+
+This workflow retrieves a simulator build for iOS development.
+
+```yaml .eas/workflows/get-build-simulator.yml
+name: Get Simulator Build
+
+jobs:
+  get_build:
+    name: Get Simulator Build
+    type: get-build
+    params:
+      platform: ios
+      simulator: true
+      profile: development
+```
+
+</Collapsible>
+
+## Submit
+
+Submit an Android or iOS build to the app store using EAS Submit.
+
+> Submission jobs require additional configuration to run within a CI/CD process. See our [Apple App Store CI/CD submission guide](/submit/ios/#submitting-your-app-using-cicd-services) and [Google Play Store CI/CD submission guide](/submit/android/#submitting-your-app-using-cicd-services) for more information.
+
+### Syntax
+
+```yaml
+jobs:
+  submit_to_store:
+    type: submit
+    params:
+      build_id: string
+      profile: production
+```
+
+#### Parameters
+
+You can pass the following parameters into the `params` list:
+
+| Parameter | Type   | Description                                                    |
+| --------- | ------ | -------------------------------------------------------------- |
+| build_id  | string | Required. The ID of the build to submit.                       |
+| profile   | string | Optional. The submit profile to use. Defaults to `production`. |
+
+#### Outputs
+
+You can reference the following outputs in subsequent jobs:
+
+| Output                | Type   | Description                                       |
+| --------------------- | ------ | ------------------------------------------------- |
+| apple_app_id          | string | The Apple App ID of the submitted build.          |
+| ios_bundle_identifier | string | The iOS bundle identifier of the submitted build. |
+| android_package_id    | string | The Android package ID of the submitted build.    |
+
+### Examples
+
+Here are some practical examples of using the submit job:
+
+<Collapsible summary="Submit iOS build">
+
+This workflow submits an iOS build to the App Store using the production submit profile.
+
+```yaml .eas/workflows/submit-ios.yml
+name: Submit iOS Build
+
+jobs:
+  submit:
+    name: Submit to App Store
+    type: submit
+    params:
+      build_id: ${{ needs.build_ios.outputs.build_id }}
+      profile: production
+```
+
+</Collapsible>
+
+<Collapsible summary="Submit Android build">
+
+This workflow submits an Android build to the Play Store using the production submit profile.
+
+```yaml .eas/workflows/submit-android.yml
+name: Submit Android Build
+
+jobs:
+  submit:
+    name: Submit to Play Store
+    type: submit
+    params:
+      build_id: ${{ needs.build_android.outputs.build_id }}
+      profile: production
+```
+
+</Collapsible>
+
+## Update
+
+Publish an update using EAS Update.
+
+### Syntax
+
+```yaml
+jobs:
+  publish_update:
+    type: update
+    params:
+      message: string
+      platform: all
+      branch: production
+      channel: production
+```
+
+#### Parameters
+
+You can pass the following parameters into the `params` list:
+
+| Parameter | Type   | Description                                                                                                                                                                                                                                          |
+| --------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| message   | string | Optional. Message to use for the update. If not provided, the commit message will be used.                                                                                                                                                           |
+| platform  | string | Optional. Platform to use for the update ("android", "ios" or "all").                                                                                                                                                                                |
+| branch    | string | Optional. Branch to use for the update. If not provided, the branch from the workflow run will be used. For manually run workflows you need to provide a value. Example: `${{ github.ref_name }}`. Provide _either_ a branch or a channel, not both. |
+| channel   | string | Optional. Channel to use for the update. Provide _either_ a branch or a channel, not both.                                                                                                                                                           |
+
+#### Outputs
+
+You can reference the following outputs in subsequent jobs:
+
+| Output                | Type   | Description                                                   |
+| --------------------- | ------ | ------------------------------------------------------------- |
+| first_update_group_id | string | The ID of the first update group.                             |
+| updates_json          | string | A JSON string containing information about all update groups. |
+
+### Examples
+
+Here are some practical examples of using the update job:
+
+<Collapsible summary="Basic update to production channel">
+
+This workflow publishes an update to the production channel whenever you push to the main branch, using the commit message as the update message.
+
+```yaml .eas/workflows/update-production.yml
+name: Update Production
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  update_production:
+    name: Update Production Channel
+    type: update
+    params:
+      channel: production
+      message: 'Production update: ${{ github.event.head_commit.message }}'
+```
+
+</Collapsible>
+
+<Collapsible summary="Platform-specific updates">
+
+This workflow publishes separate updates for Android and iOS platforms, allowing for platform-specific changes.
+
+```yaml .eas/workflows/update-platforms.yml
+name: Platform-specific Updates
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  update_android:
+    name: Update Android
+    type: update
+    params:
+      platform: android
+      channel: production
+      message: 'Android update: ${{ github.event.head_commit.message }}'
+
+  update_ios:
+    name: Update iOS
+    type: update
+    params:
+      platform: ios
+      channel: production
+      message: 'iOS update: ${{ github.event.head_commit.message }}'
+```
+
+</Collapsible>
+
+<Collapsible summary="Update with branch-based deployment">
+
+This workflow publishes updates based on the branch name, allowing for different environments (staging/production) based on the branch.
+
+```yaml .eas/workflows/update-branches.yml
+name: Branch-based Updates
+
+on:
+  push:
+    branches: ['main', 'staging']
+
+jobs:
+  update_branch:
+    name: Update Branch
+    type: update
+    params:
+      branch: ${{ github.ref_name }}
+      message: 'Update for branch: ${{ github.ref_name }}'
+```
+
+</Collapsible>
+
+<Collapsible summary="Update with custom message and platform targeting">
+
+This workflow allows manual triggering of updates with custom platform selection and message, useful for controlled deployments.
+
+```yaml .eas/workflows/update-custom.yml
+name: Custom Update
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Platform to update'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - android
+          - ios
+      message:
+        description: 'Update message'
+        required: true
+        type: string
+
+jobs:
+  update_custom:
+    name: Custom Update
+    type: update
+    params:
+      platform: ${{ github.event.inputs.platform }}
+      channel: production
+      message: ${{ github.event.inputs.message }}
+```
+
+</Collapsible>
+
+## Maestro
+
+Run Maestro tests on a build.
+
+> **important** Maestro tests are experimental and may experience flakiness.
+
+### Syntax
+
+```yaml
+jobs:
+  run_maestro_tests:
+    type: maestro
+    environment: preview
+    image: latest
+    params:
+      build_id: string
+      flow_path: string
+      shards: 1
+      retries: 1
+```
+
+#### Parameters
+
+You can pass the following parameters into the `params` list:
+
+| Parameter | Type   | Description                                                            |
+| --------- | ------ | ---------------------------------------------------------------------- |
+| build_id  | string | Required. The ID of the build to test.                                 |
+| flow_path | string | Required. The path to the Maestro flow file(s) to run.                 |
+| shards    | number | Optional. The number of shards to split the tests into. Defaults to 1. |
+| retries   | number | Optional. The number of times to retry failed tests. Defaults to 1.    |
+
+### Examples
+
+Here are some practical examples of using the Maestro job:
+
+<Collapsible summary="Basic Maestro test">
+
+This workflow runs Maestro tests on an iOS build using the default settings.
+
+```yaml .eas/workflows/maestro-basic.yml
+name: Basic Maestro Test
+
+jobs:
+  test:
+    name: Run Maestro Tests
+    type: maestro
+    environment: preview
+    image: latest
+    params:
+      build_id: ${{ needs.build_ios.outputs.build_id }}
+      flow_path: ./maestro/flows
+```
+
+</Collapsible>
+
+<Collapsible summary="Maestro test with sharding">
+
+This workflow runs Maestro tests on an Android build with 4 shards and 2 retries for failed tests.
+
+```yaml .eas/workflows/maestro-sharded.yml
+name: Sharded Maestro Test
+
+jobs:
+  test:
+    name: Run Sharded Maestro Tests
+    type: maestro
+    environment: preview
+    image: latest
+    params:
+      build_id: ${{ needs.build_android.outputs.build_id }}
+      flow_path: ./maestro/flows
+      shards: 4
+      retries: 2
+```
+
+</Collapsible>
+
+## Slack
+
+Send a message to a Slack channel using a webhook URL.
+
+### Syntax
+
+```yaml
+jobs:
+  send_slack_notification:
+    type: slack
+    params:
+      webhook_url: string
+      message: string
+      payload: object
+```
+
+#### Parameters
+
+You can pass the following parameters into the `params` list:
+
+| Parameter   | Type   | Description                                                               |
+| ----------- | ------ | ------------------------------------------------------------------------- |
+| webhook_url | string | Required. The Slack webhook URL to send the message to.                   |
+| message     | string | Required if payload is not provided. The message to send.                 |
+| payload     | object | Required if message is not provided. The Slack Block Kit payload to send. |
+
+### Examples
+
+Here are some practical examples of using the Slack job:
+
+<Collapsible summary="Simple build notification">
+
+This workflow builds an iOS app and then sends a notification with the app identifier and version from the build job outputs.
+
+```yaml .eas/workflows/slack-build-notification.yml
+name: Build Notification
+
+jobs:
+  build_ios:
+    name: Build iOS
+    type: build
+    params:
+      platform: ios
+      profile: production
+
+  notify_build:
+    name: Notify Build Status
+    needs: build_ios
+    type: slack
+    params:
+      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+      message: 'Build completed for app ${{ needs.build_ios.outputs.app_identifier }} (version ${{ needs.build_ios.outputs.app_version }})'
+```
+
+</Collapsible>
+
+<Collapsible summary="Rich build notification with Block Kit">
+
+This workflow builds an Android app and sends a rich notification using the build job outputs.
+
+```yaml .eas/workflows/slack-rich-notification.yml
+name: Rich Build Notification
+
+jobs:
+  build_android:
+    name: Build Android
+    type: build
+    params:
+      platform: android
+      profile: production
+
+  notify_build:
+    name: Notify Build Status
+    needs: build_android
+    type: slack
+    params:
+      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+      payload:
+        blocks:
+          - type: header
+            text:
+              type: plain_text
+              text: 'Build Completed'
+          - type: section
+            fields:
+              - type: mrkdwn
+                text: "*App:*\n${{ needs.build_android.outputs.app_identifier }}"
+              - type: mrkdwn
+                text: "*Version:*\n${{ needs.build_android.outputs.app_version }}"
+          - type: section
+            fields:
+              - type: mrkdwn
+                text: "*Build ID:*\n${{ needs.build_android.outputs.build_id }}"
+              - type: mrkdwn
+                text: "*Platform:*\n${{ needs.build_android.outputs.platform }}"
+          - type: section
+            text:
+              type: mrkdwn
+              text: 'Distribution: ${{ needs.build_android.outputs.distribution }}'
+```
+
+</Collapsible>
+
+<Collapsible summary="Test results summary">
+
+This workflow builds an iOS app and sends a test results summary using the build job outputs.
+
+```yaml .eas/workflows/slack-test-results.yml
+name: Test Results Notification
+
+jobs:
+  build_ios:
+    name: Build iOS
+    type: build
+    params:
+      platform: ios
+      profile: production
+
+  notify_tests:
+    name: Notify Test Results
+    needs: build_ios
+    type: slack
+    params:
+      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+      payload:
+        blocks:
+          - type: header
+            text:
+              type: plain_text
+              text: 'Test Results'
+          - type: section
+            fields:
+              - type: mrkdwn
+                text: "*App:*\n${{ needs.build_ios.outputs.app_identifier }}"
+              - type: mrkdwn
+                text: "*Build ID:*\n${{ needs.build_ios.outputs.build_id }}"
+          - type: section
+            text:
+              type: mrkdwn
+              text: 'Platform: ${{ needs.build_ios.outputs.platform }}'
+```
+
+</Collapsible>
+
+<Collapsible summary="Deployment notification with environment">
+
+This workflow builds an Android app and sends a detailed deployment notification using the build job outputs.
+
+```yaml .eas/workflows/slack-deployment.yml
+name: Deployment Notification
+
+jobs:
+  build_android:
+    name: Build Android
+    type: build
+    params:
+      platform: android
+      profile: production
+
+  notify_deployment:
+    name: Notify Deployment
+    needs: build_android
+    type: slack
+    params:
+      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+      payload:
+        blocks:
+          - type: header
+            text:
+              type: plain_text
+              text: '🚀 Deployment Complete'
+          - type: section
+            fields:
+              - type: mrkdwn
+                text: "*App:*\n${{ needs.build_android.outputs.app_identifier }}"
+              - type: mrkdwn
+                text: "*Version:*\n${{ needs.build_android.outputs.app_version }}"
+          - type: section
+            fields:
+              - type: mrkdwn
+                text: "*Build ID:*\n${{ needs.build_android.outputs.build_id }}"
+              - type: mrkdwn
+                text: "*Platform:*\n${{ needs.build_android.outputs.platform }}"
+          - type: section
+            text:
+              type: mrkdwn
+              text: 'Distribution: ${{ needs.build_android.outputs.distribution }}'
+```
+
+</Collapsible>

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -634,7 +634,7 @@ jobs:
 
 ## Maestro
 
-Run Maestro tests on a Android emulator or iOS simulator build.
+Run Maestro tests on a Android emulator or iOS Simulator build.
 
 > **important** Maestro tests are experimental and may experience flakiness.
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -11,6 +11,12 @@ Pre-packaged jobs are ready-to-use workflow jobs that help you automate common t
 
 Build your project into an Android or iOS app.
 
+Build jobs can be customized so that you can execute custom commands during the build process. See [Custom builds](/custom-builds/get-started/) for more information.
+
+### Prerequisites
+
+To successfully use the build job, you'll need to complete a build with EAS CLI using the same platform and profile as the pre-packaged job. Learn how to [create your first build](/build/setup/) to get started.
+
 ### Syntax
 
 ```yaml
@@ -18,8 +24,8 @@ jobs:
   build_app:
     type: build
     params:
-      platform: android | ios
-      profile: string
+      platform: android | ios # required
+      profile: string # optional, default: production
 ```
 
 #### Parameters
@@ -35,21 +41,21 @@ You can pass the following parameters into the `params` list:
 
 You can reference the following outputs in subsequent jobs:
 
-| Output            | Type   | Description                                                 |
-| ----------------- | ------ | ----------------------------------------------------------- |
-| build_id          | string | The ID of the created build.                                |
-| app_build_version | string | The build version of the app.                               |
-| app_identifier    | string | The bundle identifier/package name of the app.              |
-| app_version       | string | The version of the app.                                     |
-| channel           | string | The update channel used for the build.                      |
-| distribution      | string | The distribution method used. Can be `internal` or `store`. |
-| fingerprint_hash  | string | The fingerprint hash of the build.                          |
-| git_commit_hash   | string | The git commit hash used for the build.                     |
-| platform          | string | The platform the build was created for.                     |
-| profile           | string | The build profile used.                                     |
-| runtime_version   | string | The runtime version used.                                   |
-| sdk_version       | string | The SDK version used.                                       |
-| simulator         | string | Whether the build is for simulator.                         |
+| Output            | Type   | Description                                                        |
+| ----------------- | ------ | ------------------------------------------------------------------ |
+| build_id          | string | The ID of the created build.                                       |
+| app_build_version | string | The version code/build number of the app.                          |
+| app_identifier    | string | The bundle identifier/package name of the app.                     |
+| app_version       | string | The version of the app.                                            |
+| channel           | string | The update channel used for the build.                             |
+| distribution      | string | The distribution method used. Can be `internal` or `store`.        |
+| fingerprint_hash  | string | The fingerprint hash of the build.                                 |
+| git_commit_hash   | string | The git commit hash used for the build.                            |
+| platform          | string | The platform the build was created for. Either `android` or `ios`. |
+| profile           | string | The build profile used.                                            |
+| runtime_version   | string | The runtime version used.                                          |
+| sdk_version       | string | The SDK version used.                                              |
+| simulator         | string | Whether the build is for simulator.                                |
 
 ### Examples
 
@@ -162,7 +168,11 @@ jobs:
 
 ## Deploy
 
-Deploy your application using EAS Hosting.
+Deploy your application using [EAS Hosting](/eas/hosting/introduction).
+
+### Prerequisites
+
+To deploy your application using EAS Hosting, you'll need to set up your project. See [Get Started with EAS Hosting](/eas/hosting/get-started/#prerequisites) for more information.
 
 ### Syntax
 
@@ -171,18 +181,18 @@ jobs:
   deploy_web:
     type: deploy
     params:
-      alias: string
-      prod: boolean
+      alias: string # optional
+      prod: boolean # optional
 ```
 
 #### Parameters
 
 You can pass the following parameters into the `params` list:
 
-| Parameter | Type    | Description                                |
-| --------- | ------- | ------------------------------------------ |
-| alias     | string  | Optional. The alias to deploy to.          |
-| prod      | boolean | Optional. Whether to deploy to production. |
+| Parameter | Type    | Description                                                                        |
+| --------- | ------- | ---------------------------------------------------------------------------------- |
+| alias     | string  | Optional. The [alias](/eas/hosting/deployments-and-aliases/#aliases) to deploy to. |
+| prod      | boolean | Optional. Whether to deploy to production.                                         |
 
 ### Examples
 
@@ -223,65 +233,22 @@ jobs:
 
 </Collapsible>
 
-<Collapsible summary="Deployment to preview environment">
-
-This workflow deploys your application to a preview environment using a custom alias.
-
-```yaml .eas/workflows/deploy-preview.yml
-name: Preview Deployment
-
-jobs:
-  deploy:
-    name: Deploy to Preview
-    type: deploy
-    params:
-      alias: preview
-      prod: false
-```
-
-</Collapsible>
-
-<Collapsible summary="Multi-alias deployment">
-
-This workflow deploys your application to both staging and production environments using different aliases.
-
-```yaml .eas/workflows/deploy-multi-alias.yml
-name: Multi-alias Deployment
-
-jobs:
-  deploy_staging:
-    name: Deploy to Staging
-    type: deploy
-    params:
-      alias: staging
-      prod: false
-
-  deploy_production:
-    name: Deploy to Production
-    type: deploy
-    params:
-      alias: production
-      prod: true
-```
-
-</Collapsible>
-
 ## Fingerprint
 
-Calculate fingerprint of Android and iOS builds.
+Calculates a fingerprint of your project.
 
-> **warning** This job type only supports [CNG (managed)](/workflow/continuous-native-generation/) workflows. If you commit your **android** or **ios** directories, the fingerprint job won't work.
+> **Note** This job type only supports [CNG (managed)](/workflow/continuous-native-generation/) workflows. If you commit your **android** or **ios** directories, the fingerprint job won't work.
 
 ### Syntax
 
 ```yaml
 jobs:
-  calculate_fingerprint:
+  fingerprint:
     type: fingerprint
     params:
-      environment: production
-      env:
-        APP_VARIANT: staging
+      environment: production | preview | development # optional, defaults to production
+      env: # optional
+        APP_VARIANT: staging # just an example
 ```
 
 #### Parameters
@@ -315,7 +282,7 @@ name: Basic Fingerprint
 
 jobs:
   fingerprint:
-    name: Calculate Fingerprints
+    name: Calculate Fingerprint
     type: fingerprint
     params:
       environment: production
@@ -332,7 +299,7 @@ name: Fingerprint with Environment Variables
 
 jobs:
   fingerprint:
-    name: Calculate Fingerprints
+    name: Calculate Fingerprint
     type: fingerprint
     params:
       environment: production
@@ -354,18 +321,18 @@ jobs:
   get_build:
     type: get-build
     params:
-      platform: ios
-      profile: production
-      distribution: store
-      channel: production
-      app_identifier: com.example.app
-      app_build_version: 1
-      app_version: 1.0.0
-      git_commit_hash: abc123
-      fingerprint_hash: def456
-      sdk_version: 49.0.0
-      runtime_version: 1.0.0
-      simulator: false
+      platform: ios | android # optional
+      profile: string # optional
+      distribution: store | internal | simulator # optional
+      channel: string # optional
+      app_identifier: string # optional
+      app_build_version: string # optional
+      app_version: string # optional
+      git_commit_hash: string # optional
+      fingerprint_hash: string # optional
+      sdk_version: string # optional
+      runtime_version: string # optional
+      simulator: boolean # optional
 ```
 
 #### Parameters
@@ -474,7 +441,9 @@ jobs:
 
 Submit an Android or iOS build to the app store using EAS Submit.
 
-> Submission jobs require additional configuration to run within a CI/CD process. See our [Apple App Store CI/CD submission guide](/submit/ios/#submitting-your-app-using-cicd-services) and [Google Play Store CI/CD submission guide](/submit/android/#submitting-your-app-using-cicd-services) for more information.
+### Prerequisites
+
+Submission jobs require additional configuration to run within a CI/CD process. See our [Apple App Store CI/CD submission guide](/submit/ios/#submitting-your-app-using-cicd-services) and [Google Play Store CI/CD submission guide](/submit/android/#submitting-your-app-using-cicd-services) for more information.
 
 ### Syntax
 
@@ -483,8 +452,8 @@ jobs:
   submit_to_store:
     type: submit
     params:
-      build_id: string
-      profile: production
+      build_id: string # required
+      profile: string # optional, default: production
 ```
 
 #### Parameters
@@ -548,7 +517,11 @@ jobs:
 
 ## Update
 
-Publish an update using EAS Update.
+Publish an update using [EAS Update](/eas-update/introduction/).
+
+### Prerequisites
+
+To publish update previews and to send over-the-air updates, you'll need to run `npx eas-cli@latest update:configure`, then create new builds. Learn more about [configuring EAS Update](/eas-update/getting-started/#prerequisites).
 
 ### Syntax
 
@@ -557,22 +530,22 @@ jobs:
   publish_update:
     type: update
     params:
-      message: string
-      platform: all
-      branch: production
-      channel: production
+      message: string # optional
+      platform: string # optional - android | ios | all, defaults to all
+      branch: string # optional
+      channel: string # optional - cannot be used with branch
 ```
 
 #### Parameters
 
 You can pass the following parameters into the `params` list:
 
-| Parameter | Type   | Description                                                                                                                                                                                                                                          |
-| --------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| message   | string | Optional. Message to use for the update. If not provided, the commit message will be used.                                                                                                                                                           |
-| platform  | string | Optional. Platform to use for the update ("android", "ios" or "all").                                                                                                                                                                                |
-| branch    | string | Optional. Branch to use for the update. If not provided, the branch from the workflow run will be used. For manually run workflows you need to provide a value. Example: `${{ github.ref_name }}`. Provide _either_ a branch or a channel, not both. |
-| channel   | string | Optional. Channel to use for the update. Provide _either_ a branch or a channel, not both.                                                                                                                                                           |
+| Parameter | Type   | Description                                                                                                                                                                                                                                                         |
+| --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| message   | string | Optional. Message to use for the update. If not provided, the commit message will be used.                                                                                                                                                                          |
+| platform  | string | Optional. Platform to use for the update. Can be `android`, `ios`, or `all`. Defaults to `all`.                                                                                                                                                                     |
+| branch    | string | Optional. Branch to use for the update. If not provided, the branch from the workflow run will be used. For manually run workflows you need to provide a value. Example: `${{ github.ref_name \|\| 'testing' }}`. Provide _either_ a branch or a channel, not both. |
+| channel   | string | Optional. Channel to use for the update. Provide _either_ a branch or a channel, not both.                                                                                                                                                                          |
 
 #### Outputs
 
@@ -604,7 +577,6 @@ jobs:
     type: update
     params:
       channel: production
-      message: 'Production update: ${{ github.event.head_commit.message }}'
 ```
 
 </Collapsible>
@@ -627,7 +599,6 @@ jobs:
     params:
       platform: android
       channel: production
-      message: 'Android update: ${{ github.event.head_commit.message }}'
 
   update_ios:
     name: Update iOS
@@ -635,7 +606,6 @@ jobs:
     params:
       platform: ios
       channel: production
-      message: 'iOS update: ${{ github.event.head_commit.message }}'
 ```
 
 </Collapsible>
@@ -662,45 +632,9 @@ jobs:
 
 </Collapsible>
 
-<Collapsible summary="Update with custom message and platform targeting">
-
-This workflow allows manual triggering of updates with custom platform selection and message, useful for controlled deployments.
-
-```yaml .eas/workflows/update-custom.yml
-name: Custom Update
-
-on:
-  workflow_dispatch:
-    inputs:
-      platform:
-        description: 'Platform to update'
-        required: true
-        default: 'all'
-        type: choice
-        options:
-          - all
-          - android
-          - ios
-      message:
-        description: 'Update message'
-        required: true
-        type: string
-
-jobs:
-  update_custom:
-    name: Custom Update
-    type: update
-    params:
-      platform: ${{ github.event.inputs.platform }}
-      channel: production
-      message: ${{ github.event.inputs.message }}
-```
-
-</Collapsible>
-
 ## Maestro
 
-Run Maestro tests on a build.
+Run Maestro tests on a Android emulator or iOS simulator build.
 
 > **important** Maestro tests are experimental and may experience flakiness.
 
@@ -710,13 +644,13 @@ Run Maestro tests on a build.
 jobs:
   run_maestro_tests:
     type: maestro
-    environment: preview
-    image: latest
+    environment: production | preview | development # optional, defaults to preview
+    image: string # optional. See https://docs.expo.dev/build-reference/infrastructure/ for a list of available images.
     params:
-      build_id: string
-      flow_path: string
-      shards: 1
-      retries: 1
+      build_id: string # required
+      flow_path: string | string[] # required
+      shards: number # optional, defaults to 1
+      retries: number # optional, defaults to 1
 ```
 
 #### Parameters
@@ -736,7 +670,7 @@ Here are some practical examples of using the Maestro job:
 
 <Collapsible summary="Basic Maestro test">
 
-This workflow runs Maestro tests on an iOS build using the default settings.
+This workflow runs Maestro tests on an iOS simulator build using the default settings.
 
 ```yaml .eas/workflows/maestro-basic.yml
 name: Basic Maestro Test
@@ -746,9 +680,8 @@ jobs:
     name: Run Maestro Tests
     type: maestro
     environment: preview
-    image: latest
     params:
-      build_id: ${{ needs.build_ios.outputs.build_id }}
+      build_id: ${{ needs.build_ios_simulator.outputs.build_id }}
       flow_path: ./maestro/flows
 ```
 
@@ -756,7 +689,7 @@ jobs:
 
 <Collapsible summary="Maestro test with sharding">
 
-This workflow runs Maestro tests on an Android build with 4 shards and 2 retries for failed tests.
+This workflow runs Maestro tests on an Android emulator build with 4 shards and 2 retries for failed tests.
 
 ```yaml .eas/workflows/maestro-sharded.yml
 name: Sharded Maestro Test
@@ -766,9 +699,8 @@ jobs:
     name: Run Sharded Maestro Tests
     type: maestro
     environment: preview
-    image: latest
     params:
-      build_id: ${{ needs.build_android.outputs.build_id }}
+      build_id: ${{ needs.build_android_emulator.outputs.build_id }}
       flow_path: ./maestro/flows
       shards: 4
       retries: 2
@@ -778,7 +710,7 @@ jobs:
 
 ## Slack
 
-Send a message to a Slack channel using a webhook URL.
+Send a message to a Slack channel using a [Slack webhook URL](https://api.slack.com/messaging/webhooks).
 
 ### Syntax
 
@@ -787,26 +719,26 @@ jobs:
   send_slack_notification:
     type: slack
     params:
-      webhook_url: string
-      message: string
-      payload: object
+      webhook_url: string # required
+      message: string # required if payload is not provided
+      payload: object # required if message is not provided
 ```
 
 #### Parameters
 
 You can pass the following parameters into the `params` list:
 
-| Parameter   | Type   | Description                                                               |
-| ----------- | ------ | ------------------------------------------------------------------------- |
-| webhook_url | string | Required. The Slack webhook URL to send the message to.                   |
-| message     | string | Required if payload is not provided. The message to send.                 |
-| payload     | object | Required if message is not provided. The Slack Block Kit payload to send. |
+| Parameter   | Type   | Description                                                                                                                                                                |
+| ----------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| webhook_url | string | Required. The Slack webhook URL to send the message to. Currently only hardcoded strings are supported. Using webhooks stored in `env` are upcoming but not yet supported. |
+| message     | string | Required if payload is not provided. The message to send.                                                                                                                  |
+| payload     | object | Required if message is not provided. The [Slack Block Kit](https://api.slack.com/block-kit) payload to send.                                                               |
 
 ### Examples
 
 Here are some practical examples of using the Slack job:
 
-<Collapsible summary="Simple build notification">
+<Collapsible summary="Basic build notification">
 
 This workflow builds an iOS app and then sends a notification with the app identifier and version from the build job outputs.
 
@@ -826,7 +758,7 @@ jobs:
     needs: build_ios
     type: slack
     params:
-      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+      webhook_url: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
       message: 'Build completed for app ${{ needs.build_ios.outputs.app_identifier }} (version ${{ needs.build_ios.outputs.app_version }})'
 ```
 
@@ -852,101 +784,13 @@ jobs:
     needs: build_android
     type: slack
     params:
-      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+      webhook_url: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
       payload:
         blocks:
           - type: header
             text:
               type: plain_text
               text: 'Build Completed'
-          - type: section
-            fields:
-              - type: mrkdwn
-                text: "*App:*\n${{ needs.build_android.outputs.app_identifier }}"
-              - type: mrkdwn
-                text: "*Version:*\n${{ needs.build_android.outputs.app_version }}"
-          - type: section
-            fields:
-              - type: mrkdwn
-                text: "*Build ID:*\n${{ needs.build_android.outputs.build_id }}"
-              - type: mrkdwn
-                text: "*Platform:*\n${{ needs.build_android.outputs.platform }}"
-          - type: section
-            text:
-              type: mrkdwn
-              text: 'Distribution: ${{ needs.build_android.outputs.distribution }}'
-```
-
-</Collapsible>
-
-<Collapsible summary="Test results summary">
-
-This workflow builds an iOS app and sends a test results summary using the build job outputs.
-
-```yaml .eas/workflows/slack-test-results.yml
-name: Test Results Notification
-
-jobs:
-  build_ios:
-    name: Build iOS
-    type: build
-    params:
-      platform: ios
-      profile: production
-
-  notify_tests:
-    name: Notify Test Results
-    needs: build_ios
-    type: slack
-    params:
-      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
-      payload:
-        blocks:
-          - type: header
-            text:
-              type: plain_text
-              text: 'Test Results'
-          - type: section
-            fields:
-              - type: mrkdwn
-                text: "*App:*\n${{ needs.build_ios.outputs.app_identifier }}"
-              - type: mrkdwn
-                text: "*Build ID:*\n${{ needs.build_ios.outputs.build_id }}"
-          - type: section
-            text:
-              type: mrkdwn
-              text: 'Platform: ${{ needs.build_ios.outputs.platform }}'
-```
-
-</Collapsible>
-
-<Collapsible summary="Deployment notification with environment">
-
-This workflow builds an Android app and sends a detailed deployment notification using the build job outputs.
-
-```yaml .eas/workflows/slack-deployment.yml
-name: Deployment Notification
-
-jobs:
-  build_android:
-    name: Build Android
-    type: build
-    params:
-      platform: android
-      profile: production
-
-  notify_deployment:
-    name: Notify Deployment
-    needs: build_android
-    type: slack
-    params:
-      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
-      payload:
-        blocks:
-          - type: header
-            text:
-              type: plain_text
-              text: '🚀 Deployment Complete'
           - type: section
             fields:
               - type: mrkdwn

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -32,10 +32,10 @@ jobs:
 
 You can pass the following parameters into the `params` list:
 
-| Parameter | Type   | Description                                                            |
-| --------- | ------ | ---------------------------------------------------------------------- |
+| Parameter | Type   | Description                                                                |
+| --------- | ------ | -------------------------------------------------------------------------- |
 | platform  | string | **Required.** The platform to build for. Can be either `android` or `ios`. |
-| profile   | string | Optional. The build profile to use. Defaults to `production`.          |
+| profile   | string | Optional. The build profile to use. Defaults to `production`.              |
 
 #### Outputs
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -471,7 +471,7 @@ Learn about the different pre-packaged jobs below.
 
 #### `build`
 
-Creates an Android or iOS build of your project using [EAS Build](/build/introduction/).
+Creates an Android or iOS build of your project using [EAS Build](/build/introduction/). See [Build job documentation](/eas/workflows/pre-packaged-jobs#build) for detailed information and examples.
 
 ```yaml
 jobs:
@@ -504,11 +504,9 @@ This job outputs the following properties:
 }
 ```
 
-Build jobs can be customized so that you can execute custom commands during the build process. See [Custom builds](/custom-builds/get-started/) for more information.
-
 #### `deploy`
 
-Deploys your application using [EAS Hosting](/eas/hosting/introduction/).
+Deploys your application using [EAS Hosting](/eas/hosting/introduction/). See [Deploy job documentation](/eas/workflows/pre-packaged-jobs#deploy) for detailed information and examples.
 
 ```yaml
 jobs:
@@ -523,7 +521,7 @@ jobs:
 
 #### `fingerprint`
 
-Calculates fingerprint of Android and iOS builds.
+Calculates a fingerprint of your project. See [Fingerprint job documentation](/eas/workflows/pre-packaged-jobs#fingerprint) for detailed information and examples.
 
 ```yaml
 jobs:
@@ -537,8 +535,6 @@ jobs:
         APP_VARIANT: staging # just an example
 ```
 
-> **warning** This job type only supports [CNG (managed)](/workflow/continuous-native-generation/) workflows. If you commit your **android** or **ios** directories, the fingerprint job won't work.
-
 This job outputs the following properties:
 
 ```json
@@ -550,7 +546,7 @@ This job outputs the following properties:
 
 #### `get-build`
 
-Retrieves an existing build from EAS that matches the provided parameters.
+Retrieves an existing build from EAS that matches the provided parameters. See [Get Build job documentation](/eas/workflows/pre-packaged-jobs#get-build) for detailed information and examples.
 
 ```yaml
 jobs:
@@ -595,9 +591,7 @@ This job outputs the following properties:
 
 #### `submit`
 
-Submits an Android or iOS build to the app store using [EAS Submit](/submit/introduction/). For `environment`, it uses the same environment used to create the build referenced in `build_id`.
-
-> Submission jobs require additional configuration to run within a CI/CD process. See our [Apple App Store CI/CD submission guide](/submit/ios/#submitting-your-app-using-cicd-services) and [Google Play Store CI/CD submission guide](/submit/android/#submitting-your-app-using-cicd-services) for more information.
+Submits an Android or iOS build to the app store using [EAS Submit](/submit/introduction/). See [Submit job documentation](/eas/workflows/pre-packaged-jobs#submit) for detailed information and examples.
 
 ```yaml
 jobs:
@@ -622,7 +616,7 @@ This job outputs the following properties:
 
 #### `update`
 
-Publishes an update using [EAS Update](/eas-update/introduction/).
+Publishes an update using [EAS Update](/eas-update/introduction/). See [Update job documentation](/eas/workflows/pre-packaged-jobs#update) for detailed information and examples.
 
 ```yaml
 jobs:
@@ -648,7 +642,7 @@ This job outputs the following properties:
 
 #### `maestro`
 
-Runs [Maestro](https://maestro.mobile.dev/) tests on a build.
+Runs [Maestro](https://maestro.mobile.dev/) tests on a build. See [Maestro job documentation](/eas/workflows/pre-packaged-jobs#maestro) for detailed information and examples.
 
 > **important** Maestro tests are experimental and may experience flakiness.
 
@@ -669,7 +663,7 @@ jobs:
 
 #### `slack`
 
-Sends a message to a Slack channel using a webhook URL.
+Sends a message to a Slack channel using a webhook URL. See [Slack job documentation](/eas/workflows/pre-packaged-jobs#slack) for detailed information and examples.
 
 ```yaml
 jobs:


### PR DESCRIPTION
# Why

Information about pre-packaged jobs were buried in the syntax doc. This PR gives them their own doc that explains their prerequisites, syntax, and shows some examples with each job so that it's easier to see how each one works.

# Test plan

Make sure the changes read well and that the doc is accurate: /eas/workflows/pre-packaged-jobs/

<img width="1392" alt="Screenshot 2025-05-19 at 5 42 55 PM" src="https://github.com/user-attachments/assets/1818520d-eb65-4e8e-9335-16ae3ffe9c0b" />
