### PR TITLE
[docs][notifications] remove deprecated api usage

### DIFF
--- a/docs/pages/versions/v53.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/notifications.mdx
@@ -204,7 +204,8 @@ import * as Notifications from 'expo-notifications';
 // to show the alert
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
-    shouldShowAlert: true,
+    shouldShowBanner: true,
+    shouldShowList: true,
     shouldPlaySound: false,
     shouldSetBadge: false,
   }),


### PR DESCRIPTION
# Why

Updated the `setNotificationHandler` example in the notifications documentation to use the newer properties `shouldShowBanner` and `shouldShowList` instead of the deprecated `shouldShowAlert` property.

# How

Modified the code example.

# Test Plan


# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)