### PR TITLE
[docs] Fix heading case in multiple docs

### DIFF
--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -29,7 +29,7 @@ There are two ways you can add a custom font into your project:
 
 Expo SDK officially supports OTF and TTF font formats across Android, iOS and web platforms. If your font is in another font format, you have to set up advanced configuration to support that format in your project.
 
-### Variable Fonts
+### Variable fonts
 
 Variable fonts, including variable font implementations in OTF and TTF, do not have support across all platforms. For full platform support, use static fonts. Alternatively, use a utility such as [fontTools](https://fonttools.readthedocs.io/en/latest/varLib/mutator.html) to extract the specific axis configuration you want to use from the variable font and save it as a separate font file.
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -425,7 +425,7 @@ OnActivityResult { activity, payload ->
 
 </PaddedAPIBox>
 
-## View Definition components
+## View definition components
 
 The view definition consists of the DSL components that describe the view's functionality and behavior. Those components can only be used within a [`View`](#view) closure.
 

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -298,7 +298,7 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-## Enable Emulator Location
+## Enable emulator location
 
 ### Android Emulator
 

--- a/docs/pages/versions/v51.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/location.mdx
@@ -197,7 +197,7 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-## Enable Emulator Location
+## Enable emulator location
 
 ### Android Emulator
 

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -298,7 +298,7 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-## Enable Emulator Location
+## Enable emulator location
 
 ### Android Emulator
 

--- a/docs/pages/versions/v53.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/location.mdx
@@ -298,7 +298,7 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-## Enable Emulator Location
+## Enable emulator location
 
 ### Android Emulator
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix heading case in multiple docs as per our writing stye guide which states we use sentence case instead of title case.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
