### PR TITLE
[core][iOS] Use dynamic type for AsyncFunction result conversion

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,10 +16,10 @@
 - [iOS] Call `createRootViewController` from the `ExpoReactNativeFactoryDelegate`. ([#36787](https://github.com/expo/expo/pull/36787) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Prevent crash on failed networked requests ([#36896](https://github.com/expo/expo/pull/36896) by [@adrum](https://github.com/adrum))
 
-
 ### 💡 Others
 
 - Improved `@expo/ui/swift-ui-primitives` integrations. ([#36937](https://github.com/expo/expo/pull/36937) by [@kudo](https://github.com/kudo))
+- [iOS] Use dynamic type for AsyncFunction result conversion ([#36986](https://github.com/expo/expo/pull/36986) by [@jakex7](https://github.com/jakex7))
 
 ## 2.3.13 — 2025-05-08
 

--- a/packages/expo-modules-core/ios/Core/Conversions.swift
+++ b/packages/expo-modules-core/ios/Core/Conversions.swift
@@ -185,9 +185,11 @@ public struct Conversions {
     dynamicType: AnyDynamicType? = nil
   ) -> Any {
     if let appContext {
+      // Dynamic type is provided
       if dynamicType as? DynamicVoidType == nil, let result = try? dynamicType?.convertResult(value as Any, appContext: appContext) {
         return result
       }
+      // Dynamic type can be obtained from the value
       if let value = value as? AnyArgument, let result = try? type(of: value).getDynamicType().convertResult(value as Any, appContext: appContext) {
         return result
       }

--- a/packages/expo-modules-core/ios/Core/Conversions.swift
+++ b/packages/expo-modules-core/ios/Core/Conversions.swift
@@ -184,8 +184,13 @@ public struct Conversions {
     appContext: AppContext? = nil,
     dynamicType: AnyDynamicType? = nil
   ) -> Any {
-    if let appContext, let result = try? dynamicType?.convertResult(value as Any, appContext: appContext) {
-      return result
+    if let appContext {
+      if dynamicType as? DynamicVoidType == nil, let result = try? dynamicType?.convertResult(value as Any, appContext: appContext) {
+        return result
+      }
+      if let value = value as? AnyArgument {
+        return try! type(of: value).getDynamicType().convertResult(value as Any, appContext: appContext)
+      }
     }
     return convertFunctionResultInRuntime(value, appContext: appContext)
   }

--- a/packages/expo-modules-core/ios/Core/Conversions.swift
+++ b/packages/expo-modules-core/ios/Core/Conversions.swift
@@ -188,8 +188,8 @@ public struct Conversions {
       if dynamicType as? DynamicVoidType == nil, let result = try? dynamicType?.convertResult(value as Any, appContext: appContext) {
         return result
       }
-      if let value = value as? AnyArgument {
-        return try! type(of: value).getDynamicType().convertResult(value as Any, appContext: appContext)
+      if let value = value as? AnyArgument, let result = try? type(of: value).getDynamicType().convertResult(value as Any, appContext: appContext) {
+        return result
       }
     }
     return convertFunctionResultInRuntime(value, appContext: appContext)

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
@@ -59,6 +59,7 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
   }
 
   func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
+    // Postpone object creation to execute on the JS thread.
     JavaScriptSharedObjectBinding.init {
       // If the result is a native shared object, create its JS representation and add the pair to the registry of shared objects.
       if let sharedObject = result as? SharedObject {
@@ -67,6 +68,7 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
           return jsObject
         }
         guard let jsObject = try? appContext.newObject(nativeClassId: typeIdentifier) else {
+          // Throwing is not possible here due to swift-objC interop.
           log.warn("Unable to create a JS object for \(description)")
           return JavaScriptObject()
         }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
@@ -59,27 +59,36 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
   }
 
   func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
-    // If the result is a native shared object, create its JS representation and add the pair to the registry of shared objects.
-    if let sharedObject = result as? SharedObject {
-      // If the JS object already exists, just return it.
-      if let jsObject = sharedObject.getJavaScriptObject() {
+    JavaScriptSharedObjectBinding {
+      // If the result is a native shared object, create its JS representation and add the pair to the registry of shared objects.
+      if let sharedObject = result as? SharedObject {
+        // If the JS object already exists, just return it.
+        if let jsObject = sharedObject.getJavaScriptObject() {
+          return jsObject
+        }
+        guard let jsObject = try? appContext.newObject(nativeClassId: typeIdentifier) else {
+          log.warn("Unable to create a JS object for \(description)")
+          return JavaScriptObject()
+        }
+
+        // Add newly created objects to the registry.
+        appContext.sharedObjectRegistry.add(native: sharedObject, javaScript: jsObject)
+
         return jsObject
       }
-      guard let jsObject = try? appContext.newObject(nativeClassId: typeIdentifier) else {
-        log.warn("Unable to create a JS object for \(description)")
-        return Optional<Any>.none as Any
-      }
-
-      // Add newly created objects to the registry.
-      appContext.sharedObjectRegistry.add(native: sharedObject, javaScript: jsObject)
-
-      return jsObject
+      return JavaScriptObject()
     }
-    return result
   }
 
   var description: String {
     return "SharedObject<\(innerType)>"
+  }
+  
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    if let value = value as? JavaScriptSharedObjectBinding {
+      return try JavaScriptValue.from(value.get(), runtime: appContext.runtime)
+    }
+    throw NativeSharedObjectNotFoundException()
   }
 }
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
@@ -59,7 +59,7 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
   }
 
   func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
-    JavaScriptSharedObjectBinding {
+    JavaScriptSharedObjectBinding.init {
       // If the result is a native shared object, create its JS representation and add the pair to the registry of shared objects.
       if let sharedObject = result as? SharedObject {
         // If the JS object already exists, just return it.
@@ -83,7 +83,7 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
   var description: String {
     return "SharedObject<\(innerType)>"
   }
-  
+
   func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
     if let value = value as? JavaScriptSharedObjectBinding {
       return try JavaScriptValue.from(value.get(), runtime: appContext.runtime)

--- a/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
@@ -65,7 +65,7 @@ public final class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyA
 
   func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> ()) {
     let promise = Promise(appContext: appContext) { value in
-      callback(.success(Conversions.convertFunctionResult(value, appContext: appContext)))
+      callback(.success(Conversions.convertFunctionResult(value, appContext: appContext, dynamicType: ~ReturnType.self)))
     } rejecter: { exception in
       callback(.failure(exception))
     }

--- a/packages/expo-modules-core/ios/Core/Promise.swift
+++ b/packages/expo-modules-core/ios/Core/Promise.swift
@@ -19,17 +19,6 @@ public struct Promise: AnyArgument {
   }
 
   public func resolve(_ value: Any? = nil) {
-    if let value = value as? AnySharedObject {
-      resolver(JavaScriptSharedObjectBinding.init {
-        return Conversions.convertFunctionResult(
-          value,
-          appContext: appContext,
-          dynamicType: type(of: value).getDynamicType()
-          // swiftlint:disable:next force_cast
-        ) as! JavaScriptObject
-      })
-      return
-    }
     resolver(value)
   }
 


### PR DESCRIPTION
# Why

To use dynamic type on async function results (same as on sync function) when possible.

# How

* `Conversions.convertFunctionResult` is called with dynamic type
* `Conversions.convertFunctionResult` is calling `getDynamicType` when provided type is `DynamicVoidType` (async function uses resolve instead of return)
* Moved `JavaScriptSharedObjectBinding.init` to `DynamicSharedObjectType.convertResult` to remove special handling in Promise

# Test Plan

Tests should pass

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
