### PR TITLE
[core][Android] Handle conflicting custom type converters

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/CustomTypeConvertersTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/CustomTypeConvertersTest.kt
@@ -26,6 +26,10 @@ class CustomTypeConvertersTest {
           Truth.assertThat(listOfNumber).isEqualTo(listOf(1, 2, 3))
           CustomType()
         }
+        .from { listOfString: List<String> ->
+          Truth.assertThat(listOfString).isEqualTo(listOf("a", "b", "c"))
+          CustomType()
+        }
     }
 
     override fun definition() = ModuleDefinition {
@@ -55,6 +59,10 @@ class CustomTypeConvertersTest {
 
     Truth.assertThat(
       call("convert", "[1, 2, 3]").getBool()
+    ).isTrue()
+
+    Truth.assertThat(
+      call("convert", "['a', 'b', 'c']").getBool()
     ).isTrue()
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ExpectedType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ExpectedType.kt
@@ -132,12 +132,15 @@ class ExpectedType(
   override operator fun equals(other: Any?): Boolean {
     if (other !is ExpectedType) return false
 
-    if (this.innerPossibleTypes.size != other.innerPossibleTypes.size) return false
+    if (this.innerPossibleTypes.size != other.innerPossibleTypes.size) {
+      return false
+    }
+
     for (i in this.innerPossibleTypes.indices) {
       if (this.innerPossibleTypes[i].expectedCppType != other.innerPossibleTypes[i].expectedCppType) {
         return false
       }
-      if (this.innerPossibleTypes[i].getFirstParameterType() != other.innerPossibleTypes[i].getFirstParameterType()) {
+      if (this.innerPossibleTypes[i] != other.innerPossibleTypes[i]) {
         return false
       }
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -46,13 +46,13 @@ class RecordTypeConverter<T : Record>(
       .toMap()
   }
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): T =
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): T =
     exceptionDecorator({ cause -> RecordCastException(type, cause) }) {
       val jsMap = value.asMap()
       return convertFromReadableMap(jsMap, context)
     }
 
-  override fun convertFromAny(value: Any, context: AppContext?): T {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): T {
     if (value is ReadableMap) {
       return convertFromReadableMap(value, context)
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
@@ -17,7 +17,7 @@ class SharedObjectTypeConverter<T : SharedObject>(
   val type: KType
 ) : NullAwareTypeConverter<T>(type.isMarkedNullable) {
   @Suppress("UNCHECKED_CAST")
-  override fun convertNonOptional(value: Any, context: AppContext?): T {
+  override fun convertNonOptional(value: Any, context: AppContext?, forceConversion: Boolean): T {
     val id = SharedObjectId(
       if (value is Dynamic) {
         value.asInt()
@@ -64,7 +64,7 @@ class SharedRefTypeConverter<T : SharedRef<*>>(
     return@lazy null
   }
 
-  override fun convertNonOptional(value: Any, context: AppContext?): T {
+  override fun convertNonOptional(value: Any, context: AppContext?, forceConversion: Boolean): T {
     val sharedObject = sharedObjectTypeConverter.convert(value, context)
     if (sharedObject !is SharedRef<*>) {
       throw InvalidSharedObjectTypeException(type)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
@@ -13,7 +13,7 @@ import expo.modules.kotlin.jni.ExpectedType
  * In that way, we produce the same output for JSI and bridge implementation.
  */
 class AnyTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Any>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Any {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Any {
     return when (value.type) {
       ReadableType.Boolean -> value.asBoolean()
       ReadableType.Number -> value.asDouble()
@@ -24,7 +24,7 @@ class AnyTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Any>(is
     }
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): Any = value
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Any = value
 
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.ANY)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
@@ -19,7 +19,7 @@ class ArrayTypeConverter(
     }
   )
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Array<*> {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Array<*> {
     val jsArray = value.asArray()
     val array = createTypedArray(jsArray.size())
     for (i in 0 until jsArray.size()) {
@@ -29,15 +29,15 @@ class ArrayTypeConverter(
           exceptionDecorator({ cause ->
             CollectionElementCastException(arrayType, arrayType.arguments.first().type!!, type, cause)
           }) {
-            arrayElementConverter.convert(this, context)
+            arrayElementConverter.convert(this, context, forceConversion)
           }
         }
     }
     return array
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): Array<*> {
-    return if (arrayElementConverter.isTrivial()) {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Array<*> {
+    return if (arrayElementConverter.isTrivial() && !forceConversion) {
       value as Array<*>
     } else {
       (value as Array<*>).map {
@@ -49,7 +49,7 @@ class ArrayTypeConverter(
             cause
           )
         }) {
-          arrayElementConverter.convert(it, context)
+          arrayElementConverter.convert(it, context, forceConversion)
         }
       }.toTypedArray()
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ByteArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ByteArrayTypeConverter.kt
@@ -7,7 +7,7 @@ import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
 class ByteArrayTypeConverter(isOptional: Boolean) : NullAwareTypeConverter<ByteArray>(isOptional) {
-  override fun convertNonOptional(value: Any, context: AppContext?): ByteArray = value as ByteArray
+  override fun convertNonOptional(value: Any, context: AppContext?, forceConversion: Boolean): ByteArray = value as ByteArray
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.UINT8_TYPED_ARRAY)
   override fun isTrivial() = false
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
@@ -10,6 +10,7 @@ import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.SingleType
+import androidx.core.graphics.toColorInt
 
 /**
  * Color components for named colors following the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color)
@@ -173,7 +174,7 @@ private val namedColors = mapOf(
 class ColorTypeConverter(
   isOptional: Boolean
 ) : DynamicAwareTypeConverters<Color>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Color {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Color {
     return when (value.type) {
       ReadableType.Number -> colorFromInt(value.asDouble().toInt())
       ReadableType.String -> colorFromString(value.asString())
@@ -185,7 +186,7 @@ class ColorTypeConverter(
     }
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): Color {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Color {
     return when (value) {
       is Int -> {
         colorFromInt(value)
@@ -220,7 +221,7 @@ class ColorTypeConverter(
       )
     }
 
-    return Color.valueOf(Color.parseColor(value))
+    return Color.valueOf(value.toColorInt())
   }
 
   override fun getCppRequiredTypes(): ExpectedType =

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DateTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DateTypeConverter.kt
@@ -16,7 +16,7 @@ import java.time.format.DateTimeFormatter
 
 @RequiresApi(Build.VERSION_CODES.O)
 class DateTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<LocalDate>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): LocalDate {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): LocalDate {
     return when (value.type) {
       ReadableType.String -> LocalDate.parse(value.asString(), DateTimeFormatter.ISO_DATE_TIME)
       ReadableType.Number -> convertFromLong(value.asDouble().toLong())
@@ -24,7 +24,7 @@ class DateTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<LocalD
     }
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): LocalDate {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): LocalDate {
     return when (value) {
       is String -> LocalDate.parse(value, DateTimeFormatter.ISO_DATE_TIME)
       is Long -> convertFromLong(value)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DurationTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/DurationTypeConverter.kt
@@ -10,14 +10,14 @@ import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
 class DurationTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Duration>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Duration {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Duration {
     if (value.type != ReadableType.Number) {
       throw IllegalArgumentException("Expected a number, but received ${value.type}")
     }
     return value.asDouble().toDuration(DurationUnit.SECONDS)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): Duration {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Duration {
     return (value as Double).toDuration(DurationUnit.SECONDS)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
@@ -26,7 +26,7 @@ class UnconvertedValue(
 
   fun getConvertedValue(): Any {
     if (convertedValue == null) {
-      convertedValue = typeConverter.convert(unconvertedValue, contextHolder.get())
+      convertedValue = typeConverter.convert(unconvertedValue, contextHolder.get(), forceConversion = true)
     }
 
     return convertedValue!!

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
@@ -37,7 +37,7 @@ class EnumTypeConverter(
 
   override fun isTrivial() = false
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Enum<*> {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Enum<*> {
     if (primaryConstructor.parameters.isEmpty()) {
       return convertEnumWithoutParameter(value.asString(), enumConstants)
     } else if (primaryConstructor.parameters.size == 1) {
@@ -51,7 +51,7 @@ class EnumTypeConverter(
     throw IncompatibleArgTypeException(value.type.toKType(), enumClass.createType())
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): Enum<*> {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Enum<*> {
     if (primaryConstructor.parameters.isEmpty()) {
       return convertEnumWithoutParameter(value as String, enumConstants)
     } else if (primaryConstructor.parameters.size == 1) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JavaScriptFunctionTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JavaScriptFunctionTypeConverter.kt
@@ -9,7 +9,7 @@ import kotlin.reflect.KType
 class JavaScriptFunctionTypeConverter<T : Any>(
   val type: KType
 ) : NullAwareTypeConverter<JavaScriptFunction<T>>(type.isMarkedNullable) {
-  override fun convertNonOptional(value: Any, context: AppContext?): JavaScriptFunction<T> {
+  override fun convertNonOptional(value: Any, context: AppContext?, forceConversion: Boolean): JavaScriptFunction<T> {
     @Suppress("UNCHECKED_CAST")
     val jsFunction = value as JavaScriptFunction<T>
     jsFunction.returnType = requireNotNull(type.arguments.first().type)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ListTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ListTypeConverter.kt
@@ -20,7 +20,7 @@ class ListTypeConverter(
     }
   )
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): List<*> {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): List<*> {
     if (value.type != ReadableType.Array) {
       return listOf(
         exceptionDecorator({ cause ->
@@ -31,17 +31,17 @@ class ListTypeConverter(
             cause
           )
         }) {
-          elementConverter.convert(value, context)
+          elementConverter.convert(value, context, forceConversion)
         }
       )
     }
 
     val jsArray = value.asArray()
-    return convertFromReadableArray(jsArray, context)
+    return convertFromReadableArray(jsArray, context, forceConversion)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): List<*> {
-    return if (elementConverter.isTrivial()) {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): List<*> {
+    return if (elementConverter.isTrivial() && !forceConversion) {
       value as List<*>
     } else {
       (value as List<*>).map {
@@ -53,13 +53,13 @@ class ListTypeConverter(
             cause
           )
         }) {
-          elementConverter.convert(it, context)
+          elementConverter.convert(it, context, forceConversion)
         }
       }
     }
   }
 
-  private fun convertFromReadableArray(jsArray: ReadableArray, context: AppContext?): List<*> {
+  private fun convertFromReadableArray(jsArray: ReadableArray, context: AppContext?, forceConversion: Boolean): List<*> {
     return List(jsArray.size()) { index ->
       jsArray.getDynamic(index).recycle {
         exceptionDecorator({ cause ->
@@ -70,7 +70,7 @@ class ListTypeConverter(
             cause
           )
         }) {
-          elementConverter.convert(this, context)
+          elementConverter.convert(this, context, forceConversion)
         }
       }
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
@@ -26,13 +26,13 @@ class MapTypeConverter(
     }
   )
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Map<*, *> {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Map<*, *> {
     val jsMap = value.asMap()
-    return convertFromReadableMap(jsMap, context)
+    return convertFromReadableMap(jsMap, context, forceConversion)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): Map<*, *> {
-    return if (valueConverter.isTrivial()) {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Map<*, *> {
+    return if (valueConverter.isTrivial() && !forceConversion) {
       value as Map<*, *>
     } else {
       (value as Map<*, *>).mapValues { (_, v) ->
@@ -44,13 +44,13 @@ class MapTypeConverter(
             cause
           )
         }) {
-          valueConverter.convert(v, context)
+          valueConverter.convert(v, context, forceConversion)
         }
       }
     }
   }
 
-  private fun convertFromReadableMap(jsMap: ReadableMap, context: AppContext?): Map<*, *> {
+  private fun convertFromReadableMap(jsMap: ReadableMap, context: AppContext?, forceConversion: Boolean): Map<*, *> {
     val result = mutableMapOf<String, Any?>()
 
     jsMap.entryIterator.forEach { (key, value) ->
@@ -58,7 +58,7 @@ class MapTypeConverter(
         exceptionDecorator({ cause ->
           CollectionElementCastException(mapType, mapType.arguments[1].type!!, type, cause)
         }) {
-          result[key] = valueConverter.convert(this, context)
+          result[key] = valueConverter.convert(this, context, forceConversion)
         }
       }
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
@@ -28,32 +28,32 @@ class PairTypeConverter(
     )
   )
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Pair<*, *> {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Pair<*, *> {
     val jsArray = value.asArray()
-    return convertFromReadableArray(jsArray, context)
+    return convertFromReadableArray(jsArray, context, forceConversion)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): Pair<*, *> {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Pair<*, *> {
     if (value is ReadableArray) {
-      return convertFromReadableArray(value, context)
+      return convertFromReadableArray(value, context, forceConversion)
     }
 
     return value as Pair<*, *>
   }
 
-  private fun convertFromReadableArray(jsArray: ReadableArray, context: AppContext?): Pair<*, *> {
+  private fun convertFromReadableArray(jsArray: ReadableArray, context: AppContext?, forceConversion: Boolean): Pair<*, *> {
     return Pair(
-      convertElement(context, jsArray, 0),
-      convertElement(context, jsArray, 1)
+      convertElement(context, jsArray, 0, forceConversion),
+      convertElement(context, jsArray, 1, forceConversion)
     )
   }
 
-  private fun convertElement(context: AppContext?, array: ReadableArray, index: Int): Any? {
+  private fun convertElement(context: AppContext?, array: ReadableArray, index: Int, forceConversion: Boolean): Any? {
     return array.getDynamic(index).recycle {
       exceptionDecorator({ cause ->
         CollectionElementCastException(pairType, pairType.arguments[index].type!!, type, cause)
       }) {
-        converters[index].convert(this, context)
+        converters[index].convert(this, context, forceConversion)
       }
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReadableArgumentsTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReadableArgumentsTypeConverter.kt
@@ -11,11 +11,11 @@ import expo.modules.kotlin.jni.ExpectedType
 class ReadableArgumentsTypeConverter(
   isOptional: Boolean
 ) : DynamicAwareTypeConverters<ReadableArguments>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): ReadableArguments {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): ReadableArguments {
     return MapArguments(value.asMap().toHashMap())
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): ReadableArguments {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): ReadableArguments {
     return MapArguments((value as ReadableMap).toHashMap())
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/SetTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/SetTypeConverter.kt
@@ -19,13 +19,13 @@ class SetTypeConverter(
     }
   )
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Set<*> {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Set<*> {
     val jsArray = value.asArray()
-    return convertFromReadableArray(jsArray, context)
+    return convertFromReadableArray(jsArray, context, forceConversion)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): Set<*> {
-    return if (elementConverter.isTrivial()) {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Set<*> {
+    return if (elementConverter.isTrivial() && !forceConversion) {
       (value as List<*>).toSet()
     } else {
       (value as List<*>).map {
@@ -37,13 +37,13 @@ class SetTypeConverter(
             cause
           )
         }) {
-          elementConverter.convert(it, context)
+          elementConverter.convert(it, context, forceConversion)
         }
       }.toSet()
     }
   }
 
-  private fun convertFromReadableArray(jsArray: ReadableArray, context: AppContext?): Set<*> {
+  private fun convertFromReadableArray(jsArray: ReadableArray, context: AppContext?, forceConversion: Boolean): Set<*> {
     return List(jsArray.size()) { index ->
       jsArray.getDynamic(index).recycle {
         exceptionDecorator({ cause ->
@@ -54,7 +54,7 @@ class SetTypeConverter(
             cause
           )
         }) {
-          elementConverter.convert(this, context)
+          elementConverter.convert(this, context, forceConversion)
         }
       }
     }.toSet()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypedArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypedArrayTypeConverter.kt
@@ -18,7 +18,7 @@ import expo.modules.kotlin.typedarray.Uint8Array
 import expo.modules.kotlin.typedarray.Uint8ClampedArray
 
 abstract class BaseTypeArrayConverter<T : TypedArray>(isOptional: Boolean) : NullAwareTypeConverter<T>(isOptional) {
-  override fun convertNonOptional(value: Any, context: AppContext?): T = wrapJavaScriptTypedArray(value as JavaScriptTypedArray)
+  override fun convertNonOptional(value: Any, context: AppContext?, forceConversion: Boolean): T = wrapJavaScriptTypedArray(value as JavaScriptTypedArray)
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.TYPED_ARRAY)
   override fun isTrivial() = false
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/UnitTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/UnitTypeConverter.kt
@@ -5,7 +5,7 @@ import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
 class UnitTypeConverter : TypeConverter<Unit>() {
-  override fun convert(value: Any?, context: AppContext?) = Unit
+  override fun convert(value: Any?, context: AppContext?, forceConversion: Boolean) = Unit
 
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.ANY)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/io/FileTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/io/FileTypeConverter.kt
@@ -8,12 +8,12 @@ import expo.modules.kotlin.types.DynamicAwareTypeConverters
 import java.io.File
 
 class FileTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<File>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): File {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): File {
     val path = value.asString()
     return File(path)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): File {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): File {
     val path = value as String
     return File(path)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/io/PathTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/io/PathTypeConverter.kt
@@ -12,12 +12,12 @@ import java.nio.file.Paths
 
 @RequiresApi(Build.VERSION_CODES.O)
 class PathTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Path>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Path {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Path {
     val stringPath = value.asString()
     return Paths.get(stringPath)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): Path {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Path {
     val stringPath = value as String
     return Paths.get(stringPath)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/URLTypConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/URLTypConverter.kt
@@ -8,12 +8,12 @@ import expo.modules.kotlin.types.DynamicAwareTypeConverters
 import java.net.URL
 
 class URLTypConverter(isOptional: Boolean) : DynamicAwareTypeConverters<URL>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): URL {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): URL {
     val stringURL = value.asString()
     return URL(stringURL)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): URL {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): URL {
     val stringURL = value as String
     return URL(stringURL)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/UriTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/UriTypeConverter.kt
@@ -7,16 +7,17 @@ import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.types.DynamicAwareTypeConverters
 import java.net.URI
+import androidx.core.net.toUri
 
 class UriTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Uri>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): Uri {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Uri {
     val stringUri = value.asString()
-    return Uri.parse(stringUri)
+    return stringUri.toUri()
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): Uri {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Uri {
     val stringUri = value as String
-    return Uri.parse(stringUri)
+    return stringUri.toUri()
   }
 
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.STRING)
@@ -25,12 +26,12 @@ class UriTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Uri>(is
 }
 
 class JavaURITypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<URI>(isOptional) {
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?): URI {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): URI {
     val stringUri = value.asString()
     return URI.create(stringUri)
   }
 
-  override fun convertFromAny(value: Any, context: AppContext?): URI {
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): URI {
     val stringUri = value as String
     return URI.create(stringUri)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewTypeConverter.kt
@@ -15,7 +15,7 @@ class ViewTypeConverter<T : View>(
   val type: KType
 ) : TypeConverter<T>() {
 
-  override fun convert(value: Any?, context: AppContext?): T? {
+  override fun convert(value: Any?, context: AppContext?, forceConversion: Boolean): T? {
     val appContext = context.toStrongReference()
     appContext.assertMainThread()
 


### PR DESCRIPTION
# Why

Handles conflicting custom type converter.

When your custom type converter can handle multiple input types, there is a chance that those types can conflict. For example, if you add conversion from `List<Int>` to a custom type and from `List<String>` to the same type, we can decide based on type which converter should be triggered. The only information that we have on the native side is that we're dealing with List.

# How

I've changed how the conversion chain:
Before:
- js -> cpp converter -> custom converter

Now:
- js -> cpp converter -> default kotlin converter (if needed) -> custom converter 

I've also added a new flag, `forceConversion`, which will trigger Kotlin converters even if they are trivial, to ensure that the expected type aligns with the type from the user's custom converter.

# Test Plan

- unit tests ✅ 