### PR TITLE
[docs][notifications] highlight setup instructions in installation section

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -49,6 +49,10 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 <APIInstallSection />
 
+<br />
+Then proceed to [configuration](#configuration) to set up the [config plugin](#app-config) and
+obtain the [credentials](#credentials) for push notifications.
+
 ## Usage
 
 Check out the example Snack below to see Notifications in action, make sure to use a physical device to test it. Push notifications don't work on emulators/simulators.

--- a/docs/pages/versions/v53.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/notifications.mdx
@@ -49,6 +49,10 @@ import { PlatformTags } from '~/ui/components/Tag/PlatformTags';
 
 <APIInstallSection />
 
+<br />
+Then proceed to [configuration](#configuration) to set up the [config plugin](#app-config) and
+obtain the [credentials](#credentials) for push notifications.
+
 ## Usage
 
 Check out the example Snack below to see Notifications in action, make sure to use a physical device to test it. Push notifications don't work on emulators/simulators.


### PR DESCRIPTION
# Why

Added a clearer navigation path in the Notifications documentation to help users understand the setup process for push notifications.

# How

Added a line of text with links to the configuration section, config plugin, and credentials sections after the installation instructions in the Notifications documentation.

# Test Plan

tested locally

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)