### PR TITLE
[docs] Reduce Sentry sample rate

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -40,9 +40,9 @@ Sentry.init({
     /https:\/\/expo\.nodejs\.cn/,
   ],
   integrations: [Sentry.browserTracingIntegration(), Sentry.extraErrorDataIntegration()],
-  tracesSampleRate: 0.002,
-  replaysSessionSampleRate: 0.0001,
-  replaysOnErrorSampleRate: 0.05,
+  tracesSampleRate: 0.0001,
+  replaysSessionSampleRate: 0.000005,
+  replaysOnErrorSampleRate: 0.002,
 });
 
 await import('@sentry/react').then(lazyLoadedSentry => {


### PR DESCRIPTION
Why
===
Address quota alerts by reducing the sampling rate for performance metrics and replays.

How
===
Reduce performance metrics by 20x (tracesSampleRate) and replays by about 20x as well (replaysSessionSampleRate) to have ample headroom.

Test Plan
===
None, relying on lint/visual inspection for this config change.
