### PR TITLE
[maps][docs] Fix config plugin example in reference

### DIFF
--- a/docs/pages/versions/v52.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/maps.mdx
@@ -110,7 +110,7 @@ To display the user's location on the map, you need to declare and request locat
       [
         "expo-maps",
         {
-          "requestLocationPermission": "true",
+          "requestLocationPermission": true,
           "locationPermission": "Allow $(PRODUCT_NAME) to use your location"
         }
       ]

--- a/docs/pages/versions/v53.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/maps.mdx
@@ -110,7 +110,7 @@ To display the user's location on the map, you need to declare and request locat
       [
         "expo-maps",
         {
-          "requestLocationPermission": "true",
+          "requestLocationPermission": true,
           "locationPermission": "Allow $(PRODUCT_NAME) to use your location"
         }
       ]


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #36995

# How

<!--
How did you build this feature or fix this bug and why?
-->

As stated in #36995, the config plugin example in Expo Maps reference when utilizing `requestLocationPermission`, its value should be a boolean instead of a string.

Follow up changes for SDK 53, and 52 references.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
