### PR TITLE
have the option to select what device to open app on

### DIFF
--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -6,7 +6,7 @@
   "version": "53.0.27",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
+    "android": "expo start --android --device",
     "ios": "expo start --ios",
     "web": "expo start --web",
     "test": "jest --watchAll"


### PR DESCRIPTION
# Why

<!--
So if my phone doesn't connect to my PC, then it auto runs the emulator which I don't want I would like to choose first
-->

# How

<!--
added --device next to android don't know about ios tho
-->

# Test Plan

<!--
I have used this multiple time with my project and seems to work
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
