### PR TITLE
[docs] Add DNS instructions for wildcard subdomains and further explanations of DNS records for EAS Hosting

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -76,6 +76,7 @@ exceptions:
   - '.*Developer Mode.*'
   - '.*Dynamic.*'
   - '.*detach.*'
+  - '.*DNS.*'
   - '.*E2E.*'
   - '.*EAS.*'
   - '.*EAS Build.*'

--- a/docs/pages/eas/hosting/custom-domain.mdx
+++ b/docs/pages/eas/hosting/custom-domain.mdx
@@ -72,8 +72,7 @@ Both of these records are equivalent, however some DNS providers do not allow CN
 
 > **info** If you had a custom domains set up already before **19 March 2025**, you must press the "Refresh" button in your project's [Hosting settings](https://expo.dev/accounts/[accountName]/projects/[projectName]/hosting/settings) before following instructions for setting up wildcard domains.
 
-After following the above steps, your custom domain will handle requests and is assigned to the production deployment.
-You can set up further subdomain DNS records to handle requests for other aliases than the production alias.
+While only a single custom domain can be set up per project, you can set up further subdomain DNS records to handle requests for other aliases than just the production alias.
 As long as a subdomain record is set up with a label that matches an alias in your hosting project, requests will be handled by that alias' deployment.
 
 For example, after [creating a `staging` alias](/eas/hosting/deployments-and-aliases/#aliases), you may set up CNAME record for your alias:

--- a/docs/pages/eas/hosting/custom-domain.mdx
+++ b/docs/pages/eas/hosting/custom-domain.mdx
@@ -44,7 +44,8 @@ You will need to own a domain name you want to use.
 5. Press the refresh button until all checks pass. Depending on your DNS provider, this step usually only takes a couple of minutes.
 
 > If you require for the domain name switchover to be **zero downtime**, it's important to fill out these records one by one in the order they are presented in the table.
-> That is, add the **TXT** record for verification, press the refresh button until the UI says verification is successful, then proceed to the next one.
+> That is, add the **Verification TXT** record first, and press "Refresh" until the UI confirms the verification record. Then add the **SSL CNAME** record next until
+> it is confirmed, and set up the third record last.
 > If downtime isn't important or relevant, you may add all three DNS records at once.
 
 After assigning a custom domain to your app, the custom domain will route to your **production** deployment.

--- a/docs/pages/eas/hosting/custom-domain.mdx
+++ b/docs/pages/eas/hosting/custom-domain.mdx
@@ -68,7 +68,7 @@ Lastly, the third DNS entry that the dashboard presents will always be the actua
 
 Both of these records are equivalent, however some DNS providers do not allow CNAME records to be set up on apex domains.
 
-### Wildcard Subdomains
+### Alias and wildcard subdomains
 
 > **info** If you had a custom domains set up already before **19 March 2025**, you must press the "Refresh" button in your project's [Hosting settings](https://expo.dev/accounts/[accountName]/projects/[projectName]/hosting/settings) before following instructions for setting up wildcard domains.
 

--- a/docs/pages/eas/hosting/custom-domain.mdx
+++ b/docs/pages/eas/hosting/custom-domain.mdx
@@ -49,3 +49,39 @@ You will need to own a domain name you want to use.
 > If downtime isn't important or relevant, you may add all three DNS records at once.
 
 After assigning a custom domain to your app, the custom domain will route to your **production** deployment.
+
+### Custom Domain DNS Records
+
+Two of the three records the dashboard presents you are to validate ownership of your domain.
+The **Verification TXT** record proves ownership of your domain, since it adds a custom token that can be read back to verify you're setting the domain up on a domain you control.
+The **SSL CNAME** record proves ownership of your domain to a certificate authority, also known as Domain Control Validation (DCV). This is a CNAME record because both renewal and validation is delegated to an automated process, which prevents certificates from expiring.
+
+Both records are created on a subdomain of the custom domain you're setting up.
+- If you're setting up `example.com`, the records must be created on `_cf-custom-hostname.example.com` and `_acme-challenge.example.com` respectively
+- If you're setting up `anything.example.com`, the records must be created on `_cf-custom-hostname.anything.example.com` and `_acme-challenge.example.com` respectively
+
+Lastly, the third DNS entry that the dashboard presents will always be the actual DNS record that points your domain at EAS Hosting.
+- For apex domains the dashboard typically recommends an **A record** to `172.66.0.241`
+- For subdomains, the dashboard typically recommends a **CNAME record** to `fallback.expo.app`
+
+Both of these records are equivalent, however some DNS providers do not allow CNAME records to be set up on apex domains.
+
+### Wildcard Subdomains
+
+> **info** If you had a custom domains set up already before **19 March 2025**, you must press the "Refresh" button in your project's [Hosting settings](https://expo.dev/accounts/[accountName]/projects/[projectName]/hosting/settings) before following instructions for setting up wildcard domains.
+
+After following the above steps, your custom domain will handle requests and is assigned to the production deployment.
+You can set up further subdomain DNS records to handle requests for other aliases than the production alias.
+As long as a subdomain record is set up with a label that matches an alias in your hosting project, requests will be handled by that alias' deployment.
+
+For example, after [creating a `staging` alias](/eas/hosting/deployments-and-aliases/#aliases), you may set up CNAME record for your alias:
+- If you've set up an apex domain, for example `example.com`, create a CNAME record on `staging.example.com` set to `fallback.expo.app`
+- If you've set up subdomain domain, for example `anything.example.com`, create a CNAME record on `staging.anything.example.com` set to `fallback.expo.app`
+
+If you'd like to direct any subdomain request to any alias you've created, you may instead set up a wildcard CNAME record:
+- If you've set up an apex domain, for example `example.com`, create a CNAME record on `*.example.com` set to `fallback.expo.app`
+- If you've set up subdomain domain, for example `anything.example.com`, create a CNAME record on `*.anything.example.com` set to `fallback.expo.app`
+
+A wildcard CNAME record always starts with `*` and stands for any subdomain. As long as subdomains on your custom domain are set to `fallback.expo.app`, EAS Hosting will attempt to send the request to the deployment assigned to an alias with a matching name.
+
+The exception are `www` subdomains. If you've set up a `www` subdomain, and no alias named `www` exists, the request will be redirect to the custom domain with a 308 response and be treated as request to the production deployment. If you wish to only set up an automatic redirection for the `www` subdomain on your custom domain, create a CNAME record on `www.<yourdomain>` set to `fallback.expo.app`.

--- a/docs/pages/eas/hosting/custom-domain.mdx
+++ b/docs/pages/eas/hosting/custom-domain.mdx
@@ -63,7 +63,7 @@ Both records are created on a subdomain of the custom domain you're setting up.
 
 Lastly, the third DNS entry that the dashboard presents will always be the actual DNS record that points your domain at EAS Hosting.
 
-- For apex domains the dashboard typically recommends an **A record** to `172.66.0.241`
+- For apex domains, the dashboard typically recommends an **A record** to `172.66.0.241`
 - For subdomains, the dashboard typically recommends a **CNAME record** to `fallback.expo.app`
 
 Both of these records are equivalent, however some DNS providers do not allow CNAME records to be set up on apex domains.
@@ -83,8 +83,8 @@ For example, after [creating a `staging` alias](/eas/hosting/deployments-and-ali
 If you'd like to direct any subdomain request to any alias you've created, you may instead set up a wildcard CNAME record:
 
 - If you've set up an apex domain, for example `example.com`, create a CNAME record on `*.example.com` set to `fallback.expo.app`
-- If you've set up subdomain domain, for example `anything.example.com`, create a CNAME record on `*.anything.example.com` set to `fallback.expo.app`
+- If you've set up a subdomain domain, for example `anything.example.com`, create a CNAME record on `*.anything.example.com` set to `fallback.expo.app`
 
 A wildcard CNAME record always starts with `*` and stands for any subdomain. As long as subdomains on your custom domain are set to `fallback.expo.app`, EAS Hosting will attempt to send the request to the deployment assigned to an alias with a matching name.
 
-The exception are `www` subdomains. If you've set up a `www` subdomain, and no alias named `www` exists, the request will be redirect to the custom domain with a 308 response and be treated as request to the production deployment. If you wish to only set up an automatic redirection for the `www` subdomain on your custom domain, create a CNAME record on `www.<yourdomain>` set to `fallback.expo.app`.
+The exceptions are `www` subdomains. If you've set up a `www` subdomain, and no alias named `www` exists, the request will be redirected to the custom domain with a 308 response and be treated as a request to the production deployment. If you wish to only set up an automatic redirection for the `www` subdomain on your custom domain, create a CNAME record on `www.<yourdomain>` set to `fallback.expo.app`.

--- a/docs/pages/eas/hosting/custom-domain.mdx
+++ b/docs/pages/eas/hosting/custom-domain.mdx
@@ -50,17 +50,19 @@ You will need to own a domain name you want to use.
 
 After assigning a custom domain to your app, the custom domain will route to your **production** deployment.
 
-### Custom Domain DNS Records
+### Custom domain DNS records
 
 Two of the three records the dashboard presents you are to validate ownership of your domain.
 The **Verification TXT** record proves ownership of your domain, since it adds a custom token that can be read back to verify you're setting the domain up on a domain you control.
 The **SSL CNAME** record proves ownership of your domain to a certificate authority, also known as Domain Control Validation (DCV). This is a CNAME record because both renewal and validation is delegated to an automated process, which prevents certificates from expiring.
 
 Both records are created on a subdomain of the custom domain you're setting up.
+
 - If you're setting up `example.com`, the records must be created on `_cf-custom-hostname.example.com` and `_acme-challenge.example.com` respectively
 - If you're setting up `anything.example.com`, the records must be created on `_cf-custom-hostname.anything.example.com` and `_acme-challenge.example.com` respectively
 
 Lastly, the third DNS entry that the dashboard presents will always be the actual DNS record that points your domain at EAS Hosting.
+
 - For apex domains the dashboard typically recommends an **A record** to `172.66.0.241`
 - For subdomains, the dashboard typically recommends a **CNAME record** to `fallback.expo.app`
 
@@ -75,10 +77,12 @@ You can set up further subdomain DNS records to handle requests for other aliase
 As long as a subdomain record is set up with a label that matches an alias in your hosting project, requests will be handled by that alias' deployment.
 
 For example, after [creating a `staging` alias](/eas/hosting/deployments-and-aliases/#aliases), you may set up CNAME record for your alias:
+
 - If you've set up an apex domain, for example `example.com`, create a CNAME record on `staging.example.com` set to `fallback.expo.app`
 - If you've set up subdomain domain, for example `anything.example.com`, create a CNAME record on `staging.anything.example.com` set to `fallback.expo.app`
 
 If you'd like to direct any subdomain request to any alias you've created, you may instead set up a wildcard CNAME record:
+
 - If you've set up an apex domain, for example `example.com`, create a CNAME record on `*.example.com` set to `fallback.expo.app`
 - If you've set up subdomain domain, for example `anything.example.com`, create a CNAME record on `*.anything.example.com` set to `fallback.expo.app`
 

--- a/docs/pages/eas/hosting/custom-domain.mdx
+++ b/docs/pages/eas/hosting/custom-domain.mdx
@@ -59,7 +59,7 @@ The **SSL CNAME** record proves ownership of your domain to a certificate author
 Both records are created on a subdomain of the custom domain you're setting up.
 
 - If you're setting up `example.com`, the records must be created on `_cf-custom-hostname.example.com` and `_acme-challenge.example.com` respectively
-- If you're setting up `anything.example.com`, the records must be created on `_cf-custom-hostname.anything.example.com` and `_acme-challenge.example.com` respectively
+- If you're setting up `anything.example.com`, the records must be created on `_cf-custom-hostname.anything.example.com` and `_acme-challenge.anything.example.com` respectively
 
 Lastly, the third DNS entry that the dashboard presents will always be the actual DNS record that points your domain at EAS Hosting.
 
@@ -70,10 +70,10 @@ Both of these records are equivalent, however some DNS providers do not allow CN
 
 ### Alias and wildcard subdomains
 
-> **info** If you had a custom domains set up already before **19 March 2025**, you must press the "Refresh" button in your project's [Hosting settings](https://expo.dev/accounts/[accountName]/projects/[projectName]/hosting/settings) before following instructions for setting up wildcard domains.
+> **info** If you had a custom domain set up already before **March 19, 2025**, you must press the "Refresh" button in your project's [Hosting settings](https://expo.dev/accounts/[accountName]/projects/[projectName]/hosting/settings) before following instructions for setting up wildcard domains.
 
 While only a single custom domain can be set up per project, you can set up further subdomain DNS records to handle requests for other aliases than just the production alias.
-As long as a subdomain record is set up with a label that matches an alias in your hosting project, requests will be handled by that alias' deployment.
+Requests will be routed to the deployment whose alias matches the subdomain.
 
 For example, after [creating a `staging` alias](/eas/hosting/deployments-and-aliases/#aliases), you may set up CNAME record for your alias:
 


### PR DESCRIPTION
# Why

We've added support for wildcard records to EAS Hosting and now handle:
- `www.<customdomain>` redirection to `<customdomain>` i.e. production/origin redirection
- `<alias>.<customdomain>` handling for any alias
- `*.<customdomain>` wildcard record handling for aliases

# How

- Explain what the records are and what they're set to in detail (so people are comfortable diverging from the dashboard's instructions when they add additional records)
- Add note that people need to "Refresh" before following the new wildcard instructions
- Add records needed for all three of the above DNS setups