### PR TITLE
[video][android] Fix video being blank for some sources

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `onFirstFrameRender` not being emitted for sources with `pixelWidthHeightRatio` different than 1. ([#37009](https://github.com/expo/expo/pull/37009) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 2.1.9 — 2025-05-08

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/FirstFrameEventGenerator.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/FirstFrameEventGenerator.kt
@@ -64,7 +64,7 @@ internal class FirstFrameEventGenerator(
 
   private fun isPlayerSurfaceLayoutValid(): Boolean {
     // Sometimes the video size announced by the track will is 1px off the render size.
-    val epsilon = 0.01
+    val epsilon = 0.05
     val player = playerReference.get() ?: run {
       return false
     }
@@ -75,13 +75,14 @@ internal class FirstFrameEventGenerator(
     val surfaceHeight = player.surfaceSize.height
     val sourceWidth = player.videoSize.width
     val sourceHeight = player.videoSize.height
+    val sourcePixelWidthHeightRatio = player.videoSize.pixelWidthHeightRatio
 
     if (surfaceWidth == 0 || surfaceHeight == 0) {
       return false
     }
 
     val surfaceAspectRatio = surfaceWidth.toFloat() / surfaceHeight
-    val trackAspectRatio = sourceWidth.toFloat() / sourceHeight
+    val trackAspectRatio = sourceWidth.toFloat() / sourceHeight * sourcePixelWidthHeightRatio
 
     val videoSizeIsUnknown = sourceWidth == 0 || sourceHeight == 0
     val hasFillContentFit = currentPlayerView.resizeMode == ContentFit.FILL.toResizeMode()


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/36942

Fixes`onFirstFrameRender` not being emitted for sources with `pixelWidthHeightRatio` different than 1. Without this event we never show the video surface.

# How

Include the `pixelWidthHeightRatio` in the calculations for the `onFirstFrameRender` event.

While I was there I also increased the `epsilon` param to `0.05`, turns out that 0.01 may be a bit too low for very low resolution videos (I didn't find any videos that actually break because of this, but I prefer to stay on the safe side).

# Test Plan

Tested in BareExpo on Android 15 emulator

