### PR TITLE
[core][iOS] Add default values to prop definition

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,7 +9,7 @@
 - [iOS] Add module registry encoder for JSON. ([#36677](https://github.com/expo/expo/pull/36677) by [@aleqsio](https://github.com/aleqsio))
 - [Android] New custom Type Converter API ([#36823](https://github.com/expo/expo/pull/36823) by [@jakex7](https://github.com/jakex7))
 - [iOS] Natively support `rgb` color conversions. ([#36914](https://github.com/expo/expo/pull/36914) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Add default values to prop definition.
+- [iOS] Add default values to prop definition. ([#37011](https://github.com/expo/expo/pull/37011) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [iOS] Add module registry encoder for JSON. ([#36677](https://github.com/expo/expo/pull/36677) by [@aleqsio](https://github.com/aleqsio))
 - [Android] New custom Type Converter API ([#36823](https://github.com/expo/expo/pull/36823) by [@jakex7](https://github.com/jakex7))
 - [iOS] Natively support `rgb` color conversions. ([#36914](https://github.com/expo/expo/pull/36914) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Add default values to prop definition.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Api/Factories/ViewFactories.swift
+++ b/packages/expo-modules-core/ios/Api/Factories/ViewFactories.swift
@@ -46,6 +46,22 @@ public func Prop<ViewType: UIView, PropType: AnyArgument>(
   )
 }
 
+/**
+ Creates a view prop that defines its name, default value and setter.
+ */
+public func Prop<ViewType: UIView, PropType: AnyArgument>(
+  _ name: String,
+  _ defaultValue: PropType,
+  @_implicitSelfCapture _ setter: @escaping (ViewType, PropType) -> Void
+) -> ConcreteViewProp<ViewType, PropType> {
+  return ConcreteViewProp(
+    name: name,
+    propType: ~PropType.self,
+    defaultValue: defaultValue,
+    setter: setter
+  )
+}
+
 // MARK: - View lifecycle
 
 /**

--- a/packages/expo-modules-core/ios/Core/Views/ConcreteViewProp.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ConcreteViewProp.swift
@@ -17,6 +17,11 @@ public final class ConcreteViewProp<ViewType: UIView, PropType: AnyArgument>: An
   private let propType: AnyDynamicType
 
   /**
+   Default prop value
+   */
+  private let defaultValue: PropType?
+
+  /**
    Closure to call to set the actual property on the given view.
    */
   private let setter: SetterType
@@ -24,6 +29,14 @@ public final class ConcreteViewProp<ViewType: UIView, PropType: AnyArgument>: An
   internal init(name: String, propType: AnyDynamicType, setter: @escaping SetterType) {
     self.name = name
     self.propType = propType
+    self.defaultValue = nil
+    self.setter = setter
+  }
+
+  internal init(name: String, propType: AnyDynamicType, defaultValue: PropType, setter: @escaping SetterType) {
+    self.name = name
+    self.propType = propType
+    self.defaultValue = defaultValue
     self.setter = setter
   }
 
@@ -35,6 +48,9 @@ public final class ConcreteViewProp<ViewType: UIView, PropType: AnyArgument>: An
     // Given view must be castable to the generic `ViewType` type.
     guard let view = view as? ViewType else {
       throw IncompatibleViewException((propName: name, viewType: ViewType.self))
+    }
+    if Optional.isNil(value), let defaultValue {
+      return setter(view, defaultValue)
     }
     guard let value = try propType.cast(value, appContext: appContext) as? PropType else {
       throw Conversions.CastingException<PropType>(value)


### PR DESCRIPTION
# Why

iOS part of ENG-7136

# How

Instead of using optionals as prop types, provide a way to add the default value.
```patch
-      Prop("placeholderContentFit") { (view, placeholderContentFit: ContentFit?) in
-        view.placeholderContentFit = placeholderContentFit ?? .scaleDown
+      Prop("placeholderContentFit", .scaleDown) { (view, placeholderContentFit: ContentFit) in
+        view.placeholderContentFit = placeholderContentFit
       }
```

# Test Plan

Use the new pattern in the module definition for components like Image or LinearGradient.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
