### PR TITLE
[core][Android] Add default values to prop definition

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -446,6 +446,7 @@ Defines a setter for the view prop of given name.
 #### Arguments
 
 - **name**: `String` — Name of view prop that you want to define a setter.
+- **defaultValue**: `ValueType` — Optional default value used when the setter is called with `null`.
 - **setter**: `(view: ViewType, value: ValueType) -> ()` — Closure that is invoked when the view rerenders.
 
 This property can only be used within a [`View`](#view) closure.
@@ -460,6 +461,24 @@ Prop("background") { (view: UIView, color: UIColor) in
 
 ```kotlin
 Prop("background") { view: View, @ColorInt color: Int ->
+  view.setBackgroundColor(color)
+}
+```
+
+</CodeBlocksTable>
+
+Prop definition with default value.
+
+<CodeBlocksTable>
+
+```swift
+Prop("background", UIColor.black) { (view: UIView, color: UIColor) in
+  view.backgroundColor = color
+}
+```
+
+```kotlin
+Prop("background", Color.BLACK) { view: View, @ColorInt color: Int ->
   view.setBackgroundColor(color)
 }
 ```

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,13 +9,12 @@
 - [iOS] Add module registry encoder for JSON. ([#36677](https://github.com/expo/expo/pull/36677) by [@aleqsio](https://github.com/aleqsio))
 - [Android] New custom Type Converter API ([#36823](https://github.com/expo/expo/pull/36823) by [@jakex7](https://github.com/jakex7))
 - [iOS] Natively support `rgb` color conversions. ([#36914](https://github.com/expo/expo/pull/36914) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Add default values to prop definition. ([#37011](https://github.com/expo/expo/pull/37011) by [@jakex7](https://github.com/jakex7))
+- Add default values to prop definition. ([#37011](https://github.com/expo/expo/pull/37011), [#37013](https://github.com/expo/expo/pull/37013) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 
 - [iOS] Call `createRootViewController` from the `ExpoReactNativeFactoryDelegate`. ([#36787](https://github.com/expo/expo/pull/36787) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Prevent crash on failed networked requests ([#36896](https://github.com/expo/expo/pull/36896) by [@adrum](https://github.com/adrum))
-
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
@@ -12,12 +12,25 @@ class ConcreteViewProp<ViewType : View, PropType>(
   propType: AnyType,
   private val setter: (view: ViewType, prop: PropType) -> Unit
 ) : AnyViewProp(name, propType) {
+  private var defaultValue: PropType? = null
+
+  constructor(
+    name: String,
+    propType: AnyType,
+    defaultValue: PropType,
+    setter: (view: ViewType, prop: PropType) -> Unit
+  ) : this(name, propType, setter) {
+    this.defaultValue = defaultValue
+  }
 
   @Suppress("UNCHECKED_CAST")
   override fun set(prop: Dynamic, onView: View, appContext: AppContext?) {
     exceptionDecorator({
       PropSetException(name, onView::class, it)
     }) {
+      if (prop.isNull && defaultValue != null) {
+        return setter(onView as ViewType, defaultValue as PropType)
+      }
       setter(onView as ViewType, type.convert(prop, appContext) as PropType)
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
@@ -10,7 +10,7 @@ import expo.modules.kotlin.types.AnyType
 open class ConcreteViewProp<ViewType : View, PropType>(
   name: String,
   propType: AnyType,
-  protected val setter: (view: ViewType, prop: PropType) -> Unit,
+  protected val setter: (view: ViewType, prop: PropType) -> Unit
 ) : AnyViewProp(name, propType) {
   @Suppress("UNCHECKED_CAST")
   override fun set(prop: Dynamic, onView: View, appContext: AppContext?) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
@@ -7,33 +7,35 @@ import expo.modules.kotlin.exception.PropSetException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.types.AnyType
 
-class ConcreteViewProp<ViewType : View, PropType>(
+open class ConcreteViewProp<ViewType : View, PropType>(
   name: String,
   propType: AnyType,
-  private val setter: (view: ViewType, prop: PropType) -> Unit
+  protected val setter: (view: ViewType, prop: PropType) -> Unit,
 ) : AnyViewProp(name, propType) {
-  private var defaultValue: PropType? = null
-
-  constructor(
-    name: String,
-    propType: AnyType,
-    defaultValue: PropType,
-    setter: (view: ViewType, prop: PropType) -> Unit
-  ) : this(name, propType, setter) {
-    this.defaultValue = defaultValue
-  }
-
   @Suppress("UNCHECKED_CAST")
   override fun set(prop: Dynamic, onView: View, appContext: AppContext?) {
     exceptionDecorator({
       PropSetException(name, onView::class, it)
     }) {
-      if (prop.isNull && defaultValue != null) {
-        return setter(onView as ViewType, defaultValue as PropType)
-      }
       setter(onView as ViewType, type.convert(prop, appContext) as PropType)
     }
   }
 
   override val isNullable: Boolean = propType.kType.isMarkedNullable
+}
+
+class ConcreteViewPropWithDefault<ViewType : View, PropType>(
+  name: String,
+  propType: AnyType,
+  setter: (view: ViewType, prop: PropType) -> Unit,
+  private val defaultValue: PropType
+) : ConcreteViewProp<ViewType, PropType>(name, propType, setter) {
+  @Suppress("UNCHECKED_CAST")
+  override fun set(prop: Dynamic, onView: View, appContext: AppContext?) {
+    if (prop.isNull) {
+      setter(onView as ViewType, defaultValue)
+      return
+    }
+    super.set(prop, onView, appContext)
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -163,8 +163,6 @@ class ViewDefinitionBuilder<T : View>(
     )
   }
 
-  // Prop("x", 0) { view, prop: Int -> }
-
   inline fun <reified ViewType : View, reified PropType, reified CustomValueType> PropGroup(
     vararg props: Pair<String, CustomValueType>,
     noinline body: (view: ViewType, value: CustomValueType, prop: PropType) -> Unit

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -155,13 +155,15 @@ class ViewDefinitionBuilder<T : View>(
     defaultValue: PropType,
     noinline body: (view: ViewType, prop: PropType) -> Unit
   ) {
-    props[name] = ConcreteViewProp(
+    props[name] = ConcreteViewPropWithDefault(
       name,
       toAnyType<PropType>(),
-      defaultValue,
-      body
+      body,
+      defaultValue
     )
   }
+
+  // Prop("x", 0) { view, prop: Int -> }
 
   inline fun <reified ViewType : View, reified PropType, reified CustomValueType> PropGroup(
     vararg props: Pair<String, CustomValueType>,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -146,6 +146,23 @@ class ViewDefinitionBuilder<T : View>(
     )
   }
 
+  /**
+   * Creates a view prop that defines its name, default value and setter.
+   */
+  @JvmName("PropGeneric")
+  inline fun <reified ViewType : View, reified PropType> Prop(
+    name: String,
+    defaultValue: PropType,
+    noinline body: (view: ViewType, prop: PropType) -> Unit
+  ) {
+    props[name] = ConcreteViewProp(
+      name,
+      toAnyType<PropType>(),
+      defaultValue,
+      body
+    )
+  }
+
   inline fun <reified ViewType : View, reified PropType, reified CustomValueType> PropGroup(
     vararg props: Pair<String, CustomValueType>,
     noinline body: (view: ViewType, value: CustomValueType, prop: PropType) -> Unit


### PR DESCRIPTION
# Why

Android part of ENG-7136, continuation of #37011

# How

Instead of using optionals as prop types, provide a way to add the default value.
```diff
-      Prop("placeholderContentFit") { view: ExpoImageViewWrapper, placeholderContentFit: ContentFit? ->
-         view.placeholderContentFit = placeholderContentFit ?: ContentFit.ScaleDown
+      Prop("placeholderContentFit", ContentFit.ScaleDown) { view: ExpoImageViewWrapper, placeholderContentFit: ContentFit ->
+         view.placeholderContentFit = placeholderContentFit
       }
```

# Test Plan

Use the new pattern in the module definition for components like Image or LinearGradient.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
