### PR TITLE
[video][android] Fix `onFirstFrameRender` not working on Android

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Fix `onFirstFrameRender` not being emitted for sources with `pixelWidthHeightRatio` different than 1. ([#37009](https://github.com/expo/expo/pull/37009) by [@behenate](https://github.com/behenate))
 - [Android] Fix `useExoShutter` prop not being exposed to the JS side. ([#37012](https://github.com/expo/expo/pull/37012) by [@behenate](https://github.com/behenate))
+- [Android] Add missing `onFirstFrameRender` event to the `VideoView` definition. ([#37014](https://github.com/expo/expo/pull/37014) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -363,7 +363,8 @@ private inline fun <reified T : VideoView> ViewDefinitionBuilder<T>.VideoViewCom
     "onPictureInPictureStart",
     "onPictureInPictureStop",
     "onFullscreenEnter",
-    "onFullscreenExit"
+    "onFullscreenExit",
+    "onFirstFrameRender"
   )
   Prop("player") { view: T, player: VideoPlayer ->
     view.videoPlayer = player


### PR DESCRIPTION
# Why

`onFirstFrameRender` wasn't being emitted on Android. It was missing in the ViewDefinition. I think I might have removed it accidentally while resolving merge conflicts in the past.

# How

Added `"onFirstFrameRender"` into the events list.

# Test Plan

Tested in BareExpo on Android
