### PR TITLE
[expo] Rethrow unhandled error

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Call `createRootViewController` from the `ExpoReactNativeFactoryDelegate`. ([#36787](https://github.com/expo/expo/pull/36787) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Re-throw error in `handleInstanceException` if nothing is registered to handle the error.
 
 ### 💡 Others
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Call `createRootViewController` from the `ExpoReactNativeFactoryDelegate`. ([#36787](https://github.com/expo/expo/pull/36787) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Re-throw error in `handleInstanceException` if nothing is registered to handle the error.
+- [Android] Re-throw error in `handleInstanceException` if nothing is registered to handle it. ([#37021](https://github.com/expo/expo/pull/37021) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo/android/src/rn78/main/expo/modules/ExpoReactHostFactory.kt
+++ b/packages/expo/android/src/rn78/main/expo/modules/ExpoReactHostFactory.kt
@@ -68,8 +68,12 @@ object ExpoReactHostFactory {
       get() = reactNativeHostWrapper.packages
 
     override fun handleInstanceException(error: Exception) {
+      val handlers = reactNativeHostWrapper.reactNativeHostHandlers
+      if (handlers.isEmpty()) {
+        throw error
+      }
       val useDeveloperSupport = reactNativeHostWrapper.useDeveloperSupport
-      reactNativeHostWrapper.reactNativeHostHandlers.forEach { handler ->
+      handlers.forEach { handler ->
         handler.onReactInstanceException(useDeveloperSupport, error)
       }
     }


### PR DESCRIPTION
# Why
Closes #37019
Currently, when an error is thrown and we have nothing registered to handle it in `handleInstanceException` we just swallow the error. 

# How
React Natives DefaultReactHostDelegate just rethrows the error so we do the same if there is nothing else registered to handle it.

# Test Plan
In the provided repro. The error is thrown and crashes the app as expected.

