### PR TITLE
[expo] Fix conflict between React Native Web and Reanimated 4 types

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Call `createRootViewController` from the `ExpoReactNativeFactoryDelegate`. ([#36787](https://github.com/expo/expo/pull/36787) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Re-throw error in `handleInstanceException` if nothing is registered to handle it. ([#37021](https://github.com/expo/expo/pull/37021) by [@alanjhughes](https://github.com/alanjhughes))
+- [types] Fix conflict between React Native Web and Reanimated 4 types ([#37024](https://github.com/expo/expo/pull/37024) by [@marklawlor](https://github.com/marklawlor))
 
 ### 💡 Others
 

--- a/packages/expo/types/react-native-web.d.ts
+++ b/packages/expo/types/react-native-web.d.ts
@@ -13,21 +13,21 @@ declare module 'react-native' {
     /** @platform web */
     backdropFilter?: string;
     /** @platform web */
-    animationDelay?: string;
+    animationDelay?: string | string[] | number | number[];
     /** @platform web */
-    animationDirection?: string;
+    animationDirection?: string | string[];
     /** @platform web */
-    animationDuration?: string;
+    animationDuration?: string | string[] | number | number[];
     /** @platform web */
-    animationFillMode?: string;
+    animationFillMode?: string | string[];
     /** @platform web */
-    animationName?: string | any[];
+    animationName?: string | Record<string, any> | (string | Record<string, any>)[];
     /** @platform web */
-    animationIterationCount?: number | 'infinite';
+    animationIterationCount?: number | 'infinite' | (number | 'infinite')[];
     /** @platform web */
-    animationPlayState?: string;
+    animationPlayState?: string | string[];
     /** @platform web */
-    animationTimingFunction?: string;
+    animationTimingFunction?: string | string[];
     /** @platform web */
     backgroundAttachment?: string;
     /** @platform web */
@@ -99,13 +99,13 @@ declare module 'react-native' {
     /** @platform web */
     touchAction?: string;
     /** @platform web */
-    transitionDelay?: string;
+    transitionDelay?: string | string[];
     /** @platform web */
-    transitionDuration?: string;
+    transitionDuration?: string | string[];
     /** @platform web */
-    transitionProperty?: string;
+    transitionProperty?: string | string[];
     /** @platform web */
-    transitionTimingFunction?: string;
+    transitionTimingFunction?: string | Function | (string | Function)[];
     /** @platform web */
     userSelect?: string;
     /** @platform web */
@@ -132,21 +132,21 @@ declare module 'react-native' {
     /** @platform web */
     backdropFilter?: string;
     /** @platform web */
-    animationDelay?: string;
+    animationDelay?: string | string[] | number | number[];
     /** @platform web */
-    animationDirection?: string;
+    animationDirection?: string | string[];
     /** @platform web */
-    animationDuration?: string;
+    animationDuration?: string | string[] | number | number[];
     /** @platform web */
-    animationFillMode?: string;
+    animationFillMode?: string | string[];
     /** @platform web */
-    animationName?: string | any[];
+    animationName?: string | Record<string, any> | (string | Record<string, any>)[];
     /** @platform web */
-    animationIterationCount?: number | 'infinite';
+    animationIterationCount?: number | 'infinite' | (number | 'infinite')[];
     /** @platform web */
-    animationPlayState?: string;
+    animationPlayState?: string | string[];
     /** @platform web */
-    animationTimingFunction?: string;
+    animationTimingFunction?: string | string[];
     /** @platform web */
     backgroundAttachment?: string;
     /** @platform web */
@@ -218,13 +218,13 @@ declare module 'react-native' {
     /** @platform web */
     touchAction?: string;
     /** @platform web */
-    transitionDelay?: string;
+    transitionDelay?: string | string[];
     /** @platform web */
-    transitionDuration?: string;
+    transitionDuration?: string | string[];
     /** @platform web */
-    transitionProperty?: string;
+    transitionProperty?: string | string[];
     /** @platform web */
-    transitionTimingFunction?: string;
+    transitionTimingFunction?: string | Function | (string | Function)[];
     /** @platform web */
     userSelect?: string;
     /** @platform web */


### PR DESCRIPTION
# Why

FIx #34387

The custom `react-native-web` transition and animation types are conflicting with Reanimated 4 types.

https://docs.swmansion.com/react-native-reanimated/docs/next/css-transitions
https://docs.swmansion.com/react-native-reanimated/docs/next/category/animations

# How

This PR simply mixes the two types together. There's no correct answer to fix this, as its plausible that a person could both be using Reanimated 4 and CSS animations in the same project.