### PR TITLE
[expo-go] Replace glide on splashscreen

### DIFF
--- a/apps/expo-go/android/expoview/build.gradle
+++ b/apps/expo-go/android/expoview/build.gradle
@@ -133,7 +133,8 @@ dependencies {
   implementation 'androidx.lifecycle:lifecycle-process:2.8.7'
   implementation 'androidx.compose.foundation:foundation-android:1.7.6'
 
-  implementation 'com.github.bumptech.glide:compose:1.0.0-beta01'
+  implementation 'io.coil-kt.coil3:coil-compose:3.2.0'
+  implementation 'io.coil-kt.coil3:coil-network-okhttp:3.2.0'
   implementation 'androidx.compose.material3:material3:1.4.0-alpha10'
   implementation 'androidx.core:core-splashscreen:1.0.1'
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/legacy/SplashScreenView.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/legacy/SplashScreenView.kt
@@ -4,6 +4,7 @@ package host.exp.exponent.experience.splashscreen.legacy
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.util.Log
 import android.view.ViewGroup
 import android.widget.RelativeLayout
 import androidx.compose.foundation.background
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -22,14 +24,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
-import com.bumptech.glide.integration.compose.GlideImage
-import com.bumptech.glide.integration.compose.placeholder
+import coil3.ImageLoader
+import coil3.compose.AsyncImage
+import coil3.compose.rememberAsyncImagePainter
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import host.exp.expoview.R
 
 // this needs to stay for versioning to work
@@ -80,32 +87,26 @@ fun SplashScreenView(
       verticalArrangement = Arrangement.spacedBy(30.dp),
       horizontalAlignment = Alignment.CenterHorizontally
     ) {
-      SplashScreenImage(
-        resizeMode = SplashScreenImageResizeMode.CONTAIN,
-        imageUrl
-      )
+      SplashScreenImage(imageUrl)
       Text(appName, fontSize = 20.sp, fontWeight = FontWeight.SemiBold)
     }
   }
 }
 
-@OptIn(ExperimentalGlideComposeApi::class)
 @Composable
 fun SplashScreenImage(
-  resizeMode: SplashScreenImageResizeMode,
   imageUrl: String? = null
 ) {
-  val width = 200.dp
-  val height = 200.dp
-
-  GlideImage(
-    model = imageUrl,
+  AsyncImage(
+    model = ImageRequest.Builder(LocalContext.current)
+      .data(imageUrl)
+      .crossfade(true)
+      .build(),
     contentDescription = "Splash Screen Image",
-    contentScale = resizeMode.toContentScale(),
-    loading = placeholder(R.drawable.project_default_icon),
+    contentScale = ContentScale.Fit,
+    placeholder = painterResource(R.drawable.project_default_icon),
     modifier = Modifier
-      .width(width)
-      .height(height)
+      .size(200.dp)
       .background(Color.White)
       .shadow(4.dp, RoundedCornerShape(30.dp))
   )

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/legacy/SplashScreenView.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/splashscreen/legacy/SplashScreenView.kt
@@ -4,7 +4,6 @@ package host.exp.exponent.experience.splashscreen.legacy
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.util.Log
 import android.view.ViewGroup
 import android.widget.RelativeLayout
 import androidx.compose.foundation.background
@@ -12,14 +11,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -32,9 +27,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil3.ImageLoader
 import coil3.compose.AsyncImage
-import coil3.compose.rememberAsyncImagePainter
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import host.exp.expoview.R


### PR DESCRIPTION
# Why
Glides compose integration is in beta and has proven too unstable for us to use. It is currently the leading cause of crashes in expo go on crashlytics so I'm dropping it in favour of coil until its stable. 

# How
Replace glide with coil

# Test Plan
Expo go. The splashscreen behaves as before.

