### PR TITLE
[ios][audio] Fix adding request headers

### DIFF
--- a/apps/native-component-list/src/screens/Audio/expo-audio/AudioScreen.tsx
+++ b/apps/native-component-list/src/screens/Audio/expo-audio/AudioScreen.tsx
@@ -25,6 +25,10 @@ export default function AudioScreen(props: any) {
       <AudioPlayer
         source={{
           uri: 'https://p.scdn.co/mp3-preview/f7a8ab9c5768009b65a30e9162555e8f21046f46?cid=162b7dc01f3a4a2ca32ed3cec83d1e02',
+          headers: {
+            'Test-Header': 'Some-header',
+            Auth: 'Bearer some-token',
+          },
         }}
         style={styles.player}
       />

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Support base64 strings as an audio source. ([#37031](https://github.com/expo/expo/pull/37031) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Correctly add the http headers to the `AVURLAsset`.
+- [iOS] Correctly add the http headers to the `AVURLAsset`. ([#37029](https://github.com/expo/expo/pull/37029) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Support base64 strings as an audio source. ([#37031](https://github.com/expo/expo/pull/37031) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Correctly add the http headers to the `AVURLAsset`.
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioUtils.swift
+++ b/packages/expo-audio/ios/AudioUtils.swift
@@ -117,7 +117,7 @@ struct AudioUtils {
     if let headers = source.headers {
       options = ["AVURLAssetHTTPHeaderFieldsKey": headers]
     }
-    
+
     let asset = AVURLAsset(url: finalUrl, options: options)
     return AVPlayerItem(asset: asset)
   }

--- a/packages/expo-audio/ios/AudioUtils.swift
+++ b/packages/expo-audio/ios/AudioUtils.swift
@@ -90,7 +90,13 @@ struct AudioUtils {
       } else {
         url
       }
-      let asset = AVURLAsset(url: finalUrl, options: source.headers)
+
+      var options: [String: Any]?
+      if let headers = source.headers {
+        options = ["AVURLAssetHTTPHeaderFieldsKey": headers]
+      }
+
+      let asset = AVURLAsset(url: finalUrl, options: options)
       let item = AVPlayerItem(asset: asset)
       return AVPlayer(playerItem: item)
     }
@@ -106,7 +112,13 @@ struct AudioUtils {
     } else {
       url
     }
-    let asset = AVURLAsset(url: finalUrl, options: source.headers)
+
+    var options: [String: Any]?
+    if let headers = source.headers {
+      options = ["AVURLAssetHTTPHeaderFieldsKey": headers]
+    }
+    
+    let asset = AVURLAsset(url: finalUrl, options: options)
     return AVPlayerItem(asset: asset)
   }
 


### PR DESCRIPTION
# Why
Closes #37044
The headers were not being correctly added to the `AVURLAsset`s request. 

# How
Add the headers using the correct key in the `options` dictionary.

# Test Plan
Bare expo. Inspecting the request shows the headers are present. 

