### PR TITLE
[ios][audio] Handle base64 audio source

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Support base64 strings as an audio source.
+
 ### 💡 Others
 
 ## 0.4.5 — 2025-05-08

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Support base64 strings as an audio source.
+- [iOS] Support base64 strings as an audio source. ([#37031](https://github.com/expo/expo/pull/37031) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioUtils.swift
+++ b/packages/expo-audio/ios/AudioUtils.swift
@@ -164,7 +164,6 @@ struct AudioUtils {
       try data.write(to: fileURL)
       return fileURL
     } catch {
-      print("Error saving base64 data to file: \(error)")
       return nil
     }
   }

--- a/packages/expo-audio/ios/AudioUtils.swift
+++ b/packages/expo-audio/ios/AudioUtils.swift
@@ -85,7 +85,12 @@ struct AudioUtils {
 
   static func createAVPlayer(from source: AudioSource?) -> AVPlayer {
     if let source, let url = source.uri {
-      let asset = AVURLAsset(url: url, options: source.headers)
+      let finalUrl = if url.isBase64Audio {
+        handleBase64Asset(base64String: url.absoluteString) ?? url
+      } else {
+        url
+      }
+      let asset = AVURLAsset(url: finalUrl, options: source.headers)
       let item = AVPlayerItem(asset: asset)
       return AVPlayer(playerItem: item)
     }
@@ -96,7 +101,12 @@ struct AudioUtils {
     guard let source, let url = source.uri else {
       return nil
     }
-    let asset = AVURLAsset(url: url, options: source.headers)
+    let finalUrl = if url.isBase64Audio {
+      handleBase64Asset(base64String: url.absoluteString) ?? url
+    } else {
+      url
+    }
+    let asset = AVURLAsset(url: finalUrl, options: source.headers)
     return AVPlayerItem(asset: asset)
   }
 
@@ -133,6 +143,39 @@ struct AudioUtils {
     return settings
   }
 
+  private static func handleBase64Asset(base64String: String) -> URL? {
+    let components = base64String.components(separatedBy: ",")
+    guard components.count == 2 else {
+      return nil
+    }
+    let mimeType = components[0].components(separatedBy: ";")[0].components(separatedBy: ":")[1]
+    let base64Data = components[1]
+
+    guard let data = Data(base64Encoded: base64Data, options: .ignoreUnknownCharacters) else {
+      return nil
+    }
+
+    let fileExtension = getFileExtension(for: mimeType)
+    let tempDirectory = FileManager.default.temporaryDirectory
+    let fileName = UUID().uuidString + "." + fileExtension
+    let fileURL = tempDirectory.appendingPathComponent(fileName)
+
+    do {
+      try data.write(to: fileURL)
+      return fileURL
+    } catch {
+      print("Error saving base64 data to file: \(error)")
+      return nil
+    }
+  }
+
+  static func getFileExtension(for mimeType: String) -> String {
+    if let utType = UTType(mimeType: mimeType) {
+      return utType.preferredFilenameExtension ?? "dat"
+    }
+    return "dat"
+  }
+
   private static func createRecordingUrl(from dir: URL, with options: RecordingOptions) -> URL {
     let directoryPath = dir.appendingPathComponent("ExpoAudio")
     FileSystemUtilities.ensureDirExists(at: directoryPath)
@@ -158,5 +201,11 @@ struct AudioUtils {
     if !mode.playsInSilentMode && mode.shouldPlayInBackground {
       throw InvalidAudioModeException("playsInSilentMode == false and staysActiveInBackground == true cannot be set on iOS.")
     }
+  }
+}
+
+private extension URL {
+  var isBase64Audio: Bool {
+    return absoluteString.hasPrefix("data:audio/")
   }
 }


### PR DESCRIPTION
# Why
Closes #37018
Recurrence of an issue in expo-av #24711

# How
Write the data to a temporary file and use that as the audio url for the asset.

# Test Plan
In the provided repro. base64 strings are handled correctly

