### PR TITLE
[rn-0.80.0.rc-2] upgraded to RN 0.80.0.rc-2

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -59,6 +59,7 @@ PODS:
     - ExpoModulesCore
     - ExpoModulesTestCore
   - Expo (53.0.9):
+    - boost
     - DoubleConversion
     - ExpoModulesCore
     - fast_float
@@ -574,6 +575,7 @@ PODS:
   - ExpoMeshGradient (0.3.4):
     - ExpoModulesCore
   - ExpoModulesCore (2.3.13):
+    - boost
     - DoubleConversion
     - fast_float
     - fmt
@@ -603,6 +605,7 @@ PODS:
     - SocketRocket
     - Yoga
   - ExpoModulesCore/Tests (2.3.13):
+    - boost
     - DoubleConversion
     - ExpoModulesTestCore
     - fast_float
@@ -709,6 +712,7 @@ PODS:
     - ExpoModulesCore
     - UMAppLoader
   - EXUpdates (0.28.13):
+    - boost
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -743,6 +747,7 @@ PODS:
     - SocketRocket
     - Yoga
   - EXUpdates/Tests (0.28.13):
+    - boost
     - DoubleConversion
     - EASClient
     - EXManifests
@@ -780,12 +785,12 @@ PODS:
   - EXUpdatesInterface (1.1.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.80.0-rc.1)
+  - FBLazyVector (0.80.0-rc.2)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.80.0-rc.1):
-    - hermes-engine/Pre-built (= 0.80.0-rc.1)
-  - hermes-engine/Pre-built (0.80.0-rc.1)
+  - hermes-engine (0.80.0-rc.2):
+    - hermes-engine/Pre-built (= 0.80.0-rc.2)
+  - hermes-engine/Pre-built (0.80.0-rc.2)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -868,28 +873,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.80.0-rc.1)
-  - RCTRequired (0.80.0-rc.1)
-  - RCTTypeSafety (0.80.0-rc.1):
-    - FBLazyVector (= 0.80.0-rc.1)
-    - RCTRequired (= 0.80.0-rc.1)
-    - React-Core (= 0.80.0-rc.1)
+  - RCTDeprecation (0.80.0-rc.2)
+  - RCTRequired (0.80.0-rc.2)
+  - RCTTypeSafety (0.80.0-rc.2):
+    - FBLazyVector (= 0.80.0-rc.2)
+    - RCTRequired (= 0.80.0-rc.2)
+    - React-Core (= 0.80.0-rc.2)
   - ReachabilitySwift (5.2.4)
-  - React (0.80.0-rc.1):
-    - React-Core (= 0.80.0-rc.1)
-    - React-Core/DevSupport (= 0.80.0-rc.1)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.1)
-    - React-RCTActionSheet (= 0.80.0-rc.1)
-    - React-RCTAnimation (= 0.80.0-rc.1)
-    - React-RCTBlob (= 0.80.0-rc.1)
-    - React-RCTImage (= 0.80.0-rc.1)
-    - React-RCTLinking (= 0.80.0-rc.1)
-    - React-RCTNetwork (= 0.80.0-rc.1)
-    - React-RCTSettings (= 0.80.0-rc.1)
-    - React-RCTText (= 0.80.0-rc.1)
-    - React-RCTVibration (= 0.80.0-rc.1)
-  - React-callinvoker (0.80.0-rc.1)
-  - React-Core (0.80.0-rc.1):
+  - React (0.80.0-rc.2):
+    - React-Core (= 0.80.0-rc.2)
+    - React-Core/DevSupport (= 0.80.0-rc.2)
+    - React-Core/RCTWebSocket (= 0.80.0-rc.2)
+    - React-RCTActionSheet (= 0.80.0-rc.2)
+    - React-RCTAnimation (= 0.80.0-rc.2)
+    - React-RCTBlob (= 0.80.0-rc.2)
+    - React-RCTImage (= 0.80.0-rc.2)
+    - React-RCTLinking (= 0.80.0-rc.2)
+    - React-RCTNetwork (= 0.80.0-rc.2)
+    - React-RCTSettings (= 0.80.0-rc.2)
+    - React-RCTText (= 0.80.0-rc.2)
+    - React-RCTVibration (= 0.80.0-rc.2)
+  - React-callinvoker (0.80.0-rc.2)
+  - React-Core (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -899,7 +904,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.1)
+    - React-Core/Default (= 0.80.0-rc.2)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -913,79 +918,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.1)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.1)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.80.0-rc.1):
+  - React-Core/CoreModulesHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1009,7 +942,55 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.80.0-rc.1):
+  - React-Core/Default (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0-rc.2)
+    - React-Core/RCTWebSocket (= 0.80.0-rc.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1033,7 +1014,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.80.0-rc.1):
+  - React-Core/RCTAnimationHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1057,7 +1038,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.80.0-rc.1):
+  - React-Core/RCTBlobHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1081,7 +1062,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.80.0-rc.1):
+  - React-Core/RCTImageHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1105,7 +1086,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.80.0-rc.1):
+  - React-Core/RCTLinkingHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1129,7 +1110,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.80.0-rc.1):
+  - React-Core/RCTNetworkHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1153,7 +1134,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.80.0-rc.1):
+  - React-Core/RCTSettingsHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1177,7 +1158,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.80.0-rc.1):
+  - React-Core/RCTTextHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1201,7 +1182,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.80.0-rc.1):
+  - React-Core/RCTVibrationHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1211,7 +1192,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.1)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -1225,7 +1206,31 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.80.0-rc.1):
+  - React-Core/RCTWebSocket (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0-rc.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1233,19 +1238,19 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.80.0-rc.1)
-    - React-Core/CoreModulesHeaders (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - RCTTypeSafety (= 0.80.0-rc.2)
+    - React-Core/CoreModulesHeaders (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.80.0-rc.1)
+    - React-RCTImage (= 0.80.0-rc.2)
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.80.0-rc.1):
+  - React-cxxreact (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1254,19 +1259,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-debug (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-debug (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
-    - React-runtimeexecutor (= 0.80.0-rc.1)
-    - React-timing (= 0.80.0-rc.1)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
+    - React-runtimeexecutor (= 0.80.0-rc.2)
+    - React-timing (= 0.80.0-rc.2)
     - SocketRocket
-  - React-debug (0.80.0-rc.1)
-  - React-defaultsnativemodule (0.80.0-rc.1):
+  - React-debug (0.80.0-rc.2)
+  - React-defaultsnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1284,7 +1289,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.80.0-rc.1):
+  - React-domnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1303,7 +1308,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.80.0-rc.1):
+  - React-Fabric (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1317,22 +1322,22 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.80.0-rc.1)
-    - React-Fabric/attributedstring (= 0.80.0-rc.1)
-    - React-Fabric/componentregistry (= 0.80.0-rc.1)
-    - React-Fabric/componentregistrynative (= 0.80.0-rc.1)
-    - React-Fabric/components (= 0.80.0-rc.1)
-    - React-Fabric/consistency (= 0.80.0-rc.1)
-    - React-Fabric/core (= 0.80.0-rc.1)
-    - React-Fabric/dom (= 0.80.0-rc.1)
-    - React-Fabric/imagemanager (= 0.80.0-rc.1)
-    - React-Fabric/leakchecker (= 0.80.0-rc.1)
-    - React-Fabric/mounting (= 0.80.0-rc.1)
-    - React-Fabric/observers (= 0.80.0-rc.1)
-    - React-Fabric/scheduler (= 0.80.0-rc.1)
-    - React-Fabric/telemetry (= 0.80.0-rc.1)
-    - React-Fabric/templateprocessor (= 0.80.0-rc.1)
-    - React-Fabric/uimanager (= 0.80.0-rc.1)
+    - React-Fabric/animations (= 0.80.0-rc.2)
+    - React-Fabric/attributedstring (= 0.80.0-rc.2)
+    - React-Fabric/componentregistry (= 0.80.0-rc.2)
+    - React-Fabric/componentregistrynative (= 0.80.0-rc.2)
+    - React-Fabric/components (= 0.80.0-rc.2)
+    - React-Fabric/consistency (= 0.80.0-rc.2)
+    - React-Fabric/core (= 0.80.0-rc.2)
+    - React-Fabric/dom (= 0.80.0-rc.2)
+    - React-Fabric/imagemanager (= 0.80.0-rc.2)
+    - React-Fabric/leakchecker (= 0.80.0-rc.2)
+    - React-Fabric/mounting (= 0.80.0-rc.2)
+    - React-Fabric/observers (= 0.80.0-rc.2)
+    - React-Fabric/scheduler (= 0.80.0-rc.2)
+    - React-Fabric/telemetry (= 0.80.0-rc.2)
+    - React-Fabric/templateprocessor (= 0.80.0-rc.2)
+    - React-Fabric/uimanager (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1344,32 +1349,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.80.0-rc.1):
+  - React-Fabric/animations (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1394,7 +1374,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.80.0-rc.1):
+  - React-Fabric/attributedstring (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1419,7 +1399,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.80.0-rc.1):
+  - React-Fabric/componentregistry (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1444,36 +1424,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0-rc.1)
-    - React-Fabric/components/root (= 0.80.0-rc.1)
-    - React-Fabric/components/scrollview (= 0.80.0-rc.1)
-    - React-Fabric/components/view (= 0.80.0-rc.1)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.80.0-rc.1):
+  - React-Fabric/componentregistrynative (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1498,7 +1449,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.80.0-rc.1):
+  - React-Fabric/components (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0-rc.2)
+    - React-Fabric/components/root (= 0.80.0-rc.2)
+    - React-Fabric/components/scrollview (= 0.80.0-rc.2)
+    - React-Fabric/components/view (= 0.80.0-rc.2)
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1523,7 +1503,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.80.0-rc.1):
+  - React-Fabric/components/root (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1548,7 +1528,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.80.0-rc.1):
+  - React-Fabric/components/scrollview (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1575,7 +1580,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.80.0-rc.1):
+  - React-Fabric/consistency (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1600,7 +1605,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.80.0-rc.1):
+  - React-Fabric/core (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1625,7 +1630,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.80.0-rc.1):
+  - React-Fabric/dom (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1650,7 +1655,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.80.0-rc.1):
+  - React-Fabric/imagemanager (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1675,7 +1680,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.80.0-rc.1):
+  - React-Fabric/leakchecker (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1700,7 +1705,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.80.0-rc.1):
+  - React-Fabric/mounting (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1725,7 +1730,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.80.0-rc.1):
+  - React-Fabric/observers (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1739,7 +1744,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.80.0-rc.1)
+    - React-Fabric/observers/events (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1751,7 +1756,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.80.0-rc.1):
+  - React-Fabric/observers/events (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1776,7 +1781,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.80.0-rc.1):
+  - React-Fabric/scheduler (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1803,7 +1808,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.80.0-rc.1):
+  - React-Fabric/telemetry (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1828,7 +1833,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.80.0-rc.1):
+  - React-Fabric/templateprocessor (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1853,7 +1858,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.80.0-rc.1):
+  - React-Fabric/uimanager (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1867,33 +1872,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.80.0-rc.1)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/uimanager/consistency (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1906,7 +1885,33 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.80.0-rc.1):
+  - React-Fabric/uimanager/consistency (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-FabricComponents (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1921,8 +1926,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.80.0-rc.1)
-    - React-FabricComponents/textlayoutmanager (= 0.80.0-rc.1)
+    - React-FabricComponents/components (= 0.80.0-rc.2)
+    - React-FabricComponents/textlayoutmanager (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1935,7 +1940,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.80.0-rc.1):
+  - React-FabricComponents/components (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1950,15 +1955,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.80.0-rc.1)
-    - React-FabricComponents/components/iostextinput (= 0.80.0-rc.1)
-    - React-FabricComponents/components/modal (= 0.80.0-rc.1)
-    - React-FabricComponents/components/rncore (= 0.80.0-rc.1)
-    - React-FabricComponents/components/safeareaview (= 0.80.0-rc.1)
-    - React-FabricComponents/components/scrollview (= 0.80.0-rc.1)
-    - React-FabricComponents/components/text (= 0.80.0-rc.1)
-    - React-FabricComponents/components/textinput (= 0.80.0-rc.1)
-    - React-FabricComponents/components/unimplementedview (= 0.80.0-rc.1)
+    - React-FabricComponents/components/inputaccessory (= 0.80.0-rc.2)
+    - React-FabricComponents/components/iostextinput (= 0.80.0-rc.2)
+    - React-FabricComponents/components/modal (= 0.80.0-rc.2)
+    - React-FabricComponents/components/rncore (= 0.80.0-rc.2)
+    - React-FabricComponents/components/safeareaview (= 0.80.0-rc.2)
+    - React-FabricComponents/components/scrollview (= 0.80.0-rc.2)
+    - React-FabricComponents/components/text (= 0.80.0-rc.2)
+    - React-FabricComponents/components/textinput (= 0.80.0-rc.2)
+    - React-FabricComponents/components/unimplementedview (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1971,61 +1976,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/modal (0.80.0-rc.1):
+  - React-FabricComponents/components/inputaccessory (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2052,7 +2003,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.80.0-rc.1):
+  - React-FabricComponents/components/iostextinput (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2079,7 +2030,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.80.0-rc.1):
+  - React-FabricComponents/components/modal (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2106,7 +2057,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.80.0-rc.1):
+  - React-FabricComponents/components/rncore (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2133,7 +2084,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.80.0-rc.1):
+  - React-FabricComponents/components/safeareaview (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2160,7 +2111,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.80.0-rc.1):
+  - React-FabricComponents/components/scrollview (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2187,7 +2138,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.80.0-rc.1):
+  - React-FabricComponents/components/text (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2214,7 +2165,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.80.0-rc.1):
+  - React-FabricComponents/components/textinput (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2241,7 +2192,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.80.0-rc.1):
+  - React-FabricComponents/components/unimplementedview (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2250,22 +2201,76 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.80.0-rc.1)
-    - RCTTypeSafety (= 0.80.0-rc.1)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.80.0-rc.2)
+    - RCTTypeSafety (= 0.80.0-rc.2)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-hermes
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.1)
+    - React-jsiexecutor (= 0.80.0-rc.2)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.80.0-rc.1):
+  - React-featureflags (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2274,7 +2279,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.80.0-rc.1):
+  - React-featureflagsnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2290,7 +2295,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.80.0-rc.1):
+  - React-graphics (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2304,7 +2309,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.80.0-rc.1):
+  - React-hermes (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2313,16 +2318,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.1)
+    - React-cxxreact (= 0.80.0-rc.2)
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.1)
+    - React-jsiexecutor (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.1)
+    - React-perflogger (= 0.80.0-rc.2)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.80.0-rc.1):
+  - React-idlecallbacksnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2338,7 +2343,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.80.0-rc.1):
+  - React-ImageManager (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2353,7 +2358,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.80.0-rc.1):
+  - React-jserrorhandler (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2368,7 +2373,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.80.0-rc.1):
+  - React-jsi (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2378,7 +2383,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.80.0-rc.1):
+  - React-jsiexecutor (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2387,14 +2392,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.1)
+    - React-perflogger (= 0.80.0-rc.2)
     - SocketRocket
-  - React-jsinspector (0.80.0-rc.1):
+  - React-jsinspector (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2408,10 +2413,10 @@ PODS:
     - React-jsinspectorcdp
     - React-jsinspectornetwork
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.1)
-    - React-runtimeexecutor (= 0.80.0-rc.1)
+    - React-perflogger (= 0.80.0-rc.2)
+    - React-runtimeexecutor (= 0.80.0-rc.2)
     - SocketRocket
-  - React-jsinspectorcdp (0.80.0-rc.1):
+  - React-jsinspectorcdp (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2420,7 +2425,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.80.0-rc.1):
+  - React-jsinspectornetwork (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2430,7 +2435,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-jsinspectorcdp
     - SocketRocket
-  - React-jsinspectortracing (0.80.0-rc.1):
+  - React-jsinspectortracing (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2440,7 +2445,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-oscompat
     - SocketRocket
-  - React-jsitooling (0.80.0-rc.1):
+  - React-jsitooling (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2448,15 +2453,15 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - SocketRocket
-  - React-jsitracing (0.80.0-rc.1):
+  - React-jsitracing (0.80.0-rc.2):
     - React-jsi
-  - React-logger (0.80.0-rc.1):
+  - React-logger (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2465,7 +2470,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.80.0-rc.1):
+  - React-Mapbuffer (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2475,7 +2480,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.80.0-rc.1):
+  - React-microtasksnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2730,7 +2735,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.80.0-rc.1):
+  - React-NativeModulesApple (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2751,8 +2756,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.80.0-rc.1)
-  - React-perflogger (0.80.0-rc.1):
+  - React-oscompat (0.80.0-rc.2)
+  - React-perflogger (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2761,7 +2766,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.80.0-rc.1):
+  - React-performancetimeline (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2774,9 +2779,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.80.0-rc.1):
-    - React-Core/RCTActionSheetHeaders (= 0.80.0-rc.1)
-  - React-RCTAnimation (0.80.0-rc.1):
+  - React-RCTActionSheet (0.80.0-rc.2):
+    - React-Core/RCTActionSheetHeaders (= 0.80.0-rc.2)
+  - React-RCTAnimation (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2792,7 +2797,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.80.0-rc.1):
+  - React-RCTAppDelegate (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2825,7 +2830,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.80.0-rc.1):
+  - React-RCTBlob (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2844,7 +2849,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.80.0-rc.1):
+  - React-RCTFabric (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2878,7 +2883,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.80.0-rc.1):
+  - React-RCTFBReactNativeSpec (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2896,7 +2901,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCommon
     - SocketRocket
-  - React-RCTImage (0.80.0-rc.1):
+  - React-RCTImage (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2912,14 +2917,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.80.0-rc.1):
-    - React-Core/RCTLinkingHeaders (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+  - React-RCTLinking (0.80.0-rc.2):
+    - React-Core/RCTLinkingHeaders (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.1)
-  - React-RCTNetwork (0.80.0-rc.1):
+    - ReactCommon/turbomodule/core (= 0.80.0-rc.2)
+  - React-RCTNetwork (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2937,7 +2942,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.80.0-rc.1):
+  - React-RCTRuntime (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2957,7 +2962,7 @@ PODS:
     - React-RuntimeCore
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.80.0-rc.1):
+  - React-RCTSettings (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2972,10 +2977,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.80.0-rc.1):
-    - React-Core/RCTTextHeaders (= 0.80.0-rc.1)
+  - React-RCTText (0.80.0-rc.2):
+    - React-Core/RCTTextHeaders (= 0.80.0-rc.2)
     - Yoga
-  - React-RCTVibration (0.80.0-rc.1):
+  - React-RCTVibration (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2989,11 +2994,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.80.0-rc.1)
-  - React-renderercss (0.80.0-rc.1):
+  - React-rendererconsistency (0.80.0-rc.2)
+  - React-renderercss (0.80.0-rc.2):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.80.0-rc.1):
+  - React-rendererdebug (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3003,8 +3008,8 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-rncore (0.80.0-rc.1)
-  - React-RuntimeApple (0.80.0-rc.1):
+  - React-rncore (0.80.0-rc.2)
+  - React-RuntimeApple (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3033,7 +3038,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.80.0-rc.1):
+  - React-RuntimeCore (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3056,9 +3061,9 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.80.0-rc.1):
-    - React-jsi (= 0.80.0-rc.1)
-  - React-RuntimeHermes (0.80.0-rc.1):
+  - React-runtimeexecutor (0.80.0-rc.2):
+    - React-jsi (= 0.80.0-rc.2)
+  - React-RuntimeHermes (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3078,7 +3083,7 @@ PODS:
     - React-RuntimeCore
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.80.0-rc.1):
+  - React-runtimescheduler (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3101,8 +3106,8 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.80.0-rc.1)
-  - React-utils (0.80.0-rc.1):
+  - React-timing (0.80.0-rc.2)
+  - React-utils (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3113,11 +3118,11 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-hermes
-    - React-jsi (= 0.80.0-rc.1)
+    - React-jsi (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactAppDependencyProvider (0.80.0-rc.1):
+  - ReactAppDependencyProvider (0.80.0-rc.2):
     - ReactCodegen
-  - ReactCodegen (0.80.0-rc.1):
+  - ReactCodegen (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3144,7 +3149,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.80.0-rc.1):
+  - ReactCommon (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3152,9 +3157,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.80.0-rc.1)
+    - ReactCommon/turbomodule (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactCommon/turbomodule (0.80.0-rc.1):
+  - ReactCommon/turbomodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3163,15 +3168,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
-    - ReactCommon/turbomodule/bridging (= 0.80.0-rc.1)
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
+    - ReactCommon/turbomodule/bridging (= 0.80.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.80.0-rc.1):
+  - ReactCommon/turbomodule/bridging (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3180,13 +3185,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.80.0-rc.1):
+  - ReactCommon/turbomodule/core (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3195,14 +3200,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-debug (= 0.80.0-rc.1)
-    - React-featureflags (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
-    - React-utils (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-debug (= 0.80.0-rc.2)
+    - React-featureflags (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
+    - React-utils (= 0.80.0-rc.2)
     - SocketRocket
   - RNCAsyncStorage (2.1.2):
     - boost
@@ -4275,9 +4280,9 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  BenchmarkingModule: a97859cac8efb2f5411b2052e61841b349813a4a
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  BenchmarkingModule: 9e58a2f29c4fdd9a07d97ef766ce7fd7edb7c287
+  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EASClient: 83423c51dde4c5504cb4186e1f39728273ed334b
   EXApplication: b28de982d44768fc593de9d19ca5a7a0e49685b1
   EXAV: 0809cbb31eba2111d5413f2dbb547ba9727478ee
@@ -4286,10 +4291,10 @@ SPEC CHECKSUMS:
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
   EXManifests: 75cba7539b60676be1911d024252a11b846085ed
   EXNotifications: f0f1c97d04f06c51ea073d7b2396431e5611c1ea
-  Expo: 22dc35ce67dc330d6a2d80598f29c654fe276830
+  Expo: 449fa5f24115c93d2573a8f012ace3187e3b02a5
   expo-dev-client: b32e7e9c0a420a5256e38b12e8eebbf14a7031ed
-  expo-dev-launcher: d506f26639ee2676977c4a8c47668a77d2d09d23
-  expo-dev-menu: 2aa06bd228fe6a52e2276b71c59b90a8ec88c8a3
+  expo-dev-launcher: d2f62aae6c777d65233c8d3546dbdf5f85c0f667
+  expo-dev-menu: f2a08f1ecf61b6282f3784add26ebd29cbc85ae2
   expo-dev-menu-interface: 609c35ae8b97479cdd4c9e23c8cf6adc44beea0e
   ExpoAppleAuthentication: 7e358fcbcbacb7685cddb0bbeede0acd677e58f6
   ExpoAsset: 3ea3275cca6a7793b3d36fbf1075c590f803fbcb
@@ -4327,12 +4332,12 @@ SPEC CHECKSUMS:
   ExpoMaps: f7f4cd0a94ca57eed995a4b749f757f2c716a5fe
   ExpoMediaLibrary: ad61cd80ca07da02be3d676e3d9b04b311a82c2c
   ExpoMeshGradient: ee97f0bfd80356910ca4fc2b67663ea0d9e14a41
-  ExpoModulesCore: b57f1f9dbf35e11a01ac115ded48edd14dcd9b47
+  ExpoModulesCore: 0b7a0299baa6c8de3b9331869d61df3e7c2f5e0f
   ExpoModulesTestCore: c87ba2da38070e3483a3049453a4dc898b972eb2
   ExpoNetwork: 9fdbef259f313a1ba7ede5fa977ee3dfed6fe653
   ExpoPrint: 187f43f5d16bc8db93fb6609707ed40b8e90d3a6
   ExpoScreenCapture: 4de83d2f4e377a60ac246548212fa3cb91863a90
-  ExpoScreenOrientation: 8d41cc8226b4111899309bbce025e5290ba66336
+  ExpoScreenOrientation: c0ea1650e8e1959b855711f6674cd570e5928c8b
   ExpoSecureStore: 3148869ad24ab94f9e0c5777c7941d7a37d60399
   ExpoSensors: a997847b03472f79eabb7989446088bd8f791657
   ExpoSharing: 04b346bdd7c8ea1fa87047ac7bba65c37bde4f51
@@ -4350,109 +4355,109 @@ SPEC CHECKSUMS:
   ExpoWebBrowser: 1051486eb45a2f4d1ee075712604f43f3009f90e
   EXStructuredHeaders: 32bec6771c2db18c4cd47cecae530d1d06cdf972
   EXTaskManager: 0128b9f39a088b0c762d8d1c42017e6d44200b29
-  EXUpdates: 581f73524beb53c1c46052b776a130743be28507
+  EXUpdates: 9d87d1b97634263b9f8623eb7e763e58b48dc9fb
   EXUpdatesInterface: 64f35449b8ef89ce08cdd8952a4d119b5de6821d
-  fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
-  FBLazyVector: 84b955f7b4da8b895faf5946f73748267347c975
+  fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
+  FBLazyVector: a29cb71e603040d186ede90b91213d24051fa395
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
-  hermes-engine: 314be5250afa5692b57b4dd1705959e1973a8ebe
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
+  hermes-engine: c3d5654d916ddbfde13f2a14f03df529e8fce18f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: c210f6206cbb1195b25799bb48c0f4d01151d4f8
+  lottie-react-native: 75b793d20dd0c6c16605e9af592ca9d008cdb92a
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
-  RCTDeprecation: 230869f38f83ae51956d38c92f05254206bada2c
-  RCTRequired: 549f9bbe320852a24c783f42653901e6a686bff8
-  RCTTypeSafety: 6a69dd0144f99ccbdc46f4eb1a5072979ccf40de
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
+  RCTDeprecation: 339b52fd8eeae650a419b219f55baa2d7e4e7ac6
+  RCTRequired: 4b6dd8d557716607245fdd5ec8dcac9e3fca36ec
+  RCTTypeSafety: 827d6724a7d766b573c1fdf6acab8e93b8ccb9b3
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 6d4f7cc02ade4a926aed958d2f41f44e3162eb91
-  React-callinvoker: d5f0e4463448c54d85d1c932bb2151086eabdb32
-  React-Core: c7765d25462595bc3b687e711718b4e39db4384c
-  React-CoreModules: df439afbe3c663bd82b172d33377cddeed701a7e
-  React-cxxreact: 13011feb31e9bf2d4e62e0e01266e76ab0eb2af0
-  React-debug: f3412fe8198e2811b239777f1149e7aee110bc94
-  React-defaultsnativemodule: d27ec9d295137d1211ca990a50857feb054d6565
-  React-domnativemodule: 70a88f919cb7c43ead8a3603a89a79253bad577e
-  React-Fabric: c033a162c4e357b109584b146b2f5a162c8ef58c
-  React-FabricComponents: 4bd6fdcc540c5382858f2e27780c3ea2c4c298d0
-  React-FabricImage: f1920bb45bc08dc16dff43156746593de048fde9
-  React-featureflags: 9011f9bfc690f6543744c2fbd8edd54dad157479
-  React-featureflagsnativemodule: bd61c3757c62e10901730eb672859ceed849bdda
-  React-graphics: 46cf342c230b383c66ad2dfb026cf5fa5226630c
-  React-hermes: 0be4a7c2631d2e16ae7b8b80d684f986cf091ec0
-  React-idlecallbacksnativemodule: 2019e0e37350ae9c16a172ff2c5b047385893c31
-  React-ImageManager: 09f9ab7e0859b396fa8c1831e666bfb0a2c0ca70
-  React-jserrorhandler: 9ac4919ef4664b3ae2fa43a28e3355d3171f26c8
-  React-jsi: 51012a1761d2a90ffdc5c7e23a1adad981a8cdb2
-  React-jsiexecutor: d8941f4b05d56ce68190505d937040de1f72c709
-  React-jsinspector: 2686dd01c1c0fa954ad8a6bbe29fc8176258643d
-  React-jsinspectorcdp: 842fed0b3d221ec5c3dcc4b5e6af42905e2f0a4a
-  React-jsinspectornetwork: ccfa7d29d8b7c5fc4db8eba4dab0383f062a3c03
-  React-jsinspectortracing: 2c7167bb0b883da6cd8f9b0a3cc29c46a24bd36b
-  React-jsitooling: a40f3aa3a790f593990955cd9fb4df5b816fe8ce
-  React-jsitracing: 124b3d8e966312beabb42fdc18bc71ce763394c7
-  React-logger: 752aeba6029bfcde5e4001b6cadfcc5d984a9dff
-  React-Mapbuffer: 87868c938dfe459d024127d9755c0bca44e96a68
-  React-microtasksnativemodule: 01459d49fb19d699228ae9748b5f5b9eaa366c56
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-pager-view: 682422a9cd034c335cae12106c5ca8f892cffe9d
-  react-native-safe-area-context: bd8e149c82b5a20cfd55e9775d82f1b5954b7e6d
-  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
-  react-native-slider: 56b308308abe55943cac13b1818da5f0fecd372d
-  react-native-view-shot: 86844f7d310b4a26d84102a2c5078203c627b3be
-  react-native-webview: 7dd453f59dcc0fa3e4de6ced4dd2be0ac1955fde
-  React-NativeModulesApple: b00b96e89ef10f186f3c7427b141cb39c055e3bd
-  React-oscompat: 7c11d5c1fc5e8ea8ec94084b893ac56a8e897dd4
-  React-perflogger: 79e4553b51a1a87b50876daa95800471866a5a38
-  React-performancetimeline: d7c5d2d92fbeeba7d816f8f6476bf4de8dc68773
-  React-RCTActionSheet: 26ab80f23a43c6bdb8b8f4f6484e50c5f44880bf
-  React-RCTAnimation: 057729e2cf685fecd1d4f4a7775123f17f6d7dcb
-  React-RCTAppDelegate: b5e1bfc5c746e5137597a3ad53be8f7b54507b2f
-  React-RCTBlob: 802eb8b948594c38a0ac50faaaeb5a83b1143e2e
-  React-RCTFabric: 85a814f2eb62d4eea8f8344a823490ff104a7aa4
-  React-RCTFBReactNativeSpec: 3a9185a1c7a9f2f15d42668166fa22fb81f64f1f
-  React-RCTImage: 838984dfcde1fa7a7b3d225dcae15daa095ba3cf
-  React-RCTLinking: 0634dd69549eb70ca4da5c5a0eef5ed233993a34
-  React-RCTNetwork: e0a068887d8fc23bd999175a46660be8fb10b1c3
-  React-RCTRuntime: 23b6bfb6f92234733e1cfda599522106a31a36d6
-  React-RCTSettings: eed9cb7e03a01ed1a08394686350e323f271a9f3
-  React-RCTText: b8e0255162f3793194e05408ec6cb25821461164
-  React-RCTVibration: 7f572eac5a19c9e727b8042b0b60a63eb4c2d823
-  React-rendererconsistency: fb3bd722891a4cc8bab33f4bbf585910c545f3ba
-  React-renderercss: a4a490821e19a38359e955fdfe8df2acb88f0bd1
-  React-rendererdebug: 25511e517b2bf54a3dffbe54b9364968f65a8e81
-  React-rncore: 1f0037879900801c02e92b206fccf916744cafbd
-  React-RuntimeApple: 2758bc7ac5329e69bcd345d5e967b1d8e916dbb3
-  React-RuntimeCore: 179f66ed9832a6af4254586ce2b4c0147aabb37b
-  React-runtimeexecutor: a9f689b57d863d371bd1762591c4fc805de90dc3
-  React-RuntimeHermes: e4546ee1c3965db728070b130410a5b93703bc6c
-  React-runtimescheduler: 53a6176e2c01cd6e52e4321db200cc34be4ab27b
-  React-timing: d729454ff3fd734dd46013c2c2673aa0da6cd2cf
-  React-utils: cdb942859774617eee363d58455da394dd8356ce
-  ReactAppDependencyProvider: 5d4564ba3be2ec04c2f12fa7726f9c43b1cc9741
-  ReactCodegen: b8f26b16ee2d8875b88b420c217544ac77c3711e
-  ReactCommon: 96a832390a887840dcc5eb3d6918f7fe1494883e
-  RNCAsyncStorage: 3decb3356025058623474790bf552590acaa3da9
-  RNCMaskedView: 7e0ce15656772a939ff0d269100bca3a182163c8
-  RNCPicker: 4890555bd4c19e4ef395b11f6ae18293b4f0db51
-  RNDateTimePicker: 88d8916a57e5bdd603dcaf177fc0f2d6372c92c3
-  RNFlashList: 3d87e2c97db48005075574cf525d0e889ba63179
-  RNGestureHandler: e61ff6d07f74c2184c0f00a001089f06818aa7ae
-  RNReanimated: cb686bdb40e31cc38bad1c9f491922473da07cdb
-  RNScreens: 10ca32b82794369e5857df3c8ca5937c415fbfd3
-  RNSVG: f52557c8b2e0b26e00fc7ed80e1e2ee883ab71a8
+  React: a1830b4b3cff49aa1424b3c63cac6b2bead56a4f
+  React-callinvoker: 85e7c913e9aa96c61fb505af9b304f4fd12ec658
+  React-Core: 8ef9a875466ec8e1004bd1fed5638d3dcdc5439c
+  React-CoreModules: bd8b0e3011b27bdcbe1e15aa03b41edd7331cb73
+  React-cxxreact: 462c3be821106d97c197d0af89ae9886e5a93f5e
+  React-debug: 5af7750f97a9b96e296c4743f78907921964ce98
+  React-defaultsnativemodule: 183b67a1e98f0e73cdb0e895203a8ddd06be4d36
+  React-domnativemodule: 2cb7c3a94520b856d3a0d27d6ed499be138f2860
+  React-Fabric: 35945322d0d702e090b7eff423e64b2c1abccf0c
+  React-FabricComponents: 440686614f720baa1c0395830988d1e78241bec7
+  React-FabricImage: 354b0b87ac9c21e436e9172a3ca0d5ddc77e2d35
+  React-featureflags: 79950c143d25fdafb7be92eb012e9cc172471897
+  React-featureflagsnativemodule: 3de77a999be7ecf2975761f22cf0875d1be79619
+  React-graphics: a70befd182af5bfe77d7f37929bd68423567b053
+  React-hermes: 4a4b9610feff0b9361cb9b1173ba5d7f14b8eaf6
+  React-idlecallbacksnativemodule: fef0ffd2543f9868c1b39cc0ef63c60f3695d93a
+  React-ImageManager: 81393603429e60ec779129eab4904cb4b2430386
+  React-jserrorhandler: 4d206426161af95647b3f2dcc76fd1878d0feaa0
+  React-jsi: 6bd195018f415fe65cc14fc2b82fdbf8022db2e8
+  React-jsiexecutor: 639604430b81b3e09498a8608ed22b58989ad2e0
+  React-jsinspector: ee3f12c77d1ce1060412f93c955ebb507ed986b3
+  React-jsinspectorcdp: bb773dc307b82d05c8a162c9e3db5d633afeaa43
+  React-jsinspectornetwork: c82817824cdc23ac8868a4140780b429d260dba8
+  React-jsinspectortracing: d5714c64818867ba6fe33aa29406a1a5a6781c7e
+  React-jsitooling: 121890b11f9550b3488541427d60be7296b959d5
+  React-jsitracing: b7932f90a52b09953ebf1446cb18b9acaa9d5037
+  React-logger: 97b83557fb6c53d7bf3ba31e10695aa7959b2969
+  React-Mapbuffer: c5325441a01e38337d2f6010360a657059c464a7
+  React-microtasksnativemodule: 62c909456914af65e9372f0680f83694beaebf46
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-pager-view: 03553493db7fd49946d709ab6d65c7ef0cc929be
+  react-native-safe-area-context: 47c1782a327ca2affa9bec5a2f95534cbabb620a
+  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
+  react-native-slider: dd3636cb9b888b4d8aaf7ac0bb5e0d2921c5eec6
+  react-native-view-shot: a18275ac858eb4866365148517774182319c7aee
+  react-native-webview: a53cadbdc946b2d14055284ee9f5f81c1d4817a3
+  React-NativeModulesApple: 87e676164ebadd55b400663b4571c4022f76f494
+  React-oscompat: 4dd2483349b4831478aefaee5383b9689521612d
+  React-perflogger: 52e7e072582c777a4323ee7471729d1b28aef9c1
+  React-performancetimeline: fe78af3c8d00a2d1261d280531203f8fbbaa4b9b
+  React-RCTActionSheet: 637d0560b58e21a20ae498b1272440c79e471781
+  React-RCTAnimation: 5a7b014c525e0b89baa626e88ace369c642b1a8d
+  React-RCTAppDelegate: 9c233a5a6c722d980d5f1bac066f247b3cbebb77
+  React-RCTBlob: fcb766c955a8eb2f94e85b28db387abcfe3480a8
+  React-RCTFabric: d282c54c4e2a88ce7daa6d54c5cc96c8bded0515
+  React-RCTFBReactNativeSpec: 84bc55e6d1cdde8862dfdef236cc5e5d8f39921e
+  React-RCTImage: 28245c7f53874bbeefcf8bda8de1283c5f93d13c
+  React-RCTLinking: 503721813b57b3bb0aa06fc9b092ad9bec65b9eb
+  React-RCTNetwork: 234723ddaf17ccc2ddbae8ff544f644274940ac7
+  React-RCTRuntime: fa8517347cd4f31fbbfd2fb72a8643b4a34c3b3d
+  React-RCTSettings: d79af692bef22683c44cbe55f9ce823f61b1f2b3
+  React-RCTText: 385f49baf872fab4e8e4f87f31b72ac2ff140216
+  React-RCTVibration: a12051842416e423971748e26a6db6ea66732f51
+  React-rendererconsistency: 78483139826d7b03663093c781e535d30773aca9
+  React-renderercss: 2e646d2a5b4f10580a8556bd8afd1a05f66fb2d9
+  React-rendererdebug: 43ac356fc1d96b691854cc26ddab8aeba0f08f59
+  React-rncore: 64f6c9ebb626d5fc204aeaeea880b4f2220af899
+  React-RuntimeApple: f98806b18a0ab360e8ff4435e57bcf0b875e1833
+  React-RuntimeCore: 473cb858bee905bd617e33e3cd0b4996e37d2832
+  React-runtimeexecutor: a7c556446d3ede28f56c3f5adaf14a00a35d4091
+  React-RuntimeHermes: 45539d07d900693c60bc3d423c85b34ca4dace1e
+  React-runtimescheduler: bc66d28aea5bd9abf4a6aeb19466ad42463dbde5
+  React-timing: fd9c334ce6fb6075921084299a2fd5c538352b1d
+  React-utils: ece43bc95e748e9c21edfea6fc32ce3883448e42
+  ReactAppDependencyProvider: 92ea8aa743b2643d51873c6cd89bc9cd142e7919
+  ReactCodegen: 6391803c802f591c07824939f97f6e84d862c840
+  ReactCommon: 9e45a41bdc4bb215727d8dee04eba6f0900e2b1a
+  RNCAsyncStorage: 8de84536d0038b97a1b85d23681c2aed5f641430
+  RNCMaskedView: aac38cf7e947ff80e483996d1acd43c5ad4ab610
+  RNCPicker: 9f14f7b5511d88d7608b344e9089916ff8a47298
+  RNDateTimePicker: c525b5bb1b2d9766d3fa5e178495c222d8a75c87
+  RNFlashList: 30e89fd3a2a5825e2d317e27b963302b2f4a0030
+  RNGestureHandler: 683d606f47ef460f46688aef0d995c6fc3ca6595
+  RNReanimated: 12166f0ce1098c4eddfb67e4bea61f690a340d39
+  RNScreens: 1dde4b934a98cb214c88391717b0e98c56d5506d
+  RNSVG: b93bfc39443b95ecaea98711a93212aa5e4f0b7c
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   UMAppLoader: 55159b69750129faa7a51c493cb8ea55a7b64eb9
-  Yoga: 641086d9089de90327f09178a27eceaf86a7ae5e
+  Yoga: 1cf315b6f6373fa6118b88bf0c7a2c6dd760706c
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: a4b563d9d9c73e29b619314cb8136ce02bea61e0

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -64,7 +64,7 @@
     "native-component-list": "*",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.80.0-rc.1",
+    "react-native": "0.80.0-rc.2",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-pager-view": "6.7.1",
     "react-native-reanimated": "3.17.4",

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -21,7 +21,7 @@
       },
       "ios": {
         "cache": {
-          "key": "sdk53-0.80.0-rc.1",
+          "key": "sdk53-0.80.0-rc.2",
           "customPaths": ["../expo-go/ios/Pods"]
         },
         "image": "macos-sonoma-14.6-xcode-16.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -369,7 +369,7 @@ PODS:
   - EXUpdatesInterface (1.1.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.80.0-rc.1)
+  - FBLazyVector (0.80.0-rc.2)
   - FirebaseAnalytics (11.11.0):
     - FirebaseAnalytics/AdIdSupport (= 11.11.0)
     - FirebaseCore (~> 11.11.0)
@@ -573,28 +573,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.80.0-rc.1)
-  - RCTRequired (0.80.0-rc.1)
-  - RCTTypeSafety (0.80.0-rc.1):
-    - FBLazyVector (= 0.80.0-rc.1)
-    - RCTRequired (= 0.80.0-rc.1)
-    - React-Core (= 0.80.0-rc.1)
+  - RCTDeprecation (0.80.0-rc.2)
+  - RCTRequired (0.80.0-rc.2)
+  - RCTTypeSafety (0.80.0-rc.2):
+    - FBLazyVector (= 0.80.0-rc.2)
+    - RCTRequired (= 0.80.0-rc.2)
+    - React-Core (= 0.80.0-rc.2)
   - ReachabilitySwift (5.2.4)
-  - React (0.80.0-rc.1):
-    - React-Core (= 0.80.0-rc.1)
-    - React-Core/DevSupport (= 0.80.0-rc.1)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.1)
-    - React-RCTActionSheet (= 0.80.0-rc.1)
-    - React-RCTAnimation (= 0.80.0-rc.1)
-    - React-RCTBlob (= 0.80.0-rc.1)
-    - React-RCTImage (= 0.80.0-rc.1)
-    - React-RCTLinking (= 0.80.0-rc.1)
-    - React-RCTNetwork (= 0.80.0-rc.1)
-    - React-RCTSettings (= 0.80.0-rc.1)
-    - React-RCTText (= 0.80.0-rc.1)
-    - React-RCTVibration (= 0.80.0-rc.1)
-  - React-callinvoker (0.80.0-rc.1)
-  - React-Core (0.80.0-rc.1):
+  - React (0.80.0-rc.2):
+    - React-Core (= 0.80.0-rc.2)
+    - React-Core/DevSupport (= 0.80.0-rc.2)
+    - React-Core/RCTWebSocket (= 0.80.0-rc.2)
+    - React-RCTActionSheet (= 0.80.0-rc.2)
+    - React-RCTAnimation (= 0.80.0-rc.2)
+    - React-RCTBlob (= 0.80.0-rc.2)
+    - React-RCTImage (= 0.80.0-rc.2)
+    - React-RCTLinking (= 0.80.0-rc.2)
+    - React-RCTNetwork (= 0.80.0-rc.2)
+    - React-RCTSettings (= 0.80.0-rc.2)
+    - React-RCTText (= 0.80.0-rc.2)
+    - React-RCTVibration (= 0.80.0-rc.2)
+  - React-callinvoker (0.80.0-rc.2)
+  - React-Core (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -604,7 +604,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.1)
+    - React-Core/Default (= 0.80.0-rc.2)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -618,79 +618,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.1)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.1)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.80.0-rc.1):
+  - React-Core/CoreModulesHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -714,7 +642,55 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.80.0-rc.1):
+  - React-Core/Default (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0-rc.2)
+    - React-Core/RCTWebSocket (= 0.80.0-rc.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -738,7 +714,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.80.0-rc.1):
+  - React-Core/RCTAnimationHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -762,7 +738,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.80.0-rc.1):
+  - React-Core/RCTBlobHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -786,7 +762,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.80.0-rc.1):
+  - React-Core/RCTImageHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -810,7 +786,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.80.0-rc.1):
+  - React-Core/RCTLinkingHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -834,7 +810,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.80.0-rc.1):
+  - React-Core/RCTNetworkHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -858,7 +834,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.80.0-rc.1):
+  - React-Core/RCTSettingsHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -882,7 +858,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.80.0-rc.1):
+  - React-Core/RCTTextHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -906,7 +882,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.80.0-rc.1):
+  - React-Core/RCTVibrationHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -916,7 +892,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.1)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -930,7 +906,31 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.80.0-rc.1):
+  - React-Core/RCTWebSocket (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0-rc.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -938,19 +938,19 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.80.0-rc.1)
-    - React-Core/CoreModulesHeaders (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - RCTTypeSafety (= 0.80.0-rc.2)
+    - React-Core/CoreModulesHeaders (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.80.0-rc.1)
+    - React-RCTImage (= 0.80.0-rc.2)
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.80.0-rc.1):
+  - React-cxxreact (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -959,19 +959,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-debug (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-debug (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
-    - React-runtimeexecutor (= 0.80.0-rc.1)
-    - React-timing (= 0.80.0-rc.1)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
+    - React-runtimeexecutor (= 0.80.0-rc.2)
+    - React-timing (= 0.80.0-rc.2)
     - SocketRocket
-  - React-debug (0.80.0-rc.1)
-  - React-defaultsnativemodule (0.80.0-rc.1):
+  - React-debug (0.80.0-rc.2)
+  - React-defaultsnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -989,7 +989,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.80.0-rc.1):
+  - React-domnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1008,7 +1008,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.80.0-rc.1):
+  - React-Fabric (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1022,22 +1022,22 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.80.0-rc.1)
-    - React-Fabric/attributedstring (= 0.80.0-rc.1)
-    - React-Fabric/componentregistry (= 0.80.0-rc.1)
-    - React-Fabric/componentregistrynative (= 0.80.0-rc.1)
-    - React-Fabric/components (= 0.80.0-rc.1)
-    - React-Fabric/consistency (= 0.80.0-rc.1)
-    - React-Fabric/core (= 0.80.0-rc.1)
-    - React-Fabric/dom (= 0.80.0-rc.1)
-    - React-Fabric/imagemanager (= 0.80.0-rc.1)
-    - React-Fabric/leakchecker (= 0.80.0-rc.1)
-    - React-Fabric/mounting (= 0.80.0-rc.1)
-    - React-Fabric/observers (= 0.80.0-rc.1)
-    - React-Fabric/scheduler (= 0.80.0-rc.1)
-    - React-Fabric/telemetry (= 0.80.0-rc.1)
-    - React-Fabric/templateprocessor (= 0.80.0-rc.1)
-    - React-Fabric/uimanager (= 0.80.0-rc.1)
+    - React-Fabric/animations (= 0.80.0-rc.2)
+    - React-Fabric/attributedstring (= 0.80.0-rc.2)
+    - React-Fabric/componentregistry (= 0.80.0-rc.2)
+    - React-Fabric/componentregistrynative (= 0.80.0-rc.2)
+    - React-Fabric/components (= 0.80.0-rc.2)
+    - React-Fabric/consistency (= 0.80.0-rc.2)
+    - React-Fabric/core (= 0.80.0-rc.2)
+    - React-Fabric/dom (= 0.80.0-rc.2)
+    - React-Fabric/imagemanager (= 0.80.0-rc.2)
+    - React-Fabric/leakchecker (= 0.80.0-rc.2)
+    - React-Fabric/mounting (= 0.80.0-rc.2)
+    - React-Fabric/observers (= 0.80.0-rc.2)
+    - React-Fabric/scheduler (= 0.80.0-rc.2)
+    - React-Fabric/telemetry (= 0.80.0-rc.2)
+    - React-Fabric/templateprocessor (= 0.80.0-rc.2)
+    - React-Fabric/uimanager (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1049,32 +1049,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.80.0-rc.1):
+  - React-Fabric/animations (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1099,7 +1074,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.80.0-rc.1):
+  - React-Fabric/attributedstring (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1124,7 +1099,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.80.0-rc.1):
+  - React-Fabric/componentregistry (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1149,36 +1124,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0-rc.1)
-    - React-Fabric/components/root (= 0.80.0-rc.1)
-    - React-Fabric/components/scrollview (= 0.80.0-rc.1)
-    - React-Fabric/components/view (= 0.80.0-rc.1)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.80.0-rc.1):
+  - React-Fabric/componentregistrynative (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1203,7 +1149,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.80.0-rc.1):
+  - React-Fabric/components (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0-rc.2)
+    - React-Fabric/components/root (= 0.80.0-rc.2)
+    - React-Fabric/components/scrollview (= 0.80.0-rc.2)
+    - React-Fabric/components/view (= 0.80.0-rc.2)
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1228,7 +1203,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.80.0-rc.1):
+  - React-Fabric/components/root (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1253,7 +1228,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.80.0-rc.1):
+  - React-Fabric/components/scrollview (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1280,7 +1280,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.80.0-rc.1):
+  - React-Fabric/consistency (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1305,7 +1305,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.80.0-rc.1):
+  - React-Fabric/core (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1330,7 +1330,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.80.0-rc.1):
+  - React-Fabric/dom (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1355,7 +1355,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.80.0-rc.1):
+  - React-Fabric/imagemanager (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1380,7 +1380,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.80.0-rc.1):
+  - React-Fabric/leakchecker (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1405,7 +1405,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.80.0-rc.1):
+  - React-Fabric/mounting (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1430,7 +1430,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.80.0-rc.1):
+  - React-Fabric/observers (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1444,7 +1444,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.80.0-rc.1)
+    - React-Fabric/observers/events (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1456,7 +1456,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.80.0-rc.1):
+  - React-Fabric/observers/events (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1481,7 +1481,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.80.0-rc.1):
+  - React-Fabric/scheduler (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1508,7 +1508,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.80.0-rc.1):
+  - React-Fabric/telemetry (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1533,7 +1533,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.80.0-rc.1):
+  - React-Fabric/templateprocessor (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1558,7 +1558,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.80.0-rc.1):
+  - React-Fabric/uimanager (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1572,33 +1572,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.80.0-rc.1)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/uimanager/consistency (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1611,7 +1585,33 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.80.0-rc.1):
+  - React-Fabric/uimanager/consistency (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-FabricComponents (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1626,8 +1626,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.80.0-rc.1)
-    - React-FabricComponents/textlayoutmanager (= 0.80.0-rc.1)
+    - React-FabricComponents/components (= 0.80.0-rc.2)
+    - React-FabricComponents/textlayoutmanager (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1640,7 +1640,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.80.0-rc.1):
+  - React-FabricComponents/components (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1655,15 +1655,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.80.0-rc.1)
-    - React-FabricComponents/components/iostextinput (= 0.80.0-rc.1)
-    - React-FabricComponents/components/modal (= 0.80.0-rc.1)
-    - React-FabricComponents/components/rncore (= 0.80.0-rc.1)
-    - React-FabricComponents/components/safeareaview (= 0.80.0-rc.1)
-    - React-FabricComponents/components/scrollview (= 0.80.0-rc.1)
-    - React-FabricComponents/components/text (= 0.80.0-rc.1)
-    - React-FabricComponents/components/textinput (= 0.80.0-rc.1)
-    - React-FabricComponents/components/unimplementedview (= 0.80.0-rc.1)
+    - React-FabricComponents/components/inputaccessory (= 0.80.0-rc.2)
+    - React-FabricComponents/components/iostextinput (= 0.80.0-rc.2)
+    - React-FabricComponents/components/modal (= 0.80.0-rc.2)
+    - React-FabricComponents/components/rncore (= 0.80.0-rc.2)
+    - React-FabricComponents/components/safeareaview (= 0.80.0-rc.2)
+    - React-FabricComponents/components/scrollview (= 0.80.0-rc.2)
+    - React-FabricComponents/components/text (= 0.80.0-rc.2)
+    - React-FabricComponents/components/textinput (= 0.80.0-rc.2)
+    - React-FabricComponents/components/unimplementedview (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1676,61 +1676,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/modal (0.80.0-rc.1):
+  - React-FabricComponents/components/inputaccessory (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1757,7 +1703,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.80.0-rc.1):
+  - React-FabricComponents/components/iostextinput (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1784,7 +1730,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.80.0-rc.1):
+  - React-FabricComponents/components/modal (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1811,7 +1757,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.80.0-rc.1):
+  - React-FabricComponents/components/rncore (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1838,7 +1784,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.80.0-rc.1):
+  - React-FabricComponents/components/safeareaview (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1865,7 +1811,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.80.0-rc.1):
+  - React-FabricComponents/components/scrollview (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1892,7 +1838,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.80.0-rc.1):
+  - React-FabricComponents/components/text (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1919,7 +1865,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.80.0-rc.1):
+  - React-FabricComponents/components/textinput (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1946,7 +1892,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.80.0-rc.1):
+  - React-FabricComponents/components/unimplementedview (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1955,22 +1901,76 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.80.0-rc.1)
-    - RCTTypeSafety (= 0.80.0-rc.1)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.80.0-rc.2)
+    - RCTTypeSafety (= 0.80.0-rc.2)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-hermes
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.1)
+    - React-jsiexecutor (= 0.80.0-rc.2)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.80.0-rc.1):
+  - React-featureflags (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1979,7 +1979,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.80.0-rc.1):
+  - React-featureflagsnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1995,7 +1995,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.80.0-rc.1):
+  - React-graphics (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2009,7 +2009,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.80.0-rc.1):
+  - React-hermes (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2018,16 +2018,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.1)
+    - React-cxxreact (= 0.80.0-rc.2)
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.1)
+    - React-jsiexecutor (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.1)
+    - React-perflogger (= 0.80.0-rc.2)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.80.0-rc.1):
+  - React-idlecallbacksnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2043,7 +2043,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.80.0-rc.1):
+  - React-ImageManager (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2058,12 +2058,12 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jsc (0.80.0-rc.1):
-    - React-jsc/Fabric (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
-  - React-jsc/Fabric (0.80.0-rc.1):
-    - React-jsi (= 0.80.0-rc.1)
-  - React-jserrorhandler (0.80.0-rc.1):
+  - React-jsc (0.80.0-rc.2):
+    - React-jsc/Fabric (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
+  - React-jsc/Fabric (0.80.0-rc.2):
+    - React-jsi (= 0.80.0-rc.2)
+  - React-jserrorhandler (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2078,7 +2078,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.80.0-rc.1):
+  - React-jsi (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2088,7 +2088,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.80.0-rc.1):
+  - React-jsiexecutor (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2097,14 +2097,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.1)
+    - React-perflogger (= 0.80.0-rc.2)
     - SocketRocket
-  - React-jsinspector (0.80.0-rc.1):
+  - React-jsinspector (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2118,10 +2118,10 @@ PODS:
     - React-jsinspectorcdp
     - React-jsinspectornetwork
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.1)
-    - React-runtimeexecutor (= 0.80.0-rc.1)
+    - React-perflogger (= 0.80.0-rc.2)
+    - React-runtimeexecutor (= 0.80.0-rc.2)
     - SocketRocket
-  - React-jsinspectorcdp (0.80.0-rc.1):
+  - React-jsinspectorcdp (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2130,7 +2130,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.80.0-rc.1):
+  - React-jsinspectornetwork (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2140,7 +2140,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-jsinspectorcdp
     - SocketRocket
-  - React-jsinspectortracing (0.80.0-rc.1):
+  - React-jsinspectortracing (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2150,7 +2150,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-oscompat
     - SocketRocket
-  - React-jsitooling (0.80.0-rc.1):
+  - React-jsitooling (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2158,15 +2158,15 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - SocketRocket
-  - React-jsitracing (0.80.0-rc.1):
+  - React-jsitracing (0.80.0-rc.2):
     - React-jsi
-  - React-logger (0.80.0-rc.1):
+  - React-logger (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2175,7 +2175,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.80.0-rc.1):
+  - React-Mapbuffer (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2185,7 +2185,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.80.0-rc.1):
+  - React-microtasksnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2477,7 +2477,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.80.0-rc.1):
+  - React-NativeModulesApple (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2498,8 +2498,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.80.0-rc.1)
-  - React-perflogger (0.80.0-rc.1):
+  - React-oscompat (0.80.0-rc.2)
+  - React-perflogger (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2508,7 +2508,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.80.0-rc.1):
+  - React-performancetimeline (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2521,9 +2521,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.80.0-rc.1):
-    - React-Core/RCTActionSheetHeaders (= 0.80.0-rc.1)
-  - React-RCTAnimation (0.80.0-rc.1):
+  - React-RCTActionSheet (0.80.0-rc.2):
+    - React-Core/RCTActionSheetHeaders (= 0.80.0-rc.2)
+  - React-RCTAnimation (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2539,7 +2539,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.80.0-rc.1):
+  - React-RCTAppDelegate (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2572,7 +2572,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.80.0-rc.1):
+  - React-RCTBlob (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2591,7 +2591,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.80.0-rc.1):
+  - React-RCTFabric (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2625,7 +2625,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.80.0-rc.1):
+  - React-RCTFBReactNativeSpec (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2643,7 +2643,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCommon
     - SocketRocket
-  - React-RCTImage (0.80.0-rc.1):
+  - React-RCTImage (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2659,14 +2659,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.80.0-rc.1):
-    - React-Core/RCTLinkingHeaders (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+  - React-RCTLinking (0.80.0-rc.2):
+    - React-Core/RCTLinkingHeaders (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.1)
-  - React-RCTNetwork (0.80.0-rc.1):
+    - ReactCommon/turbomodule/core (= 0.80.0-rc.2)
+  - React-RCTNetwork (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2684,7 +2684,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.80.0-rc.1):
+  - React-RCTRuntime (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2704,7 +2704,7 @@ PODS:
     - React-RuntimeCore
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.80.0-rc.1):
+  - React-RCTSettings (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2719,10 +2719,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.80.0-rc.1):
-    - React-Core/RCTTextHeaders (= 0.80.0-rc.1)
+  - React-RCTText (0.80.0-rc.2):
+    - React-Core/RCTTextHeaders (= 0.80.0-rc.2)
     - Yoga
-  - React-RCTVibration (0.80.0-rc.1):
+  - React-RCTVibration (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2736,11 +2736,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.80.0-rc.1)
-  - React-renderercss (0.80.0-rc.1):
+  - React-rendererconsistency (0.80.0-rc.2)
+  - React-renderercss (0.80.0-rc.2):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.80.0-rc.1):
+  - React-rendererdebug (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2750,8 +2750,8 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-rncore (0.80.0-rc.1)
-  - React-RuntimeApple (0.80.0-rc.1):
+  - React-rncore (0.80.0-rc.2)
+  - React-RuntimeApple (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2780,7 +2780,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.80.0-rc.1):
+  - React-RuntimeCore (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2803,9 +2803,9 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.80.0-rc.1):
-    - React-jsi (= 0.80.0-rc.1)
-  - React-RuntimeHermes (0.80.0-rc.1):
+  - React-runtimeexecutor (0.80.0-rc.2):
+    - React-jsi (= 0.80.0-rc.2)
+  - React-RuntimeHermes (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2825,7 +2825,7 @@ PODS:
     - React-RuntimeCore
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.80.0-rc.1):
+  - React-runtimescheduler (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2848,8 +2848,8 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.80.0-rc.1)
-  - React-utils (0.80.0-rc.1):
+  - React-timing (0.80.0-rc.2)
+  - React-utils (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2860,11 +2860,11 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-hermes
-    - React-jsi (= 0.80.0-rc.1)
+    - React-jsi (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactAppDependencyProvider (0.80.0-rc.1):
+  - ReactAppDependencyProvider (0.80.0-rc.2):
     - ReactCodegen
-  - ReactCodegen (0.80.0-rc.1):
+  - ReactCodegen (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2891,7 +2891,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.80.0-rc.1):
+  - ReactCommon (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2899,9 +2899,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.80.0-rc.1)
+    - ReactCommon/turbomodule (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactCommon/turbomodule (0.80.0-rc.1):
+  - ReactCommon/turbomodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2910,15 +2910,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
-    - ReactCommon/turbomodule/bridging (= 0.80.0-rc.1)
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
+    - ReactCommon/turbomodule/bridging (= 0.80.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.80.0-rc.1):
+  - ReactCommon/turbomodule/bridging (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2927,13 +2927,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.80.0-rc.1):
+  - ReactCommon/turbomodule/core (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2942,14 +2942,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-debug (= 0.80.0-rc.1)
-    - React-featureflags (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
-    - React-utils (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-debug (= 0.80.0-rc.2)
+    - React-featureflags (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
+    - React-utils (= 0.80.0-rc.2)
     - SocketRocket
   - RNCAsyncStorage (2.1.2):
     - boost
@@ -4080,69 +4080,69 @@ SPEC CHECKSUMS:
   EXConstants: be238322d57d084dc055dbd5d6fe6479510504ce
   EXImageLoader: ab4fcf9240cf3636a83c00e3fc5229d692899428
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: 951161dd9a63523c4eef0fa2a7476639a7ba230d
-  EXNotifications: f0c7597a22645faf9ce9e74f1b1078c16fb7575f
-  Expo: 0315b01bc35f319ef6607e125b8a2a16f0ef5f5e
-  ExpoAppleAuthentication: 4d2e0c88a4463229760f1fbb9a937a810efb6863
-  ExpoAsset: 3bc9adb7dbbf27ae82c18ca97eb988a3ae7e73b1
-  ExpoAudio: 3eb18f4be81d8b9b1be89ef984ee7007bcfb7dc7
-  ExpoBackgroundFetch: 6ea99684804a3a264b08f18cbb3b45a0ecd410ed
-  ExpoBackgroundTask: 8fb71e8c886f7b6156b12a603f76468e14ff34ee
-  ExpoBattery: f824a89ff65cc0a26a3d3b5ad34d52c81bf75de3
-  ExpoBlur: 7f9379db213e4a56aeceda82e94a7fea1b1d8c48
-  ExpoBrightness: c335c6ccc082d5249a4b38dba5cd9a08aa0bf62b
-  ExpoCalendar: f5f94ea8dcd957b1434beb4e1c0da1af063322e6
-  ExpoCamera: 316809537daad6a5bd2c04b98e0589304beb5551
-  ExpoCellular: 42e0ce2ea38fed4427b28963a51ab86f981dc6ca
-  ExpoClipboard: c9771e7aa5f1316183e4a6f40a5755a0b98a6b8d
-  ExpoContacts: 3dd51c3c53017b4ca05f18e786d1eb1ace729ef3
-  ExpoCrypto: e5098d184ff5989ac395542d5d41f84e2051bffa
-  ExpoDevice: 7082f03af1c588333ef1417d5aa8287081d94b24
-  ExpoDocumentPicker: 5487ce33530198f4ecf724e650d390b2abe84c15
-  ExpoDomWebView: 7da35d25b340e2eef229d3c083279fcb982d3e35
-  ExpoFileSystem: c36eb8155eb2381c83dda7dc210e3eec332368b6
-  ExpoFont: abbb91a911eb961652c2b0a22eef801860425ed6
-  ExpoGL: 91fc38ca1ffc07b29c6848b396a5a793ac0304cf
-  ExpoHaptics: 0ff6e0d83cd891178a306e548da1450249d54500
-  ExpoHead: af044f3e9c99e7d8d21bf653b4c2f2ef53a7f082
-  ExpoImage: e7738bebc58cee17e93fa161f2444f9c343996f5
-  ExpoImageManipulator: 1e06e7a1e56f454e75d01b7032c1e44963bfc865
-  ExpoImagePicker: 0963da31800c906e01c03e25d7c849f16ebf02a2
-  ExpoKeepAwake: bf0811570c8da182bfb879169437d4de298376e7
-  ExpoLinearGradient: a3126d055dd021c1eb38a2cf28052ccbd1a2b3e2
-  ExpoLinking: b85ff4eafeae6fc638c6cace60007ae521af0ef4
-  ExpoLivePhoto: 1336460da8e4eb2ee56e00636bb5fee4dfb7e82d
-  ExpoLocalAuthentication: 490fac71e8b2ad9f1252ee7c7b391f85db1fae33
-  ExpoLocalization: f6c6aaa3bfff77b666bb958bdfeb5c55df21d990
-  ExpoLocation: a319a1b2c00b82c29e8a24227e0f00d1e19662c5
-  ExpoMailComposer: 80202cd81ced18423d7f32f71a8fdd57d363d473
-  ExpoMediaLibrary: ef14f0390b06ddecca98118eb7332e92efe4765a
-  ExpoMeshGradient: 0cf84ffc9edb16fa2866f940a2dafd4aa7981992
-  ExpoModulesCore: 02e7023db6e900ff25151706704a4456ff38027c
-  ExpoModulesTestCore: d6662b74972dc77882320e188edf12cbcb2545e9
-  ExpoNetwork: 92cac43c13a2d9e9c1470ec8804836574ff34068
-  ExpoPrint: b278f5d9ac844f4b1f65dd06183970602e09bc8b
-  ExpoScreenCapture: 9a8af9f915c2d733d1af8c6c34456f17dc6ede0a
-  ExpoScreenOrientation: 94c8ff1f851c988094dac7f661da6f4a79efeb57
-  ExpoSecureStore: b367d9f62c9102d808afbeb1561636d4276e439d
-  ExpoSensors: 38ae3a55b484410a7976fa3ff78ea80339252e75
-  ExpoSharing: b0377be82430d07398c6a4cd60b5a15696accbd3
-  ExpoSMS: 770f0b60a777f5d3f65fd7fc369ff62ff97e09a9
-  ExpoSpeech: 9b3bdf552e69c8015c246dc52b5ad5fcdbec878e
-  ExpoSQLite: 9f6471a32aeddaea2c57594bebb42ca78aa19fe9
-  ExpoStoreReview: f70e5929ba4a594078dd3285d5151427167f48fa
-  ExpoSymbols: 5324de61341b396965a1cd3d2c738227b13d6a60
-  ExpoSystemUI: 82c970cf8495449698e7343b4f78a0d04bcec9ee
-  ExpoTrackingTransparency: b78875f39a0c37b39ac275466314b606497831b1
-  ExpoVideo: 2c64da924a5915db157485edfe8d3c1a32def964
-  ExpoVideoThumbnails: ef1a4c7bff9ab3b4e006ce17576c3f09320b4cf4
-  ExpoWebBrowser: 06fb5f767f53ad53944b068cdd207984cb998712
+  EXManifests: 75cba7539b60676be1911d024252a11b846085ed
+  EXNotifications: f0f1c97d04f06c51ea073d7b2396431e5611c1ea
+  Expo: 449fa5f24115c93d2573a8f012ace3187e3b02a5
+  ExpoAppleAuthentication: 7e358fcbcbacb7685cddb0bbeede0acd677e58f6
+  ExpoAsset: 3ea3275cca6a7793b3d36fbf1075c590f803fbcb
+  ExpoAudio: 58670fa530972e56145c4f26dee8bc39416ed78b
+  ExpoBackgroundFetch: 76c48b3cd9a4ee46e5267614a30fac804de6f33e
+  ExpoBackgroundTask: 9296d983f3d612359419e015ded65ebe9de30ba2
+  ExpoBattery: 2bdb40a8943dae1cbab23ccaaab09d0cc78de0ae
+  ExpoBlur: 5d95f7ca771a0f3b9618466525dd68e46dc95f3a
+  ExpoBrightness: 05e750736f8886dcf235212b0caf85b0f605fc88
+  ExpoCalendar: 660542dc1c5ef98f46bedcc8745aa707df5d501a
+  ExpoCamera: e88fc30631e63e5504ce19d52c563a6ec49e17d2
+  ExpoCellular: 040f1a7a3dc3a6f573f2b077a7911bdbe3aeb923
+  ExpoClipboard: c187b3101e5f38cce4c6321788e0047f1c29e152
+  ExpoContacts: 870a98e359ee83ab9fa15eee40c66d15731747a8
+  ExpoCrypto: fc94a8865ce0e06c68c10c3993f9ac9a6424d0c2
+  ExpoDevice: 7a961caede6638aa0d37d0d3aa884ab957a2e3d3
+  ExpoDocumentPicker: d1bb0c63fc686a74455bd7c2cd54545fa6231b66
+  ExpoDomWebView: d97348ddd1e1981e30f052d58a4bcb7bfbb737f5
+  ExpoFileSystem: 3a98ca2a6f13674ecfd97327d1b44a8ace444cbd
+  ExpoFont: 312c73403bbd4f98e1d6a5330641a56292583cd2
+  ExpoGL: 8f7f43291e400621ef9aeb7af347816c2051ddc7
+  ExpoHaptics: 68c215e070f660e0a29c45dcda4f60eeff08aefb
+  ExpoHead: 5df88545652c2d3a3ea50bcd7f6be6ca935ac997
+  ExpoImage: ef8b25fddd3613a0bbdb2936d0583bc6588197dd
+  ExpoImageManipulator: 094b748056f2654d5d7813370c910e20ef3d79b4
+  ExpoImagePicker: d2fff488a0738343a3cc21e98544ee9feafaa0e6
+  ExpoKeepAwake: e8dedc115d9f6f24b153ccd2d1d8efcdfd68a527
+  ExpoLinearGradient: 42e58f6db5ebc20b6fbbf7d31013264644ab12a4
+  ExpoLinking: 5d151d4a497d7e375308602f0a89b4e8acf7b5f8
+  ExpoLivePhoto: b47b0598f335a979749ec76d4b3e5a4f9fa84150
+  ExpoLocalAuthentication: fd8b38cdb709f6c327995668223529763619a5c6
+  ExpoLocalization: 7cd94f24bc3ff2f263cb4258fe1e86a97bc1ea64
+  ExpoLocation: afc197fce1045ac7325f095b0c149308e1653aab
+  ExpoMailComposer: e0340cff1246b9c9c493f9a0f9549d92c53d7950
+  ExpoMediaLibrary: ad61cd80ca07da02be3d676e3d9b04b311a82c2c
+  ExpoMeshGradient: ee97f0bfd80356910ca4fc2b67663ea0d9e14a41
+  ExpoModulesCore: 0b7a0299baa6c8de3b9331869d61df3e7c2f5e0f
+  ExpoModulesTestCore: c87ba2da38070e3483a3049453a4dc898b972eb2
+  ExpoNetwork: 9fdbef259f313a1ba7ede5fa977ee3dfed6fe653
+  ExpoPrint: 187f43f5d16bc8db93fb6609707ed40b8e90d3a6
+  ExpoScreenCapture: 4de83d2f4e377a60ac246548212fa3cb91863a90
+  ExpoScreenOrientation: c0ea1650e8e1959b855711f6674cd570e5928c8b
+  ExpoSecureStore: 3148869ad24ab94f9e0c5777c7941d7a37d60399
+  ExpoSensors: a997847b03472f79eabb7989446088bd8f791657
+  ExpoSharing: 04b346bdd7c8ea1fa87047ac7bba65c37bde4f51
+  ExpoSMS: de195632beeb7ef00556750da10da667596d8967
+  ExpoSpeech: fceabf6bf31aa9530ef0696e6793571edb702068
+  ExpoSQLite: c092c9454ad72ba09e29c494470a4fe41996f741
+  ExpoStoreReview: bed43bea90a5876a6a480504f95fea1521dacaa7
+  ExpoSymbols: b5dbeee7d8d901d15016d4084a7096b64644e3bb
+  ExpoSystemUI: 5ae7571742a69d0fc29145b6512f53879a3f42e5
+  ExpoTrackingTransparency: 843029c42d70de59bb0503f6fc747b9d2fe67f7b
+  ExpoVideo: 54ce43735b4ceb6b3828e3eec3b750b0fe10314c
+  ExpoVideoThumbnails: 4280333bee3bd4d69b3b139bd50a8b7c967095ae
+  ExpoWebBrowser: 1051486eb45a2f4d1ee075712604f43f3009f90e
   EXStructuredHeaders: 32bec6771c2db18c4cd47cecae530d1d06cdf972
-  EXTaskManager: a7a2d34c0fa6a459dcd9f50844ecbec886bd2da8
-  EXUpdates: bbcdb32ab776bdcf06202498a7314cc6bbf419d4
-  EXUpdatesInterface: 7ff005b7af94ee63fa452ea7bb95d7a8ff40277a
+  EXTaskManager: 0128b9f39a088b0c762d8d1c42017e6d44200b29
+  EXUpdates: 3e352b121c235fe6c41532d7931ae47c2561ab96
+  EXUpdatesInterface: 64f35449b8ef89ce08cdd8952a4d119b5de6821d
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: a7f87938d9553c58c1fc8c4a952e1c6b41a8dcfd
+  FBLazyVector: a29cb71e603040d186ede90b91213d24051fa395
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
   FirebaseCore: 2321536f9c423b1f857e047a82b8a42abc6d9e2c
   FirebaseCoreExtension: 3a64994969dd05f4bcb7e6896c654eded238e75b
@@ -4158,110 +4158,110 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 23516557c1f8951dee5152917a6027e52f3347f3
+  hermes-engine: 138c9bbaf158570b1b78bcaa148f086951aa090c
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: c210f6206cbb1195b25799bb48c0f4d01151d4f8
+  lottie-react-native: 75b793d20dd0c6c16605e9af592ca9d008cdb92a
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
-  RCTDeprecation: 83ffb90c23ee5cea353bd32008a7bca100908f8c
-  RCTRequired: eb7c0aba998009f47a540bec9e9d69a54f68136e
-  RCTTypeSafety: 659ae318c09de0477fd27bbc9e140071c7ea5c93
+  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  RCTDeprecation: 339b52fd8eeae650a419b219f55baa2d7e4e7ac6
+  RCTRequired: 4b6dd8d557716607245fdd5ec8dcac9e3fca36ec
+  RCTTypeSafety: 827d6724a7d766b573c1fdf6acab8e93b8ccb9b3
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 6d4f7cc02ade4a926aed958d2f41f44e3162eb91
-  React-callinvoker: d5f0e4463448c54d85d1c932bb2151086eabdb32
-  React-Core: c7765d25462595bc3b687e711718b4e39db4384c
-  React-CoreModules: df439afbe3c663bd82b172d33377cddeed701a7e
-  React-cxxreact: 13011feb31e9bf2d4e62e0e01266e76ab0eb2af0
-  React-debug: f3412fe8198e2811b239777f1149e7aee110bc94
-  React-defaultsnativemodule: d27ec9d295137d1211ca990a50857feb054d6565
-  React-domnativemodule: 70a88f919cb7c43ead8a3603a89a79253bad577e
-  React-Fabric: c033a162c4e357b109584b146b2f5a162c8ef58c
-  React-FabricComponents: 4bd6fdcc540c5382858f2e27780c3ea2c4c298d0
-  React-FabricImage: f1920bb45bc08dc16dff43156746593de048fde9
-  React-featureflags: 9011f9bfc690f6543744c2fbd8edd54dad157479
-  React-featureflagsnativemodule: bd61c3757c62e10901730eb672859ceed849bdda
-  React-graphics: 46cf342c230b383c66ad2dfb026cf5fa5226630c
-  React-hermes: 0be4a7c2631d2e16ae7b8b80d684f986cf091ec0
-  React-idlecallbacksnativemodule: 2019e0e37350ae9c16a172ff2c5b047385893c31
-  React-ImageManager: 09f9ab7e0859b396fa8c1831e666bfb0a2c0ca70
-  React-jsc: b7fa3479307298ae4b48fda65a5dfbcb29da4d72
-  React-jserrorhandler: 9ac4919ef4664b3ae2fa43a28e3355d3171f26c8
-  React-jsi: 51012a1761d2a90ffdc5c7e23a1adad981a8cdb2
-  React-jsiexecutor: d8941f4b05d56ce68190505d937040de1f72c709
-  React-jsinspector: 2686dd01c1c0fa954ad8a6bbe29fc8176258643d
-  React-jsinspectorcdp: 842fed0b3d221ec5c3dcc4b5e6af42905e2f0a4a
-  React-jsinspectornetwork: ccfa7d29d8b7c5fc4db8eba4dab0383f062a3c03
-  React-jsinspectortracing: 2c7167bb0b883da6cd8f9b0a3cc29c46a24bd36b
-  React-jsitooling: a40f3aa3a790f593990955cd9fb4df5b816fe8ce
-  React-jsitracing: 124b3d8e966312beabb42fdc18bc71ce763394c7
-  React-logger: 752aeba6029bfcde5e4001b6cadfcc5d984a9dff
-  React-Mapbuffer: 87868c938dfe459d024127d9755c0bca44e96a68
-  React-microtasksnativemodule: 01459d49fb19d699228ae9748b5f5b9eaa366c56
-  react-native-google-maps: c4f5c5b2dda17e7cb2cb2b37a81f140b039b3e7e
-  react-native-maps: 9febd31278b35cd21e4fad2cf6fa708993be5dab
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-pager-view: 682422a9cd034c335cae12106c5ca8f892cffe9d
-  react-native-safe-area-context: bd8e149c82b5a20cfd55e9775d82f1b5954b7e6d
-  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
-  react-native-skia: aca750009e25e8c904499677708773b6eb75b1b2
-  react-native-slider: 56b308308abe55943cac13b1818da5f0fecd372d
-  react-native-view-shot: 86844f7d310b4a26d84102a2c5078203c627b3be
-  react-native-webview: 7dd453f59dcc0fa3e4de6ced4dd2be0ac1955fde
-  React-NativeModulesApple: b00b96e89ef10f186f3c7427b141cb39c055e3bd
-  React-oscompat: 7c11d5c1fc5e8ea8ec94084b893ac56a8e897dd4
-  React-perflogger: 79e4553b51a1a87b50876daa95800471866a5a38
-  React-performancetimeline: d7c5d2d92fbeeba7d816f8f6476bf4de8dc68773
-  React-RCTActionSheet: 26ab80f23a43c6bdb8b8f4f6484e50c5f44880bf
-  React-RCTAnimation: 057729e2cf685fecd1d4f4a7775123f17f6d7dcb
-  React-RCTAppDelegate: b5e1bfc5c746e5137597a3ad53be8f7b54507b2f
-  React-RCTBlob: 802eb8b948594c38a0ac50faaaeb5a83b1143e2e
-  React-RCTFabric: 85a814f2eb62d4eea8f8344a823490ff104a7aa4
-  React-RCTFBReactNativeSpec: 3a9185a1c7a9f2f15d42668166fa22fb81f64f1f
-  React-RCTImage: 838984dfcde1fa7a7b3d225dcae15daa095ba3cf
-  React-RCTLinking: 0634dd69549eb70ca4da5c5a0eef5ed233993a34
-  React-RCTNetwork: e0a068887d8fc23bd999175a46660be8fb10b1c3
-  React-RCTRuntime: 23b6bfb6f92234733e1cfda599522106a31a36d6
-  React-RCTSettings: eed9cb7e03a01ed1a08394686350e323f271a9f3
-  React-RCTText: b8e0255162f3793194e05408ec6cb25821461164
-  React-RCTVibration: 7f572eac5a19c9e727b8042b0b60a63eb4c2d823
-  React-rendererconsistency: fb3bd722891a4cc8bab33f4bbf585910c545f3ba
-  React-renderercss: a4a490821e19a38359e955fdfe8df2acb88f0bd1
-  React-rendererdebug: 25511e517b2bf54a3dffbe54b9364968f65a8e81
-  React-rncore: 1f0037879900801c02e92b206fccf916744cafbd
-  React-RuntimeApple: 2758bc7ac5329e69bcd345d5e967b1d8e916dbb3
-  React-RuntimeCore: 179f66ed9832a6af4254586ce2b4c0147aabb37b
-  React-runtimeexecutor: a9f689b57d863d371bd1762591c4fc805de90dc3
-  React-RuntimeHermes: e4546ee1c3965db728070b130410a5b93703bc6c
-  React-runtimescheduler: 53a6176e2c01cd6e52e4321db200cc34be4ab27b
-  React-timing: d729454ff3fd734dd46013c2c2673aa0da6cd2cf
-  React-utils: cdb942859774617eee363d58455da394dd8356ce
-  ReactAppDependencyProvider: 5d4564ba3be2ec04c2f12fa7726f9c43b1cc9741
-  ReactCodegen: f32d4b772f0abd841cc917a4ad7c87ae83d399da
-  ReactCommon: 96a832390a887840dcc5eb3d6918f7fe1494883e
-  RNCAsyncStorage: 3decb3356025058623474790bf552590acaa3da9
-  RNCMaskedView: 7e0ce15656772a939ff0d269100bca3a182163c8
-  RNCPicker: 4890555bd4c19e4ef395b11f6ae18293b4f0db51
-  RNDateTimePicker: 88d8916a57e5bdd603dcaf177fc0f2d6372c92c3
-  RNFlashList: 3d87e2c97db48005075574cf525d0e889ba63179
-  RNGestureHandler: e61ff6d07f74c2184c0f00a001089f06818aa7ae
-  RNReanimated: cb686bdb40e31cc38bad1c9f491922473da07cdb
-  RNScreens: 10ca32b82794369e5857df3c8ca5937c415fbfd3
-  RNSVG: f52557c8b2e0b26e00fc7ed80e1e2ee883ab71a8
+  React: a1830b4b3cff49aa1424b3c63cac6b2bead56a4f
+  React-callinvoker: 85e7c913e9aa96c61fb505af9b304f4fd12ec658
+  React-Core: 8ef9a875466ec8e1004bd1fed5638d3dcdc5439c
+  React-CoreModules: bd8b0e3011b27bdcbe1e15aa03b41edd7331cb73
+  React-cxxreact: 462c3be821106d97c197d0af89ae9886e5a93f5e
+  React-debug: 5af7750f97a9b96e296c4743f78907921964ce98
+  React-defaultsnativemodule: 183b67a1e98f0e73cdb0e895203a8ddd06be4d36
+  React-domnativemodule: 2cb7c3a94520b856d3a0d27d6ed499be138f2860
+  React-Fabric: 35945322d0d702e090b7eff423e64b2c1abccf0c
+  React-FabricComponents: 440686614f720baa1c0395830988d1e78241bec7
+  React-FabricImage: 354b0b87ac9c21e436e9172a3ca0d5ddc77e2d35
+  React-featureflags: 79950c143d25fdafb7be92eb012e9cc172471897
+  React-featureflagsnativemodule: 3de77a999be7ecf2975761f22cf0875d1be79619
+  React-graphics: a70befd182af5bfe77d7f37929bd68423567b053
+  React-hermes: 4a4b9610feff0b9361cb9b1173ba5d7f14b8eaf6
+  React-idlecallbacksnativemodule: fef0ffd2543f9868c1b39cc0ef63c60f3695d93a
+  React-ImageManager: 81393603429e60ec779129eab4904cb4b2430386
+  React-jsc: d6c6c14f5669d54d320f10dc8883e562058aa8d1
+  React-jserrorhandler: 4d206426161af95647b3f2dcc76fd1878d0feaa0
+  React-jsi: 6bd195018f415fe65cc14fc2b82fdbf8022db2e8
+  React-jsiexecutor: 639604430b81b3e09498a8608ed22b58989ad2e0
+  React-jsinspector: ee3f12c77d1ce1060412f93c955ebb507ed986b3
+  React-jsinspectorcdp: bb773dc307b82d05c8a162c9e3db5d633afeaa43
+  React-jsinspectornetwork: c82817824cdc23ac8868a4140780b429d260dba8
+  React-jsinspectortracing: d5714c64818867ba6fe33aa29406a1a5a6781c7e
+  React-jsitooling: 121890b11f9550b3488541427d60be7296b959d5
+  React-jsitracing: b7932f90a52b09953ebf1446cb18b9acaa9d5037
+  React-logger: 97b83557fb6c53d7bf3ba31e10695aa7959b2969
+  React-Mapbuffer: c5325441a01e38337d2f6010360a657059c464a7
+  React-microtasksnativemodule: 62c909456914af65e9372f0680f83694beaebf46
+  react-native-google-maps: 7cc1184afe41fbd15a3dffd53c924819f6587b69
+  react-native-maps: ee1e65647460c3d41e778071be5eda10e3da6225
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-pager-view: 03553493db7fd49946d709ab6d65c7ef0cc929be
+  react-native-safe-area-context: 47c1782a327ca2affa9bec5a2f95534cbabb620a
+  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
+  react-native-skia: 02ffb448bb7c1d181d9b6860274c2ac142331b11
+  react-native-slider: dd3636cb9b888b4d8aaf7ac0bb5e0d2921c5eec6
+  react-native-view-shot: a18275ac858eb4866365148517774182319c7aee
+  react-native-webview: a53cadbdc946b2d14055284ee9f5f81c1d4817a3
+  React-NativeModulesApple: 87e676164ebadd55b400663b4571c4022f76f494
+  React-oscompat: 4dd2483349b4831478aefaee5383b9689521612d
+  React-perflogger: 52e7e072582c777a4323ee7471729d1b28aef9c1
+  React-performancetimeline: fe78af3c8d00a2d1261d280531203f8fbbaa4b9b
+  React-RCTActionSheet: 637d0560b58e21a20ae498b1272440c79e471781
+  React-RCTAnimation: 5a7b014c525e0b89baa626e88ace369c642b1a8d
+  React-RCTAppDelegate: 9c233a5a6c722d980d5f1bac066f247b3cbebb77
+  React-RCTBlob: fcb766c955a8eb2f94e85b28db387abcfe3480a8
+  React-RCTFabric: d282c54c4e2a88ce7daa6d54c5cc96c8bded0515
+  React-RCTFBReactNativeSpec: 84bc55e6d1cdde8862dfdef236cc5e5d8f39921e
+  React-RCTImage: 28245c7f53874bbeefcf8bda8de1283c5f93d13c
+  React-RCTLinking: 503721813b57b3bb0aa06fc9b092ad9bec65b9eb
+  React-RCTNetwork: 234723ddaf17ccc2ddbae8ff544f644274940ac7
+  React-RCTRuntime: fa8517347cd4f31fbbfd2fb72a8643b4a34c3b3d
+  React-RCTSettings: d79af692bef22683c44cbe55f9ce823f61b1f2b3
+  React-RCTText: 385f49baf872fab4e8e4f87f31b72ac2ff140216
+  React-RCTVibration: a12051842416e423971748e26a6db6ea66732f51
+  React-rendererconsistency: 78483139826d7b03663093c781e535d30773aca9
+  React-renderercss: 2e646d2a5b4f10580a8556bd8afd1a05f66fb2d9
+  React-rendererdebug: 43ac356fc1d96b691854cc26ddab8aeba0f08f59
+  React-rncore: 64f6c9ebb626d5fc204aeaeea880b4f2220af899
+  React-RuntimeApple: f98806b18a0ab360e8ff4435e57bcf0b875e1833
+  React-RuntimeCore: 473cb858bee905bd617e33e3cd0b4996e37d2832
+  React-runtimeexecutor: a7c556446d3ede28f56c3f5adaf14a00a35d4091
+  React-RuntimeHermes: 45539d07d900693c60bc3d423c85b34ca4dace1e
+  React-runtimescheduler: bc66d28aea5bd9abf4a6aeb19466ad42463dbde5
+  React-timing: fd9c334ce6fb6075921084299a2fd5c538352b1d
+  React-utils: ece43bc95e748e9c21edfea6fc32ce3883448e42
+  ReactAppDependencyProvider: 92ea8aa743b2643d51873c6cd89bc9cd142e7919
+  ReactCodegen: 049cecbdd254edc399f76524cb4b7da73e9a673c
+  ReactCommon: 9e45a41bdc4bb215727d8dee04eba6f0900e2b1a
+  RNCAsyncStorage: 8de84536d0038b97a1b85d23681c2aed5f641430
+  RNCMaskedView: aac38cf7e947ff80e483996d1acd43c5ad4ab610
+  RNCPicker: 9f14f7b5511d88d7608b344e9089916ff8a47298
+  RNDateTimePicker: c525b5bb1b2d9766d3fa5e178495c222d8a75c87
+  RNFlashList: 30e89fd3a2a5825e2d317e27b963302b2f4a0030
+  RNGestureHandler: 683d606f47ef460f46688aef0d995c6fc3ca6595
+  RNReanimated: 12166f0ce1098c4eddfb67e4bea61f690a340d39
+  RNScreens: 1dde4b934a98cb214c88391717b0e98c56d5506d
+  RNSVG: b93bfc39443b95ecaea98711a93212aa5e4f0b7c
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Stripe: ddb4645ea7f46475ce790b4a6c6475ec3e45bfd4
-  stripe-react-native: f1db782b66245718a814c47bca472dd7147693e5
+  stripe-react-native: 107246fb8bc4f484c902e9995c7a3362dd838813
   StripeApplePay: ab8fc9905220fe4d5a46fd8b790065982bbfbad8
   StripeCore: 1c40a6b42a385bf96d051a6184dd3969b9ab3174
   StripeFinancialConnections: 4c5c2136191e0a385332eb59566f9b966d40a660
@@ -4270,7 +4270,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: 724c562849578aa4747d17e9f3cfe0ef3f8ab7fb
   StripeUICore: 0e0f3005fd3027dad3d3d77927f371d5fe4eb9ac
   UMAppLoader: 55159b69750129faa7a51c493cb8ea55a7b64eb9
-  Yoga: 641086d9089de90327f09178a27eceaf86a7ae5e
+  Yoga: 1cf315b6f6373fa6118b88bf0c7a2c6dd760706c
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 9f104a55d90568cbeff5ed1bb052a935a9042f4f

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -68,7 +68,7 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.1",
+    "react-native": "0.80.0-rc.2",
     "react-native-edge-to-edge": "1.6.0",
     "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~2.24.0",

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -9,6 +9,6 @@
     "expo": "~53.0.9",
     "expo-clipboard": "~7.1.4",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.1"
+    "react-native": "0.80.0-rc.2"
   }
 }

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -137,7 +137,7 @@
     "processing-js": "^1.6.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.80.0-rc.1",
+    "react-native": "0.80.0-rc.2",
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-maps": "1.20.1",

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -568,7 +568,7 @@ PODS:
   - EXUpdatesInterface (1.1.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.80.0-rc.1)
+  - FBLazyVector (0.80.0-rc.2)
   - fmt (11.0.2)
   - glog (0.3.5)
   - hermes-engine (0.80.0-rc.1):
@@ -625,28 +625,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.80.0-rc.1)
-  - RCTRequired (0.80.0-rc.1)
-  - RCTTypeSafety (0.80.0-rc.1):
-    - FBLazyVector (= 0.80.0-rc.1)
-    - RCTRequired (= 0.80.0-rc.1)
-    - React-Core (= 0.80.0-rc.1)
+  - RCTDeprecation (0.80.0-rc.2)
+  - RCTRequired (0.80.0-rc.2)
+  - RCTTypeSafety (0.80.0-rc.2):
+    - FBLazyVector (= 0.80.0-rc.2)
+    - RCTRequired (= 0.80.0-rc.2)
+    - React-Core (= 0.80.0-rc.2)
   - ReachabilitySwift (5.0.0)
-  - React (0.80.0-rc.1):
-    - React-Core (= 0.80.0-rc.1)
-    - React-Core/DevSupport (= 0.80.0-rc.1)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.1)
-    - React-RCTActionSheet (= 0.80.0-rc.1)
-    - React-RCTAnimation (= 0.80.0-rc.1)
-    - React-RCTBlob (= 0.80.0-rc.1)
-    - React-RCTImage (= 0.80.0-rc.1)
-    - React-RCTLinking (= 0.80.0-rc.1)
-    - React-RCTNetwork (= 0.80.0-rc.1)
-    - React-RCTSettings (= 0.80.0-rc.1)
-    - React-RCTText (= 0.80.0-rc.1)
-    - React-RCTVibration (= 0.80.0-rc.1)
-  - React-callinvoker (0.80.0-rc.1)
-  - React-Core (0.80.0-rc.1):
+  - React (0.80.0-rc.2):
+    - React-Core (= 0.80.0-rc.2)
+    - React-Core/DevSupport (= 0.80.0-rc.2)
+    - React-Core/RCTWebSocket (= 0.80.0-rc.2)
+    - React-RCTActionSheet (= 0.80.0-rc.2)
+    - React-RCTAnimation (= 0.80.0-rc.2)
+    - React-RCTBlob (= 0.80.0-rc.2)
+    - React-RCTImage (= 0.80.0-rc.2)
+    - React-RCTLinking (= 0.80.0-rc.2)
+    - React-RCTNetwork (= 0.80.0-rc.2)
+    - React-RCTSettings (= 0.80.0-rc.2)
+    - React-RCTText (= 0.80.0-rc.2)
+    - React-RCTVibration (= 0.80.0-rc.2)
+  - React-callinvoker (0.80.0-rc.2)
+  - React-Core (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -656,7 +656,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.1)
+    - React-Core/Default (= 0.80.0-rc.2)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -670,79 +670,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.1)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.1)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.80.0-rc.1):
+  - React-Core/CoreModulesHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -766,7 +694,55 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.80.0-rc.1):
+  - React-Core/Default (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0-rc.2)
+    - React-Core/RCTWebSocket (= 0.80.0-rc.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -790,7 +766,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.80.0-rc.1):
+  - React-Core/RCTAnimationHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -814,7 +790,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.80.0-rc.1):
+  - React-Core/RCTBlobHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -838,7 +814,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.80.0-rc.1):
+  - React-Core/RCTImageHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -862,7 +838,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.80.0-rc.1):
+  - React-Core/RCTLinkingHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -886,7 +862,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.80.0-rc.1):
+  - React-Core/RCTNetworkHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -910,7 +886,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.80.0-rc.1):
+  - React-Core/RCTSettingsHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -934,7 +910,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.80.0-rc.1):
+  - React-Core/RCTTextHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -958,7 +934,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.80.0-rc.1):
+  - React-Core/RCTVibrationHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -968,7 +944,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.1)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -982,7 +958,31 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.80.0-rc.1):
+  - React-Core/RCTWebSocket (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0-rc.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -990,19 +990,19 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.80.0-rc.1)
-    - React-Core/CoreModulesHeaders (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - RCTTypeSafety (= 0.80.0-rc.2)
+    - React-Core/CoreModulesHeaders (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.80.0-rc.1)
+    - React-RCTImage (= 0.80.0-rc.2)
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.80.0-rc.1):
+  - React-cxxreact (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1011,19 +1011,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-debug (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-debug (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
-    - React-runtimeexecutor (= 0.80.0-rc.1)
-    - React-timing (= 0.80.0-rc.1)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
+    - React-runtimeexecutor (= 0.80.0-rc.2)
+    - React-timing (= 0.80.0-rc.2)
     - SocketRocket
-  - React-debug (0.80.0-rc.1)
-  - React-defaultsnativemodule (0.80.0-rc.1):
+  - React-debug (0.80.0-rc.2)
+  - React-defaultsnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1041,7 +1041,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.80.0-rc.1):
+  - React-domnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1060,7 +1060,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.80.0-rc.1):
+  - React-Fabric (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1074,22 +1074,22 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.80.0-rc.1)
-    - React-Fabric/attributedstring (= 0.80.0-rc.1)
-    - React-Fabric/componentregistry (= 0.80.0-rc.1)
-    - React-Fabric/componentregistrynative (= 0.80.0-rc.1)
-    - React-Fabric/components (= 0.80.0-rc.1)
-    - React-Fabric/consistency (= 0.80.0-rc.1)
-    - React-Fabric/core (= 0.80.0-rc.1)
-    - React-Fabric/dom (= 0.80.0-rc.1)
-    - React-Fabric/imagemanager (= 0.80.0-rc.1)
-    - React-Fabric/leakchecker (= 0.80.0-rc.1)
-    - React-Fabric/mounting (= 0.80.0-rc.1)
-    - React-Fabric/observers (= 0.80.0-rc.1)
-    - React-Fabric/scheduler (= 0.80.0-rc.1)
-    - React-Fabric/telemetry (= 0.80.0-rc.1)
-    - React-Fabric/templateprocessor (= 0.80.0-rc.1)
-    - React-Fabric/uimanager (= 0.80.0-rc.1)
+    - React-Fabric/animations (= 0.80.0-rc.2)
+    - React-Fabric/attributedstring (= 0.80.0-rc.2)
+    - React-Fabric/componentregistry (= 0.80.0-rc.2)
+    - React-Fabric/componentregistrynative (= 0.80.0-rc.2)
+    - React-Fabric/components (= 0.80.0-rc.2)
+    - React-Fabric/consistency (= 0.80.0-rc.2)
+    - React-Fabric/core (= 0.80.0-rc.2)
+    - React-Fabric/dom (= 0.80.0-rc.2)
+    - React-Fabric/imagemanager (= 0.80.0-rc.2)
+    - React-Fabric/leakchecker (= 0.80.0-rc.2)
+    - React-Fabric/mounting (= 0.80.0-rc.2)
+    - React-Fabric/observers (= 0.80.0-rc.2)
+    - React-Fabric/scheduler (= 0.80.0-rc.2)
+    - React-Fabric/telemetry (= 0.80.0-rc.2)
+    - React-Fabric/templateprocessor (= 0.80.0-rc.2)
+    - React-Fabric/uimanager (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1101,32 +1101,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.80.0-rc.1):
+  - React-Fabric/animations (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1151,7 +1126,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.80.0-rc.1):
+  - React-Fabric/attributedstring (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1176,7 +1151,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.80.0-rc.1):
+  - React-Fabric/componentregistry (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1201,36 +1176,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0-rc.1)
-    - React-Fabric/components/root (= 0.80.0-rc.1)
-    - React-Fabric/components/scrollview (= 0.80.0-rc.1)
-    - React-Fabric/components/view (= 0.80.0-rc.1)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.80.0-rc.1):
+  - React-Fabric/componentregistrynative (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1255,7 +1201,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.80.0-rc.1):
+  - React-Fabric/components (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0-rc.2)
+    - React-Fabric/components/root (= 0.80.0-rc.2)
+    - React-Fabric/components/scrollview (= 0.80.0-rc.2)
+    - React-Fabric/components/view (= 0.80.0-rc.2)
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1280,7 +1255,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.80.0-rc.1):
+  - React-Fabric/components/root (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1305,7 +1280,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.80.0-rc.1):
+  - React-Fabric/components/scrollview (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1332,7 +1332,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.80.0-rc.1):
+  - React-Fabric/consistency (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1357,7 +1357,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.80.0-rc.1):
+  - React-Fabric/core (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1382,7 +1382,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.80.0-rc.1):
+  - React-Fabric/dom (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1407,7 +1407,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.80.0-rc.1):
+  - React-Fabric/imagemanager (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1432,7 +1432,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.80.0-rc.1):
+  - React-Fabric/leakchecker (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1457,7 +1457,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.80.0-rc.1):
+  - React-Fabric/mounting (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1482,7 +1482,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.80.0-rc.1):
+  - React-Fabric/observers (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1496,7 +1496,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.80.0-rc.1)
+    - React-Fabric/observers/events (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1508,7 +1508,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.80.0-rc.1):
+  - React-Fabric/observers/events (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1533,7 +1533,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.80.0-rc.1):
+  - React-Fabric/scheduler (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1560,7 +1560,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.80.0-rc.1):
+  - React-Fabric/telemetry (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1585,7 +1585,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.80.0-rc.1):
+  - React-Fabric/templateprocessor (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1610,7 +1610,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.80.0-rc.1):
+  - React-Fabric/uimanager (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1624,33 +1624,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.80.0-rc.1)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/uimanager/consistency (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1663,7 +1637,33 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.80.0-rc.1):
+  - React-Fabric/uimanager/consistency (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-FabricComponents (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1678,8 +1678,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.80.0-rc.1)
-    - React-FabricComponents/textlayoutmanager (= 0.80.0-rc.1)
+    - React-FabricComponents/components (= 0.80.0-rc.2)
+    - React-FabricComponents/textlayoutmanager (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1692,7 +1692,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.80.0-rc.1):
+  - React-FabricComponents/components (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1707,15 +1707,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.80.0-rc.1)
-    - React-FabricComponents/components/iostextinput (= 0.80.0-rc.1)
-    - React-FabricComponents/components/modal (= 0.80.0-rc.1)
-    - React-FabricComponents/components/rncore (= 0.80.0-rc.1)
-    - React-FabricComponents/components/safeareaview (= 0.80.0-rc.1)
-    - React-FabricComponents/components/scrollview (= 0.80.0-rc.1)
-    - React-FabricComponents/components/text (= 0.80.0-rc.1)
-    - React-FabricComponents/components/textinput (= 0.80.0-rc.1)
-    - React-FabricComponents/components/unimplementedview (= 0.80.0-rc.1)
+    - React-FabricComponents/components/inputaccessory (= 0.80.0-rc.2)
+    - React-FabricComponents/components/iostextinput (= 0.80.0-rc.2)
+    - React-FabricComponents/components/modal (= 0.80.0-rc.2)
+    - React-FabricComponents/components/rncore (= 0.80.0-rc.2)
+    - React-FabricComponents/components/safeareaview (= 0.80.0-rc.2)
+    - React-FabricComponents/components/scrollview (= 0.80.0-rc.2)
+    - React-FabricComponents/components/text (= 0.80.0-rc.2)
+    - React-FabricComponents/components/textinput (= 0.80.0-rc.2)
+    - React-FabricComponents/components/unimplementedview (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1728,61 +1728,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/modal (0.80.0-rc.1):
+  - React-FabricComponents/components/inputaccessory (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1809,7 +1755,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.80.0-rc.1):
+  - React-FabricComponents/components/iostextinput (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1836,7 +1782,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.80.0-rc.1):
+  - React-FabricComponents/components/modal (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1863,7 +1809,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.80.0-rc.1):
+  - React-FabricComponents/components/rncore (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1890,7 +1836,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.80.0-rc.1):
+  - React-FabricComponents/components/safeareaview (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1917,7 +1863,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.80.0-rc.1):
+  - React-FabricComponents/components/scrollview (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1944,7 +1890,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.80.0-rc.1):
+  - React-FabricComponents/components/text (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1971,7 +1917,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.80.0-rc.1):
+  - React-FabricComponents/components/textinput (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1998,7 +1944,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.80.0-rc.1):
+  - React-FabricComponents/components/unimplementedview (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2007,22 +1953,76 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.80.0-rc.1)
-    - RCTTypeSafety (= 0.80.0-rc.1)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.80.0-rc.2)
+    - RCTTypeSafety (= 0.80.0-rc.2)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-hermes
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.1)
+    - React-jsiexecutor (= 0.80.0-rc.2)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.80.0-rc.1):
+  - React-featureflags (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2031,7 +2031,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.80.0-rc.1):
+  - React-featureflagsnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2047,7 +2047,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.80.0-rc.1):
+  - React-graphics (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2061,7 +2061,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.80.0-rc.1):
+  - React-hermes (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2070,16 +2070,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.1)
+    - React-cxxreact (= 0.80.0-rc.2)
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.1)
+    - React-jsiexecutor (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.1)
+    - React-perflogger (= 0.80.0-rc.2)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.80.0-rc.1):
+  - React-idlecallbacksnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2095,7 +2095,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.80.0-rc.1):
+  - React-ImageManager (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2110,7 +2110,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.80.0-rc.1):
+  - React-jserrorhandler (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2125,7 +2125,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.80.0-rc.1):
+  - React-jsi (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2135,7 +2135,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.80.0-rc.1):
+  - React-jsiexecutor (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2144,14 +2144,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.1)
+    - React-perflogger (= 0.80.0-rc.2)
     - SocketRocket
-  - React-jsinspector (0.80.0-rc.1):
+  - React-jsinspector (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2165,10 +2165,10 @@ PODS:
     - React-jsinspectorcdp
     - React-jsinspectornetwork
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.1)
-    - React-runtimeexecutor (= 0.80.0-rc.1)
+    - React-perflogger (= 0.80.0-rc.2)
+    - React-runtimeexecutor (= 0.80.0-rc.2)
     - SocketRocket
-  - React-jsinspectorcdp (0.80.0-rc.1):
+  - React-jsinspectorcdp (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2177,7 +2177,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.80.0-rc.1):
+  - React-jsinspectornetwork (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2187,7 +2187,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-jsinspectorcdp
     - SocketRocket
-  - React-jsinspectortracing (0.80.0-rc.1):
+  - React-jsinspectortracing (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2197,7 +2197,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-oscompat
     - SocketRocket
-  - React-jsitooling (0.80.0-rc.1):
+  - React-jsitooling (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2205,15 +2205,15 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - SocketRocket
-  - React-jsitracing (0.80.0-rc.1):
+  - React-jsitracing (0.80.0-rc.2):
     - React-jsi
-  - React-logger (0.80.0-rc.1):
+  - React-logger (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2222,7 +2222,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.80.0-rc.1):
+  - React-Mapbuffer (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2232,7 +2232,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.80.0-rc.1):
+  - React-microtasksnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2247,7 +2247,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-NativeModulesApple (0.80.0-rc.1):
+  - React-NativeModulesApple (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2268,8 +2268,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.80.0-rc.1)
-  - React-perflogger (0.80.0-rc.1):
+  - React-oscompat (0.80.0-rc.2)
+  - React-perflogger (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2278,7 +2278,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.80.0-rc.1):
+  - React-performancetimeline (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2291,9 +2291,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.80.0-rc.1):
-    - React-Core/RCTActionSheetHeaders (= 0.80.0-rc.1)
-  - React-RCTAnimation (0.80.0-rc.1):
+  - React-RCTActionSheet (0.80.0-rc.2):
+    - React-Core/RCTActionSheetHeaders (= 0.80.0-rc.2)
+  - React-RCTAnimation (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2309,7 +2309,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.80.0-rc.1):
+  - React-RCTAppDelegate (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2342,7 +2342,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.80.0-rc.1):
+  - React-RCTBlob (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2361,7 +2361,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.80.0-rc.1):
+  - React-RCTFabric (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2395,7 +2395,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.80.0-rc.1):
+  - React-RCTFBReactNativeSpec (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2413,7 +2413,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCommon
     - SocketRocket
-  - React-RCTImage (0.80.0-rc.1):
+  - React-RCTImage (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2429,14 +2429,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.80.0-rc.1):
-    - React-Core/RCTLinkingHeaders (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+  - React-RCTLinking (0.80.0-rc.2):
+    - React-Core/RCTLinkingHeaders (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.1)
-  - React-RCTNetwork (0.80.0-rc.1):
+    - ReactCommon/turbomodule/core (= 0.80.0-rc.2)
+  - React-RCTNetwork (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2454,7 +2454,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.80.0-rc.1):
+  - React-RCTRuntime (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2474,7 +2474,7 @@ PODS:
     - React-RuntimeCore
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.80.0-rc.1):
+  - React-RCTSettings (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2489,10 +2489,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.80.0-rc.1):
-    - React-Core/RCTTextHeaders (= 0.80.0-rc.1)
+  - React-RCTText (0.80.0-rc.2):
+    - React-Core/RCTTextHeaders (= 0.80.0-rc.2)
     - Yoga
-  - React-RCTVibration (0.80.0-rc.1):
+  - React-RCTVibration (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2506,11 +2506,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.80.0-rc.1)
-  - React-renderercss (0.80.0-rc.1):
+  - React-rendererconsistency (0.80.0-rc.2)
+  - React-renderercss (0.80.0-rc.2):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.80.0-rc.1):
+  - React-rendererdebug (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2520,8 +2520,8 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-rncore (0.80.0-rc.1)
-  - React-RuntimeApple (0.80.0-rc.1):
+  - React-rncore (0.80.0-rc.2)
+  - React-RuntimeApple (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2550,7 +2550,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.80.0-rc.1):
+  - React-RuntimeCore (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2573,9 +2573,9 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.80.0-rc.1):
-    - React-jsi (= 0.80.0-rc.1)
-  - React-RuntimeHermes (0.80.0-rc.1):
+  - React-runtimeexecutor (0.80.0-rc.2):
+    - React-jsi (= 0.80.0-rc.2)
+  - React-RuntimeHermes (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2595,7 +2595,7 @@ PODS:
     - React-RuntimeCore
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.80.0-rc.1):
+  - React-runtimescheduler (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2618,8 +2618,8 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.80.0-rc.1)
-  - React-utils (0.80.0-rc.1):
+  - React-timing (0.80.0-rc.2)
+  - React-utils (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2630,11 +2630,11 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-hermes
-    - React-jsi (= 0.80.0-rc.1)
+    - React-jsi (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactAppDependencyProvider (0.80.0-rc.1):
+  - ReactAppDependencyProvider (0.80.0-rc.2):
     - ReactCodegen
-  - ReactCodegen (0.80.0-rc.1):
+  - ReactCodegen (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2661,7 +2661,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.80.0-rc.1):
+  - ReactCommon (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2669,9 +2669,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.80.0-rc.1)
+    - ReactCommon/turbomodule (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactCommon/turbomodule (0.80.0-rc.1):
+  - ReactCommon/turbomodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2680,15 +2680,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
-    - ReactCommon/turbomodule/bridging (= 0.80.0-rc.1)
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
+    - ReactCommon/turbomodule/bridging (= 0.80.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.80.0-rc.1):
+  - ReactCommon/turbomodule/bridging (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2697,13 +2697,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.80.0-rc.1):
+  - ReactCommon/turbomodule/core (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2712,14 +2712,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-debug (= 0.80.0-rc.1)
-    - React-featureflags (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
-    - React-utils (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-debug (= 0.80.0-rc.2)
+    - React-featureflags (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
+    - React-utils (= 0.80.0-rc.2)
     - SocketRocket
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
@@ -3051,24 +3051,24 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EASClient: 961c6b0118bed52023fd2c129d41cbca212d60c4
+  EASClient: 83423c51dde4c5504cb4186e1f39728273ed334b
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: 951161dd9a63523c4eef0fa2a7476639a7ba230d
-  EXNotifications: f0c7597a22645faf9ce9e74f1b1078c16fb7575f
-  expo-dev-launcher: 85357d34998f8a131c8859ff571c415f79a1cb2c
-  expo-dev-menu: 7fe5af098979d974db69376ec73a49bba2252956
+  EXManifests: 75cba7539b60676be1911d024252a11b846085ed
+  EXNotifications: f0f1c97d04f06c51ea073d7b2396431e5611c1ea
+  expo-dev-launcher: d2f62aae6c777d65233c8d3546dbdf5f85c0f667
+  expo-dev-menu: f2a08f1ecf61b6282f3784add26ebd29cbc85ae2
   expo-dev-menu-interface: 609c35ae8b97479cdd4c9e23c8cf6adc44beea0e
-  ExpoClipboard: c9771e7aa5f1316183e4a6f40a5755a0b98a6b8d
-  ExpoFileSystem: c36eb8155eb2381c83dda7dc210e3eec332368b6
-  ExpoImage: e7738bebc58cee17e93fa161f2444f9c343996f5
-  ExpoMediaLibrary: ef14f0390b06ddecca98118eb7332e92efe4765a
-  ExpoModulesCore: 02e7023db6e900ff25151706704a4456ff38027c
-  ExpoModulesTestCore: d6662b74972dc77882320e188edf12cbcb2545e9
+  ExpoClipboard: c187b3101e5f38cce4c6321788e0047f1c29e152
+  ExpoFileSystem: 3a98ca2a6f13674ecfd97327d1b44a8ace444cbd
+  ExpoImage: ef8b25fddd3613a0bbdb2936d0583bc6588197dd
+  ExpoMediaLibrary: ad61cd80ca07da02be3d676e3d9b04b311a82c2c
+  ExpoModulesCore: 0b7a0299baa6c8de3b9331869d61df3e7c2f5e0f
+  ExpoModulesTestCore: c87ba2da38070e3483a3049453a4dc898b972eb2
   EXStructuredHeaders: 32bec6771c2db18c4cd47cecae530d1d06cdf972
-  EXUpdates: 50721aa6acab2ffe59dc2c22732ac17a31e4af94
-  EXUpdatesInterface: 7ff005b7af94ee63fa452ea7bb95d7a8ff40277a
+  EXUpdates: 9d87d1b97634263b9f8623eb7e763e58b48dc9fb
+  EXUpdatesInterface: 64f35449b8ef89ce08cdd8952a4d119b5de6821d
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: a7f87938d9553c58c1fc8c4a952e1c6b41a8dcfd
+  FBLazyVector: a29cb71e603040d186ede90b91213d24051fa395
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 138c9bbaf158570b1b78bcaa148f086951aa090c
@@ -3079,76 +3079,76 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
-  RCTDeprecation: 230869f38f83ae51956d38c92f05254206bada2c
-  RCTRequired: 549f9bbe320852a24c783f42653901e6a686bff8
-  RCTTypeSafety: 6a69dd0144f99ccbdc46f4eb1a5072979ccf40de
+  RCTDeprecation: 339b52fd8eeae650a419b219f55baa2d7e4e7ac6
+  RCTRequired: 4b6dd8d557716607245fdd5ec8dcac9e3fca36ec
+  RCTTypeSafety: 827d6724a7d766b573c1fdf6acab8e93b8ccb9b3
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  React: 6d4f7cc02ade4a926aed958d2f41f44e3162eb91
-  React-callinvoker: d5f0e4463448c54d85d1c932bb2151086eabdb32
-  React-Core: c7765d25462595bc3b687e711718b4e39db4384c
-  React-CoreModules: df439afbe3c663bd82b172d33377cddeed701a7e
-  React-cxxreact: 13011feb31e9bf2d4e62e0e01266e76ab0eb2af0
-  React-debug: f3412fe8198e2811b239777f1149e7aee110bc94
-  React-defaultsnativemodule: d27ec9d295137d1211ca990a50857feb054d6565
-  React-domnativemodule: 70a88f919cb7c43ead8a3603a89a79253bad577e
-  React-Fabric: c033a162c4e357b109584b146b2f5a162c8ef58c
-  React-FabricComponents: 4bd6fdcc540c5382858f2e27780c3ea2c4c298d0
-  React-FabricImage: f1920bb45bc08dc16dff43156746593de048fde9
-  React-featureflags: 9011f9bfc690f6543744c2fbd8edd54dad157479
-  React-featureflagsnativemodule: bd61c3757c62e10901730eb672859ceed849bdda
-  React-graphics: 46cf342c230b383c66ad2dfb026cf5fa5226630c
-  React-hermes: 0be4a7c2631d2e16ae7b8b80d684f986cf091ec0
-  React-idlecallbacksnativemodule: 2019e0e37350ae9c16a172ff2c5b047385893c31
-  React-ImageManager: 09f9ab7e0859b396fa8c1831e666bfb0a2c0ca70
-  React-jserrorhandler: 9ac4919ef4664b3ae2fa43a28e3355d3171f26c8
-  React-jsi: 51012a1761d2a90ffdc5c7e23a1adad981a8cdb2
-  React-jsiexecutor: d8941f4b05d56ce68190505d937040de1f72c709
-  React-jsinspector: 2686dd01c1c0fa954ad8a6bbe29fc8176258643d
-  React-jsinspectorcdp: 842fed0b3d221ec5c3dcc4b5e6af42905e2f0a4a
-  React-jsinspectornetwork: ccfa7d29d8b7c5fc4db8eba4dab0383f062a3c03
-  React-jsinspectortracing: 2c7167bb0b883da6cd8f9b0a3cc29c46a24bd36b
-  React-jsitooling: a40f3aa3a790f593990955cd9fb4df5b816fe8ce
-  React-jsitracing: 124b3d8e966312beabb42fdc18bc71ce763394c7
-  React-logger: 752aeba6029bfcde5e4001b6cadfcc5d984a9dff
-  React-Mapbuffer: 87868c938dfe459d024127d9755c0bca44e96a68
-  React-microtasksnativemodule: 01459d49fb19d699228ae9748b5f5b9eaa366c56
-  React-NativeModulesApple: b00b96e89ef10f186f3c7427b141cb39c055e3bd
-  React-oscompat: 7c11d5c1fc5e8ea8ec94084b893ac56a8e897dd4
-  React-perflogger: 79e4553b51a1a87b50876daa95800471866a5a38
-  React-performancetimeline: d7c5d2d92fbeeba7d816f8f6476bf4de8dc68773
-  React-RCTActionSheet: 26ab80f23a43c6bdb8b8f4f6484e50c5f44880bf
-  React-RCTAnimation: 057729e2cf685fecd1d4f4a7775123f17f6d7dcb
-  React-RCTAppDelegate: b5e1bfc5c746e5137597a3ad53be8f7b54507b2f
-  React-RCTBlob: 802eb8b948594c38a0ac50faaaeb5a83b1143e2e
-  React-RCTFabric: 85a814f2eb62d4eea8f8344a823490ff104a7aa4
-  React-RCTFBReactNativeSpec: 3a9185a1c7a9f2f15d42668166fa22fb81f64f1f
-  React-RCTImage: 838984dfcde1fa7a7b3d225dcae15daa095ba3cf
-  React-RCTLinking: 0634dd69549eb70ca4da5c5a0eef5ed233993a34
-  React-RCTNetwork: e0a068887d8fc23bd999175a46660be8fb10b1c3
-  React-RCTRuntime: 23b6bfb6f92234733e1cfda599522106a31a36d6
-  React-RCTSettings: eed9cb7e03a01ed1a08394686350e323f271a9f3
-  React-RCTText: b8e0255162f3793194e05408ec6cb25821461164
-  React-RCTVibration: 7f572eac5a19c9e727b8042b0b60a63eb4c2d823
-  React-rendererconsistency: fb3bd722891a4cc8bab33f4bbf585910c545f3ba
-  React-renderercss: a4a490821e19a38359e955fdfe8df2acb88f0bd1
-  React-rendererdebug: 25511e517b2bf54a3dffbe54b9364968f65a8e81
-  React-rncore: 1f0037879900801c02e92b206fccf916744cafbd
-  React-RuntimeApple: 2758bc7ac5329e69bcd345d5e967b1d8e916dbb3
-  React-RuntimeCore: 179f66ed9832a6af4254586ce2b4c0147aabb37b
-  React-runtimeexecutor: a9f689b57d863d371bd1762591c4fc805de90dc3
-  React-RuntimeHermes: e4546ee1c3965db728070b130410a5b93703bc6c
-  React-runtimescheduler: 53a6176e2c01cd6e52e4321db200cc34be4ab27b
-  React-timing: d729454ff3fd734dd46013c2c2673aa0da6cd2cf
-  React-utils: cdb942859774617eee363d58455da394dd8356ce
-  ReactAppDependencyProvider: 5d4564ba3be2ec04c2f12fa7726f9c43b1cc9741
-  ReactCodegen: cd52a9fc7178a36ff696a69c49da4208db3891a4
-  ReactCommon: 96a832390a887840dcc5eb3d6918f7fe1494883e
+  React: a1830b4b3cff49aa1424b3c63cac6b2bead56a4f
+  React-callinvoker: 85e7c913e9aa96c61fb505af9b304f4fd12ec658
+  React-Core: 8ef9a875466ec8e1004bd1fed5638d3dcdc5439c
+  React-CoreModules: bd8b0e3011b27bdcbe1e15aa03b41edd7331cb73
+  React-cxxreact: 462c3be821106d97c197d0af89ae9886e5a93f5e
+  React-debug: 5af7750f97a9b96e296c4743f78907921964ce98
+  React-defaultsnativemodule: 183b67a1e98f0e73cdb0e895203a8ddd06be4d36
+  React-domnativemodule: 2cb7c3a94520b856d3a0d27d6ed499be138f2860
+  React-Fabric: 35945322d0d702e090b7eff423e64b2c1abccf0c
+  React-FabricComponents: 440686614f720baa1c0395830988d1e78241bec7
+  React-FabricImage: 354b0b87ac9c21e436e9172a3ca0d5ddc77e2d35
+  React-featureflags: 79950c143d25fdafb7be92eb012e9cc172471897
+  React-featureflagsnativemodule: 3de77a999be7ecf2975761f22cf0875d1be79619
+  React-graphics: a70befd182af5bfe77d7f37929bd68423567b053
+  React-hermes: 4a4b9610feff0b9361cb9b1173ba5d7f14b8eaf6
+  React-idlecallbacksnativemodule: fef0ffd2543f9868c1b39cc0ef63c60f3695d93a
+  React-ImageManager: 81393603429e60ec779129eab4904cb4b2430386
+  React-jserrorhandler: 4d206426161af95647b3f2dcc76fd1878d0feaa0
+  React-jsi: 6bd195018f415fe65cc14fc2b82fdbf8022db2e8
+  React-jsiexecutor: 639604430b81b3e09498a8608ed22b58989ad2e0
+  React-jsinspector: ee3f12c77d1ce1060412f93c955ebb507ed986b3
+  React-jsinspectorcdp: bb773dc307b82d05c8a162c9e3db5d633afeaa43
+  React-jsinspectornetwork: c82817824cdc23ac8868a4140780b429d260dba8
+  React-jsinspectortracing: d5714c64818867ba6fe33aa29406a1a5a6781c7e
+  React-jsitooling: 121890b11f9550b3488541427d60be7296b959d5
+  React-jsitracing: b7932f90a52b09953ebf1446cb18b9acaa9d5037
+  React-logger: 97b83557fb6c53d7bf3ba31e10695aa7959b2969
+  React-Mapbuffer: c5325441a01e38337d2f6010360a657059c464a7
+  React-microtasksnativemodule: 62c909456914af65e9372f0680f83694beaebf46
+  React-NativeModulesApple: 87e676164ebadd55b400663b4571c4022f76f494
+  React-oscompat: 4dd2483349b4831478aefaee5383b9689521612d
+  React-perflogger: 52e7e072582c777a4323ee7471729d1b28aef9c1
+  React-performancetimeline: fe78af3c8d00a2d1261d280531203f8fbbaa4b9b
+  React-RCTActionSheet: 637d0560b58e21a20ae498b1272440c79e471781
+  React-RCTAnimation: 5a7b014c525e0b89baa626e88ace369c642b1a8d
+  React-RCTAppDelegate: 9c233a5a6c722d980d5f1bac066f247b3cbebb77
+  React-RCTBlob: fcb766c955a8eb2f94e85b28db387abcfe3480a8
+  React-RCTFabric: d282c54c4e2a88ce7daa6d54c5cc96c8bded0515
+  React-RCTFBReactNativeSpec: 84bc55e6d1cdde8862dfdef236cc5e5d8f39921e
+  React-RCTImage: 28245c7f53874bbeefcf8bda8de1283c5f93d13c
+  React-RCTLinking: 503721813b57b3bb0aa06fc9b092ad9bec65b9eb
+  React-RCTNetwork: 234723ddaf17ccc2ddbae8ff544f644274940ac7
+  React-RCTRuntime: fa8517347cd4f31fbbfd2fb72a8643b4a34c3b3d
+  React-RCTSettings: d79af692bef22683c44cbe55f9ce823f61b1f2b3
+  React-RCTText: 385f49baf872fab4e8e4f87f31b72ac2ff140216
+  React-RCTVibration: a12051842416e423971748e26a6db6ea66732f51
+  React-rendererconsistency: 78483139826d7b03663093c781e535d30773aca9
+  React-renderercss: 2e646d2a5b4f10580a8556bd8afd1a05f66fb2d9
+  React-rendererdebug: 43ac356fc1d96b691854cc26ddab8aeba0f08f59
+  React-rncore: 64f6c9ebb626d5fc204aeaeea880b4f2220af899
+  React-RuntimeApple: f98806b18a0ab360e8ff4435e57bcf0b875e1833
+  React-RuntimeCore: 473cb858bee905bd617e33e3cd0b4996e37d2832
+  React-runtimeexecutor: a7c556446d3ede28f56c3f5adaf14a00a35d4091
+  React-RuntimeHermes: 45539d07d900693c60bc3d423c85b34ca4dace1e
+  React-runtimescheduler: bc66d28aea5bd9abf4a6aeb19466ad42463dbde5
+  React-timing: fd9c334ce6fb6075921084299a2fd5c538352b1d
+  React-utils: ece43bc95e748e9c21edfea6fc32ce3883448e42
+  ReactAppDependencyProvider: 92ea8aa743b2643d51873c6cd89bc9cd142e7919
+  ReactCodegen: dea7a1695434703c5eb55c4d62b3423c85d0a777
+  ReactCommon: 9e45a41bdc4bb215727d8dee04eba6f0900e2b1a
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 641086d9089de90327f09178a27eceaf86a7ae5e
+  Yoga: 1cf315b6f6373fa6118b88bf0c7a2c6dd760706c
 
 PODFILE CHECKSUM: 870fa397ae4619d927d79738cdc4b86a76b46e38
 

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -18,7 +18,7 @@
     "native-component-list": "*",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.80.0-rc.1"
+    "react-native": "0.80.0-rc.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -30,7 +30,7 @@
     "native-component-list": "*",
     "react-native-gesture-handler": "~2.24.0",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.1",
+    "react-native": "0.80.0-rc.2",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "4.9.2"
   },

--- a/apps/paper-tester/ios/Podfile.lock
+++ b/apps/paper-tester/ios/Podfile.lock
@@ -413,7 +413,7 @@ PODS:
   - EXUpdatesInterface (1.1.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.80.0-rc.1)
+  - FBLazyVector (0.80.0-rc.2)
   - fmt (11.0.2)
   - glog (0.3.5)
   - hermes-engine (0.80.0-rc.1):
@@ -455,28 +455,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.80.0-rc.1)
-  - RCTRequired (0.80.0-rc.1)
-  - RCTTypeSafety (0.80.0-rc.1):
-    - FBLazyVector (= 0.80.0-rc.1)
-    - RCTRequired (= 0.80.0-rc.1)
-    - React-Core (= 0.80.0-rc.1)
+  - RCTDeprecation (0.80.0-rc.2)
+  - RCTRequired (0.80.0-rc.2)
+  - RCTTypeSafety (0.80.0-rc.2):
+    - FBLazyVector (= 0.80.0-rc.2)
+    - RCTRequired (= 0.80.0-rc.2)
+    - React-Core (= 0.80.0-rc.2)
   - ReachabilitySwift (5.2.4)
-  - React (0.80.0-rc.1):
-    - React-Core (= 0.80.0-rc.1)
-    - React-Core/DevSupport (= 0.80.0-rc.1)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.1)
-    - React-RCTActionSheet (= 0.80.0-rc.1)
-    - React-RCTAnimation (= 0.80.0-rc.1)
-    - React-RCTBlob (= 0.80.0-rc.1)
-    - React-RCTImage (= 0.80.0-rc.1)
-    - React-RCTLinking (= 0.80.0-rc.1)
-    - React-RCTNetwork (= 0.80.0-rc.1)
-    - React-RCTSettings (= 0.80.0-rc.1)
-    - React-RCTText (= 0.80.0-rc.1)
-    - React-RCTVibration (= 0.80.0-rc.1)
-  - React-callinvoker (0.80.0-rc.1)
-  - React-Core (0.80.0-rc.1):
+  - React (0.80.0-rc.2):
+    - React-Core (= 0.80.0-rc.2)
+    - React-Core/DevSupport (= 0.80.0-rc.2)
+    - React-Core/RCTWebSocket (= 0.80.0-rc.2)
+    - React-RCTActionSheet (= 0.80.0-rc.2)
+    - React-RCTAnimation (= 0.80.0-rc.2)
+    - React-RCTBlob (= 0.80.0-rc.2)
+    - React-RCTImage (= 0.80.0-rc.2)
+    - React-RCTLinking (= 0.80.0-rc.2)
+    - React-RCTNetwork (= 0.80.0-rc.2)
+    - React-RCTSettings (= 0.80.0-rc.2)
+    - React-RCTText (= 0.80.0-rc.2)
+    - React-RCTVibration (= 0.80.0-rc.2)
+  - React-callinvoker (0.80.0-rc.2)
+  - React-Core (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -486,7 +486,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.1)
+    - React-Core/Default (= 0.80.0-rc.2)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -500,79 +500,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.1)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.1)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.80.0-rc.1):
+  - React-Core/CoreModulesHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -596,7 +524,55 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.80.0-rc.1):
+  - React-Core/Default (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0-rc.2)
+    - React-Core/RCTWebSocket (= 0.80.0-rc.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -620,7 +596,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.80.0-rc.1):
+  - React-Core/RCTAnimationHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -644,7 +620,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.80.0-rc.1):
+  - React-Core/RCTBlobHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -668,7 +644,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.80.0-rc.1):
+  - React-Core/RCTImageHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -692,7 +668,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.80.0-rc.1):
+  - React-Core/RCTLinkingHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -716,7 +692,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.80.0-rc.1):
+  - React-Core/RCTNetworkHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -740,7 +716,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.80.0-rc.1):
+  - React-Core/RCTSettingsHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -764,7 +740,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.80.0-rc.1):
+  - React-Core/RCTTextHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -788,7 +764,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.80.0-rc.1):
+  - React-Core/RCTVibrationHeaders (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -798,7 +774,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.1)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -812,7 +788,31 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.80.0-rc.1):
+  - React-Core/RCTWebSocket (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0-rc.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -820,19 +820,19 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.80.0-rc.1)
-    - React-Core/CoreModulesHeaders (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - RCTTypeSafety (= 0.80.0-rc.2)
+    - React-Core/CoreModulesHeaders (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.80.0-rc.1)
+    - React-RCTImage (= 0.80.0-rc.2)
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.80.0-rc.1):
+  - React-cxxreact (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -841,19 +841,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-debug (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-debug (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
-    - React-runtimeexecutor (= 0.80.0-rc.1)
-    - React-timing (= 0.80.0-rc.1)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
+    - React-runtimeexecutor (= 0.80.0-rc.2)
+    - React-timing (= 0.80.0-rc.2)
     - SocketRocket
-  - React-debug (0.80.0-rc.1)
-  - React-defaultsnativemodule (0.80.0-rc.1):
+  - React-debug (0.80.0-rc.2)
+  - React-defaultsnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -871,7 +871,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.80.0-rc.1):
+  - React-domnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -890,7 +890,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.80.0-rc.1):
+  - React-Fabric (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -904,22 +904,22 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.80.0-rc.1)
-    - React-Fabric/attributedstring (= 0.80.0-rc.1)
-    - React-Fabric/componentregistry (= 0.80.0-rc.1)
-    - React-Fabric/componentregistrynative (= 0.80.0-rc.1)
-    - React-Fabric/components (= 0.80.0-rc.1)
-    - React-Fabric/consistency (= 0.80.0-rc.1)
-    - React-Fabric/core (= 0.80.0-rc.1)
-    - React-Fabric/dom (= 0.80.0-rc.1)
-    - React-Fabric/imagemanager (= 0.80.0-rc.1)
-    - React-Fabric/leakchecker (= 0.80.0-rc.1)
-    - React-Fabric/mounting (= 0.80.0-rc.1)
-    - React-Fabric/observers (= 0.80.0-rc.1)
-    - React-Fabric/scheduler (= 0.80.0-rc.1)
-    - React-Fabric/telemetry (= 0.80.0-rc.1)
-    - React-Fabric/templateprocessor (= 0.80.0-rc.1)
-    - React-Fabric/uimanager (= 0.80.0-rc.1)
+    - React-Fabric/animations (= 0.80.0-rc.2)
+    - React-Fabric/attributedstring (= 0.80.0-rc.2)
+    - React-Fabric/componentregistry (= 0.80.0-rc.2)
+    - React-Fabric/componentregistrynative (= 0.80.0-rc.2)
+    - React-Fabric/components (= 0.80.0-rc.2)
+    - React-Fabric/consistency (= 0.80.0-rc.2)
+    - React-Fabric/core (= 0.80.0-rc.2)
+    - React-Fabric/dom (= 0.80.0-rc.2)
+    - React-Fabric/imagemanager (= 0.80.0-rc.2)
+    - React-Fabric/leakchecker (= 0.80.0-rc.2)
+    - React-Fabric/mounting (= 0.80.0-rc.2)
+    - React-Fabric/observers (= 0.80.0-rc.2)
+    - React-Fabric/scheduler (= 0.80.0-rc.2)
+    - React-Fabric/telemetry (= 0.80.0-rc.2)
+    - React-Fabric/templateprocessor (= 0.80.0-rc.2)
+    - React-Fabric/uimanager (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -931,32 +931,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.80.0-rc.1):
+  - React-Fabric/animations (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -981,7 +956,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.80.0-rc.1):
+  - React-Fabric/attributedstring (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1006,7 +981,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.80.0-rc.1):
+  - React-Fabric/componentregistry (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1031,36 +1006,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0-rc.1)
-    - React-Fabric/components/root (= 0.80.0-rc.1)
-    - React-Fabric/components/scrollview (= 0.80.0-rc.1)
-    - React-Fabric/components/view (= 0.80.0-rc.1)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.80.0-rc.1):
+  - React-Fabric/componentregistrynative (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1085,7 +1031,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.80.0-rc.1):
+  - React-Fabric/components (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0-rc.2)
+    - React-Fabric/components/root (= 0.80.0-rc.2)
+    - React-Fabric/components/scrollview (= 0.80.0-rc.2)
+    - React-Fabric/components/view (= 0.80.0-rc.2)
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1110,7 +1085,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.80.0-rc.1):
+  - React-Fabric/components/root (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1135,7 +1110,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.80.0-rc.1):
+  - React-Fabric/components/scrollview (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1162,7 +1162,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.80.0-rc.1):
+  - React-Fabric/consistency (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1187,7 +1187,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.80.0-rc.1):
+  - React-Fabric/core (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1212,7 +1212,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.80.0-rc.1):
+  - React-Fabric/dom (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1237,7 +1237,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.80.0-rc.1):
+  - React-Fabric/imagemanager (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1262,7 +1262,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.80.0-rc.1):
+  - React-Fabric/leakchecker (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1287,7 +1287,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.80.0-rc.1):
+  - React-Fabric/mounting (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1312,7 +1312,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.80.0-rc.1):
+  - React-Fabric/observers (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1326,7 +1326,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.80.0-rc.1)
+    - React-Fabric/observers/events (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1338,7 +1338,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.80.0-rc.1):
+  - React-Fabric/observers/events (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1363,7 +1363,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.80.0-rc.1):
+  - React-Fabric/scheduler (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1390,7 +1390,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.80.0-rc.1):
+  - React-Fabric/telemetry (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1415,7 +1415,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.80.0-rc.1):
+  - React-Fabric/templateprocessor (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1440,7 +1440,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.80.0-rc.1):
+  - React-Fabric/uimanager (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1454,33 +1454,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.80.0-rc.1)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/uimanager/consistency (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1493,7 +1467,33 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.80.0-rc.1):
+  - React-Fabric/uimanager/consistency (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-FabricComponents (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1508,8 +1508,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.80.0-rc.1)
-    - React-FabricComponents/textlayoutmanager (= 0.80.0-rc.1)
+    - React-FabricComponents/components (= 0.80.0-rc.2)
+    - React-FabricComponents/textlayoutmanager (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1522,7 +1522,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.80.0-rc.1):
+  - React-FabricComponents/components (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1537,15 +1537,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.80.0-rc.1)
-    - React-FabricComponents/components/iostextinput (= 0.80.0-rc.1)
-    - React-FabricComponents/components/modal (= 0.80.0-rc.1)
-    - React-FabricComponents/components/rncore (= 0.80.0-rc.1)
-    - React-FabricComponents/components/safeareaview (= 0.80.0-rc.1)
-    - React-FabricComponents/components/scrollview (= 0.80.0-rc.1)
-    - React-FabricComponents/components/text (= 0.80.0-rc.1)
-    - React-FabricComponents/components/textinput (= 0.80.0-rc.1)
-    - React-FabricComponents/components/unimplementedview (= 0.80.0-rc.1)
+    - React-FabricComponents/components/inputaccessory (= 0.80.0-rc.2)
+    - React-FabricComponents/components/iostextinput (= 0.80.0-rc.2)
+    - React-FabricComponents/components/modal (= 0.80.0-rc.2)
+    - React-FabricComponents/components/rncore (= 0.80.0-rc.2)
+    - React-FabricComponents/components/safeareaview (= 0.80.0-rc.2)
+    - React-FabricComponents/components/scrollview (= 0.80.0-rc.2)
+    - React-FabricComponents/components/text (= 0.80.0-rc.2)
+    - React-FabricComponents/components/textinput (= 0.80.0-rc.2)
+    - React-FabricComponents/components/unimplementedview (= 0.80.0-rc.2)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1558,61 +1558,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.80.0-rc.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/modal (0.80.0-rc.1):
+  - React-FabricComponents/components/inputaccessory (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1639,7 +1585,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.80.0-rc.1):
+  - React-FabricComponents/components/iostextinput (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1666,7 +1612,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.80.0-rc.1):
+  - React-FabricComponents/components/modal (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1693,7 +1639,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.80.0-rc.1):
+  - React-FabricComponents/components/rncore (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1720,7 +1666,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.80.0-rc.1):
+  - React-FabricComponents/components/safeareaview (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1747,7 +1693,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.80.0-rc.1):
+  - React-FabricComponents/components/scrollview (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1774,7 +1720,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.80.0-rc.1):
+  - React-FabricComponents/components/text (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1801,7 +1747,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.80.0-rc.1):
+  - React-FabricComponents/components/textinput (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1828,7 +1774,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.80.0-rc.1):
+  - React-FabricComponents/components/unimplementedview (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1837,22 +1783,76 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.80.0-rc.1)
-    - RCTTypeSafety (= 0.80.0-rc.1)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.80.0-rc.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.80.0-rc.2)
+    - RCTTypeSafety (= 0.80.0-rc.2)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-hermes
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.1)
+    - React-jsiexecutor (= 0.80.0-rc.2)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.80.0-rc.1):
+  - React-featureflags (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1861,7 +1861,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.80.0-rc.1):
+  - React-featureflagsnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1877,7 +1877,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.80.0-rc.1):
+  - React-graphics (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1891,7 +1891,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.80.0-rc.1):
+  - React-hermes (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1900,16 +1900,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.1)
+    - React-cxxreact (= 0.80.0-rc.2)
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.1)
+    - React-jsiexecutor (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.1)
+    - React-perflogger (= 0.80.0-rc.2)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.80.0-rc.1):
+  - React-idlecallbacksnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1925,7 +1925,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.80.0-rc.1):
+  - React-ImageManager (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1940,7 +1940,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.80.0-rc.1):
+  - React-jserrorhandler (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1955,7 +1955,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.80.0-rc.1):
+  - React-jsi (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1965,7 +1965,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.80.0-rc.1):
+  - React-jsiexecutor (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1974,14 +1974,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.1)
+    - React-perflogger (= 0.80.0-rc.2)
     - SocketRocket
-  - React-jsinspector (0.80.0-rc.1):
+  - React-jsinspector (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1995,10 +1995,10 @@ PODS:
     - React-jsinspectorcdp
     - React-jsinspectornetwork
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.1)
-    - React-runtimeexecutor (= 0.80.0-rc.1)
+    - React-perflogger (= 0.80.0-rc.2)
+    - React-runtimeexecutor (= 0.80.0-rc.2)
     - SocketRocket
-  - React-jsinspectorcdp (0.80.0-rc.1):
+  - React-jsinspectorcdp (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2007,7 +2007,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.80.0-rc.1):
+  - React-jsinspectornetwork (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2017,7 +2017,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-jsinspectorcdp
     - SocketRocket
-  - React-jsinspectortracing (0.80.0-rc.1):
+  - React-jsinspectortracing (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2027,7 +2027,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-oscompat
     - SocketRocket
-  - React-jsitooling (0.80.0-rc.1):
+  - React-jsitooling (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2035,15 +2035,15 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - SocketRocket
-  - React-jsitracing (0.80.0-rc.1):
+  - React-jsitracing (0.80.0-rc.2):
     - React-jsi
-  - React-logger (0.80.0-rc.1):
+  - React-logger (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2052,7 +2052,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.80.0-rc.1):
+  - React-Mapbuffer (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2062,7 +2062,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.80.0-rc.1):
+  - React-microtasksnativemodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2077,7 +2077,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-NativeModulesApple (0.80.0-rc.1):
+  - React-NativeModulesApple (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2098,8 +2098,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.80.0-rc.1)
-  - React-perflogger (0.80.0-rc.1):
+  - React-oscompat (0.80.0-rc.2)
+  - React-perflogger (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2108,7 +2108,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.80.0-rc.1):
+  - React-performancetimeline (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2121,9 +2121,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.80.0-rc.1):
-    - React-Core/RCTActionSheetHeaders (= 0.80.0-rc.1)
-  - React-RCTAnimation (0.80.0-rc.1):
+  - React-RCTActionSheet (0.80.0-rc.2):
+    - React-Core/RCTActionSheetHeaders (= 0.80.0-rc.2)
+  - React-RCTAnimation (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2139,7 +2139,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.80.0-rc.1):
+  - React-RCTAppDelegate (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2172,7 +2172,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.80.0-rc.1):
+  - React-RCTBlob (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2191,7 +2191,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.80.0-rc.1):
+  - React-RCTFabric (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2225,7 +2225,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.80.0-rc.1):
+  - React-RCTFBReactNativeSpec (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2243,7 +2243,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCommon
     - SocketRocket
-  - React-RCTImage (0.80.0-rc.1):
+  - React-RCTImage (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2259,14 +2259,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.80.0-rc.1):
-    - React-Core/RCTLinkingHeaders (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
+  - React-RCTLinking (0.80.0-rc.2):
+    - React-Core/RCTLinkingHeaders (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.1)
-  - React-RCTNetwork (0.80.0-rc.1):
+    - ReactCommon/turbomodule/core (= 0.80.0-rc.2)
+  - React-RCTNetwork (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2284,7 +2284,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.80.0-rc.1):
+  - React-RCTRuntime (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2304,7 +2304,7 @@ PODS:
     - React-RuntimeCore
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.80.0-rc.1):
+  - React-RCTSettings (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2319,10 +2319,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.80.0-rc.1):
-    - React-Core/RCTTextHeaders (= 0.80.0-rc.1)
+  - React-RCTText (0.80.0-rc.2):
+    - React-Core/RCTTextHeaders (= 0.80.0-rc.2)
     - Yoga
-  - React-RCTVibration (0.80.0-rc.1):
+  - React-RCTVibration (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2336,11 +2336,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.80.0-rc.1)
-  - React-renderercss (0.80.0-rc.1):
+  - React-rendererconsistency (0.80.0-rc.2)
+  - React-renderercss (0.80.0-rc.2):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.80.0-rc.1):
+  - React-rendererdebug (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2350,8 +2350,8 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-rncore (0.80.0-rc.1)
-  - React-RuntimeApple (0.80.0-rc.1):
+  - React-rncore (0.80.0-rc.2)
+  - React-RuntimeApple (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2380,7 +2380,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.80.0-rc.1):
+  - React-RuntimeCore (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2403,9 +2403,9 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.80.0-rc.1):
-    - React-jsi (= 0.80.0-rc.1)
-  - React-RuntimeHermes (0.80.0-rc.1):
+  - React-runtimeexecutor (0.80.0-rc.2):
+    - React-jsi (= 0.80.0-rc.2)
+  - React-RuntimeHermes (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2425,7 +2425,7 @@ PODS:
     - React-RuntimeCore
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.80.0-rc.1):
+  - React-runtimescheduler (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2448,8 +2448,8 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.80.0-rc.1)
-  - React-utils (0.80.0-rc.1):
+  - React-timing (0.80.0-rc.2)
+  - React-utils (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2460,11 +2460,11 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-hermes
-    - React-jsi (= 0.80.0-rc.1)
+    - React-jsi (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactAppDependencyProvider (0.80.0-rc.1):
+  - ReactAppDependencyProvider (0.80.0-rc.2):
     - ReactCodegen
-  - ReactCodegen (0.80.0-rc.1):
+  - ReactCodegen (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2491,7 +2491,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.80.0-rc.1):
+  - ReactCommon (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2499,9 +2499,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.80.0-rc.1)
+    - ReactCommon/turbomodule (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactCommon/turbomodule (0.80.0-rc.1):
+  - ReactCommon/turbomodule (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2510,15 +2510,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
-    - ReactCommon/turbomodule/bridging (= 0.80.0-rc.1)
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
+    - ReactCommon/turbomodule/bridging (= 0.80.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.80.0-rc.1):
+  - ReactCommon/turbomodule/bridging (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2527,13 +2527,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.80.0-rc.1):
+  - ReactCommon/turbomodule/core (0.80.0-rc.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2542,14 +2542,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.1)
-    - React-cxxreact (= 0.80.0-rc.1)
-    - React-debug (= 0.80.0-rc.1)
-    - React-featureflags (= 0.80.0-rc.1)
-    - React-jsi (= 0.80.0-rc.1)
-    - React-logger (= 0.80.0-rc.1)
-    - React-perflogger (= 0.80.0-rc.1)
-    - React-utils (= 0.80.0-rc.1)
+    - React-callinvoker (= 0.80.0-rc.2)
+    - React-cxxreact (= 0.80.0-rc.2)
+    - React-debug (= 0.80.0-rc.2)
+    - React-featureflags (= 0.80.0-rc.2)
+    - React-jsi (= 0.80.0-rc.2)
+    - React-logger (= 0.80.0-rc.2)
+    - React-perflogger (= 0.80.0-rc.2)
+    - React-utils (= 0.80.0-rc.2)
     - SocketRocket
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
@@ -2906,7 +2906,7 @@ SPEC CHECKSUMS:
   EXUpdates: 7940d9eb92ebfb648aba35bc6d5e3fc132691311
   EXUpdatesInterface: 64f35449b8ef89ce08cdd8952a4d119b5de6821d
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: a7f87938d9553c58c1fc8c4a952e1c6b41a8dcfd
+  FBLazyVector: a29cb71e603040d186ede90b91213d24051fa395
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 138c9bbaf158570b1b78bcaa148f086951aa090c
@@ -2914,76 +2914,76 @@ SPEC CHECKSUMS:
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: 230869f38f83ae51956d38c92f05254206bada2c
-  RCTRequired: 549f9bbe320852a24c783f42653901e6a686bff8
-  RCTTypeSafety: 6a69dd0144f99ccbdc46f4eb1a5072979ccf40de
+  RCTDeprecation: 339b52fd8eeae650a419b219f55baa2d7e4e7ac6
+  RCTRequired: 4b6dd8d557716607245fdd5ec8dcac9e3fca36ec
+  RCTTypeSafety: 827d6724a7d766b573c1fdf6acab8e93b8ccb9b3
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 6d4f7cc02ade4a926aed958d2f41f44e3162eb91
-  React-callinvoker: d5f0e4463448c54d85d1c932bb2151086eabdb32
-  React-Core: 5dc7db66bcdddf3afc1dda5698313b371efc22a6
-  React-CoreModules: b2b28f2b9b1ef7a49e509647fc0bd5122979071d
-  React-cxxreact: 3ac0c434d76320da7b417e185e9772b36c672acb
-  React-debug: f3412fe8198e2811b239777f1149e7aee110bc94
-  React-defaultsnativemodule: c2d8784a7ace6052d7aec187aa29d177afb12db1
-  React-domnativemodule: 6c16e11d4f6a8dc152719b3d24a92fc04f75c51e
-  React-Fabric: 899a4bdbe7ccda31bf4e83ef0b725a7865c20c08
-  React-FabricComponents: 9cad6eb6da40b75422bf69477607e1218402c543
-  React-FabricImage: aef15c4247431d9afe05d3669af7168d2ca72276
-  React-featureflags: 770d16b9e278c066a19274ef26659a80e9119521
-  React-featureflagsnativemodule: f6de9b3f0ec115347d957ef7d2ecef327952cd96
-  React-graphics: 6cca04c9024e31c6ff21dc9d2d5f9066f1471ff3
-  React-hermes: 31977a4bf64c14bbe6f0d721ff6bbde3bb1cbc13
-  React-idlecallbacksnativemodule: 75222bd48aeabcabf6b86814f8161c4161b15104
-  React-ImageManager: 7ce254bf85573db32409390744c25e64b90bd9d0
-  React-jserrorhandler: 90c19e2df29ede5fa27a099e11357a9a66080201
-  React-jsi: c49bbfc1a1716dd484934ed1ed47834634c89e9a
-  React-jsiexecutor: e45fbad18afae0016f7da966e35c17e0d1d36e19
-  React-jsinspector: dd464bcd2b46c4ef0e8b0132a7156f0baf205119
-  React-jsinspectorcdp: 8d0bc08186fa28b0e88016c893dd66bc48d326d3
-  React-jsinspectornetwork: dc651c43a0892ee5d13bbfc33247070d97d75330
-  React-jsinspectortracing: 40cfaaaccb3f7cd143b76f9be125e564c09882d5
-  React-jsitooling: a38b6a88235701d9693de72dca5b7af1e62928cb
-  React-jsitracing: 74823e67cb982a1efafaf20dff7c974542be5486
-  React-logger: 3578782a2e50915a3b1dba101c0d60c8e0c6bd86
-  React-Mapbuffer: e815e269a09c9c18185beef30f827d258a2aa72b
-  React-microtasksnativemodule: a38accb69e3d6eb3df0aed5046093180fdb806d8
-  React-NativeModulesApple: c151f918bfdefdf9c58bc3ca02b0950cd3bf85d3
-  React-oscompat: 7c11d5c1fc5e8ea8ec94084b893ac56a8e897dd4
-  React-perflogger: 8b85475730aac7b10f120e76f731448088879c2a
-  React-performancetimeline: 84a2bfff1682ff020e49390d9c814fb72a64fe4f
-  React-RCTActionSheet: 26ab80f23a43c6bdb8b8f4f6484e50c5f44880bf
-  React-RCTAnimation: a2923af5aeaf2bd851cae839fff0137bd74a02d0
-  React-RCTAppDelegate: 744487c655cdf2b530d2210ba4d9e8e36deccd79
-  React-RCTBlob: 90b29b91712df5c6d171f62e2f97e2ec36dbf25b
-  React-RCTFabric: 13259ab073a6d3e57b06e388853ae03f6ae9ce80
-  React-RCTFBReactNativeSpec: f19f88414d2f48468ed2d30f2d6947ddf334b497
-  React-RCTImage: b3cc102c4c11c94edeb06dac86f1431339fe477c
-  React-RCTLinking: edaa5bd23a2c3117f9f11c2409ee5ea279d70c83
-  React-RCTNetwork: d871c3a5c586b37e2d39b0094aff0b0d53b3233a
-  React-RCTRuntime: 8b48fab7901a3c3ba39aeb0810aa94021a711160
-  React-RCTSettings: 9029d3d8e5f62a6bc87001ec6013aebc5bef46e1
-  React-RCTText: ea13d9076f87ac8d6302a05e64c8ae05517cc65f
-  React-RCTVibration: 70231b9bea0655d5adeea1d5d85e4ff9097b0b1a
-  React-rendererconsistency: fb3bd722891a4cc8bab33f4bbf585910c545f3ba
-  React-renderercss: 0174a34880686fea89c7f8a2bc8a0e5a08b5d45b
-  React-rendererdebug: 716537a998a0ae74cde127896b2d8975ebe4e668
-  React-rncore: 1f0037879900801c02e92b206fccf916744cafbd
-  React-RuntimeApple: 567b3177529dd0598761f03639f3a796c833b78a
-  React-RuntimeCore: c02296fc18e690cbc2d4aaea93e5bdc695ad52ae
-  React-runtimeexecutor: a9f689b57d863d371bd1762591c4fc805de90dc3
-  React-RuntimeHermes: 05ed24a45f57fbd746c3aeb044fce062fb0679df
-  React-runtimescheduler: d04756d0c75fede1aa6de3c64fed908a5dfc000a
-  React-timing: d729454ff3fd734dd46013c2c2673aa0da6cd2cf
-  React-utils: cbc9d024a2fcfdd4c99e43b410d4877281ec6c49
-  ReactAppDependencyProvider: c84ff0b585ca7f6c29c584bde921afd743a70aa7
-  ReactCodegen: 51570b8628718beea79fac4ae8710cb83e377ffe
-  ReactCommon: 8d7b8d8ea983045f2ba80e1d8cd05416e882185f
+  React: a1830b4b3cff49aa1424b3c63cac6b2bead56a4f
+  React-callinvoker: 85e7c913e9aa96c61fb505af9b304f4fd12ec658
+  React-Core: 8ef9a875466ec8e1004bd1fed5638d3dcdc5439c
+  React-CoreModules: bd8b0e3011b27bdcbe1e15aa03b41edd7331cb73
+  React-cxxreact: 462c3be821106d97c197d0af89ae9886e5a93f5e
+  React-debug: 5af7750f97a9b96e296c4743f78907921964ce98
+  React-defaultsnativemodule: 183b67a1e98f0e73cdb0e895203a8ddd06be4d36
+  React-domnativemodule: 2cb7c3a94520b856d3a0d27d6ed499be138f2860
+  React-Fabric: 35945322d0d702e090b7eff423e64b2c1abccf0c
+  React-FabricComponents: 440686614f720baa1c0395830988d1e78241bec7
+  React-FabricImage: 354b0b87ac9c21e436e9172a3ca0d5ddc77e2d35
+  React-featureflags: 79950c143d25fdafb7be92eb012e9cc172471897
+  React-featureflagsnativemodule: 3de77a999be7ecf2975761f22cf0875d1be79619
+  React-graphics: a70befd182af5bfe77d7f37929bd68423567b053
+  React-hermes: 4a4b9610feff0b9361cb9b1173ba5d7f14b8eaf6
+  React-idlecallbacksnativemodule: fef0ffd2543f9868c1b39cc0ef63c60f3695d93a
+  React-ImageManager: 81393603429e60ec779129eab4904cb4b2430386
+  React-jserrorhandler: 4d206426161af95647b3f2dcc76fd1878d0feaa0
+  React-jsi: 6bd195018f415fe65cc14fc2b82fdbf8022db2e8
+  React-jsiexecutor: 639604430b81b3e09498a8608ed22b58989ad2e0
+  React-jsinspector: ee3f12c77d1ce1060412f93c955ebb507ed986b3
+  React-jsinspectorcdp: bb773dc307b82d05c8a162c9e3db5d633afeaa43
+  React-jsinspectornetwork: c82817824cdc23ac8868a4140780b429d260dba8
+  React-jsinspectortracing: d5714c64818867ba6fe33aa29406a1a5a6781c7e
+  React-jsitooling: 121890b11f9550b3488541427d60be7296b959d5
+  React-jsitracing: b7932f90a52b09953ebf1446cb18b9acaa9d5037
+  React-logger: 97b83557fb6c53d7bf3ba31e10695aa7959b2969
+  React-Mapbuffer: c5325441a01e38337d2f6010360a657059c464a7
+  React-microtasksnativemodule: 62c909456914af65e9372f0680f83694beaebf46
+  React-NativeModulesApple: 87e676164ebadd55b400663b4571c4022f76f494
+  React-oscompat: 4dd2483349b4831478aefaee5383b9689521612d
+  React-perflogger: 52e7e072582c777a4323ee7471729d1b28aef9c1
+  React-performancetimeline: fe78af3c8d00a2d1261d280531203f8fbbaa4b9b
+  React-RCTActionSheet: 637d0560b58e21a20ae498b1272440c79e471781
+  React-RCTAnimation: 5a7b014c525e0b89baa626e88ace369c642b1a8d
+  React-RCTAppDelegate: e9c8cdb5eddf5b4f480668fa305cfbab43402c5d
+  React-RCTBlob: fcb766c955a8eb2f94e85b28db387abcfe3480a8
+  React-RCTFabric: ff8b66d5bcfd3188dd9f1af8bfff47edf4c65ee0
+  React-RCTFBReactNativeSpec: 25a2589b1d0218a14b4b9d60c0c2c38cf6fe14b5
+  React-RCTImage: 28245c7f53874bbeefcf8bda8de1283c5f93d13c
+  React-RCTLinking: 503721813b57b3bb0aa06fc9b092ad9bec65b9eb
+  React-RCTNetwork: 234723ddaf17ccc2ddbae8ff544f644274940ac7
+  React-RCTRuntime: 9bddaec0db2d98aaad4747e663db05fe4726f4aa
+  React-RCTSettings: d79af692bef22683c44cbe55f9ce823f61b1f2b3
+  React-RCTText: 385f49baf872fab4e8e4f87f31b72ac2ff140216
+  React-RCTVibration: a12051842416e423971748e26a6db6ea66732f51
+  React-rendererconsistency: 78483139826d7b03663093c781e535d30773aca9
+  React-renderercss: 2e646d2a5b4f10580a8556bd8afd1a05f66fb2d9
+  React-rendererdebug: 43ac356fc1d96b691854cc26ddab8aeba0f08f59
+  React-rncore: 64f6c9ebb626d5fc204aeaeea880b4f2220af899
+  React-RuntimeApple: f98806b18a0ab360e8ff4435e57bcf0b875e1833
+  React-RuntimeCore: 473cb858bee905bd617e33e3cd0b4996e37d2832
+  React-runtimeexecutor: a7c556446d3ede28f56c3f5adaf14a00a35d4091
+  React-RuntimeHermes: 45539d07d900693c60bc3d423c85b34ca4dace1e
+  React-runtimescheduler: bc66d28aea5bd9abf4a6aeb19466ad42463dbde5
+  React-timing: fd9c334ce6fb6075921084299a2fd5c538352b1d
+  React-utils: ece43bc95e748e9c21edfea6fc32ce3883448e42
+  ReactAppDependencyProvider: 92ea8aa743b2643d51873c6cd89bc9cd142e7919
+  ReactCodegen: dea7a1695434703c5eb55c4d62b3423c85d0a777
+  ReactCommon: 9e45a41bdc4bb215727d8dee04eba6f0900e2b1a
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 641086d9089de90327f09178a27eceaf86a7ae5e
+  Yoga: 1cf315b6f6373fa6118b88bf0c7a2c6dd760706c
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 3804a87e56a668c985591eb93d940dc71b129e80

--- a/apps/paper-tester/package.json
+++ b/apps/paper-tester/package.json
@@ -22,7 +22,7 @@
     "expo-video": "~2.1.9",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.80.0-rc.1",
+    "react-native": "0.80.0-rc.2",
     "react-native-web": "~0.20.0"
   },
   "devDependencies": {

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -31,7 +31,7 @@
     "expo-speech": "~13.1.7",
     "expo-sqlite": "~15.2.10",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.1",
+    "react-native": "0.80.0-rc.2",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-webview": "13.13.5"

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -15,7 +15,7 @@
     "expo-router": "^5.0.7",
     "expo-splash-screen": "~0.30.8",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.1",
+    "react-native": "0.80.0-rc.2",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1"
   },

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -50,7 +50,7 @@
     "jasmine-core": "^2.4.1",
     "lodash": "^4.17.19",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.1",
+    "react-native": "0.80.0-rc.2",
     "react-native-gesture-handler": "~2.24.0",
     "sinon": "^7.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "resolutions": {
-    "react-native": "0.80.0-rc.1",
+    "react-native": "0.80.0-rc.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "@react-navigation/bottom-tabs": "7.3.10",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -55,7 +55,7 @@
     "@babel/plugin-transform-parameters": "^7.24.7",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
-    "@react-native/babel-preset": "0.80.0-rc.1",
+    "@react-native/babel-preset": "0.80.0-rc.2",
     "babel-plugin-react-native-web": "~0.19.13",
     "babel-plugin-transform-flow-enums": "^0.0.2",
     "babel-plugin-syntax-hermes-parser": "^0.25.1",

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -50,7 +50,7 @@
     "graphql": "^16.0.1",
     "graphql-request": "^3.6.1",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.1",
+    "react-native": "0.80.0-rc.2",
     "react-query": "^3.34.16",
     "url": "^0.11.0"
   },

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -59,7 +59,7 @@
     "expo-module-scripts": "^4.1.7",
     "fuse.js": "^6.4.6",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.1",
+    "react-native": "0.80.0-rc.2",
     "url": "^0.11.0",
     "use-subscription": "^1.8.0"
   },

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -92,7 +92,7 @@
   "lottie-react-native": "7.2.2",
   "react": "19.1.0",
   "react-dom": "19.1.0",
-  "react-native": "0.80.0-rc.1",
+  "react-native": "0.80.0-rc.2",
   "react-native-web": "~0.20.0",
   "react-native-edge-to-edge": "1.6.0",
   "react-native-gesture-handler": "~2.24.0",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -97,7 +97,7 @@
     "expo-module-scripts": "^4.1.7",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.80.0-rc.1",
+    "react-native": "0.80.0-rc.2",
     "web-streams-polyfill": "^3.3.2",
     "ws": "^8.18.0"
   },

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -14,7 +14,7 @@
     "expo": "~53.0.9",
     "expo-status-bar": "~2.2.3",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.1"
+    "react-native": "0.80.0-rc.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -14,7 +14,7 @@
     "expo": "~53.0.9",
     "expo-status-bar": "~2.2.3",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.1"
+    "react-native": "0.80.0-rc.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -14,7 +14,7 @@
     "expo": "~53.0.9",
     "expo-status-bar": "~2.2.3",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.1"
+    "react-native": "0.80.0-rc.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -31,7 +31,7 @@
     "expo-web-browser": "~14.1.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.80.0-rc.1",
+    "react-native": "0.80.0-rc.2",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "expo-web-browser": "~14.1.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.80.0-rc.1",
+    "react-native": "0.80.0-rc.2",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3028,23 +3028,23 @@
   resolved "https://registry.yarnpkg.com/@react-native-segmented-control/segmented-control/-/segmented-control-2.5.7.tgz#7c91ef7dede8752796a234321fafa2c604fc82af"
   integrity sha512-l84YeVX8xAU3lvOJSvV4nK/NbGhIm2gBfveYolwaoCbRp+/SLXtc6mYrQmM9ScXNwU14mnzjQTpTHWl5YPnkzQ==
 
-"@react-native/assets-registry@0.80.0-rc.1":
-  version "0.80.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.80.0-rc.1.tgz#d36c5a73267835f5878a7e1787ea9b6a1ed19033"
-  integrity sha512-zRWPsoeEexc95Q7omB0i37wBaNs4BDOSGuLy8AvujZzWo7o3ha0J4OuUoOvH1oX8oBy4ob4RvlVgyZ/TtRTCsA==
+"@react-native/assets-registry@0.80.0-rc.2":
+  version "0.80.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.80.0-rc.2.tgz#af3c398323686ee18b57aca2133c4a92822fdd53"
+  integrity sha512-uycWw5ZoU7E4zAfSVjTuWA+GOB/85xwDiKu4sUNDGLQ90IdaCIBN87tgxLL8krYI1k7Pb6t2+IoOEIkjjvgWYw==
 
-"@react-native/babel-plugin-codegen@0.80.0-rc.1":
-  version "0.80.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.80.0-rc.1.tgz#e5c007b1645b857daaca4db170f6117debd52a4f"
-  integrity sha512-HSE0Jemz+lm34/501b1aL80TnOnLwVcZOKs/cp5RI1UuWILXLqvqxOlR7k8lVapoIDaCtUhKDTZt13PeO9jV3g==
+"@react-native/babel-plugin-codegen@0.80.0-rc.2":
+  version "0.80.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.80.0-rc.2.tgz#75ebb8c0c3eb990a7ebf01f2ba31840ef81fcd61"
+  integrity sha512-yKAzLEPLtIwhCDQQJFv/YudTOcLhoXwGo0qfNmKHLPw3ts91snxdkC+OUTL6UXiYM99YkjosY2AM/pWgCN6vHw==
   dependencies:
     "@babel/traverse" "^7.25.3"
-    "@react-native/codegen" "0.80.0-rc.1"
+    "@react-native/codegen" "0.80.0-rc.2"
 
-"@react-native/babel-preset@0.80.0-rc.1":
-  version "0.80.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.80.0-rc.1.tgz#18c9735b5e3472fa07be48e69afb618693241181"
-  integrity sha512-K2VOMLdS/xMikJJJEuUFx7Ivc7+EyqUgRB+DzBWBkIsBfb1htkonnvO9bnT52UCassvif4MJH3STfyprukg21A==
+"@react-native/babel-preset@0.80.0-rc.2":
+  version "0.80.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.80.0-rc.2.tgz#5292f945a92ef1cadb9a2e701a8ecae62cf2eb8b"
+  integrity sha512-MYDuRQRMkJDbIPzLa0NBwYo9cUqTvk728fpad+ACLr5ofQEAdvOh9cGWlXCcyjR8uQvOPiEALsMprYxFCZO0oQ==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/plugin-proposal-export-default-from" "^7.24.7"
@@ -3087,15 +3087,15 @@
     "@babel/plugin-transform-typescript" "^7.25.2"
     "@babel/plugin-transform-unicode-regex" "^7.24.7"
     "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.80.0-rc.1"
+    "@react-native/babel-plugin-codegen" "0.80.0-rc.2"
     babel-plugin-syntax-hermes-parser "0.28.1"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
 
-"@react-native/codegen@0.80.0-rc.1":
-  version "0.80.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.80.0-rc.1.tgz#d81db2c7798e52779dcfea4e301df40914416336"
-  integrity sha512-TYa6AkJULNVuYnkxpmq59o2oXXo/xDXl0pZwQNGkcGuuaYioJhA9XsWFCAg+OS9kn3eNIPgg1PUwwAQoLh8Pxw==
+"@react-native/codegen@0.80.0-rc.2":
+  version "0.80.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.80.0-rc.2.tgz#595f1b95b198cf8783b8fb519b96e7728df98a59"
+  integrity sha512-8ZincRjw5ArjH2BVuHKKLeq6Y/W3f2+R79/2WkhwUzwhMq1ZscrKpCieHIt3CzcYV0woDUsuzHkB+b7ql2h8Lw==
   dependencies:
     glob "^7.1.1"
     hermes-parser "0.28.1"
@@ -3103,12 +3103,12 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/community-cli-plugin@0.80.0-rc.1":
-  version "0.80.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.80.0-rc.1.tgz#af22c8df4d0b1584363eb8fb1c7c8472530a0396"
-  integrity sha512-hXE/Zy0dPK8TRhpDwvFVC+byQNL8XEbOMNWonFoK63M3n0Lz2RIPTgwXjl9/uplGI9qM1VpoBEu/7tT40sb/Vg==
+"@react-native/community-cli-plugin@0.80.0-rc.2":
+  version "0.80.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.80.0-rc.2.tgz#345373ad171dd74391cf94e78113fe924fe1cdbf"
+  integrity sha512-TUIryZMPyc027Q4tJ0W7YOLjGOJOu8UWqz1zda+SK6ZmmYokuvHu0h9ZiNTcyT7G2huq4xLbbv2srel5rOXiPg==
   dependencies:
-    "@react-native/dev-middleware" "0.80.0-rc.1"
+    "@react-native/dev-middleware" "0.80.0-rc.2"
     chalk "^4.0.0"
     debug "^4.4.0"
     invariant "^2.2.4"
@@ -3122,10 +3122,10 @@
   resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.79.2.tgz#1377de6d9cabe5455bf332e06408167da5f60c19"
   integrity sha512-cGmC7X6kju76DopSBNc+PRAEetbd7TWF9J9o84hOp/xL3ahxR2kuxJy0oJX8Eg8oehhGGEXTuMKHzNa3rDBeSg==
 
-"@react-native/debugger-frontend@0.80.0-rc.1":
-  version "0.80.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.80.0-rc.1.tgz#1de1f8d29bc332dc645766b886d3808390eb8654"
-  integrity sha512-TOo0CKTMKM8whdLnVH6K0OvKRTQQMhrtYsaH3Q429783Awx5MZrxbMAcdd0nxFCL9ELeFxWWpz5LhLbtXrLVQQ==
+"@react-native/debugger-frontend@0.80.0-rc.2":
+  version "0.80.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.80.0-rc.2.tgz#c36dc10a78140b248b1121dae993dcf58af87855"
+  integrity sha512-RQbsUBxyH2/j4QUsfwURI+WQto6RPtsbCGp2IcHzaPg9rGgGRzSJ5V+B0VJka0g0aXBP6pkG0zEaCJ1MLrtOtg==
 
 "@react-native/dev-middleware@0.79.2":
   version "0.79.2"
@@ -3144,13 +3144,13 @@
     serve-static "^1.16.2"
     ws "^6.2.3"
 
-"@react-native/dev-middleware@0.80.0-rc.1":
-  version "0.80.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.80.0-rc.1.tgz#6b3f20d670941035b69133415d1a882281a2a287"
-  integrity sha512-oWyRP5bqa5M4/Qlp5ITZocEFkscrMvn8wY+SBQGMDqP0w6G7RA9SqjHnGXVHpzgyK1QmgMWqLhRNxON4HdCqXg==
+"@react-native/dev-middleware@0.80.0-rc.2":
+  version "0.80.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.80.0-rc.2.tgz#7b9fe790384715f3514ab4b3c3120be5b8b10d7e"
+  integrity sha512-Mh4448gO5arEUplY3Tlf+frLIrL3vcVx4u2+WOayBbC6t2/w2ZK5FFkkb+8QMf4kZ1Y/DGNjvdQGGQYEFYghwQ==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.80.0-rc.1"
+    "@react-native/debugger-frontend" "0.80.0-rc.2"
     chrome-launcher "^0.15.2"
     chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
@@ -3161,35 +3161,35 @@
     serve-static "^1.16.2"
     ws "^6.2.3"
 
-"@react-native/gradle-plugin@0.80.0-rc.1":
-  version "0.80.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.80.0-rc.1.tgz#29d182ec20a3dad0f06db522427eb5f47bc217bf"
-  integrity sha512-1H4XFY9d3ZHz36Df4X7NKZDPpDKmYjqFZnxjzL2pnMi9BwU3weQB1jYs1SGP/bXQLGAHYPrtcc/LRso0g4jELw==
+"@react-native/gradle-plugin@0.80.0-rc.2":
+  version "0.80.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.80.0-rc.2.tgz#44149de9539d96659ee0faeb510f4c492278046b"
+  integrity sha512-Sn8P6aWzOO0MTL33hNp/uqEimzagUV3ol9BP35vjjVY+Wk2SCurrbSgulKWyn8JkllUmlJ7SAxz4JTes05I5BA==
 
-"@react-native/js-polyfills@0.80.0-rc.1":
-  version "0.80.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.80.0-rc.1.tgz#3849a74c4476dad50d150e87775642cf130977bf"
-  integrity sha512-RxaUhSB18O/uFxLJrWcmCRZ+tbw7Eu+/H44FmEgVSh1z/Ut4lT9Fdz0l9kQr6hP6UoY0dIn4OcFfmZ9pUrTTOw==
+"@react-native/js-polyfills@0.80.0-rc.2":
+  version "0.80.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.80.0-rc.2.tgz#9a5e1d968917503a239b329e9023f921cafdea65"
+  integrity sha512-yBQVq/Ia8w/IpWWic3WMSg7gR64/peTanA8VAaN6Ska4UFQHXDcDZLDXP8npIxBbg1EInvz9GVCLiqdhaXC+Wg==
 
 "@react-native/normalize-colors@0.79.2":
   version "0.79.2"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.79.2.tgz#9ab70ca257c7411e4ab74cf7f91332c27d39cc6f"
   integrity sha512-+b+GNrupWrWw1okHnEENz63j7NSMqhKeFMOyzYLBwKcprG8fqJQhDIGXfizKdxeIa5NnGSAevKL1Ev1zJ56X8w==
 
-"@react-native/normalize-colors@0.80.0-rc.1":
-  version "0.80.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.80.0-rc.1.tgz#46d8d1f025a4077b12fa7d7bc37bd6ac1bfa5c96"
-  integrity sha512-wTkJift4JTe2njW/Ly46YXUViKv8Okx5xYeefBYbf5XkBMmjqzoRe7O+q3k9/03FoN1M/ut33VdZbNySKEEPSg==
+"@react-native/normalize-colors@0.80.0-rc.2":
+  version "0.80.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.80.0-rc.2.tgz#f2e63079e604fe0737847641af317faba7a585ae"
+  integrity sha512-5ctdoo7US2QYn+AK4prviXuN0UXXtVq6vbYeGZD+jlQy6f5L4SM8ba5DUvTX29gN6OLqALz9/h6VVuQwlCoP4w==
 
 "@react-native/normalize-colors@^0.74.1":
   version "0.74.88"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.74.88.tgz#46f4c7270c8e6853281d7dd966e0eb362068e41a"
   integrity sha512-He5oTwPBxvXrxJ91dZzpxR7P+VYmc9IkJfhuH8zUiU50ckrt+xWNjtVugPdUv4LuVjmZ36Vk2EX8bl1gVn2dVA==
 
-"@react-native/virtualized-lists@0.80.0-rc.1":
-  version "0.80.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.80.0-rc.1.tgz#15e5209064b370ea30df19eecc9fbb6a0c9149b3"
-  integrity sha512-pxnQKDwSrtAqL5y7qtn3CjOrqiv+12XYkVOd6x52JHXUie7J+olp0qLDxhfEXqP0QKikiCKyxr+vkLE2ie2H/A==
+"@react-native/virtualized-lists@0.80.0-rc.2":
+  version "0.80.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.80.0-rc.2.tgz#6900088be137a6a1c9f58c7b47687f4c2904f985"
+  integrity sha512-aCaGKM4RALCDBhTYWczwndeC23zqJWQR7/nvz+bmLF52p4LcJdKpDEGxEiTgqc510Paj1s+A9ExYlSFn2jw4/A==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -13229,19 +13229,19 @@ react-native-webview@13.13.5:
     escape-string-regexp "^4.0.0"
     invariant "2.2.4"
 
-react-native@0.80.0-rc.1:
-  version "0.80.0-rc.1"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.80.0-rc.1.tgz#5d042c993d659f3b38f36cb117dbf56e8d0826dc"
-  integrity sha512-LTBSEJLjmuVf76gSG83Rv+lIriDM6bqJERzoYsmnq7QR1WqmmdwivE/0V9ey6wLxrXiUySOM5tW0paIPVdDsIA==
+react-native@0.80.0-rc.2:
+  version "0.80.0-rc.2"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.80.0-rc.2.tgz#536d41be9bf8baeeb0f4ef3617de814f7baa6654"
+  integrity sha512-Iup76nzXvGmvs8+5HQQIhbwoZ4rktGg0QdjQEgiCrniOml59tUIkbmOq68MNBnf3v0wURy1yMCfaZuvnDHSkiw==
   dependencies:
     "@jest/create-cache-key-function" "^29.7.0"
-    "@react-native/assets-registry" "0.80.0-rc.1"
-    "@react-native/codegen" "0.80.0-rc.1"
-    "@react-native/community-cli-plugin" "0.80.0-rc.1"
-    "@react-native/gradle-plugin" "0.80.0-rc.1"
-    "@react-native/js-polyfills" "0.80.0-rc.1"
-    "@react-native/normalize-colors" "0.80.0-rc.1"
-    "@react-native/virtualized-lists" "0.80.0-rc.1"
+    "@react-native/assets-registry" "0.80.0-rc.2"
+    "@react-native/codegen" "0.80.0-rc.2"
+    "@react-native/community-cli-plugin" "0.80.0-rc.2"
+    "@react-native/gradle-plugin" "0.80.0-rc.2"
+    "@react-native/js-polyfills" "0.80.0-rc.2"
+    "@react-native/normalize-colors" "0.80.0-rc.2"
+    "@react-native/virtualized-lists" "0.80.0-rc.2"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"


### PR DESCRIPTION
# Why

Upgraded to RN 0.80.0.rc-2

# How

Updated RN versions

# Test Plan

CI

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
