### PR TITLE
[0.80.0][kotlin] fixed use of backing map in ReactStylesDiffMap

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMapHelper.kt
+++ b/packages/expo-modules-core/android/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMapHelper.kt
@@ -1,8 +1,10 @@
 package com.facebook.react.uimanager
 
 import com.facebook.react.bridge.ReadableMap
+import expo.modules.core.interfaces.DoNotStrip
 import java.lang.reflect.Field
 
+@get:DoNotStrip
 private val backingMapField: Field by lazy {
   ReactStylesDiffMap::class.java.getDeclaredField("backingMap").apply {
     isAccessible = true

--- a/packages/expo-modules-core/android/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMapHelper.kt
+++ b/packages/expo-modules-core/android/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMapHelper.kt
@@ -1,10 +1,23 @@
 package com.facebook.react.uimanager
 
 import com.facebook.react.bridge.ReadableMap
+import java.lang.reflect.Field
+
+private val backingMapField: Field by lazy {
+  ReactStylesDiffMap::class.java.getDeclaredField("internal_backingMap").apply {
+    isAccessible = true
+  }
+}
 
 /**
  * Access the package private property declared inside of [ReactStylesDiffMap]
+ * TODO: We should stop using this field and find a better way to access the backing map:
+ * See: https://github.com/facebook/react-native/pull/51386
  */
 fun ReactStylesDiffMap.getBackingMap(): ReadableMap {
-  return mBackingMap
+  return try {
+    backingMapField.get(this) as ReadableMap
+  } catch (e: ReflectiveOperationException) {
+    throw RuntimeException("Unable to access internal_backingMap via reflection", e)
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMapHelper.kt
+++ b/packages/expo-modules-core/android/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMapHelper.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.ReadableMap
 import java.lang.reflect.Field
 
 private val backingMapField: Field by lazy {
-  ReactStylesDiffMap::class.java.getDeclaredField("internal_backingMap").apply {
+  ReactStylesDiffMap::class.java.getDeclaredField("backingMap").apply {
     isAccessible = true
   }
 }


### PR DESCRIPTION
# Why

After RN Java->Kotlin upgrade, our ReactStylesDiffMap helper didn't compile. 

# How

- Added a fix to RN to expose the field
- Used the field

# Test Plan

PaperTester

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
