### PR TITLE
[android][camera] Make `createCamera` suspend

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [Android] Make `createCamera` a suspend function.
+
 ## 16.1.6 — 2025-04-30
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- [Android] Make `createCamera` a suspend function.
+- [Android] Make `createCamera` a suspend function. ([#37038](https://github.com/expo/expo/pull/37038) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 16.1.6 — 2025-04-30
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
@@ -351,7 +351,9 @@ class CameraViewModule : Module() {
       }
 
       OnViewDidUpdateProps { view ->
-        view.createCamera()
+        moduleScope.launch {
+          view.createCamera()
+        }
       }
 
       AsyncFunction("takePicture") { view: ExpoCameraView, options: PictureOptions, promise: Promise ->

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -415,12 +415,12 @@ class ExpoCameraView(
     val cameraProvider = ProcessCameraProvider.awaitInstance(context)
 
     ratio?.let {
-//      previewView.scaleType =
-//        if (ratio == CameraRatio.FOUR_THREE || ratio == CameraRatio.SIXTEEN_NINE) {
-//          PreviewView.ScaleType.FIT_CENTER
-//        } else {
-//          PreviewView.ScaleType.FILL_CENTER
-//        }
+      previewView.scaleType =
+        if (ratio == CameraRatio.FOUR_THREE || ratio == CameraRatio.SIXTEEN_NINE) {
+          PreviewView.ScaleType.FIT_CENTER
+        } else {
+          PreviewView.ScaleType.FILL_CENTER
+        }
     }
 
     val resolutionSelector = buildResolutionSelector()

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -39,6 +39,7 @@ import androidx.camera.core.UseCaseGroup
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.core.resolutionselector.ResolutionStrategy
 import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.lifecycle.awaitInstance
 import androidx.camera.video.FallbackStrategy
 import androidx.camera.video.FileOutputOptions
 import androidx.camera.video.QualitySelector
@@ -64,12 +65,12 @@ import expo.modules.camera.records.FlashMode
 import expo.modules.camera.records.FocusMode
 import expo.modules.camera.records.VideoQuality
 import expo.modules.camera.tasks.ResolveTakenPicture
+import expo.modules.camera.utils.BarCodeScannerResult
+import expo.modules.camera.utils.BarCodeScannerResult.BoundingBox
 import expo.modules.camera.utils.FileSystemUtils
 import expo.modules.camera.utils.mapX
 import expo.modules.camera.utils.mapY
 import expo.modules.core.errors.ModuleDestroyedException
-import expo.modules.camera.utils.BarCodeScannerResult
-import expo.modules.camera.utils.BarCodeScannerResult.BoundingBox
 import expo.modules.interfaces.camera.CameraViewInterface
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.Promise
@@ -99,7 +100,7 @@ class ExpoCameraView(
   private val currentActivity
     get() = appContext.throwingActivity as AppCompatActivity
 
-  val orientationEventListener by lazy {
+  private val orientationEventListener by lazy {
     object : OrientationEventListener(appContext.throwingActivity) {
       override fun onOrientationChanged(orientation: Int) {
         if (orientation == ORIENTATION_UNKNOWN) {
@@ -123,7 +124,6 @@ class ExpoCameraView(
   private var activeRecording: Recording? = null
 
   private var cameraProvider: ProcessCameraProvider? = null
-  private val providerFuture = ProcessCameraProvider.getInstance(context)
   private var imageCaptureUseCase: ImageCapture? = null
   private var imageAnalysisUseCase: ImageAnalysis? = null
   private var recorder: Recorder? = null
@@ -407,85 +407,80 @@ class ExpoCameraView(
   }
 
   @SuppressLint("UnsafeOptInUsageError")
-  fun createCamera() {
+  suspend fun createCamera() {
     if (!shouldCreateCamera || previewPaused) {
       return
     }
     shouldCreateCamera = false
-    providerFuture.addListener(
-      {
-        val cameraProvider: ProcessCameraProvider = providerFuture.get()
+    val cameraProvider = ProcessCameraProvider.awaitInstance(context)
 
-        ratio?.let {
-          previewView.scaleType =
-            if (ratio == CameraRatio.FOUR_THREE || ratio == CameraRatio.SIXTEEN_NINE) {
-              PreviewView.ScaleType.FIT_CENTER
-            } else {
-              PreviewView.ScaleType.FILL_CENTER
-            }
+    ratio?.let {
+//      previewView.scaleType =
+//        if (ratio == CameraRatio.FOUR_THREE || ratio == CameraRatio.SIXTEEN_NINE) {
+//          PreviewView.ScaleType.FIT_CENTER
+//        } else {
+//          PreviewView.ScaleType.FILL_CENTER
+//        }
+    }
+
+    val resolutionSelector = buildResolutionSelector()
+    val preview = Preview.Builder()
+      .setResolutionSelector(resolutionSelector)
+      .build()
+      .also {
+        it.surfaceProvider = previewView.surfaceProvider
+      }
+
+    glSurfaceTexture?.let {
+      it.setDefaultBufferSize(previewView.width, previewView.height)
+      preview.setSurfaceProvider { request ->
+        val surface = Surface(it)
+        request.provideSurface(surface, ContextCompat.getMainExecutor(context)) {
+          surface.release()
         }
+      }
+    }
 
-        val resolutionSelector = buildResolutionSelector()
-        val preview = Preview.Builder()
-          .setResolutionSelector(resolutionSelector)
-          .build()
-          .also {
-            it.surfaceProvider = previewView.surfaceProvider
-          }
+    val cameraSelector = CameraSelector.Builder()
+      .requireLensFacing(lensFacing.mapToCharacteristic())
+      .build()
 
-        glSurfaceTexture?.let {
-          it.setDefaultBufferSize(previewView.width, previewView.height)
-          preview.setSurfaceProvider { request ->
-            val surface = Surface(it)
-            request.provideSurface(surface, ContextCompat.getMainExecutor(context)) {
-              surface.release()
-            }
-          }
+    imageCaptureUseCase = ImageCapture.Builder()
+      .setResolutionSelector(resolutionSelector)
+      .setFlashMode(flashMode.mapToLens())
+      .build()
+
+    val videoCapture = createVideoCapture()
+    imageAnalysisUseCase = createImageAnalyzer()
+
+    val useCases = UseCaseGroup.Builder().apply {
+      addUseCase(preview)
+      if (cameraMode == CameraMode.PICTURE) {
+        imageCaptureUseCase?.let {
+          addUseCase(it)
         }
-
-        val cameraSelector = CameraSelector.Builder()
-          .requireLensFacing(lensFacing.mapToCharacteristic())
-          .build()
-
-        imageCaptureUseCase = ImageCapture.Builder()
-          .setResolutionSelector(resolutionSelector)
-          .setFlashMode(flashMode.mapToLens())
-          .build()
-
-        val videoCapture = createVideoCapture()
-        imageAnalysisUseCase = createImageAnalyzer()
-
-        val useCases = UseCaseGroup.Builder().apply {
-          addUseCase(preview)
-          if (cameraMode == CameraMode.PICTURE) {
-            imageCaptureUseCase?.let {
-              addUseCase(it)
-            }
-            imageAnalysisUseCase?.let {
-              addUseCase(it)
-            }
-          } else {
-            addUseCase(videoCapture)
-          }
-        }.build()
-
-        try {
-          cameraProvider.unbindAll()
-          camera = cameraProvider.bindToLifecycle(currentActivity, cameraSelector, useCases)
-          camera?.let {
-            observeCameraState(it.cameraInfo)
-          }
-          // Set the previous zoom level after recreating the camera
-          setCameraZoom(zoom)
-          this.cameraProvider = cameraProvider
-        } catch (_: Exception) {
-          onMountError(
-            CameraMountErrorEvent("Camera component could not be rendered - is there any other instance running?")
-          )
+        imageAnalysisUseCase?.let {
+          addUseCase(it)
         }
-      },
-      ContextCompat.getMainExecutor(context)
-    )
+      } else {
+        addUseCase(videoCapture)
+      }
+    }.build()
+
+    try {
+      cameraProvider.unbindAll()
+      camera = cameraProvider.bindToLifecycle(currentActivity, cameraSelector, useCases)
+      camera?.let {
+        observeCameraState(it.cameraInfo)
+      }
+      // Set the previous zoom level after recreating the camera
+      setCameraZoom(zoom)
+      this.cameraProvider = cameraProvider
+    } catch (_: Exception) {
+      onMountError(
+        CameraMountErrorEvent("Camera component could not be rendered - is there any other instance running?")
+      )
+    }
   }
 
   private fun createImageAnalyzer(): ImageAnalysis =
@@ -620,7 +615,9 @@ class ExpoCameraView(
   fun resumePreview() {
     shouldCreateCamera = true
     previewPaused = false
-    createCamera()
+    scope.launch {
+      createCamera()
+    }
   }
 
   fun pausePreview() {
@@ -638,7 +635,7 @@ class ExpoCameraView(
   }
 
   private fun getDeviceOrientation() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-    appContext.throwingActivity.display?.rotation ?: 0
+    context.display.rotation
   } else {
     (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay.rotation
   }
@@ -732,7 +729,9 @@ class ExpoCameraView(
   override fun setPreviewTexture(surfaceTexture: SurfaceTexture?) {
     glSurfaceTexture = surfaceTexture
     shouldCreateCamera = true
-    createCamera()
+    scope.launch {
+      createCamera()
+    }
   }
 
   override fun getPreviewSizeAsArray() = intArrayOf(previewView.width, previewView.height)

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/analyzers/BarcodeAnalyzer.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/analyzers/BarcodeAnalyzer.kt
@@ -59,8 +59,8 @@ class BarcodeAnalyzer(private val lensFacing: CameraType, formats: List<BarcodeT
               raw,
               extra,
               cornerPoints,
-              image.width,
-              image.height
+              imageProxy.width,
+              imageProxy.height
             )
           )
         }


### PR DESCRIPTION
# Why
A minor improvement. Makes `createCamera` a suspend function. Makes the functions more readable and should be more efficient.

# How
Uses the `awaitInstance` on the `ProcessCameraProvider` and drop the future.

# Test Plan
Bare expo. Camera works as normal. Also tested the expo-gl integration. Working as before.

