### PR TITLE
[0.80.0][kotlin] fixed breaking changes in 0.80 after kotlin conversion

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/GlideUrlWrapperLoader.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/GlideUrlWrapperLoader.kt
@@ -28,7 +28,7 @@ class GlideUrlWrapperLoader(
             originalResponse
               .newBuilder()
               .body(
-                ProgressResponseBody(originalResponse.body) { bytesWritten, contentLength, done ->
+                ProgressResponseBody(originalResponse.body ?: throw NullPointerException()) { bytesWritten, contentLength, done ->
                   model.progressListener?.onProgress(bytesWritten, contentLength, done)
                 }
               )

--- a/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/GlideUrlWrapperLoader.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/GlideUrlWrapperLoader.kt
@@ -28,7 +28,7 @@ class GlideUrlWrapperLoader(
             originalResponse
               .newBuilder()
               .body(
-                ProgressResponseBody(originalResponse.body ?: throw NullPointerException()) { bytesWritten, contentLength, done ->
+                ProgressResponseBody(requireNotNull(originalResponse.body)) { bytesWritten, contentLength, done ->
                   model.progressListener?.onProgress(bytesWritten, contentLength, done)
                 }
               )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReactLifecycleDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReactLifecycleDelegate.kt
@@ -37,7 +37,7 @@ class ReactLifecycleDelegate(appContext: AppContext) : LifecycleEventListener, A
     appContextHolder.get()?.onActivityResult(activity, requestCode, resultCode, data)
   }
 
-  override fun onNewIntent(intent: Intent?) {
+  override fun onNewIntent(intent: Intent) {
     appContextHolder.get()?.onNewIntent(intent)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/events/KModuleEventEmitterWrapper.kt
@@ -110,11 +110,11 @@ open class KEventEmitterWrapper(
   private class UIEvent(
     surfaceId: Int,
     viewId: Int,
-    private val eventName: String,
+    private val eventNameInternal: String,
     private val eventBody: WritableMap?,
     private val coalescingKey: Short?
   ) : com.facebook.react.uimanager.events.Event<UIEvent>(surfaceId, viewId) {
-    override fun getEventName(): String = normalizeEventName(eventName)
+    override fun getEventName(): String = normalizeEventName(eventNameInternal)
     override fun canCoalesce(): Boolean = coalescingKey != null
     override fun getCoalescingKey(): Short = coalescingKey ?: 0
     override fun getEventData(): WritableMap = eventBody ?: Arguments.createMap()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -248,6 +248,13 @@ internal class CollectionElementCastException private constructor(
 }
 
 @DoNotStrip
+class DynamicCastException(
+  typeName: String
+) : CodedException(
+  message = "Could not cast dynamic value to '$typeName'."
+)
+
+@DoNotStrip
 class JavaScriptEvaluateException(
   message: String,
   val jsStack: String

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -249,9 +249,9 @@ internal class CollectionElementCastException private constructor(
 
 @DoNotStrip
 class DynamicCastException(
-  typeName: String
+  type: KClass<*>
 ) : CodedException(
-  message = "Could not cast dynamic value to '$typeName'."
+  message = "Could not cast dynamic value to '${type.qualifiedName}'."
 )
 
 @DoNotStrip

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -5,6 +5,8 @@ import com.facebook.react.bridge.ReadableMap
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.allocators.ObjectConstructor
 import expo.modules.kotlin.allocators.ObjectConstructorFactory
+import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.FieldCastException
 import expo.modules.kotlin.exception.FieldRequiredException
 import expo.modules.kotlin.exception.RecordCastException
@@ -48,7 +50,7 @@ class RecordTypeConverter<T : Record>(
 
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): T =
     exceptionDecorator({ cause -> RecordCastException(type, cause) }) {
-      val jsMap = value.asMap()
+      val jsMap = value.asMap() ?: throw DynamicCastException("map")
       return convertFromReadableMap(jsMap, context, forceConversion)
     }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.records
 
 import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.allocators.ObjectConstructor
@@ -50,7 +51,7 @@ class RecordTypeConverter<T : Record>(
 
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): T =
     exceptionDecorator({ cause -> RecordCastException(type, cause) }) {
-      val jsMap = value.asMap() ?: throw DynamicCastException("map")
+      val jsMap = value.asMap() ?: throw DynamicCastException(ReadableMap::class)
       return convertFromReadableMap(jsMap, context, forceConversion)
     }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
@@ -4,6 +4,7 @@ import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableType
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.NullArgumentException
+import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
@@ -18,9 +19,9 @@ class AnyTypeConverter : DynamicAwareTypeConverters<Any>() {
     return when (value.type) {
       ReadableType.Boolean -> value.asBoolean()
       ReadableType.Number -> value.asDouble()
-      ReadableType.String -> value.asString()
-      ReadableType.Map -> value.asMap().toHashMap()
-      ReadableType.Array -> value.asArray().toArrayList()
+      ReadableType.String -> value.asString() ?: throw DynamicCastException("string")
+      ReadableType.Map -> (value.asMap()  ?: throw DynamicCastException("map") ).toHashMap()
+      ReadableType.Array -> (value.asArray()  ?: throw DynamicCastException("array")).toArrayList()
       ReadableType.Null -> throw NullArgumentException()
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
@@ -1,6 +1,8 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.NullArgumentException
@@ -19,9 +21,9 @@ class AnyTypeConverter : DynamicAwareTypeConverters<Any>() {
     return when (value.type) {
       ReadableType.Boolean -> value.asBoolean()
       ReadableType.Number -> value.asDouble()
-      ReadableType.String -> value.asString() ?: throw DynamicCastException("string")
-      ReadableType.Map -> (value.asMap()  ?: throw DynamicCastException("map") ).toHashMap()
-      ReadableType.Array -> (value.asArray()  ?: throw DynamicCastException("array")).toArrayList()
+      ReadableType.String -> value.asString() ?: throw DynamicCastException(String::class)
+      ReadableType.Map -> (value.asMap()  ?: throw DynamicCastException(ReadableMap::class)).toHashMap()
+      ReadableType.Array -> (value.asArray()  ?: throw DynamicCastException(ReadableArray::class)).toArrayList()
       ReadableType.Null -> throw NullArgumentException()
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
 import expo.modules.kotlin.exception.DynamicCastException
@@ -21,7 +22,7 @@ open class ArrayTypeConverter(
   )
 
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Array<*> {
-    val jsArray = value.asArray() ?: throw DynamicCastException("array")
+    val jsArray = value.asArray() ?: throw DynamicCastException(ReadableArray::class)
     val array = createTypedArray(jsArray.size())
     for (i in 0 until jsArray.size()) {
       array[i] = jsArray

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin.types
 import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
+import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.recycle
@@ -20,7 +21,7 @@ open class ArrayTypeConverter(
   )
 
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Array<*> {
-    val jsArray = value.asArray()
+    val jsArray = value.asArray() ?: throw DynamicCastException("array")
     val array = createTypedArray(jsArray.size())
     for (i in 0 until jsArray.size()) {
       array[i] = jsArray

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
@@ -6,6 +6,7 @@ import androidx.annotation.RequiresApi
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableType
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
@@ -175,9 +176,9 @@ class ColorTypeConverter : DynamicAwareTypeConverters<Color>() {
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Color {
     return when (value.type) {
       ReadableType.Number -> colorFromInt(value.asDouble().toInt())
-      ReadableType.String -> colorFromString(value.asString())
+      ReadableType.String -> colorFromString(value.asString() ?: throw DynamicCastException("string"))
       ReadableType.Array -> {
-        val colorsArray = value.asArray().toArrayList().map { it as Double }.toDoubleArray()
+        val colorsArray = (value.asArray() ?: throw DynamicCastException("array")).toArrayList().map { it as Double }.toDoubleArray()
         colorFromDoubleArray(colorsArray)
       }
       else -> throw UnexpectedException("Unknown argument type: ${value.type}")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
@@ -12,6 +12,7 @@ import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.SingleType
 import androidx.core.graphics.toColorInt
+import com.facebook.react.bridge.ReadableArray
 
 /**
  * Color components for named colors following the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color)
@@ -176,9 +177,9 @@ class ColorTypeConverter : DynamicAwareTypeConverters<Color>() {
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Color {
     return when (value.type) {
       ReadableType.Number -> colorFromInt(value.asDouble().toInt())
-      ReadableType.String -> colorFromString(value.asString() ?: throw DynamicCastException("string"))
+      ReadableType.String -> colorFromString(value.asString() ?: throw DynamicCastException(String::class))
       ReadableType.Array -> {
-        val colorsArray = (value.asArray() ?: throw DynamicCastException("array")).toArrayList().map { it as Double }.toDoubleArray()
+        val colorsArray = (value.asArray() ?: throw DynamicCastException(ReadableArray::class)).toArrayList().map { it as Double }.toDoubleArray()
         colorFromDoubleArray(colorsArray)
       }
       else -> throw UnexpectedException("Unknown argument type: ${value.type}")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.EnumNoSuchValueException
 import expo.modules.kotlin.exception.IncompatibleArgTypeException
 import expo.modules.kotlin.jni.ExpectedType
@@ -38,7 +39,7 @@ class EnumTypeConverter(
 
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Enum<*> {
     if (primaryConstructor.parameters.isEmpty()) {
-      return convertEnumWithoutParameter(value.asString(), enumConstants)
+      return convertEnumWithoutParameter(value.asString() ?: throw DynamicCastException("string"), enumConstants)
     } else if (primaryConstructor.parameters.size == 1) {
       return convertEnumWithParameter(
         value,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
@@ -39,7 +39,7 @@ class EnumTypeConverter(
 
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Enum<*> {
     if (primaryConstructor.parameters.isEmpty()) {
-      return convertEnumWithoutParameter(value.asString() ?: throw DynamicCastException("string"), enumConstants)
+      return convertEnumWithoutParameter(value.asString() ?: throw DynamicCastException(String::class), enumConstants)
     } else if (primaryConstructor.parameters.size == 1) {
       return convertEnumWithParameter(
         value,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ExpoDynamic.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ExpoDynamic.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.exception.DynamicCastException
 
 class ExpoDynamic(private val dynamic: Dynamic) {
   enum class Type {
@@ -32,7 +33,7 @@ class ExpoDynamic(private val dynamic: Dynamic) {
     }
 
   fun asArray(): List<Any?> {
-    return dynamic.asArray().toArrayList()
+    return (dynamic.asArray() ?: throw DynamicCastException("array")).toArrayList()
   }
 
   fun asBoolean(): Boolean {
@@ -48,10 +49,10 @@ class ExpoDynamic(private val dynamic: Dynamic) {
   }
 
   fun asMap(): Map<String, Any?> {
-    return dynamic.asMap().toHashMap()
+    return (dynamic.asMap() ?: throw DynamicCastException("map")).toHashMap()
   }
 
   fun asString(): String {
-    return dynamic.asString()
+    return dynamic.asString() ?: throw DynamicCastException("string")
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ExpoDynamic.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ExpoDynamic.kt
@@ -1,6 +1,8 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
 import expo.modules.kotlin.exception.DynamicCastException
 
 class ExpoDynamic(private val dynamic: Dynamic) {
@@ -33,7 +35,7 @@ class ExpoDynamic(private val dynamic: Dynamic) {
     }
 
   fun asArray(): List<Any?> {
-    return (dynamic.asArray() ?: throw DynamicCastException("array")).toArrayList()
+    return (dynamic.asArray() ?: throw DynamicCastException(ReadableArray::class)).toArrayList()
   }
 
   fun asBoolean(): Boolean {
@@ -49,10 +51,10 @@ class ExpoDynamic(private val dynamic: Dynamic) {
   }
 
   fun asMap(): Map<String, Any?> {
-    return (dynamic.asMap() ?: throw DynamicCastException("map")).toHashMap()
+    return (dynamic.asMap() ?: throw DynamicCastException(ReadableMap::class)).toHashMap()
   }
 
   fun asString(): String {
-    return dynamic.asString() ?: throw DynamicCastException("string")
+    return dynamic.asString() ?: throw DynamicCastException(String::class)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ListTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ListTypeConverter.kt
@@ -5,6 +5,7 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableType
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
+import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.recycle
@@ -36,7 +37,7 @@ class ListTypeConverter(
       )
     }
 
-    val jsArray = value.asArray()
+    val jsArray = value.asArray() ?: throw DynamicCastException("array")
     return convertFromReadableArray(jsArray, context, forceConversion)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ListTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ListTypeConverter.kt
@@ -37,7 +37,7 @@ class ListTypeConverter(
       )
     }
 
-    val jsArray = value.asArray() ?: throw DynamicCastException("array")
+    val jsArray = value.asArray() ?: throw DynamicCastException(ReadableArray::class)
     return convertFromReadableArray(jsArray, context, forceConversion)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
@@ -5,6 +5,7 @@ import com.facebook.react.bridge.DynamicFromObject
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
+import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.recycle
@@ -26,8 +27,8 @@ class MapTypeConverter(
     }
   )
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Map<*, *> {
-    val jsMap = value.asMap()
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean)): Map<*, *> {
+    val jsMap = value.asMap() ?: throw DynamicCastException("map")
     return convertFromReadableMap(jsMap, context, forceConversion)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
@@ -27,7 +27,7 @@ class MapTypeConverter(
     }
   )
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean)): Map<*, *> {
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Map<*, *> {
     val jsMap = value.asMap() ?: throw DynamicCastException("map")
     return convertFromReadableMap(jsMap, context, forceConversion)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
@@ -28,7 +28,7 @@ class MapTypeConverter(
   )
 
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Map<*, *> {
-    val jsMap = value.asMap() ?: throw DynamicCastException("map")
+    val jsMap = value.asMap() ?: throw DynamicCastException(ReadableMap::class)
     return convertFromReadableMap(jsMap, context, forceConversion)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
@@ -4,6 +4,7 @@ import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
+import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
@@ -29,7 +30,7 @@ class PairTypeConverter(
   )
 
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Pair<*, *> {
-    val jsArray = value.asArray()
+    val jsArray = value.asArray() ?: throw DynamicCastException("array")
     return convertFromReadableArray(jsArray, context, forceConversion)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
@@ -30,7 +30,7 @@ class PairTypeConverter(
   )
 
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Pair<*, *> {
-    val jsArray = value.asArray() ?: throw DynamicCastException("array")
+    val jsArray = value.asArray() ?: throw DynamicCastException(ReadableArray::class)
     return convertFromReadableArray(jsArray, context, forceConversion)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReadableArgumentsTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReadableArgumentsTypeConverter.kt
@@ -5,12 +5,15 @@ import com.facebook.react.bridge.ReadableMap
 import expo.modules.core.arguments.MapArguments
 import expo.modules.core.arguments.ReadableArguments
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
-class ReadableArgumentsTypeConverter : DynamicAwareTypeConverters<ReadableArguments>() {
+class ReadableArgumentsTypeConverter(
+  isOptional: Boolean
+) : DynamicAwareTypeConverters<ReadableArguments>(isOptional) {
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): ReadableArguments {
-    return MapArguments(value.asMap().toHashMap())
+    return MapArguments((value.asMap() ?: throw DynamicCastException("map")).toHashMap())
   }
 
   override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): ReadableArguments {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReadableArgumentsTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReadableArgumentsTypeConverter.kt
@@ -9,9 +9,7 @@ import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
-class ReadableArgumentsTypeConverter(
-  isOptional: Boolean
-) : DynamicAwareTypeConverters<ReadableArguments>(isOptional) {
+class ReadableArgumentsTypeConverter() : DynamicAwareTypeConverters<ReadableArguments>() {
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): ReadableArguments {
     return MapArguments((value.asMap() ?: throw DynamicCastException("map")).toHashMap())
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReadableArgumentsTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReadableArgumentsTypeConverter.kt
@@ -11,7 +11,7 @@ import expo.modules.kotlin.jni.ExpectedType
 
 class ReadableArgumentsTypeConverter() : DynamicAwareTypeConverters<ReadableArguments>() {
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): ReadableArguments {
-    return MapArguments((value.asMap() ?: throw DynamicCastException("map")).toHashMap())
+    return MapArguments((value.asMap() ?: throw DynamicCastException(ReadableMap::class)).toHashMap())
   }
 
   override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): ReadableArguments {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/SetTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/SetTypeConverter.kt
@@ -4,6 +4,7 @@ import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CollectionElementCastException
+import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.recycle
@@ -20,7 +21,7 @@ class SetTypeConverter(
   )
 
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Set<*> {
-    val jsArray = value.asArray()
+    val jsArray = value.asArray() ?: throw DynamicCastException("array")
     return convertFromReadableArray(jsArray, context, forceConversion)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/SetTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/SetTypeConverter.kt
@@ -21,7 +21,7 @@ class SetTypeConverter(
   )
 
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Set<*> {
-    val jsArray = value.asArray() ?: throw DynamicCastException("array")
+    val jsArray = value.asArray() ?: throw DynamicCastException(ReadableArray::class)
     return convertFromReadableArray(jsArray, context, forceConversion)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -209,19 +209,19 @@ object TypeConverterProviderImpl : TypeConverterProvider {
 
       String::class to createTrivialTypeConverter(
         ExpectedType(CppType.STRING)
-      ) { it.asString() ?: throw DynamicCastException("string") },
+      ) { it.asString() ?: throw DynamicCastException(String::class) },
 
       ReadableArray::class to createTrivialTypeConverter(
         ExpectedType(CppType.READABLE_ARRAY)
-      ) { it.asArray() ?: throw DynamicCastException("array") },
+      ) { it.asArray() ?: throw DynamicCastException(ReadableArray::class) },
       ReadableMap::class to createTrivialTypeConverter(
         ExpectedType(CppType.READABLE_MAP)
-      ) { it.asMap() ?: throw DynamicCastException("map") },
+      ) { it.asMap() ?: throw DynamicCastException(ReadableMap::class) },
 
       IntArray::class to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.INT)
       ) {
-        val jsArray = it.asArray() ?: throw DynamicCastException("array")
+        val jsArray = it.asArray() ?: throw DynamicCastException(ReadableArray::class)
         IntArray(jsArray.size()) { index ->
           jsArray.getInt(index)
         }
@@ -229,7 +229,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       LongArray::class to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.LONG)
       ) {
-        val jsArray = it.asArray() ?: throw DynamicCastException("array")
+        val jsArray = it.asArray() ?: throw DynamicCastException(ReadableArray::class)
         LongArray(jsArray.size()) { index ->
           jsArray.getDouble(index).toLong()
         }
@@ -237,7 +237,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       DoubleArray::class to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.DOUBLE)
       ) {
-        val jsArray = it.asArray() ?: throw DynamicCastException("array")
+        val jsArray = it.asArray() ?: throw DynamicCastException(ReadableArray::class)
         DoubleArray(jsArray.size()) { index ->
           jsArray.getDouble(index)
         }
@@ -245,7 +245,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       FloatArray::class to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.FLOAT)
       ) {
-        val jsArray = it.asArray() ?: throw DynamicCastException("array")
+        val jsArray = it.asArray() ?: throw DynamicCastException(ReadableArray::class)
         FloatArray(jsArray.size()) { index ->
           jsArray.getDouble(index).toFloat()
         }
@@ -253,7 +253,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       BooleanArray::class to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.BOOLEAN)
       ) {
-        val jsArray = it.asArray() ?: throw DynamicCastException("array")
+        val jsArray = it.asArray() ?: throw DynamicCastException(ReadableArray::class)
         BooleanArray(jsArray.size()) { index ->
           jsArray.getBoolean(index)
         }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -8,6 +8,7 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.core.arguments.ReadableArguments
 import expo.modules.kotlin.apifeatures.EitherType
+import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.MissingTypeConverter
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
@@ -208,19 +209,19 @@ object TypeConverterProviderImpl : TypeConverterProvider {
 
       String::class to createTrivialTypeConverter(
         ExpectedType(CppType.STRING)
-      ) { it.asString() },
+      ) { it.asString() ?: throw DynamicCastException("string") },
 
       ReadableArray::class to createTrivialTypeConverter(
         ExpectedType(CppType.READABLE_ARRAY)
-      ) { it.asArray() },
+      ) { it.asArray() ?: throw DynamicCastException("array") },
       ReadableMap::class to createTrivialTypeConverter(
         ExpectedType(CppType.READABLE_MAP)
-      ) { it.asMap() },
+      ) { it.asMap() ?: throw DynamicCastException("map") },
 
       IntArray::class to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.INT)
       ) {
-        val jsArray = it.asArray()
+        val jsArray = it.asArray() ?: throw DynamicCastException("array")
         IntArray(jsArray.size()) { index ->
           jsArray.getInt(index)
         }
@@ -228,7 +229,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       LongArray::class to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.LONG)
       ) {
-        val jsArray = it.asArray()
+        val jsArray = it.asArray() ?: throw DynamicCastException("array")
         LongArray(jsArray.size()) { index ->
           jsArray.getDouble(index).toLong()
         }
@@ -236,7 +237,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       DoubleArray::class to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.DOUBLE)
       ) {
-        val jsArray = it.asArray()
+        val jsArray = it.asArray() ?: throw DynamicCastException("array")
         DoubleArray(jsArray.size()) { index ->
           jsArray.getDouble(index)
         }
@@ -244,7 +245,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       FloatArray::class to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.FLOAT)
       ) {
-        val jsArray = it.asArray()
+        val jsArray = it.asArray() ?: throw DynamicCastException("array")
         FloatArray(jsArray.size()) { index ->
           jsArray.getDouble(index).toFloat()
         }
@@ -252,7 +253,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       BooleanArray::class to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.BOOLEAN)
       ) {
-        val jsArray = it.asArray()
+        val jsArray = it.asArray() ?: throw DynamicCastException("array")
         BooleanArray(jsArray.size()) { index ->
           jsArray.getBoolean(index)
         }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/UriTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/UriTypeConverter.kt
@@ -8,11 +8,12 @@ import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.types.DynamicAwareTypeConverters
 import java.net.URI
 import androidx.core.net.toUri
+import expo.modules.kotlin.exception.DynamicCastException
 
 class UriTypeConverter : DynamicAwareTypeConverters<Uri>() {
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Uri {
     val stringUri = value.asString()
-    return stringUri.toUri()
+    return stringUri?.toUri() ?: throw DynamicCastException("uri")
   }
 
   override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Uri {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/UriTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/net/UriTypeConverter.kt
@@ -13,7 +13,7 @@ import expo.modules.kotlin.exception.DynamicCastException
 class UriTypeConverter : DynamicAwareTypeConverters<Uri>() {
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Uri {
     val stringUri = value.asString()
-    return stringUri?.toUri() ?: throw DynamicCastException("uri")
+    return stringUri?.toUri() ?: throw DynamicCastException(Uri::class)
   }
 
   override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Uri {


### PR DESCRIPTION
# Why

React Native 0.80 introduces some breaking changes after converting from Java -> Kotlin. Mainly about changing nullability on parameter types. This is intended and should not be fixed in RN.

# How

Fixed our use of the APIs.

# Test Plan

CI

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
