### PR TITLE
[expo-ui] Fix tvOS compile errors in DisclosureGroup, FormView, gesture modifiers

### DIFF
--- a/packages/expo-ui/ios/DisclosureGroupView.swift
+++ b/packages/expo-ui/ios/DisclosureGroupView.swift
@@ -14,9 +14,13 @@ internal struct DisclosureGroupView: ExpoSwiftUI.View {
   @ObservedObject var props: DisclosureGroupViewProps
 
   var body: some View {
+    #if os(tvOS)
+    Text("DisclosureGroupView is not supported on tvOS")
+    #else
     DisclosureGroup(props.label) {
       Children()
     }
     .modifier(CommonViewModifiers(props: props))
+    #endif
   }
 }

--- a/packages/expo-ui/ios/FormView.swift
+++ b/packages/expo-ui/ios/FormView.swift
@@ -19,7 +19,7 @@ internal struct FormView: ExpoSwiftUI.View {
     }
     .modifier(CommonViewModifiers(props: props))
 
-    if #available(iOS 16.0, *) {
+    if #available(iOS 16.0, tvOS 16.0, *) {
       form.scrollDisabled(!props.scrollEnabled)
     } else {
       form

--- a/packages/expo-ui/ios/Modifiers/View+GestureModifiers.swift
+++ b/packages/expo-ui/ios/Modifiers/View+GestureModifiers.swift
@@ -7,13 +7,15 @@ internal extension View {
   @ViewBuilder
   func applyOnTapGesture(useTapGesture: Bool?, eventDispatcher: EventDispatcher, useContentShape: Bool = false) -> some View {
     if useTapGesture == true {
-      self
-        .if(useContentShape) {
-          $0.contentShape(Rectangle())
-        }
-        .onTapGesture {
-          eventDispatcher()
-        }
+      if #available(iOS 13.0, macOS 10.13, tvOS 16.0, *) {
+        self
+          .if(useContentShape) {
+            $0.contentShape(Rectangle())
+          }
+          .onTapGesture {
+            eventDispatcher()
+          }
+      }
     } else {
       self
     }

--- a/packages/expo-ui/ios/SliderView.swift
+++ b/packages/expo-ui/ios/SliderView.swift
@@ -49,7 +49,7 @@ struct SliderView: ExpoSwiftUI.View {
       value = sliderValue
     })
     #else
-    Text("Slider not supported on this platform")
+    Text("Slider is not supported on tvOS")
     #endif
   }
 }


### PR DESCRIPTION
# Why

Fix tvOS breakages introduced in expo-ui.

# How

Run TV compile CI manually on local box, fix errors in Xcode.

# Test Plan

CI should pass
