### PR TITLE
[docs] Add `single` mode to "Get Started" page

### DIFF
--- a/docs/pages/eas/hosting/get-started.mdx
+++ b/docs/pages/eas/hosting/get-started.mdx
@@ -76,10 +76,11 @@ You can check whether you are logged in by running `eas whoami`.
 <Step label="3">
 ## Prepare your project
 
-In your app config file set [`expo.web.output`](/versions/latest/config/app/#output) to either `static` or `server`.
+For your app config file's [`expo.web.output`](/versions/latest/config/app/#output), decide whether to set it to either `single`, `static` or `server`.
 
+- `single`: Exports your Expo app to a single-page app with only one `index.html` output
 - `static`: Exports your Expo app to a [statically generated web app](/router/reference/static-rendering/)
-- `server`: Supports [server functions](/guides/server-components/#react-server-functions) and [API routes](/router/reference/api-routes/) as well as the static pages for your website
+- `server`: Supports [server functions](/guides/server-components/#react-server-functions) and [API routes](/router/reference/api-routes/) as well as static pages for your app
 
 > Don't worry if you're not sure which output mode you need, you can always change this value later and re-deploy.
 

--- a/docs/pages/eas/hosting/get-started.mdx
+++ b/docs/pages/eas/hosting/get-started.mdx
@@ -39,7 +39,7 @@ Paid subscribers can create more deployments, have more bandwidth, storage, requ
 
 <Collapsible summary="An Expo Router web project">
 
-If using an existing project, ensure that in your project's app config, the web output ([`expo.web.output`](/versions/latest/config/app/#output)) is set to either `static` or `server` (single page apps are not supported on EAS Hosting).
+If using an existing project, ensure that in your project's app config, the web output ([`expo.web.output`](/versions/latest/config/app/#output)) is set to either `static`, or `server` (single page apps are not supported on EAS Hosting).
 
 Don't have a project yet? No problem. It's quick and easy to create a "Hello world" app that you can use with this guide.
 

--- a/docs/pages/eas/hosting/get-started.mdx
+++ b/docs/pages/eas/hosting/get-started.mdx
@@ -39,8 +39,6 @@ Paid subscribers can create more deployments, have more bandwidth, storage, requ
 
 <Collapsible summary="An Expo Router web project">
 
-If using an existing project, ensure that in your project's app config, the web output ([`expo.web.output`](/versions/latest/config/app/#output)) is set to either `static`, or `server` (single page apps are not supported on EAS Hosting).
-
 Don't have a project yet? No problem. It's quick and easy to create a "Hello world" app that you can use with this guide.
 
 Run the following command to create a new project:
@@ -76,7 +74,7 @@ You can check whether you are logged in by running `eas whoami`.
 <Step label="3">
 ## Prepare your project
 
-For your app config file's [`expo.web.output`](/versions/latest/config/app/#output), decide whether to set it to either `single`, `static` or `server`.
+For your app config file's [`expo.web.output`](/versions/latest/config/app/#output), decide whether to set it to either `single`, `static`, or `server`.
 
 - `single`: Exports your Expo app to a single-page app with only one `index.html` output
 - `static`: Exports your Expo app to a [statically generated web app](/router/reference/static-rendering/)

--- a/docs/pages/eas/hosting/introduction.mdx
+++ b/docs/pages/eas/hosting/introduction.mdx
@@ -13,7 +13,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 
 **EAS Hosting** is a service for quickly deploying your web projects built using [Expo Router](/router/introduction/) and React Native web. It seamlessly integrates with the Expo CLI, allowing you to automate the deployment of API routes, server functions, and server-side assets.
 
-Hosting supports both [static](/router/reference/static-rendering/) and [server mode](/router/reference/api-routes/) web projects and offers the fastest path from `npx create-expo-app` to a fully deployed web app with API routes.
+Hosting offers the fastest path from `npx create-expo-app` to a fully deployed web app with API routes and server functions.
 
 ### Get started
 


### PR DESCRIPTION
# Why

All export modes have been supported for a while. We should update the docs to reflect that the `single` export mode is now supported as well.

# How

- Getting started section
  - Rewrite this section to mention `single` without removing it. It's still beneficial for us to prompt the user to change this export value, but we should simple mention all available values.
- Introduction section
  - Remove mention of static/server; This is easily interpreted as a limitation and we should just remove it