### PR TITLE
Docs Router 101 Navigation - Example snippets mistake

### DIFF
--- a/docs/pages/router/basics/navigation.mdx
+++ b/docs/pages/router/basics/navigation.mdx
@@ -152,7 +152,7 @@ export default function Page() {
       <Pressable
         onPress={() =>
           router.navigate({
-            pathname: '/user',
+            pathname: '/user/[id]',
             params: { id: 'bacon' }
           })
         }


### PR DESCRIPTION
# Why

The example code snippet for navigating to a dynamic route in the docs uses an incorrect pathname. It should match the actual dynamic file path (e.g., /user/[id]) rather than the resolved route (/user). This can cause confusion for users and unexpected behavior.

# How

Updated the code example in the documentation to use the correct `pathname: '/user/[id]'` when calling `router.navigate`. This aligns with how dynamic routes are defined in Expo Router (e.g., `app/user/[id].tsx`).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Manually verified the updated snippet works as expected in an Expo Router app with a dynamic route defined at `app/user/[id].tsx`. Navigation successfully passed the id param and loaded the correct screen.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
