### PR TITLE
[expo-contacts] Updating contact removes Birthday

### DIFF
--- a/apps/test-suite/tests/Contacts.js
+++ b/apps/test-suite/tests/Contacts.js
@@ -208,20 +208,19 @@ export async function test({ describe, it, xdescribe, jasmine, expect, afterAll 
 
     // https://github.com/expo/expo/issues/36863
     it('Contacts.updateContactAsync() does not delete birthday', async () => {
+      const birthday = {
+        day: 30,
+        month: 2,
+        year: 1990,
+      };
       const contactId = await createContact({
-        [Contacts.Fields.Birthday]: {
-          day: 30,
-          month: 2,
-          year: 1990,
-        },
+        [Contacts.Fields.Birthday]: birthday,
         [Contacts.Fields.FirstName]: 'Theman',
         [Contacts.Fields.LastName]: 'Batholamew',
       });
-      expect(typeof contactId).toBe('string');
 
       const contact = await Contacts.getContactByIdAsync(contactId, [Contacts.Fields.Birthday]);
       expect(contact.birthday).toBeDefined();
-      console.log('contact', contact);
 
       const modifiedId = await Contacts.updateContactAsync({
         id: contactId,
@@ -230,8 +229,11 @@ export async function test({ describe, it, xdescribe, jasmine, expect, afterAll 
       const modifiedContact = await Contacts.getContactByIdAsync(modifiedId, [
         Contacts.Fields.Birthday,
       ]);
-      console.log('modifiedContact', modifiedContact);
-      expect(modifiedContact.birthday).toBeDefined();
+
+      expect(modifiedContact.birthday).toEqual({
+        format: 'gregorian',
+        ...birthday,
+      });
       await Contacts.removeContactAsync(contactId);
     });
 
@@ -555,24 +557,26 @@ export async function test({ describe, it, xdescribe, jasmine, expect, afterAll 
       expect(result[Contacts.Fields.FirstName]).toEqual('Andy');
     });
 
-    it('Contacts.updateContactAsync() and toggle isFavorite', async () => {
-      const contacts = await Contacts.getContactsAsync({
-        fields: [Contacts.Fields.IsFavorite],
+    if (isAndroid) {
+      it('Contacts.updateContactAsync() and toggle isFavorite', async () => {
+        const contacts = await Contacts.getContactsAsync({
+          fields: [Contacts.Fields.IsFavorite],
+        });
+        const favoriteContact = contacts.data.find((contact) => contact.isFavorite);
+        expect(favoriteContact).toBeDefined();
+        expect(typeof favoriteContact.isFavorite).toBe('boolean');
+        expect(favoriteContact.isFavorite).toBe(true);
+        await Contacts.updateContactAsync({
+          id: favoriteContact.id,
+          [Contacts.Fields.IsFavorite]: false,
+        });
+        const modifiedContact = await Contacts.getContactByIdAsync(favoriteContact.id, [
+          Contacts.Fields.IsFavorite,
+        ]);
+        expect(typeof modifiedContact.isFavorite).toBe('boolean');
+        expect(modifiedContact.isFavorite).toBe(false);
       });
-      const favoriteContact = contacts.data.find((contact) => contact.isFavorite);
-      expect(favoriteContact).toBeDefined();
-      expect(typeof favoriteContact.isFavorite).toBe('boolean');
-      expect(favoriteContact.isFavorite).toBe(true);
-      await Contacts.updateContactAsync({
-        id: favoriteContact.id,
-        [Contacts.Fields.IsFavorite]: false,
-      });
-      const modifiedContact = await Contacts.getContactByIdAsync(favoriteContact.id, [
-        Contacts.Fields.IsFavorite,
-      ]);
-      expect(typeof modifiedContact.isFavorite).toBe('boolean');
-      expect(modifiedContact.isFavorite).toBe(false);
-    });
+    }
 
     it('Contacts.removeContactAsync() finishes successfully', async () => {
       const contactId = await createSimpleContact('Hi', 'Joe');

--- a/apps/test-suite/tests/Contacts.js
+++ b/apps/test-suite/tests/Contacts.js
@@ -206,6 +206,35 @@ export async function test({ describe, it, xdescribe, jasmine, expect, afterAll 
       });
     });
 
+    // https://github.com/expo/expo/issues/36863
+    it('Contacts.updateContactAsync() does not delete birthday', async () => {
+      const contactId = await createContact({
+        [Contacts.Fields.Birthday]: {
+          day: 30,
+          month: 2,
+          year: 1990,
+        },
+        [Contacts.Fields.FirstName]: 'Theman',
+        [Contacts.Fields.LastName]: 'Batholamew',
+      });
+      expect(typeof contactId).toBe('string');
+
+      const contact = await Contacts.getContactByIdAsync(contactId, [Contacts.Fields.Birthday]);
+      expect(contact.birthday).toBeDefined();
+      console.log('contact', contact);
+
+      const modifiedId = await Contacts.updateContactAsync({
+        id: contactId,
+        [Contacts.Fields.IsFavorite]: false,
+      });
+      const modifiedContact = await Contacts.getContactByIdAsync(modifiedId, [
+        Contacts.Fields.Birthday,
+      ]);
+      console.log('modifiedContact', modifiedContact);
+      expect(modifiedContact.birthday).toBeDefined();
+      await Contacts.removeContactAsync(contactId);
+    });
+
     it('Contacts.updateContactAsync() with multiple urls / remove url', async () => {
       const contactId = await Contacts.addContactAsync({
         [Contacts.Fields.FirstName]: 'Ken',

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] fixed `updateContactAsync()` removing contact rawDates / birthday ([#36863][https://github.com/expo/expo/issues/36863]) by [@NorseGaud](https://github.com/NorseGaud)
+- [Android] fixed `updateContactAsync()` removing contact rawDates / birthday ([#37054](https://github.com/expo/expo/pull/37054) by [@NorseGaud](https://github.com/NorseGaud)
 
 ### 💡 Others
 

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed isFavorite changes/updates nulling the rawDates/birthday for contacts ([#36863][https://github.com/expo/expo/issues/36863]) by [@NorseGaud](https://github.com/NorseGaud)
+- [Android] fixed `updateContactAsync()` removing contact rawDates / birthday ([#36863][https://github.com/expo/expo/issues/36863]) by [@NorseGaud](https://github.com/NorseGaud)
 
 ### 💡 Others
 

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed isFavorite changes/updates nulling the rawDates/birthday for contacts ([#36863][https://github.com/expo/expo/issues/36863]) by [@NorseGaud](https://github.com/NorseGaud)
+
 ### 💡 Others
 
 - Remove "Please" from warnings and errors ([#36862](https://github.com/expo/expo/pull/36862) by [@brentvatne](https://github.com/brentvatne))

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/models/DateModel.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/models/DateModel.kt
@@ -51,15 +51,39 @@ open class DateModel : BaseModel() {
   }
 
   private fun formatDateString(): String? {
-    val year = map.getDouble("year", -1.0).toInt().takeIf { it > 0 }
-    val month = map.getDouble("month", -1.0).toInt().takeIf { it >= 0 }?.plus(1)
-    val day = map.getDouble("day", -1.0).toInt().takeIf { it > 0 }
+    var year = map.getDouble("year", -1.0).toInt().takeIf { it > 0 }
+    var month = map.getDouble("month", -1.0).toInt().takeIf { it >= 0 }?.plus(1) // URI month is 1-indexed
+    var day = map.getDouble("day", -1.0).toInt().takeIf { it > 0 }
+
+    // If year, month, or day are not in the map (e.g., when loaded from DB rather than JS object),
+    // try to parse them from the raw `data` field.
+    if ((year == null || month == null || day == null) && this.data != null) {
+      val dateStr = this.data!!
+      try {
+        if (dateStr.startsWith("--")) { // Format like --MM-DD
+          if (dateStr.length >= "--MM-DD".length) {
+            month = dateStr.substring(2, 4).toInt().takeIf { it in 1..12 }
+            day = dateStr.substring(5, 7).toInt().takeIf { it in 1..31 }
+            year = null // Explicitly null for no-year format
+          }
+        } else { // Format like YYYY-MM-DD
+          if (dateStr.length >= "YYYY-MM-DD".length) {
+            year = dateStr.substring(0, 4).toInt().takeIf { it > 0 }
+            month = dateStr.substring(5, 7).toInt().takeIf { it in 1..12 }
+            day = dateStr.substring(8, 10).toInt().takeIf { it in 1..31 }
+          }
+        }
+      } catch (e: NumberFormatException) {
+        Log.e("DateModel", "Error parsing date string: $dateStr", e)
+        // Log or handle parsing error if necessary, otherwise proceed with potentially null components
+      }
+    }
 
     return when {
       year != null && month != null && day != null ->
         String.format(Locale.US, "%04d-%02d-%02d", year, month, day)
 
-      month != null && day != null ->
+      month != null && day != null -> // No year
         String.format(Locale.US, "--%02d-%02d", month, day)
 
       else -> null

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/models/DateModel.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/models/DateModel.kt
@@ -6,7 +6,7 @@ import android.provider.ContactsContract
 import android.provider.ContactsContract.CommonDataKinds
 import expo.modules.contacts.Columns
 import java.util.Locale
-import android.util.Log
+
 const val BIRTHDAY = "birthday"
 private const val ANNIVERSARY = "anniversary"
 private const val OTHER = "other"
@@ -51,33 +51,15 @@ open class DateModel : BaseModel() {
   }
 
   private fun formatDateString(): String? {
-    var year = map.getDouble("year", -1.0).toInt().takeIf { it > 0 }
-    var month = map.getDouble("month", -1.0).toInt().takeIf { it >= 0 }?.plus(1) // URI month is 1-indexed
-    var day = map.getDouble("day", -1.0).toInt().takeIf { it > 0 }
-
-    // If year, month, or day are not in the map (e.g., when loaded from DB rather than JS object),
-    // try to parse them from the raw `data` field.
-    if ((year == null || month == null || day == null) && this.data != null) {
-      val dateStr = this.data!!
-      try {
-        if (dateStr.startsWith("--")) { // Format like --MM-DD
-          if (dateStr.length >= "--MM-DD".length) {
-            month = dateStr.substring(2, 4).toInt().takeIf { it in 1..12 }
-            day = dateStr.substring(5, 7).toInt().takeIf { it in 1..31 }
-            year = null // Explicitly null for no-year format
-          }
-        } else { // Format like YYYY-MM-DD
-          if (dateStr.length >= "YYYY-MM-DD".length) {
-            year = dateStr.substring(0, 4).toInt().takeIf { it > 0 }
-            month = dateStr.substring(5, 7).toInt().takeIf { it in 1..12 }
-            day = dateStr.substring(8, 10).toInt().takeIf { it in 1..31 }
-          }
-        }
-      } catch (e: NumberFormatException) {
-        Log.e("DateModel", "Error parsing date string: $dateStr", e)
-        // Log or handle parsing error if necessary, otherwise proceed with potentially null components
-      }
+    val existingFormattedDate = this.data
+    if (existingFormattedDate != null) {
+      // when the date is loaded from an existing contact (from cursor)
+      return existingFormattedDate
     }
+
+    val year = map.getDouble("year", -1.0).toInt().takeIf { it > 0 }
+    val month = map.getDouble("month", -1.0).toInt().takeIf { it >= 0 }?.plus(1)
+    val day = map.getDouble("day", -1.0).toInt().takeIf { it > 0 }
 
     return when {
       year != null && month != null && day != null ->

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/models/DateModel.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/models/DateModel.kt
@@ -6,7 +6,7 @@ import android.provider.ContactsContract
 import android.provider.ContactsContract.CommonDataKinds
 import expo.modules.contacts.Columns
 import java.util.Locale
-
+import android.util.Log
 const val BIRTHDAY = "birthday"
 private const val ANNIVERSARY = "anniversary"
 private const val OTHER = "other"


### PR DESCRIPTION
# Why

closes #36919 and #36863

# How

- update `DateModel`'s `formatDateString`

# Test Plan

Added a test case

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
