### PR TITLE
[docs] Updates workflows get started doc

### DIFF
--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -99,7 +99,7 @@ jobs:
       platform: ios
 ```
 
-The workflow above will create a production build for Android and iOS in parallel.
+The workflow above will create a production build for Android and iOS in parallel. To run this workflow successfully, you'll need to [set up and build your project using EAS CLI](/build/setup/) first.
 
 </Step>
 

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -6,30 +6,18 @@ description: Learn how to use EAS Workflows to automate your React Native CI/CD 
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { DownloadSlide } from '~/ui/components/DownloadSlide';
+import { FileTree } from '~/ui/components/FileTree';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-Builds, submissions, updates, and more are all a part of delivering your app to users. EAS Workflows consist of a sequence of jobs, which help you and your team get things done. With workflows, you can build your project, run end-to-end tests, submit that build to the app stores, and then run custom scripts after the submission is complete. Since each job can have prerequisites and conditionals, you can automate your and your team's CI/CD for your React Native project.
-
-## Get started
-
-Learn what EAS Workflows are and how to use them to automate your CI/CD processes with the following video tutorial:
+EAS Workflows allow you to automate your development and release processes. It's a React Native CI/CD service that can build and submit your biweekly app store releases, create preview updates for every commit, and more.
 
 <VideoBoxLink
   videoId="OJ2u9tQCpr4"
   title="Watch: Get Started with EAS Workflows"
   description="Learn how to automate some of the most common processes that every app development team must tackle: creating development builds, publishing preview updates, and deploying to production."
-/>
-
-<br />
-<br />
-
-Share the following slide in your next team meeting to discuss what EAS Workflows are and how they can help your team:
-
-<DownloadSlide
-  title="EAS Workflows CI/CD sync slide"
-  description="Learn the benefits of using EAS Workflows to automate your CI/CD processes."
-  imageUrl="/static/images/eas-workflows/eas-worfklows-slide.png"
 />
 
 <br />
@@ -45,93 +33,118 @@ EAS Workflows are great for operations related to your Expo apps, while other CI
 
 </Collapsible>
 
-## Set up your project
+<Collapsible summary="Considering Workflows? Share the following slide in your next team meeting">
+Share the following slide in your next team meeting to discuss what EAS Workflows are and how they can help your team:
 
-If you haven't already, you'll need to create a project and sync it with EAS:
-
-<Collapsible summary="Create a project and sync it with EAS">
-  You can create a new project with the following command:
-
-{' '}
-
-<Terminal cmd={['$ npx create-expo-app@latest']} />
-
-Once you've created the project, login with your account:
-
-{' '}
-
-<Terminal cmd={['$ npx eas-cli@latest login']} />
-
-Finally, link the project you have locally with EAS:
-
-  <Terminal cmd={['$ npx eas-cli@latest init']} />
+<DownloadSlide
+  title="EAS Workflows CI/CD sync slide"
+  description="Learn the benefits of using EAS Workflows to automate your CI/CD processes."
+  imageUrl="/static/images/eas-workflows/eas-worfklows-slide.png"
+/>
 </Collapsible>
 
-## Configure your project
+## Get started
 
-EAS Workflows require a GitHub repository that's linked to your EAS project to run. You can link a GitHub repo to your EAS project with the following steps:
+<Prerequisites numberOfRequirements={4}>
+  <Requirement number={1} title="Sign up for an Expo account">
+    You'll need to [sign up](https://expo.dev/signup) for an Expo account.
+  </Requirement>
+  <Requirement number={2} title="Create a project">
+    You'll need to create a project with the following command:
+
+    <Terminal cmd={['$ npx create-expo-app@latest']} />
+
+  </Requirement>
+  <Requirement number={3} title="Sync the project with EAS">
+    You'll need to sync the project with EAS with the following command. This will create an EAS project and link it to your local project:
+
+    <Terminal cmd={['$ npx eas-cli@latest init']} />
+
+  </Requirement>
+  <Requirement number={4} title="Add eas.json">
+    You'll need to add an `eas.json` file to the root of your project if it doesn't already exist:
+
+    <Terminal cmd={['$ touch eas.json && echo "{}" > eas.json']} />
+
+  </Requirement>
+</Prerequisites>
+
+<Step label="1">
+  Create a directory named **.eas/workflows** at the root of your project with a YAML file inside of
+  it. For example: **.eas/workflows/create-production-builds.yml**.
+
+  <FileTree
+  files={[
+    ['my-app/.eas/workflows/create-production-builds.yml', ''],
+    ['my-app/eas.json', ''],
+  ]}
+/>
+</Step>
+
+<Step label="2">
+
+Add the following YAML to the `create-production-builds.yml` file:
+
+```yaml .eas/workflows/create-production-builds.yml
+name: Create Production Builds
+
+jobs:
+  build_android:
+    type: build # This job type creates a production build for Android
+    params:
+      platform: android
+  build_ios:
+    type: build # This job type creates a production build for iOS
+    params:
+      platform: ios
+```
+
+The workflow above will create a production build for Android and iOS in parallel.
+
+</Step>
+
+<Step label="3">
+
+Finally, run the workflow with the following command:
+
+<Terminal cmd={['$ npx eas-cli@latest workflow:run create-production-builds.yml']} />
+
+Once you do, you can see your workflow running on your project's [workflows page](https://expo.dev/accounts/[account]/projects/[projectName]/workflows).
+
+</Step>
+
+## More
+
+### Automate workflows with GitHub events
+
+You can trigger a workflow by pushing a commit to your GitHub repository. You can link a GitHub repo to your EAS project with the following steps:
 
 - Navigate to your project's [GitHub settings](https://expo.dev/accounts/%5Baccount%5D/projects/%5BprojectName%5D/github).
 - Follow the UI to install the GitHub app.
 - Select the GitHub repository that matches the Expo project and connect it.
 
-## Write a workflow
+Then, add the [`on` trigger](/eas/workflows/syntax/#on) to your workflow file. For example, if you want to trigger the workflow when a commit is pushed to the `main` branch, you can add the following:
 
-First, create a directory named **.eas/workflows** at the root of your project with a YAML file inside of it. For example: **.eas/workflows/hello-world.yml**.
+```yaml .eas/workflows/create-production-builds.yml
+name: Create Production Builds
 
-Now we're ready to write the contents of **hello-world.yml**. Each workflow consists of three top-level elements:
-
-- `name`: defines the name of the workflow. For example: "Hello World"
-- `on`: defines when this workflow should be triggered. For example, when pushing a new commit to a GitHub branch.
-- `jobs`: a sequence of jobs which can depend on and pass data between each other. For example: a job that runs a unit test followed by a job that builds your project into an app.
-
-Here's an example of a workflow that prints "Hello, world":
-
-```yaml .eas/workflows/hello-world.yml
-name: Hello World
-
+# @info #
 on:
   push:
-    branches: ['*']
+    branches: ['main']
+  # @end #
 
-jobs:
-  Hello World:
-    steps:
-      - run: echo "Hello, World"
+  jobs:
+    build_android:
+      type: build
+      params:
+        platform: android
+    build_ios:
+      type: build
 ```
 
-Here's another example that creates and submits an iOS build of a project on every push to every branch. This is similar to running `eas build --platform ios --profile production --auto-submit`:
+### VS Code extension
 
-```yaml .eas/workflows/ios-build-and-submit.yml
-name: Release iOS app
-
-on:
-  push:
-    branches: ['*']
-
-jobs:
-  build:
-    type: build
-    params:
-      platform: ios
-      profile: production
-  submit:
-    needs: [build]
-    type: submit
-    params:
-      build_id: ${{ needs.build.outputs.build_id }}
-```
-
-> **info** Download the [Expo Tools VS Code extension](https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools) to get descriptions and autocompletions for your workflow files.
-
-## Run your workflow
-
-Once you have a workflow file and your project is connected to Expo's GitHub app, you can trigger your workflow by pushing a commit to your GitHub repository. For the workflow to run, you'll need to make sure the trigger (defined with `on`) you defined in your workflow is met.
-
-Alternatively, you can trigger a workflow manually by running the following command:
-
-<Terminal cmd={['$ npx eas-cli@latest workflow:run .eas/workflows/<your-workflow-file>.yml']} />
-
-Once you do, you can see your workflow running on your project's [workflows page](https://expo.dev/accounts/[account]/projects/[projectName]/workflows).
+Download the [Expo Tools VS Code extension](https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools) to get descriptions and autocompletions for your workflow files.
 
 > Got feedback or feature requests? Send us an email at workflows@expo.dev.


### PR DESCRIPTION
# Why

Workflows no longer require a GitHub connection to set up, so this updates the get started doc to be more succinct.

# Test Plan

Make sure the changes read well and are accurate.
<img width="1871" alt="Screenshot 2025-05-23 at 8 43 24 AM" src="https://github.com/user-attachments/assets/bd9a42f9-e886-44c2-9d94-06b85632ed06" />

