### PR TITLE
[maps] Fix onMapClick and onMapLongClick nesting

### DIFF
--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix onMapClick and onMapLongClick nesting ([#37059](https://github.com/expo/expo/pull/37059) by [@jakex7](https://github.com/jakex7))
+- Fix onMapClick and onMapLongClick nesting. ([#37059](https://github.com/expo/expo/pull/37059) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix onMapClick and onMapLongClick nesting ([#37059](https://github.com/expo/expo/pull/37059) by [@jakex7](https://github.com/jakex7))
+
 ### 💡 Others
 
 ## 0.10.0 — 2025-05-08

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
@@ -59,8 +59,8 @@ class GoogleMapsView(context: Context, appContext: AppContext) : ExpoComposeView
 
   private val onMapLoaded by EventDispatcher<Unit>()
 
-  private val onMapClick by EventDispatcher<Coordinates>()
-  private val onMapLongClick by EventDispatcher<Coordinates>()
+  private val onMapClick by EventDispatcher<MapClickEvent>()
+  private val onMapLongClick by EventDispatcher<MapClickEvent>()
   private val onPOIClick by EventDispatcher<POIRecord>()
   private val onMarkerClick by EventDispatcher<MarkerRecord>()
   private val onPolylineClick by EventDispatcher<PolylineRecord>()
@@ -94,12 +94,16 @@ class GoogleMapsView(context: Context, appContext: AppContext) : ExpoComposeView
         },
         onMapClick = { latLng ->
           onMapClick(
-            Coordinates(latLng.latitude, latLng.longitude)
+            MapClickEvent(
+              Coordinates(latLng.latitude, latLng.longitude)
+            )
           )
         },
         onMapLongClick = { latLng ->
           onMapLongClick(
-            Coordinates(latLng.latitude, latLng.longitude)
+            MapClickEvent(
+              Coordinates(latLng.latitude, latLng.longitude)
+            )
           )
         },
         onPOIClick = { poi ->

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/Records.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/Records.kt
@@ -71,7 +71,7 @@ data class MarkerRecord(
 data class PolylineRecord(
   @Field
   val id: String = UUID.randomUUID().toString(),
-  
+
   @Field
   val coordinates: List<Coordinates> = emptyList(),
 
@@ -82,8 +82,8 @@ data class PolylineRecord(
   val color: Int = 0xFF0000FF.toInt(),
 
   @Field
-  val width: Float = 10f,
-): Record
+  val width: Float = 10f
+) : Record
 
 data class PolygonRecord(
   @Field
@@ -100,7 +100,7 @@ data class PolygonRecord(
 
   @Field
   val color: Int = 0xFF0000FF.toInt()
-): Record
+) : Record
 
 data class CameraPositionRecord(
   @Field
@@ -127,7 +127,7 @@ data class CircleRecord(
   val lineColor: Int? = null,
 
   @Field
-  val lineWidth: Float? = null,
+  val lineWidth: Float? = null
 ) : Record
 
 data class UserLocationRecord(
@@ -258,6 +258,11 @@ data class CameraMoveEvent(
 
   @Field
   val bearing: Float
+) : Record
+
+data class MapClickEvent(
+  @Field
+  val coordinates: Coordinates
 ) : Record
 
 data class CameraPositionStreetViewRecord(

--- a/packages/expo-maps/ios/AppleMapsViewiOS17.swift
+++ b/packages/expo-maps/ios/AppleMapsViewiOS17.swift
@@ -88,8 +88,10 @@ struct AppleMapsViewiOS17: View, AppleMapsViewProtocol {
       .onTapGesture(coordinateSpace: .local) { position in
         if let coordinate = reader.convert(position, from: .local) {
           props.onMapClick([
-            "latitude": coordinate.latitude,
-            "longitude": coordinate.longitude
+            "coordinates": [
+              "latitude": coordinate.latitude,
+              "longitude": coordinate.longitude
+            ]
           ])
         }
       }

--- a/packages/expo-maps/ios/AppleMapsViewiOS18.swift
+++ b/packages/expo-maps/ios/AppleMapsViewiOS18.swift
@@ -169,8 +169,10 @@ struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
 
           // Send an event of map click regardless
           props.onMapClick([
-            "latitude": coordinate.latitude,
-            "longitude": coordinate.longitude
+            "coordinates": [
+              "latitude": coordinate.latitude,
+              "longitude": coordinate.longitude
+            ]
           ])
         }
       }


### PR DESCRIPTION
# Why

Fixes #36997

According to the types/docs, `onMapClick` and `onMapLongClick` should be a type of `(event: { coordinates: Coordinates }) => void` but it actually was `(event: Coordinates) => void`

# How

Nest latitude and longitude inside coordinates key.

# Test Plan

Bare Expo -> Expo Maps -> Maps Events

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
