### PR TITLE
[tools] align Node target versions, speed up build

### DIFF
--- a/tools/taskfile-swc.js
+++ b/tools/taskfile-swc.js
@@ -17,7 +17,7 @@ module.exports = function (task) {
         },
         env: {
           targets: {
-            node: '14.17.6',
+            node: '22',
           },
         },
         jsc: {

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2018",
-    "lib": ["es2021", "esnext.asynciterable"],
+    "target": "es2023",
+    "lib": ["es2023", "esnext.asynciterable"],
     "module": "commonjs",
     "sourceMap": true,
     "inlineSources": true,


### PR DESCRIPTION
# Why

Spotted some Node version misaligns in the tools app.

# How

Align Node target versions, to match what's used in the repo, speed up build slightly.

# Test Plan

`et` builds, and few tested commands works as expected.

## Build times OMM

### Before
![Screenshot 2025-05-26 at 10 40 38](https://github.com/user-attachments/assets/b958f256-0b07-4914-b7cc-e788db469a1b)

### After
![Screenshot 2025-05-26 at 10 35 24](https://github.com/user-attachments/assets/03f08cf2-3e6d-49ab-987d-92bcb772c4c1)

