### PR TITLE
[core][Android] Add benchmark test

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/BenchmarkTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/BenchmarkTest.kt
@@ -2,16 +2,15 @@ package expo.modules.kotlin.jni
 
 import org.junit.Ignore
 import org.junit.Test
-import kotlin.time.DurationUnit
+import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.measureTime
-import kotlin.time.toDuration
 
 @Ignore("Benchmark tests are not run by default. They are used to measure performance of the JSI bridge and should be run manually when needed.")
 class BenchmarkTest {
   @Test
   fun benchmark() {
     val numberOfTries = 10
-    var totalAvg = 0.toDuration(unit = DurationUnit.MILLISECONDS)
+    var totalAvg = 0.nanoseconds
     repeat(numberOfTries) {
       withSingleModule({
         Function("add") { a: Int, b: Int ->
@@ -19,7 +18,7 @@ class BenchmarkTest {
         }
       }) {
         val numberOfCalls = 10_000
-        var total = 0.toDuration(unit = DurationUnit.MILLISECONDS)
+        var total = 0.nanoseconds
         repeat(numberOfCalls) {
           val time = measureTime {
             callVoid("add", "1, 2")

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/BenchmarkTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/BenchmarkTest.kt
@@ -1,0 +1,39 @@
+package expo.modules.kotlin.jni
+
+import org.junit.Ignore
+import org.junit.Test
+import kotlin.time.DurationUnit
+import kotlin.time.measureTime
+import kotlin.time.toDuration
+
+@Ignore("Benchmark tests are not run by default. They are used to measure performance of the JSI bridge and should be run manually when needed.")
+class BenchmarkTest {
+  @Test
+  fun benchmark() {
+    val numberOfTries = 10
+    var totalAvg = 0.toDuration(unit = DurationUnit.MILLISECONDS)
+    repeat(numberOfTries) {
+      withSingleModule({
+        Function("add") { a: Int, b: Int ->
+          a + b
+        }
+      }) {
+        val numberOfCalls = 10_000
+        var total = 0.toDuration(unit = DurationUnit.MILLISECONDS)
+        repeat(numberOfCalls) {
+          val time = measureTime {
+            callVoid("add", "1, 2")
+          }
+
+          total += time
+        }
+
+        val average = total / numberOfCalls
+        totalAvg += average
+        println("Average time: $average")
+      }
+    }
+    val avg = totalAvg / numberOfTries
+    println("Average time for $numberOfTries tries: $avg")
+  }
+}

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -152,6 +152,10 @@ class SingleTestContext(
     "$moduleRef.$functionName($args)"
   )
 
+  fun callVoid(functionName: String, args: String = "") = jsiInterop.evaluateVoidScript(
+    "$moduleRef.$functionName($args)"
+  )
+
   fun callClass(className: String, functionName: String? = null, args: String = ""): JavaScriptValue {
     if (functionName == null) {
       return jsiInterop.evaluateScript("new $moduleRef.$className()")

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -44,6 +44,7 @@ void JSIContext::registerNatives() {
                                     JSIContext::installJSIForBridgeless),
 #endif
                    makeNativeMethod("evaluateScript", JSIContext::evaluateScript),
+                   makeNativeMethod("evaluateVoidScript", JSIContext::evaluateVoidScript),
                    makeNativeMethod("global", JSIContext::global),
                    makeNativeMethod("createObject", JSIContext::createObject),
                    makeNativeMethod("drainJSEventLoop", JSIContext::drainJSEventLoop),
@@ -216,6 +217,12 @@ jni::local_ref<JavaScriptValue::javaobject> JSIContext::evaluateScript(
   jni::JString script
 ) {
   return runtimeHolder->evaluateScript(script.toStdString());
+}
+
+void JSIContext::evaluateVoidScript(
+  jni::JString script
+) {
+  runtimeHolder->evaluateVoidScript(script.toStdString());
 }
 
 jni::local_ref<JavaScriptObject::javaobject> JSIContext::global() noexcept {

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -91,6 +91,8 @@ public:
    */
   jni::local_ref<JavaScriptValue::javaobject> evaluateScript(jni::JString script);
 
+  void evaluateVoidScript(jni::JString script);
+
   /**
    * Exposes a `JavaScriptRuntime::global` function to Kotlin
    */

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -51,6 +51,27 @@ JavaScriptRuntime::evaluateScript(const std::string &script) {
   }
 }
 
+void JavaScriptRuntime::evaluateVoidScript(const std::string &script) {
+  auto scriptBuffer = std::make_shared<jsi::StringBuffer>(script);
+  try {
+    runtime->evaluateJavaScript(scriptBuffer, "<<evaluated>>");
+  } catch (const jsi::JSError &error) {
+    jni::throwNewJavaException(
+      JavaScriptEvaluateException::create(
+        error.getMessage(),
+        error.getStack()
+      ).get()
+    );
+  } catch (const jsi::JSIException &error) {
+    jni::throwNewJavaException(
+      JavaScriptEvaluateException::create(
+        error.what(),
+        ""
+      ).get()
+    );
+  }
+}
+
 jni::local_ref<JavaScriptObject::javaobject> JavaScriptRuntime::global() noexcept {
   auto global = std::make_shared<jsi::Object>(runtime->global());
   return JavaScriptObject::newInstance(getJSIContext(get()), weak_from_this(), global);

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -50,6 +50,15 @@ public:
   );
 
   /**
+   * Evaluates given JavaScript source code.
+   * @throws if the input format is unknown, or evaluation causes an error,
+   * a jni::JniException<JavaScriptEvaluateException> will be thrown.
+   */
+  void evaluateVoidScript(
+    const std::string &script
+  );
+
+  /**
    * Returns the runtime global object for use in Kotlin.
    */
   jni::local_ref<jni::HybridClass<JavaScriptObject, Destructible>::javaobject> global() noexcept;

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
@@ -80,6 +80,13 @@ class JSIContext : Destructible, AutoCloseable {
   external fun evaluateScript(script: String): JavaScriptValue
 
   /**
+   * Evaluates given JavaScript source code.
+   * @throws JavaScriptEvaluateException if the input format is unknown or evaluation causes an error
+   */
+  @Throws(JavaScriptEvaluateException::class)
+  external fun evaluateVoidScript(script: String)
+
+  /**
    * Returns the runtime global object
    */
   external fun global(): JavaScriptObject


### PR DESCRIPTION
# Why

Adds benchmark test

# How

- added benchmark
- added a new function that ignores results from eval; when calculating our API overhead, we don’t want to account for the overhead of wrapping results in JavaScriptValue

# Test Plan

- run benchmark test ✅ 