### PR TITLE
[core][Android] Improve time to retrieve the Expo module

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Improved `@expo/ui/swift-ui-primitives` integrations. ([#36937](https://github.com/expo/expo/pull/36937) by [@kudo](https://github.com/kudo))
 - [iOS] Use dynamic type for AsyncFunction result conversion ([#36986](https://github.com/expo/expo/pull/36986) by [@jakex7](https://github.com/jakex7))
+- [Android] Improve time to retrieve the Expo module.
 
 ## 2.3.13 — 2025-05-08
 

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -30,12 +30,12 @@ ExpoModulesHostObject::~ExpoModulesHostObject() {
 jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {
   auto cName = name.utf8(runtime);
 
-  if (!installer->hasModule(cName)) {
-    modulesCache.erase(cName);
-    return jsi::Value::undefined();
-  }
   if (UniqueJSIObject &cachedObject = modulesCache[cName]) {
     return jsi::Value(runtime, *cachedObject);
+  }
+
+  if (!installer->hasModule(cName)) {
+    return jsi::Value::undefined();
   }
 
   // Create a lazy object for the specific module. It defers initialization of the final module object.
@@ -50,7 +50,8 @@ jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropName
 
       auto module = installer->getModule(cName);
       return module->cthis()->getJSIObject(rt);
-    });
+    }
+  );
 
   // Save the module's lazy host object for later use.
   modulesCache[cName] = std::make_unique<jsi::Object>(


### PR DESCRIPTION
# Why

Improves time to retrieve the cached Expo module.

# How

I’ve reordered the process for retrieving the cached expo module. Instead of running the JNI function to check if the module exists, we first verify if it’s in the cache. By doing this, we reduce the number of calls through the JNI.

# Test Plan

- bare-expo ✅ 