### PR TITLE
Add missing ./build/resolveAssetSource export in expo-assets

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Remove "Please" from warnings and errors ([#36862](https://github.com/expo/expo/pull/36862) by [@brentvatne](https://github.com/brentvatne))
+- Add missing `./build/resolveAssetSource` export in expo-assets ([#37083](https://github.com/expo/expo/pull/37083) by [ACHP](https://github.com/ACHP))
 
 ## 11.1.5 — 2025-05-03
 

--- a/packages/expo-asset/package.json
+++ b/packages/expo-asset/package.json
@@ -28,6 +28,7 @@
     "./app.plugin.js": "./app.plugin.js",
     "./tools/hashAssetFiles": "./tools/hashAssetFiles.js",
     "./package.json": "./package.json",
+    "./build/resolveAssetSource": "./build/resolveAssetSource.js",
     ".": {
       "react-server": "./build/index.server.js",
       "default": "./build/index.js"


### PR DESCRIPTION
# Why

Since the [introduction of the "useImage" hook ](https://github.com/expo/expo/pull/31171), expo-image now depends on `react-native/Libraries/Image/resolveAssetSource'`

https://github.com/expo/expo/blob/8baac7eafbe2a63f803bab94e77f59b9de4865fb/packages/expo-image/src/utils/resolveAssetSource.tsx#L1

But react-native web does not expose such files at all, meaning that if we alias `react-native` to `react-native-web` we cannot properly use expo-image.


Expo web solves this by doing another specific alias to `expo-asset/build/resolveAssetSource`

https://github.com/expo/expo/blob/8baac7eafbe2a63f803bab94e77f59b9de4865fb/packages/%40expo/cli/src/start/server/metro/withMetroMultiPlatform.ts#L185-L190

So I think it's a legit solution to apply to my build config (rsbuild/rspack):
But when applying the exact same workaround I have an error:
``` shell
  × Package subpath './build/resolveAssetSource.js' is not defined by "exports" in /Users/****/projects/****/****/node_modules/expo-asset/package.json

 @ ../node_modules/expo-image/src/utils/resolveSources.tsx
 @ ../node_modules/expo-image/src/Image.tsx
 @ ../node_modules/expo-image/src/index.ts
 ```
 
 Ideally I guess rn-web should just export this function, I've seen some opened issues but I don't feel like this is going anywhere.
 I guess the reason it works with metro is just that metro is not as strict as rsbuild or vite or else …

# How

We can simply export `./build/resolveAssetSource` from expo-assets's package.json

# Test Plan

"It works on my machine"

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
