### PR TITLE
[ios][dev-menu] Fix custom actions not triggering after reload

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix custom menu actions not triggering their callbacks after a reload.
+- [iOS] Fix custom menu actions not triggering their callbacks after a reload. ([#37084](https://github.com/expo/expo/pull/37084) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix custom menu actions not triggering their callbacks after a reload.
+
 ### 💡 Others
 
 ## 6.1.10 — 2025-05-01

--- a/packages/expo-dev-menu/README.md
+++ b/packages/expo-dev-menu/README.md
@@ -12,7 +12,7 @@ The `expo-dev-menu` repository consists of two different parts, the exported pac
 
 Local development is usually done through [`bare-expo`](/apps/bare-expo).
 
-First, make sure to `yarn` and `yarn start` in `expo-dev-menu` which will add the port for the dev menu packager to [`dev-menu-packager-host`](./assets/dev-menu-packager-host). This is bundled into the native code in `bare-expo` so need to be done first. When done with local development, you need to reset the contents of `dev-menu-packager-host`!
+First, make sure to `yarn` and `yarn start` in `expo-dev-menu` which will add the port for the dev menu packager to [`dev-menu-packager-host`](./assets/dev-menu-packager-host). This is bundled into the native code in `bare-expo` so it needs to be done first. When done with local development, you need to reset the contents of `dev-menu-packager-host`!
 
 ### Making JavaScript changes inside the `app` folder
 

--- a/packages/expo-dev-menu/babel.config.js
+++ b/packages/expo-dev-menu/babel.config.js
@@ -1,7 +1,7 @@
 function tryResolveModule(module) {
   try {
     return require.resolve(module);
-  } catch (e) {
+  } catch {
     console.error(`Couldn't resolve vendored module - ${module}.`);
     return null;
   }

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -192,8 +192,8 @@ open class DevMenuManager: NSObject {
       return
     }
 
-    let args = data == nil ? [eventName] : [eventName, data!]
-    bridge.enqueueJSCall("RCTDeviceEventEmitter.emit", args: args)
+    let eventDispatcher = bridge.moduleRegistry.module(forName: "EventDispatcher") as? RCTEventDispatcher
+    eventDispatcher?.sendDeviceEvent(withName: eventName, body: data)
   }
 
   // MARK: delegate stubs
@@ -302,7 +302,7 @@ open class DevMenuManager: NSObject {
     }
 
     let devDelegate = DevMenuDevOptionsDelegate(forBridge: bridge)
-    guard let devSettings = devDelegate.devSettings else {
+    guard devDelegate.devSettings != nil else {
       return nil
     }
 

--- a/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegate.swift
+++ b/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegate.swift
@@ -17,7 +17,7 @@ public class ExpoReactDelegate: NSObject {
     initialProperties: [AnyHashable: Any]?,
     launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> UIView {
-    return self.handlers.lazy
+    return self.handlers
       .compactMap { $0.createReactRootView(reactDelegate: self, moduleName: moduleName, initialProperties: initialProperties, launchOptions: launchOptions) }
       .first(where: { _ in true })
       ?? {


### PR DESCRIPTION
# Why
Closes #36359

# How
After a reload, the RCTInstance is null when we try to `enqueueJSCall` on our bridge reference. Instead of doing it this way, we can take the `RCTEventDispatcher` from the module registry and use it directly.

# Test Plan
Bare-expo on new and old arch. Dev menu events are emitted correctly on custom actions.

