### PR TITLE
[docs] Fix examples in Expo Router docs

### DIFF
--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -198,9 +198,9 @@ export function SplashScreenController() {
 Use the **SessionProvider** in the root layout to provide the authentication context to the entire app. Ensure the **SplashScreenController** is inside the **SessionProvider**
 
 ```tsx app/_layout.tsx
-import { Slot } from 'expo-router';
+import { Stack } from 'expo-router';
 import { SessionProvider } from '../ctx';
-import { SplashScreenController } form '../splash'
+import { SplashScreenController } from '../splash';
 
 export default function Root() {
   // Set up the auth context and render our layout inside of it.
@@ -214,7 +214,7 @@ export default function Root() {
 
 // Separate this into a new component so it can access the SessionProvider context later
 function RootNavigator() {
-  return <Stack />
+  return <Stack />;
 }
 ```
 

--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -26,6 +26,7 @@ A bare minimum structure of a custom tab layout would consist of a `TabList` (co
 
 ```tsx app/(tabs)/_layout.tsx|collapseHeight=440
 import { Tabs, TabList, TabTrigger, TabSlot } from 'expo-router/ui';
+import { Text } from 'react-native';
 
 // Defining the layout of the custom tab navigator
 export default function Layout() {
@@ -199,7 +200,7 @@ The `TabList` is both the configuration and default appearance of the `Tabs`, bu
 ```tsx TabButton.tsx
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { TabTriggerSlotProps } from 'expo-router/ui';
-import { ComponentProps, Ref, forwardRef } from 'react';
+import { ComponentProps, Ref } from 'react';
 import { Text, Pressable, View } from 'react-native';
 
 type Icon = ComponentProps<typeof FontAwesome>['name'];
@@ -236,6 +237,9 @@ export function TabButton({ icon, children, isFocused, ...props }: TabButtonProp
 In Expo SDK 52 and below (React 18), use the legacy `forwardRef` function to access the `ref` handle.
 
 ```diff
+- import { ComponentProps, Ref } from 'react';
++ import { ComponentProps, Ref, forwardRef } from 'react';
+
 - export function TabButton({ ref }) {
 + export const TabButton = forwardRef((props: TabButtonProps, ref: Ref<View>) => {
 ```

--- a/docs/pages/router/basics/common-navigation-patterns.mdx
+++ b/docs/pages/router/basics/common-navigation-patterns.mdx
@@ -175,7 +175,7 @@ The data source for checking authentication status could be React context, a sta
 In the **app/login.tsx** file, attempt to reroute the user to the `/(logged-in)` route after successful authentication:
 
 ```tsx app/login.tsx
-import { Button } from 'react-native';
+import { Button, View } from 'react-native';
 import { useRouter } from 'expo-router';
 
 export default function Login() {

--- a/docs/pages/router/basics/navigation.mdx
+++ b/docs/pages/router/basics/navigation.mdx
@@ -18,6 +18,7 @@ Like in React Navigation, you can call a function from an `onPress` handler to n
 
 ```tsx
 import { useRouter } from 'expo-router';
+import { Button } from 'react-native';
 
 export default function Home() {
   const router = useRouter();
@@ -129,10 +130,10 @@ Each of these links will navigate to the same page:
 
 {/* prettier-ignore */}
 ```tsx app/index.tsx
-/* @info Import the <CODE>Link</CODE> React component from <CODE>expo-router</CODE>. */
-import { Link } from 'expo-router';
+/* @info Import the <CODE>Link</CODE> React component and <CODE>router</CODE> to navigate imperatively from <CODE>expo-router</CODE>. */
+import { Link, router } from 'expo-router';
 /* @end */
-import { View, Pressable } from 'react-native';
+import { View, Pressable, Text } from 'react-native';
 
 export default function Page() {
   return (
@@ -244,7 +245,7 @@ export default function Page() {
 The `prefetch` prop on a `<Link />` component enables prefetching of the target screen when the component is rendered. This allows for faster navigation by preparing the screen in advance.
 
 ```tsx
-import { Redirect } from 'expo-router';
+import { Link } from 'expo-router';
 
 export default function Page() {
   return <Link href="/about" prefetch />;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #37052

While going through Expo Router docs, I found more such issues like missing import statements or importing a wrong component in code examples. This PR fixes that in basics and advanced sections of Expo Router docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
