### PR TITLE
[expo-go] Enable RTL support

### DIFF
--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -61,6 +61,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="${appLabel}"
         android:requestLegacyExternalStorage="true"
+        android:supportsRtl="true"
         android:usesCleartextTraffic="true">
 
         <activity


### PR DESCRIPTION
# Why
Closes #32976

# How
Add the `supportsRtl` attribute to the `application` tag

# Test Plan
Tested in Expo Go with the provided repro.
