### PR TITLE
[docs] Minor fix for BackgroundTask docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/background-task.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-task.mdx
@@ -128,7 +128,7 @@ export default function BackgroundTaskScreen() {
   const updateAsync = async () => {
     const status = await BackgroundTask.getStatusAsync();
     setStatus(status);
-    const isRegistered = await BackgroundTask.isTaskRegisteredAsync(BACKGROUND_TASK_IDENTIFIER);
+    const isRegistered = await TaskManager.isTaskRegisteredAsync(BACKGROUND_TASK_IDENTIFIER);
     setIsRegistered(isRegistered);
   };
 


### PR DESCRIPTION
 isTaskRegisteredAsync function exists on TaskManager and not BackgroundTask

# Why

While going through the documentation and following the sample provided I identified this minor type/error in code where `BackgroundTask.isTaskRegisteredAsync` is called which does not exist as per API reference

# How

Minor documentation update

# Test Plan

-

# Checklist
- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
