### PR TITLE
[docs] Fix grammatical mistake in Deploy to testflight callout

### DIFF
--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -85,7 +85,7 @@ export function QuickStart() {
             <div>
               <Terminal cmd={['$ npx testflight']} />
               <CALLOUT theme="secondary">
-                This is iOS only command that will upload your app to TestFlight.
+                This is an iOS-only command that will upload your app to TestFlight.
               </CALLOUT>
             </div>
           </div>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

There's a grammatical error in the Deploy to TestFlight callout on the home page. This PR fixes it.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-05-27 at 00 24 57](https://github.com/user-attachments/assets/65c037e8-fd5b-47fd-9d7e-3e2193622fe3)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
