### PR TITLE
[docs] Fix language inconsistency for YAML code blocks

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -59,7 +59,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 - Global Yarn configuration in **~/.yarnrc.yml**:
 
-  ```yml ~/.yarnrc.yml
+  ```yaml ~/.yarnrc.yml
   unsafeHttpWhitelist:
     - '*'
   npmRegistryServer: 'http://10.4.0.19:4873'
@@ -263,7 +263,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 - Global Yarn configuration in **~/.yarnrc.yml**:
 
-  ```yml ~/.yarnrc.yml
+  ```yaml ~/.yarnrc.yml
   unsafeHttpWhitelist:
     - '*'
   npmRegistryServer: 'http://10.94.183.70:4873'

--- a/docs/pages/eas/hosting/workflows.mdx
+++ b/docs/pages/eas/hosting/workflows.mdx
@@ -16,7 +16,7 @@ To use [EAS workflows](/eas/workflows/get-started/) to automatically deploy your
 
 Add the following file to **.eas/workflows/deploy.yml**. This will use the production environment variables, export the web bundle, deploy your project and promote it to production whenever you push to the `main` branch.
 
-```yml .eas/workflows/deploy.yml
+```yaml .eas/workflows/deploy.yml
 name: Deploy
 
 on:

--- a/docs/pages/eas/workflows/reference/e2e-tests.mdx
+++ b/docs/pages/eas/workflows/reference/e2e-tests.mdx
@@ -38,7 +38,7 @@ Let's create two simple Maestro flows for the example app. Start by creating a d
 
 Inside, create a new file called **home.yml**. This flow will launch the app and assert that the text "Welcome!" is visible on the home screen.
 
-```yml .maestro/home.yml
+```yaml .maestro/home.yml
 appId: dev.expo.eastestsexample # This is an example app id. Replace it with your app id.
 ---
 - launchApp
@@ -47,7 +47,7 @@ appId: dev.expo.eastestsexample # This is an example app id. Replace it with you
 
 Next, create a new flow called **expand_test.yml**. This flow will open the "Explore" screen in the example app, click on the "File-based routing" collapsible, and assert that the text "This app has two screens." is visible on the screen.
 
-```yml .maestro/expand_test.yml
+```yaml .maestro/expand_test.yml
 appId: dev.expo.eastestsexample # This is an example app id. Replace it with your app id.
 ---
 - launchApp
@@ -107,7 +107,7 @@ The above build profile creates an **.apk** for Android and an **.app** for iOS.
 
 At the root of your project, create an **.eas/workflows** directory. Then, add a YAML file for your E2E test workflow, such as **.eas/workflows/e2e-test-android.yml**.
 
-```yml .eas/workflows/e2e-test-android.yml
+```yaml .eas/workflows/e2e-test-android.yml
 name: e2e-test-android
 
 on:
@@ -132,7 +132,7 @@ This workflow builds an **.apk** for Android using the `e2e-test` build profile 
 
 Here's an example of the same test workflow for iOS:
 
-```yml .eas/workflows/e2e-test.yml
+```yaml .eas/workflows/e2e-test.yml
 name: e2e-test-ios
 
 on:

--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -123,7 +123,7 @@ Yarn 2+ handles package management differently than Yarn 1. One of the core chan
 
 By default, a project created with `create-expo-app` and Yarn 2+ uses [`nodeLinker`](https://yarnpkg.com/features/linkers#nodelinker-node-modules) with its value set to `node-modules` to install dependencies.
 
-```yml .yarnrc.yml
+```yaml .yarnrc.yml
 nodeLinker: node-modules
 ```
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Fix language inconsistency for YAML code blocks in multiple docs since majority of the code blocks that use YAML as their code language, prefer `yaml`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
