### PR TITLE
[docs] Update Wordiness rule under Vale configuration

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/Wordiness.yml
+++ b/docs/.vale/writing-styles/expo-docs/Wordiness.yml
@@ -11,5 +11,4 @@ swap:
   - in lieu of: instead of
   - in order to: to
   - none at all: none
-  - not possible: impossible
   - take into account: consider


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Using the word "impossible" can be taken out of context and seems harsh with more subtle "not possible...". We should remove this as a warning under Vale configuration for wordiness.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run lint-prose` and there should be no warnings.

![CleanShot 2025-05-27 at 02 18 36](https://github.com/user-attachments/assets/a5a8f1bf-a522-4e6e-992e-f8a6815f61bd)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
