### PR TITLE
[core][Android] Reduce number of conversions

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [Android] Improve time to retrieve the Expo module. ([#37082](https://github.com/expo/expo/pull/37082) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Reduce the memory footprint of calling function from the native module. ([#37080](https://github.com/expo/expo/pull/37080) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Changed how nullable types are converted. ([#37055](https://github.com/expo/expo/pull/37055) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Reduce the number of conversions needed to call a function from the native module.
 
 ## 2.3.13 — 2025-05-08
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [Android] Improve time to retrieve the Expo module. ([#37082](https://github.com/expo/expo/pull/37082) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Reduce the memory footprint of calling function from the native module. ([#37080](https://github.com/expo/expo/pull/37080) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Changed how nullable types are converted. ([#37055](https://github.com/expo/expo/pull/37055) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Reduce the number of conversions needed to call a function from the native module.
+- [Android] Reduce the number of conversions needed to call a function from the native module. ([#37099](https://github.com/expo/expo/pull/37099) by [@lukmccall](https://github.com/lukmccall))
 
 ## 2.3.13 — 2025-05-08
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -5,6 +5,7 @@ package expo.modules.kotlin.jni
 import com.google.common.truth.Truth
 import expo.modules.kotlin.RuntimeContext
 import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.jni.extensions.addSingleQuotes
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
@@ -197,8 +198,8 @@ class JSIAsyncFunctionsTest {
     Truth.assertThat(exception.message).contains("java.lang.IllegalStateException")
   }
 
-  @Test(expected = PromiseException::class)
-  fun should_reject_if_js_value_cannot_be_passed() = withSingleModule({
+  @Test(expected = JavaScriptEvaluateException::class)
+  fun should_throw_if_js_value_cannot_be_passed() = withSingleModule({
     AsyncFunction("f") { _: Int -> }
   }) {
     callAsync("f", "Symbol()")

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSISuspendableFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSISuspendableFunctionsTest.kt
@@ -5,6 +5,7 @@ package expo.modules.kotlin.jni
 import com.google.common.truth.Truth
 import expo.modules.kotlin.RuntimeContext
 import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.jni.extensions.addSingleQuotes
 import expo.modules.kotlin.records.Field
@@ -197,8 +198,8 @@ class JSISuspendableFunctionsTest {
     Truth.assertThat(exception.message).contains("java.lang.IllegalStateException")
   }
 
-  @Test(expected = PromiseException::class)
-  fun should_reject_if_js_value_cannot_be_passed() = withSingleModule({
+  @Test(expected = JavaScriptEvaluateException::class)
+  fun should_throw_if_js_value_cannot_be_passed() = withSingleModule({
     AsyncFunction("f") Coroutine { _: Int -> }
   }) {
     callAsync("f", "Symbol()")

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -74,37 +74,37 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
     nullptr
   );
 
+#define CONVERT(arg, type, index) \
+try {                             \
+  auto converterValue = type->converter->convert(rt, env, arg); \
+  env->SetObjectArrayElement(argumentArray, index, converterValue); \
+  env->DeleteLocalRef(converterValue);                          \
+} catch (std::exception &exception) {                           \
+  auto stringRepresentation = arg.toString(rt).utf8(rt);        \
+  throwNewJavaException(                                       \
+    UnexpectedException::create(                               \
+      "[" + this->info.name + "] Cannot convert '" + stringRepresentation + \
+      "' to a Kotlin type.").get()                             \
+  );                              \
+}
 
-  const auto getCurrentArg = [&thisValue, args, takesOwner = info.takesOwner](
-    size_t index
-  ) -> const jsi::Value & {
-    if (!takesOwner) {
-      return args[index];
+  if (!info.takesOwner) {
+    for (size_t argIndex = 0; argIndex < count; argIndex++) {
+      const jsi::Value &arg = args[argIndex];
+      auto &type = info.argTypes[argIndex];
+      CONVERT(arg, type, argIndex)
     }
+  } else {
+    auto &thisType = info.argTypes[0];
+    CONVERT(thisValue, thisType, 0)
 
-    if (index != 0) {
-      return args[index - 1];
-    }
-    return thisValue;
-  };
-
-  for (size_t argIndex = 0; argIndex < count; argIndex++) {
-    const jsi::Value &arg = getCurrentArg(argIndex);
-    auto &type = info.argTypes[argIndex];
-
-    if (type->converter->canConvert(rt, arg)) {
-      auto converterValue = type->converter->convert(rt, env, arg);
-      env->SetObjectArrayElement(argumentArray, argIndex, converterValue);
-      env->DeleteLocalRef(converterValue);
-    } else {
-      auto stringRepresentation = arg.toString(rt).utf8(rt);
-      throwNewJavaException(
-        UnexpectedException::create(
-          "[" + this->info.name + "] Cannot convert '" + stringRepresentation +
-          "' to a Kotlin type.").get()
-      );
+    for (size_t argIndex = 1; argIndex < count; argIndex++) {
+      const jsi::Value &arg = args[argIndex];
+      auto &type = info.argTypes[argIndex];
+      CONVERT(arg, type, argIndex)
     }
   }
+#undef CONVERT
 
   return argumentArray;
 }

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -99,7 +99,7 @@ try {                             \
     CONVERT(thisValue, thisType, 0)
 
     for (size_t argIndex = 1; argIndex < count; argIndex++) {
-      const jsi::Value &arg = args[argIndex];
+      const jsi::Value &arg = args[argIndex - 1];
       auto &type = info.argTypes[argIndex];
       CONVERT(arg, type, argIndex)
     }

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -412,13 +412,6 @@ jobject ListFrontendConverter::convert(
   auto arrayList = java::ArrayList<jobject>::create(size);
   for (size_t i = 0; i < size; i++) {
     auto jsValue = jsArray.getValueAtIndex(rt, i);
-
-    // TODO(@lukmccall): pass information to CPP if the underlying type is nullable or not.
-    if (jsValue.isNull() || jsValue.isUndefined()) {
-      arrayList->add(nullptr);
-      continue;
-    }
-
     auto convertedElement = parameterConverter->convert(
       rt, env, jsValue
     );
@@ -467,12 +460,6 @@ jobject MapFrontendConverter::convert(
     auto jsValue = jsObject.getProperty(rt, key);
 
     auto convertedKey = env->NewStringUTF(key.utf8(rt).c_str());
-
-    // TODO(@lukmccall): pass information to CPP if the underlying type is nullable or not.
-    if (jsValue.isNull() || jsValue.isUndefined()) {
-      map->put(convertedKey, nullptr);
-      continue;
-    }
 
     auto convertedValue = valueConverter->convert(
       rt, env, jsValue
@@ -537,10 +524,6 @@ jobject AnyFrontendConvert::convert(
   JNIEnv *env,
   const jsi::Value &value
 ) const {
-  if (value.isUndefined() || value.isNull()) {
-    return nullptr;
-  }
-
   if (booleanConverter.canConvert(rt, value)) {
     return booleanConverter.convert(rt, env, value);
   }
@@ -551,10 +534,6 @@ jobject AnyFrontendConvert::convert(
 
   if (stringConverter.canConvert(rt, value)) {
     return stringConverter.convert(rt, env, value);
-  }
-
-  if (!value.isObject()) {
-    return nullptr;
   }
 
   const jsi::Object &obj = value.asObject(rt);

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -95,7 +95,7 @@ abstract class AnyFunction(
    * @throws `CodedException` if conversion isn't possible
    */
   @Throws(CodedException::class)
-  protected fun convertArgs(args: Array<Any?>, appContext: AppContext? = null): Array<out Any?> {
+  protected fun convertArgs(args: Array<Any?>, appContext: AppContext? = null, forceConversion: Boolean = false): Array<out Any?> {
     if (requiredArgumentsCount > args.size || args.size > desiredArgsTypes.size) {
       throw InvalidArgsNumberException(args.size, desiredArgsTypes.size, requiredArgumentsCount)
     }
@@ -111,7 +111,7 @@ abstract class AnyFunction(
       exceptionDecorator({ cause ->
         ArgumentCastException(desiredType.kType, index, element?.javaClass.toString(), cause)
       }) {
-        finalArgs[index] = desiredType.convert(element, appContext)
+        finalArgs[index] = desiredType.convert(element, appContext, forceConversion)
       }
     }
     return finalArgs

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
@@ -9,6 +9,7 @@ import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.exception.toCodedException
 import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.types.AnyType
+import expo.modules.kotlin.types.inheritFrom
 import expo.modules.kotlin.weak
 import kotlinx.coroutines.launch
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
@@ -321,7 +321,7 @@ class AnyType(
 
   fun convert(value: Any?, appContext: AppContext? = null, forceConversion: Boolean = false): Any? {
     // We can skip conversion if we already did it on the C++ side.
-    if (converter.isTrivial() && value !is Dynamic) {
+    if (!forceConversion && converter.isTrivial() && value !is Dynamic) {
       return value
     }
     return converter.convert(value, appContext, forceConversion)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.types
 
 import android.net.Uri
+import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.core.arguments.ReadableArguments
@@ -20,6 +21,7 @@ import expo.modules.kotlin.typedarray.Uint16Array
 import expo.modules.kotlin.typedarray.Uint32Array
 import expo.modules.kotlin.typedarray.Uint8Array
 import expo.modules.kotlin.typedarray.Uint8ClampedArray
+import expo.modules.kotlin.types.AnyTypeProvider.typesMap
 import java.io.File
 import java.net.URI
 import java.net.URL
@@ -138,11 +140,11 @@ object AnyTypeProvider {
       put((klass to true), AnyType(EmptyKType(klass, true)))
     }
   }
+}
 
-  inline fun <reified T> cachedAnyType(): AnyType? {
-    val key = Pair(T::class, null is T)
-    return typesMap[key]
-  }
+inline fun <reified T> AnyTypeProvider.cachedAnyType(): AnyType? {
+  val key = Pair(T::class, null is T)
+  return typesMap[key]
 }
 
 inline fun <reified T> lazyTypeOf() = { typeOf<T>() }.toLazyType<T>()
@@ -318,15 +320,20 @@ class AnyType(
   }
 
   fun convert(value: Any?, appContext: AppContext? = null, forceConversion: Boolean = false): Any? {
+    // We can skip conversion if we already did it on the C++ side.
+    if (converter.isTrivial() && value !is Dynamic) {
+      return value
+    }
     return converter.convert(value, appContext, forceConversion)
   }
 
   fun getCppRequiredTypes(): ExpectedType = converter.getCppRequiredTypes()
+}
 
-  internal inline fun <reified T> inheritFrom(): Boolean {
-    val kClass = kType.classifier as? KClass<*> ?: return false
-    val jClass = kClass.java
+inline fun <reified T> AnyType.inheritFrom(): Boolean {
+  return true
+  val kClass = kType.classifier as? KClass<*> ?: return false
+  val jClass = kClass.java
 
-    return T::class.java.isAssignableFrom(jClass)
-  }
+  return T::class.java.isAssignableFrom(jClass)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/NullableTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/NullableTypeConverter.kt
@@ -15,6 +15,11 @@ class NullableTypeConverter<Type : Any>(
       return null
     }
 
+    if (innerConverter.isTrivial() && !forceConversion && value !is Dynamic) {
+      @Suppress("UNCHECKED_CAST")
+      return value as Type
+    }
+
     return innerConverter.convert(value, context, forceConversion)
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReturnType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReturnType.kt
@@ -1,18 +1,20 @@
 package expo.modules.kotlin.types
 
 import android.os.Bundle
+import expo.modules.kotlin.types.ReturnTypeProvider.types
 import expo.modules.kotlin.types.folly.FollyDynamicExtensionConverter
+import kotlin.collections.set
 import kotlin.reflect.KClass
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 
 object ReturnTypeProvider {
   val types = mutableMapOf<KClass<*>, ReturnType>()
+}
 
-  inline fun <reified T> get(): ReturnType {
-    return types[T::class] ?: ReturnType(T::class).also {
-      types[T::class] = it
-    }
+inline fun <reified T> ReturnTypeProvider.get(): ReturnType {
+  return types[T::class] ?: ReturnType(T::class).also {
+    types[T::class] = it
   }
 }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
@@ -19,7 +19,7 @@ class AnyFunctionTest {
     desiredArgsTypes: Array<AnyType>
   ) : AsyncFunctionComponent("my-method", desiredArgsTypes) {
     override fun callUserImplementation(args: Array<Any?>, promise: Promise, appContext: AppContext) {
-      convertArgs(args)
+      convertArgs(args, appContext, forceConversion = true)
       throw NullPointerException()
     }
   }


### PR DESCRIPTION
# Why

Reduces the number of conversions needed to call a native function. 

# How

In most cases, the entire data conversion occurs on the C++ side. Previously, we made another pass through the data on the native side. This PR aims to change that and reduce the number of conversions. 

# Test Plan

- bare-expo ✅ 
- unit tests ✅ 