### PR TITLE
[document-picker] avoid hard crash in case of an exception

### DIFF
--- a/apps/native-component-list/src/screens/DocumentPickerScreen.tsx
+++ b/apps/native-component-list/src/screens/DocumentPickerScreen.tsx
@@ -12,23 +12,30 @@ export default function DocumentPickerScreen() {
     React.useState<DocumentPicker.DocumentPickerResult | null>(null);
 
   const openPicker = async () => {
-    const time = Date.now();
-    const result = await DocumentPicker.getDocumentAsync({
-      copyToCacheDirectory: copyToCache,
-      multiple,
-    });
-    console.log(`Duration: ${Date.now() - time}ms`);
-    console.log(`Results:`, result);
-    if (!result.canceled) {
-      setPickerResult(result);
-    } else {
+    try {
+      const time = Date.now();
+      const result = await DocumentPicker.getDocumentAsync({
+        copyToCacheDirectory: copyToCache,
+        multiple,
+      });
+      console.log(`Duration: ${Date.now() - time}ms`);
+      console.log(`Results:`, result);
+      if (!result.canceled) {
+        setPickerResult(result);
+      } else {
+        setTimeout(() => {
+          if (Platform.OS === 'web') {
+            alert('Cancelled');
+          } else {
+            Alert.alert('Cancelled');
+          }
+        }, 100);
+      }
+    } catch (err) {
+      console.error('Error picking document:', err);
       setTimeout(() => {
-        if (Platform.OS === 'web') {
-          alert('Cancelled');
-        } else {
-          Alert.alert('Cancelled');
-        }
-      }, 100);
+        Alert.alert('error', `Error picking document: ${err}`);
+      }, 150);
     }
   };
 

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] avoid hard crash in case of an exception ([#37110](https://github.com/expo/expo/pull/37110) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 ## 13.1.5 — 2025-04-30

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentDetailsReader.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentDetailsReader.kt
@@ -5,9 +5,10 @@ import android.net.Uri
 import android.provider.OpenableColumns
 import android.provider.DocumentsContract
 import java.io.File
+import java.io.IOException
 
 class DocumentDetailsReader(private val context: Context) {
-  fun read(uri: Uri): DocumentInfo? {
+  fun read(uri: Uri): DocumentInfo {
     context
       .contentResolver
       .query(uri, null, null, null, null)
@@ -47,7 +48,6 @@ class DocumentDetailsReader(private val context: Context) {
         }
 
         return DocumentInfo(uri, name, mimeType, size, lastModified)
-      }
-    return null
+      } ?: throw IOException("Failed to read document details for URI: $uri")
   }
 }

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerExceptions.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerExceptions.kt
@@ -5,8 +5,5 @@ import expo.modules.kotlin.exception.CodedException
 class PickingInProgressException :
   CodedException("Different document picking in progress. Await other document picking first.")
 
-class FailedToCopyToCacheException :
-  CodedException("Failed to copy to cache directory.")
-
 class FailedToReadDocumentException :
   CodedException("Failed to read the selected document.")


### PR DESCRIPTION
# Why

Improve error handling in the DocumentPicker module to properly catch and report errors during document picking operations.

# How

- replaces a faulty `promise.resolve` (which lead to a app crash through [this](https://github.com/expo/expo/blob/7dd9e5287b7604342b81bc44085a8853752c0682/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt#L40)) with `promise.reject`
- Enhanced error handling in the Android implementation:
  - there were a couple places that would return null, but down the line the `null` would be turned into an exception. I modified these to return the exception right away, which simplifies the flow a little. Any exception is caught by a top-level try-catch and results in a promise rejection.
  - Added try/catch block in the testing DocumentPickerScreen to properly handle and display errors

# Test Plan

Tested locally. Small files can be picked and copied. If an error is thrown (like with the large file screenshot), the promise is rejected.

<details>
<summary>screenshots</summary>

![copy-error](https://github.com/user-attachments/assets/95d6da8b-42fc-49f1-a9d3-ed1a0d2d91c1)
![ok-without-copy](https://github.com/user-attachments/assets/be081f5e-5ddd-4174-ac4c-eb36be201338)


</details>

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)