### PR TITLE
[docs] Add header and screen options from React Navigation to Stack in Expo Router

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -23,6 +23,7 @@
     "schema-sync": "node --async-stack-traces --unhandled-rejections=strict ./scripts/schema-sync.js",
     "permissions-sync-android": "npx scrape-permissions-json@latest components/plugins/permissions/data --android",
     "versions-schema-sync": "node ./scripts/fetch-versions-schema.js",
+    "react-navigation-docs-sync": "node ./scripts/fetch-react-navigation-options.js",
     "postinstall": "yarn copy-latest && yarn generate-static-resources"
   },
   "packageManager": "yarn@4.9.1",

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -7,6 +7,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
+import { ReactNavigationOptions } from '~/ui/components/ReactNavigationOptions';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 <VideoBoxLink
@@ -164,6 +165,12 @@ const styles = StyleSheet.create({
 });
 ```
 
+### Available header options
+
+The `Stack` navigator supports comprehensive header configuration options. Below are all the header-related options available:
+
+<ReactNavigationOptions category="header" />
+
 ### Set screen options dynamically
 
 To configure a route's option dynamically, you can always use the `<Stack.Screen>` component in that route's file.
@@ -242,6 +249,12 @@ const styles = StyleSheet.create({
   },
 });
 ```
+
+### Other screen options
+
+For a complete list of all available other screen options including animations, gestures, and other configurations:
+
+<ReactNavigationOptions excludeCategories={['header']} />
 
 ## Custom push behavior
 

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -3,9 +3,6 @@ title: Stack
 description: Learn how to use the Stack navigator in Expo Router.
 ---
 
-import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
-
-import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
 import { ReactNavigationOptions } from '~/ui/components/ReactNavigationOptions';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
@@ -489,12 +486,3 @@ export default function Layout() {
 ```
 
 For more information on available options, see [`@react-navigation/stack` documentation](https://reactnavigation.org/docs/stack-navigator).
-
-## More
-
-<BoxLink
-  title="Native Stack Navigator options"
-  Icon={BookOpen02Icon}
-  description="For a list of all options available in the stack layout, see React Navigation's documentation."
-  href="https://reactnavigation.org/docs/native-stack-navigator#options"
-/>

--- a/docs/public/data/react-navigation-options.json
+++ b/docs/public/data/react-navigation-options.json
@@ -1,0 +1,438 @@
+{
+  "source": "React Navigation Documentation (Markdown)",
+  "sourceUrl": "https://raw.githubusercontent.com/react-navigation/react-navigation.github.io/main/versioned_docs/version-7.x/native-stack-navigator.md",
+  "fetchedAt": "2025-05-27T17:50:47.572Z",
+  "totalOptions": 71,
+  "categories": {
+    "header": 26,
+    "other": 45
+  },
+  "options": [
+    {
+      "name": "title",
+      "description": "String that can be used as a fallback for `headerTitle`.",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerBackButtonMenuEnabled",
+      "description": "Boolean indicating whether to show the menu on longPress of iOS >= 14 back button. Defaults to `true`.",
+      "platform": "iOS only",
+      "category": "header"
+    },
+    {
+      "name": "headerBackVisible",
+      "description": "Whether the back button is visible in the header. You can use it to show a back button alongside `headerLeft` if you have specified it.\n\nThis will have no effect on the first screen in the stack.",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerBackTitle",
+      "description": "Title string used by the back button on iOS. Defaults to the previous scene's title, \"Back\" or arrow icon depending on the available space. See `headerBackButtonDisplayMode` to read about limitations and customize the behavior.\n\nUse `headerBackButtonDisplayMode: \"minimal\"` to hide it.",
+      "platform": "iOS only",
+      "category": "header"
+    },
+    {
+      "name": "headerBackButtonDisplayMode",
+      "description": "How the back button displays icon and title.\n\nSupported values:\n\n- \"default\" - Displays one of the following depending on the available space: previous screen's title, generic title (e.g. 'Back') or no title (only icon).\n- \"generic\" – Displays one of the following depending on the available space: generic title (e.g. 'Back') or no title (only icon).\n- \"minimal\" – Always displays only the icon without a title.\n\nThe space-aware behavior is disabled when:\n\n- The iOS version is 13 or lower\n- Custom font family or size is set (e.g. with `headerBackTitleStyle`)\n- Back button menu is disabled (e.g. with `headerBackButtonMenuEnabled`)\n\nIn such cases, a static title and icon are always displayed.",
+      "platform": "iOS only",
+      "category": "header"
+    },
+    {
+      "name": "headerBackTitleStyle",
+      "description": "Style object for header back title. Supported properties:\n\n- `fontFamily`\n- `fontSize`",
+      "platform": "iOS only",
+      "category": "header"
+    },
+    {
+      "name": "headerBackImageSource",
+      "description": "Image to display in the header as the icon in the back button. Defaults to back icon image for the platform\n\n- A chevron on iOS\n- An arrow on Android",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerLargeStyle",
+      "description": "Style of the header when a large title is shown. The large title is shown if `headerLargeTitle` is `true` and the edge of any scrollable content reaches the matching edge of the header.\n\nSupported properties:\n\n- backgroundColor",
+      "platform": "iOS only",
+      "category": "header"
+    },
+    {
+      "name": "headerLargeTitle",
+      "description": "Whether to enable header with large title which collapses to regular header on scroll.\nDefaults to `false`.\n\nFor large title to collapse on scroll, the content of the screen should be wrapped in a scrollable view such as `ScrollView` or `FlatList`. If the scrollable area doesn't fill the screen, the large title won't collapse on scroll. You also need to specify `contentInsetAdjustmentBehavior=\"automatic\"` in your `ScrollView`, `FlatList` etc.",
+      "platform": "iOS only",
+      "category": "header"
+    },
+    {
+      "name": "headerLargeTitleShadowVisible",
+      "description": "Whether drop shadow of header is visible when a large title is shown.",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerLargeTitleStyle",
+      "description": "Style object for large title in header. Supported properties:\n\n- `fontFamily`\n- `fontSize`\n- `fontWeight`\n- `color`",
+      "platform": "iOS only",
+      "category": "header"
+    },
+    {
+      "name": "headerShown",
+      "description": "Whether to show the header. The header is shown by default. Setting this to `false` hides the header.",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerStyle",
+      "description": "Style object for header. Supported properties:\n\n- `backgroundColor`",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerShadowVisible",
+      "description": "Whether to hide the elevation shadow (Android) or the bottom border (iOS) on the header.\n\nAndroid:\n\niOS:",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerTransparent",
+      "description": "Boolean indicating whether the navigation bar is translucent.\n\nDefaults to `false`. Setting this to `true` makes the header absolutely positioned - so that the header floats over the screen so that it overlaps the content underneath, and changes the background color to `transparent` unless specified in `headerStyle`.\n\nThis is useful if you want to render a semi-transparent header or a blurred background.\n\nNote that if you don't want your content to appear under the header, you need to manually add a top margin to your content. React Navigation won't do it automatically.\n\nTo get the height of the header, you can use `HeaderHeightContext` with React's Context API or `useHeaderHeight`.",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerBlurEffect",
+      "description": "Blur effect for the translucent header. The `headerTransparent` option needs to be set to `true` for this to work.\n\nSupported values:\n\n- `extraLight`\n\n- `light`\n  \n\n- `dark`\n  \n\n- `regular`\n  \n\n- `prominent`\n  \n\n- `systemUltraThinMaterial`\n  \n\n- `systemThinMaterial`\n  \n\n- `systemMaterial`\n  \n\n- `systemThickMaterial`\n  \n\n- `systemChromeMaterial`\n  \n\n- `systemUltraThinMaterialLight`\n  \n\n- `systemThinMaterialLight`\n  \n\n- `systemMaterialLight`\n  \n\n- `systemThickMaterialLight`\n  \n\n- `systemChromeMaterialLight`\n  \n\n- `systemUltraThinMaterialDark`\n  \n- `systemThinMaterialDark`\n  \n\n- `systemMaterialDark`\n  \n- `systemThickMaterialDark`\n  \n\n- `systemChromeMaterialDark`",
+      "platform": "iOS only",
+      "category": "header"
+    },
+    {
+      "name": "headerBackground",
+      "description": "Function which returns a React Element to render as the background of the header. This is useful for using backgrounds such as an image or a gradient.",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerTintColor",
+      "description": "Tint color for the header. Changes the color of back button and title.",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerLeft",
+      "description": "Function which returns a React Element to display on the left side of the header. This replaces the back button. See `headerBackVisible` to show the back button along side left element.",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerRight",
+      "description": "Function which returns a React Element to display on the right side of the header.",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerTitle",
+      "description": "String or a function that returns a React Element to be used by the header. Defaults to `title` or name of the screen.\n\nWhen a function is passed, it receives `tintColor` and`children` in the options object as an argument. The title string is passed in `children`.\n\nNote that if you render a custom element by passing a function, animations for the title won't work.",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerTitleAlign",
+      "description": "How to align the header title. Possible values:\n\n- `left`\n  \n\n- `center`\n  \n\nDefaults to `left` on platforms other than iOS.\n\nNot supported on iOS. It's always `center` on iOS and cannot be changed.",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerTitleStyle",
+      "description": "Style object for header title. Supported properties:\n\n- `fontFamily`\n- `fontSize`\n- `fontWeight`\n- `color`",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "headerSearchBarOptions",
+      "description": "Options to render a native search bar on iOS. Search bars are rarely static so normally it is controlled by passing an object to `headerSearchBarOptions` navigation option in the component's body.\n\nYou also need to specify `contentInsetAdjustmentBehavior=\"automatic\"` in your `ScrollView`, `FlatList` etc. If you don't have a `ScrollView`, specify `headerTransparent: false`.\n\nSupported properties are:",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "ref",
+      "description": "Ref to manipulate the search input imperatively. It contains the following methods:\n\n- `focus` - focuses the search bar\n- `blur` - removes focus from the search bar\n- `setText` - sets the search bar's content to given value\n- `clearText` - removes any text present in the search bar input field\n- `cancelSearch` - cancel the search and close the search bar",
+      "platform": "Both",
+      "category": "other"
+    },
+    {
+      "name": "autoCapitalize",
+      "description": "Controls whether the text is automatically auto-capitalized as it is entered by the user.\nPossible values:\n\n- `none`\n- `words`\n- `sentences`\n- `characters`\n\nDefaults to `sentences`.",
+      "platform": "Both",
+      "category": "other"
+    },
+    {
+      "name": "autoFocus",
+      "description": "Whether to automatically focus search bar when it's shown. Defaults to `false`.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "barTintColor",
+      "description": "The search field background color. By default bar tint color is translucent.",
+      "platform": "iOS only",
+      "category": "other"
+    },
+    {
+      "name": "tintColor",
+      "description": "The color for the cursor caret and cancel button text.",
+      "platform": "iOS only",
+      "category": "other"
+    },
+    {
+      "name": "cancelButtonText",
+      "description": "The text to be used instead of default `Cancel` button text.",
+      "platform": "iOS only",
+      "category": "other"
+    },
+    {
+      "name": "disableBackButtonOverride",
+      "description": "Whether the back button should close search bar's text input or not. Defaults to `false`.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "hideNavigationBar",
+      "description": "Boolean indicating whether to hide the navigation bar during searching. Defaults to `true`.",
+      "platform": "iOS only",
+      "category": "other"
+    },
+    {
+      "name": "hideWhenScrolling",
+      "description": "Boolean indicating whether to hide the search bar when scrolling. Defaults to `true`.",
+      "platform": "iOS only",
+      "category": "other"
+    },
+    {
+      "name": "inputType",
+      "description": "The type of the input. Defaults to `\"text\"`.\n\nSupported values:\n\n- `\"text\"`\n- `\"phone\"`\n- `\"number\"`\n- `\"email\"`",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "obscureBackground",
+      "description": "Boolean indicating whether to obscure the underlying content with semi-transparent overlay. Defaults to `true`.",
+      "platform": "Both",
+      "category": "other"
+    },
+    {
+      "name": "placeholder",
+      "description": "Text displayed when search field is empty.",
+      "platform": "Both",
+      "category": "other"
+    },
+    {
+      "name": "textColor",
+      "description": "The color of the text in the search field.",
+      "platform": "Both",
+      "category": "other"
+    },
+    {
+      "name": "hintTextColor",
+      "description": "The color of the hint text in the search field.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "headerIconColor",
+      "description": "The color of the search and close icons shown in the header",
+      "platform": "Android only",
+      "category": "header"
+    },
+    {
+      "name": "shouldShowHintSearchIcon",
+      "description": "Whether to show the search hint icon when search bar is focused. Defaults to `true`.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "onBlur",
+      "description": "A callback that gets called when search bar has lost focus.",
+      "platform": "Both",
+      "category": "other"
+    },
+    {
+      "name": "onCancelButtonPress",
+      "description": "A callback that gets called when the cancel button is pressed.",
+      "platform": "Both",
+      "category": "other"
+    },
+    {
+      "name": "onChangeText",
+      "description": "A callback that gets called when the text changes. It receives the current text value of the search bar.",
+      "platform": "Both",
+      "category": "other"
+    },
+    {
+      "name": "header",
+      "description": "Custom header to use instead of the default header.\n\nThis accepts a function that returns a React Element to display as a header. The function receives an object containing the following properties as the argument:\n\n- `navigation` - The navigation object for the current screen.\n- `route` - The route object for the current screen.\n- `options` - The options for the current screen\n- `back` - Options for the back button, contains an object with a `title` property to use for back button label.\n\nTo set a custom header for all the screens in the navigator, you can specify this option in the `screenOptions` prop of the navigator.\n\nNote that if you specify a custom header, the native functionality such as large title, search bar etc. won't work.",
+      "platform": "Both",
+      "category": "header"
+    },
+    {
+      "name": "statusBarAnimation",
+      "description": "Sets the status bar animation (similar to the `StatusBar` component). Defaults to `fade` on iOS and `none` on Android.\n\nSupported values:\n\n- `\"fade\"`\n- `\"none\"`\n- `\"slide\"`\n\nOn Android, setting either `fade` or `slide` will set the transition of status bar color. On iOS, this option applies to appereance animation of the status bar.\n\nRequires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "statusBarHidden",
+      "description": "Whether the status bar should be hidden on this screen.\n\nRequires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "statusBarStyle",
+      "description": "Sets the status bar color (similar to the `StatusBar` component). Defaults to `auto`.\n\nSupported values:\n\n- `\"auto\"`\n- `\"inverted\"` (iOS only)\n- `\"dark\"`\n- `\"light\"`\n\nRequires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "statusBarBackgroundColor",
+      "description": ":::warning\n\nThis option is deprecated and will be removed in a future release (for apps targeting Android SDK 35 or above edge-to-edge mode is enabled by default\nand it is expected that the edge-to-edge will be enforced in future SDKs, see here for more information).\n\n:::\n\nSets the background color of the status bar (similar to the `StatusBar` component).",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "statusBarTranslucent",
+      "description": ":::warning\n\nThis option is deprecated and will be removed in a future release (for apps targeting Android SDK 35 or above edge-to-edge mode is enabled by default\nand it is expected that the edge-to-edge will be enforced in future SDKs, see here for more information).\n\n:::\n\nSets the translucency of the status bar (similar to the `StatusBar` component). Defaults to `false`.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "contentStyle",
+      "description": "Style object for the scene content.",
+      "platform": "Both",
+      "category": "other"
+    },
+    {
+      "name": "animationMatchesGesture",
+      "description": "Whether the gesture to dismiss should use animation provided to `animation` prop. Defaults to `false`.\n\nDoesn't affect the behavior of screens presented modally.",
+      "platform": "iOS only",
+      "category": "other"
+    },
+    {
+      "name": "fullScreenGestureEnabled",
+      "description": "Whether the gesture to dismiss should work on the whole screen. Using gesture to dismiss with this option results in the same transition animation as `simple_push`. This behavior can be changed by setting `customAnimationOnGesture` prop. Achieving the default iOS animation isn't possible due to platform limitations. Defaults to `false`.\n\nDoesn't affect the behavior of screens presented modally.",
+      "platform": "iOS only",
+      "category": "other"
+    },
+    {
+      "name": "fullScreenGestureShadowEnabled",
+      "description": "Whether the full screen dismiss gesture has shadow under view during transition. Defaults to `true`.\n\nThis does not affect the behavior of transitions that don't use gestures enabled by `fullScreenGestureEnabled` prop.",
+      "platform": "Both",
+      "category": "other"
+    },
+    {
+      "name": "gestureEnabled",
+      "description": "Whether you can use gestures to dismiss this screen. Defaults to `true`.",
+      "platform": "iOS only",
+      "category": "other"
+    },
+    {
+      "name": "animationTypeForReplace",
+      "description": "The type of animation to use when this screen replaces another screen. Defaults to `push`.\n\nSupported values:\n\n- `push`: the new screen will perform push animation.\n\n  \n\n- `pop`: the new screen will perform pop animation.",
+      "platform": "Both",
+      "category": "other"
+    },
+    {
+      "name": "animation",
+      "description": "How the screen should animate when pushed or popped.\n\nSupported values:\n\n- `default`: use the platform default animation\n  \n\n- `fade`: fade screen in or out\n  \n\n- `fade_from_bottom`: fade the new screen from bottom\n  \n\n- `flip`: flip the screen, requires `presentation: \"modal\"` (iOS only)\n  \n\n- `simple_push`: default animation, but without shadow and native header transition (iOS only, uses default animation on Android)\n  \n\n- `slide_from_bottom`: slide in the new screen from bottom\n  \n\n- `slide_from_right`: slide in the new screen from right (Android only, uses default animation on iOS)\n  \n\n- `slide_from_left`: slide in the new screen from left (Android only, uses default animation on iOS)\n  \n\n- `none`: don't animate the screen",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "presentation",
+      "description": "How should the screen be presented.\n\nSupported values:\n\n- `card`: the new screen will be pushed onto a stack, which means the default animation will be slide from the side on iOS, the animation on Android will vary depending on the OS version and theme.\n  \n\n- `modal`: the new screen will be presented modally. this also allows for a nested stack to be rendered inside the screen.\n  \n\n- `transparentModal`: the new screen will be presented modally, but in addition, the previous screen will stay so that the content below can still be seen if the screen has translucent background.\n  \n\n- `containedModal`: will use \"UIModalPresentationCurrentContext\" modal style on iOS and will fallback to \"modal\" on Android.\n  \n\n- `containedTransparentModal`: will use \"UIModalPresentationOverCurrentContext\" modal style on iOS and will fallback to \"transparentModal\" on Android.\n  \n\n- `fullScreenModal`: will use \"UIModalPresentationFullScreen\" modal style on iOS and will fallback to \"modal\" on Android. A screen using this presentation style can't be dismissed by gesture.\n  \n\n- `formSheet`: will use \"BottomSheetBehavior\" on Android and \"UIModalPresentationFormSheet\" modal style on iOS.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "sheetAllowedDetents",
+      "description": ":::note\n\nWorks only when `presentation` is set to `formSheet`.\n\n:::\n\nDescribes heights where a sheet can rest.\n\nSupported values:\n\n- `fitToContents` - intents to set the sheet height to the height of its contents.\n- Array of fractions, e.g. `[0.25, 0.5, 0.75]`:\n  - Heights should be described as fraction (a number from `[0, 1]` interval) of screen height / maximum detent height.\n  - The array **must** be sorted in ascending order. This invariant is verified only in developement mode, where violation results in error.\n  - iOS accepts any number of detents, while **Android is limited to three** - any surplus values, beside first three are ignored.\n\nDefaults to `[1.0]`.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "sheetElevation",
+      "description": ":::note\n\nWorks only when `presentation` is set to `formSheet`.\n\n:::\n\nInteger value describing elevation of the sheet, impacting shadow on the top edge of the sheet.\n\nNot dynamic - changing it after the component is rendered won't have an effect.\n\nDefaults to `24`.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "sheetExpandsWhenScrolledToEdge",
+      "description": ":::note\n\nWorks only when `presentation` is set to `formSheet`.\n\n:::\n\nWhether the sheet should expand to larger detent when scrolling.\n\nDefaults to `true`.\n\n:::warning\n\nPlease note that for this interaction to work, the ScrollView must be \"first-subview-chain\" descendant of the Screen component. This restriction is due to platform requirements.\n\n:::",
+      "platform": "iOS only",
+      "category": "other"
+    },
+    {
+      "name": "sheetCornerRadius",
+      "description": ":::note\n\nWorks only when `presentation` is set to `formSheet`.\n\n:::\n\nThe corner radius that the sheet will try to render with.\n\nIf set to non-negative value it will try to render sheet with provided radius, else it will apply system default.\n\nIf left unset, system default is used.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "sheetInitialDetentIndex",
+      "description": ":::note\n\nWorks only when `presentation` is set to `formSheet`.\n\n:::\n\n**Index** of the detent the sheet should expand to after being opened.\n\nIf the specified index is out of bounds of `sheetAllowedDetents` array, in dev environment more errors will be thrown, in production the value will be reset to default value.\n\nAdditionaly there is `last` value available, when set the sheet will expand initially to last (largest) detent.\n\nDefaults to `0` - which represents first detent in the detents array.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "sheetGrabberVisible",
+      "description": ":::note\n\nWorks only when `presentation` is set to `formSheet`.\n\n:::\n\nBoolean indicating whether the sheet shows a grabber at the top.\n\nDefaults to `false`.",
+      "platform": "iOS only",
+      "category": "other"
+    },
+    {
+      "name": "sheetLargestUndimmedDetentIndex",
+      "description": ":::note\n\nWorks only when `presentation` is set to `formSheet`.\n\n:::\n\nThe largest sheet detent for which a view underneath won't be dimmed.\n\nThis prop can be set to an number, which indicates index of detent in `sheetAllowedDetents` array for which there won't be a dimming view beneath the sheet.\n\nAdditionaly there are following options available:\n\n- `none` - there will be dimming view for all detents levels,\n- `last` - there won't be a dimming view for any detent level.\n\nDefaults to `none`, indicating that the dimming view should be always present.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "orientation",
+      "description": "The display orientation to use for the screen.\n\nSupported values:\n\n- `default` - resolves to \"all\" without \"portrait_down\" on iOS. On Android, this lets the system decide the best orientation.\n- `all`: all orientations are permitted.\n- `portrait`: portrait orientations are permitted.\n- `portrait_up`: right-side portrait orientation is permitted.\n- `portrait_down`: upside-down portrait orientation is permitted.\n- `landscape`: landscape orientations are permitted.\n- `landscape_left`: landscape-left orientation is permitted.\n- `landscape_right`: landscape-right orientation is permitted.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "autoHideHomeIndicator",
+      "description": "Boolean indicating whether the home indicator should prefer to stay hidden. Defaults to `false`.",
+      "platform": "iOS only",
+      "category": "other"
+    },
+    {
+      "name": "gestureDirection",
+      "description": "Sets the direction in which you should swipe to dismiss the screen.\n\nSupported values:\n\n- `vertical` – dismiss screen vertically\n- `horizontal` – dismiss screen horizontally (default)\n\nWhen using `vertical` option, options `fullScreenGestureEnabled: true`, `customAnimationOnGesture: true` and `animation: 'slide_from_bottom'` are set by default.",
+      "platform": "iOS only",
+      "category": "other"
+    },
+    {
+      "name": "animationDuration",
+      "description": "Changes the duration (in milliseconds) of `slide_from_bottom`, `fade_from_bottom`, `fade` and `simple_push` transitions on iOS. Defaults to `350`.\n\nThe duration of `default` and `flip` transitions isn't customizable.",
+      "platform": "iOS only",
+      "category": "other"
+    },
+    {
+      "name": "navigationBarColor",
+      "description": ":::warning\n\nThis option is deprecated and will be removed in a future release (for apps targeting Android SDK 35 or above edge-to-edge mode is enabled by default\nand it is expected that the edge-to-edge will be enforced in future SDKs, see here for more information).\n\n:::\n\nSets the navigation bar color. Defaults to initial status bar color.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "navigationBarHidden",
+      "description": "Boolean indicating whether the navigation bar should be hidden. Defaults to `false`.",
+      "platform": "Android only",
+      "category": "other"
+    },
+    {
+      "name": "freezeOnBlur",
+      "description": "Boolean indicating whether to prevent inactive screens from re-rendering. Defaults to `false`.\nDefaults to `true` when `enableFreeze()` from `react-native-screens` package is run at the top of the application.\n\nOnly supported on iOS and Android.",
+      "platform": "iOS only",
+      "category": "other"
+    }
+  ]
+}

--- a/docs/public/data/react-navigation-options.json
+++ b/docs/public/data/react-navigation-options.json
@@ -1,11 +1,11 @@
 {
   "source": "React Navigation Documentation (Markdown)",
   "sourceUrl": "https://raw.githubusercontent.com/react-navigation/react-navigation.github.io/main/versioned_docs/version-7.x/native-stack-navigator.md",
-  "fetchedAt": "2025-05-27T17:50:47.572Z",
-  "totalOptions": 71,
+  "fetchedAt": "2025-05-27T18:45:49.302Z",
+  "totalOptions": 52,
   "categories": {
-    "header": 26,
-    "other": 45
+    "header": 25,
+    "other": 27
   },
   "options": [
     {
@@ -88,7 +88,7 @@
     },
     {
       "name": "headerShadowVisible",
-      "description": "Whether to hide the elevation shadow (Android) or the bottom border (iOS) on the header.\n\nAndroid:\n\niOS:",
+      "description": "Whether to hide the elevation shadow (Android) or the bottom border (iOS) on the header.",
       "platform": "Both",
       "category": "header"
     },
@@ -100,7 +100,7 @@
     },
     {
       "name": "headerBlurEffect",
-      "description": "Blur effect for the translucent header. The `headerTransparent` option needs to be set to `true` for this to work.\n\nSupported values:\n\n- `extraLight`\n\n- `light`\n  \n\n- `dark`\n  \n\n- `regular`\n  \n\n- `prominent`\n  \n\n- `systemUltraThinMaterial`\n  \n\n- `systemThinMaterial`\n  \n\n- `systemMaterial`\n  \n\n- `systemThickMaterial`\n  \n\n- `systemChromeMaterial`\n  \n\n- `systemUltraThinMaterialLight`\n  \n\n- `systemThinMaterialLight`\n  \n\n- `systemMaterialLight`\n  \n\n- `systemThickMaterialLight`\n  \n\n- `systemChromeMaterialLight`\n  \n\n- `systemUltraThinMaterialDark`\n  \n- `systemThinMaterialDark`\n  \n\n- `systemMaterialDark`\n  \n- `systemThickMaterialDark`\n  \n\n- `systemChromeMaterialDark`",
+      "description": "Blur effect for the translucent header. The `headerTransparent` option needs to be set to `true` for this to work.\n\nSupported values: <CODE>extraLight</CODE>, <CODE>light</CODE>, <CODE>dark</CODE>, <CODE>regular</CODE>, <CODE>prominent</CODE>, <CODE>systemUltraThinMaterial</CODE>, <CODE>systemThinMaterial</CODE>, <CODE>systemMaterial</CODE>, <CODE>systemThickMaterial</CODE>, <CODE>systemChromeMaterial</CODE>, <CODE>systemUltraThinMaterialLight</CODE>, <CODE>systemThinMaterialLight</CODE>, <CODE>systemMaterialLight</CODE>, <CODE>systemThickMaterialLight</CODE>, <CODE>systemChromeMaterialLight</CODE>, <CODE>systemUltraThinMaterialDark</CODE>, <CODE>systemThinMaterialDark</CODE>, <CODE>systemMaterialDark</CODE>, <CODE>systemThickMaterialDark</CODE>- `systemChromeMaterialDark`",
       "platform": "iOS only",
       "category": "header"
     },
@@ -148,123 +148,9 @@
     },
     {
       "name": "headerSearchBarOptions",
-      "description": "Options to render a native search bar on iOS. Search bars are rarely static so normally it is controlled by passing an object to `headerSearchBarOptions` navigation option in the component's body.\n\nYou also need to specify `contentInsetAdjustmentBehavior=\"automatic\"` in your `ScrollView`, `FlatList` etc. If you don't have a `ScrollView`, specify `headerTransparent: false`.\n\nSupported properties are:",
-      "platform": "Both",
+      "description": "Options to render a native search bar on iOS. Search bars are rarely static so normally it is controlled by passing an object to `headerSearchBarOptions` navigation option in the component's body.\n\nYou also need to specify `contentInsetAdjustmentBehavior=\"automatic\"` in your `ScrollView`, `FlatList` etc. If you don't have a `ScrollView`, specify `headerTransparent: false`.\n\nSupported properties are:\n\n**ref**\n\nRef to manipulate the search input imperatively. It contains the following methods:\n\n- `focus` - focuses the search bar\n- `blur` - removes focus from the search bar\n- `setText` - sets the search bar's content to given value\n- `clearText` - removes any text present in the search bar input field\n- `cancelSearch` - cancel the search and close the search bar\n\n**autoCapitalize**\n\nControls whether the text is automatically auto-capitalized as it is entered by the user.\nPossible values:\n\n- `none`\n- `words`\n- `sentences`\n- `characters`\n\nDefaults to `sentences`.\n\n**autoFocus**\n\nWhether to automatically focus search bar when it's shown. Defaults to `false`.\n\n**barTintColor**\n\nThe search field background color. By default bar tint color is translucent.\n\n**tintColor**\n\nThe color for the cursor caret and cancel button text.\n\n**cancelButtonText**\n\nThe text to be used instead of default `Cancel` button text.\n\n**disableBackButtonOverride**\n\nWhether the back button should close search bar's text input or not. Defaults to `false`.\n\n**hideNavigationBar**\n\nBoolean indicating whether to hide the navigation bar during searching. Defaults to `true`.\n\n**hideWhenScrolling**\n\nBoolean indicating whether to hide the search bar when scrolling. Defaults to `true`.\n\n**inputType**\n\nThe type of the input. Defaults to `\"text\"`.\n\nSupported values:\n\n- `\"text\"`\n- `\"phone\"`\n- `\"number\"`\n- `\"email\"`\n\n**obscureBackground**\n\nBoolean indicating whether to obscure the underlying content with semi-transparent overlay. Defaults to `true`.\n\n**placeholder**\n\nText displayed when search field is empty.\n\n**textColor**\n\nThe color of the text in the search field.\n\n**hintTextColor**\n\nThe color of the hint text in the search field.\n\n**headerIconColor**\n\nThe color of the search and close icons shown in the header\n\n**shouldShowHintSearchIcon**\n\nWhether to show the search hint icon when search bar is focused. Defaults to `true`.\n\n**onBlur**\n\nA callback that gets called when search bar has lost focus.\n\n**onCancelButtonPress**\n\nA callback that gets called when the cancel button is pressed.\n\n**onChangeText**\n\nA callback that gets called when the text changes. It receives the current text value of the search bar.",
+      "platform": "iOS only",
       "category": "header"
-    },
-    {
-      "name": "ref",
-      "description": "Ref to manipulate the search input imperatively. It contains the following methods:\n\n- `focus` - focuses the search bar\n- `blur` - removes focus from the search bar\n- `setText` - sets the search bar's content to given value\n- `clearText` - removes any text present in the search bar input field\n- `cancelSearch` - cancel the search and close the search bar",
-      "platform": "Both",
-      "category": "other"
-    },
-    {
-      "name": "autoCapitalize",
-      "description": "Controls whether the text is automatically auto-capitalized as it is entered by the user.\nPossible values:\n\n- `none`\n- `words`\n- `sentences`\n- `characters`\n\nDefaults to `sentences`.",
-      "platform": "Both",
-      "category": "other"
-    },
-    {
-      "name": "autoFocus",
-      "description": "Whether to automatically focus search bar when it's shown. Defaults to `false`.",
-      "platform": "Android only",
-      "category": "other"
-    },
-    {
-      "name": "barTintColor",
-      "description": "The search field background color. By default bar tint color is translucent.",
-      "platform": "iOS only",
-      "category": "other"
-    },
-    {
-      "name": "tintColor",
-      "description": "The color for the cursor caret and cancel button text.",
-      "platform": "iOS only",
-      "category": "other"
-    },
-    {
-      "name": "cancelButtonText",
-      "description": "The text to be used instead of default `Cancel` button text.",
-      "platform": "iOS only",
-      "category": "other"
-    },
-    {
-      "name": "disableBackButtonOverride",
-      "description": "Whether the back button should close search bar's text input or not. Defaults to `false`.",
-      "platform": "Android only",
-      "category": "other"
-    },
-    {
-      "name": "hideNavigationBar",
-      "description": "Boolean indicating whether to hide the navigation bar during searching. Defaults to `true`.",
-      "platform": "iOS only",
-      "category": "other"
-    },
-    {
-      "name": "hideWhenScrolling",
-      "description": "Boolean indicating whether to hide the search bar when scrolling. Defaults to `true`.",
-      "platform": "iOS only",
-      "category": "other"
-    },
-    {
-      "name": "inputType",
-      "description": "The type of the input. Defaults to `\"text\"`.\n\nSupported values:\n\n- `\"text\"`\n- `\"phone\"`\n- `\"number\"`\n- `\"email\"`",
-      "platform": "Android only",
-      "category": "other"
-    },
-    {
-      "name": "obscureBackground",
-      "description": "Boolean indicating whether to obscure the underlying content with semi-transparent overlay. Defaults to `true`.",
-      "platform": "Both",
-      "category": "other"
-    },
-    {
-      "name": "placeholder",
-      "description": "Text displayed when search field is empty.",
-      "platform": "Both",
-      "category": "other"
-    },
-    {
-      "name": "textColor",
-      "description": "The color of the text in the search field.",
-      "platform": "Both",
-      "category": "other"
-    },
-    {
-      "name": "hintTextColor",
-      "description": "The color of the hint text in the search field.",
-      "platform": "Android only",
-      "category": "other"
-    },
-    {
-      "name": "headerIconColor",
-      "description": "The color of the search and close icons shown in the header",
-      "platform": "Android only",
-      "category": "header"
-    },
-    {
-      "name": "shouldShowHintSearchIcon",
-      "description": "Whether to show the search hint icon when search bar is focused. Defaults to `true`.",
-      "platform": "Android only",
-      "category": "other"
-    },
-    {
-      "name": "onBlur",
-      "description": "A callback that gets called when search bar has lost focus.",
-      "platform": "Both",
-      "category": "other"
-    },
-    {
-      "name": "onCancelButtonPress",
-      "description": "A callback that gets called when the cancel button is pressed.",
-      "platform": "Both",
-      "category": "other"
-    },
-    {
-      "name": "onChangeText",
-      "description": "A callback that gets called when the text changes. It receives the current text value of the search bar.",
-      "platform": "Both",
-      "category": "other"
     },
     {
       "name": "header",
@@ -292,13 +178,13 @@
     },
     {
       "name": "statusBarBackgroundColor",
-      "description": ":::warning\n\nThis option is deprecated and will be removed in a future release (for apps targeting Android SDK 35 or above edge-to-edge mode is enabled by default\nand it is expected that the edge-to-edge will be enforced in future SDKs, see here for more information).\n\n:::\n\nSets the background color of the status bar (similar to the `StatusBar` component).",
+      "description": "This option is deprecated and will be removed in a future release (for apps targeting Android SDK 35 or above edge-to-edge mode is enabled by default\nand it is expected that the edge-to-edge will be enforced in future SDKs, see here for more information).\n\nSets the background color of the status bar (similar to the `StatusBar` component).",
       "platform": "Android only",
       "category": "other"
     },
     {
       "name": "statusBarTranslucent",
-      "description": ":::warning\n\nThis option is deprecated and will be removed in a future release (for apps targeting Android SDK 35 or above edge-to-edge mode is enabled by default\nand it is expected that the edge-to-edge will be enforced in future SDKs, see here for more information).\n\n:::\n\nSets the translucency of the status bar (similar to the `StatusBar` component). Defaults to `false`.",
+      "description": "This option is deprecated and will be removed in a future release (for apps targeting Android SDK 35 or above edge-to-edge mode is enabled by default\nand it is expected that the edge-to-edge will be enforced in future SDKs, see here for more information).\n\nSets the translucency of the status bar (similar to the `StatusBar` component). Defaults to `false`.",
       "platform": "Android only",
       "category": "other"
     },
@@ -352,43 +238,43 @@
     },
     {
       "name": "sheetAllowedDetents",
-      "description": ":::note\n\nWorks only when `presentation` is set to `formSheet`.\n\n:::\n\nDescribes heights where a sheet can rest.\n\nSupported values:\n\n- `fitToContents` - intents to set the sheet height to the height of its contents.\n- Array of fractions, e.g. `[0.25, 0.5, 0.75]`:\n  - Heights should be described as fraction (a number from `[0, 1]` interval) of screen height / maximum detent height.\n  - The array **must** be sorted in ascending order. This invariant is verified only in developement mode, where violation results in error.\n  - iOS accepts any number of detents, while **Android is limited to three** - any surplus values, beside first three are ignored.\n\nDefaults to `[1.0]`.",
+      "description": "Works only when `presentation` is set to `formSheet`.\n\nDescribes heights where a sheet can rest.\n\nSupported values:\n\n- `fitToContents` - intents to set the sheet height to the height of its contents.\n- Array of fractions, e.g. `[0.25, 0.5, 0.75]`:\n  - Heights should be described as fraction (a number from `[0, 1]` interval) of screen height / maximum detent height.\n  - The array **must** be sorted in ascending order. This invariant is verified only in developement mode, where violation results in error.\n  - iOS accepts any number of detents, while **Android is limited to three** - any surplus values, beside first three are ignored.\n\nDefaults to `[1.0]`.",
       "platform": "Android only",
       "category": "other"
     },
     {
       "name": "sheetElevation",
-      "description": ":::note\n\nWorks only when `presentation` is set to `formSheet`.\n\n:::\n\nInteger value describing elevation of the sheet, impacting shadow on the top edge of the sheet.\n\nNot dynamic - changing it after the component is rendered won't have an effect.\n\nDefaults to `24`.",
+      "description": "Works only when `presentation` is set to `formSheet`.\n\nInteger value describing elevation of the sheet, impacting shadow on the top edge of the sheet.\n\nNot dynamic - changing it after the component is rendered won't have an effect.\n\nDefaults to `24`.",
       "platform": "Android only",
       "category": "other"
     },
     {
       "name": "sheetExpandsWhenScrolledToEdge",
-      "description": ":::note\n\nWorks only when `presentation` is set to `formSheet`.\n\n:::\n\nWhether the sheet should expand to larger detent when scrolling.\n\nDefaults to `true`.\n\n:::warning\n\nPlease note that for this interaction to work, the ScrollView must be \"first-subview-chain\" descendant of the Screen component. This restriction is due to platform requirements.\n\n:::",
+      "description": "Works only when `presentation` is set to `formSheet`.\n\nWhether the sheet should expand to larger detent when scrolling.\n\nDefaults to `true`.\n\nPlease note that for this interaction to work, the ScrollView must be \"first-subview-chain\" descendant of the Screen component. This restriction is due to platform requirements.",
       "platform": "iOS only",
       "category": "other"
     },
     {
       "name": "sheetCornerRadius",
-      "description": ":::note\n\nWorks only when `presentation` is set to `formSheet`.\n\n:::\n\nThe corner radius that the sheet will try to render with.\n\nIf set to non-negative value it will try to render sheet with provided radius, else it will apply system default.\n\nIf left unset, system default is used.",
+      "description": "Works only when `presentation` is set to `formSheet`.\n\nThe corner radius that the sheet will try to render with.\n\nIf set to non-negative value it will try to render sheet with provided radius, else it will apply system default.\n\nIf left unset, system default is used.",
       "platform": "Android only",
       "category": "other"
     },
     {
       "name": "sheetInitialDetentIndex",
-      "description": ":::note\n\nWorks only when `presentation` is set to `formSheet`.\n\n:::\n\n**Index** of the detent the sheet should expand to after being opened.\n\nIf the specified index is out of bounds of `sheetAllowedDetents` array, in dev environment more errors will be thrown, in production the value will be reset to default value.\n\nAdditionaly there is `last` value available, when set the sheet will expand initially to last (largest) detent.\n\nDefaults to `0` - which represents first detent in the detents array.",
+      "description": "Works only when `presentation` is set to `formSheet`.\n\n**Index** of the detent the sheet should expand to after being opened.\n\nIf the specified index is out of bounds of `sheetAllowedDetents` array, in dev environment more errors will be thrown, in production the value will be reset to default value.\n\nAdditionaly there is `last` value available, when set the sheet will expand initially to last (largest) detent.\n\nDefaults to `0` - which represents first detent in the detents array.",
       "platform": "Android only",
       "category": "other"
     },
     {
       "name": "sheetGrabberVisible",
-      "description": ":::note\n\nWorks only when `presentation` is set to `formSheet`.\n\n:::\n\nBoolean indicating whether the sheet shows a grabber at the top.\n\nDefaults to `false`.",
+      "description": "Works only when `presentation` is set to `formSheet`.\n\nBoolean indicating whether the sheet shows a grabber at the top.\n\nDefaults to `false`.",
       "platform": "iOS only",
       "category": "other"
     },
     {
       "name": "sheetLargestUndimmedDetentIndex",
-      "description": ":::note\n\nWorks only when `presentation` is set to `formSheet`.\n\n:::\n\nThe largest sheet detent for which a view underneath won't be dimmed.\n\nThis prop can be set to an number, which indicates index of detent in `sheetAllowedDetents` array for which there won't be a dimming view beneath the sheet.\n\nAdditionaly there are following options available:\n\n- `none` - there will be dimming view for all detents levels,\n- `last` - there won't be a dimming view for any detent level.\n\nDefaults to `none`, indicating that the dimming view should be always present.",
+      "description": "Works only when `presentation` is set to `formSheet`.\n\nThe largest sheet detent for which a view underneath won't be dimmed.\n\nThis prop can be set to an number, which indicates index of detent in `sheetAllowedDetents` array for which there won't be a dimming view beneath the sheet.\n\nAdditionaly there are following options available:\n\n- `none` - there will be dimming view for all detents levels,\n- `last` - there won't be a dimming view for any detent level.\n\nDefaults to `none`, indicating that the dimming view should be always present.",
       "platform": "Android only",
       "category": "other"
     },
@@ -418,7 +304,7 @@
     },
     {
       "name": "navigationBarColor",
-      "description": ":::warning\n\nThis option is deprecated and will be removed in a future release (for apps targeting Android SDK 35 or above edge-to-edge mode is enabled by default\nand it is expected that the edge-to-edge will be enforced in future SDKs, see here for more information).\n\n:::\n\nSets the navigation bar color. Defaults to initial status bar color.",
+      "description": "This option is deprecated and will be removed in a future release (for apps targeting Android SDK 35 or above edge-to-edge mode is enabled by default\nand it is expected that the edge-to-edge will be enforced in future SDKs, see here for more information).\n\nSets the navigation bar color. Defaults to initial status bar color.",
       "platform": "Android only",
       "category": "other"
     },

--- a/docs/public/data/react-navigation-options.json
+++ b/docs/public/data/react-navigation-options.json
@@ -1,7 +1,7 @@
 {
   "source": "React Navigation Documentation (Markdown)",
   "sourceUrl": "https://raw.githubusercontent.com/react-navigation/react-navigation.github.io/main/versioned_docs/version-7.x/native-stack-navigator.md",
-  "fetchedAt": "2025-05-27T18:45:49.302Z",
+  "fetchedAt": "2025-05-27T18:58:23.643Z",
   "totalOptions": 52,
   "categories": {
     "header": 25,
@@ -100,7 +100,7 @@
     },
     {
       "name": "headerBlurEffect",
-      "description": "Blur effect for the translucent header. The `headerTransparent` option needs to be set to `true` for this to work.\n\nSupported values: <CODE>extraLight</CODE>, <CODE>light</CODE>, <CODE>dark</CODE>, <CODE>regular</CODE>, <CODE>prominent</CODE>, <CODE>systemUltraThinMaterial</CODE>, <CODE>systemThinMaterial</CODE>, <CODE>systemMaterial</CODE>, <CODE>systemThickMaterial</CODE>, <CODE>systemChromeMaterial</CODE>, <CODE>systemUltraThinMaterialLight</CODE>, <CODE>systemThinMaterialLight</CODE>, <CODE>systemMaterialLight</CODE>, <CODE>systemThickMaterialLight</CODE>, <CODE>systemChromeMaterialLight</CODE>, <CODE>systemUltraThinMaterialDark</CODE>, <CODE>systemThinMaterialDark</CODE>, <CODE>systemMaterialDark</CODE>, <CODE>systemThickMaterialDark</CODE>- `systemChromeMaterialDark`",
+      "description": "Blur effect for the translucent header. The `headerTransparent` option needs to be set to `true` for this to work.\n\nSupported values: `extraLight`, `light`, `dark`, `regular`, `prominent`, `systemUltraThinMaterial`, `systemThinMaterial`, `systemMaterial`, `systemThickMaterial`, `systemChromeMaterial`, `systemUltraThinMaterialLight`, `systemThinMaterialLight`, `systemMaterialLight`, `systemThickMaterialLight`, `systemChromeMaterialLight`, `systemUltraThinMaterialDark`, `systemThinMaterialDark`, `systemMaterialDark`, `systemThickMaterialDark`, `systemChromeMaterialDark`",
       "platform": "iOS only",
       "category": "header"
     },
@@ -148,7 +148,7 @@
     },
     {
       "name": "headerSearchBarOptions",
-      "description": "Options to render a native search bar on iOS. Search bars are rarely static so normally it is controlled by passing an object to `headerSearchBarOptions` navigation option in the component's body.\n\nYou also need to specify `contentInsetAdjustmentBehavior=\"automatic\"` in your `ScrollView`, `FlatList` etc. If you don't have a `ScrollView`, specify `headerTransparent: false`.\n\nSupported properties are:\n\n**ref**\n\nRef to manipulate the search input imperatively. It contains the following methods:\n\n- `focus` - focuses the search bar\n- `blur` - removes focus from the search bar\n- `setText` - sets the search bar's content to given value\n- `clearText` - removes any text present in the search bar input field\n- `cancelSearch` - cancel the search and close the search bar\n\n**autoCapitalize**\n\nControls whether the text is automatically auto-capitalized as it is entered by the user.\nPossible values:\n\n- `none`\n- `words`\n- `sentences`\n- `characters`\n\nDefaults to `sentences`.\n\n**autoFocus**\n\nWhether to automatically focus search bar when it's shown. Defaults to `false`.\n\n**barTintColor**\n\nThe search field background color. By default bar tint color is translucent.\n\n**tintColor**\n\nThe color for the cursor caret and cancel button text.\n\n**cancelButtonText**\n\nThe text to be used instead of default `Cancel` button text.\n\n**disableBackButtonOverride**\n\nWhether the back button should close search bar's text input or not. Defaults to `false`.\n\n**hideNavigationBar**\n\nBoolean indicating whether to hide the navigation bar during searching. Defaults to `true`.\n\n**hideWhenScrolling**\n\nBoolean indicating whether to hide the search bar when scrolling. Defaults to `true`.\n\n**inputType**\n\nThe type of the input. Defaults to `\"text\"`.\n\nSupported values:\n\n- `\"text\"`\n- `\"phone\"`\n- `\"number\"`\n- `\"email\"`\n\n**obscureBackground**\n\nBoolean indicating whether to obscure the underlying content with semi-transparent overlay. Defaults to `true`.\n\n**placeholder**\n\nText displayed when search field is empty.\n\n**textColor**\n\nThe color of the text in the search field.\n\n**hintTextColor**\n\nThe color of the hint text in the search field.\n\n**headerIconColor**\n\nThe color of the search and close icons shown in the header\n\n**shouldShowHintSearchIcon**\n\nWhether to show the search hint icon when search bar is focused. Defaults to `true`.\n\n**onBlur**\n\nA callback that gets called when search bar has lost focus.\n\n**onCancelButtonPress**\n\nA callback that gets called when the cancel button is pressed.\n\n**onChangeText**\n\nA callback that gets called when the text changes. It receives the current text value of the search bar.",
+      "description": "Options to render a native search bar on iOS. Search bars are rarely static so normally it is controlled by passing an object to `headerSearchBarOptions` navigation option in the component's body.\n\nYou also need to specify `contentInsetAdjustmentBehavior=\"automatic\"` in your `ScrollView`, `FlatList` etc. If you don't have a `ScrollView`, specify `headerTransparent: false`.\n\nSupported properties are:\n\n**ref**\n\nRef to manipulate the search input imperatively. It contains the following methods:\n\n- `focus` - focuses the search bar\n- `blur` - removes focus from the search bar\n- `setText` - sets the search bar's content to given value\n- `clearText` - removes any text present in the search bar input field\n- `cancelSearch` - cancel the search and close the search bar\n\n**autoCapitalize**\n\nControls whether the text is automatically auto-capitalized as it is entered by the user.\nPossible values:\n\n- `none`\n- `words`\n- `sentences`\n- `characters`\n\nDefaults to `sentences`.\n\n**autoFocus**\n\nWhether to automatically focus search bar when it's shown. Defaults to `false`.\n\n**barTintColor**\n\nThe search field background color. By default bar tint color is translucent.\n\n**tintColor**\n\nThe color for the cursor caret and cancel button text.\n\n**cancelButtonText**\n\nThe text to be used instead of default `Cancel` button text.\n\n**disableBackButtonOverride**\n\nWhether the back button should close search bar's text input or not. Defaults to `false`.\n\n**hideNavigationBar**\n\nBoolean indicating whether to hide the navigation bar during searching. Defaults to `true`.\n\n**hideWhenScrolling**\n\nBoolean indicating whether to hide the search bar when scrolling. Defaults to `true`.\n\n**inputType**\n\nThe type of the input. Defaults to `\"text\"`.\n\nSupported values: `\"text\"`, `\"phone\"`, `\"number\"`, `\"email\"`\n\n**obscureBackground**\n\nBoolean indicating whether to obscure the underlying content with semi-transparent overlay. Defaults to `true`.\n\n**placeholder**\n\nText displayed when search field is empty.\n\n**textColor**\n\nThe color of the text in the search field.\n\n**hintTextColor**\n\nThe color of the hint text in the search field.\n\n**headerIconColor**\n\nThe color of the search and close icons shown in the header\n\n**shouldShowHintSearchIcon**\n\nWhether to show the search hint icon when search bar is focused. Defaults to `true`.\n\n**onBlur**\n\nA callback that gets called when search bar has lost focus.\n\n**onCancelButtonPress**\n\nA callback that gets called when the cancel button is pressed.\n\n**onChangeText**\n\nA callback that gets called when the text changes. It receives the current text value of the search bar.",
       "platform": "iOS only",
       "category": "header"
     },
@@ -160,7 +160,7 @@
     },
     {
       "name": "statusBarAnimation",
-      "description": "Sets the status bar animation (similar to the `StatusBar` component). Defaults to `fade` on iOS and `none` on Android.\n\nSupported values:\n\n- `\"fade\"`\n- `\"none\"`\n- `\"slide\"`\n\nOn Android, setting either `fade` or `slide` will set the transition of status bar color. On iOS, this option applies to appereance animation of the status bar.\n\nRequires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.",
+      "description": "Sets the status bar animation (similar to the `StatusBar` component). Defaults to `fade` on iOS and `none` on Android.\n\nSupported values: `\"fade\"`, `\"none\"`, `\"slide\"`\n\nOn Android, setting either `fade` or `slide` will set the transition of status bar color. On iOS, this option applies to appereance animation of the status bar.\n\nRequires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.",
       "platform": "Android only",
       "category": "other"
     },
@@ -172,7 +172,7 @@
     },
     {
       "name": "statusBarStyle",
-      "description": "Sets the status bar color (similar to the `StatusBar` component). Defaults to `auto`.\n\nSupported values:\n\n- `\"auto\"`\n- `\"inverted\"` (iOS only)\n- `\"dark\"`\n- `\"light\"`\n\nRequires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.",
+      "description": "Sets the status bar color (similar to the `StatusBar` component). Defaults to `auto`.\n\nSupported values: `\"auto\"`, `\"inverted\"`, `\"dark\"`, `\"light\"`\n\nRequires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.",
       "platform": "Android only",
       "category": "other"
     },
@@ -220,25 +220,25 @@
     },
     {
       "name": "animationTypeForReplace",
-      "description": "The type of animation to use when this screen replaces another screen. Defaults to `push`.\n\nSupported values:\n\n- `push`: the new screen will perform push animation.\n\n  \n\n- `pop`: the new screen will perform pop animation.",
+      "description": "The type of animation to use when this screen replaces another screen. Defaults to `push`.\n\nSupported values: `push`, `pop`",
       "platform": "Both",
       "category": "other"
     },
     {
       "name": "animation",
-      "description": "How the screen should animate when pushed or popped.\n\nSupported values:\n\n- `default`: use the platform default animation\n  \n\n- `fade`: fade screen in or out\n  \n\n- `fade_from_bottom`: fade the new screen from bottom\n  \n\n- `flip`: flip the screen, requires `presentation: \"modal\"` (iOS only)\n  \n\n- `simple_push`: default animation, but without shadow and native header transition (iOS only, uses default animation on Android)\n  \n\n- `slide_from_bottom`: slide in the new screen from bottom\n  \n\n- `slide_from_right`: slide in the new screen from right (Android only, uses default animation on iOS)\n  \n\n- `slide_from_left`: slide in the new screen from left (Android only, uses default animation on iOS)\n  \n\n- `none`: don't animate the screen",
+      "description": "How the screen should animate when pushed or popped.\n\nSupported values: `default`, `fade`, `fade_from_bottom`, `flip`, `simple_push`, `slide_from_bottom`, `slide_from_right`, `slide_from_left`, `none`",
       "platform": "Android only",
       "category": "other"
     },
     {
       "name": "presentation",
-      "description": "How should the screen be presented.\n\nSupported values:\n\n- `card`: the new screen will be pushed onto a stack, which means the default animation will be slide from the side on iOS, the animation on Android will vary depending on the OS version and theme.\n  \n\n- `modal`: the new screen will be presented modally. this also allows for a nested stack to be rendered inside the screen.\n  \n\n- `transparentModal`: the new screen will be presented modally, but in addition, the previous screen will stay so that the content below can still be seen if the screen has translucent background.\n  \n\n- `containedModal`: will use \"UIModalPresentationCurrentContext\" modal style on iOS and will fallback to \"modal\" on Android.\n  \n\n- `containedTransparentModal`: will use \"UIModalPresentationOverCurrentContext\" modal style on iOS and will fallback to \"transparentModal\" on Android.\n  \n\n- `fullScreenModal`: will use \"UIModalPresentationFullScreen\" modal style on iOS and will fallback to \"modal\" on Android. A screen using this presentation style can't be dismissed by gesture.\n  \n\n- `formSheet`: will use \"BottomSheetBehavior\" on Android and \"UIModalPresentationFormSheet\" modal style on iOS.",
+      "description": "How should the screen be presented.\n\nSupported values: `card`, `modal`, `transparentModal`, `containedModal`, `containedTransparentModal`, `fullScreenModal`, `formSheet`",
       "platform": "Android only",
       "category": "other"
     },
     {
       "name": "sheetAllowedDetents",
-      "description": "Works only when `presentation` is set to `formSheet`.\n\nDescribes heights where a sheet can rest.\n\nSupported values:\n\n- `fitToContents` - intents to set the sheet height to the height of its contents.\n- Array of fractions, e.g. `[0.25, 0.5, 0.75]`:\n  - Heights should be described as fraction (a number from `[0, 1]` interval) of screen height / maximum detent height.\n  - The array **must** be sorted in ascending order. This invariant is verified only in developement mode, where violation results in error.\n  - iOS accepts any number of detents, while **Android is limited to three** - any surplus values, beside first three are ignored.\n\nDefaults to `[1.0]`.",
+      "description": "Works only when `presentation` is set to `formSheet`.\n\nDescribes heights where a sheet can rest.\n\nSupported values: `fitToContents`\n\nDefaults to `[1.0]`.",
       "platform": "Android only",
       "category": "other"
     },
@@ -280,7 +280,7 @@
     },
     {
       "name": "orientation",
-      "description": "The display orientation to use for the screen.\n\nSupported values:\n\n- `default` - resolves to \"all\" without \"portrait_down\" on iOS. On Android, this lets the system decide the best orientation.\n- `all`: all orientations are permitted.\n- `portrait`: portrait orientations are permitted.\n- `portrait_up`: right-side portrait orientation is permitted.\n- `portrait_down`: upside-down portrait orientation is permitted.\n- `landscape`: landscape orientations are permitted.\n- `landscape_left`: landscape-left orientation is permitted.\n- `landscape_right`: landscape-right orientation is permitted.",
+      "description": "The display orientation to use for the screen.\n\nSupported values: `default`, `all`, `portrait`, `portrait_up`, `portrait_down`, `landscape`, `landscape_left`, `landscape_right`",
       "platform": "Android only",
       "category": "other"
     },
@@ -292,7 +292,7 @@
     },
     {
       "name": "gestureDirection",
-      "description": "Sets the direction in which you should swipe to dismiss the screen.\n\nSupported values:\n\n- `vertical` – dismiss screen vertically\n- `horizontal` – dismiss screen horizontally (default)\n\nWhen using `vertical` option, options `fullScreenGestureEnabled: true`, `customAnimationOnGesture: true` and `animation: 'slide_from_bottom'` are set by default.",
+      "description": "Sets the direction in which you should swipe to dismiss the screen.\n\nSupported values: `vertical`, `horizontal`\n\nWhen using `vertical` option, options `fullScreenGestureEnabled: true`, `customAnimationOnGesture: true` and `animation: 'slide_from_bottom'` are set by default.",
       "platform": "iOS only",
       "category": "other"
     },

--- a/docs/scripts/fetch-react-navigation-options.js
+++ b/docs/scripts/fetch-react-navigation-options.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const MARKDOWN_URL =
+  'https://raw.githubusercontent.com/react-navigation/react-navigation.github.io/main/versioned_docs/version-7.x/native-stack-navigator.md';
+const OUTPUT_FILE = path.join(__dirname, '../public/data/react-navigation-options.json');
+
+async function fetchMarkdownContent() {
+  const response = await fetch(MARKDOWN_URL);
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  return response.text();
+}
+
+function parseOptionsFromMarkdown(markdown) {
+  const options = [];
+  const optionsMatch = markdown.match(/### Options([\S\s]*?)(?=### (?:Events|Helpers|Hooks)|$)/);
+  if (!optionsMatch) {
+    return options;
+  }
+
+  const optionsSection = optionsMatch[1];
+  const optionMatches = optionsSection.matchAll(
+    /#### `([^`]+)`([\S\s]*?)(?=#### |##### |### |## |$)/g
+  );
+
+  for (const match of optionMatches) {
+    const [, optionName, content] = match;
+
+    if (
+      optionName.includes('Event') ||
+      optionName.includes('Helper') ||
+      optionName.includes('Hook') ||
+      optionName.startsWith('use') ||
+      optionName.includes('transitionStart') ||
+      optionName.includes('transitionEnd')
+    ) {
+      continue;
+    }
+
+    let platform = 'Both';
+    if (content.includes('Only supported on iOS')) {
+      platform = 'iOS only';
+    } else if (content.includes('Only supported on Android')) {
+      platform = 'Android only';
+    }
+
+    let description = content
+      .replace(/^\s+/, '')
+      .replace(/:::warning[\S\s]*?(?=\n\n|\n[A-Z]|$)/g, '')
+      .replace(/:::note[\S\s]*?(?=\n\n|\n[A-Z]|$)/g, '')
+      .replace(/:::/g, '')
+      .replace(/Only supported on iOS\./g, '')
+      .replace(/Only supported on Android\./g, '')
+      .replace(/Only supported on Android and iOS\./g, '')
+      .replace(/<img[^>]*>/g, '')
+      .replace(/<video[^>]*>[\S\s]*?<\/video>/g, '')
+      .replace(/Example:\s*\n\n```[\S\s]*?```/g, '')
+      .replace(/Example:\s*\n\n[^\n]*\n/g, '')
+      .replace(/\[([^\]]+)]\([^)]+\)/g, '$1')
+      .trim();
+
+    description = description
+      .replace(/\n{3,}/g, '\n\n')
+      .replace(/\n\s*$/g, '')
+      .trim();
+
+    let category = 'other';
+    if (optionName.toLowerCase().includes('header') || optionName.toLowerCase().includes('title')) {
+      category = 'header';
+    }
+
+    options.push({
+      name: optionName,
+      description,
+      platform,
+      category,
+    });
+  }
+
+  return options;
+}
+
+function saveOptionsToFile(options) {
+  const outputData = {
+    source: 'React Navigation Documentation (Markdown)',
+    sourceUrl: MARKDOWN_URL,
+    fetchedAt: new Date().toISOString(),
+    totalOptions: options.length,
+    categories: {
+      header: options.filter(opt => opt.category === 'header').length,
+      other: options.filter(opt => opt.category === 'other').length,
+    },
+    options,
+  };
+
+  const outputDir = path.dirname(OUTPUT_FILE);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(outputData, null, 2));
+}
+
+async function main() {
+  try {
+    const markdown = await fetchMarkdownContent();
+    const options = parseOptionsFromMarkdown(markdown);
+    saveOptionsToFile(options);
+    console.log(
+      `✅ Fetched ${options.length} options (${options.filter(opt => opt.category === 'header').length} header, ${options.filter(opt => opt.category === 'other').length} other)`
+    );
+  } catch (error) {
+    console.error('❌ Error:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/docs/scripts/fetch-react-navigation-options.js
+++ b/docs/scripts/fetch-react-navigation-options.js
@@ -89,7 +89,7 @@ function parseOptionsFromMarkdown(markdown) {
       .trim();
 
     description = description.replace(
-      /Supported values:\s*\n\n((?:- `[^`]+`(?:\s*\n(?:<[^>]*>|\s)*)*\n)*)/g,
+      /Supported values:\s*\n\n([\S\s]*?)(?=\n\n[A-Z]|\n\n\*\*|$)/g,
       (match, listContent) => {
         const values = [];
         const valueMatches = listContent.matchAll(/- `([^`]+)`/g);
@@ -97,8 +97,8 @@ function parseOptionsFromMarkdown(markdown) {
           values.push(valueMatch[1]);
         }
 
-        if (values.length > 1 && values.every(val => /^[A-Za-z]\w*(?:[A-Z]\w*)*$/.test(val))) {
-          return `Supported values: <CODE>${values.join('</CODE>, <CODE>')}</CODE>`;
+        if (values.length > 0) {
+          return `Supported values: ${values.map(val => `\`${val}\``).join(', ')}`;
         }
         return match;
       }

--- a/docs/ui/components/ReactNavigationOptions/index.tsx
+++ b/docs/ui/components/ReactNavigationOptions/index.tsx
@@ -1,0 +1,109 @@
+import ReactMarkdown from 'react-markdown';
+
+import { mdComponents } from '~/components/plugins/api/APISectionUtils';
+import reactNavigationOptionsData from '~/public/data/react-navigation-options.json';
+import { Collapsible } from '~/ui/components/Collapsible';
+import { Table, Row, Cell } from '~/ui/components/Table';
+import { PlatformTag } from '~/ui/components/Tag/PlatformTag';
+import { CODE } from '~/ui/components/Text';
+
+type ReactNavigationOption = {
+  name: string;
+  description: string;
+  platform: 'Both' | 'iOS only' | 'Android only';
+  category: 'header' | 'other';
+};
+
+type ReactNavigationOptionsData = {
+  source: string;
+  sourceUrl: string;
+  fetchedAt: string;
+  totalOptions: number;
+  categories: {
+    header: number;
+    other: number;
+  };
+  options: ReactNavigationOption[];
+};
+
+type ReactNavigationOptionsProps = {
+  category?: string;
+  excludeCategories?: string[];
+  title?: string;
+};
+
+const PlatformCell = ({ option }: { option: ReactNavigationOption }) => {
+  if (option.platform === 'iOS only') {
+    return <PlatformTag platform="ios" />;
+  }
+  if (option.platform === 'Android only') {
+    return <PlatformTag platform="android" />;
+  }
+  return (
+    <div className="flex gap-1">
+      <PlatformTag platform="android" />
+      <PlatformTag platform="ios" />
+    </div>
+  );
+};
+
+const OptionRow = ({ option }: { option: ReactNavigationOption }) => {
+  return (
+    <Row>
+      <Cell>
+        <CODE className="text-sm font-semibold">{option.name}</CODE>
+      </Cell>
+      <Cell>
+        <PlatformCell option={option} />
+      </Cell>
+      <Cell>
+        <div className="text-sm">
+          <ReactMarkdown components={mdComponents}>{option.description}</ReactMarkdown>
+        </div>
+      </Cell>
+    </Row>
+  );
+};
+
+export const ReactNavigationOptions = ({
+  category,
+  excludeCategories,
+  title,
+}: ReactNavigationOptionsProps) => {
+  const data = reactNavigationOptionsData as ReactNavigationOptionsData;
+
+  let filteredOptions = data.options;
+  if (category) {
+    filteredOptions = data.options.filter(option => option.category === category);
+  }
+
+  if (excludeCategories && excludeCategories.length > 0) {
+    filteredOptions = filteredOptions.filter(
+      option => !excludeCategories.includes(option.category)
+    );
+  }
+
+  const sortedOptions = filteredOptions.sort((a, b) => a.name.localeCompare(b.name));
+
+  if (category && sortedOptions.length === 0) {
+    return <div className="text-sm text-secondary">No options found for category: {category}</div>;
+  }
+
+  const defaultTitle = category ? 'Header options' : 'Screen options';
+
+  return (
+    <div>
+      {title && <h3 className="mb-4 text-lg font-semibold">{title}</h3>}
+      <Collapsible summary={<span>{title ?? defaultTitle}</span>}>
+        <Table
+          headers={['Option', 'Platform', 'Description']}
+          headersAlign={['left', 'left', 'left']}
+          className="text-sm">
+          {sortedOptions.map(option => (
+            <OptionRow key={option.name} option={option} />
+          ))}
+        </Table>
+      </Collapsible>
+    </div>
+  );
+};


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15606

# How

<!--
How did you build this feature or fix this bug and why?
-->

This pull request introduces a new feature to synchronize React Navigation options with the documentation, enhances the `Stack` navigator page with detailed option references, and removes outdated links. Additionally, it includes a script to automate fetching React Navigation options and adds a JSON file to store this data.

* Added a new script `react-navigation-docs-sync` in `docs/package.json` to fetch and synchronize React Navigation options from their official documentation.
* Created a JSON file `docs/public/data/react-navigation-options.json` to store fetched React Navigation options, categorized into "header" and "other" options.
- Display data using existing markdown components into two categories: header related screen options and other screenOptions.
- Updated `docs/pages/router/advanced/stack.mdx` to include:
  * A new section "Available header options" with a `<ReactNavigationOptions category="header" />` component to dynamically display header-related options.
  * A new section "Other screen options" with a `<ReactNavigationOptions excludeCategories={['header']} />` component to display non-header options.
 
# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview:
- /router/advanced/stack/#available-header-options
- /router/advanced/stack/#other-screen-options

## Preview

![CleanShot 2025-05-28 at 00 30 04@2x](https://github.com/user-attachments/assets/0097de55-a1bf-47ac-887c-6a16ed3d6944)

![CleanShot 2025-05-28 at 00 29 57@2x](https://github.com/user-attachments/assets/e7d30cd8-ae74-4e35-84db-5051b923a692)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
