### PR TITLE
[typo] Fix spelling in eslint-plugin-expo

### DIFF
--- a/packages/eslint-plugin-expo/README.md
+++ b/packages/eslint-plugin-expo/README.md
@@ -46,4 +46,4 @@ Then configure the rules you want to use under the rules section.
 | Name                                                               | Description                                          |
 | :----------------------------------------------------------------- | :--------------------------------------------------- |
 | [no-dynamic-env-var](docs/rules/no-dynamic-env-var.md)             | Prevents process.env from being accessed dynamically |
-| [no-env-var-destructuring](docs/rules/no-env-var-destructuring.md) | Disallow desctructuring of environment variables     |
+| [no-env-var-destructuring](docs/rules/no-env-var-destructuring.md) | Disallow destructuring of environment variables     |

--- a/packages/eslint-plugin-expo/build/rules/noEnvVarDestructuring.js
+++ b/packages/eslint-plugin-expo/build/rules/noEnvVarDestructuring.js
@@ -8,11 +8,11 @@ exports.noEnvVarDestructuring = createRule({
     meta: {
         type: 'problem',
         docs: {
-            description: 'Disallow desctructuring of environment variables',
+            description: 'Disallow destructuring of environment variables',
         },
         schema: [],
         messages: {
-            unexpectedDestructuring: 'Unexpected desctucturing. Cannot descructure {{value}} from process.env',
+            unexpectedDestructuring: 'Unexpected destructuring. Cannot destructure {{value}} from process.env',
         },
     },
     defaultOptions: [],

--- a/packages/eslint-plugin-expo/docs/rules/no-env-var-destructuring.md
+++ b/packages/eslint-plugin-expo/docs/rules/no-env-var-destructuring.md
@@ -1,4 +1,4 @@
-# Disallow desctructuring of environment variables (`expo/no-env-var-destructuring`)
+# Disallow destructuring of environment variables (`expo/no-env-var-destructuring`)
 
 Expo's Metro config injects build settings that can be used in the client bundle via environment variables. The environment variables (`process.env.*`) are replaced with the appropriate values at build time. This means that `process.env` is not a standard JavaScript object, and destructuring will break inlining on environment variables.
 

--- a/packages/eslint-plugin-expo/src/rules/noEnvVarDestructuring.ts
+++ b/packages/eslint-plugin-expo/src/rules/noEnvVarDestructuring.ts
@@ -10,12 +10,12 @@ export const noEnvVarDestructuring = createRule({
   meta: {
     type: 'problem',
     docs: {
-      description: 'Disallow desctructuring of environment variables',
+      description: 'Disallow destructuring of environment variables',
     },
     schema: [],
     messages: {
       unexpectedDestructuring:
-        'Unexpected desctucturing. Cannot descructure {{value}} from process.env',
+        'Unexpected destructuring. Cannot destructure {{value}} from process.env',
     },
   },
   defaultOptions: [],


### PR DESCRIPTION
# Why

destructuring was spelled as desctructuring.

# How

Just fixed the typo. No changes to code aside from user-facing errors.

# Test Plan

Just `yarn build` and `yarn test` in `eslint-plugin-expo`.
