### PR TITLE
[android][expo-dev-menu] Fixed Fast Refresh off by default on Android

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix Fast Refresh toggled off by default on Android.
+- [Android] Fix Fast Refresh toggled off by default on Android. ([#37132](https://github.com/expo/expo/pull/37132) by [@coolsoftwaretyler](https://github.com/coolsoftwaretyler))
 - [iOS] Fix custom menu actions not triggering their callbacks after a reload. ([#37084](https://github.com/expo/expo/pull/37084) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix Fast Refresh toggled off by default on Android.
 - [iOS] Fix custom menu actions not triggering their callbacks after a reload. ([#37084](https://github.com/expo/expo/pull/37084) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
@@ -12,7 +12,7 @@ object DevMenuDevSettings {
     if (devSettings != null) {
       return Bundle().apply {
         putBoolean("isElementInspectorShown", devSettings.isElementInspectorEnabled)
-        putBoolean("isHotLoadingEnabled", devDelegate.devInternalSettings?.isHotModuleReplacementEnabled ?: false)
+        putBoolean("isHotLoadingEnabled", devSettings.isHotModuleReplacementEnabled)
         putBoolean("isPerfMonitorShown", devSettings.isFpsDebugEnabled)
         putBoolean("isElementInspectorAvailable", devSettings.isJSDevModeEnabled)
         putBoolean("isHotLoadingAvailable", devSettings.isJSDevModeEnabled)

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuManager.kt
@@ -371,19 +371,16 @@ object DevMenuManager : DevMenuManagerInterface, LifecycleEventListener {
 
   fun toggleFastRefresh() {
     val devToolsDelegate = getDevToolsDelegate()
-    val internalSettings = devToolsDelegate?.devInternalSettings
+    val internalSettings = devToolsDelegate?.devSettings
       ?: return
 
     val nextEnabled = !internalSettings.isHotModuleReplacementEnabled
     internalSettings.isHotModuleReplacementEnabled = nextEnabled
 
-    val reactApplicationContext = delegateReactContext?.applicationContext as? ReactApplicationContext
-    if (reactApplicationContext != null) {
-      if (nextEnabled) {
-        reactApplicationContext.getJSModule(HMRClient::class.java).enable()
-      } else {
-        reactApplicationContext.getJSModule(HMRClient::class.java).disable()
-      }
+    if (nextEnabled) {
+      delegateReactContext?.getJSModule(HMRClient::class.java)?.enable()
+    } else {
+      delegateReactContext?.getJSModule(HMRClient::class.java)?.disable()
     }
     if (nextEnabled && !internalSettings.isJSDevModeEnabled) {
       internalSettings.isJSDevModeEnabled = true


### PR DESCRIPTION
# Why

This PR fixes https://github.com/expo/expo/issues/37113 by calling for `devSettings` directly when initializing the dev settings from the dev menu.

# How

I tested this out as a patch in my reproducer project. You can see that PR here: https://github.com/coolsoftwaretyler/fast-refresh-reproducer/pull/1, which fixes the problems cited in the issue, and includes a [video demo of the fix](https://www.dropbox.com/scl/fi/wax8ffigxn3paiht0cvel/Screen-Recording-2025-05-29-at-4.24.33-PM.mov?rlkey=0o0l274yen5asm2n66ovae60x&e=2&st=p42qk3xi&dl=0).

# Test Plan

1. On a fresh Expo app, get this patch
2. Run `npx expo prebuild --clean`
3. Run `npx expo run:android`
4. Open up dev menu with `cmd+m` on Mac
5. Fast Refresh should be toggled on by default
6. Fast Refresh should work (make a cosmetic change in `app/(tabs)/index.tsx` and see it reflected immediately)
7. Open dev menu again and toggle Fast refresh off
8. Make a cosmetic change again to the JS in `app/(tabs)/index.tsx`
9. The change should not show up immediately.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
