### PR TITLE
fix Image tint color for React 19

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix React Server Components support. ([#36801](https://github.com/expo/expo/pull/36801) by [@EvanBacon](https://github.com/EvanBacon))
 - [iOS] Fix PhotoLibrary assets being scaled twice. ([#36776](https://github.com/expo/expo/pull/36776) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Don't add transformers when unnecessary. ([#36884](https://github.com/expo/expo/pull/36884) by [@jakex7](https://github.com/jakex7))
+- [Web] Fix `tintColor` in React 19. ([#37133](https://github.com/expo/expo/pull/37133) by [@bradleyayers](https://github.com/bradleyayers))
 
 ### 💡 Others
 

--- a/packages/expo-image/build/web/ImageWrapper.d.ts.map
+++ b/packages/expo-image/build/web/ImageWrapper.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ImageWrapper.d.ts","sourceRoot":"","sources":["../../src/web/ImageWrapper.tsx"],"names":[],"mappings":"AAAA,OAAO,KAAgC,MAAM,OAAO,CAAC;AAGrD,OAAO,EAAE,iBAAiB,EAAE,MAAM,sBAAsB,CAAC;AAqBzD,QAAA,MAAM,YAAY,4FA4DjB,CAAC;AAEF,eAAe,YAAY,CAAC"}
+{"version":3,"file":"ImageWrapper.d.ts","sourceRoot":"","sources":["../../src/web/ImageWrapper.tsx"],"names":[],"mappings":"AAAA,OAAO,KAAgC,MAAM,OAAO,CAAC;AAGrD,OAAO,EAAE,iBAAiB,EAAE,MAAM,sBAAsB,CAAC;AAqBzD,QAAA,MAAM,YAAY,4FAmEjB,CAAC;AAEF,eAAe,YAAY,CAAC"}

--- a/packages/expo-image/src/web/ImageWrapper.tsx
+++ b/packages/expo-image/src/web/ImageWrapper.tsx
@@ -44,7 +44,14 @@ const ImageWrapper = React.forwardRef(
       events?.onMount?.forEach((e) => e?.());
     }, []);
 
-    const tintId = useId();
+    // Use a unique ID for the SVG filter so that multiple <Image> can be used
+    // on the same page with different tint colors without conflicts.
+    const tintId = useId()
+      // Make it safe for use as an SVG ID. SVG IDs are most strict than HTML
+      // IDs. They must be compliant with https://www.w3.org/TR/xml/#NT-Name.
+      // React 19 changed useId() to include « and ». These must be removed or
+      // the SVG filter will not work (e.g. in Safari which enforces the spec).
+      .replace(/[«»]/g, '_');
 
     // Thumbhash uri always has to start with 'thumbhash:/'
     const { resolvedSource, isImageHash } = useImageHashes(source);


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

After upgrading to React 19 the `tintColor` broke for `<Image>`.

# How

Values from `useId()` are no longer valid SVG `id` attribute values (they weren't really either before because they contained `:` which has special meaning). I went with a simple fix of replacing the problematic characters with `_`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I manually tested this in Safari.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
