### PR TITLE
[docs] Add expo-iap library to in-app-purchases.mdx docs

### DIFF
--- a/docs/pages/guides/in-app-purchases.mdx
+++ b/docs/pages/guides/in-app-purchases.mdx
@@ -49,7 +49,7 @@ The following libraries provide robust support for in-app purchase functionality
       <CODE>expo-iap</CODE>
     </>
   }
-  description="An open-source, expo compatible library providing an interface to the client-side native in-app purchase API's wrapper around Google Play Billing and StoreKit 2 APIs. Support new architecture and expo from the box"
+  description="An open-source, Expo compatible library providing an interface to the client-side native in-app purchase API wrapper around Google Play Billing and StoreKit 2 APIs. Supports New Architecture."
   href="https://github.com/hyochan/expo-iap"
   Icon={GithubIcon}
 />

--- a/docs/pages/guides/in-app-purchases.mdx
+++ b/docs/pages/guides/in-app-purchases.mdx
@@ -46,6 +46,17 @@ The following libraries provide robust support for in-app purchase functionality
 <BoxLink
   title={
     <>
+      <CODE>expo-iap</CODE>
+    </>
+  }
+  description="An open-source, expo compatible library providing an interface to the client-side native in-app purchase API's wrapper around Google Play Billing and StoreKit 2 APIs. Support new architecture and expo from the box"
+  href="https://github.com/hyochan/expo-iap"
+  Icon={GithubIcon}
+/>
+
+<BoxLink
+  title={
+    <>
       <CODE>react-native-iap</CODE>
     </>
   }


### PR DESCRIPTION
Add expo-iap to in-app-purchases.mdx

# Why

`expo-iap` is fully expo compatible library, that supports new architecture out of box and provides native API's wrapper around Google Play Billing and Storekit 2 to react native side. I think this library can be helpful for anyone who meet in-app purchases needs, especially on expo and new architecture

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
