### PR TITLE
[docs] Update FCM Credentials

### DIFF
--- a/docs/pages/push-notifications/fcm-credentials.mdx
+++ b/docs/pages/push-notifications/fcm-credentials.mdx
@@ -94,7 +94,7 @@ Upload the JSON file to EAS and configure it for sending Android notifications. 
 
 <Step label="5">
 
-Configure the **google-services.json** file in your project. Download it from the Firebase Console and place it at the root of your project directory.
+Configure the **google-services.json** file in your project. Download it from the Firebase Console and place it at the root of your project directory. If you're using version control, add it to your ignore file (for example, **.gitignore**) as it contains sensitive data.
 
 **Note**: You can skip this step if **google-services.json** has already been set up.
 


### PR DESCRIPTION
# Why

This doc page describes how to configure `google-services.json` but only warns the user to not commit the file in one place.

# How

This change adds the warning to both parts for consistency.