### PR TITLE
[docs] Update Build A Screen Tutorial Page

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -330,6 +330,7 @@ export default function Button({ label, /* @tutinfo The prop <CODEtheme</CODE> t
   /* @tutinfo Conditionally render the primary themed button. */
   if (theme === 'primary') {
   /* @end */
+  /* @tutinfo */
     return (
       <View
         style={[
@@ -344,6 +345,7 @@ export default function Button({ label, /* @tutinfo The prop <CODEtheme</CODE> t
         </Pressable>
       </View>
     );
+  /* @end */
   /* @tutinfo */
   }
   /* @end */


### PR DESCRIPTION
# Why

This entire code block is new code - it should be highlighted in green.

<img width="788" alt="image" src="https://github.com/user-attachments/assets/0fa73049-6258-47bf-a0ed-9f754850b841" />

# How

Places new tutinfo annotation to add the green highlights.

# Test Plan

N/A - just MDX.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) - I don't think I need to do this
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
