### PR TITLE
[ios][splash-screen] Get SplashScreen storyboard name from plist file

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unpublished
 
+### 🐛 Bug fixes
+
+- [iOS] Resolve StoryBoard name from Info.plist. ([#37151](https://github.com/expo/expo/pull/37151) by [@Vadko](https://github.com/Vadko))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-splash-screen/ios/SplashScreenManager.swift
+++ b/packages/expo-splash-screen/ios/SplashScreenManager.swift
@@ -57,7 +57,8 @@ public class SplashScreenManager: NSObject, RCTReloadListener {
   }
 
   private func showSplashScreen() {
-    if let vc = UIStoryboard(name: "SplashScreen", bundle: nil).instantiateInitialViewController() {
+    let splashScreenFilename = Bundle.main.object(forInfoDictionaryKey: "UILaunchStoryboardName") as? String ?? "SplashScreen"
+    if let vc = UIStoryboard(name: splashScreenFilename, bundle: nil).instantiateInitialViewController() {
       loadingView = vc.view
       loadingView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
 


### PR DESCRIPTION
# Why

In the latest version of expo-splash-screen, the SplashScreen name is hardcoded and not retrieved from the Info.plist file: [link to code](https://github.com/expo/expo/blob/b460d8f377316251a086f0cfd348403964bd67df/packages/expo-splash-screen/ios/SplashScreenManager.swift#L60)

This causes the app to crash if multiple plist files have different values for UILaunchStoryboardName. Previously, this logic existed in the package: [legacy code link](https://github.com/expo/expo/blob/sdk-50/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenViewNativeProvider.m#L10), but it was not carried over to the new Swift implementation.

# How

Implemented retrieval of the SplashScreen name dynamically from the plist file.

# Test Plan

Set a custom SplashScreen name in the Info.plist under the UILaunchStoryboardName key.
Add the SplashScreen with the custom name to the Copy Bundle Resources build phase and verify correct loading.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
