### PR TITLE
[audio] Automatic interruption handling

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [iOS] Support base64 strings as an audio source. ([#37031](https://github.com/expo/expo/pull/37031) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Correctly add the http headers to the `AVURLAsset`. ([#37029](https://github.com/expo/expo/pull/37029) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix inconsistent audio sampling. ([#37154](https://github.com/expo/expo/pull/37154) by [@alanjhughes](https://github.com/alanjhughes))
+- Add automatic interruption handling. ([#37153](https://github.com/expo/expo/pull/37153) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why
Closes #37139
We are not currently handling system interruptions (alarms, calls, etc.)

# How
- On android, update the focus handler to resume or pause playback based on the type of focus change. Android does not trigger focus changes when recording.
- On iOS, subscribe to interrupt notifications and handle pausing and resuming when the interrupt begins and ends. 

# Test Plan
Bare-expo. The app will now resume playback or recording on ios if it is interrupted by the system for any reason automatically. It will do the same with audio playback on android.
