### PR TITLE
[ios][audio] Fix inconsistent audio sampling

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [iOS] Support base64 strings as an audio source. ([#37031](https://github.com/expo/expo/pull/37031) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Correctly add the http headers to the `AVURLAsset`. ([#37029](https://github.com/expo/expo/pull/37029) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix inconsistent audio sampling.
+- [iOS] Fix inconsistent audio sampling. ([#37154](https://github.com/expo/expo/pull/37154) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Support base64 strings as an audio source. ([#37031](https://github.com/expo/expo/pull/37031) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Correctly add the http headers to the `AVURLAsset`. ([#37029](https://github.com/expo/expo/pull/37029) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix inconsistent audio sampling.
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why
I noticed that the audio sampling is inconsistent. Some times it fails to start. Mostly in the case of remote assets when they have not finished loading by the time the audio tap is installed but it can also happen with local assets.

# How
Observe changes in the player status and only attempt to install the tap once the asset has loaded.

# Test Plan
Bare-expo. Audio sampling now works consistently.

