### PR TITLE
[docs] Add missing indentation to navigation snippet

### DIFF
--- a/docs/pages/tutorial/add-navigation.mdx
+++ b/docs/pages/tutorial/add-navigation.mdx
@@ -337,7 +337,7 @@ Let's also change the background color of the tab bar and header using `screenOp
     headerShadowVisible: false,
     headerTintColor: '#fff',
     tabBarStyle: {
-    backgroundColor: '#25292e',
+      backgroundColor: '#25292e',
     },
   }}
 >


### PR DESCRIPTION
# Why

Improve consistency in the code snippet for `/docs`.

# How

I have added missing indentation.

# Test Plan

No need to run tests on changes in `/docs`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
