### PR TITLE
[ios][audio] Improve audio tap memory safety and cleanup

### DIFF
--- a/apps/native-component-list/src/screens/Audio/expo-audio/Player.tsx
+++ b/apps/native-component-list/src/screens/Audio/expo-audio/Player.tsx
@@ -103,7 +103,7 @@ export default function Player(props: Props) {
     }
 
     return (
-      <TouchableOpacity onPress={onPress} disabled={!props.isLoaded}>
+      <TouchableOpacity onPressIn={onPress} disabled={!props.isLoaded}>
         <Ionicons name={iconName as 'pause' | 'play'} style={[styles.icon, styles.playPauseIcon]} />
       </TouchableOpacity>
     );

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -177,23 +177,25 @@ public class AudioPlayer: SharedRef<AVPlayer> {
       return
     }
 
-    guard !tapInstalled else {
+    guard !(audioProcessor?.isTapInstalled ?? false) else {
+      tapInstalled = true
       return
     }
 
-    if audioProcessor != nil {
-      uninstallTap()
+    if let audioProcessor {
+      audioProcessor.invalidate()
     }
 
     audioProcessor = AudioTapProcessor(player: ref)
-    tapInstalled = audioProcessor?.installTap() ?? false
+    let success = audioProcessor?.installTap() ?? false
+    tapInstalled = success
 
-    if tapInstalled {
+    if success {
       audioProcessor?.sampleBufferCallback = { [weak self] buffer, frameCount, timestamp in
-        guard let self,
-        let audioBuffer = buffer?.pointee,
-        let data = audioBuffer.mData,
-        samplingEnabled else {
+        guard let self = self,
+              let audioBuffer = buffer?.pointee,
+              let data = audioBuffer.mData,
+              self.samplingEnabled else {
           return
         }
 
@@ -201,7 +203,7 @@ public class AudioPlayer: SharedRef<AVPlayer> {
         let dataPointer = data.assumingMemoryBound(to: Float.self)
 
         let channels = (0..<channelCount).map { channelIndex in
-          let channelData = stride(from: channelIndex, to: frameCount, by: channelCount).map { frameIndex in
+          let channelData = stride(from: channelIndex, to: Int(frameCount), by: channelCount).map { frameIndex in
             dataPointer[frameIndex]
           }
           return ["frames": channelData]
@@ -217,19 +219,24 @@ public class AudioPlayer: SharedRef<AVPlayer> {
 
   private func uninstallTap() {
     tapInstalled = false
-    audioProcessor?.sampleBufferCallback = nil
     audioProcessor?.uninstallTap()
+    audioProcessor?.sampleBufferCallback = nil
   }
 
   private func addPlaybackEndNotification() {
-    if let previous = endObserver {
-      NotificationCenter.default.removeObserver(previous)
+    if let endObserver {
+      NotificationCenter.default.removeObserver(endObserver)
     }
+
     endObserver = NotificationCenter.default.addObserver(
       forName: .AVPlayerItemDidPlayToEndTime,
       object: ref.currentItem,
       queue: nil
-    ) { _ in
+    ) { [weak self] _ in
+      guard let self else {
+        return
+      }
+
       if self.isLooping {
         self.ref.seek(to: CMTime.zero)
         self.ref.play()
@@ -244,9 +251,18 @@ public class AudioPlayer: SharedRef<AVPlayer> {
   }
 
   private func registerTimeObserver() {
+    if let timeToken {
+      ref.removeTimeObserver(timeToken)
+    }
+
     let updateInterval = interval / 1000
     let interval = CMTime(seconds: updateInterval, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
-    timeToken = ref.addPeriodicTimeObserver(forInterval: interval, queue: nil) { time in
+
+    timeToken = ref.addPeriodicTimeObserver(forInterval: interval, queue: nil) { [weak self] time in
+      guard let self else {
+        return
+      }
+
       self.updateStatus(with: [
         "currentTime": time.seconds
       ])
@@ -254,6 +270,8 @@ public class AudioPlayer: SharedRef<AVPlayer> {
   }
 
   public override func sharedObjectWillRelease() {
+    AudioComponentRegistry.shared.remove(self)
+
     cancellables.removeAll()
 
     if samplingEnabled {
@@ -261,10 +279,11 @@ public class AudioPlayer: SharedRef<AVPlayer> {
       uninstallTap()
     }
 
-    AudioComponentRegistry.shared.remove(self)
+    audioProcessor?.invalidate()
+    audioProcessor = nil
 
-    if let token = timeToken {
-      ref.removeTimeObserver(token as Any)
+    if let timeToken {
+      ref.removeTimeObserver(timeToken)
     }
 
     if let endObserver {

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -177,7 +177,7 @@ public class AudioPlayer: SharedRef<AVPlayer> {
       return
     }
 
-    guard !(audioProcessor?.isTapInstalled ?? false) else {
+    guard audioProcessor?.isTapInstalled != true else {
       tapInstalled = true
       return
     }
@@ -193,9 +193,9 @@ public class AudioPlayer: SharedRef<AVPlayer> {
     if success {
       audioProcessor?.sampleBufferCallback = { [weak self] buffer, frameCount, timestamp in
         guard let self = self,
-              let audioBuffer = buffer?.pointee,
-              let data = audioBuffer.mData,
-              self.samplingEnabled else {
+          let audioBuffer = buffer?.pointee,
+          let data = audioBuffer.mData,
+          self.samplingEnabled else {
           return
         }
 

--- a/packages/expo-audio/ios/AudioTapProcessor.h
+++ b/packages/expo-audio/ios/AudioTapProcessor.h
@@ -5,11 +5,13 @@ typedef void (^SampleBufferCallback)(AudioBuffer *audioBuffer, long frameCount, 
 
 @interface AudioTapProcessor : NSObject
 
-@property (nonatomic, copy) SampleBufferCallback sampleBufferCallback;
-@property (nonatomic, strong) AVPlayer *player;
+@property (nonatomic, copy, nullable) SampleBufferCallback sampleBufferCallback;
+@property (nonatomic, strong, readonly) AVPlayer *player;
+@property (nonatomic, readonly) BOOL isTapInstalled;
 
 - (instancetype)initWithPlayer:(AVPlayer *)player;
-- (bool)installTap;
+- (BOOL)installTap;
 - (void)uninstallTap;
+- (void)invalidate;
 
 @end

--- a/packages/expo-audio/ios/AudioTapProcessor.m
+++ b/packages/expo-audio/ios/AudioTapProcessor.m
@@ -2,6 +2,7 @@
 
 #import "AudioTapProcessor.h"
 #import <AudioToolbox/AudioToolbox.h>
+#import <os/lock.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -9,74 +10,161 @@ typedef struct AVAudioTapProcessorContext {
   Boolean isNonInterleaved;
   Boolean supportedTapProcessingFormat;
   void *self;
+  Boolean isValid;
 } AVAudioTapProcessorContext;
 
 
-@implementation AudioTapProcessor
+@implementation AudioTapProcessor {
+  os_unfair_lock _lock;
+  MTAudioProcessingTapRef _audioProcessingTap;
+  BOOL _isTapInstalled;
+  BOOL _isInvalidated;
+}
 
 - (instancetype)initWithPlayer:(AVPlayer *)player {
   self = [super init];
   if (self) {
     _player = player;
+    _lock = OS_UNFAIR_LOCK_INIT;
+    _isTapInstalled = NO;
+    _isInvalidated = NO;
+    _audioProcessingTap = NULL;
   }
   return self;
 }
 
-- (bool)installTap {
+- (BOOL)isTapInstalled {
+  os_unfair_lock_lock(&_lock);
+  BOOL installed = _isTapInstalled;
+  os_unfair_lock_unlock(&_lock);
+  return installed;
+}
+
+- (BOOL)installTap {
+  os_unfair_lock_lock(&_lock);
+  
+  if (_isInvalidated || _isTapInstalled) {
+    os_unfair_lock_unlock(&_lock);
+    return _isTapInstalled;
+  }
+  
   if (![_player currentItem]) {
-    return false;
+    os_unfair_lock_unlock(&_lock);
+    return NO;
   }
   
   AVAssetTrack *track = _player.currentItem.tracks.firstObject.assetTrack;
   if (!track) {
-    return false;
+    os_unfair_lock_unlock(&_lock);
+    return NO;
   }
   
   AVMutableAudioMix *audioMix = [AVMutableAudioMix audioMix];
-  if (audioMix) {
-    AVMutableAudioMixInputParameters *audioMixInputParameters = [AVMutableAudioMixInputParameters audioMixInputParametersWithTrack:track];
-    if (audioMixInputParameters) {
-      MTAudioProcessingTapCallbacks callbacks;
-      callbacks.version = kMTAudioProcessingTapCallbacksVersion_0;
-      callbacks.clientInfo = (__bridge void *)self;
-      callbacks.init = tapInit;
-      callbacks.finalize = tapFinalize;
-      callbacks.prepare = tapPrepare;
-      callbacks.unprepare = tapUnprepare;
-      callbacks.process = tapProcess;
-      
-      MTAudioProcessingTapRef audioProcessingTap;
-      OSStatus status = MTAudioProcessingTapCreate(kCFAllocatorDefault, &callbacks, kMTAudioProcessingTapCreationFlag_PreEffects, &audioProcessingTap);
-      if (status == noErr) {
-        audioMixInputParameters.audioTapProcessor = audioProcessingTap;
-        audioMix.inputParameters = @[audioMixInputParameters];
-        [_player.currentItem setAudioMix:audioMix];
-        CFRelease(audioProcessingTap);
-      } else {
-        return false;
-      }
-    }
+  if (!audioMix) {
+    os_unfair_lock_unlock(&_lock);
+    return NO;
   }
-  return true;
+  
+  AVMutableAudioMixInputParameters *audioMixInputParameters = [AVMutableAudioMixInputParameters audioMixInputParametersWithTrack:track];
+  if (!audioMixInputParameters) {
+    os_unfair_lock_unlock(&_lock);
+    return NO;
+  }
+  
+  MTAudioProcessingTapCallbacks callbacks;
+  callbacks.version = kMTAudioProcessingTapCallbacksVersion_0;
+  callbacks.clientInfo = (__bridge void *)self;
+  callbacks.init = tapInit;
+  callbacks.finalize = tapFinalize;
+  callbacks.prepare = tapPrepare;
+  callbacks.unprepare = tapUnprepare;
+  callbacks.process = tapProcess;
+  
+  OSStatus status = MTAudioProcessingTapCreate(kCFAllocatorDefault, &callbacks, kMTAudioProcessingTapCreationFlag_PreEffects, &_audioProcessingTap);
+  if (status == noErr) {
+    audioMixInputParameters.audioTapProcessor = _audioProcessingTap;
+    audioMix.inputParameters = @[audioMixInputParameters];
+    [_player.currentItem setAudioMix:audioMix];
+    _isTapInstalled = YES;
+    os_unfair_lock_unlock(&_lock);
+    return YES;
+  } else {
+    NSLog(@"Failed to create audio processing tap: %d", (int)status);
+    os_unfair_lock_unlock(&_lock);
+    return NO;
+  }
 }
 
 - (void)uninstallTap {
-  [_player.currentItem setAudioMix:nil];
+  os_unfair_lock_lock(&_lock);
+  
+  if (_isTapInstalled && !_isInvalidated) {
+    [_player.currentItem setAudioMix:nil];
+    _isTapInstalled = NO;
+    
+    if (_audioProcessingTap) {
+      AVAudioTapProcessorContext *context = (AVAudioTapProcessorContext *)MTAudioProcessingTapGetStorage(_audioProcessingTap);
+      if (context) {
+        context->isValid = NO;
+        context->self = NULL;
+      }
+    }
+    
+    _audioProcessingTap = NULL;
+  }
+  
+  os_unfair_lock_unlock(&_lock);
+}
+
+- (void)invalidate {
+  os_unfair_lock_lock(&_lock);
+  
+  _isInvalidated = YES;
+  self.sampleBufferCallback = nil;
+  
+  if (_isTapInstalled) {
+    [_player.currentItem setAudioMix:nil];
+    _isTapInstalled = NO;
+    
+    if (_audioProcessingTap) {
+      AVAudioTapProcessorContext *context = (AVAudioTapProcessorContext *)MTAudioProcessingTapGetStorage(_audioProcessingTap);
+      if (context) {
+        context->isValid = NO;
+        context->self = NULL;
+      }
+    }
+    _audioProcessingTap = NULL;
+  }
+  
+  os_unfair_lock_unlock(&_lock);
+}
+
+- (void)dealloc {
+  [self invalidate];
 }
 
 #pragma mark - Audio Sample Buffer Callbacks (MTAudioProcessingTapCallbacks)
 
 void tapInit(MTAudioProcessingTapRef tap, void *clientInfo, void **tapStorageOut) {
   AVAudioTapProcessorContext *context = calloc(1, sizeof(AVAudioTapProcessorContext));
-  context->isNonInterleaved = false;
-  context->self = clientInfo;
-  *tapStorageOut = context;
+  if (context) {
+    context->isNonInterleaved = false;
+    context->self = clientInfo;
+    context->isValid = true;
+    *tapStorageOut = context;
+  } else {
+
+    *tapStorageOut = NULL;
+  }
 }
 
 void tapFinalize(MTAudioProcessingTapRef tap) {
   AVAudioTapProcessorContext *context = (AVAudioTapProcessorContext *)MTAudioProcessingTapGetStorage(tap);
-  context->self = NULL;
-  free(context);
+  if (context) {
+    context->isValid = false;
+    context->self = NULL;
+    free(context);
+  }
 }
 
 void tapPrepare(MTAudioProcessingTapRef tap, CMItemCount maxFrames, const AudioStreamBasicDescription *processingFormat) {
@@ -98,29 +186,35 @@ void tapPrepare(MTAudioProcessingTapRef tap, CMItemCount maxFrames, const AudioS
 
 void tapUnprepare(MTAudioProcessingTapRef tap) {
   AVAudioTapProcessorContext *context = (AVAudioTapProcessorContext *)MTAudioProcessingTapGetStorage(tap);
-  context->self = NULL;
+  if (context) {
+    context->isValid = false;
+    context->self = NULL;
+  }
 }
 
 void tapProcess(MTAudioProcessingTapRef tap, CMItemCount numberFrames, MTAudioProcessingTapFlags flags, AudioBufferList *bufferListInOut, CMItemCount *numberFramesOut, MTAudioProcessingTapFlags *flagsOut) {
   AVAudioTapProcessorContext *context = (AVAudioTapProcessorContext *)MTAudioProcessingTapGetStorage(tap);
-  if (!context || !context->self) {
-    NSLog(@"Audio Processing Tap storage or context is invalid!");
-    return;
-  }
-  
-  AudioTapProcessor *_self = (__bridge AudioTapProcessor *)context->self;
-  if (!_self.sampleBufferCallback) {
-    return;
-  }
   
   OSStatus status = MTAudioProcessingTapGetSourceAudio(tap, numberFrames, bufferListInOut, flagsOut, NULL, numberFramesOut);
   if (status != noErr) {
-    NSLog(@"MTAudioProcessingTapGetSourceAudio: %d", (int)status);
     return;
   }
   
-  double seconds = CMTimeGetSeconds([_self->_player.currentItem currentTime]);
-  _self.sampleBufferCallback(&bufferListInOut->mBuffers[0], numberFrames, seconds);
+  if (!context || !context->isValid || !context->self) {
+    return;
+  }
+  
+  AudioTapProcessor *processor = (__bridge AudioTapProcessor *)context->self;
+  
+  if (!context->isValid) {
+    return;
+  }
+  
+  SampleBufferCallback callback = processor.sampleBufferCallback;
+  if (callback && bufferListInOut && bufferListInOut->mNumberBuffers > 0) {
+    double timestamp = 0.0; 
+    callback(&bufferListInOut->mBuffers[0], (long)numberFrames, timestamp);
+  }
 }
 
 

--- a/packages/expo-audio/ios/AudioTapProcessor.m
+++ b/packages/expo-audio/ios/AudioTapProcessor.m
@@ -153,7 +153,6 @@ void tapInit(MTAudioProcessingTapRef tap, void *clientInfo, void **tapStorageOut
     context->isValid = true;
     *tapStorageOut = context;
   } else {
-
     *tapStorageOut = NULL;
   }
 }


### PR DESCRIPTION
# Why
Improves the memory safety and cleanup when using the audio tap.

# How
Improves how we handle the audio tap context and invalidates it correctly. This prevents crashes when when the audio module is destroyed but the sample buffer callback might be still called.

# Test Plan
Bare-expo. Working as expected.

