### PR TITLE
[video][ios][1/4] `onStatusChange` audit - Fix player not entering 'error' state when loading fails

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [Android] Fix `onFirstFrameRender` not being emitted for sources with `pixelWidthHeightRatio` different than 1. ([#37009](https://github.com/expo/expo/pull/37009) by [@behenate](https://github.com/behenate))
 - [Android] Fix `useExoShutter` prop not being exposed to the JS side. ([#37012](https://github.com/expo/expo/pull/37012) by [@behenate](https://github.com/behenate))
 - [Android] Add missing `onFirstFrameRender` event to the `VideoView` definition. ([#37014](https://github.com/expo/expo/pull/37014) by [@behenate](https://github.com/behenate))
+- [iOS] Fix player not entering 'error' state when loading fails on iOS. ([#37177](https://github.com/expo/expo/pull/37177) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/VideoPlayerItem.swift
+++ b/packages/expo-video/ios/VideoPlayerItem.swift
@@ -37,7 +37,9 @@ class VideoPlayerItem: AVPlayerItem {
 
     let asset = VideoAsset(url: url, videoSource: videoSource)
     self.urlAsset = asset
-    _ = try await asset.load(.duration, .preferredTransform, .isPlayable)
+    // We can ignore any exceptions thrown during the load. The asset will be assigned to the `VideoPlayer` anyways
+    // and cause it to go into .error state trigerring the `onStatusChange` event.
+    _ = try? await asset.load(.duration, .preferredTransform, .isPlayable)
 
     super.init(asset: urlAsset, automaticallyLoadedAssetKeys: nil)
     self.createTracksLoadingTask()


### PR DESCRIPTION
# Why

The new loading method was catching the loading error and throwing it. We should actually ignore the error and let the player handle it.

Fixes https://github.com/expo/expo/issues/36673

# How

Ignored the loading error, and assigned the source to the player anyways. This way the player enters the .error state - the same as with the old synchronous loading method.

# Test Plan

Tested in BareExpo 
