### PR TITLE
[video][ios][2/4] onStatusChange audit - fix status while loading a new source asynchronously

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Android] Fix `useExoShutter` prop not being exposed to the JS side. ([#37012](https://github.com/expo/expo/pull/37012) by [@behenate](https://github.com/behenate))
 - [Android] Add missing `onFirstFrameRender` event to the `VideoView` definition. ([#37014](https://github.com/expo/expo/pull/37014) by [@behenate](https://github.com/behenate))
 - [iOS] Fix player not entering 'error' state when loading fails on iOS. ([#37177](https://github.com/expo/expo/pull/37177) by [@behenate](https://github.com/behenate))
+- [iOS] Fix player reporting status `readyToPlay` while a source is being loaded asynchronously. ([#37180](https://github.com/expo/expo/pull/37180) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -169,7 +169,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
 
   private override init(_ ref: AVPlayer) {
     super.init(ref)
-    observer = VideoPlayerObserver(owner: self)
+    observer = VideoPlayerObserver(owner: self, videoSourceLoader: videoSourceLoader)
     observer?.registerDelegate(delegate: self)
     VideoManager.shared.register(videoPlayer: self)
 

--- a/packages/expo-video/ios/VideoSourceLoader.swift
+++ b/packages/expo-video/ios/VideoSourceLoader.swift
@@ -2,7 +2,19 @@ import AVKit
 
 internal class VideoSourceLoader {
   private(set) var isLoading: Bool = true
-  private var currentTask: Task<VideoPlayerItem?, Error>?
+  private var currentSource: VideoSource?
+  private var currentTask: Task<LoadingResult, Error>?
+
+  private var listeners = Set<WeakVideoSourceLoaderListener>()
+
+  func registerListener(listener: VideoSourceLoaderListener) {
+    let weakListener = WeakVideoSourceLoaderListener(value: listener)
+    listeners.insert(weakListener)
+  }
+
+  func unregisterListener(listener: VideoSourceLoaderListener) {
+    listeners.remove(WeakVideoSourceLoaderListener(value: listener))
+  }
 
   /**
    Asynchronously loads a video item from the provided `videoSource`. If another loading operation is in progress, it will be cancelled.
@@ -12,16 +24,31 @@ internal class VideoSourceLoader {
    */
   func load(videoSource: VideoSource) async throws -> VideoPlayerItem? {
     isLoading = true
-    currentTask?.cancel()
+    if let currentTask {
+      currentTask.cancel()
+      listeners.forEach { listener in
+        listener.value?.onLoadingCancelled(loader: self, videoSource: currentSource)
+      }
+    }
 
     let newTask = Task {
       return try await loadImpl(videoSource: videoSource)
     }
 
     self.currentTask = newTask
-    let result = try await newTask.value
+    self.currentSource = videoSource
+    let loadingResult = try await newTask.value
+
+    if !loadingResult.isCancelled {
+      listeners.forEach { listener in
+        listener.value?.onLoadingFinished(loader: self, videoSource: videoSource, result: loadingResult.value)
+      }
+    }
+
     isLoading = false
-    return result
+    self.currentSource = nil
+    self.currentTask = nil
+    return loadingResult.value
   }
 
   func cancelCurrentTask() {
@@ -34,20 +61,29 @@ internal class VideoSourceLoader {
     cancelCurrentTask()
   }
 
-  private func loadImpl(videoSource: VideoSource) async throws -> VideoPlayerItem? {
+  private func loadImpl(videoSource: VideoSource) async throws -> LoadingResult {
+    listeners.forEach { listener in
+      listener.value?.onLoadingStarted(loader: self, videoSource: videoSource)
+    }
+
     guard
       let url = videoSource.uri
     else {
-      return nil
+      return LoadingResult(value: nil, isCancelled: false)
     }
 
     let playerItem = try await VideoPlayerItem(videoSource: videoSource)
 
     if Task.isCancelled {
       print("The loading task has been cancelled")
-      return nil
+      return LoadingResult(value: nil, isCancelled: true)
     }
 
-    return playerItem
+    return LoadingResult(value: playerItem, isCancelled: false)
   }
+}
+
+private struct LoadingResult {
+  let value: VideoPlayerItem?
+  let isCancelled: Bool
 }

--- a/packages/expo-video/ios/VideoSourceLoaderListener.swift
+++ b/packages/expo-video/ios/VideoSourceLoaderListener.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+protocol VideoSourceLoaderListener: AnyObject {
+  func onLoadingStarted(loader: VideoSourceLoader, videoSource: VideoSource?)
+  func onLoadingFinished(loader: VideoSourceLoader, videoSource: VideoSource?, result: VideoPlayerItem?)
+  func onLoadingCancelled(loader: VideoSourceLoader, videoSource: VideoSource?)
+}
+
+extension VideoSourceLoaderListener {
+  func onLoadingStarted(loader: VideoSourceLoader, videoSource: VideoSource?) {}
+  func onLoadingFinished(loader: VideoSourceLoader, videoSource: VideoSource?, result: VideoPlayerItem?) {}
+  func onLoadingCancelled(loader: VideoSourceLoader, videoSource: VideoSource?) {}
+}
+
+final class WeakVideoSourceLoaderListener: Hashable {
+  private(set) weak var value: VideoSourceLoaderListener?
+
+  init(value: VideoSourceLoaderListener? = nil) {
+    self.value = value
+  }
+
+  static func == (lhs: WeakVideoSourceLoaderListener, rhs: WeakVideoSourceLoaderListener) -> Bool {
+    guard let lhsValue = lhs.value, let rhsValue = rhs.value else {
+      return lhs.value == nil && rhs.value == nil
+    }
+    return ObjectIdentifier(lhsValue) == ObjectIdentifier(rhsValue)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    if let value {
+      hasher.combine(ObjectIdentifier(value))
+    }
+  }
+}


### PR DESCRIPTION
# Why

With asynchronous loading the player will continue playing the current source until the next one has been loading. This means that the status stays at `.readyToPlay` even though the player is loading a new source. 

# How

This PR adds a listener functionality to the `VideoSourceLoader` while the loader is loading a new source the current status resulting from playback is ignored and `.loading` is returned.

# Test Plan

Tested on a physical iOS 18 device.

