### PR TITLE
[video][ios][3/4] onStatusChange audit - Fix player going into `loading` status for a single frame when unpausing

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Android] Add missing `onFirstFrameRender` event to the `VideoView` definition. ([#37014](https://github.com/expo/expo/pull/37014) by [@behenate](https://github.com/behenate))
 - [iOS] Fix player not entering 'error' state when loading fails on iOS. ([#37177](https://github.com/expo/expo/pull/37177) by [@behenate](https://github.com/behenate))
 - [iOS] Fix player reporting status `readyToPlay` while a source is being loaded asynchronously. ([#37180](https://github.com/expo/expo/pull/37180) by [@behenate](https://github.com/behenate))
+- [iOS] Fix player going into `loading` status for a single frame when unpausing with a full buffer. ([#37181](https://github.com/expo/expo/pull/37181) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -408,7 +408,10 @@ class VideoPlayerObserver: VideoSourceLoaderListener {
 
     if player.timeControlStatus != .waitingToPlayAtSpecifiedRate && player.status == .readyToPlay && currentItem?.isPlaybackBufferEmpty != true {
       status = .readyToPlay
-    } else if player.timeControlStatus == .waitingToPlayAtSpecifiedRate {
+    }
+    // Every time the player is unpaused timeControlStatus goes into .waitingToPlayAtSpecifiedRate while evaluating buffering rate.
+    // This takes less than a frame and we can ignore this change to avoid unnecessary status changes.
+    else if player.timeControlStatus == .waitingToPlayAtSpecifiedRate && player.reasonForWaitingToPlay != .evaluatingBufferingRate {
       status = .loading
     }
 


### PR DESCRIPTION
# Why
Fixes https://github.com/expo/expo/issues/33738

The player will go into `.loading` for a few milliseconds state every time it is unpaused. This was because the `AVPlayer.timeControlStatus` will go into a waiting state.

# How

We can check for the reason for the waiting state. When the bug appears the state is always `.evaluatingBufferingRate`. We can filter it out without any negative side effects to detecting the loading state.

# Test Plan

Tested in BareExpo on iOS 18 device.
