### PR TITLE
[video][ios][4/4] onStatusChange audit - Fix player entering `loading` state for null sources.

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [iOS] Fix player not entering 'error' state when loading fails on iOS. ([#37177](https://github.com/expo/expo/pull/37177) by [@behenate](https://github.com/behenate))
 - [iOS] Fix player reporting status `readyToPlay` while a source is being loaded asynchronously. ([#37180](https://github.com/expo/expo/pull/37180) by [@behenate](https://github.com/behenate))
 - [iOS] Fix player going into `loading` status for a single frame when unpausing with a full buffer. ([#37181](https://github.com/expo/expo/pull/37181) by [@behenate](https://github.com/behenate))
+- [iOS] Fix player getting stuck in `loading` state for null sources. ([#37183](https://github.com/expo/expo/pull/37183) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -408,11 +408,17 @@ class VideoPlayerObserver: VideoSourceLoaderListener {
 
     if player.timeControlStatus != .waitingToPlayAtSpecifiedRate && player.status == .readyToPlay && currentItem?.isPlaybackBufferEmpty != true {
       status = .readyToPlay
-    }
-    // Every time the player is unpaused timeControlStatus goes into .waitingToPlayAtSpecifiedRate while evaluating buffering rate.
-    // This takes less than a frame and we can ignore this change to avoid unnecessary status changes.
-    else if player.timeControlStatus == .waitingToPlayAtSpecifiedRate && player.reasonForWaitingToPlay != .evaluatingBufferingRate {
-      status = .loading
+    } else if player.timeControlStatus == .waitingToPlayAtSpecifiedRate {
+      switch player.reasonForWaitingToPlay {
+      case .noItemToPlay:
+        status = .idle
+      case .evaluatingBufferingRate:
+        // Every time the player is unpaused timeControlStatus goes into .waitingToPlayAtSpecifiedRate while evaluating buffering rate.
+        // This takes less than a frame and we can ignore this change to avoid unnecessary status changes.
+        break
+      default:
+        status = .loading
+      }
     }
 
     if isPlaying != (player.timeControlStatus == .playing) {


### PR DESCRIPTION
# Why

The player will enter `loading` instead of `idle` state for null sources.

# How

Checked if the reason for waiting is is `noItemToPlay` in that case set the status to `idle`.

# Test Plan

Tested in BareExpo on a iOS 18 device.
