### PR TITLE
[android][updates] Cleanup resources on destroy

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Remove "Please" from warnings and errors ([#36862](https://github.com/expo/expo/pull/36862) by [@brentvatne](https://github.com/brentvatne))
+- [Android] Cleanup state machine resources when the module is destroyed.
 
 ## 0.28.13 — 2025-05-08
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - Remove "Please" from warnings and errors ([#36862](https://github.com/expo/expo/pull/36862) by [@brentvatne](https://github.com/brentvatne))
-- [Android] Cleanup state machine resources when the module is destroyed.
+- [Android] Cleanup state machine resources when the module is destroyed. ([#37193](https://github.com/expo/expo/pull/37193) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.28.13 — 2025-05-08
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
@@ -181,6 +181,10 @@ class DisabledUpdatesController(
     }
   }
 
+  override fun shutdown() {
+    // no-op
+  }
+
   companion object {
     private val TAG = DisabledUpdatesController::class.java.simpleName
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -29,6 +29,7 @@ import expo.modules.updates.statemachine.UpdatesStateValue
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -269,6 +270,11 @@ class EnabledUpdatesController(
         continuation.resumeWithException(e.toCodedException())
       }
     }
+  }
+
+  override fun shutdown() {
+    stateMachine.shutdown()
+    controllerScope.cancel()
   }
 
   override fun setUpdateURLAndRequestHeadersOverride(configOverride: UpdatesConfigurationOverride?) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
@@ -163,4 +163,6 @@ interface IUpdatesController {
   suspend fun setExtraParam(key: String, value: String?)
 
   fun setUpdateURLAndRequestHeadersOverride(configOverride: UpdatesConfigurationOverride?)
+
+  fun shutdown()
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -19,7 +19,10 @@ import java.lang.ref.WeakReference
  * the callbacks that are invoked.
  */
 object UpdatesController {
+  @Volatile
   private var singletonInstance: IUpdatesController? = null
+
+  @Volatile
   private var overrideConfiguration: UpdatesConfiguration? = null
 
   @JvmStatic
@@ -131,10 +134,11 @@ object UpdatesController {
    * @param context the base context of the application, ideally a [ReactApplication]
    */
   @JvmStatic
+  @Synchronized
   fun initialize(context: Context) {
     if (singletonInstance == null) {
       initializeWithoutStarting(context)
-      singletonInstance!!.start()
+      singletonInstance?.start()
     }
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -364,6 +364,10 @@ class UpdatesDevLauncherController(
     throw NotAvailableInDevClientException("Updates.setUpdateURLAndRequestHeadersOverride() is not supported in development builds.")
   }
 
+  override fun shutdown() {
+    // no-op
+  }
+
   companion object {
     private val TAG = UpdatesDevLauncherController::class.java.simpleName
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -59,6 +59,7 @@ class UpdatesModule : Module(), IUpdatesEventManagerObserver {
 
     OnDestroy {
       UpdatesController.removeUpdatesEventManagerObserver()
+      UpdatesController.instance.shutdown()
     }
 
     AsyncFunction("reload") Coroutine { ->

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StateMachineSerialExecutorQueue.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StateMachineSerialExecutorQueue.kt
@@ -6,6 +6,7 @@ import expo.modules.updates.statemachine.UpdatesStateValue
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -27,9 +28,10 @@ class StateMachineSerialExecutorQueue(
 
   private val procedureChannel = Channel<ProcedureHolder>(Channel.UNLIMITED)
   private val mutex = Mutex()
+  private val executorJob: Job
 
   init {
-    scope.launch {
+    executorJob = scope.launch {
       for (holder in procedureChannel) {
         executeProcedure(holder)
       }
@@ -82,5 +84,10 @@ class StateMachineSerialExecutorQueue(
         procedureChannel.send(ProcedureHolder(stateMachineProcedure, completableDeferred))
       }
     }
+  }
+
+  fun cancel() {
+    executorJob.cancel()
+    procedureChannel.close()
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -198,4 +198,8 @@ class UpdatesStateMachine(
       }
     }
   }
+
+  fun shutdown() {
+    serialExecutorQueue.cancel()
+  }
 }


### PR DESCRIPTION
# Why
Add proper cleanup of the state machines resources when the module is destroyed.

# How
Currently the state machines channel and coroutines are not cleaned up when the module is destroyed, this could lead to resource leaks. Also, some of the procedures did not handle cancellation so that has been added. It's just logs but it may be helpful

# Test Plan
CI. Works as expected in a release build of bare-expo 

