### PR TITLE
[docs] Add a guide on Expo Go -> dev builds

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -104,6 +104,7 @@ export const home = [
       'Development builds',
       [
         makePage('develop/development-builds/introduction.mdx'),
+        makePage('develop/development-builds/expo-go-to-dev-build.mdx'),
         makePage('develop/development-builds/create-a-build.mdx'),
         makePage('develop/development-builds/use-development-builds.mdx'),
         makePage('develop/development-builds/share-with-your-team.mdx'),

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -1,7 +1,7 @@
 ---
-title: Create a development build
+title: Create a development build on EAS
 description: Learn how to create development builds for a project.
-sidebar_title: Create a build
+sidebar_title: Create a build on EAS
 searchRank: 97
 searchPosition: 2
 ---
@@ -14,7 +14,6 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { Tab, Tabs } from '~/ui/components/Tabs';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 When you create a new Expo app with `npx create-expo-app`, you start off with a project where you update the JavaScript code on your local machine and view the changes in the Expo Go app. A **development build** is essentially **your own version of Expo Go** where you are free to use any native libraries and change any native config. In this guide, you will learn how to convert your project that runs on Expo Go into a development build, which will make the native side of your app fully customizable.
@@ -59,7 +58,7 @@ Any EAS CLI command can be built on your local machine with the `--local` flag. 
 
 <Collapsible summary="Build locally without EAS">
 
-To build locally without EAS requires your local [development environment](https://reactnative.dev/docs/set-up-your-environment?os=macos&platform=ios) to be set up with native build tools. This is the only way to test your iOS build on an iPhone device without a paid Apple Developer Account (only possible on macOS). Read more about [local app compilation](/guides/local-app-development/#local-app-compilation).
+To build locally without EAS requires your local [development environment](https://reactnative.dev/docs/set-up-your-environment?os=macos&platform=ios) to be set up with native build tools. This is the only way to test your iOS build on an iPhone device without a paid Apple Developer Account (only possible on macOS). Read more about [local app compilation](/guides/local-app-development/#local-app-compilation) and see the guide on [Expo Go to Development Build](/develop/development-builds/expo-go-to-dev-build/).
 
 |             | Android    | iOS Simulator | iPhone device |
 | ----------- | ---------- | ------------- | ------------- |
@@ -91,10 +90,6 @@ Apps that don't use [Continuous Native Generation](/workflow/continuous-native-g
 
 ### Build the native app (Android)
 
-<Tabs>
-
-<Tab label="Build on EAS">
-
 <Prerequisites numberOfRequirements={3}>
   <Requirement number={1} title="Expo account">
     Sign up for an [Expo](https://expo.dev/signup) account, if you haven't already.
@@ -113,39 +108,11 @@ Apps that don't use [Continuous Native Generation](/workflow/continuous-native-g
 
 Read more about [Android builds on EAS](/tutorial/eas/android-development-build).
 
-</Tab>
-
-<Tab label="On your local machine">
-
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="Development environment set up">
-    A macOS, Windows, or Linux machine with your local [development
-    environment](https://reactnative.dev/docs/set-up-your-environment?os=windows&platform=android)
-    set up.
-  </Requirement>
-  <Requirement number={2} title="An Android Emulator (optional)">
-    An [Android Emulator](/workflow/android-studio-emulator/) is optional if you want to test your
-    app on an emulator.
-  </Requirement>
-</Prerequisites>
-
-<Terminal cmd={['$ npx expo run:android']} />
-
-The same `apk` can be installed on Android devices as well as emulators.
-
-Read more about [local app development](/guides/local-app-development/#local-builds-with-expo-dev-client).
-
-</Tab>
-</Tabs>
-
 </Step>
 
 <Step label="2">
+
 ### Build the native app (iOS Simulator)
-
-<Tabs>
-
-<Tab label="Build on EAS">
 
 <Prerequisites numberOfRequirements={3}>
   <Requirement number={1} title="Expo account">
@@ -181,35 +148,10 @@ iOS Simulator builds can only be installed on simulators and not on real devices
 
 Read more about [iOS Simulator builds on EAS](/tutorial/eas/ios-development-build-for-simulators/).
 
-</Tab>
-
-<Tab label="On your local machine">
-
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="macOS">
-    iOS Simulators are available only on macOS.
-  </Requirement>
-  <Requirement number={2} title="Development environment set up">
-    Set up your local [development
-    environment](https://reactnative.dev/docs/set-up-your-environment?os=macos&platform=ios).
-  </Requirement>
-</Prerequisites>
-
-<Terminal cmd={['$ npx expo run:ios']} />
-
-Read more about [local app development](/guides/local-app-development/#local-builds-with-expo-dev-client).
-
-</Tab>
-</Tabs>
-
 </Step>
 
 <Step label="2">
 ### Build the native app (iOS device)
-
-<Tabs>
-
-<Tab label="Build on EAS">
 
 <Prerequisites numberOfRequirements={3}>
   <Requirement number={1} title="Expo account">
@@ -232,27 +174,6 @@ iOS device builds can only be installed on iPhone devices and not on iOS Simulat
 
 Read more about [iOS device builds on EAS](/tutorial/eas/ios-development-build-for-devices/).
 
-</Tab>
-
-<Tab label="On your local machine">
-
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="macOS">
-    macOS is required to compile the native app for iOS devices.
-  </Requirement>
-  <Requirement number={2} title="Development environment set up">
-    Set up your local [development
-    environment](https://reactnative.dev/docs/set-up-your-environment?os=macos&platform=ios).
-  </Requirement>
-</Prerequisites>
-
-<Terminal cmd={['$ npx expo run:ios --device']} />
-
-Read more about [local app development](/guides/local-app-development/#local-builds-with-expo-dev-client).
-
-</Tab>
-</Tabs>
-
 </Step>
 
 <Step label="3">
@@ -267,10 +188,6 @@ If you create your development build on EAS, the CLI will prompt you to install 
 #### When building locally using EAS CLI
 
 When building locally the output of the build will be an archive. You may drag and drop this on your Android Emulator/iOS Simulator to install it, or use [Expo Orbit](https://expo.dev/orbit) to install a build from your local machine.
-
-#### When building locally without EAS CLI
-
-Local builds will get installed automatically once the build finishes.
 
 </Step>
 

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -58,7 +58,7 @@ Any EAS CLI command can be built on your local machine with the `--local` flag. 
 
 <Collapsible summary="Build locally without EAS">
 
-To build locally without EAS requires your local [development environment](https://reactnative.dev/docs/set-up-your-environment?os=macos&platform=ios) to be set up with native build tools. This is the only way to test your iOS build on an iPhone device without a paid Apple Developer Account (only possible on macOS). Read more about [local app compilation](/guides/local-app-development/#local-app-compilation) and see the guide on [Expo Go to Development Build](/develop/development-builds/expo-go-to-dev-build/).
+To build locally without EAS requires your local [development environment](https://reactnative.dev/docs/set-up-your-environment?os=macos&platform=ios) to be set up with native build tools. This is the only way to test your iOS build on an iPhone device without a paid Apple Developer Account (only possible on macOS). Read more about [local app compilation](/guides/local-app-development/#local-app-compilation) and see the [Expo Go to Development Build](/develop/development-builds/expo-go-to-dev-build/) guide.
 
 |             | Android    | iOS Simulator | iPhone device |
 | ----------- | ---------- | ------------- | ------------- |

--- a/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
+++ b/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
@@ -4,6 +4,9 @@ sidebar_title: Expo Go to development build
 description: How to migrate your Expo Go project to use development builds.
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -149,4 +152,9 @@ Then, rebuild your app with the updated native code, with:
 
 All Expo build tools (`npx expo run:android|ios` and `eas build`) will **prebuild** automatically if no existing native folders are found. This means that there is no need to run prebuild manually when you're running `npx expo run:android|ios` for the first time or `eas build`.
 
-For more details on the philosophy and benefits of Continuous Native Generation (CNG) and Prebuild, see this [comprehensive guide](/workflow/continuous-native-generation/).
+<BoxLink
+  title="Continuous Native Generation (CNG)"
+  description="Learn about the philosophy and benefits of Continuous Native Generation (CNG) and Prebuild"
+  href="/workflow/continuous-native-generation/"
+  Icon={BookOpen02Icon}
+/>

--- a/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
+++ b/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
@@ -66,15 +66,15 @@ Once you have everything set up, run the following command:
 </Tab>
 </Tabs>
 
-By default, this will build and install the app on an Android Emulator/iOS Simulator. If you need to run the build on your phone, plug it into your computer (trust device and allow USB debugging if prompted, and on iOS enable [developer mode](https://docs.expo.dev/get-started/set-up-your-environment/?mode=development-build&buildEnv=local&platform=ios&device=physical#plug-in-your-device-via-usb-and-enable-developer-mode)) and run the above commands with the `--device` flag.
+By default, this will build and install the app on an Android Emulator/iOS Simulator. If you need to run the build on your phone, plug it into your computer (on Android, select trust device and allow USB debugging if prompted, and on iOS, enable [developer mode](/get-started/set-up-your-environment/?mode=development-build&buildEnv=local&platform=ios&device=physical#plug-in-your-device-via-usb-and-enable-developer-mode)) and run the above commands with the `--device` flag.
 
 ### Option 2: Build on EAS
 
 Building on EAS servers is useful when:
 
-- you can't or don't want to set up your local development environment
-- you want to build an iOS app but don't own a Mac
-- you want to share the development builds with your team
+- You can't or don't want to set up your local development environment
+- You want to build an iOS app but don't own a Mac
+- You want to share the development builds with your team
 
 <BoxLink
   title="Build on EAS"
@@ -89,7 +89,7 @@ Building on EAS servers is useful when:
 
 ## Start the bundler
 
-After building locally, `npx expo run:android:ios` will start the bundler automatically. But if you closed the bundler or are working on a dev client you built earlier, (re)start the Metro bundler with:
+After building locally, `npx expo run:android|ios` will start the bundler automatically. But if you closed the bundler or are working on a dev client you built earlier, (re)start the Metro bundler with:
 
 <Terminal cmd={['$ npx expo start']} />
 
@@ -106,10 +106,10 @@ When your project has `expo-dev-client` installed, the bundler will print out **
 You will need to run prebuild locally if you are building via `npx expo run:android|ios`, and change any native dependencies or configuration, such as:
 
 - Installing or updating a library containing native code
-- Changing `app.json` or `app.config.json`
+- Changing [app config](/workflow/configuration/)(`app.json`)
 - Upgrading your Expo SDK version
 
-In these cases, you'll want to rebuild the native directory with:
+In these cases, you'll want to rebuild the native directories with:
 
 <Terminal cmd={['$ npx expo prebuild --clean']} />
 

--- a/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
+++ b/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
@@ -66,7 +66,7 @@ Once you have everything set up, run the following command:
 </Tab>
 </Tabs>
 
-By default this will build and install the app on a simulator/emulator. If you need to run the build on your phone, plug it into your computer (trust device and allow USB debugging if prompted) and run the above commands with the `--device` flag.
+By default, this will build and install the app on an Android Emulator/iOS Simulator. If you need to run the build on your phone, plug it into your computer (trust device and allow USB debugging if prompted, and on iOS enable [developer mode](https://docs.expo.dev/get-started/set-up-your-environment/?mode=development-build&buildEnv=local&platform=ios&device=physical#plug-in-your-device-via-usb-and-enable-developer-mode)) and run the above commands with the `--device` flag.
 
 ### Option 2: Build on EAS
 

--- a/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
+++ b/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
@@ -7,6 +7,7 @@ description: How to migrate your Expo Go project to use development builds.
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { Tab, Tabs } from '~/ui/components/Tabs';
 
 To migrate from Expo Go to a development build, you'll need to follow the steps below:
 
@@ -45,13 +46,22 @@ Once you've built your native app, you won't need to build it again unless you a
 
 To build a native app on your local machine, follow the setup your environment guides for [Android](/workflow/android-studio-emulator/) and [iOS](/workflow/ios-simulator/) platforms. This involves setting up and configuring native build tools like Android Studio for Android and Xcode for iOS.
 
-Once you have everything set up, run the following command to build for iOS:
+Once you have everything set up, run the following command:
+
+<Tabs>
+
+<Tab label="Build for Android">
+
+<Terminal cmd={['$ npx expo run:android']} />
+
+</Tab>
+
+<Tab label="Build for iOS">
 
 <Terminal cmd={['$ npx expo run:ios']} />
 
-Or to build the Android app:
-
-<Terminal cmd={['$ npx expo run:android']} />
+</Tab>
+</Tabs>
 
 By default this will build and install the app on a simulator/emulator. If you need to run the build on your phone, plug it into your computer (trust device and allow USB debugging if prompted) and run the above commands with the `--device` flag.
 
@@ -67,13 +77,24 @@ To build on EAS, install the EAS CLI and log in:
 
 <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
 
-To build the development client for Android, run:
+To build the development client, run:
+
+<Tabs>
+
+<Tab label="Build for Android">
 
 <Terminal cmd={['$ eas build --platform android --profile development']} />
 
-To build the development client for iOS (this requires an Apple Developer Account), run:
+</Tab>
+
+<Tab label="Build for iOS">
 
 <Terminal cmd={['$ eas build --platform ios --profile development']} />
+
+A paid [Apple Developer](https://developer.apple.com/) account for creating [signing credentials](/app-signing/managed-credentials#generating-app-signing-credentials) so the app could be installed on an iOS device.
+
+</Tab>
+</Tabs>
 
 See the [next guide](/develop/development-builds/create-a-build) for details on various ways to build your dev client and the limitations.
 
@@ -109,11 +130,20 @@ In these cases, you'll want to rebuild the native directory with:
 
 Then, rebuild your app with the updated native code, with:
 
-<Terminal cmd={['$ npx expo run:ios']} />
+<Tabs>
 
-or
+<Tab label="Build for Android">
 
 <Terminal cmd={['$ npx expo run:android']} />
+
+</Tab>
+
+<Tab label="Build for iOS">
+
+<Terminal cmd={['$ npx expo run:ios']} />
+
+</Tab>
+</Tabs>
 
 ### When you don't need to run prebuild
 

--- a/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
+++ b/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
@@ -81,9 +81,9 @@ See the [next guide](/develop/development-builds/create-a-build) for details on 
 
 <Step label="2">
 
-## Start the JavaScript bundler
+## Start the Metro bundler
 
-After building locally, `npx expo run:<platform>` will start the bundler automatically. But if you closed the bundler or are working on a dev client you built earlier, (re)start the JavaScript bundler with:
+After building locally, `npx expo run:android:ios` will start the bundler automatically. But if you closed the bundler or are working on a dev client you built earlier, (re)start the Metro bundler with:
 
 <Terminal cmd={['$ npx expo start']} />
 
@@ -95,13 +95,15 @@ When your project has `expo-dev-client` installed, the bundler will print out **
 
 [**Prebuild** ](/workflow/continuous-native-generation/#prebuild) is a concept unique to Expo projects. It refers to the process of generating the **android** and **ios** directories based on your local configuration and properties.
 
-### When **not** to run prebuild
-
-All Expo build tools (`npx expo run:android|ios` and `eas build`) will **prebuild** automatically if no existing native folders are found. This means that there is no need to run prebuild manually when you're running `npx expo run:android|ios` for the first time or `eas build`.
-
 ### When should you run prebuild
 
-The only reason to prebuild locally is if you are building via `npx expo run:android|ios` and changing any native dependencies (for example, installing a new library or changing the native configuration). Then you'll want to rebuild the native directory with:
+You will need to run prebuild locally if you are building via `npx expo run:android|ios`, and change any native dependencies or configuration, such as:
+
+- Installing or updating a library containing native code
+- Changing `app.json` or `app.config.json`
+- Upgrading your Expo SDK version
+
+In these cases, you'll want to rebuild the native directory with:
 
 <Terminal cmd={['$ npx expo prebuild --clean']} />
 
@@ -112,5 +114,9 @@ Then, rebuild your app with the updated native code, with:
 or
 
 <Terminal cmd={['$ npx expo run:android']} />
+
+### When you don't need to run prebuild
+
+All Expo build tools (`npx expo run:android|ios` and `eas build`) will **prebuild** automatically if no existing native folders are found. This means that there is no need to run prebuild manually when you're running `npx expo run:android|ios` for the first time or `eas build`.
 
 For more details on the philosophy and benefits of Continuous Native Generation (CNG) and Prebuild, see this [comprehensive guide](/workflow/continuous-native-generation/).

--- a/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
+++ b/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
@@ -79,7 +79,7 @@ Building on EAS servers is useful when:
 <BoxLink
   title="Build on EAS"
   description="How to create your Development Build on EAS"
-  href="develop/development-builds/create-a-build/"
+  href="/develop/development-builds/create-a-build/"
   Icon={BookOpen02Icon}
 />
 
@@ -87,7 +87,7 @@ Building on EAS servers is useful when:
 
 <Step label="2">
 
-## Start the Metro bundler
+## Start the bundler
 
 After building locally, `npx expo run:android:ios` will start the bundler automatically. But if you closed the bundler or are working on a dev client you built earlier, (re)start the Metro bundler with:
 

--- a/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
+++ b/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
@@ -81,9 +81,9 @@ See the [next guide](/develop/development-builds/create-a-build) for details on 
 
 <Step label="2">
 
-## Start the dev client
+## Start the JavaScript bundler
 
-Finally, start the JavaScript bundler with:
+The building locally, `npx expo run:<platform>` will start the bundler automatically. But if you closed the bundler or are working on a dev client you build earlier, (re)start the JavaScript bundler with:
 
 <Terminal cmd={['$ npx expo start']} />
 

--- a/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
+++ b/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
@@ -1,20 +1,20 @@
 ---
 title: Convert from Expo Go to a development build
 sidebar_title: Expo Go to development build
-description: How to migrate your Expo Go project to use development builds
+description: How to migrate your Expo Go project to use development builds.
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-To migrate from Expo Go to a development build, you'll need to:
+To migrate from Expo Go to a development build, you'll need to follow the steps below:
 
 <Step label="1">
 
 ## Install the `expo-dev-client`
 
-The Expo Dev Client library includes the launcher UI (shown in the screenshots below), dev menu, extensions to test updates, and more. The Expo Go app has the dev menu built in, and that's why you need to install it separately for a development build.
+The Expo Dev Client library includes the launcher UI (shown in the screenshots below), dev menu, extensions to test over-the-air updates, and more. The Expo Go app has the dev menu built in, and that's why you need to install it separately for a development build.
 
 <Terminal cmd={['$ npx expo install expo-dev-client']} />
 
@@ -24,7 +24,7 @@ The Expo Dev Client library includes the launcher UI (shown in the screenshots b
   caption={`When you run a development build it will look like this, only with your app name and icon included rather than "Microfoam". The launcher UI is pictured in iOS on the left and Android on the right. In between, you can see an app running inside of the development build, with the customizable developer menu open.`}
 />
 
-> We recommend using the `expo-dev-client` for the best development experience, but it is possible to use development builds without installing this library. If not using the dev client, in [Step 3](/develop/development-builds/expo-go-to-dev-build/#start-the-dev-client) start the bundler with `--dev-client`. Otherwise it will default to opening in Expo Go.
+> We recommend using the `expo-dev-client` for the best development experience, but it is possible to use development builds without installing this library. If not using the dev client, in [Step 3](/develop/development-builds/expo-go-to-dev-build/#start-the-dev-client), start the bundler with `--dev-client`. Otherwise, it will default to opening in Expo Go.
 
 </Step>
 
@@ -32,18 +32,18 @@ The Expo Dev Client library includes the launcher UI (shown in the screenshots b
 
 ## Build your native app
 
-With Expo Go, we only needed to build the JavaScript bundle, but with development builds we also need to compile the native app. With Expo, there is two parts to building your native app:
+With Expo Go, you only needed to build the JavaScript bundle, but with development builds you also need to compile the native app. With Expo, there are two parts to building your native app:
 
-1. generate the native `/ios` and/or `/android` directories ([read more](/develop/development-builds/expo-go-to-dev-build/#cng-and-prebuild) on when and how you'll need to do this)
-2. use native build tools to compile the native app(s)
+1. Generate the native **android** and/or **ios** directories ([read more](/develop/development-builds/expo-go-to-dev-build/#cng-and-prebuild) on when and how you'll need to do this)
+2. Use native build tools to compile the native app(s)
 
-Once you've built your native app, you won't need to build it again unless you add or update a library with native code, or change any native coding such as the app name.
+Once you've built your native app, you won't need to build it again unless you add or update a library with native code, or change any native code or configuration, such as the app name.
 
-> After generating your `/ios` and/or `/android` directories, make sure you add them to `.gitignore` instead of checking them into Git. This ensures you can always regenerate the code locally or on CI when needed and never have to edit native code manually.
+> After generating your **android** and/or **ios** directories, make sure you add them to **.gitignore** instead of checking them into Git. This ensures you can always regenerate the code locally or on CI when needed and never have to edit native code manually.
 
 ### Option 1: Build on your local machine
 
-To build a native app on your local machine, follow the guide on [setting up your local development environment](https://reactnative.dev/docs/set-up-your-environment) for which ever platform you're looking to build for. This involves setting up and configuring native build tools like Xcode for iOS, and Android Studio for Android.
+To build a native app on your local machine, follow the setup your environment guides for [Android](/workflow/android-studio-emulator/) and [iOS](/workflow/ios-simulator/) platforms. This involves setting up and configuring native build tools like Android Studio for Android and Xcode for iOS.
 
 Once you have everything set up, run the following command to build for iOS:
 
@@ -83,7 +83,7 @@ See the [next guide](/develop/development-builds/create-a-build) for details on 
 
 ## Start the JavaScript bundler
 
-The building locally, `npx expo run:<platform>` will start the bundler automatically. But if you closed the bundler or are working on a dev client you build earlier, (re)start the JavaScript bundler with:
+After building locally, `npx expo run:<platform>` will start the bundler automatically. But if you closed the bundler or are working on a dev client you built earlier, (re)start the JavaScript bundler with:
 
 <Terminal cmd={['$ npx expo start']} />
 
@@ -93,19 +93,19 @@ When your project has `expo-dev-client` installed, the bundler will print out **
 
 ## Prebuild
 
-**Prebuild** is a concept unique to managed Expo projects. It refers to the process of generating the `/ios` and `/android` directories based on your local config and properties.
+[**Prebuild** ](/workflow/continuous-native-generation/#prebuild) is a concept unique to Expo projects. It refers to the process of generating the **android** and **ios** directories based on your local configuration and properties.
 
 ### When **not** to run prebuild
 
-All Expo build tools (`eas build` and `npx expo run:<platform>`) will **prebuild** automatically if no existing native folders are found. This means that there is no need to run prebuild manually when running `eas build` or when you're running `npx expo run:<platform>` for the first time.
+All Expo build tools (`npx expo run:android|ios` and `eas build`) will **prebuild** automatically if no existing native folders are found. This means that there is no need to run prebuild manually when you're running `npx expo run:android|ios` for the first time or `eas build`.
 
 ### When should you run prebuild
 
-The only reason to prebuild locally is if you are building via `npx expo run:<platform>` and change any native dependencies (e.g. installing a new library or changing the native config). Then you'll want to rebuild the native directory with:
+The only reason to prebuild locally is if you are building via `npx expo run:android|ios` and changing any native dependencies (for example, installing a new library or changing the native configuration). Then you'll want to rebuild the native directory with:
 
 <Terminal cmd={['$ npx expo prebuild --clean']} />
 
-and then rebuild your app with the updated native code, with:
+Then, rebuild your app with the updated native code, with:
 
 <Terminal cmd={['$ npx expo run:ios']} />
 
@@ -113,4 +113,4 @@ or
 
 <Terminal cmd={['$ npx expo run:android']} />
 
-For more details on the philosophy and benefits of CNG, refer to our [comprehensive guide](https://docs.expo.dev/workflow/continuous-native-generation/).
+For more details on the philosophy and benefits of Continuous Native Generation (CNG) and Prebuild, see this [comprehensive guide](/workflow/continuous-native-generation/).

--- a/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
+++ b/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
@@ -1,0 +1,116 @@
+---
+title: Convert from Expo Go to a development build
+sidebar_title: Expo Go to development build
+description: How to migrate your Expo Go project to use development builds
+---
+
+import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
+To migrate from Expo Go to a development build, you'll need to:
+
+<Step label="1">
+
+## Install the `expo-dev-client`
+
+The Expo Dev Client library includes the launcher UI (shown in the screenshots below), dev menu, extensions to test updates, and more. The Expo Go app has the dev menu built in, and that's why you need to install it separately for a development build.
+
+<Terminal cmd={['$ npx expo install expo-dev-client']} />
+
+<ContentSpotlight
+  alt="expo-dev-client launcher and menu UIs on Android and iOS."
+  src="/static/images/dev-client/preview.png"
+  caption={`When you run a development build it will look like this, only with your app name and icon included rather than "Microfoam". The launcher UI is pictured in iOS on the left and Android on the right. In between, you can see an app running inside of the development build, with the customizable developer menu open.`}
+/>
+
+> We recommend using the `expo-dev-client` for the best development experience, but it is possible to use development builds without installing this library. If not using the dev client, in [Step 3](/develop/development-builds/expo-go-to-dev-build/#start-the-dev-client) start the bundler with `--dev-client`. Otherwise it will default to opening in Expo Go.
+
+</Step>
+
+<Step label="2">
+
+## Build your native app
+
+With Expo Go, we only needed to build the JavaScript bundle, but with development builds we also need to compile the native app. With Expo, there is two parts to building your native app:
+
+1. generate the native `/ios` and/or `/android` directories ([read more](/develop/development-builds/expo-go-to-dev-build/#cng-and-prebuild) on when and how you'll need to do this)
+2. use native build tools to compile the native app(s)
+
+Once you've built your native app, you won't need to build it again unless you add or update a library with native code, or change any native coding such as the app name.
+
+> After generating your `/ios` and/or `/android` directories, make sure you add them to `.gitignore` instead of checking them into Git. This ensures you can always regenerate the code locally or on CI when needed and never have to edit native code manually.
+
+### Option 1: Build on your local machine
+
+To build a native app on your local machine, follow the guide on [setting up your local development environment](https://reactnative.dev/docs/set-up-your-environment) for which ever platform you're looking to build for. This involves setting up and configuring native build tools like Xcode for iOS, and Android Studio for Android.
+
+Once you have everything set up, run the following command to build for iOS:
+
+<Terminal cmd={['$ npx expo run:ios']} />
+
+Or to build the Android app:
+
+<Terminal cmd={['$ npx expo run:android']} />
+
+By default this will build and install the app on a simulator/emulator. If you need to run the build on your phone, plug it into your computer (trust device and allow USB debugging if prompted) and run the above commands with the `--device` flag.
+
+### Option 2: Build on EAS
+
+Building on EAS servers is useful when:
+
+- you can't or don't want to set up your local development environment
+- you want to build an iOS app but don't own a Mac
+- you want to share the development builds with your team
+
+To build on EAS, install the EAS CLI and log in:
+
+<Terminal cmd={['$ npm install -g eas-cli && eas login']} />
+
+To build the development client for Android, run:
+
+<Terminal cmd={['$ eas build --platform android --profile development']} />
+
+To build the development client for iOS (this requires an Apple Developer Account), run:
+
+<Terminal cmd={['$ eas build --platform ios --profile development']} />
+
+See the [next guide](/develop/development-builds/create-a-build) for details on various ways to build your dev client and the limitations.
+
+</Step>
+
+<Step label="2">
+
+## Start the dev client
+
+Finally, start the JavaScript bundler with:
+
+<Terminal cmd={['$ npx expo start']} />
+
+When your project has `expo-dev-client` installed, the bundler will print out **Using development build**, and the QR code it shows will link into the development build you created instead of Expo Go.
+
+</Step>
+
+## Prebuild
+
+**Prebuild** is a concept unique to managed Expo projects. It refers to the process of generating the `/ios` and `/android` directories based on your local config and properties.
+
+### When **not** to run prebuild
+
+All Expo build tools (`eas build` and `npx expo run:<platform>`) will **prebuild** automatically if no existing native folders are found. This means that there is no need to run prebuild manually when running `eas build` or when you're running `npx expo run:<platform>` for the first time.
+
+### When should you run prebuild
+
+The only reason to prebuild locally is if you are building via `npx expo run:<platform>` and change any native dependencies (e.g. installing a new library or changing the native config). Then you'll want to rebuild the native directory with:
+
+<Terminal cmd={['$ npx expo prebuild --clean']} />
+
+and then rebuild your app with the updated native code, with:
+
+<Terminal cmd={['$ npx expo run:ios']} />
+
+or
+
+<Terminal cmd={['$ npx expo run:android']} />
+
+For more details on the philosophy and benefits of CNG, refer to our [comprehensive guide](https://docs.expo.dev/workflow/continuous-native-generation/).

--- a/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
+++ b/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
@@ -76,30 +76,12 @@ Building on EAS servers is useful when:
 - you want to build an iOS app but don't own a Mac
 - you want to share the development builds with your team
 
-To build on EAS, install the EAS CLI and log in:
-
-<Terminal cmd={['$ npm install -g eas-cli && eas login']} />
-
-To build the development client, run:
-
-<Tabs>
-
-<Tab label="Build for Android">
-
-<Terminal cmd={['$ eas build --platform android --profile development']} />
-
-</Tab>
-
-<Tab label="Build for iOS">
-
-<Terminal cmd={['$ eas build --platform ios --profile development']} />
-
-A paid [Apple Developer](https://developer.apple.com/) account for creating [signing credentials](/app-signing/managed-credentials#generating-app-signing-credentials) so the app could be installed on an iOS device.
-
-</Tab>
-</Tabs>
-
-See the [next guide](/develop/development-builds/create-a-build) for details on various ways to build your dev client and the limitations.
+<BoxLink
+  title="Build on EAS"
+  description="How to create your Development Build on EAS"
+  href="develop/development-builds/create-a-build/"
+  Icon={BookOpen02Icon}
+/>
 
 </Step>
 

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -7,8 +7,6 @@ searchPosition: 1
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
-import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
-import { Step } from '~/ui/components/Step';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 **Development build** is the term that we use for a "Debug" build of an app that includes the [`expo-dev-client`](/versions/latest/sdk/dev-client/) library. This library augments the built-in React Native development tooling with additional capabilities, such as support for inspecting network requests and a "launcher" UI that lets you switch between different development servers (such as between a server running on your machine or a teammate's machine) and deployments of your app (such as published updates with EAS Update).

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -74,29 +74,3 @@ Expo Go can only support one SDK version at a time. When a new SDK version is re
 If you're developing on an Android Device, Android Emulator, or iOS Simulator, a compatible version of Expo Go can be [downloaded and installed](https://expo.dev/go). The only platform where this is impossible is iPhone devices because Apple does not support side-loading older versions of apps.
 
 </Collapsible>
-
-## How to convert from Expo Go to a development build
-
-To migrate from Expo Go to a development build, you'll need to:
-
-<Step label="1">
-
-### Install the `expo-dev-client`
-
-The Expo Dev Client library includes the launcher UI (shown in the screenshots below), dev menu, extensions to test updates, and more. The Expo Go app has the dev menu built in, and that's why you need to install it separately for a development build.
-
-<ContentSpotlight
-  alt="expo-dev-client launcher and menu UIs on Android and iOS."
-  src="/static/images/dev-client/preview.png"
-  caption={`When you run a development build it will look like this, only with your app name and icon included rather than "Microfoam". The launcher UI is pictured in iOS on the left and Android on the right. In between, you can see an app running inside of the development build, with the customizable developer menu open.`}
-/>
-
-</Step>
-
-<Step label="2">
-
-### Build your native app using native build tools
-
-The details on how to build the native app are platform-dependent and are covered in the [next guide](/develop/development-builds/create-a-build).
-
-</Step>

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -4,6 +4,7 @@ sidebar_title: Introduction
 description: Why use development builds and how to get started.
 searchRank: 98
 searchPosition: 1
+hideTOC: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -7,6 +7,9 @@ searchPosition: 1
 hideTOC: true
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
@@ -73,3 +76,24 @@ Expo Go can only support one SDK version at a time. When a new SDK version is re
 If you're developing on an Android Device, Android Emulator, or iOS Simulator, a compatible version of Expo Go can be [downloaded and installed](https://expo.dev/go). The only platform where this is impossible is iPhone devices because Apple does not support side-loading older versions of apps.
 
 </Collapsible>
+
+<BoxLink
+  title="Expo Go to development build"
+  description="Learn how to migrate an existing Expo Go project to using development builds"
+  href="/develop/development-builds/expo-go-to-dev-build/"
+  Icon={BookOpen02Icon}
+/>
+
+<BoxLink
+  title="Local app development"
+  description="How to build a development client on your local machine"
+  href="/guides/local-app-development"
+  Icon={BookOpen02Icon}
+/>
+
+<BoxLink
+  title="Development builds on EAS"
+  description="How to build a development client on EAS"
+  href="/develop/development-builds/create-a-build/"
+  Icon={BookOpen02Icon}
+/>


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1748907339088369

The goal is to add the following:
- a highly Googleable title
- step-by-step guide the someone could follow to convert their project
- show local builds first (to avoid the misunderstanding of having to use EAS)
- explain why the `expo-dev-client` is necessary and how to build without it
- what is prebuild
- when to run prebuild

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Add a new page with a streamlined guide for Expo Go -> Dev builds.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
<img width="1901" alt="Screenshot 2025-06-03 at 12 52 48" src="https://github.com/user-attachments/assets/805e962d-b838-428f-8a43-4fda06a0b931" />

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
