### PR TITLE
[android][camera] Fix barcode scanner coordinates and performance

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix the scenario where switching apps results in the loss of the recording video by throwing an error. ([#36854](https://github.com/expo/expo/pull/36854) by [@ladeira1](https://github.com/ladeira1))
-- [Android] Fix barcode scanner coordinates to UI mapping.
+- [Android] Fix barcode scanner coordinates to UI mapping. ([#37198](https://github.com/expo/expo/pull/37198) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix the scenario where switching apps results in the loss of the recording video by throwing an error. ([#36854](https://github.com/expo/expo/pull/36854) by [@ladeira1](https://github.com/ladeira1))
+- [Android] Fix barcode scanner coordinates to UI mapping.
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -14,6 +14,7 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.util.Size
+import kotlin.math.roundToInt
 import android.view.OrientationEventListener
 import android.view.Surface
 import android.view.View
@@ -642,32 +643,65 @@ class ExpoCameraView(
 
   private fun transformBarcodeScannerResultToViewCoordinates(barcode: BarCodeScannerResult) {
     val cornerPoints = barcode.cornerPoints
-    val previewWidth = previewView.width
-    val previewHeight = previewView.height
+    val previewWidth = previewView.width.toFloat()
+    val previewHeight = previewView.height.toFloat()
+    val imageWidth = barcode.width.toFloat()
+    val imageHeight = barcode.height.toFloat()
 
-    val facingFront = lensFacing == CameraType.FRONT
-    val portrait = getDeviceOrientation() % 2 == 0
-    val landscape = getDeviceOrientation() % 2 != 0
-
-    if (facingFront && portrait) {
-      cornerPoints.mapY { barcode.height - cornerPoints[it] }
-    }
-    if (facingFront && landscape) {
-      cornerPoints.mapX { barcode.width - cornerPoints[it] }
+    if (previewWidth <= 0 || previewHeight <= 0 || imageWidth <= 0 || imageHeight <= 0) {
+      return
     }
 
-    cornerPoints.mapX {
-      (cornerPoints[it] * previewWidth / barcode.width.toFloat())
-        .roundToInt()
+    val scaleX: Float
+    val scaleY: Float
+
+    when (previewView.scaleType) {
+      PreviewView.ScaleType.FIT_CENTER -> {
+        val previewAspectRatio = previewWidth / previewHeight
+        val imageAspectRatio = imageWidth / imageHeight
+        
+        if (previewAspectRatio > imageAspectRatio) {
+          scaleY = previewHeight / imageHeight
+          scaleX = scaleY
+        } else {
+          // Preview is taller - letterbox on top/bottom
+          scaleX = previewWidth / imageWidth
+          scaleY = scaleX
+        }
+      }
+      PreviewView.ScaleType.FILL_CENTER -> {
+        val previewAspectRatio = previewWidth / previewHeight
+        val imageAspectRatio = imageWidth / imageHeight
+        
+        if (previewAspectRatio > imageAspectRatio) {
+          // Preview is wider - scale to fill width, crop top/bottom
+          scaleX = previewWidth / imageWidth
+          scaleY = scaleX
+        } else {
+          // Preview is taller - scale to fill height, crop left/right
+          scaleY = previewHeight / imageHeight
+          scaleX = scaleY
+        }
+      }
+      else -> {
+        scaleX = previewWidth / imageWidth
+        scaleY = previewHeight / imageHeight
+      }
     }
-    cornerPoints.mapY {
-      (cornerPoints[it] * previewHeight / barcode.height.toFloat())
-        .roundToInt()
+
+    cornerPoints.mapX { index ->
+      val originalX = cornerPoints[index]
+      (originalX * scaleX).roundToInt()
+    }
+    
+    cornerPoints.mapY { index ->
+      val originalY = cornerPoints[index]
+      (originalY * scaleY).roundToInt()
     }
 
     barcode.cornerPoints = cornerPoints
-    barcode.height = height
-    barcode.width = width
+    barcode.height = previewHeight.toInt()
+    barcode.width = previewWidth.toInt()
   }
 
   private fun getCornerPointsAndBoundingBox(

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -86,7 +86,6 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.lang.Float.max
 import java.lang.Float.min
-import kotlin.math.roundToInt
 import kotlin.properties.Delegates
 
 const val ANIMATION_FAST_MILLIS = 50L
@@ -659,7 +658,7 @@ class ExpoCameraView(
       PreviewView.ScaleType.FIT_CENTER -> {
         val previewAspectRatio = previewWidth / previewHeight
         val imageAspectRatio = imageWidth / imageHeight
-        
+
         if (previewAspectRatio > imageAspectRatio) {
           scaleY = previewHeight / imageHeight
           scaleX = scaleY
@@ -672,7 +671,7 @@ class ExpoCameraView(
       PreviewView.ScaleType.FILL_CENTER -> {
         val previewAspectRatio = previewWidth / previewHeight
         val imageAspectRatio = imageWidth / imageHeight
-        
+
         if (previewAspectRatio > imageAspectRatio) {
           // Preview is wider - scale to fill width, crop top/bottom
           scaleX = previewWidth / imageWidth
@@ -693,7 +692,7 @@ class ExpoCameraView(
       val originalX = cornerPoints[index]
       (originalX * scaleX).roundToInt()
     }
-    
+
     cornerPoints.mapY { index ->
       val originalY = cornerPoints[index]
       (originalY * scaleY).roundToInt()

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/analyzers/BarcodeAnalyzer.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/analyzers/BarcodeAnalyzer.kt
@@ -44,12 +44,15 @@ class BarcodeAnalyzer(private val lensFacing: CameraType, formats: List<BarcodeT
           val barcode = barcodes.first()
           val raw = barcode.rawValue ?: barcode.rawBytes?.let { String(it) }
 
-          val cornerPoints = mutableListOf<Int>()
-          barcode.cornerPoints?.let { points ->
-            for (point in points) {
-              cornerPoints.addAll(listOf(point.x, point.y))
-            }
-          }
+          val cornerPoints = barcode.cornerPoints?.let { points ->
+            // Pre-allocate array
+            IntArray(points.size * 2).apply {
+              points.forEachIndexed { index, point ->
+                this[index * 2] = point.x
+                this[index * 2 + 1] = point.y
+              }
+            }.toList()
+          } ?: emptyList()
 
           val extra = BarCodeScannerResultSerializer.parseExtraDate(barcode)
           onComplete(
@@ -58,7 +61,7 @@ class BarcodeAnalyzer(private val lensFacing: CameraType, formats: List<BarcodeT
               barcode.displayValue,
               raw,
               extra,
-              cornerPoints,
+              cornerPoints.toMutableList(),
               imageProxy.width,
               imageProxy.height
             )
@@ -74,14 +77,17 @@ class BarcodeAnalyzer(private val lensFacing: CameraType, formats: List<BarcodeT
   }
 }
 
-private fun ByteBuffer.toByteArray(): ByteArray {
-  rewind()
-  val data = ByteArray(remaining())
-  get(data)
-  return data
+fun Array<ImageProxy.PlaneProxy>.toByteArray(): ByteArray {
+  val totalSize = this.sumOf { it.buffer.remaining() }
+  val result = ByteArray(totalSize)
+  var offset = 0
+  
+  for (plane in this) {
+    val buffer = plane.buffer
+    val size = buffer.remaining()
+    buffer.get(result, offset, size)
+    offset += size
+  }
+  
+  return result
 }
-
-fun Array<ImageProxy.PlaneProxy>.toByteArray() = this.fold(mutableListOf<Byte>()) { acc, plane ->
-  acc.addAll(plane.buffer.toByteArray().toList())
-  acc
-}.toByteArray()

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/analyzers/BarcodeAnalyzer.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/analyzers/BarcodeAnalyzer.kt
@@ -12,7 +12,6 @@ import expo.modules.camera.CameraViewHelper
 import expo.modules.camera.records.BarcodeType
 import expo.modules.camera.records.CameraType
 import expo.modules.camera.utils.BarCodeScannerResult
-import java.nio.ByteBuffer
 
 @OptIn(ExperimentalGetImage::class)
 class BarcodeAnalyzer(private val lensFacing: CameraType, formats: List<BarcodeType>, val onComplete: (BarCodeScannerResult) -> Unit) : ImageAnalysis.Analyzer {
@@ -81,13 +80,13 @@ fun Array<ImageProxy.PlaneProxy>.toByteArray(): ByteArray {
   val totalSize = this.sumOf { it.buffer.remaining() }
   val result = ByteArray(totalSize)
   var offset = 0
-  
+
   for (plane in this) {
     val buffer = plane.buffer
     val size = buffer.remaining()
     buffer.get(result, offset, size)
     offset += size
   }
-  
+
   return result
 }

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/analyzers/BarcodeAnalyzer.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/analyzers/BarcodeAnalyzer.kt
@@ -50,8 +50,8 @@ class BarcodeAnalyzer(private val lensFacing: CameraType, formats: List<BarcodeT
                 this[index * 2] = point.x
                 this[index * 2 + 1] = point.y
               }
-            }.toList()
-          } ?: emptyList()
+            }.toMutableList()
+          } ?: mutableListOf()
 
           val extra = BarCodeScannerResultSerializer.parseExtraDate(barcode)
           onComplete(
@@ -60,7 +60,7 @@ class BarcodeAnalyzer(private val lensFacing: CameraType, formats: List<BarcodeT
               barcode.displayValue,
               raw,
               extra,
-              cornerPoints.toMutableList(),
+              cornerPoints,
               imageProxy.width,
               imageProxy.height
             )

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt
@@ -255,7 +255,7 @@ class ResolveTakenPicture(
     if (angle == 0 && !mirror) {
       return source
     }
-    
+
     val matrix = Matrix()
     matrix.apply {
       postRotate(angle.toFloat())
@@ -263,7 +263,7 @@ class ResolveTakenPicture(
         postScale(-1f, 1f)
       }
     }
-    
+
     return try {
       val transformed = Bitmap.createBitmap(source, 0, 0, source.width, source.height, matrix, true)
       if (transformed != source && !source.isRecycled) {

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt
@@ -250,6 +250,12 @@ class ResolveTakenPicture(
 
   private fun decodeAndRotateBitmap(imageData: ByteArray, angle: Int, options: BitmapFactory.Options): Bitmap {
     val source = BitmapFactory.decodeByteArray(imageData, 0, imageData.size, options)
+
+    // Skip transformation if no rotation or mirroring needed
+    if (angle == 0 && !mirror) {
+      return source
+    }
+    
     val matrix = Matrix()
     matrix.apply {
       postRotate(angle.toFloat())
@@ -257,7 +263,16 @@ class ResolveTakenPicture(
         postScale(-1f, 1f)
       }
     }
-    return Bitmap.createBitmap(source, 0, 0, source.width, source.height, matrix, true)
+    
+    return try {
+      val transformed = Bitmap.createBitmap(source, 0, 0, source.width, source.height, matrix, true)
+      if (transformed != source && !source.isRecycled) {
+        source.recycle()
+      }
+      transformed
+    } catch (e: OutOfMemoryError) {
+      source
+    }
   }
 
   // Get rotation degrees from Exif orientation enum

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/utils/BarCodeScannerListMappers.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/utils/BarCodeScannerListMappers.kt
@@ -1,12 +1,12 @@
 package expo.modules.camera.utils
 
-inline fun MutableList<Int>.mapY(block: (it: Int) -> Int) {
+inline fun MutableList<Int>.mapX(block: (it: Int) -> Int) {
   for (it in 0 until this.size step 2) {
     this[it] = block(it)
   }
 }
 
-inline fun MutableList<Int>.mapX(block: (it: Int) -> Int) {
+inline fun MutableList<Int>.mapY(block: (it: Int) -> Int) {
   for (it in 1 until this.size step 2) {
     this[it] = block(it)
   }


### PR DESCRIPTION
# Why
Fixes a long standing issue with the barcode scanners corner points coordinates on android. They were not mapped correctly to the UI. Also made some minor performance improvements

# How
We were not taking the scale in to account when transforming the corner points. 

# Test Plan
Bare-expo. The SVG now maps on top of the image correctly. There is still some drift during motion that I will follow up on if I find a fix. 

