### PR TITLE
feat(cli): Implement experimental sticky native module Metro resolution

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Enable async require by default. ([#36405](https://github.com/expo/expo/pull/36405) by [@EvanBacon](https://github.com/EvanBacon))
 - Support JSON output for install check. ([#37318](https://github.com/expo/expo/pull/37318) by [@betomoedano](https://github.com/betomoedano))
+- Add `EXPO_USE_STICKY_RESOLVER` to enable experimental sticky resolution to native modules ([#37201](https://github.com/expo/expo/pull/37201) by [@kitten](https://github.com/kitten))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/createExpoStickyResolver.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/createExpoStickyResolver.test.ts
@@ -1,0 +1,37 @@
+import { _dependenciesToRegex } from '../createExpoStickyResolver';
+
+// NOTE(@kitten): This tests converting and matching dependencies from a generated regex
+// To see a more complete test for `createStickyModuleResolver` itself, see: withMetroMultiPlatform.test.ts
+describe(_dependenciesToRegex, () => {
+  it.each([
+    // Positive tests: dependencyName, input, [match1, match2]
+    ['react', 'react', ['react', '']],
+    ['react-dom', 'react-dom', ['react-dom', '']],
+    ['react-dom', 'react-dom/test', ['react-dom', '/test']],
+    ['@babel/runtime', '@babel/runtime', ['@babel/runtime', '']],
+    ['@babel/runtime', '@babel/runtime/helpers/test', ['@babel/runtime', '/helpers/test']],
+    ['library.js', 'library.js', ['library.js', '']],
+    ['library.js', 'library.js/test', ['library.js', '/test']],
+    ['a_dep', 'a_dep', ['a_dep', '']],
+
+    // Negative tests: dependencyName, input, `null`
+    ['react', 'react-dom', null],
+    ['react-dom', './react-dom', null],
+    ['react-dom', '/react-dom', null],
+    ['@babel/runtime', '@babel/helpers', null],
+    ['@babel/runtime', '@babel/helpers/test', null],
+    ['library.js', 'anything', null],
+  ])('expect dependency %s with match "%s" to output `%s`', (dependencyName, input, match) => {
+    const re = _dependenciesToRegex([dependencyName]);
+    let exec = re.exec(input);
+    if (match !== null) {
+      expect(exec?.[0]).toEqual(input);
+      expect(exec?.[1]).toEqual(match[0]);
+      expect(exec?.[2]).toEqual(match[1]);
+      exec = re.exec('');
+      expect(exec).toEqual(null);
+    } else {
+      expect(exec).toEqual(null);
+    }
+  });
+});

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -1228,8 +1228,8 @@ describe(withExtendedResolver, () => {
         },
       });
 
-      jest.mocked(getResolveFunc()).mockImplementation((_context, moduleName, _platform) => {
-        return { type: 'sourceFile', filePath: moduleName };
+      jest.mocked(getResolveFunc()).mockImplementation((context, moduleName, _platform) => {
+        return { type: 'sourceFile', filePath: context.originModulePath };
       });
 
       // Supports bare module name
@@ -1244,6 +1244,12 @@ describe(withExtendedResolver, () => {
         type: 'sourceFile',
       });
 
+      expect(getResolveFunc()).toHaveBeenLastCalledWith(
+        expect.objectContaining({ originModulePath: '/sticky/expo-router' }),
+        'expo-router',
+        platform
+      );
+
       // Supports sub-path module name
       result = modified.resolver.resolveRequest!(
         getDefaultRequestContext(),
@@ -1252,9 +1258,15 @@ describe(withExtendedResolver, () => {
       );
       expect(getResolveFunc()).toHaveBeenCalledTimes(2);
       expect(result).toEqual({
-        filePath: '/sticky/expo-router/file',
+        filePath: '/sticky/expo-router',
         type: 'sourceFile',
       });
+
+      expect(getResolveFunc()).toHaveBeenLastCalledWith(
+        expect.objectContaining({ originModulePath: '/sticky/expo-router' }),
+        'expo-router/file',
+        platform
+      );
     });
   });
 });

--- a/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
@@ -13,7 +13,7 @@ const escapeDependencyName = (dependency: string) =>
   dependency.replace(/[*.?()[\]]/g, (x) => `\\${x}`);
 
 /** Converts a list of module names to a regex that may either match bare module names or sub-modules of modules */
-const dependenciesToRegex = (dependencies: string[]) =>
+export const _dependenciesToRegex = (dependencies: string[]) =>
   new RegExp(`^(${dependencies.map(escapeDependencyName).join('|')})($|/.*)`);
 
 /** Creates a function to load a dependency of the `expo` package */
@@ -102,7 +102,7 @@ const getPlatformModuleDescription = async (
   );
   return {
     platform,
-    moduleTestRe: dependenciesToRegex(resolvedModuleNames),
+    moduleTestRe: _dependenciesToRegex(resolvedModuleNames),
     resolvedModulePaths,
   };
 };

--- a/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
@@ -40,14 +40,19 @@ const getPlatformModuleDescription = async (
     await autolinking.mergeLinkingOptionsAsync({
       searchPaths: [],
       projectRoot,
-      platform,
+      platform: platform === 'ios' ? 'apple' : platform,
       onlyProjectDeps: true,
       silent: true,
     })
   );
+  const resolvedModulesKeys = Object.keys(resolvedModules);
+  debug(
+    `Sticky resolution for ${platform} registered ${resolvedModulesKeys.length} resolutions:`,
+    resolvedModulesKeys
+  );
   return {
     platform,
-    moduleTestRe: dependenciesToRegex(Object.keys(resolvedModules)),
+    moduleTestRe: dependenciesToRegex(resolvedModulesKeys),
     resolvedModulePaths: Object.fromEntries(
       Object.entries(resolvedModules).map(([key, entry]) => [key, entry.path])
     ),

--- a/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
@@ -54,15 +54,26 @@ export type StickyModuleResolverInput = {
   [unknownPlatform: string]: never;
 };
 
-export async function createStickyModuleResolverInput(
-  projectRoot: string
-): Promise<StickyModuleResolverInput> {
+export async function createStickyModuleResolverInput({
+  platforms,
+  projectRoot,
+}: {
+  projectRoot: string;
+  platforms: string[];
+}): Promise<StickyModuleResolverInput> {
   return Object.fromEntries(
     await Promise.all(
-      AUTOLINKING_PLATFORMS.map(async (platform) => {
-        const platformModuleDescription = await getPlatformModuleDescription(projectRoot, platform);
-        return [platformModuleDescription.platform, platformModuleDescription] as const;
-      })
+      platforms
+        .filter((platform): platform is AutolinkingPlatform =>
+          AUTOLINKING_PLATFORMS.includes(platform as any)
+        )
+        .map(async (platform) => {
+          const platformModuleDescription = await getPlatformModuleDescription(
+            projectRoot,
+            platform
+          );
+          return [platformModuleDescription.platform, platformModuleDescription] as const;
+        })
     )
   ) as StickyModuleResolverInput;
 }

--- a/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
@@ -104,9 +104,7 @@ const getPlatformModuleDescription = async (
 };
 
 export type StickyModuleResolverInput = {
-  [platform in AutolinkingPlatform]: PlatformModuleDescription;
-} & {
-  [unknownPlatform: string]: never;
+  [platform in AutolinkingPlatform]?: PlatformModuleDescription;
 };
 
 export async function createStickyModuleResolverInput({
@@ -143,7 +141,7 @@ export function createStickyModuleResolver(
 
   const fileSpecifierRe = /^[\\/]|^\.\.?(?:$|[\\/])/i;
   const isAutolinkingPlatform = (platform: string | null): platform is AutolinkingPlatform =>
-    !!platform && !!input[platform];
+    !!platform && (input as any)[platform] != null;
 
   return function requestStickyModule(context, moduleName, platform) {
     if (!isAutolinkingPlatform(platform)) {
@@ -152,7 +150,7 @@ export function createStickyModuleResolver(
       return null;
     }
 
-    const moduleDescription = input[platform];
+    const moduleDescription = input[platform]!;
     const moduleMatch = moduleDescription.moduleTestRe.exec(moduleName);
     if (moduleMatch) {
       const resolvedModulePath =

--- a/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
@@ -1,0 +1,98 @@
+import type { StrictResolverFactory } from './withMetroMultiPlatform';
+import type { ExpoCustomMetroResolver } from './withMetroResolvers';
+
+const debug = require('debug')('expo:start:server:metro:sticky-resolver') as typeof console.log;
+
+// TODO(@kitten): Set to all supported platforms then filter by `config.resolver.platforms`
+const AUTOLINKING_PLATFORMS = ['android', 'ios', 'web'] as const;
+type AutolinkingPlatform = (typeof AUTOLINKING_PLATFORMS)[number];
+
+/** Converts a list of module names to a regex that may either match bare module names or sub-modules of modules */
+const dependenciesToRegex = (dependencies: string[]) =>
+  new RegExp(`^(${dependencies.join('|')})($|/.*)`);
+
+const getAutolinkingModule = (): typeof import('expo-modules-autolinking/exports') => {
+  const expoPath = require.resolve('expo/package.json');
+  const autolinkingPath = require.resolve('expo-modules-autolinking/exports', {
+    paths: [expoPath],
+  });
+  return require(autolinkingPath);
+};
+
+interface PlatformModuleDescription {
+  platform: AutolinkingPlatform;
+  moduleTestRe: RegExp;
+  resolvedModulePaths: Record<string, string>;
+}
+
+const getPlatformModuleDescription = async (
+  projectRoot: string,
+  platform: AutolinkingPlatform
+): Promise<PlatformModuleDescription> => {
+  const autolinking = getAutolinkingModule();
+  const resolvedModules = await autolinking.findModulesAsync(
+    await autolinking.mergeLinkingOptionsAsync({
+      searchPaths: [],
+      projectRoot,
+      platform,
+      onlyProjectDeps: true,
+      silent: true,
+    })
+  );
+  return {
+    platform,
+    moduleTestRe: dependenciesToRegex(Object.keys(resolvedModules)),
+    resolvedModulePaths: Object.fromEntries(
+      Object.entries(resolvedModules).map(([key, entry]) => [key, entry.path])
+    ),
+  };
+};
+
+export type StickyModuleResolverInput = {
+  [platform in AutolinkingPlatform]: PlatformModuleDescription;
+} & {
+  [unknownPlatform: string]: never;
+};
+
+export async function createStickyModuleResolverInput(
+  projectRoot: string
+): Promise<StickyModuleResolverInput> {
+  return Object.fromEntries(
+    await Promise.all(
+      AUTOLINKING_PLATFORMS.map(async (platform) => {
+        const platformModuleDescription = await getPlatformModuleDescription(projectRoot, platform);
+        return [platformModuleDescription.platform, platformModuleDescription] as const;
+      })
+    )
+  ) as StickyModuleResolverInput;
+}
+
+export function createStickyModuleResolver(
+  input: StickyModuleResolverInput,
+  getStrictResolver: StrictResolverFactory
+): ExpoCustomMetroResolver {
+  const fileSpecifierRe = /^[\\/]|^\.\.?(?:$|[\\/])/i;
+  const isAutolinkingPlatform = (platform: string | null): platform is AutolinkingPlatform =>
+    !!platform && !!input[platform];
+
+  return function requestStickyModule(context, moduleName, platform) {
+    if (!isAutolinkingPlatform(platform)) {
+      return null;
+    } else if (fileSpecifierRe.test(moduleName)) {
+      return null;
+    }
+
+    const moduleDescription = input[platform];
+    const moduleMatch = moduleDescription.moduleTestRe.exec(moduleName);
+    if (moduleMatch) {
+      const resolvedModulePath =
+        moduleDescription.resolvedModulePaths[moduleMatch[1]] || moduleName;
+      const resolvedModuleRequest = resolvedModulePath + (moduleMatch[2] || '');
+      const res = getStrictResolver(context, platform)(resolvedModuleRequest);
+      debug(`Sticky resolution for ${platform}: ${moduleName} -> ${resolvedModuleRequest}`);
+      return res;
+    }
+
+    return null;
+  };
+}

--- a/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
@@ -10,20 +10,24 @@ type AutolinkingPlatform = (typeof AUTOLINKING_PLATFORMS)[number];
 const dependenciesToRegex = (dependencies: string[]) =>
   new RegExp(`^(${dependencies.join('|')})($|/.*)`);
 
-/** Requires `expo-modules-autolinking/exports` via the `expo` package which depends on it */
-const getAutolinkingModule = (() => {
-  let autolinkingModule: typeof import('expo-modules-autolinking/exports') | undefined;
-  return (): typeof import('expo-modules-autolinking/exports') => {
-    if (!autolinkingModule) {
+/** Creates a function to load a dependency of the `expo` package */
+const createExpoDependencyLoader = <T>(request: string) => {
+  let mod: T | undefined;
+  return (): T => {
+    if (!mod) {
       const expoPath = require.resolve('expo/package.json');
-      const autolinkingPath = require.resolve('expo-modules-autolinking/exports', {
+      const autolinkingPath = require.resolve(request, {
         paths: [expoPath],
       });
-      return (autolinkingModule = require(autolinkingPath));
+      return (mod = require(autolinkingPath));
     }
-    return autolinkingModule;
+    return mod;
   };
-})();
+};
+
+const getAutolinkingModule = createExpoDependencyLoader<
+  typeof import('expo-modules-autolinking/exports')
+>('expo-modules-autolinking/exports');
 
 interface PlatformModuleDescription {
   platform: AutolinkingPlatform;

--- a/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
@@ -10,13 +10,20 @@ type AutolinkingPlatform = (typeof AUTOLINKING_PLATFORMS)[number];
 const dependenciesToRegex = (dependencies: string[]) =>
   new RegExp(`^(${dependencies.join('|')})($|/.*)`);
 
-const getAutolinkingModule = (): typeof import('expo-modules-autolinking/exports') => {
-  const expoPath = require.resolve('expo/package.json');
-  const autolinkingPath = require.resolve('expo-modules-autolinking/exports', {
-    paths: [expoPath],
-  });
-  return require(autolinkingPath);
-};
+/** Requires `expo-modules-autolinking/exports` via the `expo` package which depends on it */
+const getAutolinkingModule = (() => {
+  let autolinkingModule: typeof import('expo-modules-autolinking/exports') | undefined;
+  return (): typeof import('expo-modules-autolinking/exports') => {
+    if (!autolinkingModule) {
+      const expoPath = require.resolve('expo/package.json');
+      const autolinkingPath = require.resolve('expo-modules-autolinking/exports', {
+        paths: [expoPath],
+      });
+      return (autolinkingModule = require(autolinkingPath));
+    }
+    return autolinkingModule;
+  };
+})();
 
 interface PlatformModuleDescription {
   platform: AutolinkingPlatform;

--- a/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
@@ -3,7 +3,6 @@ import type { ExpoCustomMetroResolver } from './withMetroResolvers';
 
 const debug = require('debug')('expo:start:server:metro:sticky-resolver') as typeof console.log;
 
-// TODO(@kitten): Set to all supported platforms then filter by `config.resolver.platforms`
 const AUTOLINKING_PLATFORMS = ['android', 'ios', 'web'] as const;
 type AutolinkingPlatform = (typeof AUTOLINKING_PLATFORMS)[number];
 
@@ -79,9 +78,13 @@ export async function createStickyModuleResolverInput({
 }
 
 export function createStickyModuleResolver(
-  input: StickyModuleResolverInput,
-  getStrictResolver: StrictResolverFactory
-): ExpoCustomMetroResolver {
+  input: StickyModuleResolverInput | undefined,
+  { getStrictResolver }: { getStrictResolver: StrictResolverFactory }
+): ExpoCustomMetroResolver | undefined {
+  if (!input) {
+    return undefined;
+  }
+
   const fileSpecifierRe = /^[\\/]|^\.\.?(?:$|[\\/])/i;
   const isAutolinkingPlatform = (platform: string | null): platform is AutolinkingPlatform =>
     !!platform && !!input[platform];

--- a/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
@@ -9,9 +9,12 @@ const debug = require('debug')('expo:start:server:metro:sticky-resolver') as typ
 const AUTOLINKING_PLATFORMS = ['android', 'ios', 'web'] as const;
 type AutolinkingPlatform = (typeof AUTOLINKING_PLATFORMS)[number];
 
+const escapeDependencyName = (dependency: string) =>
+  dependency.replace(/[*.?()[\]]/g, (x) => `\\${x}`);
+
 /** Converts a list of module names to a regex that may either match bare module names or sub-modules of modules */
 const dependenciesToRegex = (dependencies: string[]) =>
-  new RegExp(`^(${dependencies.join('|')})($|/.*)`);
+  new RegExp(`^(${dependencies.map(escapeDependencyName).join('|')})($|/.*)`);
 
 /** Creates a function to load a dependency of the `expo` package */
 const createExpoDependencyLoader = <T>(request: string) => {

--- a/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
@@ -72,6 +72,8 @@ const getReactNativeConfigResolutions = async (
     // NOTE(@kitten): web will use ios here. This is desired since this function only accepts android|ios.
     // However, we'd still like to sticky resolve dependencies for web
     platform: opts.platform === 'android' ? 'android' : 'ios',
+    // TODO(@kitten): Unclear if this should be populated or directly relates to sticky resolution
+    transitiveLinkingDependencies: [],
   });
   return Object.fromEntries(
     Object.entries(configResult.dependencies).map(([key, entry]) => [key, entry.root])

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -159,6 +159,7 @@ export async function loadMetroConfigAsync(
     exp,
     platformBundlers,
     isTsconfigPathsEnabled: exp.experiments?.tsconfigPaths ?? true,
+    isStickyResolverEnabled: env.EXPO_USE_STICKY_RESOLVER,
     isFastResolverEnabled: env.EXPO_USE_FAST_RESOLVER,
     isExporting,
     isReactCanaryEnabled,

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -618,8 +618,9 @@ export function withExtendedResolver(
       return null;
     },
 
-    stickyModuleResolverInput &&
-      createStickyModuleResolver(stickyModuleResolverInput, getStrictResolver),
+    createStickyModuleResolver(stickyModuleResolverInput, {
+      getStrictResolver,
+    }),
 
     // TODO: Reduce these as much as possible in the future.
     // Complex post-resolution rewrites.

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -176,6 +176,9 @@ export function withExtendedResolver(
   if (isFastResolverEnabled) {
     Log.log(chalk.dim`Fast resolver is enabled.`);
   }
+  if (stickyModuleResolverInput) {
+    Log.log(chalk.dim`Sticky resolver is enabled.`);
+  }
 
   const defaultResolver = metroResolver.resolve;
   const resolver = isFastResolverEnabled
@@ -820,6 +823,7 @@ export async function withMetroMultiPlatformAsync(
     exp,
     platformBundlers,
     isTsconfigPathsEnabled,
+    isStickyResolverEnabled,
     isFastResolverEnabled,
     isExporting,
     isReactCanaryEnabled,
@@ -831,6 +835,7 @@ export async function withMetroMultiPlatformAsync(
     exp: ExpoConfig;
     isTsconfigPathsEnabled: boolean;
     platformBundlers: PlatformBundlers;
+    isStickyResolverEnabled?: boolean;
     isFastResolverEnabled?: boolean;
     isExporting?: boolean;
     isReactCanaryEnabled: boolean;
@@ -900,11 +905,13 @@ export async function withMetroMultiPlatformAsync(
 
   config = withWebPolyfills(config, { getMetroBundler });
 
-  // TODO(@kitten): Add flag to enable this instead of it being always on
-  const stickyModuleResolverInput = await createStickyModuleResolverInput({
-    platforms: expoConfigPlatforms,
-    projectRoot,
-  });
+  let stickyModuleResolverInput: StickyModuleResolverInput | undefined;
+  if (isStickyResolverEnabled) {
+    stickyModuleResolverInput = await createStickyModuleResolverInput({
+      platforms: expoConfigPlatforms,
+      projectRoot,
+    });
+  }
 
   return withExtendedResolver(config, {
     stickyModuleResolverInput,

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -900,7 +900,10 @@ export async function withMetroMultiPlatformAsync(
   config = withWebPolyfills(config, { getMetroBundler });
 
   // TODO(@kitten): Add flag to enable this instead of it being always on
-  const stickyModuleResolverInput = await createStickyModuleResolverInput(projectRoot);
+  const stickyModuleResolverInput = await createStickyModuleResolverInput({
+    platforms: expoConfigPlatforms,
+    projectRoot,
+  });
 
   return withExtendedResolver(config, {
     stickyModuleResolverInput,

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -16,6 +16,11 @@ import resolveFrom from 'resolve-from';
 
 import { createFallbackModuleResolver } from './createExpoFallbackResolver';
 import { createFastResolver, FailedToResolvePathError } from './createExpoMetroResolver';
+import {
+  createStickyModuleResolverInput,
+  createStickyModuleResolver,
+  StickyModuleResolverInput,
+} from './createExpoStickyResolver';
 import { isNodeExternal, shouldCreateVirtualCanary, shouldCreateVirtualShim } from './externals';
 import { isFailedToResolveNameError, isFailedToResolvePathError } from './metroErrors';
 import { getMetroBundlerWithVirtualModules } from './metroVirtualModules';
@@ -144,6 +149,7 @@ export function withExtendedResolver(
   config: ConfigT,
   {
     tsconfig,
+    stickyModuleResolverInput,
     isTsconfigPathsEnabled,
     isFastResolverEnabled,
     isExporting,
@@ -152,6 +158,7 @@ export function withExtendedResolver(
     getMetroBundler,
   }: {
     tsconfig: TsConfigPaths | null;
+    stickyModuleResolverInput?: StickyModuleResolverInput;
     isTsconfigPathsEnabled?: boolean;
     isFastResolverEnabled?: boolean;
     isExporting?: boolean;
@@ -611,6 +618,9 @@ export function withExtendedResolver(
       return null;
     },
 
+    stickyModuleResolverInput &&
+      createStickyModuleResolver(stickyModuleResolverInput, getStrictResolver),
+
     // TODO: Reduce these as much as possible in the future.
     // Complex post-resolution rewrites.
     function requestPostRewrites(
@@ -889,7 +899,11 @@ export async function withMetroMultiPlatformAsync(
 
   config = withWebPolyfills(config, { getMetroBundler });
 
+  // TODO(@kitten): Add flag to enable this instead of it being always on
+  const stickyModuleResolverInput = await createStickyModuleResolverInput(projectRoot);
+
   return withExtendedResolver(config, {
+    stickyModuleResolverInput,
     tsconfig,
     isExporting,
     isTsconfigPathsEnabled,

--- a/packages/@expo/cli/src/start/server/metro/withMetroResolvers.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroResolvers.ts
@@ -46,8 +46,9 @@ function optionsKeyForContext(context: ResolutionContext) {
  */
 export function withMetroResolvers(
   config: MetroConfig,
-  resolvers: ExpoCustomMetroResolver[]
+  inputResolvers: (ExpoCustomMetroResolver | undefined)[]
 ): MetroConfig {
+  const resolvers = inputResolvers.filter((x) => x != null);
   debug(
     `Appending ${
       resolvers.length

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -161,6 +161,11 @@ class Env {
     return boolish('EXPO_METRO_UNSTABLE_ERRORS', false);
   }
 
+  /** Enable the experimental sticky resolver for Metro. */
+  get EXPO_USE_STICKY_RESOLVER() {
+    return boolish('EXPO_USE_STICKY_RESOLVER', false);
+  }
+
   /** Enable the unstable fast resolver for Metro. */
   get EXPO_USE_FAST_RESOLVER() {
     return boolish('EXPO_USE_FAST_RESOLVER', false);


### PR DESCRIPTION
# Why

`expo-modules-autolinking` resolves Expo modules and React Native modules which may be duplicated in the dependency tree. While this doesn't cause issues in native autolinking, since duplicates are detected and discarded, Metro itself isn't aware of this.

This introduces several challenges for our usual Metro resolution, since two installations of the same dependency may be bundled. This means that while the autolinking process may link a single instance of any given native module into the native app, the JS bundle may contain multiple versions of it. This is an error that's hard to detect for our users and leads to inconsistencies when making dependency changes.

Usually dependencies are duplicated due to:
- auto-installing peer dependencies, particularly with npm
- occasionally during dependency installation and upgrades with Yarn Classic
- due to hoisting errors with Yarn Berry
- due to pnpm isolated dependencies or other monorepo setups when no dedup has been run

While we can also add detection for this in `expo install --check` and offer deduplication, resolving dependencies in line with autolinking in Metro itself has other benefits:
- this matches the expectation that native modules can only be bundled exactly once
- prevents users from running unsupported deduplication tools
- increases trust in their lockfiles and gradual updates
- prevents many SDK upgrades from failing outright

# How

The implementation is similar to the `aliasResolver` and the `fallbackResolver`. However, since `expo-modules-autolinking` is asynchronous and resolvers in Metro aren't, resolution is split up into two steps.

In the first step, we run Expo Modules autolinking (via `findModulesAsync`; `expo-modules-autolinking search`) and React Native autolinking (via `createReactNativeConfigAsync`; `expo-modules-autolinking react-native-config`) ahead of time. This creates a configuration per platform with a regular expression matching sticky modules and a mapping for their absolute paths.

In the second step, this is passed on to the sticky resolver itself, which uses it on module imports/requires and resolves them from the absolute path. This is similar to the `requestAlias` resolver and not an entirely new concept for our custom resolvers.

This logic is only enabled when `EXPO_USE_STICKY_RESOLVER` is enabled.

### Follow-up opportunities

The `expo-modules-autolinking` logic could use some improvements:
- I'd love for it not to allow all autolinking options per platform. Allowing `searchPaths` and `ignorePaths` per platform seems counter-intuitive, since `excludes` already exists. This makes module discovery in the CLI more complicated than it needs to be
- This enables us, in theory, to make autolinking consistent. We could update `react-native-config` and `search` to be combined, i.e. for the former to use the same logic and to allow for transitive dependencies

# Test Plan

- [x] tested against `bycedric/expo-monorepo-example`
- [x] tested against a freshly created Expo app
- [x] verified output from `DEBUG=expo:start:server:metro:sticky-resolver` manually
- [x] unit test for the sticky resolver itself
- [ ] tested against a "broken" monorepo example

I did a test on a non-monorepo project with `DEBUG=expo:start:server:metro:sticky-resolver`. This provides output that verifies which native modules were detected and output for each sticky resolution as it happens.
The time it takes for exports to complete seems to not have changed.

We should test this against invalid projects. We currently don't have an example for this, but since this option is experimental, if we're confident it'll not break anything, this will be testable gradually. An initial test would be to create a monorepo, then manually add a pinned expo module dependency that duplicates another to a local package that's included in the app.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
