### PR TITLE
[template] Fix scroll inset in default template

### DIFF
--- a/templates/expo-template-default/app/(tabs)/_layout.tsx
+++ b/templates/expo-template-default/app/(tabs)/_layout.tsx
@@ -4,7 +4,7 @@ import { Platform } from 'react-native';
 
 import { HapticTab } from '@/components/HapticTab';
 import { IconSymbol } from '@/components/ui/IconSymbol';
-import TabBarBackground from '@/components/ui/TabBarBackground';
+import { TabBarBackground } from '@/components/ui/TabBarBackground';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 

--- a/templates/expo-template-default/components/ParallaxScrollView.tsx
+++ b/templates/expo-template-default/components/ParallaxScrollView.tsx
@@ -26,7 +26,7 @@ export default function ParallaxScrollView({
   const colorScheme = useColorScheme() ?? 'light';
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
   const scrollOffset = useScrollViewOffset(scrollRef);
-  const bottom = useBottomTabOverflow();
+  const { scrollInsetBottom, paddingBottom } = useBottomTabOverflow();
   const headerAnimatedStyle = useAnimatedStyle(() => {
     return {
       transform: [
@@ -49,8 +49,8 @@ export default function ParallaxScrollView({
       <Animated.ScrollView
         ref={scrollRef}
         scrollEventThrottle={16}
-        scrollIndicatorInsets={{ bottom }}
-        contentContainerStyle={{ paddingBottom: bottom }}>
+        scrollIndicatorInsets={{ bottom: scrollInsetBottom }}
+        contentContainerStyle={{ paddingBottom }}>
         <Animated.View
           style={[
             styles.header,

--- a/templates/expo-template-default/components/ui/TabBarBackground.ios.tsx
+++ b/templates/expo-template-default/components/ui/TabBarBackground.ios.tsx
@@ -2,7 +2,7 @@ import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { BlurView } from 'expo-blur';
 import { StyleSheet } from 'react-native';
 
-export default function BlurTabBarBackground() {
+export function TabBarBackground() {
   return (
     <BlurView
       // System chrome material automatically adapts to the system's theme

--- a/templates/expo-template-default/components/ui/TabBarBackground.ios.tsx
+++ b/templates/expo-template-default/components/ui/TabBarBackground.ios.tsx
@@ -1,6 +1,7 @@
-import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { BlurView } from 'expo-blur';
 import { StyleSheet } from 'react-native';
+import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export function TabBarBackground() {
   return (
@@ -15,5 +16,11 @@ export function TabBarBackground() {
 }
 
 export function useBottomTabOverflow() {
-  return useBottomTabBarHeight();
+  const insets = useSafeAreaInsets();
+  const tabBarHeight = useBottomTabBarHeight();
+
+  return {
+    scrollInsetBottom: tabBarHeight - insets.bottom,
+    paddingBottom: tabBarHeight,
+  };
 }

--- a/templates/expo-template-default/components/ui/TabBarBackground.ios.tsx
+++ b/templates/expo-template-default/components/ui/TabBarBackground.ios.tsx
@@ -8,7 +8,7 @@ export function TabBarBackground() {
       // System chrome material automatically adapts to the system's theme
       // and matches the native tab bar appearance on iOS.
       tint="systemChromeMaterial"
-      intensity={100}
+      intensity={70}
       style={StyleSheet.absoluteFill}
     />
   );

--- a/templates/expo-template-default/components/ui/TabBarBackground.tsx
+++ b/templates/expo-template-default/components/ui/TabBarBackground.tsx
@@ -1,6 +1,9 @@
 // This is a shim for web and Android where the tab bar is generally opaque.
-export default undefined;
+export const TabBarBackground = undefined;
 
 export function useBottomTabOverflow() {
-  return 0;
+  return {
+    scrollInsetBottom: 0,
+    paddingBottom: 0,
+  }
 }


### PR DESCRIPTION
# Why

The `scrollIndicatorInsets` was not calculated correctly for the bottom tab bar.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Use the correct calculation to set the `scrollIndicatorInsets`
- Switch to a named export for TabBarBackground
- Update the intensity of the blur view from 100 -> 70 so it shows up on light mode

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

## Before


https://github.com/user-attachments/assets/1d1e85ba-39fd-4c63-8e19-501761487069


## After



https://github.com/user-attachments/assets/bdaf1303-2120-4787-a33b-48a7dff9c60a




<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
