### PR TITLE
[docs] Add information about testing screen capture functionality

### DIFF
--- a/docs/pages/versions/unversioned/sdk/screen-capture.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.mdx
@@ -25,6 +25,8 @@ If you want to use the screen capture callback on Android 13 or lower, you need 
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 
+> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/unversioned/sdk/screen-capture.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.mdx
@@ -25,7 +25,7 @@ If you want to use the screen capture callback on Android 13 or lower, you need 
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 
-> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
+> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS Simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/screen-capture.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-capture.mdx
@@ -25,7 +25,7 @@ If you want to use the screen capture callback on Android 13 or lower, you need 
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 
-> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS Simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
+> **important** For testing screen capture functionality: On Android, testing should be done on a physical device as emulators don't properly simulate screen capture behavior. On iOS Simulator, you can trigger screenshots using **Device** > **Trigger Screenshot** from the menu bar.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/screen-capture.mdx
@@ -19,6 +19,8 @@ This is especially important on Android since the [`android.media.projection`](h
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 
+> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v51.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/screen-capture.mdx
@@ -19,7 +19,7 @@ This is especially important on Android since the [`android.media.projection`](h
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 
-> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
+> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS Simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
 
 ## Installation
 

--- a/docs/pages/versions/v51.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/screen-capture.mdx
@@ -19,7 +19,7 @@ This is especially important on Android since the [`android.media.projection`](h
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 
-> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS Simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
+> **important** For testing screen capture functionality: On Android, testing should be done on a physical device as emulators don't properly simulate screen capture behavior. On iOS Simulator, you can trigger screenshots using **Device** > **Trigger Screenshot** from the menu bar.
 
 ## Installation
 

--- a/docs/pages/versions/v52.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/screen-capture.mdx
@@ -25,6 +25,8 @@ If you want to use the screen capture callback on Android 13 or lower, you need 
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 
+> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v52.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/screen-capture.mdx
@@ -25,7 +25,7 @@ If you want to use the screen capture callback on Android 13 or lower, you need 
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 
-> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
+> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS Simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
 
 ## Installation
 

--- a/docs/pages/versions/v52.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/screen-capture.mdx
@@ -25,7 +25,7 @@ If you want to use the screen capture callback on Android 13 or lower, you need 
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 
-> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS Simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
+> **important** For testing screen capture functionality: On Android, testing should be done on a physical device as emulators don't properly simulate screen capture behavior. On iOS Simulator, you can trigger screenshots using **Device** > **Trigger Screenshot** from the menu bar.
 
 ## Installation
 

--- a/docs/pages/versions/v53.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/screen-capture.mdx
@@ -25,6 +25,8 @@ If you want to use the screen capture callback on Android 13 or lower, you need 
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 
+> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v53.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/screen-capture.mdx
@@ -25,7 +25,7 @@ If you want to use the screen capture callback on Android 13 or lower, you need 
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 
-> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
+> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS Simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
 
 ## Installation
 

--- a/docs/pages/versions/v53.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/screen-capture.mdx
@@ -25,7 +25,7 @@ If you want to use the screen capture callback on Android 13 or lower, you need 
 
 > **warning** Currently, taking screenshots on iOS cannot be prevented. This is due to underlying OS limitations.
 
-> **important** For testing screen capture functionality: On Android, testing should be done on a real device as emulators don't properly simulate screen capture behavior. On iOS Simulator, you can trigger screenshots using Device -> Trigger Screenshot in the simulator menu.
+> **important** For testing screen capture functionality: On Android, testing should be done on a physical device as emulators don't properly simulate screen capture behavior. On iOS Simulator, you can trigger screenshots using **Device** > **Trigger Screenshot** from the menu bar.
 
 ## Installation
 


### PR DESCRIPTION
# Why
Added information regarding testing screen capture functionality on Android/iOS.

# How
You can simply visit the expo-screen-capture page and verify whether the text is visible.

<img width="300" alt="Screenshot 2025-06-04 at 13 07 12" src="https://github.com/user-attachments/assets/473109dd-81dc-4656-a872-caa4879b5486" />

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
