### PR TITLE
[android] [expo-image-picker] Prevent external applications from accessing the CropImageActivity

### DIFF
--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -23,7 +23,8 @@
 
     <activity
       android:name="com.canhub.cropper.CropImageActivity"
-      android:theme="@style/Base.Theme.AppCompat" />
+      android:theme="@style/Base.Theme.AppCompat"
+      android:exported="false" />
     <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
     <provider
       android:name=".fileprovider.ImagePickerFileProvider"


### PR DESCRIPTION
# Why

This PR addresses a critical security vulnerability where the CropImageActivity in Android applications could be exploited by malicious apps to overwrite arbitrary files. The vulnerability occurs because the activity is implicitly exported, allowing unauthorized access from external applications.

# How

The fix involves adding the android:exported="false" attribute to the CropImageActivity declaration in the Android manifest file. This change prevents external applications from accessing the CropImageActivity, thereby protecting against file corruption attacks.

# Test Plan


- Install the application with the modified manifest
- Attempt to access CropImageActivity from an external application using the following exploit code:

```java
Intent intent = new Intent();
intent.setClassName("com.amazon.mp3", "com.canhub.cropper.CropImageActivity");
startActivityForResult(intent, 0);
```
- Verify that the external application cannot launch the CropImageActivity
- Verify that the legitimate image cropping functionality still works within the application itself


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
