### PR TITLE
[docs][expo-audio] Add missing useEffect import in example code

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -101,7 +101,7 @@ const styles = StyleSheet.create({
 <SnackInline label='Recording sounds' dependencies={['expo-audio', 'expo-asset']}>
 
 ```jsx
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import { useAudioRecorder, RecordingOptions, AudioModule, RecordingPresets } from 'expo-audio';
 

--- a/docs/pages/versions/v53.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/audio.mdx
@@ -101,7 +101,7 @@ const styles = StyleSheet.create({
 <SnackInline label='Recording sounds' dependencies={['expo-audio', 'expo-asset']}>
 
 ```jsx
-import { useState,useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import { useAudioRecorder, RecordingOptions, AudioModule, RecordingPresets } from 'expo-audio';
 

--- a/docs/pages/versions/v53.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/audio.mdx
@@ -101,7 +101,7 @@ const styles = StyleSheet.create({
 <SnackInline label='Recording sounds' dependencies={['expo-audio', 'expo-asset']}>
 
 ```jsx
-import { useState } from 'react';
+import { useState,useEffect } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import { useAudioRecorder, RecordingOptions, AudioModule, RecordingPresets } from 'expo-audio';
 


### PR DESCRIPTION
# Why

The current code requires useEffect for handling side effects (like permission requests) but it was not imported from react. This PR fix this missing dependency to ensure the code runs without errors.

# How

1. Added useEffect to the import from react.

# Test Plan

- Verified that the app requests microphone permissions on launch.
- Tested recording functionality (start/stop) after granting permissions.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
