### PR TITLE
[video][android] Fix aspect ratio when auto-entering PiP

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix aspect ratio of the Picture in Picture window when auto-entering for sources with ratio different from 16:9. ([#37225](https://github.com/expo/expo/pull/37225) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 2.2.1 - 2025-06-10

--- a/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
@@ -12,8 +12,9 @@ import android.widget.ImageButton
 import androidx.media3.ui.PlayerView
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.video.player.VideoPlayer
-import expo.modules.video.utils.applyAutoEnterPiP
+import expo.modules.video.utils.applyPiPParams
 import expo.modules.video.utils.applyRectHint
+import expo.modules.video.utils.calculatePiPAspectRatio
 import expo.modules.video.utils.calculateRectHint
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
@@ -44,7 +45,10 @@ class FullscreenPlayerActivity : Activity() {
     videoPlayer = videoView.videoPlayer
     videoPlayer?.changePlayerView(playerView)
     VideoManager.registerFullscreenPlayerActivity(hashCode().toString(), this)
-    applyAutoEnterPiP(this, videoView.autoEnterPiP)
+    playerView.player?.let {
+      val aspectRatio = calculatePiPAspectRatio(it.videoSize, playerView.width, playerView.height, videoView.contentFit)
+      applyPiPParams(this, videoView.autoEnterPiP, aspectRatio)
+    }
   }
 
   override fun onPostCreate(savedInstanceState: Bundle?) {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/PlayerEvent.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/PlayerEvent.kt
@@ -156,7 +156,8 @@ sealed class PlayerEvent {
       is AudioMixingModeChanged -> listeners.forEach { it.onAudioMixingModeChanged(player, audioMixingMode, oldAudioMixingMode) }
       is VideoTrackChanged -> listeners.forEach { it.onVideoTrackChanged(player, videoTrack, oldVideoTrack) }
       is RenderedFirstFrame -> listeners.forEach { it.onRenderedFirstFrame(player) }
-      // JS-only events - VideoSourceLoaded, SubtitleTrackChanged - In the native events the TracksChanged can be used instead
+      is VideoSourceLoaded -> listeners.forEach { it.onVideoSourceLoaded(player, videoSource, duration, availableVideoTracks, availableSubtitleTracks, availableAudioTracks) }
+      // JS-only events - SubtitleTrackChanged - In the native events the TracksChanged can be used instead
       else -> Unit
     }
   }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayerListener.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayerListener.kt
@@ -6,7 +6,9 @@ import androidx.media3.common.Tracks
 import androidx.media3.common.util.UnstableApi
 import expo.modules.video.enums.AudioMixingMode
 import expo.modules.video.enums.PlayerStatus
+import expo.modules.video.records.AudioTrack
 import expo.modules.video.records.PlaybackError
+import expo.modules.video.records.SubtitleTrack
 import expo.modules.video.records.VideoSource
 import expo.modules.video.records.TimeUpdate
 import expo.modules.video.records.VideoTrack
@@ -25,5 +27,6 @@ interface VideoPlayerListener {
   fun onPlayedToEnd(player: VideoPlayer) {}
   fun onAudioMixingModeChanged(player: VideoPlayer, audioMixingMode: AudioMixingMode, oldAudioMixingMode: AudioMixingMode?) {}
   fun onVideoTrackChanged(player: VideoPlayer, videoTrack: VideoTrack?, oldVideoTrack: VideoTrack?) {}
+  fun onVideoSourceLoaded(player: VideoPlayer, videoSource: VideoSource?, duration: Double?, availableVideoTracks: List<VideoTrack>, availableSubtitleTracks: List<SubtitleTrack>, availableAudioTracks: List<AudioTrack>) {}
   fun onRenderedFirstFrame(player: VideoPlayer) {}
 }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/PictureInPictureUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/PictureInPictureUtils.kt
@@ -5,11 +5,14 @@ import android.app.PictureInPictureParams
 import android.graphics.Rect
 import android.os.Build
 import android.util.Log
+import android.util.Rational
 import androidx.annotation.OptIn
+import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.PlayerView
 import expo.modules.video.PictureInPictureConfigurationException
 import expo.modules.video.VideoView.Companion.isPictureInPictureSupported
+import expo.modules.video.enums.ContentFit
 
 @OptIn(UnstableApi::class)
 internal fun calculateRectHint(playerView: PlayerView): Rect {
@@ -34,6 +37,25 @@ internal fun calculateRectHint(playerView: PlayerView): Rect {
   return hint
 }
 
+internal fun calculatePiPAspectRatio(videoSize: VideoSize, viewWidth: Int, viewHeight: Int, contentFit: ContentFit): Rational {
+  var aspectRatio = if (contentFit == ContentFit.CONTAIN) {
+    Rational(videoSize.width, videoSize.height)
+  } else {
+    Rational(viewWidth, viewHeight)
+  }
+  // AspectRatio for the activity in picture-in-picture, must be between 2.39:1 and 1:2.39 (inclusive).
+  // https://developer.android.com/reference/android/app/PictureInPictureParams.Builder#setAspectRatio(android.util.Rational)
+  val maximumRatio = Rational(239, 100)
+  val minimumRatio = Rational(100, 239)
+
+  if (aspectRatio.toFloat() > maximumRatio.toFloat()) {
+    aspectRatio = maximumRatio
+  } else if (aspectRatio.toFloat() < minimumRatio.toFloat()) {
+    aspectRatio = minimumRatio
+  }
+  return aspectRatio
+}
+
 internal fun applyRectHint(activity: Activity, rectHint: Rect) {
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && isPictureInPictureSupported(activity)) {
     runWithPiPMisconfigurationSoftHandling {
@@ -54,10 +76,21 @@ internal fun runWithPiPMisconfigurationSoftHandling(shouldThrow: Boolean = false
   }
 }
 
-internal fun applyAutoEnterPiP(activity: Activity, autoEnterPiP: Boolean) {
-  if (Build.VERSION.SDK_INT >= 31 && isPictureInPictureSupported(activity)) {
+internal fun applyPiPParams(activity: Activity, autoEnterPiP: Boolean, aspectRatio: Rational? = null) {
+  // If the aspect ratio exceeds the limits, the app will crash
+  val safeAspectRatio = aspectRatio?.takeIf { it.toFloat() in 0.41841..2.39 }
+
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && isPictureInPictureSupported(activity)) {
+    val paramsBuilder = PictureInPictureParams.Builder()
+
+    safeAspectRatio?.let {
+      paramsBuilder.setAspectRatio(it)
+    }
+    if (Build.VERSION.SDK_INT >= 31) {
+      paramsBuilder.setAutoEnterEnabled(autoEnterPiP)
+    }
     runWithPiPMisconfigurationSoftHandling {
-      activity.setPictureInPictureParams(PictureInPictureParams.Builder().setAutoEnterEnabled(autoEnterPiP).build())
+      activity.setPictureInPictureParams(paramsBuilder.build())
     }
   }
 }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/PictureInPictureUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/PictureInPictureUtils.kt
@@ -86,7 +86,7 @@ internal fun applyPiPParams(activity: Activity, autoEnterPiP: Boolean, aspectRat
     safeAspectRatio?.let {
       paramsBuilder.setAspectRatio(it)
     }
-    if (Build.VERSION.SDK_INT >= 31) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
       paramsBuilder.setAutoEnterEnabled(autoEnterPiP)
     }
     runWithPiPMisconfigurationSoftHandling {


### PR DESCRIPTION
# Why

Fixes the aspect ratio always being 16:9 when auto-entering pip on Android.

# How

Listen for the video source loaded event, get the first video track and it's aspect ratio. Apply the aspect ratio to the PiP config.

Also did a small refactor of the PiP code to make it a bit more readable.

# Test Plan

Tested in BareExpo on Android 15 emulator
