### PR TITLE
[workspaces] Patch react-native 0.80.0-rc3

### DIFF
--- a/patches/react-native+0.80.0-rc.3.patch
+++ b/patches/react-native+0.80.0-rc.3.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js b/node_modules/react-native/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js
+index 53669fa..baadd3e 100644
+--- a/node_modules/react-native/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js
++++ b/node_modules/react-native/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js
+@@ -186,7 +186,7 @@ function findRCTComponentViewProtocolClass(filepath) {
+     const lines = fileContent.split('\n');
+     const signatureIndex = lines.findIndex(line => regex.test(line));
+     const returnRegex = /return (.*)\.class/;
+-    const classNameMatch = String(lines.slice(signatureIndex)).match(
++    const classNameMatch = String(lines.slice(signatureIndex).join('\n')).match(
+       returnRegex,
+     );
+     if (classNameMatch) {


### PR DESCRIPTION
# Why

Codegen breaks when installing react-native screens

# How

Patch react-native 0.80.0-rc3 with https://github.com/facebook/react-native/pull/51813 while RC 5 is not released 

# Test Plan

Run BareExpo on iOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
