### PR TITLE
[bare-expo][android] Fix TabNavigator insets and status bar color

### DIFF
--- a/apps/bare-expo/MainNavigator.tsx
+++ b/apps/bare-expo/MainNavigator.tsx
@@ -4,6 +4,7 @@ import { LinkingOptions, NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { useTheme } from 'ThemeProvider';
 import * as Linking from 'expo-linking';
+import { StatusBar } from 'expo-status-bar';
 import React from 'react';
 import { Platform } from 'react-native';
 import TestSuite from 'test-suite/AppNavigator';
@@ -101,9 +102,6 @@ function TabNavigator() {
         },
       }}
       safeAreaInsets={Platform.select({
-        android: {
-          bottom: 5,
-        },
         default: undefined,
       })}
       initialRouteName="test-suite">
@@ -121,6 +119,7 @@ function TabNavigator() {
 const PERSISTENCE_KEY = 'NAVIGATION_STATE_V1';
 
 export default () => {
+  const { name: themeName } = useTheme();
   const [isReady, setIsReady] = React.useState(Platform.OS === 'web');
   const [initialState, setInitialState] = React.useState();
 
@@ -169,6 +168,7 @@ export default () => {
         {Search && <Switch.Screen name="searchNavigator" component={Search} />}
         <Switch.Screen name="main" component={TabNavigator} />
       </Switch.Navigator>
+      <StatusBar style={themeName === 'light' ? 'dark' : 'light'} />
     </NavigationContainer>
   );
 };

--- a/apps/bare-expo/android/app/src/main/res/values/styles.xml
+++ b/apps/bare-expo/android/app/src/main/res/values/styles.xml
@@ -1,6 +1,7 @@
-<resources>
-  <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+<resources xmlns:tools="http://schemas.android.com/tools">
+  <style name="AppTheme" parent="Theme.EdgeToEdge">
     <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
+    <item name="android:enforceNavigationBarContrast" tools:targetApi="q">false</item>
   </style>
   <style name="Theme.App.SplashScreen" parent="Theme.SplashScreen">
     <item name="windowSplashScreenBackground">@color/splashscreen_background</item>

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -73,6 +73,7 @@
     "react-native-svg": "15.11.2",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.13.5",
+    "react-native-edge-to-edge": "~1.6.1",
     "test-suite": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
# Why

BareExpo has broken insets for the TabNavigator and the status bar content is light instead of dark

# How

Enabled edge-to-edge. Removed hardcoded 5px bottom inset, set the StatusBar content to dark.

# Test Plan

Tested in BareExpo on API 35 and 28 simulator.

| Before  | After |
| ------------- | ------------- |
| <img width="327" alt="image" src="https://github.com/user-attachments/assets/76c53af5-6a6e-44b4-9421-8bfdb1fde056" />  | <img width="328" alt="image" src="https://github.com/user-attachments/assets/f4939a14-2313-4b9d-b5fe-f950ec129808" />  |
