### PR TITLE
[jest-expo] Fix ES6 import syntax inconsistency in setup.js

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Fix ES6 import syntax inconsistency in setup.js by converting to CommonJS require. ([#37240](https://github.com/expo/expo/pull/37240) by [@huextrat](https://github.com/huextrat))
+
 - Rework mock generation for expo modules. ([#36677](https://github.com/expo/expo/pull/36677) by [@aleqsio](https://github.com/aleqsio))
 
 ## 53.0.5 — 2025-05-06

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-import merge from 'lodash/merge';
+const merge = require('lodash/merge');
 
 const findUp = require('find-up');
 const path = require('path');


### PR DESCRIPTION
# Why

fix: https://github.com/expo/expo/issues/37261

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR fixes an import syntax inconsistency in `packages/jest-expo/src/preset/setup.js` by converting an ES6 import statement to CommonJS require syntax to align with the rest of the file and package conventions.

From `jest-expo: 53.0.6` we have the following error:
```
import merge from "lodash.merge";
^^^^^^

SyntaxError: Cannot use import statement outside a module
```

# How

- The file was using mixed import syntaxes - one ES6 import for lodash/merge while all other dependencies used CommonJS require statements
- Most files in `packages/jest-expo/src/preset/` use CommonJS require syntax exclusively

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
