### PR TITLE
[calendar][iOS] Don't encode event URLs

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Don't encode event URLs. ([#37243](https://github.com/expo/expo/pull/37243) by [@jakex7](https://github.com/jakex7))
+
 ### 💡 Others
 
 ## 14.1.4 — 2025-04-30

--- a/packages/expo-calendar/ios/CalendarModule.swift
+++ b/packages/expo-calendar/ios/CalendarModule.swift
@@ -219,8 +219,8 @@ public class CalendarModule: Module {
         }
       }
 
-      if let url = maybeSetUrl(details.url) {
-        reminder.url = url
+      if let url = details.url {
+        reminder.url = URL(string: url)
       }
 
       if let startDate {
@@ -387,8 +387,8 @@ public class CalendarModule: Module {
       }
     }
 
-    if let url = maybeSetUrl(event.url) {
-      calendarEvent.url = url
+    if let url = event.url {
+      calendarEvent.url = URL(string: url)
     }
 
     if let startDate = event.startDate {
@@ -472,15 +472,6 @@ public class CalendarModule: Module {
 
     eventStore.reset()
     permittedEntities.insert(entity == .event ? .event : .reminder)
-  }
-
-  private func maybeSetUrl(_ url: String?) -> URL? {
-    var allowedQueryParamAndKey = CharacterSet.urlHostAllowed
-    allowedQueryParamAndKey.insert(charactersIn: ":/")
-    if let urlString = url?.addingPercentEncoding(withAllowedCharacters: allowedQueryParamAndKey), let url = URL(string: urlString) {
-      return url
-    }
-    return nil
   }
 
   private func getReminder(from details: Reminder) throws -> EKReminder {


### PR DESCRIPTION
# Why

Fixes #37109.
We should not encode event URL as it should already be encoded by the user. Currently using a valid url as `url: "https://expo.dev?first=this+is+a+field&second=was+it+clear+%28already%29%3F",` would end up being double-encoded 

# How

Remove additional percent encoding on url

# Test Plan

Create event using these URLs
```ts
url: `https://expo.dev?first=this+is+a+field&second=was+it+clear+%28already%29%3F`,
url: `bareexpo://apis/events?calendar=5D6D4560-5194-4F82-902A-FB173A9B8A9E`,
url: `tel:+1-816-555-1212`,
url: `https://john.doe@www.example.com:1234/forum/questions/?tag=networking&order=newest#:~:text=whatever`,
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
