### PR TITLE
[sqlite] fix exception from empty sqlite session

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix nullability of binding params. ([#37200](https://github.com/expo/expo/pull/37200) by [@lukmccall](https://github.com/lukmccall))
+- Fixed exceptions when SQLite session API returns empty buffer. ([#37246](https://github.com/expo/expo/pull/37246) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/android/src/main/cpp/NativeSessionBinding.cpp
+++ b/packages/expo-sqlite/android/src/main/cpp/NativeSessionBinding.cpp
@@ -62,8 +62,11 @@ NativeSessionBinding::sqlite3session_changeset() {
   int size = 0;
   void *buffer = nullptr;
   int result = ::exsqlite3session_changeset(session, &size, &buffer);
-  if (result != SQLITE_OK || !buffer) {
+  if (result != SQLITE_OK) {
     return nullptr;
+  }
+  if (!buffer) {
+    return jni::JArrayByte::newArray(0);
   }
   auto byteArray = jni::JArrayByte::newArray(size);
   byteArray->setRegion(0, size, reinterpret_cast<const signed char *>(buffer));
@@ -76,16 +79,23 @@ NativeSessionBinding::sqlite3session_changeset_inverted() {
   int inSize = 0;
   void *inBuffer = nullptr;
   int result = ::exsqlite3session_changeset(session, &inSize, &inBuffer);
-  if (result != SQLITE_OK || !inBuffer) {
+  if (result != SQLITE_OK) {
     return nullptr;
+  }
+  if (!inBuffer) {
+    return jni::JArrayByte::newArray(0);
   }
 
   int outSize = 0;
   void *outBuffer = nullptr;
   result = ::exsqlite3changeset_invert(inSize, inBuffer, &outSize, &outBuffer);
-  if (result != SQLITE_OK || !outBuffer) {
+  if (result != SQLITE_OK) {
     ::exsqlite3_free(inBuffer);
     return nullptr;
+  }
+  if (!outBuffer) {
+    ::exsqlite3_free(inBuffer);
+    return jni::JArrayByte::newArray(0);
   }
   auto byteArray = jni::JArrayByte::newArray(outSize);
   byteArray->setRegion(0, outSize,
@@ -117,8 +127,11 @@ jni::local_ref<jni::JArrayByte> NativeSessionBinding::sqlite3changeset_invert(
 
   int result =
       ::exsqlite3changeset_invert(inSize, inBuffer.get(), &outSize, &outBuffer);
-  if (result != SQLITE_OK || !outBuffer) {
+  if (result != SQLITE_OK) {
     return nullptr;
+  }
+  if (!outBuffer) {
+    return jni::JArrayByte::newArray(0);
   }
   auto byteArray = jni::JArrayByte::newArray(outSize);
   byteArray->setRegion(0, outSize,

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -740,7 +740,7 @@ public final class SQLiteModule: Module {
       throw SQLiteErrorException(convertSqlLiteErrorToString(database))
     }
     guard let buffer else {
-      throw SQLiteErrorException(convertSqlLiteErrorToString(database))
+      return Data()
     }
     defer { exsqlite3_free(buffer) }
     return Data(bytes: buffer, count: Int(size))
@@ -776,8 +776,7 @@ public final class SQLiteModule: Module {
 
   private func sessionInvertChangeset(database: NativeDatabase, session: NativeSession, changeset: Data) throws -> Data {
     try maybeThrowForClosedDatabase(database)
-    var result: Data?
-    try changeset.withUnsafeBytes {
+    return try changeset.withUnsafeBytes {
       let inBuffer = UnsafeMutableRawPointer(mutating: $0.baseAddress)
       var outSize: Int32 = 0
       var outBuffer: UnsafeMutableRawPointer?
@@ -786,14 +785,10 @@ public final class SQLiteModule: Module {
         throw SQLiteErrorException(convertSqlLiteErrorToString(database))
       }
       guard let outBuffer else {
-        throw SQLiteErrorException(convertSqlLiteErrorToString(database))
+        return Data()
       }
       defer { exsqlite3_free(outBuffer) }
-      result = Data(bytes: outBuffer, count: Int(outSize))
+      return Data(bytes: outBuffer, count: Int(outSize))
     }
-    guard let result else {
-      throw SQLiteErrorException(convertSqlLiteErrorToString(database))
-    }
-    return result
   }
 }


### PR DESCRIPTION
# Why

fixed the case when sqlite session api return sucessful empty buffer, we throw exceptions

# How

rather than throwing exceptions, we should return empty Uint8Array instead. this is similar to livestore wa-sqlite implementation

# Test Plan

- test repro from livestore
- ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
