### PR TITLE
[docs] Fix example code blocks in Audio

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -68,7 +68,6 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
 >
 
 ```jsx
-import { useEffect, useState } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import { useAudioPlayer } from 'expo-audio';
 
@@ -103,7 +102,7 @@ const styles = StyleSheet.create({
 ```jsx
 import { useState, useEffect } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
-import { useAudioRecorder, RecordingOptions, AudioModule, RecordingPresets } from 'expo-audio';
+import { useAudioRecorder, AudioModule, RecordingPresets } from 'expo-audio';
 
 export default function App() {
   const audioRecorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);

--- a/docs/pages/versions/v52.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/audio.mdx
@@ -72,7 +72,6 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
 >
 
 ```jsx
-import { useEffect, useState } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import { useAudioPlayer } from 'expo-audio';
 
@@ -107,7 +106,7 @@ const styles = StyleSheet.create({
 ```jsx
 import { useState } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
-import { useAudioRecorder, RecordingOptions, AudioModule, RecordingPresets } from 'expo-audio';
+import { useAudioRecorder, AudioModule, RecordingPresets } from 'expo-audio';
 
 export default function App() {
   const audioRecorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);

--- a/docs/pages/versions/v53.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/audio.mdx
@@ -68,7 +68,6 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
 >
 
 ```jsx
-import { useEffect, useState } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
 import { useAudioPlayer } from 'expo-audio';
 
@@ -103,7 +102,7 @@ const styles = StyleSheet.create({
 ```jsx
 import { useState, useEffect } from 'react';
 import { View, StyleSheet, Button } from 'react-native';
-import { useAudioRecorder, RecordingOptions, AudioModule, RecordingPresets } from 'expo-audio';
+import { useAudioRecorder, AudioModule, RecordingPresets } from 'expo-audio';
 
 export default function App() {
   const audioRecorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix code examples in Expo Audio reference by removing unused methods/components from import statements.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
