### PR TITLE
[docs] Fix code example in GLView

### DIFF
--- a/docs/pages/versions/unversioned/sdk/gl-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/gl-view.mdx
@@ -21,8 +21,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Basic GL usage' dependencies={['expo-gl']}>
 
-```js
-import React from 'react';
+```jsx
 import { View } from 'react-native';
 import { GLView } from 'expo-gl';
 
@@ -95,8 +94,7 @@ To use this API inside Reanimated worklet, you need to pass the GL context ID to
 
 <SnackInline label='GL usage in reanimated worklet' dependencies={['expo-gl', 'react-native-reanimated']}>
 
-```js
-import React from 'react';
+```jsx
 import { View } from 'react-native';
 import { runOnUI } from 'react-native-reanimated';
 import { GLView } from 'expo-gl';

--- a/docs/pages/versions/v51.0.0/sdk/gl-view.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/gl-view.mdx
@@ -21,8 +21,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Basic GL usage' dependencies={['expo-gl']}>
 
-```js
-import React from 'react';
+```jsx
 import { View } from 'react-native';
 import { GLView } from 'expo-gl';
 
@@ -95,8 +94,7 @@ To use this API inside Reanimated worklet, you need to pass the GL context ID to
 
 <SnackInline label='GL usage in reanimated worklet' dependencies={['expo-gl', 'react-native-reanimated']}>
 
-```js
-import React from 'react';
+```jsx
 import { View } from 'react-native';
 import { runOnUI } from 'react-native-reanimated';
 import { GLView } from 'expo-gl';

--- a/docs/pages/versions/v52.0.0/sdk/gl-view.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/gl-view.mdx
@@ -21,8 +21,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Basic GL usage' dependencies={['expo-gl']}>
 
-```js
-import React from 'react';
+```jsx
 import { View } from 'react-native';
 import { GLView } from 'expo-gl';
 
@@ -95,8 +94,7 @@ To use this API inside Reanimated worklet, you need to pass the GL context ID to
 
 <SnackInline label='GL usage in reanimated worklet' dependencies={['expo-gl', 'react-native-reanimated']}>
 
-```js
-import React from 'react';
+```jsx
 import { View } from 'react-native';
 import { runOnUI } from 'react-native-reanimated';
 import { GLView } from 'expo-gl';

--- a/docs/pages/versions/v53.0.0/sdk/gl-view.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/gl-view.mdx
@@ -21,8 +21,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <SnackInline label='Basic GL usage' dependencies={['expo-gl']}>
 
-```js
-import React from 'react';
+```jsx
 import { View } from 'react-native';
 import { GLView } from 'expo-gl';
 
@@ -95,8 +94,7 @@ To use this API inside Reanimated worklet, you need to pass the GL context ID to
 
 <SnackInline label='GL usage in reanimated worklet' dependencies={['expo-gl', 'react-native-reanimated']}>
 
-```js
-import React from 'react';
+```jsx
 import { View } from 'react-native';
 import { runOnUI } from 'react-native-reanimated';
 import { GLView } from 'expo-gl';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix code examples in the Expo GLView reference by removing unused methods/components from import statements. Also, use `jsx` as code language so Snack examples use JS as a base file.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
