### PR TITLE
[ios][localization] Allow iOS users to modify RTL configuration

### DIFF
--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix the issue where the iOS RTL configuration modification is overridden by the system's default language RTL property.
+- [iOS] Fix the issue where the iOS RTL configuration modification is overridden by the system's default language RTL property. ([#37256](https://github.com/expo/expo/pull/37256) by [@rogerogers](https://github.com/rogerogers))
 
 ### 💡 Others
 

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix the issue where the iOS RTL configuration modification is overridden by the system's default language RTL property.
+
 ### 💡 Others
 
 ## 16.1.5 — 2025-04-30

--- a/packages/expo-localization/ios/LocalizationModule.swift
+++ b/packages/expo-localization/ios/LocalizationModule.swift
@@ -69,7 +69,9 @@ public class LocalizationModule: Module {
       UserDefaults.standard.set(true, forKey: "RCTI18nUtil_forceRTL")
     } else {
       UserDefaults.standard.set(supportsRTL, forKey: "RCTI18nUtil_allowRTL")
-      UserDefaults.standard.set(supportsRTL ? isRTLPreferredForCurrentLocale() : false, forKey: "RCTI18nUtil_forceRTL")
+      if UserDefaults.standard.object(forKey: "RCTI18nUtil_forceRTL") == nil {
+        UserDefaults.standard.set(supportsRTL ? isRTLPreferredForCurrentLocale() : false, forKey: "RCTI18nUtil_forceRTL")
+      }
     }
 
     UserDefaults.standard.synchronize()


### PR DESCRIPTION
# Why

At present, iOS directly sets the forceRTL configuration based on the system's default language RTL, causing the RTL configuration modified by the user's call to forceRTL to be overwritten.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Before using the system's default language RTL property, check whether the user has modified the RTL configuration.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
