### PR TITLE
docs(expo-audio): note about playback position compared to expo-av

### DIFF
--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -93,7 +93,7 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-> **Info** Note: If you're migrating from [`expo-av`](av.mdx), keep in mind that `expo-audio` does not automatically reset the playback position after the sound finishes playing. When [`play()`](#play) completes, the player remains in the paused state at the end of the audio. To replay the sound, you must manually reset the position using [`seekTo(seconds)`](#seektoseconds), as demonstrated in the example above.
+> **Info** Note: If you're migrating from [`expo-av`](av.mdx), you'll notice that `expo-audio` doesn't automatically reset the playback position when audio finishes. After [`play()`](#play), the player stays paused at the end of the sound. To play it again, call [`seekTo(seconds)`](#seektoseconds) to reset the position — as shown in the example above.
 
 ### Recording sounds
 

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -150,7 +150,12 @@ export default function App() {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', backgroundColor: '#ecf0f1', padding: 10 },
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: '#ecf0f1',
+    padding: 10,
+  },
 });
 ```
 

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -83,8 +83,8 @@ export default function App() {
       <Button
         title="Replay Sound"
         onPress={() => {
-          player.seekTo(0)
-          player.play()
+          player.seekTo(0);
+          player.play();
         }}
       />
     </View>

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -31,12 +31,7 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
 {
   "expo": {
     "plugins": [
-      [
-        "expo-audio",
-        {
-          "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone."
-        }
-      ]
+      ["expo-audio", { "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone." }]
     ]
   }
 }
@@ -80,21 +75,25 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Button title="Play Sound" onPress={() => player.play()} />
+      <Button
+        title="Replay Sound"
+        onPress={() => {
+          player.seekTo(0);
+          player.play();
+        }}
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    backgroundColor: '#ecf0f1',
-    padding: 10,
-  },
+  container: { flex: 1, justifyContent: 'center', backgroundColor: '#ecf0f1', padding: 10 },
 });
 ```
 
 </SnackInline>
+
+> **Info** Note: If you're migrating from [`expo-av`](av.mdx), keep in mind that `expo-audio` does not automatically reset the playback position after the sound finishes playing. When [`play()`](#play) completes, the player remains in the paused state at the end of the audio. To replay the sound, you must manually reset the position using [`seekTo(seconds)`](#seektoseconds), as demonstrated in the example above.
 
 ### Recording sounds
 
@@ -141,12 +140,7 @@ export default function App() {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    backgroundColor: '#ecf0f1',
-    padding: 10,
-  },
+  container: { flex: 1, justifyContent: 'center', backgroundColor: '#ecf0f1', padding: 10 },
 });
 ```
 

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -31,7 +31,12 @@ You can configure `expo-audio` using its built-in [config plugin](/config-plugin
 {
   "expo": {
     "plugins": [
-      ["expo-audio", { "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone." }]
+      [
+        "expo-audio",
+        {
+          "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone."
+        }
+      ]
     ]
   }
 }
@@ -87,13 +92,18 @@ export default function App() {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, justifyContent: 'center', backgroundColor: '#ecf0f1', padding: 10 },
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: '#ecf0f1',
+    padding: 10,
+  },
 });
 ```
 
 </SnackInline>
 
-> **Info** Note: If you're migrating from [`expo-av`](av.mdx), you'll notice that `expo-audio` doesn't automatically reset the playback position when audio finishes. After [`play()`](#play), the player stays paused at the end of the sound. To play it again, call [`seekTo(seconds)`](#seektoseconds) to reset the position — as shown in the example above.
+> **Info** **Note:** If you're migrating from [`expo-av`](av.mdx), you'll notice that `expo-audio` doesn't automatically reset the playback position when audio finishes. After [`play()`](#play), the player stays paused at the end of the sound. To play it again, call [`seekTo(seconds)`](#seektoseconds) to reset the position — as shown in the example above.
 
 ### Recording sounds
 

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -83,8 +83,8 @@ export default function App() {
       <Button
         title="Replay Sound"
         onPress={() => {
-          player.seekTo(0);
-          player.play();
+          player.seekTo(0)
+          player.play()
         }}
       />
     </View>

--- a/docs/pages/versions/v53.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/audio.mdx
@@ -96,7 +96,7 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-> **Info** Note: If you're migrating from [`expo-av`](av.mdx), keep in mind that `expo-audio` does not automatically reset the playback position after the sound finishes playing. When [`play()`](#play) completes, the player remains in the paused state at the end of the audio. To replay the sound, you must manually reset the position using [`seekTo(seconds)`](#seektoseconds), as demonstrated in the example above.
+> **Info** Note: If you're migrating from [`expo-av`](av.mdx), you'll notice that `expo-audio` doesn't automatically reset the playback position when audio finishes. After [`play()`](#play), the player stays paused at the end of the sound. To play it again, call [`seekTo(seconds)`](#seektoseconds) to reset the position — as shown in the example above.
 
 ### Recording sounds
 

--- a/docs/pages/versions/v53.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/audio.mdx
@@ -80,6 +80,13 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Button title="Play Sound" onPress={() => player.play()} />
+      <Button
+        title="Replay Sound"
+        onPress={() => {
+          player.seekTo(0);
+          player.play();
+        }}
+      />
     </View>
   );
 }

--- a/docs/pages/versions/v53.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/audio.mdx
@@ -83,8 +83,8 @@ export default function App() {
       <Button
         title="Replay Sound"
         onPress={() => {
-          player.seekTo(0)
-          player.play()
+          player.seekTo(0);
+          player.play();
         }}
       />
     </View>

--- a/docs/pages/versions/v53.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/audio.mdx
@@ -96,6 +96,8 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
+> **Info** Note: If you're migrating from [`expo-av`](av.mdx), keep in mind that `expo-audio` does not automatically reset the playback position after the sound finishes playing. When [`play()`](#play) completes, the player remains in the paused state at the end of the audio. To replay the sound, you must manually reset the position using [`seekTo(seconds)`](#seektoseconds), as demonstrated in the example above.
+
 ### Recording sounds
 
 <SnackInline label='Recording sounds' dependencies={['expo-audio', 'expo-asset']}>

--- a/docs/pages/versions/v53.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/audio.mdx
@@ -103,7 +103,7 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-> **Info** Note: If you're migrating from [`expo-av`](av.mdx), you'll notice that `expo-audio` doesn't automatically reset the playback position when audio finishes. After [`play()`](#play), the player stays paused at the end of the sound. To play it again, call [`seekTo(seconds)`](#seektoseconds) to reset the position — as shown in the example above.
+> **Info** **Note:** If you're migrating from [`expo-av`](av.mdx), you'll notice that `expo-audio` doesn't automatically reset the playback position when audio finishes. After [`play()`](#play), the player stays paused at the end of the sound. To play it again, call [`seekTo(seconds)`](#seektoseconds) to reset the position — as shown in the example above.
 
 ### Recording sounds
 

--- a/docs/pages/versions/v53.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/audio.mdx
@@ -83,8 +83,8 @@ export default function App() {
       <Button
         title="Replay Sound"
         onPress={() => {
-          player.seekTo(0);
-          player.play();
+          player.seekTo(0)
+          player.play()
         }}
       />
     </View>


### PR DESCRIPTION
# Why

Discussed with @alanjhughes to add clarity around `play()` differences if coming from `expo-av`. Makes it clear to the migrating user that they made have to utilize `seekTo(seconds)` to reproduce the functionality they had before.

# How

Updated `audio.mdx` in `unversioned` and `v53.0.0` with an Info note and a small code example in the inline Snack.

# Test Plan

Ran the docs in dev mode

## Screenshot

![image](https://github.com/user-attachments/assets/d2ab23b2-d1f7-4976-b791-45fda2eece61)



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
