### PR TITLE
[docs] add first two published talks from App.js'25

### DIFF
--- a/docs/public/static/talks.ts
+++ b/docs/public/static/talks.ts
@@ -1,17 +1,29 @@
 export const TALKS = [
   {
+    title: 'Keynote: streamline React Native development',
+    event: 'App.js Conf 2025',
+    description: 'Charlie Cheever, Jon Samp',
+    videoId: 'lnxanzsP1rM',
+    home: true,
+  },
+  {
+    title: 'Deploy Everywhere with Expo Router',
+    event: 'App.js Conf 2025',
+    description: 'Evan Bacon',
+    videoId: 'GKQ_0VfYweg',
+    home: true,
+  },
+  {
     title: 'Keynote: flexibility & iteration speed',
     event: 'App.js Conf 2024',
     description: 'Charlie Cheever, James Ide',
     videoId: 'StTYy9Duk3E',
-    home: true,
   },
   {
     title: 'Getting the most out of Expo Development Builds',
     event: 'App.js Conf 2024',
     description: 'Kadi Kraman',
     videoId: '7J8LRpja9_o',
-    home: true,
   },
   {
     title: 'Fetch Once, Render Everywhere',


### PR DESCRIPTION
# Why

SWM has posted first two talks from the App.js'25 conf.

# How

Add the new videos to the talks list, display them on the home page.

# Test Plan

The changes have been reviewed by running docs app locally.

# Preview

![Screenshot 2025-06-05 at 18 38 56](https://github.com/user-attachments/assets/6e44a9df-c4c7-4180-9f60-09ab3f454f0f)
