### PR TITLE
[docs] Add video tutorial icon in docs navigation sidebar

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -76,6 +76,7 @@ These metadata items include:
 - `isAlpha`: Whether to display the alpha badge for a page. Commonly used with API pages under Reference. Defaults to `false`.
 - `searchRank`: A number between 0 and 100 that represents the relevance of a page. This value is mapped to Algolia's `record.weight.pageRank` property. Higher values indicate higher priority. We set this value to `5` by default, otherwise specified in the frontmatter.
 - `searchPosition`: The position of a page in the search results. This value is mapped to Algolia's `record.weight.position` property. Algolia sets this value to `0` by default. Pages with lower values appear higher in the results. We set this value to `50` by default, otherwise specified in the frontmatter.
+- `hasVideoLink`: To display a video link icon in the sidebar for the page that has a video tutorial link. Defaults to `false`.
 
 ### Edit Code
 

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -756,6 +756,7 @@ function makePage(file) {
     isAlpha: data.isAlpha ?? undefined,
     isDeprecated: data.isDeprecated ?? undefined,
     inExpoGo: data.inExpoGo ?? undefined,
+    hasVideoLink: data.hasVideoLink ?? undefined,
   };
   // TODO(cedric): refactor sidebarTitle into metadata
   if (data.sidebar_title) {

--- a/docs/pages/archive/e2e-tests.mdx
+++ b/docs/pages/archive/e2e-tests.mdx
@@ -2,6 +2,7 @@
 title: Run E2E tests on EAS Build
 sidebar_title: Run E2E tests
 description: Learn how to set up and run E2E tests on EAS Build with Maestro.
+hasVideoLink: true
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/build-reference/app-versions.mdx
+++ b/docs/pages/build-reference/app-versions.mdx
@@ -1,6 +1,7 @@
 ---
 title: App version management
 description: Learn about different version types and how to manage them remotely or locally.
+hasVideoLink: true
 ---
 
 import { Terminal } from '~/ui/components/Snippet';

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -2,6 +2,7 @@
 title: Debugging runtime issues
 description: Learn about different techniques available to debug your Expo project.
 sidebar_title: Runtime issues
+hasVideoLink: true
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/deploy/submit-to-app-stores.mdx
+++ b/docs/pages/deploy/submit-to-app-stores.mdx
@@ -1,6 +1,7 @@
 ---
 title: Submit to app stores
 description: Learn how to submit your app to Google Play Store and Apple App Store from the command line with EAS Submit.
+hasVideoLink: true
 ---
 
 import { AppleAppStoreIcon } from '@expo/styleguide-icons/custom/AppleAppStoreIcon';
@@ -40,12 +41,13 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
   </Requirement>
   <Requirement number={3} title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and login with your Expo account:
-    
+
     <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
+
   </Requirement>
   <Requirement number={4} title="Build a production app">
     You'll need a production build ready for store submission. You can create one using [EAS Build](/build/introduction/):
-    
+
     <Terminal cmd={['$ eas build --platform ios --profile production']} />
 
     Alternatively, you can build the app on your own computer with `eas build --platform ios --profile production --local` or with Xcode.
@@ -75,8 +77,9 @@ The command will lead you step by step through the process of submitting the app
   </Requirement>
   <Requirement number={4} title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and login with your Expo account:
-    
+
     <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
+
   </Requirement>
   <Requirement number={5} title="Include a package name in app.json">
     Include your app's package name in **app.json**:
@@ -92,7 +95,7 @@ The command will lead you step by step through the process of submitting the app
   </Requirement>
   <Requirement number={6} title="Build a production app">
     You'll need a production build ready for store submission. You can create one using [EAS Build](/build/introduction/):
-    
+
     <Terminal cmd={['$ eas build --platform android --profile production']} />
 
     Alternatively, you can build the app on your own computer with `eas build --platform android --profile production --local` or with Android Studio.

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -4,6 +4,7 @@ description: Learn how to create development builds for a project.
 sidebar_title: Create a build on EAS
 searchRank: 97
 searchPosition: 2
+hasVideoLink: true
 ---
 
 import { VideoRecorderIcon } from '@expo/styleguide-icons/outline/VideoRecorderIcon';

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -5,6 +5,7 @@ description: Why use development builds and how to get started.
 searchRank: 98
 searchPosition: 1
 hideTOC: true
+hasVideoLink: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';

--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -1,6 +1,7 @@
 ---
 title: Splash screen and app icon
 description: Learn how to add a splash screen and app icon to your Expo project.
+hasVideoLink: true
 ---
 
 import { DocsLogo } from '@expo/styleguide';

--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -2,6 +2,7 @@
 title: EAS Update Debugging
 sidebar_title: Debugging
 description: Learn how to use basic debugging techniques to fix an update issue.
+hasVideoLink: true
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/eas/hosting/get-started.mdx
+++ b/docs/pages/eas/hosting/get-started.mdx
@@ -2,6 +2,7 @@
 sidebar_title: Get started
 title: Deploy your first Expo Router and React app
 description: Learn how to deploy your Expo Router and React apps to EAS Hosting.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/eas/workflows/examples.mdx
+++ b/docs/pages/eas/workflows/examples.mdx
@@ -1,6 +1,7 @@
 ---
 title: Example CI/CD workflows
 description: Common CI/CD workflows that are useful for your project.
+hasVideoLink: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -2,6 +2,7 @@
 sidebar_title: Get started
 title: Get started with EAS Workflows
 description: Learn how to use EAS Workflows to automate your React Native CI/CD development and release processes.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -1,6 +1,7 @@
 ---
 title: Edit rich text
 description: Learn about current approaches to preview and edit rich text in React Native.
+hasVideoLink: true
 ---
 
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -1,6 +1,7 @@
 ---
 title: Keyboard handling
 description: A guide for handling common keyboard interactions on an Android or iOS device.
+hasVideoLink: true
 ---
 
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';

--- a/docs/pages/guides/local-first.mdx
+++ b/docs/pages/guides/local-first.mdx
@@ -2,6 +2,7 @@
 title: Local-first architecture with Expo
 sidebar_title: Local-first
 description: An introduction to the emerging local-first software movement, including links to relevant learning resources and tools.
+hasVideoLink: true
 ---
 
 import { Terminal } from '~/ui/components/Snippet';

--- a/docs/pages/linking/android-app-links.mdx
+++ b/docs/pages/linking/android-app-links.mdx
@@ -1,6 +1,7 @@
 ---
 title: Android App Links
 description: Learn how to configure Android App Links to open your Expo app from a standard web URL.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/linking/ios-universal-links.mdx
+++ b/docs/pages/linking/ios-universal-links.mdx
@@ -1,6 +1,7 @@
 ---
 title: iOS Universal Links
 description: Learn how to configure iOS Universal Links to open your Expo app from a standard web URL.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -2,6 +2,7 @@
 title: 'Tutorial: Creating a native module'
 sidebar_title: Create a native module
 description: A tutorial on creating a native module that persists settings with Expo Modules API.
+hasVideoLink: true
 ---
 
 import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -1,6 +1,7 @@
 ---
 title: Wrap third-party native libraries
 description: Learn how to create a simple wrapper around two separate native libraries using Expo Modules API.
+hasVideoLink: true
 ---
 
 import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';

--- a/docs/pages/push-notifications/overview.mdx
+++ b/docs/pages/push-notifications/overview.mdx
@@ -3,6 +3,7 @@ title: 'Expo push notifications: Overview'
 sidebar_title: Overview
 description: An overview of Expo push notification service.
 hideTOC: true
+hasVideoLink: true
 ---
 
 import { NotificationBoxIcon } from '@expo/styleguide-icons/outline/NotificationBoxIcon';

--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -1,6 +1,7 @@
 ---
 title: Expo push notifications setup
 description: Learn how to set up push notifications, get credentials for development and production, and send a testing push notification.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/router/advanced/authentication-rewrites.mdx
+++ b/docs/pages/router/advanced/authentication-rewrites.mdx
@@ -2,6 +2,7 @@
 title: Authentication in Expo Router using redirects
 sidebar_title: Authentication (redirects)
 description: How to implement authentication and protect routes with Expo Router.
+hasVideoLink: true
 ---
 
 > SDK 53 introduced [Protected routes](/router/advanced/protected/), a more powerful method of handling authentication. Please follow this guide if using SDK >53.

--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -2,6 +2,7 @@
 title: Authentication in Expo Router
 sidebar_title: Authentication
 description: How to implement authentication and protect routes with Expo Router.
+hasVideoLink: true
 ---
 
 > This guide requires SDK 53. For the previous version of this guide see [Authentication (redirects)](/router/advanced/authentication-rewrites/)

--- a/docs/pages/router/advanced/modals.mdx
+++ b/docs/pages/router/advanced/modals.mdx
@@ -1,6 +1,7 @@
 ---
 title: Modals
 description: Learn how to use modals in Expo Router.
+hasVideoLink: true
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/router/advanced/nesting-navigators.mdx
+++ b/docs/pages/router/advanced/nesting-navigators.mdx
@@ -1,6 +1,7 @@
 ---
 title: Nesting navigators
 description: Learn how to nest navigators in Expo Router.
+hasVideoLink: true
 ---
 
 import { FileTree } from '~/ui/components/FileTree';

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -1,6 +1,7 @@
 ---
 title: Stack
 description: Learn how to use the Stack navigator in Expo Router.
+hasVideoLink: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';

--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -1,6 +1,7 @@
 ---
 title: Tabs
 description: Learn how to use the Tabs layout in Expo Router.
+hasVideoLink: true
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/router/basics/layout.mdx
+++ b/docs/pages/router/basics/layout.mdx
@@ -2,6 +2,7 @@
 title: Navigation layouts in Expo Router
 description: Learn how to construct different relationships between pages by using directories and layout files.
 sidebar_title: Layout
+hasVideoLink: true
 ---
 
 import { FileTree } from '~/ui/components/FileTree';

--- a/docs/pages/router/basics/navigation.mdx
+++ b/docs/pages/router/basics/navigation.mdx
@@ -2,6 +2,7 @@
 title: Navigating between pages
 description: Learn the different ways to link to and navigate to pages in Expo Router.
 sidebar_title: Navigation
+hasVideoLink: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide';

--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -1,6 +1,7 @@
 ---
 title: API Routes
 description: Learn how to create server endpoints with Expo Router.
+hasVideoLink: true
 ---
 
 import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';

--- a/docs/pages/tutorial/add-navigation.mdx
+++ b/docs/pages/tutorial/add-navigation.mdx
@@ -1,6 +1,7 @@
 ---
 title: Add navigation
 description: In this chapter, learn how to add navigation to the Expo app.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -1,6 +1,7 @@
 ---
 title: Build a screen
 description: In this tutorial, learn how to use components such as React Native's Pressable and Expo Image to build a screen.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/tutorial/configuration.mdx
+++ b/docs/pages/tutorial/configuration.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configure status bar, splash screen and app icon
 description: In this tutorial, learn the basics of how to configure a status bar, app icon, and splash screen.
+hasVideoLink: true
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -1,6 +1,7 @@
 ---
 title: Create a modal
 description: In this tutorial, learn how to create a React Native modal to select an image.
+hasVideoLink: true
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -1,7 +1,7 @@
 ---
 title: Create your first app
-
 description: In this chapter, learn how to create a new Expo project.
+hasVideoLink: true
 ---
 
 import { Download03Icon } from '@expo/styleguide-icons/outline/Download03Icon';

--- a/docs/pages/tutorial/eas/android-development-build.mdx
+++ b/docs/pages/tutorial/eas/android-development-build.mdx
@@ -2,6 +2,7 @@
 title: Create and run a cloud build for Android
 sidebar_title: Android development build
 description: Learn how to configure a development build for Android devices and emulators using EAS Build.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/tutorial/eas/configure-development-build.mdx
+++ b/docs/pages/tutorial/eas/configure-development-build.mdx
@@ -2,6 +2,7 @@
 title: Configure a development build in cloud
 sidebar_title: Configure development build
 description: Learn how to configure a development build for a project using EAS Build.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/tutorial/eas/internal-distribution-builds.mdx
+++ b/docs/pages/tutorial/eas/internal-distribution-builds.mdx
@@ -2,6 +2,7 @@
 title: Create and share internal distribution build
 sidebar_title: Internal distribution build
 description: Learn about internal distribution builds, why we need them, and how to create them.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/tutorial/eas/ios-development-build-for-devices.mdx
+++ b/docs/pages/tutorial/eas/ios-development-build-for-devices.mdx
@@ -2,6 +2,7 @@
 title: Create and run a cloud build for iOS device
 sidebar_title: iOS development build for devices
 description: Learn how to configure a development build for iOS devices using EAS Build.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/tutorial/eas/ios-development-build-for-simulators.mdx
+++ b/docs/pages/tutorial/eas/ios-development-build-for-simulators.mdx
@@ -2,6 +2,7 @@
 title: Create and run a cloud build for iOS Simulator
 sidebar_title: iOS development build for simulators
 description: Learn how to configure a development build for iOS Simulators using EAS Build.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/tutorial/eas/ios-production-build.mdx
+++ b/docs/pages/tutorial/eas/ios-production-build.mdx
@@ -2,6 +2,7 @@
 title: Create a production build for iOS
 sidebar_title: iOS production build
 description: Learn about the process of creating a production build for iOS and automating the release process.
+hasVideoLink: true
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/tutorial/eas/manage-app-versions.mdx
+++ b/docs/pages/tutorial/eas/manage-app-versions.mdx
@@ -2,6 +2,7 @@
 title: Manage different app versions
 sidebar_title: Manage app versions
 description: Learn about developer-facing and user-facing app versions and how EAS Build automatically manages developer-facing versions.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/tutorial/eas/multiple-app-variants.mdx
+++ b/docs/pages/tutorial/eas/multiple-app-variants.mdx
@@ -2,6 +2,7 @@
 title: Configure multiple app variants
 sidebar_title: Multiple app variants
 description: Learn how to configure dynamic app config to install multiple app variants on a single device.
+hasVideoLink: true
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/tutorial/eas/team-development.mdx
+++ b/docs/pages/tutorial/eas/team-development.mdx
@@ -2,6 +2,7 @@
 title: Share previews with your team
 sidebar_title: Share previews
 description: Learn how to use EAS Update to send OTA updates and share previews with a team.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/tutorial/eas/using-github.mdx
+++ b/docs/pages/tutorial/eas/using-github.mdx
@@ -2,6 +2,7 @@
 title: Trigger builds from a GitHub repository
 sidebar_title: Builds from GitHub
 description: Learn about the process of triggering builds from a GitHub repository.
+hasVideoLink: true
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -1,6 +1,7 @@
 ---
 title: Add gestures
 description: In this tutorial, learn how to implement gestures from React Native Gesture Handler and Reanimated libraries.
+hasVideoLink: true
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -1,6 +1,7 @@
 ---
 title: Use an image picker
 description: In this tutorial, learn how to use Expo Image Picker.
+hasVideoLink: true
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -1,6 +1,7 @@
 ---
 title: Handle platform differences
 description: In this tutorial, learn how to handle platform differences between native and web when creating a universal app.
+hasVideoLink: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -1,6 +1,7 @@
 ---
 title: Take a screenshot
 description: In this tutorial, learn how to capture a screenshot using a third-party library and Expo Media Library.
+hasVideoLink: true
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/versions/unversioned/sdk/maps.mdx
+++ b/docs/pages/versions/unversioned/sdk/maps.mdx
@@ -6,6 +6,7 @@ packageName: 'expo-maps'
 platforms: ['ios', 'android']
 iconUrl: '/static/images/packages/expo-maps.png'
 isAlpha: true
+hasVideoLink: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/stripe/stripe-react-native'
 packageName: '@stripe/stripe-react-native'
 platforms: ['android', 'ios']
 inExpoGo: true
+hasVideoLink: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v52.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/maps.mdx
@@ -6,6 +6,7 @@ packageName: 'expo-maps'
 platforms: ['ios', 'android']
 iconUrl: '/static/images/packages/expo-maps.png'
 isAlpha: true
+hasVideoLink: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v52.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/stripe.mdx
@@ -4,6 +4,7 @@ description: A library that provides access to native APIs for integrating Strip
 sourceCodeUrl: 'https://github.com/stripe/stripe-react-native'
 packageName: '@stripe/stripe-react-native'
 platforms: ['android', 'ios']
+hasVideoLink: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/pages/versions/v53.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/maps.mdx
@@ -6,6 +6,7 @@ packageName: 'expo-maps'
 platforms: ['ios', 'android']
 iconUrl: '/static/images/packages/expo-maps.png'
 isAlpha: true
+hasVideoLink: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v53.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/stripe.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/stripe/stripe-react-native'
 packageName: '@stripe/stripe-react-native'
 platforms: ['android', 'ios']
 inExpoGo: true
+hasVideoLink: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -48,6 +48,7 @@ export type NavigationRoute = {
   isAlpha?: boolean;
   isDeprecated?: boolean;
   inExpoGo?: boolean;
+  hasVideoLink?: boolean;
   children?: NavigationRouteWithSection[];
 };
 

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -1,6 +1,7 @@
 import { LinkBase, mergeClasses } from '@expo/styleguide';
 import { AlertTriangleIcon } from '@expo/styleguide-icons/outline/AlertTriangleIcon';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons/outline/ArrowUpRightIcon';
+import { VideoRecorderIcon } from '@expo/styleguide-icons/outline/VideoRecorderIcon';
 import { AlertTriangleSolidIcon } from '@expo/styleguide-icons/solid/AlertTriangleSolidIcon';
 import { useRouter } from 'next/compat/router';
 import { useEffect, useRef, type PropsWithChildren } from 'react';
@@ -97,6 +98,7 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
           ALPHA
         </div>
       )}
+      {info.hasVideoLink && <VideoRecorderIcon className="icon-xs ml-1.5 text-palette-blue11" />}
       {isExternal && (
         <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary group-hover:text-icon-info" />
       )}

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -1,9 +1,9 @@
 import { LinkBase, mergeClasses } from '@expo/styleguide';
+import { PlaySquareDuotoneIcon } from '@expo/styleguide-icons/duotone/PlaySquareDuotoneIcon';
 import { AlertTriangleIcon } from '@expo/styleguide-icons/outline/AlertTriangleIcon';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons/outline/ArrowUpRightIcon';
-import { VideoRecorderIcon } from '@expo/styleguide-icons/outline/VideoRecorderIcon';
+import { PlaySquareIcon } from '@expo/styleguide-icons/outline/PlaySquareIcon';
 import { AlertTriangleSolidIcon } from '@expo/styleguide-icons/solid/AlertTriangleSolidIcon';
-import { VideoRecorderSolidIcon } from '@expo/styleguide-icons/solid/VideoRecorderSolidIcon';
 import { useRouter } from 'next/compat/router';
 import { useEffect, useRef, type PropsWithChildren } from 'react';
 
@@ -100,10 +100,10 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
         </div>
       )}
       {info.hasVideoLink && !isSelected && (
-        <VideoRecorderIcon className="icon-xs ml-1.5 text-palette-blue11" />
+        <PlaySquareIcon className="icon-xs ml-1.5 text-icon-secondary" />
       )}
       {info.hasVideoLink && isSelected && (
-        <VideoRecorderSolidIcon className="icon-xs ml-1.5 text-palette-blue11" />
+        <PlaySquareDuotoneIcon className="icon-xs ml-1.5 text-palette-blue11" />
       )}
       {isExternal && (
         <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary group-hover:text-icon-info" />

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -3,6 +3,7 @@ import { AlertTriangleIcon } from '@expo/styleguide-icons/outline/AlertTriangleI
 import { ArrowUpRightIcon } from '@expo/styleguide-icons/outline/ArrowUpRightIcon';
 import { VideoRecorderIcon } from '@expo/styleguide-icons/outline/VideoRecorderIcon';
 import { AlertTriangleSolidIcon } from '@expo/styleguide-icons/solid/AlertTriangleSolidIcon';
+import { VideoRecorderSolidIcon } from '@expo/styleguide-icons/solid/VideoRecorderSolidIcon';
 import { useRouter } from 'next/compat/router';
 import { useEffect, useRef, type PropsWithChildren } from 'react';
 
@@ -98,7 +99,12 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
           ALPHA
         </div>
       )}
-      {info.hasVideoLink && <VideoRecorderIcon className="icon-xs ml-1.5 text-palette-blue11" />}
+      {info.hasVideoLink && !isSelected && (
+        <VideoRecorderIcon className="icon-xs ml-1.5 text-palette-blue11" />
+      )}
+      {info.hasVideoLink && isSelected && (
+        <VideoRecorderSolidIcon className="icon-xs ml-1.5 text-palette-blue11" />
+      )}
       {isExternal && (
         <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary group-hover:text-icon-info" />
       )}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15144

Already confirmed and shared this with @dankelly2040.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update SidebarLink component to add an icon. This icon indicates that there is video tutorial available on that page.
- Add `hasVideoLink` to pages that contain a video tutorial link.
- Add `hasVideoLink` under metadata fields in Readme.md

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
