### PR TITLE
Update api-routes.mdx - express@^5 not supported

### DIFF
--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -372,7 +372,7 @@ Before deploying to these providers, it may be good to be familiar with the basi
 
 Install the required dependencies:
 
-<Terminal cmd={['$ npm i -D express compression morgan']} />
+<Terminal cmd={['$ npm i -D express@4.20.0 compression morgan']} />
 
 </Step>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Following the API routes deployment docs using Express, I quickly ran into an error related to express@^5 not being supported.

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/54768589-2e8a-476e-af8b-2b6a8af98723" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

I've found the best solution is to downgrade Node.js to version 4.20.0 according to these: 

- https://github.com/expressjs/express/issues/6038
- https://github.com/expressjs/express/issues/5936#issuecomment-2340300012

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


Follow the instructions in the docs. After you get the error, downgrade express to 4.20.0 and the error will go away.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
