### PR TITLE
[expo-modules-core][Android] Add missing getConverterProvider method to ObjectDefinitionBuilder

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -57,6 +57,8 @@ open class ObjectDefinitionBuilder(
 
   private val eventObservers = mutableListOf<EventObservingDefinition>()
 
+  fun getConverterProvider(): TypeConverterProvider? = converters
+
   fun buildObject(): ObjectDefinitionData {
     EventObservingDefinition.Type.entries.forEach { type ->
       // If the user exports a function that is called `startObserving` or `stopObserving`, we don't add the observer


### PR DESCRIPTION
Based on recent issue reports, it seems many developers are encountering this same problem. I'm submitting this PR in hopes of getting it resolved quickly.

I've tested this fix locally by applying the patch and can confirm it resolves the issue. However, since I'm not completely sure if this is the most appropriate long-term solution, I would greatly appreciate your review and guidance.

Thank you for your time.

# Why

Apps using native modules encounter runtime crashes on Android with the following error:

```
No virtual method getConverterProvider()Lexpo/modules/kotlin/types/TypeConverterProvider;
in class Lexpo/modules/kotlin/objects/ObjectDefinitionBuilder;
```

- https://github.com/expo/expo/issues/37250


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
Added a bridge method to ObjectDefinitionBuilder that delegates to the existing converters property:

```kt
fun getConverterProvider(): TypeConverterProvider? = converters
```

Provides the missing method expected by Kotlin's synthetic accessor generation

- https://github.com/expo/expo/issues/37250#issuecomment-2945413347

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Expo project with SDK 53.0.9, 53.010, react-native 0.79.2, 0.79.3
- Run on Android: npx expo run:android
- Before fix: App crashes with "No virtual method getConverterProvider" error

```json
    "expo": "~53.0.10",
    "expo-audio": "~0.4.6",
    "expo-blur": "~14.1.5",
    "expo-build-properties": "~0.14.6",
    "expo-clipboard": "~7.1.4",
    "expo-crypto": "~14.1.4",
    "expo-dev-client": "~5.2.0",
    "expo-document-picker": "~13.1.5",
    "expo-file-system": "~18.1.10",
    "expo-font": "~13.3.1",
    "expo-image": "~2.2.0",
    "expo-image-picker": "~16.1.4",
    "expo-linear-gradient": "~14.1.5",
    "expo-linking": "~7.1.5",
    "expo-localization": "~16.1.5",
    "expo-splash-screen": "~0.30.9",
    "expo-system-ui": "~5.0.8",
    "expo-video": "~2.2.0",
    "google-translate-api-x": "^10.6.8",
    "query-string": "^9.1.1",
    "react": "19.0.0",
    "react-dom": "19.0.0",
    "react-native": "0.79.3",
```

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
