### PR TITLE
[gradle] Bump kotlin version used by plugins to `2.0.21`

### DIFF
--- a/packages/expo-dev-launcher/expo-dev-launcher-gradle-plugin/build.gradle.kts
+++ b/packages/expo-dev-launcher/expo-dev-launcher-gradle-plugin/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  kotlin("jvm") version "1.9.24"
+  kotlin("jvm") version "2.0.21"
   id("java-gradle-plugin")
 }
 

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-  kotlin("jvm") version "1.9.24" apply false
+  kotlin("jvm") version "2.0.21" apply false
   id("java-gradle-plugin")
 }

--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  kotlin("jvm") version "1.9.24"
+  kotlin("jvm") version "2.0.21"
   id("java-gradle-plugin")
 }
 

--- a/packages/expo-network-addons/expo-network-addons-gradle-plugin/build.gradle.kts
+++ b/packages/expo-network-addons/expo-network-addons-gradle-plugin/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-  kotlin("jvm") version "1.9.24"
+  kotlin("jvm") version "2.0.21"
   id("java-gradle-plugin")
 }
 


### PR DESCRIPTION
# Why

Fixes:
```
> Task :expo-module-gradle-plugin:compileKotlin FAILED
e: file:///Users/tsapeta/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/2.1.0/85f8b81009cda5890e54ba67d64b5e599c645020/kotlin-stdlib-2.1.0.jar!/META-INF/kotlin-stdlib-jdk7.kotlin_moduleModule was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.1.0, expected version is 1.9.0.
e: file:///Users/tsapeta/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/2.1.0/85f8b81009cda5890e54ba67d64b5e599c645020/kotlin-stdlib-2.1.0.jar!/META-INF/kotlin-stdlib-jdk8.kotlin_moduleModule was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.1.0, expected version is 1.9.0.
e: file:///Users/tsapeta/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/2.1.0/85f8b81009cda5890e54ba67d64b5e599c645020/kotlin-stdlib-2.1.0.jar!/META-INF/kotlin-stdlib.kotlin_moduleModule was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.1.0, expected version is 1.9.0.
e: file:///Users/tsapeta/Work/compass-app/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/build/classes/kotlin/main/META-INF/react-native-gradle-plugin.kotlin_moduleModule was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.1.0, expected version is 1.9.0.
```

# How

Bumps kotlin version of our plugins to much version used in React Native

# Test Plan

- bare-expo ✅ 