### PR TITLE
[docs] add fingerprint fileHookTransform

### DIFF
--- a/docs/pages/versions/unversioned/sdk/fingerprint.mdx
+++ b/docs/pages/versions/unversioned/sdk/fingerprint.mdx
@@ -79,7 +79,7 @@ In some cases, you may want to customize the sources before fingerprinting. For 
 - You want to stabilize dynamic values in the app config.
 - You want to transform file hashes to stable values.
 
-To do this, you can use the `fileHookTransform` option in the **fingerprint.config.js** file to transform the sources before hashing. Learn more about the [`fileHookTransform` option](#filehooktransformfunctionsource-chunk-isendoffile-encoding)
+To do this, you can use the `fileHookTransform` option in the **fingerprint.config.js** file to transform the sources before hashing. Learn more about the [`fileHookTransform` option](#filehooktransformfunctionsource-chunk-isendoffile-encoding).
 
 ```js fingerprint.config.js
 const assert = require('node:assert');
@@ -166,7 +166,7 @@ export default ({ config }) => {
   config.plugins.push((config) => config);
   return config;
 };
-````
+```
 
 It's important to note that due to this design, if you make changes to the implementation of raw config plugins functions, such as altering the **Info.plist** value within `withMyPlugin`, the fingerprint will still generate the same hash value. To ensure unique fingerprints when modifying config plugins implementations, consider the following options:
 

--- a/docs/pages/versions/unversioned/sdk/fingerprint.mdx
+++ b/docs/pages/versions/unversioned/sdk/fingerprint.mdx
@@ -53,7 +53,7 @@ Placed in your project root, **fingerprint.config.js** allows you to specify cus
 
 Below is an example **fingerprint.config.js** configuration, assuming you have `@expo/fingerprint` installed as a direct dependency:
 
-```js
+```js fingerprint.config.js
 /** @type {import('@expo/fingerprint').Config} */
 const config = {
   sourceSkips: [
@@ -70,6 +70,70 @@ If you are using `@expo/fingerprint` through `expo` (where `@expo/fingerprint` i
 ```js
 /** @type {import('expo/fingerprint').Config} */
 ```
+
+<Collapsible summary="Advanced: Customize sources before fingerprint hashing">
+
+In some cases, you may want to customize the sources before fingerprinting. For example:
+
+- You want to remove sensitive data from the app config.
+- You want to stabilize dynamic values in the app config.
+- You want to transform file hashes to stable values.
+
+To do this, you can use the `fileHookTransform` option in the **fingerprint.config.js** file to transform the sources before hashing. Learn more about the [`fileHookTransform` option](#filehooktransformfunctionsource-chunk-isendoffile-encoding)
+
+```js fingerprint.config.js
+const assert = require('node:assert');
+
+const fileChunkMap = {};
+
+/** @type {import('@expo/fingerprint').Config} */
+const config = {
+  fileHookTransform: (source, chunk, isEndOfFile, encoding) => {
+    // Remove the "updates" section from the app config
+    if (source.type === 'contents' && source.id === 'expoConfig') {
+      assert(isEndOfFile, 'contents source is expected to have single chunk.');
+      const config = JSON.parse(chunk);
+      delete config.updates;
+      return JSON.stringify(config);
+    }
+
+    // Transform content sources to an empty string
+    if (source.type === 'contents' && source.id === 'packageJson:scripts') {
+      return '';
+    }
+
+    // Transform a file source by replacing dynamic values
+    if (source.type === 'file' && source.filePath === 'eas.json') {
+      return chunk.toString().replace(/MyApp-Dev/g, 'MyApp');
+    }
+
+    // Transform a large file that is processed in multiple chunks
+    // To get the full file, buffer all chunks and return them all at once
+    if (source.type === 'file' && source.filePath === 'assets/large-image.jpg') {
+      let receivedBuffer = fileChunkMap[source.filePath] ?? Buffer.alloc(0);
+      if (chunk != null) {
+        const buffer = typeof chunk === 'string' ? Buffer.from(chunk, encoding) : chunk;
+        receivedBuffer = Buffer.concat([receivedBuffer, buffer]);
+        fileChunkMap[source.filePath] = receivedBuffer;
+      }
+      if (!isEndOfFile) {
+        return null;
+      }
+      fileChunkMap[source.filePath] = null;
+      // The full payload is available here and you can transform it as needed.
+      receivedBuffer = receivedBuffer.toString().replace(/SensitiveData/g, 'StableData');
+      return receivedBuffer;
+    }
+
+    // For other sources, just return the chunk
+    return chunk;
+  },
+};
+
+module.exports = config;
+```
+
+</Collapsible>
 
 ## Limitations
 
@@ -102,7 +166,7 @@ export default ({ config }) => {
   config.plugins.push((config) => config);
   return config;
 };
-```
+````
 
 It's important to note that due to this design, if you make changes to the implementation of raw config plugins functions, such as altering the **Info.plist** value within `withMyPlugin`, the fingerprint will still generate the same hash value. To ensure unique fingerprints when modifying config plugins implementations, consider the following options:
 

--- a/docs/pages/versions/v53.0.0/sdk/fingerprint.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/fingerprint.mdx
@@ -53,7 +53,7 @@ Placed in your project root, **fingerprint.config.js** allows you to specify cus
 
 Below is an example **fingerprint.config.js** configuration, assuming you have `@expo/fingerprint` installed as a direct dependency:
 
-```js
+```js fingerprint.config.js
 /** @type {import('@expo/fingerprint').Config} */
 const config = {
   sourceSkips: [
@@ -70,6 +70,70 @@ If you are using `@expo/fingerprint` through `expo` (where `@expo/fingerprint` i
 ```js
 /** @type {import('expo/fingerprint').Config} */
 ```
+
+<Collapsible summary="Advanced: Customize sources before fingerprint hashing">
+
+In some cases, you may want to customize the sources before fingerprinting. For example:
+
+- You want to remove sensitive data from the app config.
+- You want to stabilize dynamic values in the app config.
+- You want to transform file hashes to stable values.
+
+To do this, you can use the `fileHookTransform` option in the **fingerprint.config.js** file to transform the sources before hashing. Learn more about the [`fileHookTransform` option](#filehooktransformfunctionsource-chunk-isendoffile-encoding).
+
+```js fingerprint.config.js
+const assert = require('node:assert');
+
+const fileChunkMap = {};
+
+/** @type {import('@expo/fingerprint').Config} */
+const config = {
+  fileHookTransform: (source, chunk, isEndOfFile, encoding) => {
+    // Remove the "updates" section from the app config
+    if (source.type === 'contents' && source.id === 'expoConfig') {
+      assert(isEndOfFile, 'contents source is expected to have single chunk.');
+      const config = JSON.parse(chunk);
+      delete config.updates;
+      return JSON.stringify(config);
+    }
+
+    // Transform content sources to an empty string
+    if (source.type === 'contents' && source.id === 'packageJson:scripts') {
+      return '';
+    }
+
+    // Transform a file source by replacing dynamic values
+    if (source.type === 'file' && source.filePath === 'eas.json') {
+      return chunk.toString().replace(/MyApp-Dev/g, 'MyApp');
+    }
+
+    // Transform a large file that is processed in multiple chunks
+    // To get the full file, buffer all chunks and return them all at once
+    if (source.type === 'file' && source.filePath === 'assets/large-image.jpg') {
+      let receivedBuffer = fileChunkMap[source.filePath] ?? Buffer.alloc(0);
+      if (chunk != null) {
+        const buffer = typeof chunk === 'string' ? Buffer.from(chunk, encoding) : chunk;
+        receivedBuffer = Buffer.concat([receivedBuffer, buffer]);
+        fileChunkMap[source.filePath] = receivedBuffer;
+      }
+      if (!isEndOfFile) {
+        return null;
+      }
+      fileChunkMap[source.filePath] = null;
+      // The full payload is available here and you can transform it as needed.
+      receivedBuffer = receivedBuffer.toString().replace(/SensitiveData/g, 'StableData');
+      return receivedBuffer;
+    }
+
+    // For other sources, just return the chunk
+    return chunk;
+  },
+};
+
+module.exports = config;
+```
+
+</Collapsible>
 
 ## Limitations
 


### PR DESCRIPTION
# Why

following up https://github.com/expo/expo/pull/36131#issuecomment-2835506093

close ENG-15516

# How

added `fileHookTransform` to the fingerprint doc
![Screenshot 2025-06-06 at 9 22 59 PM](https://github.com/user-attachments/assets/e7af60f2-cdfb-4bc7-80a9-8bb5136d600b)


# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
