### PR TITLE
Updated secure store iOS plist example key/value

### DIFF
--- a/docs/pages/versions/unversioned/sdk/securestore.mdx
+++ b/docs/pages/versions/unversioned/sdk/securestore.mdx
@@ -75,8 +75,8 @@ You can configure `expo-secure-store` using its built-in [config plugin](/config
 Add `NSFaceIDUsageDescription` key to **Info.plist**:
 
 ```xml Info.plist
-<key>NSCameraUsageDescription</key>
-<string>Allow $(PRODUCT_NAME) to use the camera</string>
+<key>NSFaceIDUsageDescription</key>
+<string>Allow $(PRODUCT_NAME) to access your Face ID biometric data.</string>
 ```
 
 </ConfigReactNative>


### PR DESCRIPTION
# Why
The documentation is confusing around setting up secure store. It says to use the plist value of `NSFaceIDUsageDescription`, but in the example it uses the key for the camera.

# How
Documentation only

# Test Plan
N/A

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
