### PR TITLE
[config-plugins] add unit test for Paths

### DIFF
--- a/packages/@expo/config-plugins/src/android/__tests__/Paths-test.ts
+++ b/packages/@expo/config-plugins/src/android/__tests__/Paths-test.ts
@@ -1,6 +1,7 @@
 import { vol } from 'memfs';
 
 import {
+  getAndroidManifestAsync,
   getMainActivityAsync,
   getProjectBuildGradleAsync,
   getResourceXMLPathAsync,
@@ -109,5 +110,20 @@ describe(getResourceXMLPathAsync, () => {
     await expect(getResourceXMLPathAsync('/managed', { name: 'somn' })).rejects.toThrow(
       /Android project folder is missing in project/
     );
+  });
+});
+
+describe(getAndroidManifestAsync, () => {
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it(`gets the android manifest path`, async () => {
+    vol.fromJSON({
+      '/app/android/app/build.gradle': '',
+    });
+    expect(getAndroidManifestAsync).toBeDefined();
+    const manifestPath = await getAndroidManifestAsync('/app');
+    expect(manifestPath).toBe('/app/android/app/src/main/AndroidManifest.xml');
   });
 });

--- a/packages/@expo/config-plugins/src/ios/__tests__/Paths-test.ts
+++ b/packages/@expo/config-plugins/src/ios/__tests__/Paths-test.ts
@@ -9,6 +9,7 @@ import {
   getAllInfoPlistPaths,
   getAppDelegate,
   getXcodeProjectPath,
+  getPBXProjectPath,
   getPodfilePath,
 } from '../Paths';
 
@@ -274,5 +275,18 @@ describe(getAllInfoPlistPaths, () => {
       '/app/ios/ExampleE2ETests/Info.plist',
       '/app/ios/ExampleE2E-tvOSTests/Info.plist',
     ]);
+  });
+});
+
+describe(getPBXProjectPath, () => {
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it(`gets the pbxproj path`, () => {
+    vol.fromJSON({
+      '/app/ios/app.xcodeproj/project.pbxproj': '',
+    });
+    expect(getPBXProjectPath('/app')).toBe('/app/ios/app.xcodeproj/project.pbxproj');
   });
 });


### PR DESCRIPTION
# Why

following up https://app.graphite.dev/github/pr/expo/expo/37204/%5Bfingerprint%5D-add-useCNGForPlatforms-to-indicate-project-workflow#comment-PRRC_kwDOA-tE4c5_G5lh

# How

add unit test for `getAndroidManifestAsync` and `getPBXProjectPath`

# Test Plan

ci passed

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - just added unit test without relevant code change
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
