### PR TITLE
fix: getMaxAmplitude error by adding delay before polling recorder status

### DIFF
--- a/packages/expo-audio/src/ExpoAudio.ts
+++ b/packages/expo-audio/src/ExpoAudio.ts
@@ -81,11 +81,20 @@ export function useAudioRecorderState(recorder: AudioRecorder, interval: number 
   const [state, setState] = useState<RecorderState>(recorder.getStatus());
 
   useEffect(() => {
-    const int = setInterval(() => {
-      setState(recorder.getStatus());
-    }, interval);
+    let intervalId: ReturnType<typeof setInterval>;
 
-    return () => clearInterval(int);
+    const timeoutId = setTimeout(() => {
+      intervalId = setInterval(() => {
+        setState(recorder.getStatus());
+      }, interval);
+    }, 1000);
+
+    return () => {
+      clearTimeout(timeoutId);
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+    };
   }, [recorder.id]);
 
   return state;


### PR DESCRIPTION
# Why
In certain cases of rapid start/stop operations with expo-audio's `useAudioRecorder`, the following native error occurs on Android:

`java.lang.RuntimeException: getMaxAmplitude failed`
This error likely occurs because the underlying native MediaRecorder is not fully initialized when polling (getStatus()) begins too soon after switching or starting a new recorder instance.

In testing, this issue frequently occurred with a polling interval of 200ms, which appears too aggressive for certain devices or usage patterns.

# How

- Introduced a 1-second delay before starting the setInterval polling loop in useAudioRecorderState.
- Ensured recorder.getStatus() is only called after the recorder is stable, reducing the chance of calling into native code before initialization is complete.

```jsx
useEffect(() => {
  let intervalId: ReturnType<typeof setInterval>;

  const timeoutId = setTimeout(() => {
    intervalId = setInterval(() => {
      setState((prev) => {
        if (!recorder.isRecording) {
          return prev;
        }
        return recorder.getStatus();
      });
    }, interval);
  }, 1000); // Delay to avoid native errors

  return () => {
    clearTimeout(timeoutId);
    if (intervalId) {
      clearInterval(intervalId);
    }
  };
}, [recorder.id]);
```
This change significantly reduces the chance of encountering getMaxAmplitude failed errors, especially under fast start/stop user interactions.

# Test Plan

- Applied the updated useAudioRecorderState in a screen using the Expo Audio API.
- Set polling interval = 200ms to simulate high-frequency status updates.
- Performed multiple rapid start/stop recordings on Android.
- Confirmed that the getMaxAmplitude error no longer occurs.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
