### PR TITLE
Update build-a-screen.mdx

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -324,7 +324,7 @@ import { StyleSheet, View, Pressable, Text } from 'react-native';
 
 type Props = {
   label: string;
-  /* @tutinfo Add theme prop */theme?: 'primary';/* @end */
+  /* @tutinfo Add theme prop. */theme?: 'primary';/* @end */
 };
 
 export default function Button({ label, /* @tutinfo The prop <CODEtheme</CODE> to detect the button variant. */theme/* @end */ }: Props) {

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -324,7 +324,7 @@ import { StyleSheet, View, Pressable, Text } from 'react-native';
 
 type Props = {
   label: string;
-  theme?: 'primary';
+  /* @tutinfo Add theme prop */theme?: 'primary';/* @end */
 };
 
 export default function Button({ label, /* @tutinfo The prop <CODEtheme</CODE> to detect the button variant. */theme/* @end */ }: Props) {


### PR DESCRIPTION
# Why

There was an absence in notifying the user that the 'theme' prop had been modified.

# How

I simply added the green highlight over the text to notify the user.

# Test Plan

This change is simply stylistic, and its impact may be seen just by comparing the change from its unaltered state.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
