### PR TITLE
[cli] allow separating `expo run*` commands options from project root by using `--`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Support JSON output for install check. ([#37318](https://github.com/expo/expo/pull/37318) by [@betomoedano](https://github.com/betomoedano))
+- Add support for `--` separator in `expo run <platform>`, `expo run:android` and `expo run:ios` commands, to allow running commands like `expo run android -d -- /path/to/my_app` ([#37301](https://github.com/expo/expo/pull/37301) by [@makl11](https://github.com/makl11))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -58,6 +58,7 @@ const args = arg(
   },
   {
     permissive: true,
+    stopAtPositional: true,
   }
 );
 

--- a/packages/@expo/cli/e2e/__tests__/run-android-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/run-android-test.ts
@@ -38,7 +38,7 @@ it('runs `npx expo run:android --help`', async () => {
         Run the native Android app locally
 
       Usage
-        $ npx expo run:android <dir>
+        $ npx expo run:android [Options] [--] [ProjectRoot] Default: PWD
 
       Options 
         --no-build-cache       Clear the native build cache
@@ -50,6 +50,8 @@ it('runs `npx expo run:android --help`', async () => {
         -d, --device [device]  Device name to run the app on
         -p, --port <port>      Port to start the dev server on. Default: 8081
         -h, --help             Output usage information
+
+      Note: If specified, ProjectRoot must not be preceded by \`--device/-d\`. Use the \`--\` separator in that case.
     "
   `);
 });

--- a/packages/@expo/cli/e2e/__tests__/run-ios-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/run-ios-test.ts
@@ -36,7 +36,7 @@ it('runs `npx expo run:ios --help`', async () => {
         Run the iOS app binary locally
 
       Usage
-        $ npx expo run:ios
+        $ npx expo run:ios [Options] [--] [ProjectRoot] Default: PWD
 
       Options
         --no-build-cache                 Clear the native derived data before building
@@ -48,6 +48,8 @@ it('runs `npx expo run:ios --help`', async () => {
         -d, --device [device]            Device name or UDID to build the app on
         -p, --port <port>                Port to start the Metro bundler on. Default: 8081
         -h, --help                       Usage info
+
+      Note: If specified, ProjectRoot must not be preceded by \`--device/-d\` or \`--scheme\`. Use the \`--\` separator in that case.
 
       Build for production (unsigned) with the Release configuration:
         $ npx expo run:ios --configuration Release

--- a/packages/@expo/cli/e2e/__tests__/run-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/run-test.ts
@@ -56,7 +56,7 @@ it('runs `npx expo run android --help`', async () => {
         Run the native Android app locally
 
       Usage
-        $ npx expo run:android <dir>
+        $ npx expo run:android [Options] [--] [ProjectRoot] Default: PWD
 
       Options 
         --no-build-cache       Clear the native build cache
@@ -68,6 +68,8 @@ it('runs `npx expo run android --help`', async () => {
         -d, --device [device]  Device name to run the app on
         -p, --port <port>      Port to start the dev server on. Default: 8081
         -h, --help             Output usage information
+
+      Note: If specified, ProjectRoot must not be preceded by \`--device/-d\`. Use the \`--\` separator in that case.
     "
   `);
 });
@@ -81,7 +83,7 @@ it('runs `npx expo run ios --help`', async () => {
         Run the iOS app binary locally
 
       Usage
-        $ npx expo run:ios
+        $ npx expo run:ios [Options] [--] [ProjectRoot] Default: PWD
 
       Options
         --no-build-cache                 Clear the native derived data before building
@@ -93,6 +95,8 @@ it('runs `npx expo run ios --help`', async () => {
         -d, --device [device]            Device name or UDID to build the app on
         -p, --port <port>                Port to start the Metro bundler on. Default: 8081
         -h, --help                       Usage info
+
+      Note: If specified, ProjectRoot must not be preceded by \`--device/-d\` or \`--scheme\`. Use the \`--\` separator in that case.
 
       Build for production (unsigned) with the Release configuration:
         $ npx expo run:ios --configuration Release

--- a/packages/@expo/cli/src/run/android/index.ts
+++ b/packages/@expo/cli/src/run/android/index.ts
@@ -30,8 +30,8 @@ export const expoRunAndroid: Command = async (argv) => {
   };
   const args = assertWithOptionsArgs(rawArgsMap, {
     argv,
-
     permissive: true,
+    stopAtPositional: true,
   });
 
   // '-d' -> '--device': Boolean,
@@ -43,7 +43,7 @@ export const expoRunAndroid: Command = async (argv) => {
     Run the native Android app locally
 
   {bold Usage}
-    $ npx expo run:android <dir>
+    $ npx expo run:android [Options] [--] [ProjectRoot] {dim Default: PWD}
 
   {bold Options} 
     --no-build-cache       Clear the native build cache
@@ -55,6 +55,8 @@ export const expoRunAndroid: Command = async (argv) => {
     -d, --device [device]  Device name to run the app on
     -p, --port <port>      Port to start the dev server on. {dim Default: 8081}
     -h, --help             Output usage information
+
+  {underline Note}: If specified, ProjectRoot must not be preceded by \`--device/-d\`. Use the \`--\` separator in that case.
 `,
       0
     );

--- a/packages/@expo/cli/src/run/index.ts
+++ b/packages/@expo/cli/src/run/index.ts
@@ -18,6 +18,7 @@ export const expoRun: Command = async (argv) => {
       argv,
       // Allow additional flags for both android and ios commands
       permissive: true,
+      stopAtPositional: true,
     }
   );
 

--- a/packages/@expo/cli/src/run/ios/index.ts
+++ b/packages/@expo/cli/src/run/ios/index.ts
@@ -30,8 +30,8 @@ export const expoRunIos: Command = async (argv) => {
   };
   const args = assertWithOptionsArgs(rawArgsMap, {
     argv,
-
     permissive: true,
+    stopAtPositional: true,
   });
 
   // '-d' -> '--device': Boolean,
@@ -40,7 +40,7 @@ export const expoRunIos: Command = async (argv) => {
   if (args['--help']) {
     printHelp(
       `Run the iOS app binary locally`,
-      `npx expo run:ios`,
+      chalk`npx expo run:ios [Options] [--] [ProjectRoot] {dim Default: PWD}`,
       [
         `--no-build-cache                 Clear the native derived data before building`,
         `--no-install                     Skip installing dependencies`,
@@ -53,6 +53,8 @@ export const expoRunIos: Command = async (argv) => {
         `-h, --help                       Usage info`,
       ].join('\n'),
       [
+        '',
+        chalk`  {underline Note}: If specified, ProjectRoot must not be preceded by \`--device/-d\` or \`--scheme\`. Use the \`--\` separator in that case.`,
         '',
         chalk`  Build for production (unsigned) with the {bold Release} configuration:`,
         chalk`    {dim $} npx expo run:ios --configuration Release`,

--- a/packages/@expo/cli/src/utils/__tests__/resolveArgs-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/resolveArgs-test.ts
@@ -50,6 +50,12 @@ describe(_resolveStringOrBooleanArgs, () => {
       projectRoot: 'root',
     });
   });
+  it(`resolves to boolean with custom project root`, () => {
+    expect(_resolveStringOrBooleanArgs({ '--basic': Boolean }, ['--basic', '--', 'root'])).toEqual({
+      args: { '--basic': true },
+      projectRoot: 'root',
+    });
+  });
   it(`asserts invalid arguments`, () => {
     expect(() =>
       _resolveStringOrBooleanArgs({ '--basic': Boolean }, ['foobar', 'root', '--basic'])

--- a/packages/@expo/cli/src/utils/resolveArgs.ts
+++ b/packages/@expo/cli/src/utils/resolveArgs.ts
@@ -103,6 +103,7 @@ export function _resolveStringOrBooleanArgs(arg: Spec, args: string[]) {
   // Loop over arguments in reverse order so we can resolve if a value belongs to a flag.
   for (let i = args.length - 1; i > -1; i--) {
     const value = args[i];
+    if (value === '--') continue;
     // At this point we should have converted all aliases to fully qualified arguments.
     if (value.startsWith('--')) {
       // If we ever find an argument then it must be a boolean because we are checking in reverse
@@ -155,7 +156,7 @@ export function collapseAliases(arg: Spec, args: string[]): string[] {
 
 /** Assert that the spec has unknown arguments. */
 export function assertUnknownArgs(arg: Spec, args: string[]) {
-  const allowedArgs = Object.keys(arg);
+  const allowedArgs = ['--', ...Object.keys(arg)];
   const unknownArgs = args.filter((arg) => !allowedArgs.includes(arg) && arg.startsWith('-'));
   if (unknownArgs.length > 0) {
     throw new CommandError(`Unknown arguments: ${unknownArgs.join(', ')}`);


### PR DESCRIPTION
# Why

Before this change, there was no way to run commands like `expo run <platform> -d "/path/to/my_app"`. The args parsing rightfully assumed the path to be the device name. Using `--`allows to run commands like that. 
The help texts for the `expo run*` commands now properly document where the user can specify their project root, in addition to informing about the usage of `--`.


# How

- Set `stopAtPositional: true` for the `arg(...)` functions, that parse `argv` or subsequent `args._`, so `--` does not get stripped from `args._`
- Always allow `--` in `assertUnknownArgs(...)`
- Skip `--` in `_resolveStringOrBooleanArgs` to prevent `"--": true` in the result

# Test Plan

I added a new test for the case of a string-or-boolean arg, that should be treated as a boolean, but is followed by the path to the project root.
All other tests for the cli still pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
    - I only tested locally and ran all tests for the cli. I cannot imagine why this would break EAS Build though
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
