### PR TITLE
[docs] Fix existing React Native project info.plist instruction in SecureStore

### DIFF
--- a/docs/pages/versions/v51.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/securestore.mdx
@@ -67,8 +67,8 @@ You can configure `expo-secure-store` using its built-in [config plugin](/config
 Add `NSFaceIDUsageDescription` key to **Info.plist**:
 
 ```xml Info.plist
-<key>NSCameraUsageDescription</key>
-<string>Allow $(PRODUCT_NAME) to use the camera</string>
+<key>NSFaceIDUsageDescription</key>
+<string>Allow $(PRODUCT_NAME) to access your Face ID biometric data.</string>
 ```
 
 </ConfigReactNative>

--- a/docs/pages/versions/v52.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/securestore.mdx
@@ -75,8 +75,8 @@ You can configure `expo-secure-store` using its built-in [config plugin](/config
 Add `NSFaceIDUsageDescription` key to **Info.plist**:
 
 ```xml Info.plist
-<key>NSCameraUsageDescription</key>
-<string>Allow $(PRODUCT_NAME) to use the camera</string>
+<key>NSFaceIDUsageDescription</key>
+<string>Allow $(PRODUCT_NAME) to access your Face ID biometric data.</string>
 ```
 
 </ConfigReactNative>

--- a/docs/pages/versions/v53.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/securestore.mdx
@@ -75,8 +75,8 @@ You can configure `expo-secure-store` using its built-in [config plugin](/config
 Add `NSFaceIDUsageDescription` key to **Info.plist**:
 
 ```xml Info.plist
-<key>NSCameraUsageDescription</key>
-<string>Allow $(PRODUCT_NAME) to use the camera</string>
+<key>NSFaceIDUsageDescription</key>
+<string>Allow $(PRODUCT_NAME) to access your Face ID biometric data.</string>
 ```
 
 </ConfigReactNative>


### PR DESCRIPTION

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #37282

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Backport fix for existing React Native project **Info.plist** instruction in SecureStore references in SDK 53, 52, & 51.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
