### PR TITLE
[asset] Add resource name validation for Android.

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add resource name validation for Android.
+- Add resource name validation for Android. ([#37322](https://github.com/expo/expo/pull/37322) by [@aleqsio](https://github.com/aleqsio))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add resource name validation for Android.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-asset/plugin/build/AssetContents.js
+++ b/packages/expo-asset/plugin/build/AssetContents.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.writeContentsJsonAsync = void 0;
+exports.writeContentsJsonAsync = writeContentsJsonAsync;
 // Forked from `@expo/prebuild-config`, because its not exposed as public API or through a correct dependency chain
 // See: https://github.com/expo/expo/blob/80ee356c2c90d6498b45c95214ed7be169d63f75/packages/%40expo/prebuild-config/src/plugins/icons/AssetContents.ts
 const promises_1 = __importDefault(require("node:fs/promises"));
@@ -26,4 +26,3 @@ async function writeContentsJsonAsync(directory, { images }) {
     await promises_1.default.mkdir(directory, { recursive: true });
     await promises_1.default.writeFile(node_path_1.default.join(directory, 'Contents.json'), JSON.stringify(data, null, 2));
 }
-exports.writeContentsJsonAsync = writeContentsJsonAsync;

--- a/packages/expo-asset/plugin/build/AssetContents.js
+++ b/packages/expo-asset/plugin/build/AssetContents.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.writeContentsJsonAsync = writeContentsJsonAsync;
+exports.writeContentsJsonAsync = void 0;
 // Forked from `@expo/prebuild-config`, because its not exposed as public API or through a correct dependency chain
 // See: https://github.com/expo/expo/blob/80ee356c2c90d6498b45c95214ed7be169d63f75/packages/%40expo/prebuild-config/src/plugins/icons/AssetContents.ts
 const promises_1 = __importDefault(require("node:fs/promises"));
@@ -26,3 +26,4 @@ async function writeContentsJsonAsync(directory, { images }) {
     await promises_1.default.mkdir(directory, { recursive: true });
     await promises_1.default.writeFile(node_path_1.default.join(directory, 'Contents.json'), JSON.stringify(data, null, 2));
 }
+exports.writeContentsJsonAsync = writeContentsJsonAsync;

--- a/packages/expo-asset/plugin/build/utils.d.ts
+++ b/packages/expo-asset/plugin/build/utils.d.ts
@@ -3,4 +3,4 @@ export declare const FONT_TYPES: string[];
 export declare const MEDIA_TYPES: string[];
 export declare const ACCEPTED_TYPES: string[];
 export declare function resolveAssetPaths(assets: string[], projectRoot: string): Promise<string[]>;
-export declare function validateAssets(assets: string[]): string[];
+export declare function validateAssets(assets: string[], platform: 'android' | 'ios'): string[];

--- a/packages/expo-asset/plugin/build/utils.js
+++ b/packages/expo-asset/plugin/build/utils.js
@@ -3,9 +3,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.ACCEPTED_TYPES = exports.MEDIA_TYPES = exports.FONT_TYPES = exports.IMAGE_TYPES = void 0;
-exports.resolveAssetPaths = resolveAssetPaths;
-exports.validateAssets = validateAssets;
+exports.validateAssets = exports.resolveAssetPaths = exports.ACCEPTED_TYPES = exports.MEDIA_TYPES = exports.FONT_TYPES = exports.IMAGE_TYPES = void 0;
+const warnings_js_1 = require("@expo/config-plugins/build/utils/warnings.js");
 const promises_1 = __importDefault(require("fs/promises"));
 const path_1 = __importDefault(require("path"));
 exports.IMAGE_TYPES = ['.png', '.jpg', '.gif'];
@@ -24,19 +23,31 @@ async function resolveAssetPaths(assets, projectRoot) {
     });
     return (await Promise.all(promises)).flat();
 }
-function validateAssets(assets) {
+exports.resolveAssetPaths = resolveAssetPaths;
+const validPattern = /^[a-z0-9_]+$/;
+function isAndroidAssetNameValid(assetName) {
+    return validPattern.test(assetName);
+}
+function validateAssets(assets, platform) {
     return assets.filter((asset) => {
         const ext = path_1.default.extname(asset);
+        const name = path_1.default.basename(asset, ext);
+        const isNameValid = platform === 'android' ? isAndroidAssetNameValid(name) : true;
         const accepted = exports.ACCEPTED_TYPES.includes(ext);
         const isFont = exports.FONT_TYPES.includes(ext);
+        if (!isNameValid) {
+            (0, warnings_js_1.addWarningForPlatform)(platform, 'expo-asset', `\`${name}\` is not a supported asset name - file-based resource names must contain only lowercase a-z, 0-9, or underscore`);
+            return;
+        }
         if (!accepted) {
-            console.warn(`\`${ext}\` is not a supported asset type`);
+            (0, warnings_js_1.addWarningForPlatform)(platform, 'expo-asset', `\`${ext}\` is not a supported asset type`);
             return;
         }
         if (isFont) {
-            console.warn(`Fonts are not supported with the \`expo-asset\` plugin. Use \`expo-font\` instead. Ignoring ${asset}`);
+            (0, warnings_js_1.addWarningForPlatform)(platform, 'expo-asset', `Fonts are not supported with the \`expo-asset\` plugin. Use \`expo-font\` instead. Ignoring ${asset}`);
             return;
         }
         return asset;
     });
 }
+exports.validateAssets = validateAssets;

--- a/packages/expo-asset/plugin/build/utils.js
+++ b/packages/expo-asset/plugin/build/utils.js
@@ -3,7 +3,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.validateAssets = exports.resolveAssetPaths = exports.ACCEPTED_TYPES = exports.MEDIA_TYPES = exports.FONT_TYPES = exports.IMAGE_TYPES = void 0;
+exports.ACCEPTED_TYPES = exports.MEDIA_TYPES = exports.FONT_TYPES = exports.IMAGE_TYPES = void 0;
+exports.resolveAssetPaths = resolveAssetPaths;
+exports.validateAssets = validateAssets;
 const warnings_js_1 = require("@expo/config-plugins/build/utils/warnings.js");
 const promises_1 = __importDefault(require("fs/promises"));
 const path_1 = __importDefault(require("path"));
@@ -23,7 +25,6 @@ async function resolveAssetPaths(assets, projectRoot) {
     });
     return (await Promise.all(promises)).flat();
 }
-exports.resolveAssetPaths = resolveAssetPaths;
 const validPattern = /^[a-z0-9_]+$/;
 function isAndroidAssetNameValid(assetName) {
     return validPattern.test(assetName);
@@ -50,4 +51,3 @@ function validateAssets(assets, platform) {
         return asset;
     });
 }
-exports.validateAssets = validateAssets;

--- a/packages/expo-asset/plugin/build/withAssetsAndroid.js
+++ b/packages/expo-asset/plugin/build/withAssetsAndroid.js
@@ -14,7 +14,7 @@ const withAssetsAndroid = (config, assets) => {
         'android',
         async (config) => {
             const resolvedAssets = await (0, utils_1.resolveAssetPaths)(assets, config.modRequest.projectRoot);
-            const validAssets = (0, utils_1.validateAssets)(resolvedAssets);
+            const validAssets = (0, utils_1.validateAssets)(resolvedAssets, 'android');
             validAssets.forEach((asset) => {
                 const assetsDir = getAssetDir(asset, config.modRequest.platformProjectRoot);
                 fs_1.default.mkdirSync(assetsDir, { recursive: true });

--- a/packages/expo-asset/plugin/build/withAssetsIos.js
+++ b/packages/expo-asset/plugin/build/withAssetsIos.js
@@ -19,7 +19,7 @@ exports.withAssetsIos = withAssetsIos;
 function addAssetsToTarget(config, assets) {
     return (0, config_plugins_1.withXcodeProject)(config, async (config) => {
         const resolvedAssets = await (0, utils_1.resolveAssetPaths)(assets, config.modRequest.projectRoot);
-        const validAssets = (0, utils_1.validateAssets)(resolvedAssets);
+        const validAssets = (0, utils_1.validateAssets)(resolvedAssets, 'ios');
         const project = config.modResults;
         const platformProjectRoot = config.modRequest.platformProjectRoot;
         config_plugins_1.IOSConfig.XcodeUtils.ensureGroupRecursively(project, 'Resources');

--- a/packages/expo-asset/plugin/src/utils.ts
+++ b/packages/expo-asset/plugin/src/utils.ts
@@ -1,3 +1,4 @@
+import { addWarningForPlatform } from '@expo/config-plugins/build/utils/warnings.js';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -19,19 +20,37 @@ export async function resolveAssetPaths(assets: string[], projectRoot: string) {
   return (await Promise.all(promises)).flat();
 }
 
-export function validateAssets(assets: string[]) {
+const validPattern = /^[a-z0-9_]+$/;
+function isAndroidAssetNameValid(assetName: string) {
+  return validPattern.test(assetName);
+}
+
+export function validateAssets(assets: string[], platform: 'android' | 'ios') {
   return assets.filter((asset) => {
     const ext = path.extname(asset);
+    const name = path.basename(asset, ext);
+    const isNameValid = platform === 'android' ? isAndroidAssetNameValid(name) : true;
     const accepted = ACCEPTED_TYPES.includes(ext);
     const isFont = FONT_TYPES.includes(ext);
 
+    if (!isNameValid) {
+      addWarningForPlatform(
+        platform,
+        'expo-asset',
+        `\`${name}\` is not a supported asset name - file-based resource names must contain only lowercase a-z, 0-9, or underscore`
+      );
+      return;
+    }
+
     if (!accepted) {
-      console.warn(`\`${ext}\` is not a supported asset type`);
+      addWarningForPlatform(platform, 'expo-asset', `\`${ext}\` is not a supported asset type`);
       return;
     }
 
     if (isFont) {
-      console.warn(
+      addWarningForPlatform(
+        platform,
+        'expo-asset',
         `Fonts are not supported with the \`expo-asset\` plugin. Use \`expo-font\` instead. Ignoring ${asset}`
       );
       return;

--- a/packages/expo-asset/plugin/src/withAssetsAndroid.ts
+++ b/packages/expo-asset/plugin/src/withAssetsAndroid.ts
@@ -10,7 +10,7 @@ export const withAssetsAndroid: ConfigPlugin<string[]> = (config, assets) => {
     'android',
     async (config) => {
       const resolvedAssets = await resolveAssetPaths(assets, config.modRequest.projectRoot);
-      const validAssets = validateAssets(resolvedAssets);
+      const validAssets = validateAssets(resolvedAssets, 'android');
 
       validAssets.forEach((asset) => {
         const assetsDir = getAssetDir(asset, config.modRequest.platformProjectRoot);

--- a/packages/expo-asset/plugin/src/withAssetsIos.ts
+++ b/packages/expo-asset/plugin/src/withAssetsIos.ts
@@ -22,7 +22,7 @@ export const withAssetsIos: ConfigPlugin<string[]> = (config, assets) => {
 function addAssetsToTarget(config: ExpoConfig, assets: string[]) {
   return withXcodeProject(config, async (config) => {
     const resolvedAssets = await resolveAssetPaths(assets, config.modRequest.projectRoot);
-    const validAssets = validateAssets(resolvedAssets);
+    const validAssets = validateAssets(resolvedAssets, 'ios');
     const project = config.modResults;
     const platformProjectRoot = config.modRequest.platformProjectRoot;
     IOSConfig.XcodeUtils.ensureGroupRecursively(project, 'Resources');


### PR DESCRIPTION
# Why

Closes https://linear.app/expo/issue/ENG-15223/validate-asset-names-in-expo-asset-plugin

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
