### PR TITLE
[expo-updates] Fix iOS native debugging

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed local aar files is not being linked correctly. ([#37280](https://github.com/expo/expo/pull/37280) by [@lukmccall](https://github.com/lukmccall))
+- Fix updates native debug for iOS. ([#37323](https://github.com/expo/expo/pull/37323) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/xcode_env_generator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/xcode_env_generator.rb
@@ -13,9 +13,11 @@ def generate_or_remove_xcode_env_updates_file!()
       File.delete(xcode_env_file)
     end
     File.write(xcode_env_file, <<~EOS
+      # These force Xcode to build the JS bundle with DEV=false
       export FORCE_BUNDLING=1
       unset SKIP_BUNDLING
       export RCT_NO_LAUNCH_PACKAGER=1
+      export CONFIGURATION=Release
 EOS
     )
   else

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix updates native debug for iOS. ([#37323](https://github.com/expo/expo/pull/37323) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 - [Android] Cleanup state machine resources when the module is destroyed. ([#37193](https://github.com/expo/expo/pull/37193) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
@@ -344,7 +344,9 @@ open class AppLoader: NSObject {
             }
           }
           // This replaces the old force try
-          assert(contents != nil)
+          if !UpdatesUtils.isNativeDebuggingEnabled() {
+            assert(contents != nil)
+          }
           if let contents = contents {
             existingAsset.contentHash = UpdatesUtils.hexEncodedSHA256WithData(contents)
             existingAsset.downloadTime = Date()


### PR DESCRIPTION
# Why

When built with native debug, an Expo iOS app made from the default expo-router template shows the redbox error

```
[runtime not ready]: Error: Cannot create devtools websocket connections in embedded environments.
```

The only way to prevent this is by setting DEV=false when building the JS bundle.

This PR enforces that for iOS (it is already this way for Android), and fixes an iOS crash that occurs in native debug when the app is run for the first time.

# How

- Add `CONFIGURATION=Release` to Xcode environment for native debug
- Fix the crash in AppLoader.swift

# Test Plan

- Tested with an app created with the default template
- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
