### PR TITLE
chore(workflows,ios,0.80): update xcode to latest version

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           submodules: true
       - name: 🔨 Switch to Xcode 16.0
-        run: sudo xcode-select --switch /Applications/Xcode_16.0.app
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: 🔓 Decrypt secrets if possible
         uses: ./.github/actions/expo-git-decrypt
         with:

--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -27,7 +27,7 @@ jobs:
       - name: 👀 Checkout
         uses: actions/checkout@v4
       - name: 🔨 Switch to Xcode 16.0
-        run: sudo xcode-select --switch /Applications/Xcode_16.0.app
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true

--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           submodules: true
       - name: 🔨 Switch to Xcode 16.0
-        run: sudo xcode-select --switch /Applications/Xcode_16.0.app
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           submodules: true
       - name: 🔨 Switch to Xcode 16.0
-        run: sudo xcode-select --switch /Applications/Xcode_16.0.app
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           submodules: true
       - name: 🔨 Switch to Xcode 16.0
-        run: sudo xcode-select --switch /Applications/Xcode_16.0.app
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true


### PR DESCRIPTION
# Why

When running our workflows we're seeing that iOS builds are failing with the following exception: https://github.com/expo/expo/runs/43778152626#step:12:58

This error states that we're using a wrong version of XCode (16.0) where a higher one was expected (16.1).

The default XCode version for github actions running on the `macos-15` runner is XCode 16 - which we also set in our workflows.

The runner supports up to XCode 16.4 (latest version):

https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#xcode

# How

This commit upgrades the expected XCode version from 16.0 (explicitly) to 16.1 (explicitly) in the Expo workflows that builds with XCode.

# Test Plan

Run CI

# Checklist

- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
