### PR TITLE
fix(fingerprint): move `glob` from `devDependencies` to `dependencies`

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Move `glob` from `devDependencies` to `dependencies` as its used outside test code.
+
 ### 💡 Others
 
 ## 0.13.0 - 2025-06-08

--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Move `glob` from `devDependencies` to `dependencies` as its used outside test code.
+- Move `glob` from `devDependencies` to `dependencies` as its used outside test code. ([#37332](https://github.com/expo/expo/pull/37332) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/fingerprint/package.json
+++ b/packages/@expo/fingerprint/package.json
@@ -49,6 +49,7 @@
     "debug": "^4.3.4",
     "find-up": "^5.0.0",
     "getenv": "^2.0.0",
+    "glob": "^10.4.2",
     "ignore": "^5.3.1",
     "minimatch": "^9.0.0",
     "p-limit": "^3.1.0",
@@ -58,7 +59,6 @@
   "devDependencies": {
     "@types/find-up": "^4.0.0",
     "expo-module-scripts": "^4.1.7",
-    "glob": "^10.4.2",
     "require-from-string": "^2.0.2",
     "temp-dir": "^2.0.0"
   }


### PR DESCRIPTION
# Why

Fixes #37297

# How

- `glob` is now used outside test files which requires `glob` to be installed as a normal package
![image](https://github.com/user-attachments/assets/f07dedb4-c79f-4c33-b94d-a3ae76dbff5b)


# Test Plan

See https://github.com/expo/expo/issues/37297

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
