### PR TITLE
[tools] Add template tarball to Expo package

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `TextDecoderStream` and `TextEncoderStream` APIs to the native runtime. ([#37507](https://github.com/expo/expo/pull/37507) by [@EvanBacon](https://github.com/EvanBacon))
 - Enable async requires by default. ([#36405](https://github.com/expo/expo/pull/36405) by [@EvanBacon](https://github.com/EvanBacon))
 - Added `redirect` option support to `expo/fetch` ([#38078](https://github.com/expo/expo/pull/38078) by [@andipro123](https://github.com/andipro123))
+- Add template tarball. ([#37333](https://github.com/expo/expo/pull/37333) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -43,7 +43,8 @@
     "requiresExtraSetup.json",
     "tsconfig.base.json",
     "types",
-    "virtual"
+    "virtual",
+    "template.tgz"
   ],
   "scripts": {
     "build": "expo-module build",

--- a/tools/src/publish-packages/tasks/addTemplateTarball.ts
+++ b/tools/src/publish-packages/tasks/addTemplateTarball.ts
@@ -1,0 +1,36 @@
+import { promises } from 'fs';
+import path from 'path';
+
+import { selectPackagesToPublish } from './selectPackagesToPublish';
+import { TEMPLATES_DIR } from '../../Constants';
+import logger from '../../Logger';
+import { packToTarballAsync } from '../../Npm';
+import { Task } from '../../TasksRunner';
+import { Parcel, TaskArgs } from '../types';
+
+/**
+ * Add template tarball to Expo package.
+ */
+export const addTemplateTarball = new Task<TaskArgs>(
+  {
+    name: 'addTemplateTarball',
+    dependsOn: [selectPackagesToPublish],
+  },
+  async (parcels: Parcel[]) => {
+    const expoPackage = parcels.find((parcel) => parcel.pkg.packageName === 'expo');
+
+    if (!expoPackage) {
+      return;
+    }
+
+    logger.info('\nCopying template tarball to Expo package...');
+
+    const templatePath = path.join(TEMPLATES_DIR, 'expo-template-bare-minimum');
+    const templateTarball = await packToTarballAsync(templatePath);
+
+    await promises.copyFile(
+      path.join(templatePath, templateTarball.filename),
+      path.join(expoPackage.pkg.path, 'template.tgz')
+    );
+  }
+);

--- a/tools/src/publish-packages/tasks/addTemplateTarball.ts
+++ b/tools/src/publish-packages/tasks/addTemplateTarball.ts
@@ -1,4 +1,4 @@
-import { promises } from 'fs';
+import fs from 'fs';
 import path from 'path';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
@@ -28,9 +28,11 @@ export const addTemplateTarball = new Task<TaskArgs>(
     const templatePath = path.join(TEMPLATES_DIR, 'expo-template-bare-minimum');
     const templateTarball = await packToTarballAsync(templatePath);
 
-    await promises.copyFile(
+    const tarballDestinationPath = path.join(expoPackage.pkg.path, 'template.tgz');
+    await fs.promises.rm(tarballDestinationPath, { force: true });
+    await fs.promises.copyFile(
       path.join(templatePath, templateTarball.filename),
-      path.join(expoPackage.pkg.path, 'template.tgz')
+      tarballDestinationPath
     );
   }
 );

--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 
 import { addPublishedLabelToPullRequests } from './addPublishedLabelToPullRequests';
+import { addTemplateTarball } from './addTemplateTarball';
 import { checkEnvironmentTask } from './checkEnvironmentTask';
 import { checkPackagesIntegrity } from './checkPackagesIntegrity';
 import { checkRepositoryStatus } from './checkRepositoryStatus';
@@ -51,6 +52,12 @@ const cleanWorkingTree = new Task<TaskArgs>(
           force: true,
           paths: ['packages/**/local-maven-repo/**'],
         });
+        // Remove tarballs.
+        await Git.cleanAsync({
+          recursive: false,
+          force: true,
+          paths: ['packages/**/*.tgz', 'templates/**/*.tgz'],
+        });
       },
       'Cleaned up the working tree'
     );
@@ -76,6 +83,7 @@ export const publishPackagesPipeline = new Task<TaskArgs>(
       updateAndroidProjects,
       publishAndroidArtifacts,
       updateIosProjects,
+      addTemplateTarball,
       cutOffChangelogs,
       commitStagedChanges,
       pushCommittedChanges,


### PR DESCRIPTION
# Why

To include a template tarball in Expo package for prebuild usage

# How

Modify release scripts to include a template tarball when releasing Expo package.

# Test Plan

* Comment `cleanWorkingTree` in `tools/src/publish-packages/tasks/publishPackagesPipeline.ts`
* Run `et pp --dry`
* Run `npm pack` in `packages/expo/`
* See if built package contains `template.tgz`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
