### PR TITLE
[cli][prebuild] Use tarball from expo package first

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - Remove flipper hack support ([#37532](https://github.com/expo/expo/pull/37532) by [@EvanBacon](https://github.com/EvanBacon))
+- Use template tarball from expo package. ([#37334](https://github.com/expo/expo/pull/37334) by [@jakex7](https://github.com/jakex7))
 
 ### 🎉 New features
 

--- a/packages/@expo/cli/src/prebuild/resolveLocalTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/resolveLocalTemplate.ts
@@ -1,0 +1,26 @@
+import { ExpoConfig } from '@expo/config';
+import fs from 'fs';
+import path from 'path';
+import resolveFrom from 'resolve-from';
+
+import { extractNpmTarballAsync } from '../utils/npm';
+
+const debug = require('debug')('expo:prebuild:resolveLocalTemplate') as typeof console.log;
+
+export async function resolveLocalTemplateAsync({
+  templateDirectory,
+  projectRoot,
+  exp,
+}: {
+  templateDirectory: string;
+  projectRoot: string;
+  exp: Pick<ExpoConfig, 'name'>;
+}): Promise<string> {
+  const templatePath = resolveFrom(projectRoot, 'expo/template.tgz');
+  debug('Using local template from Expo package:', templatePath);
+  const stream = fs.createReadStream(templatePath);
+  return await extractNpmTarballAsync(stream, {
+    cwd: templateDirectory,
+    name: exp.name,
+  });
+}

--- a/packages/@expo/cli/src/prebuild/resolveLocalTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/resolveLocalTemplate.ts
@@ -1,6 +1,5 @@
-import { ExpoConfig } from '@expo/config';
+import type { ExpoConfig } from '@expo/config';
 import fs from 'fs';
-import path from 'path';
 import resolveFrom from 'resolve-from';
 
 import { extractNpmTarballAsync } from '../utils/npm';

--- a/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
@@ -106,7 +106,13 @@ export async function cloneTemplateAndCopyToProjectAsync({
   const ora = logNewSection(`Creating native ${pluralized} (${platformDirectories})`);
 
   try {
-    const templateChecksum = await cloneTemplateAsync({ templateDirectory, template, exp, ora });
+    const templateChecksum = await cloneTemplateAsync({
+      templateDirectory,
+      projectRoot,
+      template,
+      exp,
+      ora,
+    });
 
     const platforms = validateTemplatePlatforms({
       templateDirectory,


### PR DESCRIPTION
# Why

To make prebuild deterministic

# How

Use a `template.tgz` from expo package for prebuild if it exist.

# Test Plan

* Paste template.tgz into `node_modules/expo/`
* Run prebuild with debug and verify if it's using local template
```sh
- Creating native directories (./ios and ./android)
  expo:prebuild:resolveLocalTemplate Using local template from Expo package: /Users/jakubgrzywacz/Projects/expo-template-test/node_modules/expo/template.tgz +0ms
  expo:prebuild:copyTemplateFiles All platforms have an internal gitignore: true +0ms
...
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
