### PR TITLE
[docs] Update submission process to clarify default behavior of `auto-submit` for Android and iOS

### DIFF
--- a/docs/pages/build/automate-submissions.mdx
+++ b/docs/pages/build/automate-submissions.mdx
@@ -54,25 +54,36 @@ The `APP_ENV` variable from the `production` profile will be used when evaluatin
 
 ## Default submission behavior for app stores
 
-Understanding the default behavior of `--auto-submit` is important for planning your release process. Sections below describe the default submission behavior for Android and iOS.
+By default, the `--auto-submit` flag will make your build available for internal testing, but will not automatically submit your app to review for public distribution. Sections below describe the default submission behavior for Android and iOS.
 
 ### Android submissions
 
-For Android, the default submission behavior is to submit a release (production build) by choosing one of the available submission tracks. This is done by setting the [`track`](/eas/json/#track) field in your **eas.json** submission profile:
+For Android, if sufficient metadata is not provided, the default behavior is to create a draft release (by setting the default [`releaseStatus`](/eas/json/#releasestatus) to `draft`) for new apps. To control where and how your build is submitted, you can specify these fields in your **eas.json** submission profile:
+
+**Release status options:**
+
+- `draft`: Creates a draft release that requires manual promotion in the Google Play Console (default)
+- `completed`: Immediately releases to users on the specified track
+- `inProgress`: Staged rollout release (use with `rollout` percentage)
+- `halted`: Halted release
+
+When you explicitly set a track to your submission profile in **eas.json**, the `--auto-submit` flag will submit the build to the chosen track. This also requires the `releaseStatus` to be set to `completed`:
+
+**Track options:**
 
 - `internal`: Internal testing track (up to 100 testers)
 - `alpha`: Closed testing track
 - `beta`: Open testing track
 - `production`: Production track (public release)
 
-Once the track is defined in **eas.json**, the `--auto-submit` flag will submit the build to the chosen track.
-
 ### iOS submissions
 
-For iOS, the default submission behavior is to submit a release (production build) to TestFlight. This means:
+For iOS, the default submission behavior is to submit the build to TestFlight, but not for App Store review. This means:
 
+- The build is submitted to TestFlight and becomes available for internal testing.
+- If you have "Enable automatic distribution" turned on in App Store Connect, TestFlight will automatically create a group and invite all your internal TestFlight users to test the build.
+- You can also specify additional TestFlight groups using the [`groups`](/eas/json/#groups) field in your **eas.json** submission profile.
 - Using TestFlight, you can release a version of your app available for internal and external testing. TestFlight allows sharing with up to 100 testers internally and provides a public link to share with up to 10,000 external testers.
-- Your release will not be submitted to App Store review automatically.
 - The release to Apple App Store review is a manual process. Once you have made a submission to TestFlight, you'll have to manually promote the build to the App Store.
 
 This behavior ensures that all iOS releases go through TestFlight when using `--auto-submit`, allowing you to test the release before deciding to make it available to the public.

--- a/docs/pages/build/automate-submissions.mdx
+++ b/docs/pages/build/automate-submissions.mdx
@@ -58,11 +58,11 @@ By default, the `--auto-submit` flag will make your build available for internal
 
 ### Android submissions
 
-For Android, if sufficient metadata is not provided, the default behavior is to create a draft release (by setting the default [`releaseStatus`](/eas/json/#releasestatus) to `draft`) for new apps. To control where and how your build is submitted, you can specify these fields in your **eas.json** submission profile:
+For Android, if sufficient metadata is not provided, the default behavior is to create an internal release for new apps. To control where and how your build is submitted, you can specify the `releaseStatus` and `track` fields in your **eas.json** submission profile:
 
 **Release status options:**
 
-- `draft`: Creates a draft release that requires manual promotion in the Google Play Console (default)
+- `draft`: Creates a draft release that requires manual promotion in the Google Play Console
 - `completed`: Immediately releases to users on the specified track
 - `inProgress`: Staged rollout release (use with `rollout` percentage)
 - `halted`: Halted release
@@ -71,7 +71,7 @@ When you explicitly set a track to your submission profile in **eas.json**, the 
 
 **Track options:**
 
-- `internal`: Internal testing track (up to 100 testers)
+- `internal`: Internal testing track (up to 100 testers) (default)
 - `alpha`: Closed testing track
 - `beta`: Open testing track
 - `production`: Production track (public release)

--- a/docs/pages/build/automate-submissions.mdx
+++ b/docs/pages/build/automate-submissions.mdx
@@ -3,17 +3,21 @@ title: Automate submissions
 description: Learn how to enable automatic submissions with EAS Build.
 ---
 
+import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
 Many mobile deployment processes eventually evolve to the point where the app is automatically submitted to the respective store once an appropriate build is completed. This saves developers from having to wait around for the build to complete, avoids a bit of manual work, and eliminates the need to coordinate providing app store credentials to the team.
 
 EAS Build gives you automatic submissions out of the box with the `--auto-submit` flag. This flag tells EAS Build to pass the build along to EAS Submit with the appropriate submission profile upon completion. Refer to the [EAS Submit documentation](/submit/introduction) for more information on how to set up and configure submissions.
 
 When you run `eas build --auto-submit` you will be provided with a link to a submission details page, where you can track the progress of the submission. You can also find this page at any time on the [submissions dashboard for your project](https://expo.dev/accounts/[account]/projects/[project]/submissions), and it is linked from your build details page.
 
-### Selecting a submission profile
+## Selecting a submission profile
 
 By default, `--auto-submit` will try to use a submission profile with the same name as the selected build profile. If this does not exist, or if you prefer to use a different profile, you can use `--auto-submit-with-profile=<profile-name>` instead.
 
-### Build profile environment variables and submissions
+## Build profile environment variables and submissions
 
 When running `eas build --profile <profile-name> --auto-submit`, the project's **app.config.js** will be evaluated using any environment variables associated with the build profile `<profile-name>`. For example, suppose we ran `eas build -p ios --profile production --auto-submit` with the following configuration:
 
@@ -47,3 +51,39 @@ export default () => {
 ```
 
 The `APP_ENV` variable from the `production` profile will be used when evaluating **app.config.js** for the submission, and therefore the name will be `My App` and the bundle identifier will be `com.my.app`.
+
+## Default submission behavior for app stores
+
+Understanding the default behavior of `--auto-submit` is important for planning your release process. Sections below describe the default submission behavior for Android and iOS.
+
+### Android submissions
+
+For Android, the default submission behavior is to submit a release (production build) by choosing one of the available submission tracks. This is done by setting the [`track`](/eas/json/#track) field in your **eas.json** submission profile:
+
+- `internal`: Internal testing track (up to 100 testers)
+- `alpha`: Closed testing track
+- `beta`: Open testing track
+- `production`: Production track (public release)
+
+Once the track is defined in **eas.json**, the `--auto-submit` flag will submit the build to the chosen track.
+
+### iOS submissions
+
+For iOS, the default submission behavior is to submit a release (production build) to TestFlight. This means:
+
+- Using TestFlight, you can release a version of your app available for internal and external testing. TestFlight allows sharing with up to 100 testers internally and provides a public link to share with up to 10,000 external testers.
+- Your release will not be submitted to App Store review automatically.
+- The release to Apple App Store review is a manual process. Once you have made a submission to TestFlight, you'll have to manually promote the build to the App Store.
+
+This behavior ensures that all iOS releases go through TestFlight when using `--auto-submit`, allowing you to test the release before deciding to make it available to the public.
+
+### Modifying App Store listing (iOS only)
+
+Store metadata (app description, Apple advisory information, languages, and so on) is updated only when you have a **store.config.json** file present in your project's root directory and are using EAS Metadata.
+
+<BoxLink
+  href="/eas/metadata/getting-started/"
+  title="EAS Metadata"
+  description="Learn how to update your iOS app's metadata automatically."
+  Icon={EasMetadataIcon}
+/>

--- a/docs/pages/build/automate-submissions.mdx
+++ b/docs/pages/build/automate-submissions.mdx
@@ -79,7 +79,7 @@ This behavior ensures that all iOS releases go through TestFlight when using `--
 
 ### Modifying App Store listing (iOS only)
 
-Store metadata (app description, Apple advisory information, languages, and so on) is updated only when you have a **store.config.json** file present in your project's root directory and are using EAS Metadata.
+On its own, EAS Submit does not update store metadata (app description, Apple advisory information, languages, and so on). However, once you upload a build to Testflight with EAS Submit with a new version number, you can update this information with EAS Metadata.
 
 <BoxLink
   href="/eas/metadata/getting-started/"

--- a/docs/pages/tutorial/eas/ios-production-build.mdx
+++ b/docs/pages/tutorial/eas/ios-production-build.mdx
@@ -160,6 +160,8 @@ For future releases, we can streamline the process by combining build creation a
 
 <Terminal cmd={['$ eas build --platform ios --auto-submit']} />
 
+> **Note:** This command will automatically upload your build to TestFlight for internal testing, but it will not automatically submit your app for App Store review. You'll still need to manually promote the build from TestFlight to the App Store when you're ready for public release. For more information, see [Default submission behavior for app stores](/build/automate-submissions/#default-submission-behavior-for-app-stores).
+
 </Step>
 
 ## Summary


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15365

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update Automate submissions guide to add info about Android and iOS submission process. For example, in case of iOS, releasing a build will always submit to TestFlight first.
- Update EAS Tutorial> iOS production builds chapter to add a note for the above and link to the above section from the Automate submissions guide.
- Fix heading levels in the automate submissions guide
- Add a section about Modifying App Store listing (iOS only) to clarify how the metadata process work.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview:
- /build/automate-submissions/#default-submission-behavior-for-app-stores
- /tutorial/eas/ios-production-build/#automated-submissions

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
