### PR TITLE
[font] fix plugin syntax in docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/font.mdx
+++ b/docs/pages/versions/unversioned/sdk/font.mdx
@@ -52,6 +52,7 @@ The plugin allows you to embed font files at build time which is more efficient 
                 ]
               }
             ]
+          }
         }
       ]
     ]

--- a/docs/pages/versions/v53.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/font.mdx
@@ -52,6 +52,7 @@ The plugin allows you to embed font files at build time which is more efficient 
                 ]
               }
             ]
+          }
         }
       ]
     ]


### PR DESCRIPTION
# Why

Fixed a syntax error in the Font SDK documentation by adding a missing closing curly brace in the plugin configuration example.

# How

Added the missing `}` character 

# Test Plan

Verified that the code block in the documentation now has proper syntax with balanced curly braces.

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)