### PR TITLE
[docs] Fix broken links

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -499,6 +499,8 @@ const RENAMED_PAGES: Record<string, string> = {
   // After merging registerRootComponent info in `expo` API reference
   '/versions/v53.0.0/sdk/register-root-component/':
     '/versions/v53.0.0/sdk/expo/#registerrootcomponentcomponent',
+  '/versions/latest/sdk/register-root-component/':
+    '/versions/latest/sdk/expo/#registerrootcomponentcomponent',
   '/versions/v53.0.0/sdk/url/': '/versions/v53.0.0/sdk/expo/#url-api',
   '/versions/v53.0.0/sdk/encoding/': '/versions/v53.0.0/sdk/expo/#encoding-api',
 

--- a/docs/pages/config-plugins/mods.mdx
+++ b/docs/pages/config-plugins/mods.mdx
@@ -244,7 +244,7 @@ One caveat to using functions instead of strings is that serialization will repl
 
 ### Standalone package plugins
 
-> **info** See [Create a module with a config plugin](/config-plugin-and-native-module-tutorial/) for a step-by-step guide on how to create a standalone package plugin.
+> **info** See [Create a module with a config plugin](/modules/config-plugin-and-native-module-tutorial/) for a step-by-step guide on how to create a standalone package plugin.
 
 Standalone package plugins can be implemented in two ways:
 

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -37,7 +37,7 @@ This is the easiest way to build your native app, as it requires no native build
 | **Windows** | <YesIcon/> | <YesIcon/>    | <YesIcon/> (\*) |
 | **Linux**   | <YesIcon/> | <YesIcon/>    | <YesIcon/> (\*) |
 
-(\*) All builds that run on an iPhone device require a paid [Apple Developer](developer.apple.com) account for build signing.
+(\*) All builds that run on an iPhone device require a paid [Apple Developer](https://developer.apple.com) account for build signing.
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While reviewing multiple documents, I found that some internal links and one external link are not working. I also discovered that we don't have a redirect for the moved `registerrootcomponent` section in the latest version. This PR addresses both of these issues.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
