### PR TITLE
[autolinking] add System.getenv() syntax support to maven credentials

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- Added `System.getenv()` syntax support to credentials for extraMavenRepos. ([#37343](https://github.com/expo/expo/pull/37343) by [@kudo](https://github.com/kudo))
+
 ## 2.1.11 - 2025-06-08
 
 ### 💡 Others

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/configuration/MavenCredentials.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/configuration/MavenCredentials.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
-import kotlin.collections.contains
 
 /**
  * Based type of maven credentials object.

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/build.gradle.kts
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
 
   testImplementation("junit:junit:4.13.2")
   testImplementation("com.google.truth:truth:1.1.2")
+  testImplementation("io.mockk:mockk:1.14.2")
 }
 
 java {

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/MavenArtifactRepositoryExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/MavenArtifactRepositoryExtension.kt
@@ -4,6 +4,7 @@ import expo.modules.plugin.configuration.AWSMavenCredentials
 import expo.modules.plugin.configuration.BasicMavenCredentials
 import expo.modules.plugin.configuration.HttpHeaderMavenCredentials
 import expo.modules.plugin.configuration.MavenCredentials
+import expo.modules.plugin.utils.Env
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.credentials.AwsCredentials
 import org.gradle.api.credentials.HttpHeaderCredentials
@@ -35,26 +36,40 @@ internal fun MavenArtifactRepository.applyCredentials(mavenCredentials: MavenCre
     is BasicMavenCredentials -> {
       val (username, password) = mavenCredentials
       credentials { credentials ->
-        credentials.username = username
-        credentials.password = password
+        credentials.username = resolveEnvVar(username)
+        credentials.password = resolveEnvVar(password)
       }
     }
 
     is HttpHeaderMavenCredentials -> {
       val (name, value) = mavenCredentials
       credentials(HttpHeaderCredentials::class.java) { credentials ->
-        credentials.name = name
-        credentials.value = value
+        credentials.name = resolveEnvVar(name)
+        credentials.value = resolveEnvVar(value)
       }
     }
 
     is AWSMavenCredentials -> {
       val (accessKey, secretKey, sessionToken) = mavenCredentials
       credentials(AwsCredentials::class.java) { credentials ->
-        credentials.accessKey = accessKey
-        credentials.secretKey = secretKey
-        credentials.sessionToken = sessionToken
+        credentials.accessKey = resolveEnvVar(accessKey)
+        credentials.secretKey = resolveEnvVar(secretKey)
+        credentials.sessionToken = sessionToken?.let { resolveEnvVar(it) }
       }
     }
+  }
+}
+
+private val ENV_REGEX = """System\.getenv\(['"]([A-Za-z0-9_]+)['"]\)""".toRegex()
+
+/**
+ * Utility function to substitute environment variables in strings.
+ * Supports patterns like System.getEnv('VAR_NAME') or System.getEnv("VAR_NAME")
+ */
+private fun resolveEnvVar(input: String): String {
+  return ENV_REGEX.replace(input) { match ->
+    val name = match.groupValues[1]
+    // Return original if env var not found
+    Env.getProcessEnv(name) ?: match.value
   }
 }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/utils/Env.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/utils/Env.kt
@@ -1,0 +1,8 @@
+package expo.modules.plugin.utils
+
+internal object Env {
+  /**
+   * A wrapper around [System.getenv] that we can setup mock for testing.
+   */
+  fun getProcessEnv(name: String): String? = System.getenv(name)
+}

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/test/kotlin/expo/modules/plugin/MavenArtifactRepositoryExtensionTest.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/test/kotlin/expo/modules/plugin/MavenArtifactRepositoryExtensionTest.kt
@@ -1,0 +1,112 @@
+package expo.modules.plugin
+
+import com.google.common.truth.Truth
+import expo.modules.plugin.configuration.AWSMavenCredentials
+import expo.modules.plugin.configuration.BasicMavenCredentials
+import expo.modules.plugin.configuration.HttpHeaderMavenCredentials
+import expo.modules.plugin.gradle.applyCredentials
+import expo.modules.plugin.utils.Env
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.gradle.api.credentials.AwsCredentials
+import org.gradle.api.credentials.HttpHeaderCredentials
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.net.URI
+
+class MavenArtifactRepositoryExtensionTest {
+  @Before
+  fun setUp() {
+    mockkObject(Env)
+  }
+
+  @After
+  fun tearDown() {
+    unmockkObject(Env)
+  }
+
+  @Test
+  fun `should apply credentials from string values`() {
+    val project = ProjectBuilder.builder().build()
+    val mavenRepo = project.repositories.maven {
+      it.url = URI("auth.maven.test")
+      it.applyCredentials(BasicMavenCredentials("username", "password"))
+    }
+    Truth.assertThat(mavenRepo.credentials.username).isEqualTo("username")
+    Truth.assertThat(mavenRepo.credentials.password).isEqualTo("password")
+  }
+
+  @Test
+  fun `should apply credentials from environment variables`() {
+    val project = ProjectBuilder.builder().build()
+
+    every { Env.getProcessEnv("envUsername") } returns "basic1"
+    every { Env.getProcessEnv("envPassword") } returns "basic2"
+    val mavenRepoBasic = project.repositories.maven {
+      it.url = URI("auth.maven.test")
+      it.applyCredentials(BasicMavenCredentials("System.getenv('envUsername')", "System.getenv(\"envPassword\")"))
+    }
+    Truth.assertThat(mavenRepoBasic.credentials.username).isEqualTo("basic1")
+    Truth.assertThat(mavenRepoBasic.credentials.password).isEqualTo("basic2")
+
+    every { Env.getProcessEnv("envName") } returns "httpHeader1"
+    every { Env.getProcessEnv("envValue") } returns "httpHeader2"
+    val mavenRepoHttpHeader = project.repositories.maven {
+      it.url = URI("auth.maven.test")
+      it.applyCredentials(HttpHeaderMavenCredentials("System.getenv('envName')", "System.getenv(\"envValue\")"))
+    }
+    val httpHeaderCredentials = mavenRepoHttpHeader.getCredentials(HttpHeaderCredentials::class.java)
+    Truth.assertThat(httpHeaderCredentials.name).isEqualTo("httpHeader1")
+    Truth.assertThat(httpHeaderCredentials.value).isEqualTo("httpHeader2")
+
+    every { Env.getProcessEnv("envAccessKey") } returns "aws1"
+    every { Env.getProcessEnv("envSecretKey") } returns "aws2"
+    every { Env.getProcessEnv("envSessionToken") } returns "aws3"
+    val mavenRepoAws = project.repositories.maven {
+      it.url = URI("auth.maven.test")
+      it.applyCredentials(AWSMavenCredentials(
+        "System.getenv('envAccessKey')",
+        "System.getenv(\"envSecretKey\")",
+        "System.getenv('envSessionToken')"))
+    }
+    val awsCredentials = mavenRepoAws.getCredentials(AwsCredentials::class.java)
+    Truth.assertThat(awsCredentials.accessKey).isEqualTo("aws1")
+    Truth.assertThat(awsCredentials.secretKey).isEqualTo("aws2")
+    Truth.assertThat(awsCredentials.sessionToken).isEqualTo("aws3")
+  }
+
+  @Test
+  fun `should fallback to original inputs if environment variables not found`() {
+    val project = ProjectBuilder.builder().build()
+
+    val mavenRepoBasic = project.repositories.maven {
+      it.url = URI("auth.maven.test")
+      it.applyCredentials(BasicMavenCredentials("System.getenv('envUsername')", "System.getenv(\"envPassword\")"))
+    }
+    Truth.assertThat(mavenRepoBasic.credentials.username).isEqualTo("System.getenv('envUsername')")
+    Truth.assertThat(mavenRepoBasic.credentials.password).isEqualTo("System.getenv(\"envPassword\")")
+
+    val mavenRepoHttpHeader = project.repositories.maven {
+      it.url = URI("auth.maven.test")
+      it.applyCredentials(HttpHeaderMavenCredentials("System.getenv('envName')", "System.getenv(\"envValue\")"))
+    }
+    val httpHeaderCredentials = mavenRepoHttpHeader.getCredentials(HttpHeaderCredentials::class.java)
+    Truth.assertThat(httpHeaderCredentials.name).isEqualTo("System.getenv('envName')")
+    Truth.assertThat(httpHeaderCredentials.value).isEqualTo("System.getenv(\"envValue\")")
+
+    val mavenRepoAws = project.repositories.maven {
+      it.url = URI("auth.maven.test")
+      it.applyCredentials(AWSMavenCredentials(
+        "System.getenv('envAccessKey')",
+        "System.getenv(\"envSecretKey\")",
+        "System.getenv('envSessionToken')"))
+    }
+    val awsCredentials = mavenRepoAws.getCredentials(AwsCredentials::class.java)
+    Truth.assertThat(awsCredentials.accessKey).isEqualTo("System.getenv('envAccessKey')")
+    Truth.assertThat(awsCredentials.secretKey).isEqualTo("System.getenv(\"envSecretKey\")")
+    Truth.assertThat(awsCredentials.sessionToken).isEqualTo("System.getenv('envSessionToken')")
+  }
+}


### PR DESCRIPTION
# Why

fixes #36778

# How

add `System.getenv()` syntax support to extraMavenRepos credentials

# Test Plan

- added unit tests for `MavenArtifactRepository.applyCredentials`
- tested bare-expo with the following app.json

```json
      [
        "expo-build-properties",
        {
          "android": {
            "enableProguardInReleaseBuilds": true,
            "extraMavenRepos": [
              {
                "url": "https://maven.google.com",
                "authentication": "basic",
                "credentials": {
                  "username": "System.getenv('ooxxUsername')",
                  "password": "System.getenv('ooxxPassword')"
                }
              }
            ]
          }
        }
      ],
```

running prebuild and then generated the following property in gradle.properties

```
android.extraMavenRepos=[{"url":"https://maven.google.com","authentication":"basic","credentials":{"username":"System.getenv('ooxxUsername')","password":"System.getenv('ooxxPassword')"}}]
```

build and retrieve log
```sh
$ ./gradlew :app:assembleDebug --debug | grep ooxx
2025-06-10T23:11:18.503+0800 [DEBUG] [org.gradle.internal.resource.transport.http.HttpClientConfigurer] Using Credentials [username: System.getenv('ooxxUsername')] for authenticating against 'maven.google.com:-1' using Basic

$ ooxxUsername=ooxx ooxxPassword=ooxx ./gradlew :app:assembleDebug --debug | grep ooxx
2025-06-10T23:12:20.599+0800 [DEBUG] [org.gradle.internal.resource.transport.http.HttpClientConfigurer] Using Credentials [username: ooxx] for authenticating against 'maven.google.com:-1' using Basic
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
