### PR TITLE
Update @react-native-async-storage/async-storage to 2.2.0

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3209,7 +3209,7 @@ PODS:
     - React-perflogger (= 0.80.0-rc.5)
     - React-utils (= 0.80.0-rc.5)
     - SocketRocket
-  - RNCAsyncStorage (2.1.2):
+  - RNCAsyncStorage (2.2.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -4442,7 +4442,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 8b6a181160ae9a814f6a7f447921be2fa962b1b4
   ReactCodegen: aac198f788cfa6c1cfadf1a15f8ffc2dcfb8ec43
   ReactCommon: e69175d0efd16afee3d7d43e95dc714966c2ca3d
-  RNCAsyncStorage: 8de84536d0038b97a1b85d23681c2aed5f641430
+  RNCAsyncStorage: 767abb068db6ad28b5f59a129fbc9fab18b377e2
   RNCMaskedView: aac38cf7e947ff80e483996d1acd43c5ad4ab610
   RNCPicker: 9f14f7b5511d88d7608b344e9089916ff8a47298
   RNDateTimePicker: c525b5bb1b2d9766d3fa5e178495c222d8a75c87

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -43,7 +43,7 @@
     "@babel/runtime": "^7.20.0",
     "@expo/dom-webview": "0.1.4",
     "@expo/styleguide-base": "^1.0.1",
-    "@react-native-async-storage/async-storage": "2.1.2",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "8.3.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "4.5.6",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2959,7 +2959,7 @@ PODS:
     - React-perflogger (= 0.80.0-rc.5)
     - React-utils (= 0.80.0-rc.5)
     - SocketRocket
-  - RNCAsyncStorage (2.1.2):
+  - RNCAsyncStorage (2.2.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -4254,7 +4254,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 8b6a181160ae9a814f6a7f447921be2fa962b1b4
   ReactCodegen: 19609958a70f0a4c472b03d7f80f4641035a7ce2
   ReactCommon: e69175d0efd16afee3d7d43e95dc714966c2ca3d
-  RNCAsyncStorage: 8de84536d0038b97a1b85d23681c2aed5f641430
+  RNCAsyncStorage: 767abb068db6ad28b5f59a129fbc9fab18b377e2
   RNCMaskedView: aac38cf7e947ff80e483996d1acd43c5ad4ab610
   RNCPicker: 9f14f7b5511d88d7608b344e9089916ff8a47298
   RNDateTimePicker: c525b5bb1b2d9766d3fa5e178495c222d8a75c87

--- a/apps/expo-go/modules/@react-native-async-storage/async-storage/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java
+++ b/apps/expo-go/modules/@react-native-async-storage/async-storage/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java
@@ -24,7 +24,6 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.modules.common.ModuleDataCleaner;
 
 import java.util.ArrayDeque;
 import java.util.HashSet;
@@ -32,8 +31,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 @ReactModule(name = AsyncStorageModule.NAME)
-public class AsyncStorageModule
-    extends NativeAsyncStorageModuleSpec implements ModuleDataCleaner.Cleanable {
+public class AsyncStorageModule extends NativeAsyncStorageModuleSpec {
 
   // changed name to not conflict with AsyncStorage from RN repo
   public static final String NAME = "RNCAsyncStorage";
@@ -86,14 +84,6 @@ public class AsyncStorageModule
     mShuttingDown = true;
     // ensure we close database when activity is destroyed
     mReactDatabaseSupplier.closeDatabase();
-  }
-
-  @Override
-  public void clearSensitiveData() {
-    // Clear local storage. If fails, crash, since the app is potentially in a bad state and could
-    // cause a privacy violation. We're still not recovering from this well, but at least the error
-    // will be reported to the server.
-    mReactDatabaseSupplier.clearAndCloseDatabase();
   }
 
   /**

--- a/apps/expo-go/modules/@react-native-async-storage/async-storage/package.json
+++ b/apps/expo-go/modules/@react-native-async-storage/async-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-async-storage/async-storage",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "Asynchronous, persistent, key-value storage system for React Native.",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -27,7 +27,7 @@
     "@expo/vector-icons": "^14.0.0",
     "@gorhom/bottom-sheet": "4.4.6",
     "@graphql-codegen/introspection": "^2.1.1",
-    "@react-native-async-storage/async-storage": "2.1.2",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "^8.3.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "4.5.6",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -38,7 +38,7 @@
     "@expo/ui": "~0.1.1-alpha.7",
     "@lottiefiles/dotlottie-react": "^0.10.1",
     "@lottiefiles/react-lottie-player": "^3.5.4",
-    "@react-native-async-storage/async-storage": "2.1.2",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "8.3.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "4.5.6",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -3,7 +3,7 @@
   "@expo/metro-runtime": "~5.0.4",
   "@expo/vector-icons": "^14.1.0",
   "@expo/ui": "~0.1.1-alpha.7",
-  "@react-native-async-storage/async-storage": "2.1.2",
+  "@react-native-async-storage/async-storage": "2.2.0",
   "@react-native-community/datetimepicker": "8.3.0",
   "@react-native-masked-view/masked-view": "0.3.2",
   "@react-native-community/netinfo": "11.4.1",

--- a/tools/src/vendoring/config/react-native-async-storage-scoped-storage.patch
+++ b/tools/src/vendoring/config/react-native-async-storage-scoped-storage.patch
@@ -2,7 +2,7 @@
 +++ android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncLocalStorageUtil.java	2024-11-11 14:42:51
 @@ -159,7 +159,9 @@
      }
- 
+
      File nextStorageFile = ctx.getDatabasePath("AsyncStorage");
 -    File currentStorageFile = ctx.getDatabasePath(ReactDatabaseSupplier.DATABASE_NAME);
 +    // NOTE(kudo): Expo Go doesn't turn on next storage, having dummy db name to pass build
@@ -25,38 +25,38 @@
              Log.v(LOG_TAG, "Failed to migrate scoped database " + expoDatabase.getName());
 @@ -62,7 +63,9 @@
      }
- 
+
      private static boolean isAsyncStorageDatabaseCreated(Context context) {
 -        return context.getDatabasePath(ReactDatabaseSupplier.DATABASE_NAME).exists();
 +        // NOTE(kudo): Don't run migration on Expo Go for backward compatibility
 +        // return context.getDatabasePath(ReactDatabaseSupplier.DATABASE_NAME).exists();
 +        return true;
      }
- 
+
      // Find all database files that the user may have created while using Expo.
 --- android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java	1985-10-26 16:15:00
-+++ android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java	2024-11-11 14:42:51
-@@ -33,7 +33,7 @@
++++ android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java	2025-06-10 12:15:41
+@@ -31,7 +31,7 @@
  import java.util.concurrent.Executors;
- 
+
  @ReactModule(name = AsyncStorageModule.NAME)
--public final class AsyncStorageModule
-+public class AsyncStorageModule
-     extends NativeAsyncStorageModuleSpec implements ModuleDataCleaner.Cleanable {
- 
+-public final class AsyncStorageModule extends NativeAsyncStorageModuleSpec {
++public class AsyncStorageModule extends NativeAsyncStorageModuleSpec {
+
    // changed name to not conflict with AsyncStorage from RN repo
-@@ -43,7 +43,7 @@
+   public static final String NAME = "RNCAsyncStorage";
+@@ -40,7 +40,7 @@
    // https://raw.githubusercontent.com/android/platform_external_sqlite/master/dist/sqlite3.c
    private static final int MAX_SQL_KEYS = 999;
- 
+
 -  private ReactDatabaseSupplier mReactDatabaseSupplier;
 +  public ReactDatabaseSupplier mReactDatabaseSupplier;
    private boolean mShuttingDown = false;
- 
+
    private final SerialExecutor executor;
-@@ -66,6 +66,7 @@
+@@ -64,6 +64,7 @@
      this.executor = new SerialExecutor(executor);
-     reactContext.addLifecycleEventListener(this);
+
      // Creating the database MUST happen after the migration.
 +    // NOTE(kudo): ExponentAsyncStorageModule will setup the `mReactDatabaseSupplier`
      mReactDatabaseSupplier = ReactDatabaseSupplier.getInstance(reactContext);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2989,10 +2989,10 @@
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
 
-"@react-native-async-storage/async-storage@2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-2.1.2.tgz#8aae432adfc20800308e2ef3ce380864f0f9def8"
-  integrity sha512-dvlNq4AlGWC+ehtH12p65+17V0Dx7IecOWl6WanF2ja38O1Dcjjvn7jVzkUHJ5oWkQBlyASurTPlTHgKXyYiow==
+"@react-native-async-storage/async-storage@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz#a3aa565253e46286655560172f4e366e8969f5ad"
+  integrity sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==
   dependencies:
     merge-options "^3.0.4"
 


### PR DESCRIPTION
# Why 

Updates @react-native-async-storage/async-storage to 2.2.0 including support for react-native 0.80

# How
There were Andoid changes, so we needed to adjust our patch 
`et uvm -p @react-native-async-storage/async-storage -c "2.2.0"`

# Test Plan
bare expo ✅
expo go ✅

