### PR TITLE
[ios][video] fix compilation in XCode 26/iOS 26

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -25,7 +25,7 @@
 - [iOS] Fix player reporting status `readyToPlay` while a source is being loaded asynchronously. ([#37180](https://github.com/expo/expo/pull/37180) by [@behenate](https://github.com/behenate))
 - [iOS] Fix player going into `loading` status for a single frame when unpausing with a full buffer. ([#37181](https://github.com/expo/expo/pull/37181) by [@behenate](https://github.com/behenate))
 - [iOS] Fix player getting stuck in `loading` state for null sources. ([#37183](https://github.com/expo/expo/pull/37183) by [@behenate](https://github.com/behenate))
-- [iOS] Fix compilation failure on XCode 26/iOS 26. ([#37346](https://github.com/expo/expo/pull/37346) by [@behenate](https://github.com/fobos531))
+- [iOS] Fix compilation failure on XCode 26/iOS 26. ([#37346](https://github.com/expo/expo/pull/37346) by [@fobos531](https://github.com/fobos531))
 
 ## 2.1.9 — 2025-05-08
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [iOS] Fix player reporting status `readyToPlay` while a source is being loaded asynchronously. ([#37180](https://github.com/expo/expo/pull/37180) by [@behenate](https://github.com/behenate))
 - [iOS] Fix player going into `loading` status for a single frame when unpausing with a full buffer. ([#37181](https://github.com/expo/expo/pull/37181) by [@behenate](https://github.com/behenate))
 - [iOS] Fix player getting stuck in `loading` state for null sources. ([#37183](https://github.com/expo/expo/pull/37183) by [@behenate](https://github.com/behenate))
+- [iOS] Fix compilation failure on XCode 26/iOS 26. ([#37346](https://github.com/expo/expo/pull/37346) by [@behenate](https://github.com/fobos531))
 
 ## 2.1.9 — 2025-05-08
 

--- a/packages/expo-video/ios/VideoPlayerItem.swift
+++ b/packages/expo-video/ios/VideoPlayerItem.swift
@@ -39,7 +39,10 @@ class VideoPlayerItem: AVPlayerItem {
     self.urlAsset = asset
     // We can ignore any exceptions thrown during the load. The asset will be assigned to the `VideoPlayer` anyways
     // and cause it to go into .error state trigerring the `onStatusChange` event.
-    _ = try? await asset.load(.duration, .preferredTransform, .isPlayable)
+    do {
+      _ = try await asset.load(.duration, .preferredTransform, .isPlayable)
+    } catch {
+    }
 
     super.init(asset: urlAsset, automaticallyLoadedAssetKeys: nil)
     self.createTracksLoadingTask()


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

expo-video is not compiling on XCode 26

# How

<!--
How did you build this feature or fix this bug and why?
-->

The compiler is more strict about type annotations now. Using do/try/catch helps us avoid this issue.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
