### PR TITLE
[docs] fix setup environment assets theme in Auto mode

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/SelectCard.tsx
+++ b/docs/scenes/get-started/set-up-your-environment/SelectCard.tsx
@@ -22,7 +22,6 @@ export function SelectCard({
   onClick,
 }: Props) {
   const { themeName } = useTheme();
-  const isDarkMode = themeName === 'dark';
 
   return (
     <ButtonBase onClick={onClick}>
@@ -37,7 +36,13 @@ export function SelectCard({
             isSelected ? 'bg-gradient-to-b from-palette-blue3 to-palette-blue4' : 'bg-subtle'
           )}>
           <picture className="relative flex h-full w-auto items-end">
-            {isDarkMode && <source srcSet={darkImgSrc} type="image/png" />}
+            {themeName !== 'light' && (
+              <source
+                srcSet={darkImgSrc}
+                type="image/png"
+                media={themeName === 'auto' ? '(prefers-color-scheme: dark)' : undefined}
+              />
+            )}
             <img
               src={imgSrc}
               alt={alt}


### PR DESCRIPTION
# Why

Fixes ENG-12385

![Screenshot 2025-06-10 at 20 46 53](https://github.com/user-attachments/assets/89d4d873-f2ee-4c02-ab25-540b888a52d7)

# How

Adjust the logic which determines which asset file should be used in SelectCard component on the "Setup your Environment" page, while in "Auto" theme mode.

# Test Plan

The changes have been reviewed by running docs website app locally.

## Preview

https://github.com/user-attachments/assets/c863133e-320e-4b07-ad9f-d6ad5a4d3e23

