### PR TITLE
sync changelog

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -55,7 +55,7 @@
     "expo-build-properties": "~0.14.6",
     "expo-camera": "~16.1.6",
     "expo-dev-client": "~5.1.8",
-    "expo-image": "~2.1.7",
+    "expo-image": "~2.3.0",
     "expo-insights": "~0.9.3",
     "expo-network-addons": "~0.9.3",
     "expo-notifications": "~0.31.2",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -81,7 +81,7 @@
     "expo-font": "~13.3.1",
     "expo-gl": "~15.1.5",
     "expo-haptics": "~14.1.4",
-    "expo-image": "~2.1.7",
+    "expo-image": "~2.3.0",
     "expo-image-loader": "^5.1.0",
     "expo-image-manipulator": "~13.1.7",
     "expo-image-picker": "~16.1.4",

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -12,7 +12,7 @@
     "expo": "~53.0.9",
     "expo-camera": "~16.1.6",
     "expo-dev-client": "~5.1.8",
-    "expo-image": "~2.1.7",
+    "expo-image": "~2.3.0",
     "expo-notifications": "~0.31.2",
     "expo-splash-screen": "~0.30.8",
     "native-component-list": "*",

--- a/apps/paper-tester/package.json
+++ b/apps/paper-tester/package.json
@@ -14,7 +14,7 @@
     "expo-blur": "~14.1.4",
     "expo-camera": "~16.1.6",
     "expo-dev-client": "~5.1.8",
-    "expo-image": "^2.1.7",
+    "expo-image": "~2.3.0",
     "expo-linear-gradient": "~14.1.4",
     "expo-splash-screen": "~0.30.8",
     "expo-status-bar": "~2.2.3",

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 15.1.6 - 2025-06-10
+
+_This version does not introduce any user-facing changes._
+
 ## 15.1.5 - 2025-06-04
 
 ### 💡 Others

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 16.1.8 - 2025-06-10
+
+_This version does not introduce any user-facing changes._
+
 ## 16.1.7 - 2025-06-04
 
 ### 🐛 Bug fixes

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -4,15 +4,25 @@
 
 ### 🛠 Breaking changes
 
-- [iOS] `useAppleWebpCodec` has been moved from the source object to the component's prop to make it usable with the local assets. ([#37300](https://github.com/expo/expo/pull/37300) by [@tsapeta](https://github.com/tsapeta))
-
 ### 🎉 New features
+
+### 🐛 Bug fixes
+
+### 💡 Others
+
+## 2.3.0 - 2025-06-11
+
+### 🛠 Breaking changes
+
+- [iOS] `useAppleWebpCodec` has been moved from the source object to the component's prop to make it usable with the local assets. ([#37300](https://github.com/expo/expo/pull/37300) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 
 - [iOS] Fix blurry images when using `tintColor` by scaling `imageThumbnailPixelSize` with screen density. ([#37235](https://github.com/expo/expo/pull/37235) by [@hirbod](https://github.com/hirbod))
 
-### 💡 Others
+## 2.2.1 - 2025-06-10
+
+_This version does not introduce any user-facing changes._
 
 ## 2.2.0 - 2025-06-04
 

--- a/packages/expo-image/package.json
+++ b/packages/expo-image/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-image",
   "title": "Expo Image",
-  "version": "2.1.7",
+  "version": "2.3.0",
   "description": "A cross-platform, performant image component for React Native and Expo with Web support",
   "main": "src/index.ts",
   "types": "build/index.d.ts",

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 2.2.1 - 2025-06-10
+
+_This version does not introduce any user-facing changes._
+
 ## 2.2.0 - 2025-06-04
 
 ### 🎉 New features

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -44,7 +44,7 @@
   "expo-gl": "~15.1.5",
   "expo-google-app-auth": "~8.3.0",
   "expo-haptics": "~14.1.4",
-  "expo-image": "~2.1.7",
+  "expo-image": "~2.3.0",
   "expo-image-loader": "~5.1.0",
   "expo-image-manipulator": "~13.1.7",
   "expo-image-picker": "~16.1.4",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -21,7 +21,7 @@
     "expo-constants": "~17.1.6",
     "expo-font": "~13.3.1",
     "expo-haptics": "~14.1.4",
-    "expo-image": "~2.1.7",
+    "expo-image": "~2.3.0",
     "expo-linking": "~7.1.5",
     "expo-router": "~5.0.6",
     "expo-splash-screen": "~0.30.8",


### PR DESCRIPTION
# Why

sync change and bump expo-image to 2.3.0 from sdk-53

# How

- `et ssbc -b sdk-53`
- bump expo-image to 2.3.0 that aligns sdk-53

# Test Plan

n/a

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
