### PR TITLE
[expo-image][android] fix resuming animation

### DIFF
--- a/apps/native-component-list/src/screens/Image/ImageAnimationResuming.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageAnimationResuming.tsx
@@ -1,6 +1,6 @@
+import { Image } from 'expo-image';
 import { useRef, useState, useCallback } from 'react';
 import { TouchableOpacity, View, StyleSheet, Text } from 'react-native';
-import { Image } from 'expo-image';
 
 export default function App() {
   const [isPlaying, setIsPlaying] = useState<boolean>(false);

--- a/apps/native-component-list/src/screens/Image/ImageAnimationResuming.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageAnimationResuming.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import { useRef, useState, useCallback } from 'react';
 import { TouchableOpacity, View, StyleSheet, Text } from 'react-native';
 import { Image } from 'expo-image';
 
@@ -6,7 +6,7 @@ export default function App() {
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
   const expoImageRef = useRef<Image>(null);
 
-  const handleGifPlayback = async () => {
+  const handleGifPlayback = useCallback(async () => {
     if (isPlaying) {
       setIsPlaying(false);
       await expoImageRef.current?.stopAnimating();
@@ -14,7 +14,7 @@ export default function App() {
     }
     setIsPlaying(true);
     await expoImageRef.current?.startAnimating();
-  };
+  }, [isPlaying]);
 
   return (
     <View style={styles.container}>

--- a/apps/native-component-list/src/screens/Image/ImageAnimationResuming.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageAnimationResuming.tsx
@@ -1,0 +1,56 @@
+import React, { useRef, useState } from 'react';
+import { TouchableOpacity, View, StyleSheet, Text } from 'react-native';
+import { Image } from 'expo-image';
+
+export default function App() {
+  const [isPlaying, setIsPlaying] = useState<boolean>(false);
+  const expoImageRef = useRef<Image>(null);
+
+  const handleGifPlayback = async () => {
+    if (isPlaying) {
+      setIsPlaying(false);
+      await expoImageRef.current?.stopAnimating();
+      return;
+    }
+    setIsPlaying(true);
+    await expoImageRef.current?.startAnimating();
+  };
+
+  return (
+    <View style={styles.container}>
+      <Image
+        ref={expoImageRef}
+        style={{ width: 300, height: 300 }}
+        source={{
+          uri: 'https://mir-s3-cdn-cf.behance.net/project_modules/source/5eeea355389655.59822ff824b72.gif',
+        }}
+        autoplay={false}
+      />
+      <TouchableOpacity style={styles.button} onPress={handleGifPlayback}>
+        <Text style={styles.buttonText}>{isPlaying ? 'Pause' : 'Play'}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  button: {
+    marginTop: 20,
+    backgroundColor: '#007AFF',
+    width: '40%',
+    paddingVertical: 12,
+    paddingHorizontal: 30,
+    borderRadius: 8,
+  },
+  buttonText: {
+    textAlign: 'center',
+    color: 'white',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/apps/native-component-list/src/screens/Image/ImageScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageScreen.tsx
@@ -21,6 +21,13 @@ export const ImageScreens = [
     },
   },
   {
+    name: 'Animation resuming',
+    route: 'image/animation-resuming',
+    getComponent() {
+      return optionalRequire(() => require('./ImageAnimationResuming'));
+    },
+  },
+  {
     name: 'List with thousands images',
     route: 'image/flashlist',
     options: {},

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+[Android] Fix animation resuming by casting image to GifDrawable ([#37363](https://github.com/expo/expo/pull/37363) by [@Wenszel](https://github.com/Wenszel))
+
 ### 💡 Others
 
 ## 2.3.0 - 2025-06-11

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -170,17 +170,16 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
   internal var cachePolicy: CachePolicy = CachePolicy.DISK
 
   fun setIsAnimating(setAnimating: Boolean) {
-    val resource = activeView.drawable
-    /* Animatable animations always start from the beginning when resumed.
-    So we check first if the resource is a GifDrawable, because it can continue
-    from where it was paused. */
-    when (resource) {
-      is GifDrawable -> toggleGifDrawableAnimation(resource, setAnimating)
-      is Animatable -> toggleAnimatableAnimation(resource, setAnimating)
+    // Animatable animations always start from the beginning when resumed.
+    // So we check first if the resource is a GifDrawable, because it can continue
+    // from where it was paused.
+    when (val resource = activeView.drawable) {
+      is GifDrawable -> setIsAnimating(resource, setAnimating)
+      is Animatable -> setIsAnimating(resource, setAnimating)
     }
   }
 
-  private fun toggleGifDrawableAnimation(resource: GifDrawable, setAnimating: Boolean) {
+  private fun setIsAnimating(resource: GifDrawable, setAnimating: Boolean) {
     if (setAnimating) {
       if (resource.isPaused) {
         resource.resume()
@@ -192,7 +191,7 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
     }
   }
 
-  private fun toggleAnimatableAnimation(resource: Animatable, setAnimating: Boolean) {
+  private fun setIsAnimating(resource: Animatable, setAnimating: Boolean) {
     if (setAnimating) {
       resource.start()
     } else {

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -18,6 +18,7 @@ import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
 import com.bumptech.glide.request.RequestOptions
+import com.github.penfeizhou.animation.gif.GifDrawable
 import expo.modules.image.enums.ContentFit
 import expo.modules.image.enums.Priority
 import expo.modules.image.events.GlideRequestListener
@@ -170,13 +171,32 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
 
   fun setIsAnimating(setAnimating: Boolean) {
     val resource = activeView.drawable
+    /* Animatable animations always start from the beginning when resumed.
+    So we check first if the resource is a GifDrawable, because it can continue
+    from where it was paused. */
+    when (resource) {
+      is GifDrawable -> toggleGifDrawableAnimation(resource, setAnimating)
+      is Animatable -> toggleAnimatableAnimation(resource, setAnimating)
+    }
+  }
 
-    if (resource is Animatable) {
-      if (setAnimating) {
-        resource.start()
+  private fun toggleGifDrawableAnimation(resource: GifDrawable, setAnimating: Boolean) {
+    if (setAnimating) {
+      if (resource.isPaused) {
+        resource.resume()
       } else {
-        resource.stop()
+        resource.start()
       }
+    } else {
+      resource.pause()
+    }
+  }
+
+  private fun toggleAnimatableAnimation(resource: Animatable, setAnimating: Boolean) {
+    if (setAnimating) {
+      resource.start()
+    } else {
+      resource.stop()
     }
   }
 


### PR DESCRIPTION
# Why

fixes [37327](https://github.com/expo/expo/issues/37327)

# How

The start() method in Animatable restarts animation, so I added checking if the resource can be cast to GifDrawable, because it has resume and pause methods.

# Test Plan

Added "Animation resuming" screen.  

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
