### PR TITLE
[docs] Fix misalignment of check icon in sidebar

### DIFF
--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -83,17 +83,13 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
               className="flex flex-1"
               key={`${route.name}-${child.name}`}>
               <span className="inline">
-                <span>{child.sidebarTitle ?? child.name}</span>
-                {child.hasVideoLink && (
-                  <span className="inline whitespace-nowrap">
-                    {' '}
-                    {!isSelected ? (
-                      <PlaySquareIcon className="icon-xs inline align-text-bottom text-icon-secondary" />
-                    ) : (
-                      <PlaySquareDuotoneIcon className="icon-xs inline align-text-bottom text-palette-blue11" />
-                    )}
-                  </span>
-                )}
+                {child.sidebarTitle ?? child.name}
+                {child.hasVideoLink &&
+                  (!isSelected ? (
+                    <PlaySquareIcon className="icon-xs ml-1 inline text-icon-secondary" />
+                  ) : (
+                    <PlaySquareDuotoneIcon className="icon-xs ml-1 inline text-palette-blue11" />
+                  ))}
               </span>
               {completed && <CheckIcon className="icon-sm ml-auto" />}
             </SidebarLink>
@@ -157,17 +153,13 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
               className="flex flex-1"
               key={`${route.name}-${child.name}`}>
               <span className="inline">
-                <span>{child.sidebarTitle ?? child.name}</span>
-                {child.hasVideoLink && (
-                  <span className="inline whitespace-nowrap">
-                    {' '}
-                    {!isSelected ? (
-                      <PlaySquareIcon className="icon-xs inline align-text-bottom text-icon-secondary" />
-                    ) : (
-                      <PlaySquareDuotoneIcon className="icon-xs inline align-text-bottom text-palette-blue11" />
-                    )}
-                  </span>
-                )}
+                {child.sidebarTitle ?? child.name}
+                {child.hasVideoLink &&
+                  (!isSelected ? (
+                    <PlaySquareIcon className="icon-xs ml-1 inline text-icon-secondary" />
+                  ) : (
+                    <PlaySquareDuotoneIcon className="icon-xs ml-1 inline text-palette-blue11" />
+                  ))}
               </span>
               {completed && <CheckIcon className="icon-sm ml-auto" />}
             </SidebarLink>

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -74,7 +74,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
           return (
             <SidebarLink info={child} className="flex flex-1" key={`${route.name}-${child.name}`}>
               {child.sidebarTitle ?? child.name}
-              {completed && <CheckIcon className="icon-sm ml-auto mt-0.5 self-start" />}
+              {completed && <CheckIcon className="icon-sm ml-auto" />}
             </SidebarLink>
           );
         })}
@@ -132,7 +132,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
           return (
             <SidebarLink info={child} className="flex flex-1" key={`${route.name}-${child.name}`}>
               {child.sidebarTitle ?? child.name}
-              {completed && <CheckIcon className="icon-sm ml-auto mt-0.5 self-start" />}
+              {completed && <CheckIcon className="icon-sm ml-auto" />}
             </SidebarLink>
           );
         })}

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -3,6 +3,7 @@ import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
 import { EasSubmitIcon } from '@expo/styleguide-icons/custom/EasSubmitIcon';
 import { PlanEnterpriseIcon } from '@expo/styleguide-icons/custom/PlanEnterpriseIcon';
 import { StoplightIcon } from '@expo/styleguide-icons/custom/StoplightIcon';
+import { PlaySquareDuotoneIcon } from '@expo/styleguide-icons/duotone/PlaySquareDuotoneIcon';
 import { CheckIcon } from '@expo/styleguide-icons/outline/CheckIcon';
 import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 import { CodeSquare01Icon } from '@expo/styleguide-icons/outline/CodeSquare01Icon';
@@ -14,9 +15,12 @@ import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon'
 import { NotificationBoxIcon } from '@expo/styleguide-icons/outline/NotificationBoxIcon';
 import { PaletteIcon } from '@expo/styleguide-icons/outline/PaletteIcon';
 import { Phone01Icon } from '@expo/styleguide-icons/outline/Phone01Icon';
+import { PlaySquareIcon } from '@expo/styleguide-icons/outline/PlaySquareIcon';
 import { Rocket01Icon } from '@expo/styleguide-icons/outline/Rocket01Icon';
 import { TerminalBrowserIcon } from '@expo/styleguide-icons/outline/TerminalBrowserIcon';
+import { useRouter } from 'next/compat/router';
 
+import { isRouteActive } from '~/common/routes';
 import { reportEasTutorialCompleted } from '~/providers/Analytics';
 import { useTutorialChapterCompletion } from '~/providers/TutorialChapterCompletionProvider';
 import { NavigationRoute } from '~/types/common';
@@ -31,6 +35,7 @@ import { SidebarNodeProps } from './types';
 export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
   const { chapters, setChapters, getStartedChapters, setGetStartedChapters } =
     useTutorialChapterCompletion();
+  const router = useRouter();
 
   const title = route.sidebarTitle ?? route.name;
   const Icon = getIconElement(title);
@@ -70,10 +75,26 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
         {route.children.map(child => {
           const childSlug = child.href;
           const completed = isChapterCompleted(childSlug);
+          const isSelected = isRouteActive(child, router?.asPath, router?.pathname);
 
           return (
-            <SidebarLink info={child} className="flex flex-1" key={`${route.name}-${child.name}`}>
-              {child.sidebarTitle ?? child.name}
+            <SidebarLink
+              info={{ ...child, hasVideoLink: false }}
+              className="flex flex-1"
+              key={`${route.name}-${child.name}`}>
+              <span className="inline">
+                <span>{child.sidebarTitle ?? child.name}</span>
+                {child.hasVideoLink && (
+                  <span className="inline whitespace-nowrap">
+                    {' '}
+                    {!isSelected ? (
+                      <PlaySquareIcon className="icon-xs inline align-text-bottom text-icon-secondary" />
+                    ) : (
+                      <PlaySquareDuotoneIcon className="icon-xs inline align-text-bottom text-palette-blue11" />
+                    )}
+                  </span>
+                )}
+              </span>
               {completed && <CheckIcon className="icon-sm ml-auto" />}
             </SidebarLink>
           );
@@ -128,10 +149,26 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
         {route.children.map(child => {
           const childSlug = child.href;
           const completed = isGetStartedChapterCompleted(childSlug);
+          const isSelected = isRouteActive(child, router?.asPath, router?.pathname);
 
           return (
-            <SidebarLink info={child} className="flex flex-1" key={`${route.name}-${child.name}`}>
-              {child.sidebarTitle ?? child.name}
+            <SidebarLink
+              info={{ ...child, hasVideoLink: false }}
+              className="flex flex-1"
+              key={`${route.name}-${child.name}`}>
+              <span className="inline">
+                <span>{child.sidebarTitle ?? child.name}</span>
+                {child.hasVideoLink && (
+                  <span className="inline whitespace-nowrap">
+                    {' '}
+                    {!isSelected ? (
+                      <PlaySquareIcon className="icon-xs inline align-text-bottom text-icon-secondary" />
+                    ) : (
+                      <PlaySquareDuotoneIcon className="icon-xs inline align-text-bottom text-palette-blue11" />
+                    )}
+                  </span>
+                )}
+              </span>
               {completed && <CheckIcon className="icon-sm ml-auto" />}
             </SidebarLink>
           );


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16001

In docs sync, @Simek reported the following misalignment issue of the check icon in tutorial section:

![CleanShot 2025-06-11 at 19 06 36](https://github.com/user-attachments/assets/dad6d067-fe9e-410b-b4b4-01309eeda656)

This misalignment happens when video icon is active in the sidebar and only applies to the tutorial section.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remve the margin top value from the `CheckIcon` styles in the `SidebarGroup` component.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-06-11 at 21 30 48](https://github.com/user-attachments/assets/c9bf224b-a195-43c7-b036-2d383c54403f)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
