### PR TITLE
[bare-expo][video] fix ios beta 26 build and runtime problems.

### DIFF
--- a/apps/bare-expo/ios/AppDelegate.swift
+++ b/apps/bare-expo/ios/AppDelegate.swift
@@ -16,6 +16,9 @@ public class AppDelegate: ExpoAppDelegate {
     let delegate = ReactNativeDelegate()
     let factory = ExpoReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
+    
+    // Fixes networking related crashes on simulator in iOS 26 beta 1
+    nw_tls_create_options();
 
     reactNativeDelegate = delegate
     reactNativeFactory = factory

--- a/apps/bare-expo/ios/AppDelegate.swift
+++ b/apps/bare-expo/ios/AppDelegate.swift
@@ -16,9 +16,9 @@ public class AppDelegate: ExpoAppDelegate {
     let delegate = ReactNativeDelegate()
     let factory = ExpoReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
-    
+
     // Fixes networking related crashes on simulator in iOS 26 beta 1
-    nw_tls_create_options();
+    nw_tls_create_options()
 
     reactNativeDelegate = delegate
     reactNativeFactory = factory

--- a/packages/expo-video/ios/VideoPlayerItem.swift
+++ b/packages/expo-video/ios/VideoPlayerItem.swift
@@ -39,7 +39,11 @@ class VideoPlayerItem: AVPlayerItem {
     self.urlAsset = asset
     // We can ignore any exceptions thrown during the load. The asset will be assigned to the `VideoPlayer` anyways
     // and cause it to go into .error state trigerring the `onStatusChange` event.
-    _ = try? await asset.load(.duration, .preferredTransform, .isPlayable)
+    do {
+      _ = try await asset.load(.duration, .preferredTransform, .isPlayable)
+    } catch {
+        // Catch block is intentionally left empty
+    }
 
     super.init(asset: urlAsset, automaticallyLoadedAssetKeys: nil)
     self.createTracksLoadingTask()


### PR DESCRIPTION
# Why

Makes bare-expo build and run on ios simulator for beta 1 ios 26.

# How

1. Fixes build issue `Type of expression is ambiguous without a type annotation` in expo-video.
2. Fixed runtime crashes in networking stack coming from react-native for bare-expo (based on https://github.com/firebase/firebase-ios-sdk/issues/14948)

# Test Plan

Verified bare-expo now builds and loads correctly.
Think we can safely merge this if we take it away once it's fixed upstream.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
