### PR TITLE
[docs] update instruction to latest SDK

### DIFF
--- a/docs/pages/workflow/ios-simulator.mdx
+++ b/docs/pages/workflow/ios-simulator.mdx
@@ -86,8 +86,8 @@ Create a project with the desired SDK version and open it in a simulator to inst
 
 <Terminal
   cmd={[
-    '# Bootstrap an SDK 51 project',
-    '$ npx create-expo-app --template blank@51',
+    '# Bootstrap an SDK 53 project',
+    '$ npx create-expo-app --template blank@53',
     '',
     '# Open the app on a simulator to install the required Expo Go app',
     '$ npx expo start --ios',


### PR DESCRIPTION
# Why

Directing users to create a project in Expo 51 is somewhat misleading, as they would miss out on the latest features that Expo has to offer.

