### PR TITLE
[bare-expo][ios] fix: cannot find 'nw_tls_create_options' in scope

### DIFF
--- a/apps/bare-expo/ios/AppDelegate.swift
+++ b/apps/bare-expo/ios/AppDelegate.swift
@@ -1,4 +1,5 @@
 import Expo
+import Network
 import React
 import ReactAppDependencyProvider
 


### PR DESCRIPTION
# Why

#37372 broke `apps/bare-expo` for me.

```
cannot find 'nw_tls_create_options' in scope
```

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
Added `import Network` to AppDelegate.swift to fix this.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
