### PR TITLE
[bare-expo][ios][android][web] optimize performance with native-stack and fix RNGH related issues

### DIFF
--- a/apps/bare-expo/MainNavigator.tsx
+++ b/apps/bare-expo/MainNavigator.tsx
@@ -1,11 +1,12 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { LinkingOptions, NavigationContainer } from '@react-navigation/native';
-import { createStackNavigator } from '@react-navigation/stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTheme } from 'ThemeProvider';
 import * as Linking from 'expo-linking';
 import React from 'react';
 import { Platform } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import TestSuite from 'test-suite/AppNavigator';
 
 type NavigationRouteConfigMap = React.ComponentType;
@@ -57,7 +58,7 @@ if (NativeComponentList) {
 }
 
 const Tab = createBottomTabNavigator();
-const Switch = createStackNavigator();
+const Switch = createNativeStackNavigator();
 
 const linking: LinkingOptions<object> = {
   prefixes: [
@@ -155,20 +156,22 @@ export default () => {
     return null;
   }
   return (
-    <NavigationContainer
-      linking={linking}
-      initialState={initialState}
-      onStateChange={(state) => {
-        AsyncStorage.setItem(PERSISTENCE_KEY, JSON.stringify(state)).catch(console.error);
-      }}>
-      <Switch.Navigator
-        screenOptions={{ headerShown: false }}
-        initialRouteName="main"
-        id={undefined}>
-        {Redirect && <Switch.Screen name="redirect" component={Redirect} />}
-        {Search && <Switch.Screen name="searchNavigator" component={Search} />}
-        <Switch.Screen name="main" component={TabNavigator} />
-      </Switch.Navigator>
-    </NavigationContainer>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <NavigationContainer
+        linking={linking}
+        initialState={initialState}
+        onStateChange={(state) => {
+          AsyncStorage.setItem(PERSISTENCE_KEY, JSON.stringify(state)).catch(console.error);
+        }}>
+        <Switch.Navigator
+          screenOptions={{ headerShown: false }}
+          initialRouteName="main"
+          id={undefined}>
+          {Redirect && <Switch.Screen name="redirect" component={Redirect} />}
+          {Search && <Switch.Screen name="searchNavigator" component={Search} />}
+          <Switch.Screen name="main" component={TabNavigator} />
+        </Switch.Navigator>
+      </NavigationContainer>
+    </GestureHandlerRootView>
   );
 };

--- a/apps/bare-expo/ios/AppDelegate.swift
+++ b/apps/bare-expo/ios/AppDelegate.swift
@@ -1,4 +1,5 @@
 import Expo
+import Network
 import React
 import ReactAppDependencyProvider
 

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -523,14 +523,14 @@ PODS:
     - ReactCommon/turbomodule/core
   - ExpoHaptics (14.1.4):
     - ExpoModulesCore
-  - ExpoImage (2.1.7):
+  - ExpoImage (2.3.0):
     - ExpoModulesCore
     - libavif/libdav1d
     - SDWebImage (~> 5.21.0)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
     - SDWebImageWebPCoder (~> 0.14.6)
-  - ExpoImage/Tests (2.1.7):
+  - ExpoImage/Tests (2.3.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
     - libavif/libdav1d
@@ -4317,7 +4317,7 @@ SPEC CHECKSUMS:
   ExpoFont: 312c73403bbd4f98e1d6a5330641a56292583cd2
   ExpoGL: 8f7f43291e400621ef9aeb7af347816c2051ddc7
   ExpoHaptics: 68c215e070f660e0a29c45dcda4f60eeff08aefb
-  ExpoImage: ef8b25fddd3613a0bbdb2936d0583bc6588197dd
+  ExpoImage: 23fd11d3f2c4b04dc0b5e97fb41e9ead278bd0c8
   ExpoImageManipulator: 094b748056f2654d5d7813370c910e20ef3d79b4
   ExpoImagePicker: d2fff488a0738343a3cc21e98544ee9feafaa0e6
   ExpoInsights: 58e0fb0aa39cabc674cf950942d241903fc94406
@@ -4352,7 +4352,7 @@ SPEC CHECKSUMS:
   ExpoUI: 4a03c3af5dd55144c788dfa3370bd244c21645ec
   ExpoVideo: 54ce43735b4ceb6b3828e3eec3b750b0fe10314c
   ExpoVideoThumbnails: 4280333bee3bd4d69b3b139bd50a8b7c967095ae
-  ExpoWebBrowser: 1051486eb45a2f4d1ee075712604f43f3009f90e
+  ExpoWebBrowser: 8aa522ab60113768d4dc5691c36d3315cc3b297b
   EXStructuredHeaders: 32bec6771c2db18c4cd47cecae530d1d06cdf972
   EXTaskManager: 0128b9f39a088b0c762d8d1c42017e6d44200b29
   EXUpdates: 9d87d1b97634263b9f8623eb7e763e58b48dc9fb

--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -1,5 +1,5 @@
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
-import { createStackNavigator } from '@react-navigation/stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTheme } from 'ThemeProvider';
 import * as React from 'react';
 
@@ -14,7 +14,7 @@ import ExpoApis from '../screens/ExpoApisScreen';
 import { ModulesCoreScreens } from '../screens/ModulesCore/ModulesCoreScreen';
 import { type ScreenApiItem, type ScreenConfig } from '../types/ScreenConfig';
 
-const Stack = createStackNavigator();
+const Stack = createNativeStackNavigator();
 
 export const ScreensList: ScreenConfig[] = [
   {

--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -1,5 +1,5 @@
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
-import { createStackNavigator } from '@react-navigation/stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTheme } from 'ThemeProvider';
 import * as React from 'react';
 
@@ -18,7 +18,7 @@ import { UIScreens } from '../screens/UI/UIScreen';
 import { VideoScreens } from '../screens/Video/VideoScreen';
 import { type ScreenApiItem, type ScreenConfig } from '../types/ScreenConfig';
 
-const Stack = createStackNavigator();
+const Stack = createNativeStackNavigator();
 
 const ScreensList: ScreenConfig[] = [
   {

--- a/apps/native-component-list/src/navigation/RootNavigation.tsx
+++ b/apps/native-component-list/src/navigation/RootNavigation.tsx
@@ -1,5 +1,5 @@
 import { LinkingOptions, NavigationContainer } from '@react-navigation/native';
-import { createStackNavigator } from '@react-navigation/stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as Linking from 'expo-linking';
 import * as React from 'react';
 import { Text } from 'react-native';
@@ -10,7 +10,7 @@ import MainTabNavigator from './MainTabNavigator';
 import RedirectScreen from '../screens/RedirectScreen';
 import SearchScreen from '../screens/SearchScreen';
 
-const Switch = createStackNavigator();
+const Switch = createNativeStackNavigator();
 
 export const linking: LinkingOptions<object> = {
   prefixes: [Linking.createURL('/')],
@@ -42,7 +42,7 @@ export default function RootNavigation() {
           <Switch.Screen
             name="searchNavigator"
             component={SearchScreen}
-            options={{ cardStyle: { backgroundColor: 'transparent' } }}
+            options={{ contentStyle: { backgroundColor: 'black' } }}
           />
         </Switch.Navigator>
       </NavigationContainer>

--- a/apps/native-component-list/src/screens/Screens/index.tsx
+++ b/apps/native-component-list/src/screens/Screens/index.tsx
@@ -1,4 +1,7 @@
-import { createStackNavigator, StackNavigationProp } from '@react-navigation/stack';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from '@react-navigation/native-stack';
 import React from 'react';
 import { FlatList, StyleSheet, Text, TouchableHighlight, View } from 'react-native';
 
@@ -14,7 +17,7 @@ const SCREENS: Record<string, { component: any; options: { title: string } }> = 
 
 type Links = { Container: undefined; NativeStack: undefined; Navigation: undefined };
 
-type Props = { navigation: StackNavigationProp<Links> };
+type Props = { navigation: NativeStackNavigationProp<Links> };
 
 class MainScreen extends React.Component<Props> {
   static navigationOptions = {
@@ -59,8 +62,8 @@ class MainScreenItem extends React.Component<{
   }
 }
 
-const Stack = createStackNavigator();
-const SwitchStack = createStackNavigator();
+const Stack = createNativeStackNavigator();
+const SwitchStack = createNativeStackNavigator();
 
 const ExampleApp = () => (
   <SwitchStack.Navigator initialRouteName="Main" screenOptions={{ headerShown: false }}>

--- a/apps/native-component-list/src/screens/Screens/navigation/index.tsx
+++ b/apps/native-component-list/src/screens/Screens/navigation/index.tsx
@@ -1,4 +1,4 @@
-import { createStackNavigator, StackScreenProps } from '@react-navigation/stack';
+import { createNativeStackNavigator, NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as React from 'react';
 import { Animated, Button, Image, StyleSheet, TextInput, View } from 'react-native';
 
@@ -26,7 +26,7 @@ const Background: React.FunctionComponent<{ index: number }> = ({ index }) => (
 
 type Links = { Details: undefined | { index?: number } };
 
-type Props = StackScreenProps<Links, 'Details'>;
+type Props = NativeStackScreenProps<Links, 'Details'>;
 
 class DetailsScreen extends React.Component<Props, { count: number; text: string }> {
   animvalue = new Animated.Value(0);
@@ -83,7 +83,7 @@ class DetailsScreen extends React.Component<Props, { count: number; text: string
   }
 }
 
-const Stack = createStackNavigator();
+const Stack = createNativeStackNavigator();
 
 const App = () => (
   <Stack.Navigator>

--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -1,5 +1,5 @@
 import { HeaderBackButton } from '@react-navigation/elements';
-import { createStackNavigator, StackScreenProps } from '@react-navigation/stack';
+import { createNativeStackNavigator, NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useTheme } from 'ThemeProvider';
 import Fuse from 'fuse.js';
 import React from 'react';
@@ -57,7 +57,7 @@ function Header({
   );
 }
 
-function SearchScreen({ route }: StackScreenProps<SearchStack, 'search'>) {
+function SearchScreen({ route }: NativeStackScreenProps<SearchStack, 'search'>) {
   const query = route?.params?.q ?? '';
 
   const apis = React.useMemo(() => fuse.search(query).map(({ item }) => item), [query]);
@@ -76,7 +76,7 @@ type SearchStack = {
   search: { q?: string };
 };
 
-const Stack = createStackNavigator<SearchStack>();
+const Stack = createNativeStackNavigator<SearchStack>();
 
 export default function SearchScreenStack() {
   const { theme } = useTheme();

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -962,3 +962,160 @@ jobs:
 ```
 
 </Collapsible>
+
+## Require Approval
+
+Require approval from a user before continuing with the workflow. A user can approve or reject which translates to success or failure of the job.
+
+### Syntax
+
+```yaml
+jobs:
+  require_approval:
+    type: require-approval
+```
+
+#### Parameters
+
+This job doesn't take any parameters.
+
+### Examples
+
+Here are some practical examples of using the Require Approval job:
+
+<Collapsible summary="Ask for approval before deploying to production">
+
+This workflow deploys a web app to preview and then requires approval from a user before deploying to production.
+
+```yaml .eas/workflows/web.yml
+jobs:
+  web_preview:
+    name: Deploy Web Preview
+    type: deploy
+
+  require_approval:
+    name: Deploy Web to Production?
+    needs: [web_preview]
+    type: require-approval
+
+  web_production:
+    name: Deploy Web Production
+    needs: [require_approval]
+    type: deploy
+    params:
+      prod: true
+```
+
+</Collapsible>
+
+<Collapsible summary="Control flow of the workflow">
+
+This workflow lets a user decide how the story ends by requiring approval before revealing the conclusion.
+
+```yaml .eas/workflows/dragon-knight-interactive.yml
+jobs:
+  show_story_intro:
+    name: Dragon and Knight Story Intro
+    type: doc
+    params:
+      md: |
+        # The Dragon and the Knight
+
+        Once upon a time, in a land far away, a brave knight set out to face a mighty dragon.
+
+        The dragon roared, breathing fire across the valley, but the knight stood firm, shield raised high.
+
+        Now, the fate of their encounter is in your hands...
+
+  require_approval:
+    name: Should the knight and dragon become friends?
+    needs: [show_story_intro]
+    type: require-approval
+
+  happy_ending:
+    name: Friendship Ending
+    needs: [require_approval]
+    type: doc
+    params:
+      md: |
+        ## A New Friendship
+
+        The knight lowered his sword, and the dragon ceased its fire. They realized they both longed for peace. From that day on, they became the best of friends, protecting the kingdom together.
+
+  epic_battle:
+    name: Epic Battle Ending
+    after: [require_approval]
+    if: ${{ failure() }}
+    type: doc
+    params:
+      md: |
+        ## The Epic Battle
+
+        The knight charged forward, and the dragon unleashed a mighty roar. Their battle shook the mountains and echoed through the ages. In the end, both were remembered as fierce and noble adversaries.
+```
+
+</Collapsible>
+
+## Doc
+
+Displays a Markdown section in the workflow logs.
+
+### Syntax
+
+```yaml
+jobs:
+  show_whats_next:
+    type: doc
+    params:
+      md: string
+```
+
+#### Parameters
+
+You can pass the following parameters into the `params` list:
+
+| Parameter | Type   | Description                                                                                 |
+| --------- | ------ | ------------------------------------------------------------------------------------------- |
+| md        | string | Required. The Markdown content to display. You can use `${{ ... }}` workflow interpolation. |
+
+### Examples
+
+Here are some practical examples of using the Doc job:
+
+<Collapsible summary="Display instructions">
+
+This workflow builds an iOS app and then displays a Markdown section in the workflow logs.
+
+```yaml .eas/workflows/build-and-submit-ios.yml
+jobs:
+  build_ios:
+    name: Build iOS
+    type: build
+    params:
+      platform: ios
+      profile: production
+
+  submit:
+    name: Submit to App Store
+    type: submit
+    needs: [build_ios]
+    params:
+      build_id: ${{ needs.build_ios.outputs.build_id }}
+      profile: production
+
+  next_steps:
+    name: Next Steps
+    needs: [submit]
+    type: doc
+    params:
+      md: |
+        # To do next
+
+        Your app has just been sent to [App Store Connect](https://appstoreconnect.apple.com/apps).
+
+        1. Download the app from TestFlight.
+        2. Test the app a bunch.
+        3. Submit the app for review.
+```
+
+</Collapsible>

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -727,6 +727,32 @@ jobs:
       payload: object # required if message is not provided
 ```
 
+#### `require-approval`
+
+Requires approval from a user before continuing with the workflow. A user can approve or reject which translates to success or failure of the job. See [Require Approval job documentation](/eas/workflows/pre-packaged-jobs#require-approval) for detailed information and examples.
+
+```yaml
+jobs:
+  confirm:
+    # @info #
+    type: require-approval
+    # @end #
+```
+
+#### `doc`
+
+Displays a Markdown section in the workflow logs. See [Doc job documentation](/eas/workflows/pre-packaged-jobs#doc) for detailed information and examples.
+
+```yaml
+jobs:
+  next_steps:
+    # @info #
+    type: doc
+    params:
+      md: string
+    # @end #
+```
+
 ## Custom jobs
 
 Runs custom code and can use built-in EAS functions. Does not require a `type` field.

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -3,6 +3,7 @@ import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
 import { EasSubmitIcon } from '@expo/styleguide-icons/custom/EasSubmitIcon';
 import { PlanEnterpriseIcon } from '@expo/styleguide-icons/custom/PlanEnterpriseIcon';
 import { StoplightIcon } from '@expo/styleguide-icons/custom/StoplightIcon';
+import { PlaySquareDuotoneIcon } from '@expo/styleguide-icons/duotone/PlaySquareDuotoneIcon';
 import { CheckIcon } from '@expo/styleguide-icons/outline/CheckIcon';
 import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 import { CodeSquare01Icon } from '@expo/styleguide-icons/outline/CodeSquare01Icon';
@@ -14,9 +15,12 @@ import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon'
 import { NotificationBoxIcon } from '@expo/styleguide-icons/outline/NotificationBoxIcon';
 import { PaletteIcon } from '@expo/styleguide-icons/outline/PaletteIcon';
 import { Phone01Icon } from '@expo/styleguide-icons/outline/Phone01Icon';
+import { PlaySquareIcon } from '@expo/styleguide-icons/outline/PlaySquareIcon';
 import { Rocket01Icon } from '@expo/styleguide-icons/outline/Rocket01Icon';
 import { TerminalBrowserIcon } from '@expo/styleguide-icons/outline/TerminalBrowserIcon';
+import { useRouter } from 'next/compat/router';
 
+import { isRouteActive } from '~/common/routes';
 import { reportEasTutorialCompleted } from '~/providers/Analytics';
 import { useTutorialChapterCompletion } from '~/providers/TutorialChapterCompletionProvider';
 import { NavigationRoute } from '~/types/common';
@@ -31,6 +35,7 @@ import { SidebarNodeProps } from './types';
 export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
   const { chapters, setChapters, getStartedChapters, setGetStartedChapters } =
     useTutorialChapterCompletion();
+  const router = useRouter();
 
   const title = route.sidebarTitle ?? route.name;
   const Icon = getIconElement(title);
@@ -70,11 +75,23 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
         {route.children.map(child => {
           const childSlug = child.href;
           const completed = isChapterCompleted(childSlug);
+          const isSelected = isRouteActive(child, router?.asPath, router?.pathname);
 
           return (
-            <SidebarLink info={child} className="flex flex-1" key={`${route.name}-${child.name}`}>
-              {child.sidebarTitle ?? child.name}
-              {completed && <CheckIcon className="icon-sm ml-auto mt-0.5 self-start" />}
+            <SidebarLink
+              info={{ ...child, hasVideoLink: false }}
+              className="flex flex-1"
+              key={`${route.name}-${child.name}`}>
+              <span className="inline">
+                {child.sidebarTitle ?? child.name}
+                {child.hasVideoLink &&
+                  (!isSelected ? (
+                    <PlaySquareIcon className="icon-xs ml-1 inline text-icon-secondary" />
+                  ) : (
+                    <PlaySquareDuotoneIcon className="icon-xs ml-1 inline text-palette-blue11" />
+                  ))}
+              </span>
+              {completed && <CheckIcon className="icon-sm ml-auto" />}
             </SidebarLink>
           );
         })}
@@ -128,11 +145,23 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
         {route.children.map(child => {
           const childSlug = child.href;
           const completed = isGetStartedChapterCompleted(childSlug);
+          const isSelected = isRouteActive(child, router?.asPath, router?.pathname);
 
           return (
-            <SidebarLink info={child} className="flex flex-1" key={`${route.name}-${child.name}`}>
-              {child.sidebarTitle ?? child.name}
-              {completed && <CheckIcon className="icon-sm ml-auto mt-0.5 self-start" />}
+            <SidebarLink
+              info={{ ...child, hasVideoLink: false }}
+              className="flex flex-1"
+              key={`${route.name}-${child.name}`}>
+              <span className="inline">
+                {child.sidebarTitle ?? child.name}
+                {child.hasVideoLink &&
+                  (!isSelected ? (
+                    <PlaySquareIcon className="icon-xs ml-1 inline text-icon-secondary" />
+                  ) : (
+                    <PlaySquareDuotoneIcon className="icon-xs ml-1 inline text-palette-blue11" />
+                  ))}
+              </span>
+              {completed && <CheckIcon className="icon-sm ml-auto" />}
             </SidebarLink>
           );
         })}


### PR DESCRIPTION
# Why

While I was working on #37377, I noticed that the app was very janky. After a quick inspection, I realized it was using the JS navigation stack instead of the native stack. It was probably done intentionally, but updating it was quick and the navigation and feel are now so much better and faster.

Also, all screens using export from React Native Gesture Handler were broken with “NativeViewGestureHandler must be used as a descendant of GestureHandlerRootView.”


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

I switched from JS stack to native stack and tested all screens. Also ran web. Everything worked fine in my tests.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


Verified iOS, Android and Web

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/9cc64f1b-db8a-4386-9670-ad4fac8f2891) | ![after](https://github.com/user-attachments/assets/41781423-2649-48c7-a2f1-a8d30baec0eb) |
| <video src="https://github.com/user-attachments/assets/7d7a66a0-d4aa-4714-9d43-09e91e022f08" controls></video> | <video src="https://github.com/user-attachments/assets/997a17b5-89d8-44cb-a5cc-648acc814c55" controls></video> |


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
