### PR TITLE
[ios][audio] Fixed status property bug when track finishes

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed status property bug when track finishes ([#37389](https://github.com/expo/expo/pull/37389) by [@adiktiv](https://github.com/adiktiv))
 - [iOS] Fix inconsistent audio sampling. ([#37154](https://github.com/expo/expo/pull/37154) by [@alanjhughes](https://github.com/alanjhughes))
 - Add automatic interruption handling. ([#37153](https://github.com/expo/expo/pull/37153) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Improve audio tap memory safety and cleanup ([#37174](https://github.com/expo/expo/pull/37174) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -242,7 +242,7 @@ public class AudioPlayer: SharedRef<AVPlayer> {
         self.ref.play()
       } else {
         self.updateStatus(with: [
-          "isPlaying": false,
+          "playing": false,
           "currentTime": self.duration,
           "didJustFinish": true
         ])


### PR DESCRIPTION
# Why

The issue was identified while developing an audio player using the new expo-audio package. On iPhone devices, when the audio track finished playing, instead of updating the existing "playing" property to false, a new property "isPlaying" was being set to false. This inconsistency can lead to unexpected behavior in components relying on the status property.

# How

The fix involved modifying the status update logic in the native iOS module (AudioPlayer.swift) within the expo-audio package. The code change replaces the key "isPlaying" with "playing" in the status update. This ensures that when the track finishes:
- The "playing" property is set to false.
- No extra, conflicting key is introduced.

# Test Plan

1. Run the expo-audio module on an iPhone or iPhone simulator.
2. Initiate audio playback using the new expo-audio package and allow the track to finish.
3. Observe that the status object now correctly updates the "playing" property to false, and that no "isPlaying" property is present.
4. Verify through console logs and UI feedback that the bug is resolved.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
