### PR TITLE
[video][ios] Fix player not setting default audio track for some HLS

### DIFF
--- a/apps/native-component-list/src/screens/Video/videoSources.ts
+++ b/apps/native-component-list/src/screens/Video/videoSources.ts
@@ -63,6 +63,10 @@ const androidDrmSource: VideoSource = {
   uri: 'https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8',
 };
 
+export const splitAudioHLSSource: VideoSource = {
+  uri: 'https://storage.sardius.media/b94F91A2A4c1c84/archives/46D416760208A337BDd2382D503C/media/playlist.m3u8',
+};
+
 const videoLabels: string[] = [
   'Big Buck Bunny',
   'Elephants Dream',
@@ -71,6 +75,7 @@ const videoLabels: string[] = [
   'Cute Doggo (local video)',
   'Null Source',
   'Audio Track',
+  'Split audio (HLS)',
 ];
 const videoSources: VideoSource[] = [
   bigBuckBunnySource,
@@ -80,6 +85,7 @@ const videoSources: VideoSource[] = [
   localVideoSource,
   nullSource,
   audioTrackSource,
+  splitAudioHLSSource,
 ];
 
 export {

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -31,6 +31,7 @@ _This version does not introduce any user-facing changes._
 - [iOS] Fix player reporting status `readyToPlay` while a source is being loaded asynchronously. ([#37180](https://github.com/expo/expo/pull/37180) by [@behenate](https://github.com/behenate))
 - [iOS] Fix player going into `loading` status for a single frame when unpausing with a full buffer. ([#37181](https://github.com/expo/expo/pull/37181) by [@behenate](https://github.com/behenate))
 - [iOS] Fix player getting stuck in `loading` state for null sources. ([#37183](https://github.com/expo/expo/pull/37183) by [@behenate](https://github.com/behenate))
+- [iOS] Fix player not setting default audio track for some HLS streams.
 
 ## 2.1.9 — 2025-05-08
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -31,7 +31,7 @@ _This version does not introduce any user-facing changes._
 - [iOS] Fix player reporting status `readyToPlay` while a source is being loaded asynchronously. ([#37180](https://github.com/expo/expo/pull/37180) by [@behenate](https://github.com/behenate))
 - [iOS] Fix player going into `loading` status for a single frame when unpausing with a full buffer. ([#37181](https://github.com/expo/expo/pull/37181) by [@behenate](https://github.com/behenate))
 - [iOS] Fix player getting stuck in `loading` state for null sources. ([#37183](https://github.com/expo/expo/pull/37183) by [@behenate](https://github.com/behenate))
-- [iOS] Fix player not setting default audio track for some HLS streams.
+- [iOS] Fix player not setting default audio track for some HLS streams. ([#37395](https://github.com/expo/expo/pull/37395) by [@vitorclelis96](https://github.com/vitorclelis96))
 
 ## 2.1.9 — 2025-05-08
 

--- a/packages/expo-video/ios/VideoPlayerItem.swift
+++ b/packages/expo-video/ios/VideoPlayerItem.swift
@@ -80,7 +80,7 @@ class VideoPlayerItem: AVPlayerItem {
       return
     }
     if let audioGroup = self.asset.mediaSelectionGroup(forMediaCharacteristic: .audible),
-      let audioOption = audioGroup.defaultOption ?? audioGroup.options.first  {
+      let audioOption = audioGroup.defaultOption ?? audioGroup.options.first {
         self.select(audioOption, in: audioGroup)
       }
   }

--- a/packages/expo-video/ios/VideoPlayerItem.swift
+++ b/packages/expo-video/ios/VideoPlayerItem.swift
@@ -80,9 +80,9 @@ class VideoPlayerItem: AVPlayerItem {
       return
     }
     if let audioGroup = self.asset.mediaSelectionGroup(forMediaCharacteristic: .audible),
-     let audioOption = audioGroup.defaultOption ?? audioGroup.options.first  {
-      self.select(audioOption, in: audioGroup)
-    }
+      let audioOption = audioGroup.defaultOption ?? audioGroup.options.first  {
+        self.select(audioOption, in: audioGroup)
+      }
   }
 
   // AVKit API doesn't provide us with a list of available tracks for a HLS source. We can download the playlist file and parse it ourselves

--- a/packages/expo-video/ios/VideoPlayerItem.swift
+++ b/packages/expo-video/ios/VideoPlayerItem.swift
@@ -26,6 +26,7 @@ class VideoPlayerItem: AVPlayerItem {
     self.urlAsset = asset
     super.init(asset: urlAsset, automaticallyLoadedAssetKeys: nil)
     self.createTracksLoadingTask()
+    self.loadHlsDefaultAudioTrack()
   }
 
   init?(videoSource: VideoSource) async throws {
@@ -47,6 +48,7 @@ class VideoPlayerItem: AVPlayerItem {
 
     super.init(asset: urlAsset, automaticallyLoadedAssetKeys: nil)
     self.createTracksLoadingTask()
+    self.loadHlsDefaultAudioTrack()
   }
 
   func createTracksLoadingTask() {
@@ -70,6 +72,16 @@ class VideoPlayerItem: AVPlayerItem {
         }
       }
       return tracks
+    }
+  }
+
+  private func loadHlsDefaultAudioTrack() {
+    guard self.isHls else {
+      return
+    }
+    if let audioGroup = self.asset.mediaSelectionGroup(forMediaCharacteristic: .audible),
+     let audioOption = audioGroup.defaultOption ?? audioGroup.options.first  {
+      self.select(audioOption, in: audioGroup)
     }
   }
 


### PR DESCRIPTION
# Why

For some HLS streams (.m3u8 files), the audio track is not selected, even though it has at least one.

# How

A new `loadHlsDefaultAudioTrack` function has been added to the `VideoPlayerItem` class, which gets called on its `init` methods. This function sets a default audio track, if it exists.


# Test Plan

I've added a new `VideoSource` to the `native-component-list` project. This video source has the described issue. You can use the `bare-expo` app to test the changes with the new source (as well as to confirm old sources won't be changed)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
