### PR TITLE
[docs] Update Maestro and its documentation links

### DIFF
--- a/docs/pages/archive/e2e-tests.mdx
+++ b/docs/pages/archive/e2e-tests.mdx
@@ -12,7 +12,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 > **warning** **Deprecated:** This is an old and archived version of our EAS Build E2E tests guide. [See the latest version of the guide here](/eas/workflows/reference/e2e-tests/).
 
-In this guide, you will learn how to create and run E2E tests on EAS Build using [Maestro](https://maestro.mobile.dev/), which is one of the most popular tools for running E2E tests in mobile apps.
+In this guide, you will learn how to create and run E2E tests on EAS Build using [Maestro](https://maestro.dev/), which is one of the most popular tools for running E2E tests in mobile apps.
 
 The example demonstrates how to configure your EAS Build Maestro E2E tests workflow using the [default Expo template](/more/create-expo/#--template). For your own app, you will need to adjust the flows to match your app's UI.
 
@@ -101,7 +101,7 @@ appId: dev.expo.eastestsexample # This is an example app id. Replace it with you
 <Step label="5">
 ## Run Maestro tests locally
 
-To run Maestro tests locally, install the Maestro CLI by following the instructions in [Installing Maestro](https://maestro.mobile.dev/getting-started/installing-maestro).
+To run Maestro tests locally, install the Maestro CLI by following the instructions in [Installing Maestro](https://docs.maestro.dev/getting-started/installing-maestro).
 
 [Install your app on a local Android Emulator or iOS Simulator](/more/expo-cli/#compiling). Open a terminal, navigate to the Maestro directory, and run the following commands to start the tests with the Maestro CLI:
 
@@ -187,7 +187,7 @@ When the flow fails, any Maestro artifacts are automatically uploaded as build a
 
 If you want to build more advanced custom builds workflows, see the [custom build schema reference](/custom-builds/schema/) for more information.
 
-To learn more about Maestro flows and how to write them, see the [Maestro documentation](https://maestro.mobile.dev).
+To learn more about Maestro flows and how to write them, see the [Maestro documentation](https://docs.maestro.dev/).
 
 ## Troubleshooting
 

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -743,7 +743,7 @@ All-in-one function that installs Maestro, prepares a testing environment (Andro
 
 | Input       | Type     | Description                                                                                                                                                                                                                        |
 | ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `flow_path` | `string` | Path (or multiple paths, each in a separate line) to [Maestro flows](https://maestro.mobile.dev/getting-started/writing-your-first-flow) to run.                                                                                   |
+| `flow_path` | `string` | Path (or multiple paths, each in a separate line) to [Maestro flows](https://docs.maestro.dev/getting-started/writing-your-first-flow) to run.                                                                                     |
 | `app_path`  | `string` | Path (or regex pattern) to the emulator/simulator app that should be tested. If not provided, it defaults to **android/app/build/outputs/\*\*/\*.apk** for Android and to **ios/build/Build/Products/\*simulator/\*.app** for iOS. |
 
 ```yaml build-and-test.yml
@@ -1653,7 +1653,7 @@ build:
 
 #### `eas/install_maestro`
 
-Makes sure [Maestro](https://maestro.mobile.dev), the mobile UI testing framework, is installed along with all its dependencies.
+Makes sure [Maestro](https://maestro.dev/), the mobile UI testing framework, is installed along with all its dependencies.
 
 ```yaml build-and-test.yml
 build:

--- a/docs/pages/eas/workflows/reference/e2e-tests.mdx
+++ b/docs/pages/eas/workflows/reference/e2e-tests.mdx
@@ -12,7 +12,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-In this guide, you'll learn how to run end-to-end (E2E) tests on EAS Workflows using [Maestro](https://maestro.mobile.dev/). The example demonstrates how to configure your E2E tests workflow using the [default Expo template](/more/create-expo/#--template). For your own app, you'll need to adjust the flows to match your app's UI.
+In this guide, you'll learn how to run end-to-end (E2E) tests on EAS Workflows using [Maestro](https://maestro.dev/). The example demonstrates how to configure your E2E tests workflow using the [default Expo template](/more/create-expo/#--template). For your own app, you'll need to adjust the flows to match your app's UI.
 
 <Step label="1">
 ## Set up your project
@@ -61,7 +61,7 @@ appId: dev.expo.eastestsexample # This is an example app id. Replace it with you
 <Step label="3">
 ## Run Maestro tests locally (optional)
 
-To run Maestro tests locally, install the Maestro CLI by following the instructions in [Installing Maestro](https://maestro.mobile.dev/getting-started/installing-maestro).
+To run Maestro tests locally, install the Maestro CLI by following the instructions in [Installing Maestro](https://docs.maestro.dev/getting-started/installing-maestro).
 
 [Install your app on a local Android Emulator or iOS Simulator](/more/expo-cli/#compiling). Open a terminal, navigate to the Maestro directory, and run the following commands to start the tests with the Maestro CLI:
 
@@ -196,6 +196,6 @@ After the workflow starts, you can track its progress and view the results in th
 <BoxLink
   title="Maestro documentation"
   description="Learn more about Maestro flows and how to write them."
-  href="https://maestro.mobile.dev"
+  href="https://docs.maestro.dev/"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -658,7 +658,7 @@ This job outputs the following properties:
 
 #### `maestro`
 
-Runs [Maestro](https://maestro.mobile.dev/) tests on a build. See [Maestro job documentation](/eas/workflows/pre-packaged-jobs#maestro) for detailed information and examples.
+Runs [Maestro](https://maestro.dev/) tests on a build. See [Maestro job documentation](/eas/workflows/pre-packaged-jobs#maestro) for detailed information and examples.
 
 > **important** Maestro tests are experimental and may experience flakiness.
 
@@ -684,7 +684,7 @@ jobs:
 
 #### `maestro-cloud`
 
-Runs [Maestro](https://maestro.mobile.dev/) tests on a build in [Maestro Cloud](https://docs.maestro.dev/cloud/run-maestro-tests-in-the-cloud). See [Maestro Cloud job documentation](/eas/workflows/pre-packaged-jobs#maestro-cloud) for detailed information and examples.
+Runs [Maestro](https://maestro.dev/) tests on a build in [Maestro Cloud](https://docs.maestro.dev/cloud/run-maestro-tests-in-the-cloud). See [Maestro Cloud job documentation](/eas/workflows/pre-packaged-jobs#maestro-cloud) for detailed information and examples.
 
 > **important** Running tests in Maestro Cloud requires a Maestro Cloud account and Cloud Plan subscription. Go to [Maestro docs](https://docs.maestro.dev/cloud/run-maestro-tests-in-the-cloud) to learn more.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16016

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the Maestro home page and documentation links to replace the outdated link (maestro.mobile.dev/):
- https://maestro.dev/
- https://docs.maestro.dev/

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
