### PR TITLE
Upgrade React Native to 0.80.0

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -523,14 +523,14 @@ PODS:
     - ReactCommon/turbomodule/core
   - ExpoHaptics (14.1.4):
     - ExpoModulesCore
-  - ExpoImage (2.1.7):
+  - ExpoImage (2.3.0):
     - ExpoModulesCore
     - libavif/libdav1d
     - SDWebImage (~> 5.21.0)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
     - SDWebImageWebPCoder (~> 0.14.6)
-  - ExpoImage/Tests (2.1.7):
+  - ExpoImage/Tests (2.3.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
     - libavif/libdav1d
@@ -785,12 +785,20 @@ PODS:
   - EXUpdatesInterface (1.1.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.80.0-rc.5)
+  - FBLazyVector (0.80.0)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.80.0-rc.5):
-    - hermes-engine/Pre-built (= 0.80.0-rc.5)
-  - hermes-engine/Pre-built (0.80.0-rc.5)
+  - hermes-engine (0.80.0):
+    - hermes-engine/cdp (= 0.80.0)
+    - hermes-engine/Hermes (= 0.80.0)
+    - hermes-engine/inspector (= 0.80.0)
+    - hermes-engine/inspector_chrome (= 0.80.0)
+    - hermes-engine/Public (= 0.80.0)
+  - hermes-engine/cdp (0.80.0)
+  - hermes-engine/Hermes (0.80.0)
+  - hermes-engine/inspector (0.80.0)
+  - hermes-engine/inspector_chrome (0.80.0)
+  - hermes-engine/Public (0.80.0)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -873,28 +881,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.80.0-rc.5)
-  - RCTRequired (0.80.0-rc.5)
-  - RCTTypeSafety (0.80.0-rc.5):
-    - FBLazyVector (= 0.80.0-rc.5)
-    - RCTRequired (= 0.80.0-rc.5)
-    - React-Core (= 0.80.0-rc.5)
+  - RCTDeprecation (0.80.0)
+  - RCTRequired (0.80.0)
+  - RCTTypeSafety (0.80.0):
+    - FBLazyVector (= 0.80.0)
+    - RCTRequired (= 0.80.0)
+    - React-Core (= 0.80.0)
   - ReachabilitySwift (5.2.4)
-  - React (0.80.0-rc.5):
-    - React-Core (= 0.80.0-rc.5)
-    - React-Core/DevSupport (= 0.80.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.5)
-    - React-RCTActionSheet (= 0.80.0-rc.5)
-    - React-RCTAnimation (= 0.80.0-rc.5)
-    - React-RCTBlob (= 0.80.0-rc.5)
-    - React-RCTImage (= 0.80.0-rc.5)
-    - React-RCTLinking (= 0.80.0-rc.5)
-    - React-RCTNetwork (= 0.80.0-rc.5)
-    - React-RCTSettings (= 0.80.0-rc.5)
-    - React-RCTText (= 0.80.0-rc.5)
-    - React-RCTVibration (= 0.80.0-rc.5)
-  - React-callinvoker (0.80.0-rc.5)
-  - React-Core (0.80.0-rc.5):
+  - React (0.80.0):
+    - React-Core (= 0.80.0)
+    - React-Core/DevSupport (= 0.80.0)
+    - React-Core/RCTWebSocket (= 0.80.0)
+    - React-RCTActionSheet (= 0.80.0)
+    - React-RCTAnimation (= 0.80.0)
+    - React-RCTBlob (= 0.80.0)
+    - React-RCTImage (= 0.80.0)
+    - React-RCTLinking (= 0.80.0)
+    - React-RCTNetwork (= 0.80.0)
+    - React-RCTSettings (= 0.80.0)
+    - React-RCTText (= 0.80.0)
+    - React-RCTVibration (= 0.80.0)
+  - React-callinvoker (0.80.0)
+  - React-Core (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -904,7 +912,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.5)
+    - React-Core/Default (= 0.80.0)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -918,79 +926,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.5)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.80.0-rc.5):
+  - React-Core/CoreModulesHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1014,7 +950,55 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.80.0-rc.5):
+  - React-Core/Default (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0)
+    - React-Core/RCTWebSocket (= 0.80.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1038,7 +1022,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.80.0-rc.5):
+  - React-Core/RCTAnimationHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1062,7 +1046,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.80.0-rc.5):
+  - React-Core/RCTBlobHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1086,7 +1070,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.80.0-rc.5):
+  - React-Core/RCTImageHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1110,7 +1094,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.80.0-rc.5):
+  - React-Core/RCTLinkingHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1134,7 +1118,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.80.0-rc.5):
+  - React-Core/RCTNetworkHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1158,7 +1142,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.80.0-rc.5):
+  - React-Core/RCTSettingsHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1182,7 +1166,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.80.0-rc.5):
+  - React-Core/RCTTextHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1206,7 +1190,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.80.0-rc.5):
+  - React-Core/RCTVibrationHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1216,7 +1200,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.5)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -1230,7 +1214,31 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.80.0-rc.5):
+  - React-Core/RCTWebSocket (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1238,19 +1246,19 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.80.0-rc.5)
-    - React-Core/CoreModulesHeaders (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - RCTTypeSafety (= 0.80.0)
+    - React-Core/CoreModulesHeaders (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.80.0-rc.5)
+    - React-RCTImage (= 0.80.0)
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.80.0-rc.5):
+  - React-cxxreact (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1259,19 +1267,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-debug (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-debug (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
-    - React-runtimeexecutor (= 0.80.0-rc.5)
-    - React-timing (= 0.80.0-rc.5)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
+    - React-runtimeexecutor (= 0.80.0)
+    - React-timing (= 0.80.0)
     - SocketRocket
-  - React-debug (0.80.0-rc.5)
-  - React-defaultsnativemodule (0.80.0-rc.5):
+  - React-debug (0.80.0)
+  - React-defaultsnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1289,7 +1297,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.80.0-rc.5):
+  - React-domnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1308,7 +1316,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.80.0-rc.5):
+  - React-Fabric (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1322,22 +1330,22 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.80.0-rc.5)
-    - React-Fabric/attributedstring (= 0.80.0-rc.5)
-    - React-Fabric/componentregistry (= 0.80.0-rc.5)
-    - React-Fabric/componentregistrynative (= 0.80.0-rc.5)
-    - React-Fabric/components (= 0.80.0-rc.5)
-    - React-Fabric/consistency (= 0.80.0-rc.5)
-    - React-Fabric/core (= 0.80.0-rc.5)
-    - React-Fabric/dom (= 0.80.0-rc.5)
-    - React-Fabric/imagemanager (= 0.80.0-rc.5)
-    - React-Fabric/leakchecker (= 0.80.0-rc.5)
-    - React-Fabric/mounting (= 0.80.0-rc.5)
-    - React-Fabric/observers (= 0.80.0-rc.5)
-    - React-Fabric/scheduler (= 0.80.0-rc.5)
-    - React-Fabric/telemetry (= 0.80.0-rc.5)
-    - React-Fabric/templateprocessor (= 0.80.0-rc.5)
-    - React-Fabric/uimanager (= 0.80.0-rc.5)
+    - React-Fabric/animations (= 0.80.0)
+    - React-Fabric/attributedstring (= 0.80.0)
+    - React-Fabric/componentregistry (= 0.80.0)
+    - React-Fabric/componentregistrynative (= 0.80.0)
+    - React-Fabric/components (= 0.80.0)
+    - React-Fabric/consistency (= 0.80.0)
+    - React-Fabric/core (= 0.80.0)
+    - React-Fabric/dom (= 0.80.0)
+    - React-Fabric/imagemanager (= 0.80.0)
+    - React-Fabric/leakchecker (= 0.80.0)
+    - React-Fabric/mounting (= 0.80.0)
+    - React-Fabric/observers (= 0.80.0)
+    - React-Fabric/scheduler (= 0.80.0)
+    - React-Fabric/telemetry (= 0.80.0)
+    - React-Fabric/templateprocessor (= 0.80.0)
+    - React-Fabric/uimanager (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1349,32 +1357,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.80.0-rc.5):
+  - React-Fabric/animations (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1399,7 +1382,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.80.0-rc.5):
+  - React-Fabric/attributedstring (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1424,7 +1407,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.80.0-rc.5):
+  - React-Fabric/componentregistry (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1449,36 +1432,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0-rc.5)
-    - React-Fabric/components/root (= 0.80.0-rc.5)
-    - React-Fabric/components/scrollview (= 0.80.0-rc.5)
-    - React-Fabric/components/view (= 0.80.0-rc.5)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.80.0-rc.5):
+  - React-Fabric/componentregistrynative (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1503,7 +1457,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.80.0-rc.5):
+  - React-Fabric/components (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0)
+    - React-Fabric/components/root (= 0.80.0)
+    - React-Fabric/components/scrollview (= 0.80.0)
+    - React-Fabric/components/view (= 0.80.0)
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1528,7 +1511,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.80.0-rc.5):
+  - React-Fabric/components/root (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1553,7 +1536,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.80.0-rc.5):
+  - React-Fabric/components/scrollview (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1580,7 +1588,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.80.0-rc.5):
+  - React-Fabric/consistency (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1605,7 +1613,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.80.0-rc.5):
+  - React-Fabric/core (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1630,7 +1638,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.80.0-rc.5):
+  - React-Fabric/dom (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1655,7 +1663,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.80.0-rc.5):
+  - React-Fabric/imagemanager (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1680,7 +1688,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.80.0-rc.5):
+  - React-Fabric/leakchecker (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1705,7 +1713,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.80.0-rc.5):
+  - React-Fabric/mounting (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1730,7 +1738,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.80.0-rc.5):
+  - React-Fabric/observers (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1744,7 +1752,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.80.0-rc.5)
+    - React-Fabric/observers/events (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1756,7 +1764,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.80.0-rc.5):
+  - React-Fabric/observers/events (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1781,7 +1789,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.80.0-rc.5):
+  - React-Fabric/scheduler (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1808,7 +1816,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.80.0-rc.5):
+  - React-Fabric/telemetry (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1833,7 +1841,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.80.0-rc.5):
+  - React-Fabric/templateprocessor (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1858,7 +1866,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.80.0-rc.5):
+  - React-Fabric/uimanager (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1872,33 +1880,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.80.0-rc.5)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/uimanager/consistency (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1911,7 +1893,33 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.80.0-rc.5):
+  - React-Fabric/uimanager/consistency (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-FabricComponents (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1926,8 +1934,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.80.0-rc.5)
-    - React-FabricComponents/textlayoutmanager (= 0.80.0-rc.5)
+    - React-FabricComponents/components (= 0.80.0)
+    - React-FabricComponents/textlayoutmanager (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1940,7 +1948,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.80.0-rc.5):
+  - React-FabricComponents/components (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1955,15 +1963,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.80.0-rc.5)
-    - React-FabricComponents/components/iostextinput (= 0.80.0-rc.5)
-    - React-FabricComponents/components/modal (= 0.80.0-rc.5)
-    - React-FabricComponents/components/rncore (= 0.80.0-rc.5)
-    - React-FabricComponents/components/safeareaview (= 0.80.0-rc.5)
-    - React-FabricComponents/components/scrollview (= 0.80.0-rc.5)
-    - React-FabricComponents/components/text (= 0.80.0-rc.5)
-    - React-FabricComponents/components/textinput (= 0.80.0-rc.5)
-    - React-FabricComponents/components/unimplementedview (= 0.80.0-rc.5)
+    - React-FabricComponents/components/inputaccessory (= 0.80.0)
+    - React-FabricComponents/components/iostextinput (= 0.80.0)
+    - React-FabricComponents/components/modal (= 0.80.0)
+    - React-FabricComponents/components/rncore (= 0.80.0)
+    - React-FabricComponents/components/safeareaview (= 0.80.0)
+    - React-FabricComponents/components/scrollview (= 0.80.0)
+    - React-FabricComponents/components/text (= 0.80.0)
+    - React-FabricComponents/components/textinput (= 0.80.0)
+    - React-FabricComponents/components/unimplementedview (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1976,61 +1984,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/modal (0.80.0-rc.5):
+  - React-FabricComponents/components/inputaccessory (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2057,7 +2011,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.80.0-rc.5):
+  - React-FabricComponents/components/iostextinput (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2084,7 +2038,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.80.0-rc.5):
+  - React-FabricComponents/components/modal (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2111,7 +2065,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.80.0-rc.5):
+  - React-FabricComponents/components/rncore (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2138,7 +2092,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.80.0-rc.5):
+  - React-FabricComponents/components/safeareaview (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2165,7 +2119,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.80.0-rc.5):
+  - React-FabricComponents/components/scrollview (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2192,7 +2146,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.80.0-rc.5):
+  - React-FabricComponents/components/text (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2219,7 +2173,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.80.0-rc.5):
+  - React-FabricComponents/components/textinput (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2246,7 +2200,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.80.0-rc.5):
+  - React-FabricComponents/components/unimplementedview (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2255,22 +2209,76 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.80.0-rc.5)
-    - RCTTypeSafety (= 0.80.0-rc.5)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.80.0)
+    - RCTTypeSafety (= 0.80.0)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-hermes
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.5)
+    - React-jsiexecutor (= 0.80.0)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.80.0-rc.5):
+  - React-featureflags (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2279,7 +2287,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.80.0-rc.5):
+  - React-featureflagsnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2295,7 +2303,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.80.0-rc.5):
+  - React-graphics (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2309,7 +2317,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.80.0-rc.5):
+  - React-hermes (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2318,16 +2326,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.5)
+    - React-cxxreact (= 0.80.0)
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.5)
+    - React-jsiexecutor (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.5)
+    - React-perflogger (= 0.80.0)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.80.0-rc.5):
+  - React-idlecallbacksnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2343,7 +2351,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.80.0-rc.5):
+  - React-ImageManager (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2358,7 +2366,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.80.0-rc.5):
+  - React-jserrorhandler (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2373,7 +2381,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.80.0-rc.5):
+  - React-jsi (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2383,7 +2391,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.80.0-rc.5):
+  - React-jsiexecutor (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2392,14 +2400,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.5)
+    - React-perflogger (= 0.80.0)
     - SocketRocket
-  - React-jsinspector (0.80.0-rc.5):
+  - React-jsinspector (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2413,10 +2421,10 @@ PODS:
     - React-jsinspectorcdp
     - React-jsinspectornetwork
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.5)
-    - React-runtimeexecutor (= 0.80.0-rc.5)
+    - React-perflogger (= 0.80.0)
+    - React-runtimeexecutor (= 0.80.0)
     - SocketRocket
-  - React-jsinspectorcdp (0.80.0-rc.5):
+  - React-jsinspectorcdp (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2425,7 +2433,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.80.0-rc.5):
+  - React-jsinspectornetwork (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2435,7 +2443,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-jsinspectorcdp
     - SocketRocket
-  - React-jsinspectortracing (0.80.0-rc.5):
+  - React-jsinspectortracing (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2445,7 +2453,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-oscompat
     - SocketRocket
-  - React-jsitooling (0.80.0-rc.5):
+  - React-jsitooling (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2453,15 +2461,15 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - SocketRocket
-  - React-jsitracing (0.80.0-rc.5):
+  - React-jsitracing (0.80.0):
     - React-jsi
-  - React-logger (0.80.0-rc.5):
+  - React-logger (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2470,7 +2478,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.80.0-rc.5):
+  - React-Mapbuffer (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2480,7 +2488,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.80.0-rc.5):
+  - React-microtasksnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2735,7 +2743,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.80.0-rc.5):
+  - React-NativeModulesApple (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2756,8 +2764,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.80.0-rc.5)
-  - React-perflogger (0.80.0-rc.5):
+  - React-oscompat (0.80.0)
+  - React-perflogger (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2766,7 +2774,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.80.0-rc.5):
+  - React-performancetimeline (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2779,9 +2787,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.80.0-rc.5):
-    - React-Core/RCTActionSheetHeaders (= 0.80.0-rc.5)
-  - React-RCTAnimation (0.80.0-rc.5):
+  - React-RCTActionSheet (0.80.0):
+    - React-Core/RCTActionSheetHeaders (= 0.80.0)
+  - React-RCTAnimation (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2797,7 +2805,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.80.0-rc.5):
+  - React-RCTAppDelegate (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2830,7 +2838,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.80.0-rc.5):
+  - React-RCTBlob (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2849,7 +2857,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.80.0-rc.5):
+  - React-RCTFabric (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2883,7 +2891,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.80.0-rc.5):
+  - React-RCTFBReactNativeSpec (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2901,7 +2909,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCommon
     - SocketRocket
-  - React-RCTImage (0.80.0-rc.5):
+  - React-RCTImage (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2917,14 +2925,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.80.0-rc.5):
-    - React-Core/RCTLinkingHeaders (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+  - React-RCTLinking (0.80.0):
+    - React-Core/RCTLinkingHeaders (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.5)
-  - React-RCTNetwork (0.80.0-rc.5):
+    - ReactCommon/turbomodule/core (= 0.80.0)
+  - React-RCTNetwork (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2942,7 +2950,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.80.0-rc.5):
+  - React-RCTRuntime (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2962,7 +2970,7 @@ PODS:
     - React-RuntimeCore
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.80.0-rc.5):
+  - React-RCTSettings (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2977,10 +2985,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.80.0-rc.5):
-    - React-Core/RCTTextHeaders (= 0.80.0-rc.5)
+  - React-RCTText (0.80.0):
+    - React-Core/RCTTextHeaders (= 0.80.0)
     - Yoga
-  - React-RCTVibration (0.80.0-rc.5):
+  - React-RCTVibration (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2994,11 +3002,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.80.0-rc.5)
-  - React-renderercss (0.80.0-rc.5):
+  - React-rendererconsistency (0.80.0)
+  - React-renderercss (0.80.0):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.80.0-rc.5):
+  - React-rendererdebug (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3008,8 +3016,8 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-rncore (0.80.0-rc.5)
-  - React-RuntimeApple (0.80.0-rc.5):
+  - React-rncore (0.80.0)
+  - React-RuntimeApple (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3038,7 +3046,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.80.0-rc.5):
+  - React-RuntimeCore (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3061,9 +3069,9 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.80.0-rc.5):
-    - React-jsi (= 0.80.0-rc.5)
-  - React-RuntimeHermes (0.80.0-rc.5):
+  - React-runtimeexecutor (0.80.0):
+    - React-jsi (= 0.80.0)
+  - React-RuntimeHermes (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3083,7 +3091,7 @@ PODS:
     - React-RuntimeCore
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.80.0-rc.5):
+  - React-runtimescheduler (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3106,8 +3114,8 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.80.0-rc.5)
-  - React-utils (0.80.0-rc.5):
+  - React-timing (0.80.0)
+  - React-utils (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3118,11 +3126,11 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-hermes
-    - React-jsi (= 0.80.0-rc.5)
+    - React-jsi (= 0.80.0)
     - SocketRocket
-  - ReactAppDependencyProvider (0.80.0-rc.5):
+  - ReactAppDependencyProvider (0.80.0):
     - ReactCodegen
-  - ReactCodegen (0.80.0-rc.5):
+  - ReactCodegen (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3149,7 +3157,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.80.0-rc.5):
+  - ReactCommon (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3157,9 +3165,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.80.0-rc.5)
+    - ReactCommon/turbomodule (= 0.80.0)
     - SocketRocket
-  - ReactCommon/turbomodule (0.80.0-rc.5):
+  - ReactCommon/turbomodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3168,15 +3176,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
-    - ReactCommon/turbomodule/bridging (= 0.80.0-rc.5)
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
+    - ReactCommon/turbomodule/bridging (= 0.80.0)
+    - ReactCommon/turbomodule/core (= 0.80.0)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.80.0-rc.5):
+  - ReactCommon/turbomodule/bridging (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3185,13 +3193,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.80.0-rc.5):
+  - ReactCommon/turbomodule/core (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3200,14 +3208,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-debug (= 0.80.0-rc.5)
-    - React-featureflags (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
-    - React-utils (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-cxxreact (= 0.80.0)
+    - React-debug (= 0.80.0)
+    - React-featureflags (= 0.80.0)
+    - React-jsi (= 0.80.0)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
+    - React-utils (= 0.80.0)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -4317,7 +4325,7 @@ SPEC CHECKSUMS:
   ExpoFont: 312c73403bbd4f98e1d6a5330641a56292583cd2
   ExpoGL: 8f7f43291e400621ef9aeb7af347816c2051ddc7
   ExpoHaptics: 68c215e070f660e0a29c45dcda4f60eeff08aefb
-  ExpoImage: ef8b25fddd3613a0bbdb2936d0583bc6588197dd
+  ExpoImage: 23fd11d3f2c4b04dc0b5e97fb41e9ead278bd0c8
   ExpoImageManipulator: 094b748056f2654d5d7813370c910e20ef3d79b4
   ExpoImagePicker: d2fff488a0738343a3cc21e98544ee9feafaa0e6
   ExpoInsights: 58e0fb0aa39cabc674cf950942d241903fc94406
@@ -4352,16 +4360,16 @@ SPEC CHECKSUMS:
   ExpoUI: 4a03c3af5dd55144c788dfa3370bd244c21645ec
   ExpoVideo: 54ce43735b4ceb6b3828e3eec3b750b0fe10314c
   ExpoVideoThumbnails: 4280333bee3bd4d69b3b139bd50a8b7c967095ae
-  ExpoWebBrowser: 1051486eb45a2f4d1ee075712604f43f3009f90e
+  ExpoWebBrowser: 8aa522ab60113768d4dc5691c36d3315cc3b297b
   EXStructuredHeaders: 32bec6771c2db18c4cd47cecae530d1d06cdf972
   EXTaskManager: 0128b9f39a088b0c762d8d1c42017e6d44200b29
   EXUpdates: 9d87d1b97634263b9f8623eb7e763e58b48dc9fb
   EXUpdatesInterface: 64f35449b8ef89ce08cdd8952a4d119b5de6821d
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: 04f59172f2d1bc4c8afd36bbff2485df293fab12
+  FBLazyVector: 778b815a6fb3fa1599f581ffb9a5e85fad313c1d
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 7b7ffc2a07cbaa556b4a75a6da50e73f4c138ea7
+  hermes-engine: 50e36d664adc3637672d46bdb6b6bec1a23fbd0b
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4371,39 +4379,39 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: 06e57a11be6128124a3c7cbfceb09b78f6c9ffc2
-  RCTRequired: 843cc1fe500b0ba58512287c5116e31a45181bca
-  RCTTypeSafety: 71eeceddb7e708c224909ba99c37a145c98c02a7
+  RCTDeprecation: ff787f6c860a1b97dd1bc27264b61d23ad1994da
+  RCTRequired: 664eb8399ed8a83e26ab65af7c2ad390f7e61696
+  RCTTypeSafety: a5cf7a7e80baf972e331dc028e5d5c19bb2535a4
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: d24621fc58bfcf5015e3286eac7b76c05040d914
-  React-callinvoker: f36300fae0e5d711e6b9991976f64ae0cb8fad3a
-  React-Core: f284fdea10a4778b736eaa065769a2b843b530f0
-  React-CoreModules: 45ab4e286895a2312e036f5e48639bdc1a73902f
-  React-cxxreact: 7c6d58dd92feca44a013988f6282956b5f2b3229
-  React-debug: 3005e18d181d33277445c99e201d37f3114233b6
-  React-defaultsnativemodule: f78ad0be2080633d0c2dd5a48905fa556bc030a2
-  React-domnativemodule: 0686da969f67cb81b8555fb3123d1906f62d44f6
-  React-Fabric: 9e8e3acfa8c8daa36dd11c98d612c25c1e11ea59
-  React-FabricComponents: ff54b3fc511695d209a219162371d484d62dec9a
-  React-FabricImage: f1e3f9bd46068b1d5406484406c4897473756b68
-  React-featureflags: 4963e06d1885257e2d109d733837c39cfc97f836
-  React-featureflagsnativemodule: 8a91773c93c38b11bf6af402c9287155d69a1f86
-  React-graphics: da7f5a1e95962b39fb5fc02ea5c615231b4e5626
-  React-hermes: bd76cb1d809d7dd27c9ad31a7d663047e4864f92
-  React-idlecallbacksnativemodule: acb58fd1bf494f1331e3a8765a855a85942d573e
-  React-ImageManager: 251cb54baff0af00e88f96dc01e4d1ca795e2928
-  React-jserrorhandler: 74a5109317e35632dd26ffbb38243d1b5aaebed3
-  React-jsi: 904806629c68f61d6e128d19c0cee1e3605eceec
-  React-jsiexecutor: d4fab673c926d913d6e1530155378833462fde57
-  React-jsinspector: 85113ed82fd449942151731f1051d46a9e5b2830
-  React-jsinspectorcdp: 538cb3eea51969564d0d57e23de3039fb22c8d28
-  React-jsinspectornetwork: 0be7cd0206b62c86d22b864a3147d9bfcc020477
-  React-jsinspectortracing: 9c772ac4f0df8f2940a34185e6e0e67bf91148cf
-  React-jsitooling: ea0874c51c43798dc4a83feaf6ffa57b929cacdc
-  React-jsitracing: 9f866cdc3a7f8b8eda89b52c409934bc9f85903a
-  React-logger: 34f13c3effe44410ccf62b255fc12f085ac7d038
-  React-Mapbuffer: 0e9c84c9a8e55645a1f19ae14e79a761b843ddc2
-  React-microtasksnativemodule: 3302ad49a9b619ca411acfca32534f3696894b95
+  React: 606d4dccbcf29aec4dc84a7921405a28e1701a22
+  React-callinvoker: 0e13bd3c039df9ceef04f7381a81f017655c8361
+  React-Core: 701ad54ae468c2ca1e4869d659b30ebfee30ac77
+  React-CoreModules: 99d3515898255378fa2d6fc906b6dca093d280c4
+  React-cxxreact: 3410a1edbe15936bcf8eae61a546af1bec06ed98
+  React-debug: a9e91845f3670c3a19249f52919f0488b7842cf7
+  React-defaultsnativemodule: 8fad7c7173d6133d15b1532251df550d0d1c1f87
+  React-domnativemodule: 1da1f2bc921a9e4652918f37285c3830f561c86b
+  React-Fabric: e6f729f372f959bda89268c2c921fac55a9579dc
+  React-FabricComponents: f2ab7d78be2ea1dd06a7d8d606f5740cd1f54041
+  React-FabricImage: 220e8ce3ccdb483fd4283d8b21839676e8b88e27
+  React-featureflags: b64383c3268d03c3fab25c03a5c7e5fab0931a55
+  React-featureflagsnativemodule: 4c7b5cbe887d120a1797f65e6676fe9e1f9396ea
+  React-graphics: 4031c43a78b816dc1043dca24dfabf1d2622df9a
+  React-hermes: dc21a35794633bf2aef73645d273f5ee3bdf777a
+  React-idlecallbacksnativemodule: 9d6ea7839e347ffd3791315ba418370421d6c7c7
+  React-ImageManager: b743a715eca9abbf69fbd50732315565c9eb3863
+  React-jserrorhandler: 850fe8285385ffa783cc73e5e2eda8ddcb84e147
+  React-jsi: ea8a33b23165395610436c8f0d715e2c3bbcec7e
+  React-jsiexecutor: 0fb247eca0908176917380e1e1b75339f52a0c72
+  React-jsinspector: dcfc9ee7f2610ff05aa8f66fc8203cf7be875d0e
+  React-jsinspectorcdp: 6803046f78af0b3caace9002e28b0ca1fd97c1c4
+  React-jsinspectornetwork: b25ef98ec036aa1b454ebc904b983059e1ebc6e7
+  React-jsinspectortracing: 777ae30cf41f6305ffc509e53bef86bb1027395f
+  React-jsitooling: 568f4974066f14597084df606a6ad79fa52715b6
+  React-jsitracing: 47cb4a6c4b3c5e2d1d32ff4880d74d5faf58423c
+  React-logger: b69e65dc60f768e5509ac0cc27a360124bf70478
+  React-Mapbuffer: b48f9f3311fd0ec0f7a5dc39d707eff521fb5f38
+  React-microtasksnativemodule: d8568d0485a350c720c061ae835e09fc88c28715
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: 03553493db7fd49946d709ab6d65c7ef0cc929be
   react-native-safe-area-context: 47c1782a327ca2affa9bec5a2f95534cbabb620a
@@ -4411,37 +4419,37 @@ SPEC CHECKSUMS:
   react-native-slider: dd3636cb9b888b4d8aaf7ac0bb5e0d2921c5eec6
   react-native-view-shot: a18275ac858eb4866365148517774182319c7aee
   react-native-webview: a53cadbdc946b2d14055284ee9f5f81c1d4817a3
-  React-NativeModulesApple: db5c62dfdee373bfacb3ce4fe86469a84d8047d9
-  React-oscompat: acc1d2b40174ce9a8c3d61912572a51ff76a94e6
-  React-perflogger: bb0332a02764f3c6570244635ac4318211514f3c
-  React-performancetimeline: e005006283a2acb109fe0821b75c35c1cfe6e769
-  React-RCTActionSheet: dad33af1be68c5e92d5d00482f5a42f49822531c
-  React-RCTAnimation: aa0e7ddf90d94a6f625b96fc29e9c58d9bb1c449
-  React-RCTAppDelegate: b9b009eafeb778a7a4cd877614a505ea926d6d9b
-  React-RCTBlob: 14655d7b0ef157dd76d26db1fd75c4d7b92a2692
-  React-RCTFabric: 4e63c60c2944bf92d4a07fa61b2a9176f013b73c
-  React-RCTFBReactNativeSpec: 85e9189f245531263a4a3995f225def0045ef998
-  React-RCTImage: 379dc52f16dc25fe9ab843053eb785461b0ffcb5
-  React-RCTLinking: 833b53827195f23a639bebe64e048497edd28a04
-  React-RCTNetwork: e005e7b11632bb1dfcc1b13e79f11d8d9bc531d9
-  React-RCTRuntime: ef7c4c62318500ed20c02624152823fe6b1d0727
-  React-RCTSettings: ebe3edb605bade8c0bde36f51a75d95e96a2ef81
-  React-RCTText: ba698614a19a41249036227b52213f6f8a982ec3
-  React-RCTVibration: 4385bc7b39e2a435933d6447eb37f54e099a00be
-  React-rendererconsistency: 103d24d9fd9eed1760f0874edfbdc4b98288a20b
-  React-renderercss: 4841823f6d3bcc65fdbaf00906b17bee7415d598
-  React-rendererdebug: 9d95f3e58b504e4fa28798caa7c1e40cd5fc6f4a
-  React-rncore: c555e70ebd3dc73ebc494ce4e30cbaa381fa5731
-  React-RuntimeApple: 8033fb3a15d4234d92612aa293bdd358f7897bc5
-  React-RuntimeCore: ba41b7e036428a80789e755de7cbdfcffaaac973
-  React-runtimeexecutor: 52df6be38a17311756f9fbb39b9bb055f4bd01c2
-  React-RuntimeHermes: 996d88f40374434c31a859d888dff541c277cd60
-  React-runtimescheduler: 5eacdcd1db313e2d6950fb8872cc8038327d2b31
-  React-timing: d44a981781952fe0ac6dac355473b2248700cdf1
-  React-utils: 81dcddf4ae56d8defae035f0e4500572321a7fbd
-  ReactAppDependencyProvider: 8b6a181160ae9a814f6a7f447921be2fa962b1b4
-  ReactCodegen: aac198f788cfa6c1cfadf1a15f8ffc2dcfb8ec43
-  ReactCommon: e69175d0efd16afee3d7d43e95dc714966c2ca3d
+  React-NativeModulesApple: f10596688a03af66804cfbe61792be24a7888da8
+  React-oscompat: 7c0a341cc31e350da71ddf2e46de0a845d1d1626
+  React-perflogger: 4cc44451f694d6205f47bd8d5d87c9c862c3335c
+  React-performancetimeline: a81afec7aba50bdb80e5a692b03eff2dc499fe37
+  React-RCTActionSheet: 99864bd8422649219f24eca9a51445e698b70b8e
+  React-RCTAnimation: 7cb99a851a514673a1e48ca5fcbdee7c7c760da1
+  React-RCTAppDelegate: cd3bc49cec7cef167e920d5e54194d161cd8ab6d
+  React-RCTBlob: c96068eb67bf4a587f279db91c6948fc761826b9
+  React-RCTFabric: ca43b2e7bf026a8898a4eea81e9306786a892065
+  React-RCTFBReactNativeSpec: 96df6e569ad40c52f286762a59d7a96644567f5b
+  React-RCTImage: c40e65f565882df880c4f8994940c8b070923239
+  React-RCTLinking: 88992a3fb7c8caa868a2fc3489b26741e75ac5b5
+  React-RCTNetwork: 89c9222b388d90229511cc974abee608ac9c1221
+  React-RCTRuntime: 8a0222f21dacd0946aaff43976a06bd082e49e42
+  React-RCTSettings: 9e7a5f4262523dee5a1f9b0fd1e674b2a11bd7db
+  React-RCTText: 67f2955faca189ff85c3c5686505be9526df5461
+  React-RCTVibration: e4fe5861cee22c972672d29da4cdf24b6313e01d
+  React-rendererconsistency: a4db9bb060c65bce8ae83d936ed0719696055bd2
+  React-renderercss: 77c768faf43570d50e3657b97ce1a4c4614012d6
+  React-rendererdebug: 460dacb65d9ec58ba44e5c936b89e58530dd2a06
+  React-rncore: 322add36430c38049067a5d365f166256975391f
+  React-RuntimeApple: 9a7b848f3ea1b2aa6eefb0e42a5e113ed9b47f3d
+  React-RuntimeCore: d9feb0e71b045780372d72b9fd0e4326c2ee97d8
+  React-runtimeexecutor: 49ea276161508d50b3486c385e1ca7972d1699f5
+  React-RuntimeHermes: 31f857c04fda874cefef4dfbd1c8b0d234c4d606
+  React-runtimescheduler: 3cb2ab6622f9580b237a110350804933f8aec680
+  React-timing: a275a1c2e6112dba17f8f7dd496d439213bbea0d
+  React-utils: 257f8c08cb0559e458a9a9254967058434198ced
+  ReactAppDependencyProvider: cd55f820247d424280ae0b94e1ffb38963410c01
+  ReactCodegen: 1df92e7c39175eda371a0d87d1c33013f7bee756
+  ReactCommon: 658874decaf8c4fd76cfa3a878b94a869db85b1c
   RNCAsyncStorage: 767abb068db6ad28b5f59a129fbc9fab18b377e2
   RNCMaskedView: aac38cf7e947ff80e483996d1acd43c5ad4ab610
   RNCPicker: 9f14f7b5511d88d7608b344e9089916ff8a47298
@@ -4457,7 +4465,7 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   UMAppLoader: 55159b69750129faa7a51c493cb8ea55a7b64eb9
-  Yoga: c8798357f928802015a217ccd2fe692b61a090c2
+  Yoga: 0c4b7d2aacc910a1f702694fa86be830386f4ceb
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: a4b563d9d9c73e29b619314cb8136ce02bea61e0

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -789,16 +789,8 @@ PODS:
   - fmt (11.0.2)
   - glog (0.3.5)
   - hermes-engine (0.80.0):
-    - hermes-engine/cdp (= 0.80.0)
-    - hermes-engine/Hermes (= 0.80.0)
-    - hermes-engine/inspector (= 0.80.0)
-    - hermes-engine/inspector_chrome (= 0.80.0)
-    - hermes-engine/Public (= 0.80.0)
-  - hermes-engine/cdp (0.80.0)
-  - hermes-engine/Hermes (0.80.0)
-  - hermes-engine/inspector (0.80.0)
-  - hermes-engine/inspector_chrome (0.80.0)
-  - hermes-engine/Public (0.80.0)
+    - hermes-engine/Pre-built (= 0.80.0)
+  - hermes-engine/Pre-built (0.80.0)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -4369,7 +4361,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 778b815a6fb3fa1599f581ffb9a5e85fad313c1d
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 50e36d664adc3637672d46bdb6b6bec1a23fbd0b
+  hermes-engine: 7068e976238b29e97b3bafd09a994542af7d5c0b
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -64,7 +64,7 @@
     "native-component-list": "*",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.80.0-rc.5",
+    "react-native": "0.80.0",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-pager-view": "6.7.1",
     "react-native-reanimated": "3.18.0",

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -21,7 +21,7 @@
       },
       "ios": {
         "cache": {
-          "key": "sdk53-0.80.0-rc.5",
+          "key": "sdk53-0.80.0",
           "customPaths": ["../expo-go/ios/Pods"]
         },
         "image": "macos-sonoma-14.6-xcode-16.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -116,14 +116,14 @@ PODS:
     - ExpoModulesCore
   - ExpoHead (5.0.7):
     - ExpoModulesCore
-  - ExpoImage (2.1.7):
+  - ExpoImage (2.3.0):
     - ExpoModulesCore
     - libavif/libdav1d
     - SDWebImage (~> 5.21.0)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
     - SDWebImageWebPCoder (~> 0.14.6)
-  - ExpoImage/Tests (2.1.7):
+  - ExpoImage/Tests (2.3.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
     - libavif/libdav1d
@@ -369,7 +369,7 @@ PODS:
   - EXUpdatesInterface (1.1.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.80.0-rc.5)
+  - FBLazyVector (0.80.0)
   - FirebaseAnalytics (11.11.0):
     - FirebaseAnalytics/AdIdSupport (= 11.11.0)
     - FirebaseCore (~> 11.11.0)
@@ -492,17 +492,17 @@ PODS:
   - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - hermes-engine (0.80.0-rc.5):
-    - hermes-engine/cdp (= 0.80.0-rc.5)
-    - hermes-engine/Hermes (= 0.80.0-rc.5)
-    - hermes-engine/inspector (= 0.80.0-rc.5)
-    - hermes-engine/inspector_chrome (= 0.80.0-rc.5)
-    - hermes-engine/Public (= 0.80.0-rc.5)
-  - hermes-engine/cdp (0.80.0-rc.5)
-  - hermes-engine/Hermes (0.80.0-rc.5)
-  - hermes-engine/inspector (0.80.0-rc.5)
-  - hermes-engine/inspector_chrome (0.80.0-rc.5)
-  - hermes-engine/Public (0.80.0-rc.5)
+  - hermes-engine (0.80.0):
+    - hermes-engine/cdp (= 0.80.0)
+    - hermes-engine/Hermes (= 0.80.0)
+    - hermes-engine/inspector (= 0.80.0)
+    - hermes-engine/inspector_chrome (= 0.80.0)
+    - hermes-engine/Public (= 0.80.0)
+  - hermes-engine/cdp (0.80.0)
+  - hermes-engine/Hermes (0.80.0)
+  - hermes-engine/inspector (0.80.0)
+  - hermes-engine/inspector_chrome (0.80.0)
+  - hermes-engine/Public (0.80.0)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -581,28 +581,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.80.0-rc.5)
-  - RCTRequired (0.80.0-rc.5)
-  - RCTTypeSafety (0.80.0-rc.5):
-    - FBLazyVector (= 0.80.0-rc.5)
-    - RCTRequired (= 0.80.0-rc.5)
-    - React-Core (= 0.80.0-rc.5)
+  - RCTDeprecation (0.80.0)
+  - RCTRequired (0.80.0)
+  - RCTTypeSafety (0.80.0):
+    - FBLazyVector (= 0.80.0)
+    - RCTRequired (= 0.80.0)
+    - React-Core (= 0.80.0)
   - ReachabilitySwift (5.2.4)
-  - React (0.80.0-rc.5):
-    - React-Core (= 0.80.0-rc.5)
-    - React-Core/DevSupport (= 0.80.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.5)
-    - React-RCTActionSheet (= 0.80.0-rc.5)
-    - React-RCTAnimation (= 0.80.0-rc.5)
-    - React-RCTBlob (= 0.80.0-rc.5)
-    - React-RCTImage (= 0.80.0-rc.5)
-    - React-RCTLinking (= 0.80.0-rc.5)
-    - React-RCTNetwork (= 0.80.0-rc.5)
-    - React-RCTSettings (= 0.80.0-rc.5)
-    - React-RCTText (= 0.80.0-rc.5)
-    - React-RCTVibration (= 0.80.0-rc.5)
-  - React-callinvoker (0.80.0-rc.5)
-  - React-Core (0.80.0-rc.5):
+  - React (0.80.0):
+    - React-Core (= 0.80.0)
+    - React-Core/DevSupport (= 0.80.0)
+    - React-Core/RCTWebSocket (= 0.80.0)
+    - React-RCTActionSheet (= 0.80.0)
+    - React-RCTAnimation (= 0.80.0)
+    - React-RCTBlob (= 0.80.0)
+    - React-RCTImage (= 0.80.0)
+    - React-RCTLinking (= 0.80.0)
+    - React-RCTNetwork (= 0.80.0)
+    - React-RCTSettings (= 0.80.0)
+    - React-RCTText (= 0.80.0)
+    - React-RCTVibration (= 0.80.0)
+  - React-callinvoker (0.80.0)
+  - React-Core (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -612,7 +612,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.5)
+    - React-Core/Default (= 0.80.0)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -626,79 +626,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.5)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.80.0-rc.5):
+  - React-Core/CoreModulesHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -722,7 +650,55 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.80.0-rc.5):
+  - React-Core/Default (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0)
+    - React-Core/RCTWebSocket (= 0.80.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -746,7 +722,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.80.0-rc.5):
+  - React-Core/RCTAnimationHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -770,7 +746,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.80.0-rc.5):
+  - React-Core/RCTBlobHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -794,7 +770,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.80.0-rc.5):
+  - React-Core/RCTImageHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -818,7 +794,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.80.0-rc.5):
+  - React-Core/RCTLinkingHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -842,7 +818,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.80.0-rc.5):
+  - React-Core/RCTNetworkHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -866,7 +842,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.80.0-rc.5):
+  - React-Core/RCTSettingsHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -890,7 +866,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.80.0-rc.5):
+  - React-Core/RCTTextHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -914,7 +890,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.80.0-rc.5):
+  - React-Core/RCTVibrationHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -924,7 +900,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.5)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -938,7 +914,31 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.80.0-rc.5):
+  - React-Core/RCTWebSocket (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -946,19 +946,19 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.80.0-rc.5)
-    - React-Core/CoreModulesHeaders (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - RCTTypeSafety (= 0.80.0)
+    - React-Core/CoreModulesHeaders (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.80.0-rc.5)
+    - React-RCTImage (= 0.80.0)
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.80.0-rc.5):
+  - React-cxxreact (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -967,19 +967,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-debug (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-debug (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
-    - React-runtimeexecutor (= 0.80.0-rc.5)
-    - React-timing (= 0.80.0-rc.5)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
+    - React-runtimeexecutor (= 0.80.0)
+    - React-timing (= 0.80.0)
     - SocketRocket
-  - React-debug (0.80.0-rc.5)
-  - React-defaultsnativemodule (0.80.0-rc.5):
+  - React-debug (0.80.0)
+  - React-defaultsnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -997,7 +997,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.80.0-rc.5):
+  - React-domnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1016,7 +1016,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.80.0-rc.5):
+  - React-Fabric (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1030,22 +1030,22 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.80.0-rc.5)
-    - React-Fabric/attributedstring (= 0.80.0-rc.5)
-    - React-Fabric/componentregistry (= 0.80.0-rc.5)
-    - React-Fabric/componentregistrynative (= 0.80.0-rc.5)
-    - React-Fabric/components (= 0.80.0-rc.5)
-    - React-Fabric/consistency (= 0.80.0-rc.5)
-    - React-Fabric/core (= 0.80.0-rc.5)
-    - React-Fabric/dom (= 0.80.0-rc.5)
-    - React-Fabric/imagemanager (= 0.80.0-rc.5)
-    - React-Fabric/leakchecker (= 0.80.0-rc.5)
-    - React-Fabric/mounting (= 0.80.0-rc.5)
-    - React-Fabric/observers (= 0.80.0-rc.5)
-    - React-Fabric/scheduler (= 0.80.0-rc.5)
-    - React-Fabric/telemetry (= 0.80.0-rc.5)
-    - React-Fabric/templateprocessor (= 0.80.0-rc.5)
-    - React-Fabric/uimanager (= 0.80.0-rc.5)
+    - React-Fabric/animations (= 0.80.0)
+    - React-Fabric/attributedstring (= 0.80.0)
+    - React-Fabric/componentregistry (= 0.80.0)
+    - React-Fabric/componentregistrynative (= 0.80.0)
+    - React-Fabric/components (= 0.80.0)
+    - React-Fabric/consistency (= 0.80.0)
+    - React-Fabric/core (= 0.80.0)
+    - React-Fabric/dom (= 0.80.0)
+    - React-Fabric/imagemanager (= 0.80.0)
+    - React-Fabric/leakchecker (= 0.80.0)
+    - React-Fabric/mounting (= 0.80.0)
+    - React-Fabric/observers (= 0.80.0)
+    - React-Fabric/scheduler (= 0.80.0)
+    - React-Fabric/telemetry (= 0.80.0)
+    - React-Fabric/templateprocessor (= 0.80.0)
+    - React-Fabric/uimanager (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1057,32 +1057,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.80.0-rc.5):
+  - React-Fabric/animations (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1107,7 +1082,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.80.0-rc.5):
+  - React-Fabric/attributedstring (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1132,7 +1107,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.80.0-rc.5):
+  - React-Fabric/componentregistry (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1157,36 +1132,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0-rc.5)
-    - React-Fabric/components/root (= 0.80.0-rc.5)
-    - React-Fabric/components/scrollview (= 0.80.0-rc.5)
-    - React-Fabric/components/view (= 0.80.0-rc.5)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.80.0-rc.5):
+  - React-Fabric/componentregistrynative (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1211,7 +1157,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.80.0-rc.5):
+  - React-Fabric/components (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0)
+    - React-Fabric/components/root (= 0.80.0)
+    - React-Fabric/components/scrollview (= 0.80.0)
+    - React-Fabric/components/view (= 0.80.0)
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1236,7 +1211,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.80.0-rc.5):
+  - React-Fabric/components/root (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1261,7 +1236,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.80.0-rc.5):
+  - React-Fabric/components/scrollview (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1288,7 +1288,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.80.0-rc.5):
+  - React-Fabric/consistency (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1313,7 +1313,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.80.0-rc.5):
+  - React-Fabric/core (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1338,7 +1338,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.80.0-rc.5):
+  - React-Fabric/dom (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1363,7 +1363,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.80.0-rc.5):
+  - React-Fabric/imagemanager (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1388,7 +1388,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.80.0-rc.5):
+  - React-Fabric/leakchecker (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1413,7 +1413,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.80.0-rc.5):
+  - React-Fabric/mounting (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1438,7 +1438,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.80.0-rc.5):
+  - React-Fabric/observers (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1452,7 +1452,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.80.0-rc.5)
+    - React-Fabric/observers/events (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1464,7 +1464,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.80.0-rc.5):
+  - React-Fabric/observers/events (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1489,7 +1489,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.80.0-rc.5):
+  - React-Fabric/scheduler (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1516,7 +1516,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.80.0-rc.5):
+  - React-Fabric/telemetry (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1541,7 +1541,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.80.0-rc.5):
+  - React-Fabric/templateprocessor (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1566,7 +1566,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.80.0-rc.5):
+  - React-Fabric/uimanager (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1580,33 +1580,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.80.0-rc.5)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/uimanager/consistency (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1619,7 +1593,33 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.80.0-rc.5):
+  - React-Fabric/uimanager/consistency (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-FabricComponents (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1634,8 +1634,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.80.0-rc.5)
-    - React-FabricComponents/textlayoutmanager (= 0.80.0-rc.5)
+    - React-FabricComponents/components (= 0.80.0)
+    - React-FabricComponents/textlayoutmanager (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1648,7 +1648,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.80.0-rc.5):
+  - React-FabricComponents/components (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1663,15 +1663,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.80.0-rc.5)
-    - React-FabricComponents/components/iostextinput (= 0.80.0-rc.5)
-    - React-FabricComponents/components/modal (= 0.80.0-rc.5)
-    - React-FabricComponents/components/rncore (= 0.80.0-rc.5)
-    - React-FabricComponents/components/safeareaview (= 0.80.0-rc.5)
-    - React-FabricComponents/components/scrollview (= 0.80.0-rc.5)
-    - React-FabricComponents/components/text (= 0.80.0-rc.5)
-    - React-FabricComponents/components/textinput (= 0.80.0-rc.5)
-    - React-FabricComponents/components/unimplementedview (= 0.80.0-rc.5)
+    - React-FabricComponents/components/inputaccessory (= 0.80.0)
+    - React-FabricComponents/components/iostextinput (= 0.80.0)
+    - React-FabricComponents/components/modal (= 0.80.0)
+    - React-FabricComponents/components/rncore (= 0.80.0)
+    - React-FabricComponents/components/safeareaview (= 0.80.0)
+    - React-FabricComponents/components/scrollview (= 0.80.0)
+    - React-FabricComponents/components/text (= 0.80.0)
+    - React-FabricComponents/components/textinput (= 0.80.0)
+    - React-FabricComponents/components/unimplementedview (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1684,61 +1684,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/modal (0.80.0-rc.5):
+  - React-FabricComponents/components/inputaccessory (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1765,7 +1711,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.80.0-rc.5):
+  - React-FabricComponents/components/iostextinput (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1792,7 +1738,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.80.0-rc.5):
+  - React-FabricComponents/components/modal (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1819,7 +1765,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.80.0-rc.5):
+  - React-FabricComponents/components/rncore (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1846,7 +1792,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.80.0-rc.5):
+  - React-FabricComponents/components/safeareaview (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1873,7 +1819,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.80.0-rc.5):
+  - React-FabricComponents/components/scrollview (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1900,7 +1846,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.80.0-rc.5):
+  - React-FabricComponents/components/text (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1927,7 +1873,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.80.0-rc.5):
+  - React-FabricComponents/components/textinput (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1954,7 +1900,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.80.0-rc.5):
+  - React-FabricComponents/components/unimplementedview (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1963,22 +1909,76 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.80.0-rc.5)
-    - RCTTypeSafety (= 0.80.0-rc.5)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.80.0)
+    - RCTTypeSafety (= 0.80.0)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-hermes
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.5)
+    - React-jsiexecutor (= 0.80.0)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.80.0-rc.5):
+  - React-featureflags (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1987,7 +1987,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.80.0-rc.5):
+  - React-featureflagsnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2003,7 +2003,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.80.0-rc.5):
+  - React-graphics (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2017,7 +2017,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.80.0-rc.5):
+  - React-hermes (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2026,16 +2026,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.5)
+    - React-cxxreact (= 0.80.0)
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.5)
+    - React-jsiexecutor (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.5)
+    - React-perflogger (= 0.80.0)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.80.0-rc.5):
+  - React-idlecallbacksnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2051,7 +2051,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.80.0-rc.5):
+  - React-ImageManager (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2066,12 +2066,12 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jsc (0.80.0-rc.5):
-    - React-jsc/Fabric (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
-  - React-jsc/Fabric (0.80.0-rc.5):
-    - React-jsi (= 0.80.0-rc.5)
-  - React-jserrorhandler (0.80.0-rc.5):
+  - React-jsc (0.80.0):
+    - React-jsc/Fabric (= 0.80.0)
+    - React-jsi (= 0.80.0)
+  - React-jsc/Fabric (0.80.0):
+    - React-jsi (= 0.80.0)
+  - React-jserrorhandler (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2086,7 +2086,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.80.0-rc.5):
+  - React-jsi (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2096,7 +2096,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.80.0-rc.5):
+  - React-jsiexecutor (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2105,14 +2105,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.5)
+    - React-perflogger (= 0.80.0)
     - SocketRocket
-  - React-jsinspector (0.80.0-rc.5):
+  - React-jsinspector (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2126,10 +2126,10 @@ PODS:
     - React-jsinspectorcdp
     - React-jsinspectornetwork
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.5)
-    - React-runtimeexecutor (= 0.80.0-rc.5)
+    - React-perflogger (= 0.80.0)
+    - React-runtimeexecutor (= 0.80.0)
     - SocketRocket
-  - React-jsinspectorcdp (0.80.0-rc.5):
+  - React-jsinspectorcdp (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2138,7 +2138,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.80.0-rc.5):
+  - React-jsinspectornetwork (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2148,7 +2148,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-jsinspectorcdp
     - SocketRocket
-  - React-jsinspectortracing (0.80.0-rc.5):
+  - React-jsinspectortracing (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2158,7 +2158,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-oscompat
     - SocketRocket
-  - React-jsitooling (0.80.0-rc.5):
+  - React-jsitooling (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2166,15 +2166,15 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - SocketRocket
-  - React-jsitracing (0.80.0-rc.5):
+  - React-jsitracing (0.80.0):
     - React-jsi
-  - React-logger (0.80.0-rc.5):
+  - React-logger (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2183,7 +2183,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.80.0-rc.5):
+  - React-Mapbuffer (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2193,7 +2193,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.80.0-rc.5):
+  - React-microtasksnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2485,7 +2485,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.80.0-rc.5):
+  - React-NativeModulesApple (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2506,8 +2506,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.80.0-rc.5)
-  - React-perflogger (0.80.0-rc.5):
+  - React-oscompat (0.80.0)
+  - React-perflogger (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2516,7 +2516,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.80.0-rc.5):
+  - React-performancetimeline (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2529,9 +2529,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.80.0-rc.5):
-    - React-Core/RCTActionSheetHeaders (= 0.80.0-rc.5)
-  - React-RCTAnimation (0.80.0-rc.5):
+  - React-RCTActionSheet (0.80.0):
+    - React-Core/RCTActionSheetHeaders (= 0.80.0)
+  - React-RCTAnimation (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2547,7 +2547,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.80.0-rc.5):
+  - React-RCTAppDelegate (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2580,7 +2580,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.80.0-rc.5):
+  - React-RCTBlob (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2599,7 +2599,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.80.0-rc.5):
+  - React-RCTFabric (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2633,7 +2633,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.80.0-rc.5):
+  - React-RCTFBReactNativeSpec (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2651,7 +2651,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCommon
     - SocketRocket
-  - React-RCTImage (0.80.0-rc.5):
+  - React-RCTImage (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2667,14 +2667,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.80.0-rc.5):
-    - React-Core/RCTLinkingHeaders (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+  - React-RCTLinking (0.80.0):
+    - React-Core/RCTLinkingHeaders (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.5)
-  - React-RCTNetwork (0.80.0-rc.5):
+    - ReactCommon/turbomodule/core (= 0.80.0)
+  - React-RCTNetwork (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2692,7 +2692,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.80.0-rc.5):
+  - React-RCTRuntime (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2712,7 +2712,7 @@ PODS:
     - React-RuntimeCore
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.80.0-rc.5):
+  - React-RCTSettings (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2727,10 +2727,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.80.0-rc.5):
-    - React-Core/RCTTextHeaders (= 0.80.0-rc.5)
+  - React-RCTText (0.80.0):
+    - React-Core/RCTTextHeaders (= 0.80.0)
     - Yoga
-  - React-RCTVibration (0.80.0-rc.5):
+  - React-RCTVibration (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2744,11 +2744,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.80.0-rc.5)
-  - React-renderercss (0.80.0-rc.5):
+  - React-rendererconsistency (0.80.0)
+  - React-renderercss (0.80.0):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.80.0-rc.5):
+  - React-rendererdebug (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2758,8 +2758,8 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-rncore (0.80.0-rc.5)
-  - React-RuntimeApple (0.80.0-rc.5):
+  - React-rncore (0.80.0)
+  - React-RuntimeApple (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2788,7 +2788,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.80.0-rc.5):
+  - React-RuntimeCore (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2811,9 +2811,9 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.80.0-rc.5):
-    - React-jsi (= 0.80.0-rc.5)
-  - React-RuntimeHermes (0.80.0-rc.5):
+  - React-runtimeexecutor (0.80.0):
+    - React-jsi (= 0.80.0)
+  - React-RuntimeHermes (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2833,7 +2833,7 @@ PODS:
     - React-RuntimeCore
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.80.0-rc.5):
+  - React-runtimescheduler (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2856,8 +2856,8 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.80.0-rc.5)
-  - React-utils (0.80.0-rc.5):
+  - React-timing (0.80.0)
+  - React-utils (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2868,11 +2868,11 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-hermes
-    - React-jsi (= 0.80.0-rc.5)
+    - React-jsi (= 0.80.0)
     - SocketRocket
-  - ReactAppDependencyProvider (0.80.0-rc.5):
+  - ReactAppDependencyProvider (0.80.0):
     - ReactCodegen
-  - ReactCodegen (0.80.0-rc.5):
+  - ReactCodegen (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2899,7 +2899,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.80.0-rc.5):
+  - ReactCommon (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2907,9 +2907,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.80.0-rc.5)
+    - ReactCommon/turbomodule (= 0.80.0)
     - SocketRocket
-  - ReactCommon/turbomodule (0.80.0-rc.5):
+  - ReactCommon/turbomodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2918,15 +2918,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
-    - ReactCommon/turbomodule/bridging (= 0.80.0-rc.5)
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
+    - ReactCommon/turbomodule/bridging (= 0.80.0)
+    - ReactCommon/turbomodule/core (= 0.80.0)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.80.0-rc.5):
+  - ReactCommon/turbomodule/bridging (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2935,13 +2935,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.80.0-rc.5):
+  - ReactCommon/turbomodule/core (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2950,14 +2950,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-debug (= 0.80.0-rc.5)
-    - React-featureflags (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
-    - React-utils (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-cxxreact (= 0.80.0)
+    - React-debug (= 0.80.0)
+    - React-featureflags (= 0.80.0)
+    - React-jsi (= 0.80.0)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
+    - React-utils (= 0.80.0)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -4113,7 +4113,7 @@ SPEC CHECKSUMS:
   ExpoGL: 8f7f43291e400621ef9aeb7af347816c2051ddc7
   ExpoHaptics: 68c215e070f660e0a29c45dcda4f60eeff08aefb
   ExpoHead: 5df88545652c2d3a3ea50bcd7f6be6ca935ac997
-  ExpoImage: ef8b25fddd3613a0bbdb2936d0583bc6588197dd
+  ExpoImage: 23fd11d3f2c4b04dc0b5e97fb41e9ead278bd0c8
   ExpoImageManipulator: 094b748056f2654d5d7813370c910e20ef3d79b4
   ExpoImagePicker: d2fff488a0738343a3cc21e98544ee9feafaa0e6
   ExpoKeepAwake: e8dedc115d9f6f24b153ccd2d1d8efcdfd68a527
@@ -4144,13 +4144,13 @@ SPEC CHECKSUMS:
   ExpoTrackingTransparency: 843029c42d70de59bb0503f6fc747b9d2fe67f7b
   ExpoVideo: 54ce43735b4ceb6b3828e3eec3b750b0fe10314c
   ExpoVideoThumbnails: 4280333bee3bd4d69b3b139bd50a8b7c967095ae
-  ExpoWebBrowser: 1051486eb45a2f4d1ee075712604f43f3009f90e
+  ExpoWebBrowser: 8aa522ab60113768d4dc5691c36d3315cc3b297b
   EXStructuredHeaders: 32bec6771c2db18c4cd47cecae530d1d06cdf972
   EXTaskManager: 0128b9f39a088b0c762d8d1c42017e6d44200b29
   EXUpdates: 3e352b121c235fe6c41532d7931ae47c2561ab96
   EXUpdatesInterface: 64f35449b8ef89ce08cdd8952a4d119b5de6821d
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: 04f59172f2d1bc4c8afd36bbff2485df293fab12
+  FBLazyVector: 778b815a6fb3fa1599f581ffb9a5e85fad313c1d
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
   FirebaseCore: 2321536f9c423b1f857e047a82b8a42abc6d9e2c
   FirebaseCoreExtension: 3a64994969dd05f4bcb7e6896c654eded238e75b
@@ -4166,7 +4166,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 8dbd5d2701ac3ea242a38126aadf38bfb85efd04
+  hermes-engine: 709db606271a42914645167c7ea13636592ccd6f
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4179,40 +4179,40 @@ SPEC CHECKSUMS:
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: 06e57a11be6128124a3c7cbfceb09b78f6c9ffc2
-  RCTRequired: 843cc1fe500b0ba58512287c5116e31a45181bca
-  RCTTypeSafety: 71eeceddb7e708c224909ba99c37a145c98c02a7
+  RCTDeprecation: ff787f6c860a1b97dd1bc27264b61d23ad1994da
+  RCTRequired: 664eb8399ed8a83e26ab65af7c2ad390f7e61696
+  RCTTypeSafety: a5cf7a7e80baf972e331dc028e5d5c19bb2535a4
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: d24621fc58bfcf5015e3286eac7b76c05040d914
-  React-callinvoker: f36300fae0e5d711e6b9991976f64ae0cb8fad3a
-  React-Core: 1902f442e0e3e3427ed132f38c8aa49e91f0bd46
-  React-CoreModules: 45ab4e286895a2312e036f5e48639bdc1a73902f
-  React-cxxreact: 7c6d58dd92feca44a013988f6282956b5f2b3229
-  React-debug: 3005e18d181d33277445c99e201d37f3114233b6
-  React-defaultsnativemodule: f78ad0be2080633d0c2dd5a48905fa556bc030a2
-  React-domnativemodule: 0686da969f67cb81b8555fb3123d1906f62d44f6
-  React-Fabric: 9e8e3acfa8c8daa36dd11c98d612c25c1e11ea59
-  React-FabricComponents: ff54b3fc511695d209a219162371d484d62dec9a
-  React-FabricImage: f1e3f9bd46068b1d5406484406c4897473756b68
-  React-featureflags: 4963e06d1885257e2d109d733837c39cfc97f836
-  React-featureflagsnativemodule: 8a91773c93c38b11bf6af402c9287155d69a1f86
-  React-graphics: da7f5a1e95962b39fb5fc02ea5c615231b4e5626
-  React-hermes: bd76cb1d809d7dd27c9ad31a7d663047e4864f92
-  React-idlecallbacksnativemodule: acb58fd1bf494f1331e3a8765a855a85942d573e
-  React-ImageManager: 251cb54baff0af00e88f96dc01e4d1ca795e2928
-  React-jsc: be123bf7df2501bc854da83253af9edc1ed52045
-  React-jserrorhandler: 74a5109317e35632dd26ffbb38243d1b5aaebed3
-  React-jsi: 904806629c68f61d6e128d19c0cee1e3605eceec
-  React-jsiexecutor: d4fab673c926d913d6e1530155378833462fde57
-  React-jsinspector: 85113ed82fd449942151731f1051d46a9e5b2830
-  React-jsinspectorcdp: 538cb3eea51969564d0d57e23de3039fb22c8d28
-  React-jsinspectornetwork: 0be7cd0206b62c86d22b864a3147d9bfcc020477
-  React-jsinspectortracing: 9c772ac4f0df8f2940a34185e6e0e67bf91148cf
-  React-jsitooling: ea0874c51c43798dc4a83feaf6ffa57b929cacdc
-  React-jsitracing: 9f866cdc3a7f8b8eda89b52c409934bc9f85903a
-  React-logger: 34f13c3effe44410ccf62b255fc12f085ac7d038
-  React-Mapbuffer: 0e9c84c9a8e55645a1f19ae14e79a761b843ddc2
-  React-microtasksnativemodule: 3302ad49a9b619ca411acfca32534f3696894b95
+  React: 606d4dccbcf29aec4dc84a7921405a28e1701a22
+  React-callinvoker: 0e13bd3c039df9ceef04f7381a81f017655c8361
+  React-Core: fdeee4540da2d2df85ffd3ad6b4a775ba8ebf8c9
+  React-CoreModules: 99d3515898255378fa2d6fc906b6dca093d280c4
+  React-cxxreact: 3410a1edbe15936bcf8eae61a546af1bec06ed98
+  React-debug: a9e91845f3670c3a19249f52919f0488b7842cf7
+  React-defaultsnativemodule: 8fad7c7173d6133d15b1532251df550d0d1c1f87
+  React-domnativemodule: 1da1f2bc921a9e4652918f37285c3830f561c86b
+  React-Fabric: e6f729f372f959bda89268c2c921fac55a9579dc
+  React-FabricComponents: f2ab7d78be2ea1dd06a7d8d606f5740cd1f54041
+  React-FabricImage: 220e8ce3ccdb483fd4283d8b21839676e8b88e27
+  React-featureflags: b64383c3268d03c3fab25c03a5c7e5fab0931a55
+  React-featureflagsnativemodule: 4c7b5cbe887d120a1797f65e6676fe9e1f9396ea
+  React-graphics: 4031c43a78b816dc1043dca24dfabf1d2622df9a
+  React-hermes: dc21a35794633bf2aef73645d273f5ee3bdf777a
+  React-idlecallbacksnativemodule: 9d6ea7839e347ffd3791315ba418370421d6c7c7
+  React-ImageManager: b743a715eca9abbf69fbd50732315565c9eb3863
+  React-jsc: 9a965a715a49b6169f6d3702aecf1235c963033e
+  React-jserrorhandler: 850fe8285385ffa783cc73e5e2eda8ddcb84e147
+  React-jsi: ea8a33b23165395610436c8f0d715e2c3bbcec7e
+  React-jsiexecutor: 0fb247eca0908176917380e1e1b75339f52a0c72
+  React-jsinspector: dcfc9ee7f2610ff05aa8f66fc8203cf7be875d0e
+  React-jsinspectorcdp: 6803046f78af0b3caace9002e28b0ca1fd97c1c4
+  React-jsinspectornetwork: b25ef98ec036aa1b454ebc904b983059e1ebc6e7
+  React-jsinspectortracing: 777ae30cf41f6305ffc509e53bef86bb1027395f
+  React-jsitooling: 568f4974066f14597084df606a6ad79fa52715b6
+  React-jsitracing: 47cb4a6c4b3c5e2d1d32ff4880d74d5faf58423c
+  React-logger: b69e65dc60f768e5509ac0cc27a360124bf70478
+  React-Mapbuffer: b48f9f3311fd0ec0f7a5dc39d707eff521fb5f38
+  React-microtasksnativemodule: d8568d0485a350c720c061ae835e09fc88c28715
   react-native-google-maps: 7cc1184afe41fbd15a3dffd53c924819f6587b69
   react-native-maps: ee1e65647460c3d41e778071be5eda10e3da6225
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
@@ -4223,37 +4223,37 @@ SPEC CHECKSUMS:
   react-native-slider: dd3636cb9b888b4d8aaf7ac0bb5e0d2921c5eec6
   react-native-view-shot: a18275ac858eb4866365148517774182319c7aee
   react-native-webview: a53cadbdc946b2d14055284ee9f5f81c1d4817a3
-  React-NativeModulesApple: db5c62dfdee373bfacb3ce4fe86469a84d8047d9
-  React-oscompat: acc1d2b40174ce9a8c3d61912572a51ff76a94e6
-  React-perflogger: bb0332a02764f3c6570244635ac4318211514f3c
-  React-performancetimeline: e005006283a2acb109fe0821b75c35c1cfe6e769
-  React-RCTActionSheet: dad33af1be68c5e92d5d00482f5a42f49822531c
-  React-RCTAnimation: aa0e7ddf90d94a6f625b96fc29e9c58d9bb1c449
-  React-RCTAppDelegate: b9b009eafeb778a7a4cd877614a505ea926d6d9b
-  React-RCTBlob: 14655d7b0ef157dd76d26db1fd75c4d7b92a2692
-  React-RCTFabric: 4e63c60c2944bf92d4a07fa61b2a9176f013b73c
-  React-RCTFBReactNativeSpec: 85e9189f245531263a4a3995f225def0045ef998
-  React-RCTImage: 379dc52f16dc25fe9ab843053eb785461b0ffcb5
-  React-RCTLinking: 833b53827195f23a639bebe64e048497edd28a04
-  React-RCTNetwork: e005e7b11632bb1dfcc1b13e79f11d8d9bc531d9
-  React-RCTRuntime: ef7c4c62318500ed20c02624152823fe6b1d0727
-  React-RCTSettings: ebe3edb605bade8c0bde36f51a75d95e96a2ef81
-  React-RCTText: ba698614a19a41249036227b52213f6f8a982ec3
-  React-RCTVibration: 4385bc7b39e2a435933d6447eb37f54e099a00be
-  React-rendererconsistency: 103d24d9fd9eed1760f0874edfbdc4b98288a20b
-  React-renderercss: 4841823f6d3bcc65fdbaf00906b17bee7415d598
-  React-rendererdebug: 9d95f3e58b504e4fa28798caa7c1e40cd5fc6f4a
-  React-rncore: c555e70ebd3dc73ebc494ce4e30cbaa381fa5731
-  React-RuntimeApple: 8033fb3a15d4234d92612aa293bdd358f7897bc5
-  React-RuntimeCore: ba41b7e036428a80789e755de7cbdfcffaaac973
-  React-runtimeexecutor: 52df6be38a17311756f9fbb39b9bb055f4bd01c2
-  React-RuntimeHermes: 996d88f40374434c31a859d888dff541c277cd60
-  React-runtimescheduler: 5eacdcd1db313e2d6950fb8872cc8038327d2b31
-  React-timing: d44a981781952fe0ac6dac355473b2248700cdf1
-  React-utils: 81dcddf4ae56d8defae035f0e4500572321a7fbd
-  ReactAppDependencyProvider: 8b6a181160ae9a814f6a7f447921be2fa962b1b4
-  ReactCodegen: 19609958a70f0a4c472b03d7f80f4641035a7ce2
-  ReactCommon: e69175d0efd16afee3d7d43e95dc714966c2ca3d
+  React-NativeModulesApple: f10596688a03af66804cfbe61792be24a7888da8
+  React-oscompat: 7c0a341cc31e350da71ddf2e46de0a845d1d1626
+  React-perflogger: 4cc44451f694d6205f47bd8d5d87c9c862c3335c
+  React-performancetimeline: a81afec7aba50bdb80e5a692b03eff2dc499fe37
+  React-RCTActionSheet: 99864bd8422649219f24eca9a51445e698b70b8e
+  React-RCTAnimation: 7cb99a851a514673a1e48ca5fcbdee7c7c760da1
+  React-RCTAppDelegate: cd3bc49cec7cef167e920d5e54194d161cd8ab6d
+  React-RCTBlob: c96068eb67bf4a587f279db91c6948fc761826b9
+  React-RCTFabric: ca43b2e7bf026a8898a4eea81e9306786a892065
+  React-RCTFBReactNativeSpec: 96df6e569ad40c52f286762a59d7a96644567f5b
+  React-RCTImage: c40e65f565882df880c4f8994940c8b070923239
+  React-RCTLinking: 88992a3fb7c8caa868a2fc3489b26741e75ac5b5
+  React-RCTNetwork: 89c9222b388d90229511cc974abee608ac9c1221
+  React-RCTRuntime: 8a0222f21dacd0946aaff43976a06bd082e49e42
+  React-RCTSettings: 9e7a5f4262523dee5a1f9b0fd1e674b2a11bd7db
+  React-RCTText: 67f2955faca189ff85c3c5686505be9526df5461
+  React-RCTVibration: e4fe5861cee22c972672d29da4cdf24b6313e01d
+  React-rendererconsistency: a4db9bb060c65bce8ae83d936ed0719696055bd2
+  React-renderercss: 77c768faf43570d50e3657b97ce1a4c4614012d6
+  React-rendererdebug: 460dacb65d9ec58ba44e5c936b89e58530dd2a06
+  React-rncore: 322add36430c38049067a5d365f166256975391f
+  React-RuntimeApple: 9a7b848f3ea1b2aa6eefb0e42a5e113ed9b47f3d
+  React-RuntimeCore: d9feb0e71b045780372d72b9fd0e4326c2ee97d8
+  React-runtimeexecutor: 49ea276161508d50b3486c385e1ca7972d1699f5
+  React-RuntimeHermes: 31f857c04fda874cefef4dfbd1c8b0d234c4d606
+  React-runtimescheduler: 3cb2ab6622f9580b237a110350804933f8aec680
+  React-timing: a275a1c2e6112dba17f8f7dd496d439213bbea0d
+  React-utils: 257f8c08cb0559e458a9a9254967058434198ced
+  ReactAppDependencyProvider: cd55f820247d424280ae0b94e1ffb38963410c01
+  ReactCodegen: 63c043cd02258268b8c92c301d4e3ddb8d868928
+  ReactCommon: 658874decaf8c4fd76cfa3a878b94a869db85b1c
   RNCAsyncStorage: 767abb068db6ad28b5f59a129fbc9fab18b377e2
   RNCMaskedView: aac38cf7e947ff80e483996d1acd43c5ad4ab610
   RNCPicker: 9f14f7b5511d88d7608b344e9089916ff8a47298
@@ -4278,7 +4278,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: 724c562849578aa4747d17e9f3cfe0ef3f8ab7fb
   StripeUICore: 0e0f3005fd3027dad3d3d77927f371d5fe4eb9ac
   UMAppLoader: 55159b69750129faa7a51c493cb8ea55a7b64eb9
-  Yoga: c8798357f928802015a217ccd2fe692b61a090c2
+  Yoga: 0c4b7d2aacc910a1f702694fa86be830386f4ceb
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 9f104a55d90568cbeff5ed1bb052a935a9042f4f

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -68,7 +68,7 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.5",
+    "react-native": "0.80.0",
     "react-native-edge-to-edge": "1.6.0",
     "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~2.24.0",

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -9,6 +9,6 @@
     "expo": "~53.0.9",
     "expo-clipboard": "~7.1.4",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.5"
+    "react-native": "0.80.0"
   }
 }

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -137,7 +137,7 @@
     "processing-js": "^1.6.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.80.0-rc.5",
+    "react-native": "0.80.0",
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-maps": "1.20.1",

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -572,16 +572,8 @@ PODS:
   - fmt (11.0.2)
   - glog (0.3.5)
   - hermes-engine (0.80.0):
-    - hermes-engine/cdp (= 0.80.0)
-    - hermes-engine/Hermes (= 0.80.0)
-    - hermes-engine/inspector (= 0.80.0)
-    - hermes-engine/inspector_chrome (= 0.80.0)
-    - hermes-engine/Public (= 0.80.0)
-  - hermes-engine/cdp (0.80.0)
-  - hermes-engine/Hermes (0.80.0)
-  - hermes-engine/inspector (0.80.0)
-  - hermes-engine/inspector_chrome (0.80.0)
-  - hermes-engine/Public (0.80.0)
+    - hermes-engine/Pre-built (= 0.80.0)
+  - hermes-engine/Pre-built (0.80.0)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -3079,7 +3071,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 778b815a6fb3fa1599f581ffb9a5e85fad313c1d
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 50e36d664adc3637672d46bdb6b6bec1a23fbd0b
+  hermes-engine: 7068e976238b29e97b3bafd09a994542af7d5c0b
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -404,14 +404,14 @@ PODS:
   - ExpoFileSystem/Tests (18.1.10):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - ExpoImage (2.1.7):
+  - ExpoImage (2.3.0):
     - ExpoModulesCore
     - libavif/libdav1d
     - SDWebImage (~> 5.21.0)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
     - SDWebImageWebPCoder (~> 0.14.6)
-  - ExpoImage/Tests (2.1.7):
+  - ExpoImage/Tests (2.3.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
     - libavif/libdav1d
@@ -568,12 +568,20 @@ PODS:
   - EXUpdatesInterface (1.1.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.80.0-rc.5)
+  - FBLazyVector (0.80.0)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.80.0-rc.5):
-    - hermes-engine/Pre-built (= 0.80.0-rc.5)
-  - hermes-engine/Pre-built (0.80.0-rc.5)
+  - hermes-engine (0.80.0):
+    - hermes-engine/cdp (= 0.80.0)
+    - hermes-engine/Hermes (= 0.80.0)
+    - hermes-engine/inspector (= 0.80.0)
+    - hermes-engine/inspector_chrome (= 0.80.0)
+    - hermes-engine/Public (= 0.80.0)
+  - hermes-engine/cdp (0.80.0)
+  - hermes-engine/Hermes (0.80.0)
+  - hermes-engine/inspector (0.80.0)
+  - hermes-engine/inspector_chrome (0.80.0)
+  - hermes-engine/Public (0.80.0)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -625,28 +633,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.80.0-rc.5)
-  - RCTRequired (0.80.0-rc.5)
-  - RCTTypeSafety (0.80.0-rc.5):
-    - FBLazyVector (= 0.80.0-rc.5)
-    - RCTRequired (= 0.80.0-rc.5)
-    - React-Core (= 0.80.0-rc.5)
+  - RCTDeprecation (0.80.0)
+  - RCTRequired (0.80.0)
+  - RCTTypeSafety (0.80.0):
+    - FBLazyVector (= 0.80.0)
+    - RCTRequired (= 0.80.0)
+    - React-Core (= 0.80.0)
   - ReachabilitySwift (5.0.0)
-  - React (0.80.0-rc.5):
-    - React-Core (= 0.80.0-rc.5)
-    - React-Core/DevSupport (= 0.80.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.5)
-    - React-RCTActionSheet (= 0.80.0-rc.5)
-    - React-RCTAnimation (= 0.80.0-rc.5)
-    - React-RCTBlob (= 0.80.0-rc.5)
-    - React-RCTImage (= 0.80.0-rc.5)
-    - React-RCTLinking (= 0.80.0-rc.5)
-    - React-RCTNetwork (= 0.80.0-rc.5)
-    - React-RCTSettings (= 0.80.0-rc.5)
-    - React-RCTText (= 0.80.0-rc.5)
-    - React-RCTVibration (= 0.80.0-rc.5)
-  - React-callinvoker (0.80.0-rc.5)
-  - React-Core (0.80.0-rc.5):
+  - React (0.80.0):
+    - React-Core (= 0.80.0)
+    - React-Core/DevSupport (= 0.80.0)
+    - React-Core/RCTWebSocket (= 0.80.0)
+    - React-RCTActionSheet (= 0.80.0)
+    - React-RCTAnimation (= 0.80.0)
+    - React-RCTBlob (= 0.80.0)
+    - React-RCTImage (= 0.80.0)
+    - React-RCTLinking (= 0.80.0)
+    - React-RCTNetwork (= 0.80.0)
+    - React-RCTSettings (= 0.80.0)
+    - React-RCTText (= 0.80.0)
+    - React-RCTVibration (= 0.80.0)
+  - React-callinvoker (0.80.0)
+  - React-Core (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -656,7 +664,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.5)
+    - React-Core/Default (= 0.80.0)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -670,79 +678,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.5)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.80.0-rc.5):
+  - React-Core/CoreModulesHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -766,7 +702,55 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.80.0-rc.5):
+  - React-Core/Default (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0)
+    - React-Core/RCTWebSocket (= 0.80.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -790,7 +774,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.80.0-rc.5):
+  - React-Core/RCTAnimationHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -814,7 +798,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.80.0-rc.5):
+  - React-Core/RCTBlobHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -838,7 +822,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.80.0-rc.5):
+  - React-Core/RCTImageHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -862,7 +846,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.80.0-rc.5):
+  - React-Core/RCTLinkingHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -886,7 +870,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.80.0-rc.5):
+  - React-Core/RCTNetworkHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -910,7 +894,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.80.0-rc.5):
+  - React-Core/RCTSettingsHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -934,7 +918,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.80.0-rc.5):
+  - React-Core/RCTTextHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -958,7 +942,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.80.0-rc.5):
+  - React-Core/RCTVibrationHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -968,7 +952,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.5)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -982,7 +966,31 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.80.0-rc.5):
+  - React-Core/RCTWebSocket (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -990,19 +998,19 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.80.0-rc.5)
-    - React-Core/CoreModulesHeaders (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - RCTTypeSafety (= 0.80.0)
+    - React-Core/CoreModulesHeaders (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.80.0-rc.5)
+    - React-RCTImage (= 0.80.0)
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.80.0-rc.5):
+  - React-cxxreact (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1011,19 +1019,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-debug (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-debug (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
-    - React-runtimeexecutor (= 0.80.0-rc.5)
-    - React-timing (= 0.80.0-rc.5)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
+    - React-runtimeexecutor (= 0.80.0)
+    - React-timing (= 0.80.0)
     - SocketRocket
-  - React-debug (0.80.0-rc.5)
-  - React-defaultsnativemodule (0.80.0-rc.5):
+  - React-debug (0.80.0)
+  - React-defaultsnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1041,7 +1049,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.80.0-rc.5):
+  - React-domnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1060,7 +1068,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.80.0-rc.5):
+  - React-Fabric (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1074,22 +1082,22 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.80.0-rc.5)
-    - React-Fabric/attributedstring (= 0.80.0-rc.5)
-    - React-Fabric/componentregistry (= 0.80.0-rc.5)
-    - React-Fabric/componentregistrynative (= 0.80.0-rc.5)
-    - React-Fabric/components (= 0.80.0-rc.5)
-    - React-Fabric/consistency (= 0.80.0-rc.5)
-    - React-Fabric/core (= 0.80.0-rc.5)
-    - React-Fabric/dom (= 0.80.0-rc.5)
-    - React-Fabric/imagemanager (= 0.80.0-rc.5)
-    - React-Fabric/leakchecker (= 0.80.0-rc.5)
-    - React-Fabric/mounting (= 0.80.0-rc.5)
-    - React-Fabric/observers (= 0.80.0-rc.5)
-    - React-Fabric/scheduler (= 0.80.0-rc.5)
-    - React-Fabric/telemetry (= 0.80.0-rc.5)
-    - React-Fabric/templateprocessor (= 0.80.0-rc.5)
-    - React-Fabric/uimanager (= 0.80.0-rc.5)
+    - React-Fabric/animations (= 0.80.0)
+    - React-Fabric/attributedstring (= 0.80.0)
+    - React-Fabric/componentregistry (= 0.80.0)
+    - React-Fabric/componentregistrynative (= 0.80.0)
+    - React-Fabric/components (= 0.80.0)
+    - React-Fabric/consistency (= 0.80.0)
+    - React-Fabric/core (= 0.80.0)
+    - React-Fabric/dom (= 0.80.0)
+    - React-Fabric/imagemanager (= 0.80.0)
+    - React-Fabric/leakchecker (= 0.80.0)
+    - React-Fabric/mounting (= 0.80.0)
+    - React-Fabric/observers (= 0.80.0)
+    - React-Fabric/scheduler (= 0.80.0)
+    - React-Fabric/telemetry (= 0.80.0)
+    - React-Fabric/templateprocessor (= 0.80.0)
+    - React-Fabric/uimanager (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1101,32 +1109,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.80.0-rc.5):
+  - React-Fabric/animations (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1151,7 +1134,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.80.0-rc.5):
+  - React-Fabric/attributedstring (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1176,7 +1159,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.80.0-rc.5):
+  - React-Fabric/componentregistry (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1201,36 +1184,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0-rc.5)
-    - React-Fabric/components/root (= 0.80.0-rc.5)
-    - React-Fabric/components/scrollview (= 0.80.0-rc.5)
-    - React-Fabric/components/view (= 0.80.0-rc.5)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.80.0-rc.5):
+  - React-Fabric/componentregistrynative (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1255,7 +1209,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.80.0-rc.5):
+  - React-Fabric/components (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0)
+    - React-Fabric/components/root (= 0.80.0)
+    - React-Fabric/components/scrollview (= 0.80.0)
+    - React-Fabric/components/view (= 0.80.0)
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1280,7 +1263,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.80.0-rc.5):
+  - React-Fabric/components/root (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1305,7 +1288,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.80.0-rc.5):
+  - React-Fabric/components/scrollview (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1332,7 +1340,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.80.0-rc.5):
+  - React-Fabric/consistency (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1357,7 +1365,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.80.0-rc.5):
+  - React-Fabric/core (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1382,7 +1390,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.80.0-rc.5):
+  - React-Fabric/dom (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1407,7 +1415,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.80.0-rc.5):
+  - React-Fabric/imagemanager (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1432,7 +1440,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.80.0-rc.5):
+  - React-Fabric/leakchecker (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1457,7 +1465,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.80.0-rc.5):
+  - React-Fabric/mounting (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1482,7 +1490,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.80.0-rc.5):
+  - React-Fabric/observers (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1496,7 +1504,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.80.0-rc.5)
+    - React-Fabric/observers/events (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1508,7 +1516,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.80.0-rc.5):
+  - React-Fabric/observers/events (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1533,7 +1541,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.80.0-rc.5):
+  - React-Fabric/scheduler (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1560,7 +1568,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.80.0-rc.5):
+  - React-Fabric/telemetry (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1585,7 +1593,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.80.0-rc.5):
+  - React-Fabric/templateprocessor (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1610,7 +1618,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.80.0-rc.5):
+  - React-Fabric/uimanager (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1624,33 +1632,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.80.0-rc.5)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/uimanager/consistency (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1663,7 +1645,33 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.80.0-rc.5):
+  - React-Fabric/uimanager/consistency (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-FabricComponents (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1678,8 +1686,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.80.0-rc.5)
-    - React-FabricComponents/textlayoutmanager (= 0.80.0-rc.5)
+    - React-FabricComponents/components (= 0.80.0)
+    - React-FabricComponents/textlayoutmanager (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1692,7 +1700,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.80.0-rc.5):
+  - React-FabricComponents/components (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1707,15 +1715,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.80.0-rc.5)
-    - React-FabricComponents/components/iostextinput (= 0.80.0-rc.5)
-    - React-FabricComponents/components/modal (= 0.80.0-rc.5)
-    - React-FabricComponents/components/rncore (= 0.80.0-rc.5)
-    - React-FabricComponents/components/safeareaview (= 0.80.0-rc.5)
-    - React-FabricComponents/components/scrollview (= 0.80.0-rc.5)
-    - React-FabricComponents/components/text (= 0.80.0-rc.5)
-    - React-FabricComponents/components/textinput (= 0.80.0-rc.5)
-    - React-FabricComponents/components/unimplementedview (= 0.80.0-rc.5)
+    - React-FabricComponents/components/inputaccessory (= 0.80.0)
+    - React-FabricComponents/components/iostextinput (= 0.80.0)
+    - React-FabricComponents/components/modal (= 0.80.0)
+    - React-FabricComponents/components/rncore (= 0.80.0)
+    - React-FabricComponents/components/safeareaview (= 0.80.0)
+    - React-FabricComponents/components/scrollview (= 0.80.0)
+    - React-FabricComponents/components/text (= 0.80.0)
+    - React-FabricComponents/components/textinput (= 0.80.0)
+    - React-FabricComponents/components/unimplementedview (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1728,61 +1736,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/modal (0.80.0-rc.5):
+  - React-FabricComponents/components/inputaccessory (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1809,7 +1763,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.80.0-rc.5):
+  - React-FabricComponents/components/iostextinput (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1836,7 +1790,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.80.0-rc.5):
+  - React-FabricComponents/components/modal (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1863,7 +1817,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.80.0-rc.5):
+  - React-FabricComponents/components/rncore (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1890,7 +1844,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.80.0-rc.5):
+  - React-FabricComponents/components/safeareaview (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1917,7 +1871,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.80.0-rc.5):
+  - React-FabricComponents/components/scrollview (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1944,7 +1898,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.80.0-rc.5):
+  - React-FabricComponents/components/text (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1971,7 +1925,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.80.0-rc.5):
+  - React-FabricComponents/components/textinput (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1998,7 +1952,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.80.0-rc.5):
+  - React-FabricComponents/components/unimplementedview (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2007,22 +1961,76 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.80.0-rc.5)
-    - RCTTypeSafety (= 0.80.0-rc.5)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.80.0)
+    - RCTTypeSafety (= 0.80.0)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-hermes
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.5)
+    - React-jsiexecutor (= 0.80.0)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.80.0-rc.5):
+  - React-featureflags (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2031,7 +2039,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.80.0-rc.5):
+  - React-featureflagsnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2047,7 +2055,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.80.0-rc.5):
+  - React-graphics (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2061,7 +2069,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.80.0-rc.5):
+  - React-hermes (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2070,16 +2078,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.5)
+    - React-cxxreact (= 0.80.0)
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.5)
+    - React-jsiexecutor (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.5)
+    - React-perflogger (= 0.80.0)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.80.0-rc.5):
+  - React-idlecallbacksnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2095,7 +2103,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.80.0-rc.5):
+  - React-ImageManager (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2110,7 +2118,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.80.0-rc.5):
+  - React-jserrorhandler (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2125,7 +2133,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.80.0-rc.5):
+  - React-jsi (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2135,7 +2143,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.80.0-rc.5):
+  - React-jsiexecutor (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2144,14 +2152,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.5)
+    - React-perflogger (= 0.80.0)
     - SocketRocket
-  - React-jsinspector (0.80.0-rc.5):
+  - React-jsinspector (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2165,10 +2173,10 @@ PODS:
     - React-jsinspectorcdp
     - React-jsinspectornetwork
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.5)
-    - React-runtimeexecutor (= 0.80.0-rc.5)
+    - React-perflogger (= 0.80.0)
+    - React-runtimeexecutor (= 0.80.0)
     - SocketRocket
-  - React-jsinspectorcdp (0.80.0-rc.5):
+  - React-jsinspectorcdp (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2177,7 +2185,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.80.0-rc.5):
+  - React-jsinspectornetwork (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2187,7 +2195,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-jsinspectorcdp
     - SocketRocket
-  - React-jsinspectortracing (0.80.0-rc.5):
+  - React-jsinspectortracing (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2197,7 +2205,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-oscompat
     - SocketRocket
-  - React-jsitooling (0.80.0-rc.5):
+  - React-jsitooling (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2205,15 +2213,15 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - SocketRocket
-  - React-jsitracing (0.80.0-rc.5):
+  - React-jsitracing (0.80.0):
     - React-jsi
-  - React-logger (0.80.0-rc.5):
+  - React-logger (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2222,7 +2230,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.80.0-rc.5):
+  - React-Mapbuffer (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2232,7 +2240,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.80.0-rc.5):
+  - React-microtasksnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2247,7 +2255,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-NativeModulesApple (0.80.0-rc.5):
+  - React-NativeModulesApple (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2268,8 +2276,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.80.0-rc.5)
-  - React-perflogger (0.80.0-rc.5):
+  - React-oscompat (0.80.0)
+  - React-perflogger (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2278,7 +2286,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.80.0-rc.5):
+  - React-performancetimeline (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2291,9 +2299,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.80.0-rc.5):
-    - React-Core/RCTActionSheetHeaders (= 0.80.0-rc.5)
-  - React-RCTAnimation (0.80.0-rc.5):
+  - React-RCTActionSheet (0.80.0):
+    - React-Core/RCTActionSheetHeaders (= 0.80.0)
+  - React-RCTAnimation (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2309,7 +2317,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.80.0-rc.5):
+  - React-RCTAppDelegate (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2342,7 +2350,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.80.0-rc.5):
+  - React-RCTBlob (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2361,7 +2369,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.80.0-rc.5):
+  - React-RCTFabric (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2395,7 +2403,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.80.0-rc.5):
+  - React-RCTFBReactNativeSpec (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2413,7 +2421,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCommon
     - SocketRocket
-  - React-RCTImage (0.80.0-rc.5):
+  - React-RCTImage (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2429,14 +2437,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.80.0-rc.5):
-    - React-Core/RCTLinkingHeaders (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+  - React-RCTLinking (0.80.0):
+    - React-Core/RCTLinkingHeaders (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.5)
-  - React-RCTNetwork (0.80.0-rc.5):
+    - ReactCommon/turbomodule/core (= 0.80.0)
+  - React-RCTNetwork (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2454,7 +2462,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.80.0-rc.5):
+  - React-RCTRuntime (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2474,7 +2482,7 @@ PODS:
     - React-RuntimeCore
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.80.0-rc.5):
+  - React-RCTSettings (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2489,10 +2497,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.80.0-rc.5):
-    - React-Core/RCTTextHeaders (= 0.80.0-rc.5)
+  - React-RCTText (0.80.0):
+    - React-Core/RCTTextHeaders (= 0.80.0)
     - Yoga
-  - React-RCTVibration (0.80.0-rc.5):
+  - React-RCTVibration (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2506,11 +2514,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.80.0-rc.5)
-  - React-renderercss (0.80.0-rc.5):
+  - React-rendererconsistency (0.80.0)
+  - React-renderercss (0.80.0):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.80.0-rc.5):
+  - React-rendererdebug (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2520,8 +2528,8 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-rncore (0.80.0-rc.5)
-  - React-RuntimeApple (0.80.0-rc.5):
+  - React-rncore (0.80.0)
+  - React-RuntimeApple (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2550,7 +2558,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.80.0-rc.5):
+  - React-RuntimeCore (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2573,9 +2581,9 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.80.0-rc.5):
-    - React-jsi (= 0.80.0-rc.5)
-  - React-RuntimeHermes (0.80.0-rc.5):
+  - React-runtimeexecutor (0.80.0):
+    - React-jsi (= 0.80.0)
+  - React-RuntimeHermes (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2595,7 +2603,7 @@ PODS:
     - React-RuntimeCore
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.80.0-rc.5):
+  - React-runtimescheduler (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2618,8 +2626,8 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.80.0-rc.5)
-  - React-utils (0.80.0-rc.5):
+  - React-timing (0.80.0)
+  - React-utils (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2630,11 +2638,11 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-hermes
-    - React-jsi (= 0.80.0-rc.5)
+    - React-jsi (= 0.80.0)
     - SocketRocket
-  - ReactAppDependencyProvider (0.80.0-rc.5):
+  - ReactAppDependencyProvider (0.80.0):
     - ReactCodegen
-  - ReactCodegen (0.80.0-rc.5):
+  - ReactCodegen (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2661,7 +2669,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.80.0-rc.5):
+  - ReactCommon (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2669,9 +2677,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.80.0-rc.5)
+    - ReactCommon/turbomodule (= 0.80.0)
     - SocketRocket
-  - ReactCommon/turbomodule (0.80.0-rc.5):
+  - ReactCommon/turbomodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2680,15 +2688,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
-    - ReactCommon/turbomodule/bridging (= 0.80.0-rc.5)
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
+    - ReactCommon/turbomodule/bridging (= 0.80.0)
+    - ReactCommon/turbomodule/core (= 0.80.0)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.80.0-rc.5):
+  - ReactCommon/turbomodule/bridging (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2697,13 +2705,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.80.0-rc.5):
+  - ReactCommon/turbomodule/core (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2712,14 +2720,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-debug (= 0.80.0-rc.5)
-    - React-featureflags (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
-    - React-utils (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-cxxreact (= 0.80.0)
+    - React-debug (= 0.80.0)
+    - React-featureflags (= 0.80.0)
+    - React-jsi (= 0.80.0)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
+    - React-utils (= 0.80.0)
     - SocketRocket
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
@@ -3060,7 +3068,7 @@ SPEC CHECKSUMS:
   expo-dev-menu-interface: 609c35ae8b97479cdd4c9e23c8cf6adc44beea0e
   ExpoClipboard: c187b3101e5f38cce4c6321788e0047f1c29e152
   ExpoFileSystem: 3a98ca2a6f13674ecfd97327d1b44a8ace444cbd
-  ExpoImage: ef8b25fddd3613a0bbdb2936d0583bc6588197dd
+  ExpoImage: 23fd11d3f2c4b04dc0b5e97fb41e9ead278bd0c8
   ExpoMediaLibrary: ad61cd80ca07da02be3d676e3d9b04b311a82c2c
   ExpoModulesCore: 0b7a0299baa6c8de3b9331869d61df3e7c2f5e0f
   ExpoModulesTestCore: c87ba2da38070e3483a3049453a4dc898b972eb2
@@ -3068,10 +3076,10 @@ SPEC CHECKSUMS:
   EXUpdates: 9d87d1b97634263b9f8623eb7e763e58b48dc9fb
   EXUpdatesInterface: 64f35449b8ef89ce08cdd8952a4d119b5de6821d
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: 04f59172f2d1bc4c8afd36bbff2485df293fab12
+  FBLazyVector: 778b815a6fb3fa1599f581ffb9a5e85fad313c1d
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 7b7ffc2a07cbaa556b4a75a6da50e73f4c138ea7
+  hermes-engine: 50e36d664adc3637672d46bdb6b6bec1a23fbd0b
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3079,76 +3087,76 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: 06e57a11be6128124a3c7cbfceb09b78f6c9ffc2
-  RCTRequired: 843cc1fe500b0ba58512287c5116e31a45181bca
-  RCTTypeSafety: 71eeceddb7e708c224909ba99c37a145c98c02a7
+  RCTDeprecation: ff787f6c860a1b97dd1bc27264b61d23ad1994da
+  RCTRequired: 664eb8399ed8a83e26ab65af7c2ad390f7e61696
+  RCTTypeSafety: a5cf7a7e80baf972e331dc028e5d5c19bb2535a4
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  React: d24621fc58bfcf5015e3286eac7b76c05040d914
-  React-callinvoker: f36300fae0e5d711e6b9991976f64ae0cb8fad3a
-  React-Core: f284fdea10a4778b736eaa065769a2b843b530f0
-  React-CoreModules: 45ab4e286895a2312e036f5e48639bdc1a73902f
-  React-cxxreact: 7c6d58dd92feca44a013988f6282956b5f2b3229
-  React-debug: 3005e18d181d33277445c99e201d37f3114233b6
-  React-defaultsnativemodule: f78ad0be2080633d0c2dd5a48905fa556bc030a2
-  React-domnativemodule: 0686da969f67cb81b8555fb3123d1906f62d44f6
-  React-Fabric: 9e8e3acfa8c8daa36dd11c98d612c25c1e11ea59
-  React-FabricComponents: ff54b3fc511695d209a219162371d484d62dec9a
-  React-FabricImage: f1e3f9bd46068b1d5406484406c4897473756b68
-  React-featureflags: 4963e06d1885257e2d109d733837c39cfc97f836
-  React-featureflagsnativemodule: 8a91773c93c38b11bf6af402c9287155d69a1f86
-  React-graphics: da7f5a1e95962b39fb5fc02ea5c615231b4e5626
-  React-hermes: bd76cb1d809d7dd27c9ad31a7d663047e4864f92
-  React-idlecallbacksnativemodule: acb58fd1bf494f1331e3a8765a855a85942d573e
-  React-ImageManager: 251cb54baff0af00e88f96dc01e4d1ca795e2928
-  React-jserrorhandler: 74a5109317e35632dd26ffbb38243d1b5aaebed3
-  React-jsi: 904806629c68f61d6e128d19c0cee1e3605eceec
-  React-jsiexecutor: d4fab673c926d913d6e1530155378833462fde57
-  React-jsinspector: 85113ed82fd449942151731f1051d46a9e5b2830
-  React-jsinspectorcdp: 538cb3eea51969564d0d57e23de3039fb22c8d28
-  React-jsinspectornetwork: 0be7cd0206b62c86d22b864a3147d9bfcc020477
-  React-jsinspectortracing: 9c772ac4f0df8f2940a34185e6e0e67bf91148cf
-  React-jsitooling: ea0874c51c43798dc4a83feaf6ffa57b929cacdc
-  React-jsitracing: 9f866cdc3a7f8b8eda89b52c409934bc9f85903a
-  React-logger: 34f13c3effe44410ccf62b255fc12f085ac7d038
-  React-Mapbuffer: 0e9c84c9a8e55645a1f19ae14e79a761b843ddc2
-  React-microtasksnativemodule: 3302ad49a9b619ca411acfca32534f3696894b95
-  React-NativeModulesApple: db5c62dfdee373bfacb3ce4fe86469a84d8047d9
-  React-oscompat: acc1d2b40174ce9a8c3d61912572a51ff76a94e6
-  React-perflogger: bb0332a02764f3c6570244635ac4318211514f3c
-  React-performancetimeline: e005006283a2acb109fe0821b75c35c1cfe6e769
-  React-RCTActionSheet: dad33af1be68c5e92d5d00482f5a42f49822531c
-  React-RCTAnimation: aa0e7ddf90d94a6f625b96fc29e9c58d9bb1c449
-  React-RCTAppDelegate: b9b009eafeb778a7a4cd877614a505ea926d6d9b
-  React-RCTBlob: 14655d7b0ef157dd76d26db1fd75c4d7b92a2692
-  React-RCTFabric: 4e63c60c2944bf92d4a07fa61b2a9176f013b73c
-  React-RCTFBReactNativeSpec: 85e9189f245531263a4a3995f225def0045ef998
-  React-RCTImage: 379dc52f16dc25fe9ab843053eb785461b0ffcb5
-  React-RCTLinking: 833b53827195f23a639bebe64e048497edd28a04
-  React-RCTNetwork: e005e7b11632bb1dfcc1b13e79f11d8d9bc531d9
-  React-RCTRuntime: ef7c4c62318500ed20c02624152823fe6b1d0727
-  React-RCTSettings: ebe3edb605bade8c0bde36f51a75d95e96a2ef81
-  React-RCTText: ba698614a19a41249036227b52213f6f8a982ec3
-  React-RCTVibration: 4385bc7b39e2a435933d6447eb37f54e099a00be
-  React-rendererconsistency: 103d24d9fd9eed1760f0874edfbdc4b98288a20b
-  React-renderercss: 4841823f6d3bcc65fdbaf00906b17bee7415d598
-  React-rendererdebug: 9d95f3e58b504e4fa28798caa7c1e40cd5fc6f4a
-  React-rncore: c555e70ebd3dc73ebc494ce4e30cbaa381fa5731
-  React-RuntimeApple: 8033fb3a15d4234d92612aa293bdd358f7897bc5
-  React-RuntimeCore: ba41b7e036428a80789e755de7cbdfcffaaac973
-  React-runtimeexecutor: 52df6be38a17311756f9fbb39b9bb055f4bd01c2
-  React-RuntimeHermes: 996d88f40374434c31a859d888dff541c277cd60
-  React-runtimescheduler: 5eacdcd1db313e2d6950fb8872cc8038327d2b31
-  React-timing: d44a981781952fe0ac6dac355473b2248700cdf1
-  React-utils: 81dcddf4ae56d8defae035f0e4500572321a7fbd
-  ReactAppDependencyProvider: 8b6a181160ae9a814f6a7f447921be2fa962b1b4
-  ReactCodegen: 97b98aa4cf05d5fd4c9c035bf51792bb3f180d13
-  ReactCommon: e69175d0efd16afee3d7d43e95dc714966c2ca3d
+  React: 606d4dccbcf29aec4dc84a7921405a28e1701a22
+  React-callinvoker: 0e13bd3c039df9ceef04f7381a81f017655c8361
+  React-Core: 701ad54ae468c2ca1e4869d659b30ebfee30ac77
+  React-CoreModules: 99d3515898255378fa2d6fc906b6dca093d280c4
+  React-cxxreact: 3410a1edbe15936bcf8eae61a546af1bec06ed98
+  React-debug: a9e91845f3670c3a19249f52919f0488b7842cf7
+  React-defaultsnativemodule: 8fad7c7173d6133d15b1532251df550d0d1c1f87
+  React-domnativemodule: 1da1f2bc921a9e4652918f37285c3830f561c86b
+  React-Fabric: e6f729f372f959bda89268c2c921fac55a9579dc
+  React-FabricComponents: f2ab7d78be2ea1dd06a7d8d606f5740cd1f54041
+  React-FabricImage: 220e8ce3ccdb483fd4283d8b21839676e8b88e27
+  React-featureflags: b64383c3268d03c3fab25c03a5c7e5fab0931a55
+  React-featureflagsnativemodule: 4c7b5cbe887d120a1797f65e6676fe9e1f9396ea
+  React-graphics: 4031c43a78b816dc1043dca24dfabf1d2622df9a
+  React-hermes: dc21a35794633bf2aef73645d273f5ee3bdf777a
+  React-idlecallbacksnativemodule: 9d6ea7839e347ffd3791315ba418370421d6c7c7
+  React-ImageManager: b743a715eca9abbf69fbd50732315565c9eb3863
+  React-jserrorhandler: 850fe8285385ffa783cc73e5e2eda8ddcb84e147
+  React-jsi: ea8a33b23165395610436c8f0d715e2c3bbcec7e
+  React-jsiexecutor: 0fb247eca0908176917380e1e1b75339f52a0c72
+  React-jsinspector: dcfc9ee7f2610ff05aa8f66fc8203cf7be875d0e
+  React-jsinspectorcdp: 6803046f78af0b3caace9002e28b0ca1fd97c1c4
+  React-jsinspectornetwork: b25ef98ec036aa1b454ebc904b983059e1ebc6e7
+  React-jsinspectortracing: 777ae30cf41f6305ffc509e53bef86bb1027395f
+  React-jsitooling: 568f4974066f14597084df606a6ad79fa52715b6
+  React-jsitracing: 47cb4a6c4b3c5e2d1d32ff4880d74d5faf58423c
+  React-logger: b69e65dc60f768e5509ac0cc27a360124bf70478
+  React-Mapbuffer: b48f9f3311fd0ec0f7a5dc39d707eff521fb5f38
+  React-microtasksnativemodule: d8568d0485a350c720c061ae835e09fc88c28715
+  React-NativeModulesApple: f10596688a03af66804cfbe61792be24a7888da8
+  React-oscompat: 7c0a341cc31e350da71ddf2e46de0a845d1d1626
+  React-perflogger: 4cc44451f694d6205f47bd8d5d87c9c862c3335c
+  React-performancetimeline: a81afec7aba50bdb80e5a692b03eff2dc499fe37
+  React-RCTActionSheet: 99864bd8422649219f24eca9a51445e698b70b8e
+  React-RCTAnimation: 7cb99a851a514673a1e48ca5fcbdee7c7c760da1
+  React-RCTAppDelegate: cd3bc49cec7cef167e920d5e54194d161cd8ab6d
+  React-RCTBlob: c96068eb67bf4a587f279db91c6948fc761826b9
+  React-RCTFabric: ca43b2e7bf026a8898a4eea81e9306786a892065
+  React-RCTFBReactNativeSpec: 96df6e569ad40c52f286762a59d7a96644567f5b
+  React-RCTImage: c40e65f565882df880c4f8994940c8b070923239
+  React-RCTLinking: 88992a3fb7c8caa868a2fc3489b26741e75ac5b5
+  React-RCTNetwork: 89c9222b388d90229511cc974abee608ac9c1221
+  React-RCTRuntime: 8a0222f21dacd0946aaff43976a06bd082e49e42
+  React-RCTSettings: 9e7a5f4262523dee5a1f9b0fd1e674b2a11bd7db
+  React-RCTText: 67f2955faca189ff85c3c5686505be9526df5461
+  React-RCTVibration: e4fe5861cee22c972672d29da4cdf24b6313e01d
+  React-rendererconsistency: a4db9bb060c65bce8ae83d936ed0719696055bd2
+  React-renderercss: 77c768faf43570d50e3657b97ce1a4c4614012d6
+  React-rendererdebug: 460dacb65d9ec58ba44e5c936b89e58530dd2a06
+  React-rncore: 322add36430c38049067a5d365f166256975391f
+  React-RuntimeApple: 9a7b848f3ea1b2aa6eefb0e42a5e113ed9b47f3d
+  React-RuntimeCore: d9feb0e71b045780372d72b9fd0e4326c2ee97d8
+  React-runtimeexecutor: 49ea276161508d50b3486c385e1ca7972d1699f5
+  React-RuntimeHermes: 31f857c04fda874cefef4dfbd1c8b0d234c4d606
+  React-runtimescheduler: 3cb2ab6622f9580b237a110350804933f8aec680
+  React-timing: a275a1c2e6112dba17f8f7dd496d439213bbea0d
+  React-utils: 257f8c08cb0559e458a9a9254967058434198ced
+  ReactAppDependencyProvider: cd55f820247d424280ae0b94e1ffb38963410c01
+  ReactCodegen: 2ce99436c37a92fa1b1c34979f1de388cc068587
+  ReactCommon: 658874decaf8c4fd76cfa3a878b94a869db85b1c
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: c8798357f928802015a217ccd2fe692b61a090c2
+  Yoga: 0c4b7d2aacc910a1f702694fa86be830386f4ceb
 
 PODFILE CHECKSUM: 870fa397ae4619d927d79738cdc4b86a76b46e38
 

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -18,7 +18,7 @@
     "native-component-list": "*",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.80.0-rc.5"
+    "react-native": "0.80.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -30,7 +30,7 @@
     "native-component-list": "*",
     "react-native-gesture-handler": "~2.24.0",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.5",
+    "react-native": "0.80.0",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "4.9.2"
   },

--- a/apps/paper-tester/ios/Podfile.lock
+++ b/apps/paper-tester/ios/Podfile.lock
@@ -329,7 +329,7 @@ PODS:
     - ExpoModulesCore
   - ExpoFont (13.3.1):
     - ExpoModulesCore
-  - ExpoImage (2.1.7):
+  - ExpoImage (2.3.0):
     - ExpoModulesCore
     - libavif/libdav1d
     - SDWebImage (~> 5.21.0)
@@ -413,12 +413,20 @@ PODS:
   - EXUpdatesInterface (1.1.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.80.0-rc.5)
+  - FBLazyVector (0.80.0)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.80.0-rc.5):
-    - hermes-engine/Pre-built (= 0.80.0-rc.5)
-  - hermes-engine/Pre-built (0.80.0-rc.5)
+  - hermes-engine (0.80.0):
+    - hermes-engine/cdp (= 0.80.0)
+    - hermes-engine/Hermes (= 0.80.0)
+    - hermes-engine/inspector (= 0.80.0)
+    - hermes-engine/inspector_chrome (= 0.80.0)
+    - hermes-engine/Public (= 0.80.0)
+  - hermes-engine/cdp (0.80.0)
+  - hermes-engine/Hermes (0.80.0)
+  - hermes-engine/inspector (0.80.0)
+  - hermes-engine/inspector_chrome (0.80.0)
+  - hermes-engine/Public (0.80.0)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -455,28 +463,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.80.0-rc.5)
-  - RCTRequired (0.80.0-rc.5)
-  - RCTTypeSafety (0.80.0-rc.5):
-    - FBLazyVector (= 0.80.0-rc.5)
-    - RCTRequired (= 0.80.0-rc.5)
-    - React-Core (= 0.80.0-rc.5)
+  - RCTDeprecation (0.80.0)
+  - RCTRequired (0.80.0)
+  - RCTTypeSafety (0.80.0):
+    - FBLazyVector (= 0.80.0)
+    - RCTRequired (= 0.80.0)
+    - React-Core (= 0.80.0)
   - ReachabilitySwift (5.2.4)
-  - React (0.80.0-rc.5):
-    - React-Core (= 0.80.0-rc.5)
-    - React-Core/DevSupport (= 0.80.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.5)
-    - React-RCTActionSheet (= 0.80.0-rc.5)
-    - React-RCTAnimation (= 0.80.0-rc.5)
-    - React-RCTBlob (= 0.80.0-rc.5)
-    - React-RCTImage (= 0.80.0-rc.5)
-    - React-RCTLinking (= 0.80.0-rc.5)
-    - React-RCTNetwork (= 0.80.0-rc.5)
-    - React-RCTSettings (= 0.80.0-rc.5)
-    - React-RCTText (= 0.80.0-rc.5)
-    - React-RCTVibration (= 0.80.0-rc.5)
-  - React-callinvoker (0.80.0-rc.5)
-  - React-Core (0.80.0-rc.5):
+  - React (0.80.0):
+    - React-Core (= 0.80.0)
+    - React-Core/DevSupport (= 0.80.0)
+    - React-Core/RCTWebSocket (= 0.80.0)
+    - React-RCTActionSheet (= 0.80.0)
+    - React-RCTAnimation (= 0.80.0)
+    - React-RCTBlob (= 0.80.0)
+    - React-RCTImage (= 0.80.0)
+    - React-RCTLinking (= 0.80.0)
+    - React-RCTNetwork (= 0.80.0)
+    - React-RCTSettings (= 0.80.0)
+    - React-RCTText (= 0.80.0)
+    - React-RCTVibration (= 0.80.0)
+  - React-callinvoker (0.80.0)
+  - React-Core (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -486,7 +494,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.5)
+    - React-Core/Default (= 0.80.0)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -500,79 +508,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.80.0-rc.5)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.80.0-rc.5):
+  - React-Core/CoreModulesHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -596,7 +532,55 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.80.0-rc.5):
+  - React-Core/Default (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0)
+    - React-Core/RCTWebSocket (= 0.80.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -620,7 +604,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.80.0-rc.5):
+  - React-Core/RCTAnimationHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -644,7 +628,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.80.0-rc.5):
+  - React-Core/RCTBlobHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -668,7 +652,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.80.0-rc.5):
+  - React-Core/RCTImageHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -692,7 +676,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.80.0-rc.5):
+  - React-Core/RCTLinkingHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -716,7 +700,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.80.0-rc.5):
+  - React-Core/RCTNetworkHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -740,7 +724,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.80.0-rc.5):
+  - React-Core/RCTSettingsHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -764,7 +748,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.80.0-rc.5):
+  - React-Core/RCTTextHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -788,7 +772,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.80.0-rc.5):
+  - React-Core/RCTVibrationHeaders (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -798,7 +782,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.80.0-rc.5)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -812,7 +796,31 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.80.0-rc.5):
+  - React-Core/RCTWebSocket (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.80.0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -820,19 +828,19 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.80.0-rc.5)
-    - React-Core/CoreModulesHeaders (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - RCTTypeSafety (= 0.80.0)
+    - React-Core/CoreModulesHeaders (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.80.0-rc.5)
+    - React-RCTImage (= 0.80.0)
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.80.0-rc.5):
+  - React-cxxreact (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -841,19 +849,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-debug (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-debug (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
-    - React-runtimeexecutor (= 0.80.0-rc.5)
-    - React-timing (= 0.80.0-rc.5)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
+    - React-runtimeexecutor (= 0.80.0)
+    - React-timing (= 0.80.0)
     - SocketRocket
-  - React-debug (0.80.0-rc.5)
-  - React-defaultsnativemodule (0.80.0-rc.5):
+  - React-debug (0.80.0)
+  - React-defaultsnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -871,7 +879,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.80.0-rc.5):
+  - React-domnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -890,7 +898,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.80.0-rc.5):
+  - React-Fabric (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -904,22 +912,22 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.80.0-rc.5)
-    - React-Fabric/attributedstring (= 0.80.0-rc.5)
-    - React-Fabric/componentregistry (= 0.80.0-rc.5)
-    - React-Fabric/componentregistrynative (= 0.80.0-rc.5)
-    - React-Fabric/components (= 0.80.0-rc.5)
-    - React-Fabric/consistency (= 0.80.0-rc.5)
-    - React-Fabric/core (= 0.80.0-rc.5)
-    - React-Fabric/dom (= 0.80.0-rc.5)
-    - React-Fabric/imagemanager (= 0.80.0-rc.5)
-    - React-Fabric/leakchecker (= 0.80.0-rc.5)
-    - React-Fabric/mounting (= 0.80.0-rc.5)
-    - React-Fabric/observers (= 0.80.0-rc.5)
-    - React-Fabric/scheduler (= 0.80.0-rc.5)
-    - React-Fabric/telemetry (= 0.80.0-rc.5)
-    - React-Fabric/templateprocessor (= 0.80.0-rc.5)
-    - React-Fabric/uimanager (= 0.80.0-rc.5)
+    - React-Fabric/animations (= 0.80.0)
+    - React-Fabric/attributedstring (= 0.80.0)
+    - React-Fabric/componentregistry (= 0.80.0)
+    - React-Fabric/componentregistrynative (= 0.80.0)
+    - React-Fabric/components (= 0.80.0)
+    - React-Fabric/consistency (= 0.80.0)
+    - React-Fabric/core (= 0.80.0)
+    - React-Fabric/dom (= 0.80.0)
+    - React-Fabric/imagemanager (= 0.80.0)
+    - React-Fabric/leakchecker (= 0.80.0)
+    - React-Fabric/mounting (= 0.80.0)
+    - React-Fabric/observers (= 0.80.0)
+    - React-Fabric/scheduler (= 0.80.0)
+    - React-Fabric/telemetry (= 0.80.0)
+    - React-Fabric/templateprocessor (= 0.80.0)
+    - React-Fabric/uimanager (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -931,32 +939,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.80.0-rc.5):
+  - React-Fabric/animations (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -981,7 +964,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.80.0-rc.5):
+  - React-Fabric/attributedstring (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1006,7 +989,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.80.0-rc.5):
+  - React-Fabric/componentregistry (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1031,36 +1014,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0-rc.5)
-    - React-Fabric/components/root (= 0.80.0-rc.5)
-    - React-Fabric/components/scrollview (= 0.80.0-rc.5)
-    - React-Fabric/components/view (= 0.80.0-rc.5)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.80.0-rc.5):
+  - React-Fabric/componentregistrynative (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1085,7 +1039,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.80.0-rc.5):
+  - React-Fabric/components (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.80.0)
+    - React-Fabric/components/root (= 0.80.0)
+    - React-Fabric/components/scrollview (= 0.80.0)
+    - React-Fabric/components/view (= 0.80.0)
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1110,7 +1093,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.80.0-rc.5):
+  - React-Fabric/components/root (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1135,7 +1118,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.80.0-rc.5):
+  - React-Fabric/components/scrollview (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1162,7 +1170,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.80.0-rc.5):
+  - React-Fabric/consistency (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1187,7 +1195,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.80.0-rc.5):
+  - React-Fabric/core (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1212,7 +1220,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.80.0-rc.5):
+  - React-Fabric/dom (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1237,7 +1245,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.80.0-rc.5):
+  - React-Fabric/imagemanager (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1262,7 +1270,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.80.0-rc.5):
+  - React-Fabric/leakchecker (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1287,7 +1295,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.80.0-rc.5):
+  - React-Fabric/mounting (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1312,7 +1320,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.80.0-rc.5):
+  - React-Fabric/observers (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1326,7 +1334,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.80.0-rc.5)
+    - React-Fabric/observers/events (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1338,7 +1346,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.80.0-rc.5):
+  - React-Fabric/observers/events (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1363,7 +1371,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.80.0-rc.5):
+  - React-Fabric/scheduler (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1390,7 +1398,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.80.0-rc.5):
+  - React-Fabric/telemetry (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1415,7 +1423,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.80.0-rc.5):
+  - React-Fabric/templateprocessor (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1440,7 +1448,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.80.0-rc.5):
+  - React-Fabric/uimanager (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1454,33 +1462,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.80.0-rc.5)
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/uimanager/consistency (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1493,7 +1475,33 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.80.0-rc.5):
+  - React-Fabric/uimanager/consistency (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-FabricComponents (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1508,8 +1516,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.80.0-rc.5)
-    - React-FabricComponents/textlayoutmanager (= 0.80.0-rc.5)
+    - React-FabricComponents/components (= 0.80.0)
+    - React-FabricComponents/textlayoutmanager (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1522,7 +1530,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.80.0-rc.5):
+  - React-FabricComponents/components (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1537,15 +1545,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.80.0-rc.5)
-    - React-FabricComponents/components/iostextinput (= 0.80.0-rc.5)
-    - React-FabricComponents/components/modal (= 0.80.0-rc.5)
-    - React-FabricComponents/components/rncore (= 0.80.0-rc.5)
-    - React-FabricComponents/components/safeareaview (= 0.80.0-rc.5)
-    - React-FabricComponents/components/scrollview (= 0.80.0-rc.5)
-    - React-FabricComponents/components/text (= 0.80.0-rc.5)
-    - React-FabricComponents/components/textinput (= 0.80.0-rc.5)
-    - React-FabricComponents/components/unimplementedview (= 0.80.0-rc.5)
+    - React-FabricComponents/components/inputaccessory (= 0.80.0)
+    - React-FabricComponents/components/iostextinput (= 0.80.0)
+    - React-FabricComponents/components/modal (= 0.80.0)
+    - React-FabricComponents/components/rncore (= 0.80.0)
+    - React-FabricComponents/components/safeareaview (= 0.80.0)
+    - React-FabricComponents/components/scrollview (= 0.80.0)
+    - React-FabricComponents/components/text (= 0.80.0)
+    - React-FabricComponents/components/textinput (= 0.80.0)
+    - React-FabricComponents/components/unimplementedview (= 0.80.0)
     - React-featureflags
     - React-graphics
     - React-hermes
@@ -1558,61 +1566,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.80.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/modal (0.80.0-rc.5):
+  - React-FabricComponents/components/inputaccessory (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1639,7 +1593,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.80.0-rc.5):
+  - React-FabricComponents/components/iostextinput (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1666,7 +1620,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.80.0-rc.5):
+  - React-FabricComponents/components/modal (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1693,7 +1647,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.80.0-rc.5):
+  - React-FabricComponents/components/rncore (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1720,7 +1674,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.80.0-rc.5):
+  - React-FabricComponents/components/safeareaview (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1747,7 +1701,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.80.0-rc.5):
+  - React-FabricComponents/components/scrollview (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1774,7 +1728,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.80.0-rc.5):
+  - React-FabricComponents/components/text (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1801,7 +1755,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.80.0-rc.5):
+  - React-FabricComponents/components/textinput (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1828,7 +1782,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.80.0-rc.5):
+  - React-FabricComponents/components/unimplementedview (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1837,22 +1791,76 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.80.0-rc.5)
-    - RCTTypeSafety (= 0.80.0-rc.5)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.80.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.80.0)
+    - RCTTypeSafety (= 0.80.0)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-hermes
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.5)
+    - React-jsiexecutor (= 0.80.0)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.80.0-rc.5):
+  - React-featureflags (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1861,7 +1869,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.80.0-rc.5):
+  - React-featureflagsnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1877,7 +1885,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.80.0-rc.5):
+  - React-graphics (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1891,7 +1899,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.80.0-rc.5):
+  - React-hermes (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1900,16 +1908,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.5)
+    - React-cxxreact (= 0.80.0)
     - React-jsi
-    - React-jsiexecutor (= 0.80.0-rc.5)
+    - React-jsiexecutor (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.5)
+    - React-perflogger (= 0.80.0)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.80.0-rc.5):
+  - React-idlecallbacksnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1925,7 +1933,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.80.0-rc.5):
+  - React-ImageManager (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1940,7 +1948,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.80.0-rc.5):
+  - React-jserrorhandler (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1955,7 +1963,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.80.0-rc.5):
+  - React-jsi (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1965,7 +1973,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.80.0-rc.5):
+  - React-jsiexecutor (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1974,14 +1982,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.5)
+    - React-perflogger (= 0.80.0)
     - SocketRocket
-  - React-jsinspector (0.80.0-rc.5):
+  - React-jsinspector (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1995,10 +2003,10 @@ PODS:
     - React-jsinspectorcdp
     - React-jsinspectornetwork
     - React-jsinspectortracing
-    - React-perflogger (= 0.80.0-rc.5)
-    - React-runtimeexecutor (= 0.80.0-rc.5)
+    - React-perflogger (= 0.80.0)
+    - React-runtimeexecutor (= 0.80.0)
     - SocketRocket
-  - React-jsinspectorcdp (0.80.0-rc.5):
+  - React-jsinspectorcdp (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2007,7 +2015,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.80.0-rc.5):
+  - React-jsinspectornetwork (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2017,7 +2025,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-jsinspectorcdp
     - SocketRocket
-  - React-jsinspectortracing (0.80.0-rc.5):
+  - React-jsinspectortracing (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2027,7 +2035,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-oscompat
     - SocketRocket
-  - React-jsitooling (0.80.0-rc.5):
+  - React-jsitooling (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2035,15 +2043,15 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - SocketRocket
-  - React-jsitracing (0.80.0-rc.5):
+  - React-jsitracing (0.80.0):
     - React-jsi
-  - React-logger (0.80.0-rc.5):
+  - React-logger (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2052,7 +2060,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.80.0-rc.5):
+  - React-Mapbuffer (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2062,7 +2070,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.80.0-rc.5):
+  - React-microtasksnativemodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2077,7 +2085,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-NativeModulesApple (0.80.0-rc.5):
+  - React-NativeModulesApple (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2098,8 +2106,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.80.0-rc.5)
-  - React-perflogger (0.80.0-rc.5):
+  - React-oscompat (0.80.0)
+  - React-perflogger (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2108,7 +2116,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.80.0-rc.5):
+  - React-performancetimeline (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2121,9 +2129,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.80.0-rc.5):
-    - React-Core/RCTActionSheetHeaders (= 0.80.0-rc.5)
-  - React-RCTAnimation (0.80.0-rc.5):
+  - React-RCTActionSheet (0.80.0):
+    - React-Core/RCTActionSheetHeaders (= 0.80.0)
+  - React-RCTAnimation (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2139,7 +2147,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.80.0-rc.5):
+  - React-RCTAppDelegate (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2172,7 +2180,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.80.0-rc.5):
+  - React-RCTBlob (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2191,7 +2199,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.80.0-rc.5):
+  - React-RCTFabric (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2225,7 +2233,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.80.0-rc.5):
+  - React-RCTFBReactNativeSpec (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2243,7 +2251,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCommon
     - SocketRocket
-  - React-RCTImage (0.80.0-rc.5):
+  - React-RCTImage (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2259,14 +2267,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.80.0-rc.5):
-    - React-Core/RCTLinkingHeaders (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
+  - React-RCTLinking (0.80.0):
+    - React-Core/RCTLinkingHeaders (= 0.80.0)
+    - React-jsi (= 0.80.0)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.5)
-  - React-RCTNetwork (0.80.0-rc.5):
+    - ReactCommon/turbomodule/core (= 0.80.0)
+  - React-RCTNetwork (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2284,7 +2292,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.80.0-rc.5):
+  - React-RCTRuntime (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2304,7 +2312,7 @@ PODS:
     - React-RuntimeCore
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.80.0-rc.5):
+  - React-RCTSettings (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2319,10 +2327,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.80.0-rc.5):
-    - React-Core/RCTTextHeaders (= 0.80.0-rc.5)
+  - React-RCTText (0.80.0):
+    - React-Core/RCTTextHeaders (= 0.80.0)
     - Yoga
-  - React-RCTVibration (0.80.0-rc.5):
+  - React-RCTVibration (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2336,11 +2344,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.80.0-rc.5)
-  - React-renderercss (0.80.0-rc.5):
+  - React-rendererconsistency (0.80.0)
+  - React-renderercss (0.80.0):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.80.0-rc.5):
+  - React-rendererdebug (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2350,8 +2358,8 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-rncore (0.80.0-rc.5)
-  - React-RuntimeApple (0.80.0-rc.5):
+  - React-rncore (0.80.0)
+  - React-RuntimeApple (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2380,7 +2388,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.80.0-rc.5):
+  - React-RuntimeCore (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2403,9 +2411,9 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.80.0-rc.5):
-    - React-jsi (= 0.80.0-rc.5)
-  - React-RuntimeHermes (0.80.0-rc.5):
+  - React-runtimeexecutor (0.80.0):
+    - React-jsi (= 0.80.0)
+  - React-RuntimeHermes (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2425,7 +2433,7 @@ PODS:
     - React-RuntimeCore
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.80.0-rc.5):
+  - React-runtimescheduler (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2448,8 +2456,8 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.80.0-rc.5)
-  - React-utils (0.80.0-rc.5):
+  - React-timing (0.80.0)
+  - React-utils (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2460,11 +2468,11 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-hermes
-    - React-jsi (= 0.80.0-rc.5)
+    - React-jsi (= 0.80.0)
     - SocketRocket
-  - ReactAppDependencyProvider (0.80.0-rc.5):
+  - ReactAppDependencyProvider (0.80.0):
     - ReactCodegen
-  - ReactCodegen (0.80.0-rc.5):
+  - ReactCodegen (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2491,7 +2499,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.80.0-rc.5):
+  - ReactCommon (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2499,9 +2507,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.80.0-rc.5)
+    - ReactCommon/turbomodule (= 0.80.0)
     - SocketRocket
-  - ReactCommon/turbomodule (0.80.0-rc.5):
+  - ReactCommon/turbomodule (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2510,15 +2518,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
-    - ReactCommon/turbomodule/bridging (= 0.80.0-rc.5)
-    - ReactCommon/turbomodule/core (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
+    - ReactCommon/turbomodule/bridging (= 0.80.0)
+    - ReactCommon/turbomodule/core (= 0.80.0)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.80.0-rc.5):
+  - ReactCommon/turbomodule/bridging (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2527,13 +2535,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-cxxreact (= 0.80.0)
+    - React-jsi (= 0.80.0)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.80.0-rc.5):
+  - ReactCommon/turbomodule/core (0.80.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2542,14 +2550,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.80.0-rc.5)
-    - React-cxxreact (= 0.80.0-rc.5)
-    - React-debug (= 0.80.0-rc.5)
-    - React-featureflags (= 0.80.0-rc.5)
-    - React-jsi (= 0.80.0-rc.5)
-    - React-logger (= 0.80.0-rc.5)
-    - React-perflogger (= 0.80.0-rc.5)
-    - React-utils (= 0.80.0-rc.5)
+    - React-callinvoker (= 0.80.0)
+    - React-cxxreact (= 0.80.0)
+    - React-debug (= 0.80.0)
+    - React-featureflags (= 0.80.0)
+    - React-jsi (= 0.80.0)
+    - React-logger (= 0.80.0)
+    - React-perflogger (= 0.80.0)
+    - React-utils (= 0.80.0)
     - SocketRocket
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
@@ -2896,7 +2904,7 @@ SPEC CHECKSUMS:
   ExpoCamera: e88fc30631e63e5504ce19d52c563a6ec49e17d2
   ExpoFileSystem: 3a98ca2a6f13674ecfd97327d1b44a8ace444cbd
   ExpoFont: 312c73403bbd4f98e1d6a5330641a56292583cd2
-  ExpoImage: ef8b25fddd3613a0bbdb2936d0583bc6588197dd
+  ExpoImage: 23fd11d3f2c4b04dc0b5e97fb41e9ead278bd0c8
   ExpoKeepAwake: e8dedc115d9f6f24b153ccd2d1d8efcdfd68a527
   ExpoLinearGradient: 42e58f6db5ebc20b6fbbf7d31013264644ab12a4
   ExpoModulesCore: e39be8db1df3e0b6194d41de40ac9b3bfe9a6eb9
@@ -2906,84 +2914,84 @@ SPEC CHECKSUMS:
   EXUpdates: 7940d9eb92ebfb648aba35bc6d5e3fc132691311
   EXUpdatesInterface: 64f35449b8ef89ce08cdd8952a4d119b5de6821d
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: 04f59172f2d1bc4c8afd36bbff2485df293fab12
+  FBLazyVector: 778b815a6fb3fa1599f581ffb9a5e85fad313c1d
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 7b7ffc2a07cbaa556b4a75a6da50e73f4c138ea7
+  hermes-engine: 50e36d664adc3637672d46bdb6b6bec1a23fbd0b
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: 06e57a11be6128124a3c7cbfceb09b78f6c9ffc2
-  RCTRequired: 843cc1fe500b0ba58512287c5116e31a45181bca
-  RCTTypeSafety: 71eeceddb7e708c224909ba99c37a145c98c02a7
+  RCTDeprecation: ff787f6c860a1b97dd1bc27264b61d23ad1994da
+  RCTRequired: 664eb8399ed8a83e26ab65af7c2ad390f7e61696
+  RCTTypeSafety: a5cf7a7e80baf972e331dc028e5d5c19bb2535a4
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: d24621fc58bfcf5015e3286eac7b76c05040d914
-  React-callinvoker: f36300fae0e5d711e6b9991976f64ae0cb8fad3a
-  React-Core: f284fdea10a4778b736eaa065769a2b843b530f0
-  React-CoreModules: 45ab4e286895a2312e036f5e48639bdc1a73902f
-  React-cxxreact: 7c6d58dd92feca44a013988f6282956b5f2b3229
-  React-debug: 3005e18d181d33277445c99e201d37f3114233b6
-  React-defaultsnativemodule: f78ad0be2080633d0c2dd5a48905fa556bc030a2
-  React-domnativemodule: 0686da969f67cb81b8555fb3123d1906f62d44f6
-  React-Fabric: 9e8e3acfa8c8daa36dd11c98d612c25c1e11ea59
-  React-FabricComponents: ff54b3fc511695d209a219162371d484d62dec9a
-  React-FabricImage: f1e3f9bd46068b1d5406484406c4897473756b68
-  React-featureflags: 4963e06d1885257e2d109d733837c39cfc97f836
-  React-featureflagsnativemodule: 8a91773c93c38b11bf6af402c9287155d69a1f86
-  React-graphics: da7f5a1e95962b39fb5fc02ea5c615231b4e5626
-  React-hermes: bd76cb1d809d7dd27c9ad31a7d663047e4864f92
-  React-idlecallbacksnativemodule: acb58fd1bf494f1331e3a8765a855a85942d573e
-  React-ImageManager: 251cb54baff0af00e88f96dc01e4d1ca795e2928
-  React-jserrorhandler: 74a5109317e35632dd26ffbb38243d1b5aaebed3
-  React-jsi: 904806629c68f61d6e128d19c0cee1e3605eceec
-  React-jsiexecutor: d4fab673c926d913d6e1530155378833462fde57
-  React-jsinspector: 85113ed82fd449942151731f1051d46a9e5b2830
-  React-jsinspectorcdp: 538cb3eea51969564d0d57e23de3039fb22c8d28
-  React-jsinspectornetwork: 0be7cd0206b62c86d22b864a3147d9bfcc020477
-  React-jsinspectortracing: 9c772ac4f0df8f2940a34185e6e0e67bf91148cf
-  React-jsitooling: ea0874c51c43798dc4a83feaf6ffa57b929cacdc
-  React-jsitracing: 9f866cdc3a7f8b8eda89b52c409934bc9f85903a
-  React-logger: 34f13c3effe44410ccf62b255fc12f085ac7d038
-  React-Mapbuffer: 0e9c84c9a8e55645a1f19ae14e79a761b843ddc2
-  React-microtasksnativemodule: 3302ad49a9b619ca411acfca32534f3696894b95
-  React-NativeModulesApple: db5c62dfdee373bfacb3ce4fe86469a84d8047d9
-  React-oscompat: acc1d2b40174ce9a8c3d61912572a51ff76a94e6
-  React-perflogger: bb0332a02764f3c6570244635ac4318211514f3c
-  React-performancetimeline: e005006283a2acb109fe0821b75c35c1cfe6e769
-  React-RCTActionSheet: dad33af1be68c5e92d5d00482f5a42f49822531c
-  React-RCTAnimation: aa0e7ddf90d94a6f625b96fc29e9c58d9bb1c449
-  React-RCTAppDelegate: 83f593bfa5364adecc0ed4c982b6e94b5d03a04a
-  React-RCTBlob: 14655d7b0ef157dd76d26db1fd75c4d7b92a2692
-  React-RCTFabric: b219b7dc7b27fdb5c3c4f5cc12c2a6f2910dc4f4
-  React-RCTFBReactNativeSpec: f7d644339cddab9ae50411de570465a0fd9c1657
-  React-RCTImage: 379dc52f16dc25fe9ab843053eb785461b0ffcb5
-  React-RCTLinking: 833b53827195f23a639bebe64e048497edd28a04
-  React-RCTNetwork: e005e7b11632bb1dfcc1b13e79f11d8d9bc531d9
-  React-RCTRuntime: c6425b7fb3bb18013b46cd60a294c1afba61ecd7
-  React-RCTSettings: ebe3edb605bade8c0bde36f51a75d95e96a2ef81
-  React-RCTText: ba698614a19a41249036227b52213f6f8a982ec3
-  React-RCTVibration: 4385bc7b39e2a435933d6447eb37f54e099a00be
-  React-rendererconsistency: 103d24d9fd9eed1760f0874edfbdc4b98288a20b
-  React-renderercss: 4841823f6d3bcc65fdbaf00906b17bee7415d598
-  React-rendererdebug: 9d95f3e58b504e4fa28798caa7c1e40cd5fc6f4a
-  React-rncore: c555e70ebd3dc73ebc494ce4e30cbaa381fa5731
-  React-RuntimeApple: 8033fb3a15d4234d92612aa293bdd358f7897bc5
-  React-RuntimeCore: ba41b7e036428a80789e755de7cbdfcffaaac973
-  React-runtimeexecutor: 52df6be38a17311756f9fbb39b9bb055f4bd01c2
-  React-RuntimeHermes: 996d88f40374434c31a859d888dff541c277cd60
-  React-runtimescheduler: 5eacdcd1db313e2d6950fb8872cc8038327d2b31
-  React-timing: d44a981781952fe0ac6dac355473b2248700cdf1
-  React-utils: 81dcddf4ae56d8defae035f0e4500572321a7fbd
-  ReactAppDependencyProvider: 8b6a181160ae9a814f6a7f447921be2fa962b1b4
-  ReactCodegen: 97b98aa4cf05d5fd4c9c035bf51792bb3f180d13
-  ReactCommon: e69175d0efd16afee3d7d43e95dc714966c2ca3d
+  React: 606d4dccbcf29aec4dc84a7921405a28e1701a22
+  React-callinvoker: 0e13bd3c039df9ceef04f7381a81f017655c8361
+  React-Core: 701ad54ae468c2ca1e4869d659b30ebfee30ac77
+  React-CoreModules: 99d3515898255378fa2d6fc906b6dca093d280c4
+  React-cxxreact: 3410a1edbe15936bcf8eae61a546af1bec06ed98
+  React-debug: a9e91845f3670c3a19249f52919f0488b7842cf7
+  React-defaultsnativemodule: 8fad7c7173d6133d15b1532251df550d0d1c1f87
+  React-domnativemodule: 1da1f2bc921a9e4652918f37285c3830f561c86b
+  React-Fabric: e6f729f372f959bda89268c2c921fac55a9579dc
+  React-FabricComponents: f2ab7d78be2ea1dd06a7d8d606f5740cd1f54041
+  React-FabricImage: 220e8ce3ccdb483fd4283d8b21839676e8b88e27
+  React-featureflags: b64383c3268d03c3fab25c03a5c7e5fab0931a55
+  React-featureflagsnativemodule: 4c7b5cbe887d120a1797f65e6676fe9e1f9396ea
+  React-graphics: 4031c43a78b816dc1043dca24dfabf1d2622df9a
+  React-hermes: dc21a35794633bf2aef73645d273f5ee3bdf777a
+  React-idlecallbacksnativemodule: 9d6ea7839e347ffd3791315ba418370421d6c7c7
+  React-ImageManager: b743a715eca9abbf69fbd50732315565c9eb3863
+  React-jserrorhandler: 850fe8285385ffa783cc73e5e2eda8ddcb84e147
+  React-jsi: ea8a33b23165395610436c8f0d715e2c3bbcec7e
+  React-jsiexecutor: 0fb247eca0908176917380e1e1b75339f52a0c72
+  React-jsinspector: dcfc9ee7f2610ff05aa8f66fc8203cf7be875d0e
+  React-jsinspectorcdp: 6803046f78af0b3caace9002e28b0ca1fd97c1c4
+  React-jsinspectornetwork: b25ef98ec036aa1b454ebc904b983059e1ebc6e7
+  React-jsinspectortracing: 777ae30cf41f6305ffc509e53bef86bb1027395f
+  React-jsitooling: 568f4974066f14597084df606a6ad79fa52715b6
+  React-jsitracing: 47cb4a6c4b3c5e2d1d32ff4880d74d5faf58423c
+  React-logger: b69e65dc60f768e5509ac0cc27a360124bf70478
+  React-Mapbuffer: b48f9f3311fd0ec0f7a5dc39d707eff521fb5f38
+  React-microtasksnativemodule: d8568d0485a350c720c061ae835e09fc88c28715
+  React-NativeModulesApple: f10596688a03af66804cfbe61792be24a7888da8
+  React-oscompat: 7c0a341cc31e350da71ddf2e46de0a845d1d1626
+  React-perflogger: 4cc44451f694d6205f47bd8d5d87c9c862c3335c
+  React-performancetimeline: a81afec7aba50bdb80e5a692b03eff2dc499fe37
+  React-RCTActionSheet: 99864bd8422649219f24eca9a51445e698b70b8e
+  React-RCTAnimation: 7cb99a851a514673a1e48ca5fcbdee7c7c760da1
+  React-RCTAppDelegate: 96f3e9b57518a28053e13e61b38e84f8c5735ddc
+  React-RCTBlob: c96068eb67bf4a587f279db91c6948fc761826b9
+  React-RCTFabric: 5083dbf43aec327f6feee050117dd43f469c8e12
+  React-RCTFBReactNativeSpec: 7fcc2e9f7a2da3dc840edfb6e058288f8c8a4932
+  React-RCTImage: c40e65f565882df880c4f8994940c8b070923239
+  React-RCTLinking: 88992a3fb7c8caa868a2fc3489b26741e75ac5b5
+  React-RCTNetwork: 89c9222b388d90229511cc974abee608ac9c1221
+  React-RCTRuntime: d0b738323fd15ec2013088f9c960ff526d749493
+  React-RCTSettings: 9e7a5f4262523dee5a1f9b0fd1e674b2a11bd7db
+  React-RCTText: 67f2955faca189ff85c3c5686505be9526df5461
+  React-RCTVibration: e4fe5861cee22c972672d29da4cdf24b6313e01d
+  React-rendererconsistency: a4db9bb060c65bce8ae83d936ed0719696055bd2
+  React-renderercss: 77c768faf43570d50e3657b97ce1a4c4614012d6
+  React-rendererdebug: 460dacb65d9ec58ba44e5c936b89e58530dd2a06
+  React-rncore: 322add36430c38049067a5d365f166256975391f
+  React-RuntimeApple: 9a7b848f3ea1b2aa6eefb0e42a5e113ed9b47f3d
+  React-RuntimeCore: d9feb0e71b045780372d72b9fd0e4326c2ee97d8
+  React-runtimeexecutor: 49ea276161508d50b3486c385e1ca7972d1699f5
+  React-RuntimeHermes: 31f857c04fda874cefef4dfbd1c8b0d234c4d606
+  React-runtimescheduler: 3cb2ab6622f9580b237a110350804933f8aec680
+  React-timing: a275a1c2e6112dba17f8f7dd496d439213bbea0d
+  React-utils: 257f8c08cb0559e458a9a9254967058434198ced
+  ReactAppDependencyProvider: cd55f820247d424280ae0b94e1ffb38963410c01
+  ReactCodegen: 2ce99436c37a92fa1b1c34979f1de388cc068587
+  ReactCommon: 658874decaf8c4fd76cfa3a878b94a869db85b1c
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: c8798357f928802015a217ccd2fe692b61a090c2
+  Yoga: 0c4b7d2aacc910a1f702694fa86be830386f4ceb
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 3804a87e56a668c985591eb93d940dc71b129e80

--- a/apps/paper-tester/ios/Podfile.lock
+++ b/apps/paper-tester/ios/Podfile.lock
@@ -417,16 +417,8 @@ PODS:
   - fmt (11.0.2)
   - glog (0.3.5)
   - hermes-engine (0.80.0):
-    - hermes-engine/cdp (= 0.80.0)
-    - hermes-engine/Hermes (= 0.80.0)
-    - hermes-engine/inspector (= 0.80.0)
-    - hermes-engine/inspector_chrome (= 0.80.0)
-    - hermes-engine/Public (= 0.80.0)
-  - hermes-engine/cdp (0.80.0)
-  - hermes-engine/Hermes (0.80.0)
-  - hermes-engine/inspector (0.80.0)
-  - hermes-engine/inspector_chrome (0.80.0)
-  - hermes-engine/Public (0.80.0)
+    - hermes-engine/Pre-built (= 0.80.0)
+  - hermes-engine/Pre-built (0.80.0)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -2917,7 +2909,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 778b815a6fb3fa1599f581ffb9a5e85fad313c1d
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 50e36d664adc3637672d46bdb6b6bec1a23fbd0b
+  hermes-engine: 7068e976238b29e97b3bafd09a994542af7d5c0b
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/apps/paper-tester/package.json
+++ b/apps/paper-tester/package.json
@@ -22,7 +22,7 @@
     "expo-video": "~2.1.9",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.80.0-rc.5",
+    "react-native": "0.80.0",
     "react-native-web": "~0.20.0"
   },
   "devDependencies": {

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -31,7 +31,7 @@
     "expo-speech": "~13.1.7",
     "expo-sqlite": "~15.2.10",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.5",
+    "react-native": "0.80.0",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "4.11.1",
     "react-native-webview": "13.13.5"

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -50,7 +50,7 @@
     "jasmine-core": "^2.4.1",
     "lodash": "^4.17.19",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.5",
+    "react-native": "0.80.0",
     "react-native-gesture-handler": "~2.24.0",
     "sinon": "^7.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "resolutions": {
-    "react-native": "0.80.0-rc.5",
+    "react-native": "0.80.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "@react-navigation/bottom-tabs": "7.3.10",

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### 💡 Others
 
+### ⚠️ Notices
+
+- Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 0.24.14 - 2025-06-04
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -56,7 +56,7 @@
     "@expo/spawn-async": "^1.7.2",
     "@expo/ws-tunnel": "^1.0.1",
     "@expo/xcpretty": "^4.3.0",
-    "@react-native/dev-middleware": "0.80.0-rc.5",
+    "@react-native/dev-middleware": "0.80.0",
     "@urql/core": "^5.0.6",
     "@urql/exchange-retry": "^1.3.0",
     "accepts": "^1.3.8",

--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 - Remove "Please" from warnings and errors ([#36862](https://github.com/expo/expo/pull/36862) by [@brentvatne](https://github.com/brentvatne))
 
+### ⚠️ Notices
+
+- Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 9.0.6 — 2025-05-06
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -42,7 +42,7 @@
     "@expo/config-types": "^53.0.4",
     "@expo/image-utils": "^0.7.4",
     "@expo/json-file": "^9.1.4",
-    "@react-native/normalize-colors": "0.80.0-rc.5",
+    "@react-native/normalize-colors": "0.80.0",
     "debug": "^4.3.1",
     "resolve-from": "^5.0.0",
     "semver": "^7.6.0",

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### 💡 Others
 
+### ⚠️ Notices
+
+- Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 13.2.0 - 2025-06-04
 
 ### 🎉 New features

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -55,7 +55,7 @@
     "@babel/plugin-transform-parameters": "^7.24.7",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
-    "@react-native/babel-preset": "0.80.0-rc.5",
+    "@react-native/babel-preset": "0.80.0",
     "babel-plugin-react-native-web": "~0.19.13",
     "babel-plugin-transform-flow-enums": "^0.0.2",
     "babel-plugin-syntax-hermes-parser": "^0.25.1",

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### 💡 Others
 
+### ⚠️ Notices
+
+- Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 5.1.12 - 2025-06-04
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -50,7 +50,7 @@
     "graphql": "^16.0.1",
     "graphql-request": "^3.6.1",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.5",
+    "react-native": "0.80.0",
     "react-query": "^3.34.16",
     "url": "^0.11.0"
   },

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### 💡 Others
 
+### ⚠️ Notices
+
+- Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 6.1.11 - 2025-06-04
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -59,7 +59,7 @@
     "expo-module-scripts": "^4.1.7",
     "fuse.js": "^6.4.6",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.5",
+    "react-native": "0.80.0",
     "url": "^0.11.0",
     "use-subscription": "^1.8.0"
   },

--- a/packages/expo-module-template/$package.json
+++ b/packages/expo-module-template/$package.json
@@ -28,7 +28,7 @@
     "@types/react": "~19.1.0",
     "expo-module-scripts": "^4.1.7",
     "expo": "~53.0.0",
-    "react-native": "0.80.0-rc.5"
+    "react-native": "0.80.0"
   },
   "peerDependencies": {
     "expo": "*",

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+### ⚠️ Notices
+
+- Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 4.2.5 - 2025-06-04
 
 ### 🐛 Bug fixes

--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/navigation-bar",
   "dependencies": {
-    "@react-native/normalize-colors": "0.80.0-rc.5",
+    "@react-native/normalize-colors": "0.80.0",
     "debug": "^4.3.2",
     "react-native-is-edge-to-edge": "^1.1.6",
     "react-native-edge-to-edge": "1.6.0"

--- a/packages/expo-system-ui/CHANGELOG.md
+++ b/packages/expo-system-ui/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+### ⚠️ Notices
+
+- Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 5.0.8 - 2025-06-04
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-system-ui/package.json
+++ b/packages/expo-system-ui/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/system-ui",
   "dependencies": {
-    "@react-native/normalize-colors": "0.80.0-rc.5",
+    "@react-native/normalize-colors": "0.80.0",
     "debug": "^4.3.2"
   },
   "jest": {

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+### ⚠️ Notices
+
+- Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 53.0.11 - 2025-06-08
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -92,7 +92,7 @@
   "lottie-react-native": "7.2.2",
   "react": "19.1.0",
   "react-dom": "19.1.0",
-  "react-native": "0.80.0-rc.5",
+  "react-native": "0.80.0",
   "react-native-web": "~0.20.0",
   "react-native-edge-to-edge": "1.6.0",
   "react-native-gesture-handler": "~2.24.0",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -97,7 +97,7 @@
     "expo-module-scripts": "^4.1.7",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.80.0-rc.5",
+    "react-native": "0.80.0",
     "web-streams-polyfill": "^3.3.2",
     "ws": "^8.18.0"
   },

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -14,7 +14,7 @@
     "expo": "~53.0.11",
     "expo-status-bar": "~2.2.3",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.5"
+    "react-native": "0.80.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -14,7 +14,7 @@
     "expo": "~53.0.11",
     "expo-status-bar": "~2.2.3",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.5"
+    "react-native": "0.80.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -14,7 +14,7 @@
     "expo": "~53.0.11",
     "expo-status-bar": "~2.2.3",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.5"
+    "react-native": "0.80.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -31,7 +31,7 @@
     "expo-web-browser": "~14.1.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.80.0-rc.5",
+    "react-native": "0.80.0",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-reanimated": "~3.18.0",
     "react-native-safe-area-context": "5.4.0",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "expo-web-browser": "~14.1.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.80.0-rc.5",
+    "react-native": "0.80.0",
     "react-native-reanimated": "~3.18.0",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3028,23 +3028,23 @@
   resolved "https://registry.yarnpkg.com/@react-native-segmented-control/segmented-control/-/segmented-control-2.5.7.tgz#7c91ef7dede8752796a234321fafa2c604fc82af"
   integrity sha512-l84YeVX8xAU3lvOJSvV4nK/NbGhIm2gBfveYolwaoCbRp+/SLXtc6mYrQmM9ScXNwU14mnzjQTpTHWl5YPnkzQ==
 
-"@react-native/assets-registry@0.80.0-rc.5":
-  version "0.80.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.80.0-rc.5.tgz#073ac859bcc4d12ccc39e578816f10dfc3d83941"
-  integrity sha512-7YfCs6lDuGML7HLa7SNXnoaFgqr0T1BFQE8M1UbGwzGJZMOj3PD0LzBDVjudtjO00xZONxtaQo6LDT3S0vEuLg==
+"@react-native/assets-registry@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.80.0.tgz#7c03e0cf07fdd9e4a54ce2bbe8ae49f48440d422"
+  integrity sha512-MlScsKAz99zoYghe5Rf5mUqsqz2rMB02640NxtPtBMSHNdGxxRlWu/pp1bFexDa1DYJwyIjnLgt3Z/Y90ikHfw==
 
-"@react-native/babel-plugin-codegen@0.80.0-rc.5":
-  version "0.80.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.80.0-rc.5.tgz#19aea432b9f954e1c5d0ca476b44c27880c8c093"
-  integrity sha512-B0FnnlxrC0k8e22clWT/6aT6yfhChaUAF67ntGnFt5UEjKYY858ahajE2ZMssaCNRUdsmawnxe8g1gGM863Vhg==
+"@react-native/babel-plugin-codegen@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.80.0.tgz#0515c34aca082cf629223abf02fa61e0f93ffa5e"
+  integrity sha512-LXd766LHCR/79WmhIg4zUB9jRosgw8xGJ1QnYOoef1rA7vCdubC23nhUxF+PJdfTdAl1cqX4u1dhZcjg6yXjRg==
   dependencies:
     "@babel/traverse" "^7.25.3"
-    "@react-native/codegen" "0.80.0-rc.5"
+    "@react-native/codegen" "0.80.0"
 
-"@react-native/babel-preset@0.80.0-rc.5":
-  version "0.80.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.80.0-rc.5.tgz#d143bd85516c80d4cde74cef2b64ff830f1a0ed4"
-  integrity sha512-omRiTV05AkHihhWiU1LjauVjK/gVf8Ia3w4GBQ0OUTaC7Tq2/aeP07wAyhjB3XQFy5RPmuHGtKb1tC6fS8H8cQ==
+"@react-native/babel-preset@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.80.0.tgz#6b5ad39fdf699928ade2fd62fdf2e24bceac34cd"
+  integrity sha512-ZgwbSOUPNKpIsZ6E0y3bncahh2vBf5V1URNV0tr9PBtu/LbGJ12nBKSH7gqrFdRzfEwKlhc0vP8p1oJt+A5mpw==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/plugin-proposal-export-default-from" "^7.24.7"
@@ -3087,15 +3087,15 @@
     "@babel/plugin-transform-typescript" "^7.25.2"
     "@babel/plugin-transform-unicode-regex" "^7.24.7"
     "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.80.0-rc.5"
+    "@react-native/babel-plugin-codegen" "0.80.0"
     babel-plugin-syntax-hermes-parser "0.28.1"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
 
-"@react-native/codegen@0.80.0-rc.5":
-  version "0.80.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.80.0-rc.5.tgz#f160ac91ea8db6a5d77cb41d76e7b1a0d8fdc51a"
-  integrity sha512-F3dGt9TBZ/7yG/0ZegUY+58jJigy6TUPTHLx/FXJmUDKSvGg3VYZVED5OSx1fOBiiSMs/pANs4DxwyQ6wiWF+A==
+"@react-native/codegen@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.80.0.tgz#119e53099281acd6fe3c515ca7bfd00ddcfcf05c"
+  integrity sha512-X9TsPgytoUkNrQjzAZh4dXa4AuouvYT0NzYyvnjw1ry4LESCZtKba+eY4x3+M30WPR52zjgu+UFL//14BSdCCA==
   dependencies:
     glob "^7.1.1"
     hermes-parser "0.28.1"
@@ -3103,12 +3103,12 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/community-cli-plugin@0.80.0-rc.5":
-  version "0.80.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.80.0-rc.5.tgz#b30bfeb2263fa98144cd6b76e6a34398bd286757"
-  integrity sha512-Fzpi7619G7X79BsGsMQmfLe1hWX028UbmypCfxarset+J04c5+bjUEJcCzB00P6SPhakZXj6D5MX3aXKF/TzaA==
+"@react-native/community-cli-plugin@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.80.0.tgz#58a8e4300addecb01dfc186c23b60e47ac3e6fb7"
+  integrity sha512-uadfVvzZfz5tGpqwslL12i+rELK9m6cLhtqICX0JQvS7Bu12PJwrozhKzEzIYwN9i3wl2dWrKDUr08izt7S9Iw==
   dependencies:
-    "@react-native/dev-middleware" "0.80.0-rc.5"
+    "@react-native/dev-middleware" "0.80.0"
     chalk "^4.0.0"
     debug "^4.4.0"
     invariant "^2.2.4"
@@ -3117,18 +3117,18 @@
     metro-core "^0.82.2"
     semver "^7.1.3"
 
-"@react-native/debugger-frontend@0.80.0-rc.5":
-  version "0.80.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.80.0-rc.5.tgz#0dbff7599dbbf81116d9dd5e5afa73de6ac2cc36"
-  integrity sha512-TvPYLckQ8adrJIVD5jbLGx2RyRsZMlzScV2spxMk+A4iF60RMXTzL+w9WmgrIhvI7MpElA5ASz7rDiNoqiRbdQ==
+"@react-native/debugger-frontend@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.80.0.tgz#ebdb36e73c0cb2eee52c97dcf17d78dbc1ca9689"
+  integrity sha512-lpu9Z3xtKUaKFvEcm5HSgo1KGfkDa/W3oZHn22Zy0WQ9MiOu2/ar1txgd1wjkoNiK/NethKcRdCN7mqnc6y2mA==
 
-"@react-native/dev-middleware@0.80.0-rc.5":
-  version "0.80.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.80.0-rc.5.tgz#412314422bc47d266b473c11939c84095212b720"
-  integrity sha512-/kR4741w0mB0F8V+ID6p/6Kkt4bXpqjXVItAjul1D412iw1fLr/I2UfiwNh4k7OoacVKa7U4hkuOhm0/3T8Hsw==
+"@react-native/dev-middleware@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.80.0.tgz#152b7c8f80a93b99ce6f5379855f4094afd71772"
+  integrity sha512-lLyTnJ687A5jF3fn8yR/undlCis3FG+N/apQ+Q0Lcl+GV6FsZs0U5H28YmL6lZtjOj4TLek6uGPMPmZasHx7cQ==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.80.0-rc.5"
+    "@react-native/debugger-frontend" "0.80.0"
     chrome-launcher "^0.15.2"
     chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
@@ -3139,30 +3139,30 @@
     serve-static "^1.16.2"
     ws "^6.2.3"
 
-"@react-native/gradle-plugin@0.80.0-rc.5":
-  version "0.80.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.80.0-rc.5.tgz#2c1fba2995c79e9cce5a13d7c8a0e27fcfa01fbf"
-  integrity sha512-jkSRnHDDYVZ7jzA4KuOZNnqlbIaUjPv/+glNcHB8w9Sqz3kLQdn8maQqxHVBeThPjnGfqrjey/wHM8LBCLqWTg==
+"@react-native/gradle-plugin@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.80.0.tgz#ec7ed5eb6c274068aa83b188b0192c584f1881ef"
+  integrity sha512-drmS68rabSMOuDD+YsAY2luNT8br82ycodSDORDqAg7yWQcieHMp4ZUOcdOi5iW+JCqobablT/b6qxcrBg+RaA==
 
-"@react-native/js-polyfills@0.80.0-rc.5":
-  version "0.80.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.80.0-rc.5.tgz#38a7ca122ab4a6cc6c00135016039c1aa4449f9a"
-  integrity sha512-es96lAeOWGA/8ZKynuCOGamv4Ev/jQNFm+oLzNnNt2xa7Zj/FEtViF3Ohx8cT65jMx2otHSj4dRjUTlzFACvrQ==
+"@react-native/js-polyfills@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.80.0.tgz#8016b6891955f61d20e989c50205ce0b3029ad01"
+  integrity sha512-dMX7IcBuwghySTgIeK8q03tYz/epg5ScGmJEfBQAciuhzMDMV1LBR/9wwdgD73EXM/133yC5A+TlHb3KQil4Ew==
 
-"@react-native/normalize-colors@0.80.0-rc.5":
-  version "0.80.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.80.0-rc.5.tgz#a9a290ae8c9aae34e87746a2978403e1376e825c"
-  integrity sha512-aRoXokvijZrBDXWniSWBR3k481HGtY5vldjkZ0GghlefAe2K4MZ+ZIMNRY4EVo8e8t+e/BTL+WaifxiRAFAN0A==
+"@react-native/normalize-colors@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.80.0.tgz#2a0f4346550c5ab18a2ec956112d483d802b3029"
+  integrity sha512-bJZDSopadjJxMDvysc634eTfLL4w7cAx5diPe14Ez5l+xcKjvpfofS/1Ja14DlgdMJhxGd03MTXlrxoWust3zg==
 
 "@react-native/normalize-colors@^0.74.1":
   version "0.74.88"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.74.88.tgz#46f4c7270c8e6853281d7dd966e0eb362068e41a"
   integrity sha512-He5oTwPBxvXrxJ91dZzpxR7P+VYmc9IkJfhuH8zUiU50ckrt+xWNjtVugPdUv4LuVjmZ36Vk2EX8bl1gVn2dVA==
 
-"@react-native/virtualized-lists@0.80.0-rc.5":
-  version "0.80.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.80.0-rc.5.tgz#1e38f38ca322db224b394a02937a932d8eab99b3"
-  integrity sha512-IBxXYoi5hrUfezO35SbkTRll+euUpBS64uB4VFAPk5tX2i950/hO+eN8BBIj3cxaC/RslPa0FH8UiEK1GluGLA==
+"@react-native/virtualized-lists@0.80.0":
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.80.0.tgz#6f2dc00a3e86f4bc9b34be538c18ca92c5b42dcb"
+  integrity sha512-d9zZdPS/ZRexVAkxo1eRp85U7XnnEpXA1ZpSomRKxBuStYKky1YohfEX5YD5MhphemKK24tT7JR4UhaLlmeX8Q==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -13202,19 +13202,19 @@ react-native-webview@13.13.5:
     escape-string-regexp "^4.0.0"
     invariant "2.2.4"
 
-react-native@0.80.0-rc.5:
-  version "0.80.0-rc.5"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.80.0-rc.5.tgz#9e498aae206517888dce03e52451e636b273a4dc"
-  integrity sha512-t0rG8QMlKBKWIRUpvcIHsVl6z3CgjfhmhCwOA7CGFZa6LjwPvfDT4vrrqLemv6yN8htD3rGAtFKl8Qu5AI1Gew==
+react-native@0.80.0, react-native@0.80.0-rc.5:
+  version "0.80.0"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.80.0.tgz#574bf976c1e03d27191100179a8e9ec0f19d42ef"
+  integrity sha512-b9K1ygb2MWCBtKAodKmE3UsbUuC29Pt4CrJMR0ocTA8k+8HJQTPleBPDNKL4/p0P01QO9aL/gZUddoxHempLow==
   dependencies:
     "@jest/create-cache-key-function" "^29.7.0"
-    "@react-native/assets-registry" "0.80.0-rc.5"
-    "@react-native/codegen" "0.80.0-rc.5"
-    "@react-native/community-cli-plugin" "0.80.0-rc.5"
-    "@react-native/gradle-plugin" "0.80.0-rc.5"
-    "@react-native/js-polyfills" "0.80.0-rc.5"
-    "@react-native/normalize-colors" "0.80.0-rc.5"
-    "@react-native/virtualized-lists" "0.80.0-rc.5"
+    "@react-native/assets-registry" "0.80.0"
+    "@react-native/codegen" "0.80.0"
+    "@react-native/community-cli-plugin" "0.80.0"
+    "@react-native/gradle-plugin" "0.80.0"
+    "@react-native/js-polyfills" "0.80.0"
+    "@react-native/normalize-colors" "0.80.0"
+    "@react-native/virtualized-lists" "0.80.0"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/37324

# How

- update package versions
  - `react-native  0.80.0-rc.5 -> 0.80.0`  
  - `@react-native/normalize-colors 0.80.0-rc.5 ->  0.80.0` 
  - `@react-native/babel-preset 0.80.0-rc.5 ->  0.80.0` 
  - `@react-native/dev-middleware 0.80.0-rc.5 ->  0.80.0`    

# Test Plan
 
bare-expo ios / android
fabric ios / android
ci passed

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
