### PR TITLE
[image][android] conditionally include Glide compiler when excludeAppGlideModule=false

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] Fix animation resuming by casting image to GifDrawable. ([#37363](https://github.com/expo/expo/pull/37363) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fixed contentPosition is not correct after switching theme. ([#37374](https://github.com/expo/expo/pull/37374) by [@kudo](https://github.com/kudo))
+- [Android] Make Glide compiler (`kapt "com.github.bumptech.glide:compiler"`) in the `expo-image` module conditional on the `excludeAppGlideModule` Gradle property. When `excludeAppGlideModule=true`, expo-image now omits its own annotation processing and stub `ExpoImageAppGlideModule.kt`, preventing duplicate `GeneratedAppGlideModuleImpl` conflicts in release builds. ([#37432](https://github.com/expo/expo/pull/37432) by [@antonhudz](https://github.com/antonhudz))
 
 ### 💡 Others
 

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -31,7 +31,9 @@ dependencies {
   implementation 'com.facebook.react:react-android'
 
   api "com.github.bumptech.glide:glide:${GLIDE_VERSION}"
-  kapt "com.github.bumptech.glide:compiler:${GLIDE_VERSION}"
+  if (!expoModule.safeExtGet("excludeAppGlideModule", false)) {
+      kapt "com.github.bumptech.glide:compiler:${GLIDE_VERSION}"
+  }
   api 'com.caverock:androidsvg-aar:1.4'
 
   implementation "com.github.penfeizhou.android.animation:glide-plugin:3.0.3"


### PR DESCRIPTION
# Why

When using expo-image alongside another library that defines its own @GlideModule, both modules run Glide’s annotation processor and emit a GeneratedAppGlideModuleImpl. This causes a dex merge failure during Android release builds:
**Type com.bumptech.glide.GeneratedAppGlideModuleImpl is defined multiple times**
By default, expo-image allows dropping its stub source via the excludeAppGlideModule flag—but its kapt dependency still runs unconditionally. (See [PR](https://github.com/expo/expo/pull/28283) that was fixing it, but it was not enough). This PR makes the Glide compiler conditional on that same flag so that setting excludeAppGlideModule = true fully disables expo-image’s AppGlideModule generation.

# How

In packages/expo-image/android/build.gradle:
- I wrap the existing kapt line in if (!safeExtGet("excludeAppGlideModule", false)) { … }.
- When an app’s root android/build.gradle sets: 
`ext {
  excludeAppGlideModule = true
}`
expo-image will now skip both the stub ExpoImageAppGlideModule.kt and its annotation processing, preventing any duplicate GeneratedAppGlideModuleImpl.

# Test Plan

- bare expo ✅
