### PR TITLE
[ios][audio] Accurately restore volume after interruption

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 💡 Others
 
-- [iOS] Accurately restore volume after interruption.
+- [iOS] Accurately restore volume after interruption. ([#37444](https://github.com/expo/expo/pull/37444) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.4.6 - 2025-06-04
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### 💡 Others
 
+- [iOS] Accurately restore volume after interruption.
+
 ## 0.4.6 - 2025-06-04
 
 ### 🐛 Bug fixes


### PR DESCRIPTION
# Why
The current approach to restoring audio volume after an interruption is ok but lacks accuracy. We should make sure it's restored to the exact same volume that it was interrupted at.

# How
Store the players volume at the time of interruption and use that when restoring it

# Test Plan
Bare-expo ✅

