### PR TITLE
Clarify meaning of warning

### DIFF
--- a/docs/pages/router/advanced/platform-specific-modules.mdx
+++ b/docs/pages/router/advanced/platform-specific-modules.mdx
@@ -3,7 +3,7 @@ title: Platform-specific Modules
 description: Learn how to switch modules based on the platform in Expo Router.
 ---
 
-> **warning** Platform specific extensions were added in Expo Router `3.5.0`. Follow this guide only if you are using an older version of Expo Router.
+> **warning** Platform specific extensions were added in Expo Router `3.5.0`. Follow this guide only if you are using a newer version of Expo Router.
 
 import { FileTree } from '~/ui/components/FileTree';
 


### PR DESCRIPTION
# Why

Based on the context, I think the warning means expo needs to be newer than the version referenced. If Platform-Specific-Modules were only added to Expo Router `3.5.0`, then Expo Router needs to be at least `3.5.0` to use this guide.

# How

N/A

# Test Plan

I want to make sure I am understanding the intent of the warning. If I misunderstood the meaning and the current version is right, please close this PR. I would appreciate an explanation of what I was misunderstanding, but the Expo team certainly does not owe me one.

# Checklist

I do not think these are relevant to my PR. If I am wrong, please let me know how. I will happily correct my error.
- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
