### PR TITLE
[camera][image] bump lib versions for 16kb support

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### 💡 Others
 
+### 📚 3rd party library updates
+
+- [Android] Bumped MLKit barcode scanner to 17.3.0 for Android 16KB page size support. ([#37454](https://github.com/expo/expo/pull/37454) by [@kudo](https://github.com/kudo))
+
 ## 16.1.8 - 2025-06-10
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -28,6 +28,6 @@ dependencies {
 
   implementation "androidx.camera:camera-view:${camerax_version}"
   implementation "androidx.camera:camera-extensions:${camerax_version}"
-  implementation "com.google.mlkit:barcode-scanning:17.2.0"
+  implementation "com.google.mlkit:barcode-scanning:17.3.0"
   implementation "androidx.camera:camera-mlkit-vision:${camerax_version}"
 }

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ### 💡 Others
 
+### 📚 3rd party library updates
+
+- [Android] Bumped GIF Glide plugin to 3.0.5 for Android 16KB page size support. ([#37454](https://github.com/expo/expo/pull/37454) by [@kudo](https://github.com/kudo))
+
 ## 2.3.0 - 2025-06-11
 
 ### 🛠 Breaking changes

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -36,7 +36,7 @@ dependencies {
   }
   api 'com.caverock:androidsvg-aar:1.4'
 
-  implementation "com.github.penfeizhou.android.animation:glide-plugin:3.0.3"
+  implementation "com.github.penfeizhou.android.animation:glide-plugin:3.0.5"
   implementation "com.github.bumptech.glide:avif-integration:${GLIDE_VERSION}"
 
   api 'com.github.bumptech.glide:okhttp3-integration:4.11.0'


### PR DESCRIPTION
# Why

fixes #37440

# How

- [image] bump glide gif plugin to support 16kb page size
- [camera] bump mlkit barcode scanning to 17.3.0 to support 16kb page size

# Test Plan

- verify the apk by the `check_elf_alignment.sh`
- test image and barcode scanner from bare-expo + NCL

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
