### PR TITLE
[dev-launcher] Fix tests

### DIFF
--- a/packages/expo-dev-launcher/setupTests.ts
+++ b/packages/expo-dev-launcher/setupTests.ts
@@ -30,6 +30,17 @@ jest.mock('react-native/Libraries/Components/Switch/Switch', () => {
   };
 });
 
+jest.mock('react-native/Libraries/Components/RefreshControl/RefreshControl', () => {
+  const React = require('react');
+  function MockedRefreshControl(props) {
+    return React.createElement('MockedRefreshControl', props);
+  }
+  return {
+    __esModule: true,
+    default: MockedRefreshControl,
+  };
+});
+
 jest.mock('./bundle/native-modules/DevLauncherInternal');
 jest.mock('./bundle/native-modules/DevLauncherAuth');
 jest.mock('./bundle/native-modules/DevMenuPreferences');


### PR DESCRIPTION
# Why
check-packages is failing in dev-launcher. This is because of the imports change in react native.

# How
Mock the `RefreshControl` component correctly.

# Test Plan
The tests are passing