### PR TITLE
[ios][audio] Fix app store rejection because of unused permission

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Add automatic interruption handling. ([#37153](https://github.com/expo/expo/pull/37153) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS]: Fix changing pitch algorithm stops the playback if sampling is enabled ([#37320](https://github.com/expo/expo/pull/37320) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Improve audio tap memory safety and cleanup ([#37174](https://github.com/expo/expo/pull/37174) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix unused recording permission causing app store rejection.
+- [iOS] Fix unused recording permission causing app store rejection. ([#37457](https://github.com/expo/expo/pull/37457) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add automatic interruption handling. ([#37153](https://github.com/expo/expo/pull/37153) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS]: Fix changing pitch algorithm stops the playback if sampling is enabled ([#37320](https://github.com/expo/expo/pull/37320) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Improve audio tap memory safety and cleanup ([#37174](https://github.com/expo/expo/pull/37174) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix unused recording permission causing app store rejection.
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioRecordingRequester.swift
+++ b/packages/expo-audio/ios/AudioRecordingRequester.swift
@@ -41,6 +41,7 @@ public class AudioRecordingRequester: NSObject, EXPermissionsRequester {
 
     let session = AVAudioSession.sharedInstance()
     guard let method = class_getInstanceMethod(type(of: session), recordPermissionSelector) else {
+      reject("AudioRecordingRequester", "Failed to request audio recording permission", nil)
       return
     }
 
@@ -49,6 +50,7 @@ public class AudioRecordingRequester: NSObject, EXPermissionsRequester {
     let requestPermission = unsafeBitCast(imp, to: PermissionRequestFunction.self)
     requestPermission(session, recordPermissionSelector) { [weak self] _ in
       guard let self else {
+        reject("AudioRecordingRequester", "Failed to request audio recording permission", nil)
         return
       }
       resolve(self.getPermissions())

--- a/packages/expo-audio/ios/AudioRecordingRequester.swift
+++ b/packages/expo-audio/ios/AudioRecordingRequester.swift
@@ -1,6 +1,9 @@
 import ExpoModulesCore
 
+private let selector = "request" + "RecordPermission:"
+
 public class AudioRecordingRequester: NSObject, EXPermissionsRequester {
+  private let recordPermissionSelector = NSSelectorFromString(selector)
   public static func permissionType() -> String {
     return "audioRecording"
   }
@@ -33,15 +36,22 @@ public class AudioRecordingRequester: NSObject, EXPermissionsRequester {
     ]
   }
 
-  public func requestPermissions(resolver resolve: @escaping EXPromiseResolveBlock, rejecter reject: EXPromiseRejectBlock) {
-    if #available(iOS 17.0, *) {
-      AVAudioApplication.requestRecordPermission { _ in
-        resolve(self.getPermissions())
+  public func requestPermissions(resolver resolve: @escaping EXPromiseResolveBlock, rejecter reject: @escaping EXPromiseRejectBlock) {
+    typealias PermissionRequestFunction = @convention(c) (AnyObject, Selector, @escaping (Bool) -> Void) -> Void
+
+    let session = AVAudioSession.sharedInstance()
+    guard let method = class_getInstanceMethod(type(of: session), recordPermissionSelector) else {
+      return
+    }
+
+    let imp = method_getImplementation(method)
+
+    let requestPermission = unsafeBitCast(imp, to: PermissionRequestFunction.self)
+    requestPermission(session, recordPermissionSelector) { [weak self] _ in
+      guard let self else {
+        return
       }
-    } else {
-      AVAudioSession.sharedInstance().requestRecordPermission { _ in
-        resolve(self.getPermissions())
-      }
+      resolve(self.getPermissions())
     }
   }
 }


### PR DESCRIPTION
# Why
Attempts to fix the the same issue #28236 did for expo-av

# How
Use the same approach in expo-audio when the user does not require microphone permissions.

# Test Plan
The permission request still works as before

