### PR TITLE
[ios][audio] Switch audio tap from being added pre effects to post

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### 💡 Others
 
 - [iOS] Accurately restore volume after interruption. ([#37444](https://github.com/expo/expo/pull/37444) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Switch audio tap processing effects from pre to post so volume is taken into account.
+- [iOS] Switch audio tap processing effects from pre to post so volume is taken into account. ([#37461](https://github.com/expo/expo/pull/37461) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.4.6 - 2025-06-04
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 💡 Others
 
 - [iOS] Accurately restore volume after interruption. ([#37444](https://github.com/expo/expo/pull/37444) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Switch audio tap processing effects from pre to post so volume is taken into account.
 
 ## 0.4.6 - 2025-06-04
 

--- a/packages/expo-audio/ios/AudioTapProcessor.m
+++ b/packages/expo-audio/ios/AudioTapProcessor.m
@@ -80,7 +80,7 @@ typedef struct AVAudioTapProcessorContext {
   callbacks.unprepare = nil;
   callbacks.process = tapProcess;
   
-  OSStatus status = MTAudioProcessingTapCreate(kCFAllocatorDefault, &callbacks, kMTAudioProcessingTapCreationFlag_PreEffects, &_audioProcessingTap);
+  OSStatus status = MTAudioProcessingTapCreate(kCFAllocatorDefault, &callbacks, kMTAudioProcessingTapCreationFlag_PostEffects, &_audioProcessingTap);
   if (status == noErr) {
     audioMixInputParameters.audioTapProcessor = _audioProcessingTap;
     audioMix.inputParameters = @[audioMixInputParameters];


### PR DESCRIPTION
# Why
Currently the audio tap does not take volume into account. This is because it is added before any effects are applied to the audio.

# How
Switch to adding the tap after effects have been applied so volume is taken into account.

# Test Plan
Bare-expo 
