### PR TITLE
[docs] Fix google fonts import path

### DIFF
--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -263,7 +263,7 @@ Add the config plugin to your [app config](/versions/latest/config/app/#plugins)
       "expo-font",
       {
         /* @info The path to the font file is defined from the font package inside the node_modules directory. */
-        "fonts": ["node_modules/@expo-google-fonts/inter/Inter_900Black.ttf"]
+        "fonts": ["node_modules/@expo-google-fonts/inter/900Black/Inter_900Black.ttf"]
         /* @end */
       }
     ]


### PR DESCRIPTION
# Why

https://github.com/expo/google-fonts/issues/162

We changed the import path in order to support tree shaking, but missed updating this line in the docs.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Use the correct import path.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

To verify this is where the font file lives, refer to the [published package](https://www.npmjs.com/package/@expo-google-fonts/inter?activeTab=code).

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
