### PR TITLE
Fix jsx comment syntax in dynamic routes example

### DIFF
--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -148,12 +148,12 @@ export default function TabLayout() {
   return (
     <Tabs>
       <Tabs.Screen
-        {/* Name of the dynamic route.*/}
+        // Name of the dynamic route.
         name="[user]"
         options={{
-          {/* Ensure the tab always links to the same href.*/}
+          // Ensure the tab always links to the same href.
           href: '/evanbacon',
-          {/* OR you can use the href object.*/}
+          // OR you can use the href object.
           href: {
             pathname: '/[user]',
             params: {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This fixes the jsx comment syntax in the [dynamic routes example](https://docs.expo.dev/router/advanced/tabs/#dynamic-routes) in the expo router tabs documentation.

The current syntax highlighting is broken because of it.
![image](https://github.com/user-attachments/assets/e2dbde76-b9e2-41b2-84b8-f3d92bb8fc99)

vs the correctly formatted

![image](https://github.com/user-attachments/assets/67969cf2-2b4f-4f86-a607-ea2387ff32a1)


# How

<!--
How did you build this feature or fix this bug and why?
-->

When commenting inside the JSX attributes section, you use `//` instead of `{/* */}`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
