### PR TITLE
docs: fix typo `coose -> choose` in store assets guide

### DIFF
--- a/docs/pages/guides/store-assets.mdx
+++ b/docs/pages/guides/store-assets.mdx
@@ -132,7 +132,7 @@ Below is the bare minimum needed to publish your apps.
 
 ### App Store - iPhone
 
-| Type                                         | Amount | Dimensions (coose one)      | Requirements          |
+| Type                                         | Amount | Dimensions (choose one)     | Requirements          |
 | -------------------------------------------- | ------ | --------------------------- | --------------------- |
 | Screenshots (iPhone with the dynamic island) | 2-10   | 1320 × 2868<br/>1290 × 2796 | JPG or PNG (no alpha) |
 


### PR DESCRIPTION
# Why

A friendly feedback message pointed this out.

# How

Fixed typo `coose -> choose`

# Test Plan

Docs only change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
