### PR TITLE
chore: remove autoprefixer

### DIFF
--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -37,7 +37,6 @@
     "react-native-webview": "13.13.5"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.16",
     "morgan": "^1.10.0",
     "tailwindcss": "^3.3.5",
     "tiny": "^0.0.10"

--- a/apps/router-e2e/postcss.config.mjs
+++ b/apps/router-e2e/postcss.config.mjs
@@ -1,6 +1,5 @@
 export default {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {},
   },
 };

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -48,12 +48,14 @@ Install `tailwindcss` and its required peer dependencies. Then, the run initiali
 <Terminal
   cmd={[
     '# Install Tailwind and its peer dependencies',
-    '$ npx expo install tailwindcss@3 postcss autoprefixer --dev',
+    '$ npx expo install tailwindcss@3 postcss --dev',
     '',
     '# Create a Tailwind config file',
     '$ npx tailwindcss init -p',
   ]}
 />
+
+> Expo websites do not need `autoprefixer` because we automatically add the necessary prefixes with native CSS parsing. Avoid using `autoprefixer` as it slows down the cold-boot performance.
 
 </Step>
 

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -175,12 +175,14 @@ export default function Page() {
 ```json postcss.config.json
 {
   "plugins": {
-    "autoprefixer": {}
+    "tailwindcss": {}
   }
 }
 ```
 
 Both `postcss.config.json` and `postcss.config.js` are supported, but `postcss.config.json` enables better caching.
+
+> Expo websites do not need `autoprefixer` because we automatically add the necessary prefixes with native CSS parsing. Avoid using `autoprefixer` as it slows down the cold-boot performance.
 
 #### Resetting cache after updates
 

--- a/docs/pages/versions/v51.0.0/config/metro.mdx
+++ b/docs/pages/versions/v51.0.0/config/metro.mdx
@@ -192,19 +192,19 @@ export default function Page() {
 
 ### PostCSS
 
-> Changing the Post CSS or `browserslist` config will require you to clear the Metro cache: `npx expo start --clear` | `npx expo export --clear`.
-
 [PostCSS](https://github.com/postcss/postcss) can be customized by adding a `postcss.config.json` file to the root of your project. This file should export a function that returns a PostCSS configuration object. For example:
 
 ```json postcss.config.json
 {
   "plugins": {
-    "autoprefixer": {}
+    "tailwindcss": {}
   }
 }
 ```
 
 Both `postcss.config.json` and `postcss.config.js` are supported, but `postcss.config.json` enables better caching.
+
+> Expo websites do not need `autoprefixer` because we automatically add the necessary prefixes with native CSS parsing. Avoid using `autoprefixer` as it slows down the cold-boot performance.
 
 ### SASS
 

--- a/docs/pages/versions/v52.0.0/config/metro.mdx
+++ b/docs/pages/versions/v52.0.0/config/metro.mdx
@@ -199,12 +199,14 @@ export default function Page() {
 ```json postcss.config.json
 {
   "plugins": {
-    "autoprefixer": {}
+    "tailwindcss": {}
   }
 }
 ```
 
 Both `postcss.config.json` and `postcss.config.js` are supported, but `postcss.config.json` enables better caching.
+
+> Expo websites do not need `autoprefixer` because we automatically add the necessary prefixes with native CSS parsing. Avoid using `autoprefixer` as it slows down the cold-boot performance.
 
 ### SASS
 

--- a/docs/pages/versions/v53.0.0/config/metro.mdx
+++ b/docs/pages/versions/v53.0.0/config/metro.mdx
@@ -175,12 +175,14 @@ export default function Page() {
 ```json postcss.config.json
 {
   "plugins": {
-    "autoprefixer": {}
+    "tailwindcss": {}
   }
 }
 ```
 
 Both `postcss.config.json` and `postcss.config.js` are supported, but `postcss.config.json` enables better caching.
+
+> Expo websites do not need `autoprefixer` because we automatically add the necessary prefixes with native CSS parsing. Avoid using `autoprefixer` as it slows down the cold-boot performance.
 
 #### Resetting cache after updates
 

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/postcss.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/postcss.test.ts
@@ -36,14 +36,14 @@ describe(resolvePostcssConfig, () => {
       {
         'postcss.config.json': JSON.stringify({
           plugins: {
-            autoprefixer: {},
+            tailwindcss: {},
           },
         }),
       },
       '/'
     );
 
-    expect(await resolvePostcssConfig('/')).toEqual({ plugins: { autoprefixer: {} } });
+    expect(await resolvePostcssConfig('/')).toEqual({ plugins: { tailwindcss: {} } });
   });
 
   it('resolves no config', async () => {


### PR DESCRIPTION
# Why

- We use lightning CSS for all CSS which means we don't need autoprefixer. 
- Adding autoprefixer is much slower.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
