### PR TITLE
fix: native module tutorial removes a necessary file

### DIFF
--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -45,7 +45,7 @@ Clean up the default module to start with a clean slate. Delete the view module 
     '$ cd expo-settings',
     '$ rm ios/ExpoSettingsView.swift',
     '$ rm android/src/main/java/expo/modules/settings/ExpoSettingsView.kt',
-    '$ rm src/ExpoSettingsView.tsx src/ExpoSettings.types.ts',
+    '$ rm src/ExpoSettingsView.tsx',
     '$ rm src/ExpoSettingsView.web.tsx src/ExpoSettingsModule.web.ts',
   ]}
 />


### PR DESCRIPTION
# Why

The build fails with the following error because `ExpoSettingsModule.ts` imports from the now-deleted `ExpoSettings.types.ts`:

<img width="940" alt="image" src="https://github.com/user-attachments/assets/0b629fda-4b97-42f6-8030-88c0bd995dd1" />


# How

When following the native module tutorial, a file (`src/ExpoSettings.types.ts`) that is a dependency for `ExpoSettingsModule.ts` is removed, which causes an error when trying to build the project.

# Test Plan

Follow the native module tutorial step-by-step: <https://docs.expo.dev/modules/native-module-tutorial/>

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
