### PR TITLE
feat: add support for @babel/plugin-transform-class-static-block

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add support for `@babel/plugin-transform-class-static-block` on web and native.
+- Add support for `@babel/plugin-transform-class-static-block` on web and native. ([#37495](https://github.com/expo/expo/pull/37495) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `worklets` option to enable/disable Worklets Babel plugin ([#36783](https://github.com/expo/expo/pull/36783) by [@tjzel](https://github.com/tjzel))
 
 ### 🐛 Bug fixes

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Add support for `@babel/plugin-transform-class-static-block` on web and native.
 - Add `worklets` option to enable/disable Worklets Babel plugin ([#36783](https://github.com/expo/expo/pull/36783) by [@tjzel](https://github.com/tjzel))
 
 ### 🐛 Bug fixes

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -109,7 +109,9 @@ function babelPresetExpo(api, options = {}) {
         // This is added back on hermes to ensure the react-jsx-dev plugin (`@babel/preset-react`) works as expected when
         // JSX is used in a function body. This is technically not required in production, but we
         // should retain the same behavior since it's hard to debug the differences.
-        extraPlugins.push(require('@babel/plugin-transform-parameters'));
+        extraPlugins.push(require('@babel/plugin-transform-parameters'), 
+        // Add support for class static blocks.
+        [require('@babel/plugin-transform-class-static-block'), { loose: true }]);
     }
     const inlines = {
         'process.env.EXPO_OS': platform,

--- a/packages/babel-preset-expo/build/web-preset.js
+++ b/packages/babel-preset-expo/build/web-preset.js
@@ -17,6 +17,7 @@ const defaultPlugins = [
     [require('babel-plugin-syntax-hermes-parser'), { parseLangTypes: 'flow' }],
     //
     [require('babel-plugin-transform-flow-enums')],
+    [require('@babel/plugin-transform-class-static-block'), { loose }],
     [require('@babel/plugin-transform-private-methods'), { loose }],
     [require('@babel/plugin-transform-private-property-in-object'), { loose }],
     [require('@babel/plugin-syntax-export-default-from')],

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -45,6 +45,7 @@
     "@babel/plugin-proposal-decorators": "^7.12.9",
     "@babel/plugin-syntax-export-default-from": "^7.24.7",
     "@babel/plugin-proposal-export-default-from": "^7.24.7",
+    "@babel/plugin-transform-class-static-block": "^7.27.1",
     "@babel/plugin-transform-export-namespace-from": "^7.25.9",
     "@babel/plugin-transform-flow-strip-types": "^7.25.2",
     "@babel/plugin-transform-private-methods": "^7.24.7",

--- a/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
@@ -309,6 +309,28 @@ const LANGUAGE_SAMPLES: {
     },
   },
   {
+    // https://babeljs.io/docs/babel-plugin-transform-class-static-block
+    name: `plugin-transform-class-static-block`,
+    code: `class C {
+  static #x = 42;
+  static y;
+  static {
+    try {
+      this.y = doSomethingWith(this.#x);
+    } catch {
+      this.y = "unknown";
+    }
+  }
+}`,
+    getCompiledCode({ platform }) {
+      if (platform === 'web') {
+        return `var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault");var _classPrivateFieldLooseBase2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseBase"));var _classPrivateFieldLooseKey2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));var _C;var _x=(0,_classPrivateFieldLooseKey2.default)("x");class C{}_C=C;Object.defineProperty(C,_x,{writable:true,value:42});(()=>{try{_C.y=doSomethingWith((0,_classPrivateFieldLooseBase2.default)(_C,_x)[_x]);}catch{_C.y="unknown";}})();`;
+      }
+      return `var _interopRequireDefault=require("@babel/runtime/helpers/interopRequireDefault");var _createClass2=_interopRequireDefault(require("@babel/runtime/helpers/createClass"));var _classCallCheck2=_interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));var _classPrivateFieldLooseBase2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseBase"));var _classPrivateFieldLooseKey2=_interopRequireDefault(require("@babel/runtime/helpers/classPrivateFieldLooseKey"));var _C;var _x=(0,_classPrivateFieldLooseKey2.default)("x");var C=(0,_createClass2.default)(function C(){(0,_classCallCheck2.default)(this,C);});_C=C;Object.defineProperty(C,_x,{writable:true,value:42});(()=>{try{_C.y=doSomethingWith((0,_classPrivateFieldLooseBase2.default)(_C,_x)[_x]);}catch{_C.y="unknown";}})();`;
+    },
+    hermesError: /private properties are not supported/,
+  },
+  {
     // https://babeljs.io/docs/babel-plugin-transform-arrow-functions
     // This works with Hermes but we seem to transpile it out anyways, presumably for fast refresh?
     // https://github.com/facebook/react-native/blob/b1047d49ff45f0f795c9e336e18deb9e09c34887/packages/react-native-babel-preset/src/configs/main.js#L89

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -246,7 +246,12 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     // This is added back on hermes to ensure the react-jsx-dev plugin (`@babel/preset-react`) works as expected when
     // JSX is used in a function body. This is technically not required in production, but we
     // should retain the same behavior since it's hard to debug the differences.
-    extraPlugins.push(require('@babel/plugin-transform-parameters'));
+    extraPlugins.push(
+      require('@babel/plugin-transform-parameters'),
+
+      // Add support for class static blocks.
+      [require('@babel/plugin-transform-class-static-block'), { loose: true }]
+    );
   }
 
   const inlines: Record<string, null | boolean | string> = {

--- a/packages/babel-preset-expo/src/web-preset.ts
+++ b/packages/babel-preset-expo/src/web-preset.ts
@@ -17,6 +17,7 @@ const defaultPlugins = [
   [require('babel-plugin-syntax-hermes-parser'), { parseLangTypes: 'flow' }],
   //
   [require('babel-plugin-transform-flow-enums')],
+  [require('@babel/plugin-transform-class-static-block'), { loose }],
   [require('@babel/plugin-transform-private-methods'), { loose }],
   [require('@babel/plugin-transform-private-property-in-object'), { loose }],
   [require('@babel/plugin-syntax-export-default-from')],


### PR DESCRIPTION
This pull request adds support for the `@babel/plugin-transform-class-static-block` plugin across web and native platforms in the `babel-preset-expo` package. It updates dependencies, modifies the Babel preset configuration, and includes new test cases to ensure compatibility.

### New Feature: Support for Class Static Blocks

* **Changelog Update**: Documented the addition of support for `@babel/plugin-transform-class-static-block` in the changelog.
* **Dependency Addition**: Added `@babel/plugin-transform-class-static-block` (version `^7.27.1`) to the `package.json` dependencies.

### Configuration Updates

* **Babel Preset Updates**: Integrated the `@babel/plugin-transform-class-static-block` plugin into the Babel preset for both Hermes and web platforms, with the `loose` option enabled. [[1]](diffhunk://#diff-174a2c2dd0f687e7f1d11e3aa1a7e434a9629458785bd215b8b33a1304b2800cL249-R254) [[2]](diffhunk://#diff-93d7011192b1f23bc5f98d37368b1c836abec84bf066cd58e3fb07b60ebd3fa8R20)

### Testing Enhancements

* **New Test Case**: Added a test case in `hermes-bytecode.test.ts` to verify that the `@babel/plugin-transform-class-static-block` plugin works as expected. The test includes sample input code, expected compiled output for web and native platforms, and an error check for Hermes.
