### PR TITLE
[docs] Add linking and protected routes videos to docs

### DIFF
--- a/docs/pages/linking/overview.mdx
+++ b/docs/pages/linking/overview.mdx
@@ -10,10 +10,13 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { CODE } from '~/ui/components/Text';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 ## Linking
 
 Linking allows your app to interact with incoming and outgoing URLs. In this process, the user not only gets directed to open your app, but they are taken to a specific screen (route) within the app.
+
+<VideoBoxLink videoId="kNbEEYlFIPs" title="Watch: Setting up linking with Expo" />
 
 ### Linking strategies
 

--- a/docs/pages/linking/overview.mdx
+++ b/docs/pages/linking/overview.mdx
@@ -2,6 +2,7 @@
 title: Overview of Linking, Deep Links, Android App Links, and iOS Universal Links
 sidebar_title: Overview
 description: An overview of available resources to implement Linking and Deep Links in your Expo apps.
+hasVideoLink: true
 ---
 
 import { AndroidIcon } from '@expo/styleguide-icons/custom/AndroidIcon';

--- a/docs/pages/router/advanced/protected.mdx
+++ b/docs/pages/router/advanced/protected.mdx
@@ -4,8 +4,13 @@ description: Learn how to make screens inaccessible to client-side navigation.
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 > **warning** Protected routes are available in SDK 53 and above.
+
+<VideoBoxLink videoId="zHZjJDTTHJg" title="Watch: Using protected routes" />
+
+## Overview
 
 Protected screens allow you to prevent users from accessing certain routes using client-side navigation. If a user tries to navigate to a protected screen, or if a screen becomes protected while it is active, they will be redirected to the anchor route (usually the index screen) or the first available screen in the stack.
 

--- a/docs/pages/router/advanced/protected.mdx
+++ b/docs/pages/router/advanced/protected.mdx
@@ -1,6 +1,7 @@
 ---
 title: Protected routes
 description: Learn how to make screens inaccessible to client-side navigation.
+hasVideoLink: true
 ---
 
 import { FileTree } from '~/ui/components/FileTree';


### PR DESCRIPTION
# Why

By Dan's request, add the linking and protected routes videos to our docs.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Embed the videos via VideoBoxLink

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- http://localhost:3002/linking/overview/
- http://localhost:3002/router/advanced/protected/

<img width="1418" alt="Screenshot 2025-06-18 at 08 29 18" src="https://github.com/user-attachments/assets/fbadfac2-b67b-44ea-9b13-2327bb4d9b68" />
<img width="1418" alt="Screenshot 2025-06-18 at 08 29 11" src="https://github.com/user-attachments/assets/0af54f3e-b96c-4a55-9f47-8bf9e7892dda" />


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
