### PR TITLE
[docs] Add docs on `eas/download_build`

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -990,6 +990,58 @@ jobs:
   href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/installNodeModules.ts"
 />
 
+#### `eas/download_build`
+
+Downloads application archive of a given build. By default, the downloaded artifact can be an .apk, .aab, .ipa, or .app file, or a .tar.gz archive containing one or more of these files. If the artifact is a .tar.gz archive, it will be extracted and the first file matching the specified extensions will be returned. If the build produced no application archive, the step will fail.
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      - uses: eas/download_build
+        with:
+          build_id: string # required. ID of the build to download.
+          extensions: [apk, aab, ipa, app] # optional. List of file extensions to look for. Defaults to ["apk", "aab", "ipa", "app"].
+```
+
+| Property     | Type     | Required | Default                        | Description                                                                |
+| ------------ | -------- | -------- | ------------------------------ | -------------------------------------------------------------------------- |
+| `build_id`   | string   | Yes      | –                              | The ID of the build to download. Must be a valid UUID.                     |
+| `extensions` | string[] | No       | `["apk", "aab", "ipa", "app"]` | List of file extensions to look for in the downloaded artifact or archive. |
+
+**Outputs:**
+
+- `artifact_path`: The absolute path to the matching application archive. This output can be used as input into other steps in your workflow, for example to upload or process the artifact further.
+
+Example usage:
+
+```yaml
+jobs:
+  build_ios:
+    type: build
+    params:
+      platform: ios
+      profile: production
+
+  my_job:
+    needs: [build_ios]
+    steps:
+      - uses: eas/download_build
+        id: download_build
+        with:
+          build_id: ${{ needs.build_ios.outputs.build_id }}
+      - name: Print artifact path
+        run: |
+          echo "Artifact path: ${{ steps.download_build.outputs.artifact_path }}"
+```
+
+<BoxLink
+  title="eas/download_build source code"
+  description="View the source code for the eas/download_build function on GitHub."
+  Icon={GithubIcon}
+  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/downloadBuild.ts"
+/>
+
 #### `eas/prebuild`
 
 Runs the `expo prebuild` command using the package manager (bun, npm, pnpm, or Yarn) detected based on your project with the command best suited for your build type and build environment.

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -992,7 +992,7 @@ jobs:
 
 #### `eas/download_build`
 
-Downloads application archive of a given build. By default, the downloaded artifact can be an .apk, .aab, .ipa, or .app file, or a .tar.gz archive containing one or more of these files. If the artifact is a .tar.gz archive, it will be extracted and the first file matching the specified extensions will be returned. If the build produced no application archive, the step will fail.
+Downloads application archive of a given build. By default, the downloaded artifact can be an **.apk**, **.aab**, **.ipa**, or **.app** file, or a **.tar.gz** archive containing one or more of these files. If the artifact is a **.tar.gz** archive, it will be extracted and the first file matching the specified extensions will be returned. If the build produced no application archive, the step will fail.
 
 ```yaml
 jobs:
@@ -1000,8 +1000,8 @@ jobs:
     steps:
       - uses: eas/download_build
         with:
-          build_id: string # required. ID of the build to download.
-          extensions: [apk, aab, ipa, app] # optional. List of file extensions to look for. Defaults to ["apk", "aab", "ipa", "app"].
+          build_id: string # Required. ID of the build to download.
+          extensions: [apk, aab, ipa, app] # Optional. List of file extensions to look for. Defaults to ["apk", "aab", "ipa", "app"].
 ```
 
 | Property     | Type     | Required | Default                        | Description                                                                |
@@ -1011,7 +1011,7 @@ jobs:
 
 **Outputs:**
 
-- `artifact_path`: The absolute path to the matching application archive. This output can be used as input into other steps in your workflow, for example to upload or process the artifact further.
+- `artifact_path`: The absolute path to the matching application archive. This output can be used as input into other steps in your workflow. For example, to upload or process the artifact further.
 
 Example usage:
 


### PR DESCRIPTION
# Why

I've noticed we don't have this documented.

# How

Added docs.

# Test Plan

<img width="560" alt="Zrzut ekranu 2025-06-18 o 13 00 33" src="https://github.com/user-attachments/assets/eaa22d26-b6dd-4647-9a7d-19249ab3c55f" />
<img width="560" alt="Zrzut ekranu 2025-06-18 o 13 00 38" src="https://github.com/user-attachments/assets/08f5f018-bbe3-4b6d-b3a9-e488b56dd597" />


