### PR TITLE
fix(jest-expo): add missing mock for `react-native/Libraries/Core/Devtools/getDevServer`

### DIFF
--- a/packages/expo-location/src/__tests__/Location-test.native.ts
+++ b/packages/expo-location/src/__tests__/Location-test.native.ts
@@ -4,6 +4,8 @@ import { mockProperty, unmockAllProperties } from 'jest-expo';
 import ExpoLocation from '../ExpoLocation';
 import * as Location from '../index';
 
+jest.mock('expo', () => ({ isRunningInExpoGo: jest.fn(() => true) }));
+
 const fakeReturnValue = {
   coords: {
     latitude: 1,

--- a/packages/expo/src/dom/__tests__/base-test.ts
+++ b/packages/expo/src/dom/__tests__/base-test.ts
@@ -1,8 +1,3 @@
-jest.mock('react-native/Libraries/Core/Devtools/getDevServer', () => ({
-  __esModule: true,
-  default: jest.fn().mockReturnValue({ url: 'http://localhost:8081' }),
-}));
-
 describe('getBaseURL', () => {
   let getBaseURL: typeof import('../base').getBaseURL;
 

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -4,9 +4,8 @@
  */
 'use strict';
 
-const merge = require('lodash/merge');
-
 const findUp = require('find-up');
+const merge = require('lodash/merge');
 const path = require('path');
 const mockNativeModules = require('react-native/Libraries/BatchedBridge/NativeModules').default;
 const stackTrace = require('stacktrace-js');
@@ -186,6 +185,14 @@ jest.doMock('react-native/Libraries/LogBox/LogBox', () => ({
       // Do nothing.
     },
   },
+}));
+
+jest.doMock('react-native/Libraries/Core/Devtools/getDevServer', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue({
+    url: 'http://localhost:8081',
+    bundleLoadedFromServer: true,
+  }),
 }));
 
 // Mock the `createSnapshotFriendlyRef` to return an ref that can be serialized in snapshots.


### PR DESCRIPTION
# Why

@Ubax noticed the Expo Router tests were failing due to #36405. After a quick pair session, it seems that `jest-expo` isn't updated to support or mock the `expo/src/async-require/...` code when running tests.

<img width="720" alt="image" src="https://github.com/user-attachments/assets/0ad9cbfe-50c5-47c0-a869-908e606c5023" />

With @alanjhughes, I remember having to [add a specific mock for the RN 0.79 upgrade](https://github.com/expo/expo/blame/c5ac63dc33bf11b01bf96ccd33da172c649c7e64/packages/expo/src/dom/__tests__/base-test.ts#L1-L4). This mock also exist in the React Native code base ([here](https://github.com/facebook/react-native/blob/f70c01cc30d1623ea99e0b002b81e01e41bcd0ea/packages/react-native/Libraries/Core/Devtools/__tests__/loadBundleFromServer-test.js#L18-L28))

# How

This PR moves the mock we specifically had for `expo/src/dom/__tests__/base-test.ts`, and moves it to `jest-expo`'s native setup preset.

Ideally, we should have the appropriate support in `jest-expo` for `expo/src/async-require/..` code, but I think I'm a bit unfamiliar with that part of the code base to add it. If necessary, I can look into this though!

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
