### PR TITLE
[launcher][Android] Start migrating ui to compose

### DIFF
--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -1,7 +1,17 @@
-plugins {
-  id 'com.android.library'
-  id 'expo-module-gradle-plugin'
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath("org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:${kotlinVersion}")
+    classpath("org.jetbrains.kotlin.plugin.serialization:org.jetbrains.kotlin.plugin.serialization.gradle.plugin:${kotlinVersion}")
+  }
 }
+
+apply plugin: 'com.android.library'
+apply plugin: 'expo-module-gradle-plugin'
+apply plugin: 'org.jetbrains.kotlin.plugin.compose'
+apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 
 expoModule {
   canBePublished false
@@ -69,6 +79,15 @@ dependencies {
 
   api project.dependencies.platform("io.insert-koin:koin-bom:3.5.6")
   api "io.insert-koin:koin-core"
+
+  def composeVersion = "1.8.2"
+
+  implementation "androidx.compose.foundation:foundation-android:$composeVersion"
+  implementation "androidx.compose.ui:ui:$composeVersion"
+  implementation "androidx.compose.ui:ui-tooling:$composeVersion"
+  implementation "androidx.navigation:navigation-compose:2.9.0"
+
+  implementation("com.composables:core:1.31.1")
 
   testImplementation 'androidx.test:core:1.4.0'
   testImplementation 'androidx.test:core-ktx:1.4.0'

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -371,14 +371,14 @@ class DevLauncherController private constructor() :
             categories.addAll(it)
           }
         } ?: run {
-          // If no pending intent is available, use the extras from the intent that was used to launch the app.
-          pendingIntentExtras?.let {
-            putExtras(it)
-          }
+        // If no pending intent is available, use the extras from the intent that was used to launch the app.
+        pendingIntentExtras?.let {
+          putExtras(it)
         }
+      }
 
-        // Clear the pending intent extras after using them.
-        pendingIntentExtras = null
+      // Clear the pending intent extras after using them.
+      pendingIntentExtras = null
     }
 
   private fun createBasicAppIntent() =

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/compose/DevLauncherMainView.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/compose/DevLauncherMainView.kt
@@ -1,0 +1,184 @@
+package expo.modules.devlauncher.compose
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.util.fastMaxBy
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.composables.core.Icon
+import com.composeunstyled.Button
+import expo.modules.devlauncher.compose.screens.HomeScreen
+import expo.modules.devlauncher.compose.screens.HomeScreenState
+import expo.modules.devlauncher.compose.screens.SettingsScreen
+import expo.modules.devmenu.compose.primitives.Spacer
+import expo.modules.devmenu.compose.primitives.Text
+import expo.modules.devmenu.compose.theme.Theme
+import kotlinx.serialization.Serializable
+
+@Composable
+fun Scaffold(
+  bottomTab: @Composable () -> Unit = {},
+  content: @Composable () -> Unit
+) {
+  SubcomposeLayout { constraints ->
+    val maxWidth = constraints.maxWidth
+    val maxHeight = constraints.maxHeight
+
+    val bottomTabPlaceables = subcompose("bottomTab", bottomTab).map { it.measure(constraints) }
+    val bottomTabsHeight = bottomTabPlaceables.fastMaxBy { it.height }?.height ?: 0
+    val contentPlaceables = subcompose("content", content).map { it.measure(constraints.copy(maxHeight = maxHeight - bottomTabsHeight)) }
+
+    layout(maxWidth, maxHeight) {
+      contentPlaceables.forEach { it.place(0, 0) }
+      bottomTabPlaceables.forEach { it.place(0, maxHeight - it.height) }
+    }
+  }
+}
+
+@Serializable
+object Home
+
+@Serializable
+object Settings
+
+@Composable
+fun DefaultScreenContainer(
+  content: @Composable () -> Unit
+) {
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .background(Theme.colors.background.secondary)
+  ) {
+    content()
+  }
+}
+
+@Composable
+fun BottomTabButton(
+  label: String,
+  icon: Painter,
+  isSelected: Boolean,
+  modifier: Modifier = Modifier,
+  onClick: () -> Unit
+) {
+  Button(onClick = onClick, modifier = modifier) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.padding(Theme.spacing.small)) {
+      Icon(
+        painter = icon,
+        tint = if (isSelected) {
+          Theme.colors.button.primary.background
+        } else {
+          Theme.colors.icon.default
+        },
+        contentDescription = "$label Icon"
+      )
+      Spacer(Theme.spacing.tiny)
+      Text(
+        "Home",
+        fontSize = Theme.typography.small,
+        color = if (isSelected) {
+          Theme.colors.button.primary.background
+        } else {
+          Theme.colors.text.secondary
+        }
+      )
+    }
+  }
+}
+
+data class Tab(
+  val label: String,
+  val icon: Painter,
+  val screen: Any
+)
+
+@Composable
+fun DevMenuLauncherMainView() {
+  val navController = rememberNavController()
+
+  Scaffold(bottomTab = {
+    Box(
+      contentAlignment = Alignment.Center
+    ) {
+      Row(
+        modifier = Modifier
+          .background(Theme.colors.background.default)
+          .height(IntrinsicSize.Max)
+      ) {
+        val navBackStackEntry by navController.currentBackStackEntryAsState()
+        val currentDestination = navBackStackEntry?.destination
+
+        val buttonModifier = Modifier
+          .weight(1f)
+          .fillMaxHeight()
+        val icons = listOf<Tab>(
+          Tab(
+            label = "Home",
+            icon = painterResource(id = expo.modules.devlauncher.R.drawable._expodevclientcomponents_assets_homefilledinactiveicon),
+            screen = Home
+          ),
+          Tab(
+            label = "Settings",
+            icon = painterResource(id = expo.modules.devlauncher.R.drawable._expodevclientcomponents_assets_settingsfilledinactiveicon),
+            screen = Settings
+          )
+        )
+        for (tab in icons) {
+          val isSelected = currentDestination?.hasRoute(tab.screen::class) == true
+          BottomTabButton(
+            label = tab.label,
+            icon = tab.icon,
+            modifier = buttonModifier,
+            isSelected = isSelected,
+            onClick = {
+              navController.navigate(tab.screen) {
+                popUpTo(navController.graph.id) { inclusive = true }
+              }
+            }
+          )
+        }
+      }
+    }
+  }) {
+    NavHost(
+      navController = navController,
+      startDestination = Home,
+      enterTransition = {
+        EnterTransition.None
+      },
+      exitTransition = {
+        ExitTransition.None
+      }
+    ) {
+      composable<Home> { DefaultScreenContainer { HomeScreen(HomeScreenState(appName = "BareExpo")) } }
+      composable<Settings> { DefaultScreenContainer { SettingsScreen() } }
+    }
+  }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun DevLauncherMainViewPreview() {
+  DevMenuLauncherMainView()
+}

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/compose/primitives/Accordion.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/compose/primitives/Accordion.kt
@@ -1,0 +1,97 @@
+package expo.modules.devlauncher.compose.primitives
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.composables.core.Icon
+import expo.modules.devmenu.compose.primitives.Text
+import expo.modules.devmenu.compose.theme.Theme
+
+@Composable
+fun Accordion(
+  text: String,
+  modifier: Modifier = Modifier,
+  initialState: Boolean = false,
+  accordionContent: @Composable () -> Unit = {}
+) {
+  var expanded by remember { mutableStateOf(initialState) }
+  val arrowRotation by animateFloatAsState(
+    targetValue = if (expanded) 90f else 0f,
+    label = "accordion-arrow"
+  )
+
+  Box(
+    modifier = modifier
+  ) {
+    Column {
+      Box(
+        modifier = Modifier
+          .clickable { expanded = !expanded }
+      ) {
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          modifier = Modifier
+            .padding(Theme.spacing.small)
+        ) {
+          Icon(
+            painter = painterResource(expo.modules.devmenu.R.drawable._expodevclientcomponents_assets_chevronrighticon),
+            contentDescription = "Accordion Arrow",
+            modifier = Modifier
+              .rotate(arrowRotation)
+          )
+          Spacer(Modifier.size(Theme.spacing.small))
+          Text(
+            text = text,
+            modifier = Modifier.weight(1f)
+          )
+        }
+      }
+
+      AnimatedVisibility(
+        visible = expanded,
+        enter = expandVertically(
+          expandFrom = Alignment.Top,
+          animationSpec = tween()
+        ),
+        exit = shrinkVertically(
+          shrinkTowards = Alignment.Top,
+          animationSpec = tween()
+        )
+      ) {
+        Box(
+          modifier = Modifier
+            .padding(horizontal = Theme.spacing.small)
+        ) {
+          accordionContent()
+        }
+      }
+    }
+  }
+}
+
+@Composable
+@Preview(showBackground = true, heightDp = 200)
+fun AccordionVariantPreview() {
+  Accordion(text = "Enter URL") {
+    Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ac nisl interdum, mattis purus a, consequat ipsum. Aliquam sem mauris, egestas a elit a, lacinia efficitur nisi. Maecenas scelerisque erat nisi, ac interdum mauris volutpat vel. Proin sed lectus at purus interdum porta. Ut mollis feugiat dignissim.")
+  }
+}

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/compose/screens/Home.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/compose/screens/Home.kt
@@ -1,0 +1,129 @@
+package expo.modules.devlauncher.compose.screens
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import com.composeunstyled.Button
+import com.composeunstyled.TextField
+import expo.modules.devlauncher.R
+import expo.modules.devlauncher.compose.primitives.Accordion
+import expo.modules.devlauncher.compose.ui.AppHeader
+import expo.modules.devlauncher.compose.ui.AppHeaderContainer
+import expo.modules.devlauncher.compose.ui.SectionHeader
+import expo.modules.devmenu.compose.primitives.Divider
+import expo.modules.devmenu.compose.primitives.RoundedSurface
+import expo.modules.devmenu.compose.primitives.Spacer
+import expo.modules.devmenu.compose.primitives.Text
+import expo.modules.devmenu.compose.theme.Theme
+import expo.modules.devmenu.compose.ui.MenuButton
+
+data class HomeScreenState(
+  val appName: String
+)
+
+@Composable
+fun HomeScreen(state: HomeScreenState) {
+  Column {
+    AppHeaderContainer {
+      AppHeader(state.appName)
+    }
+
+    Column(
+      modifier = Modifier
+        .padding(horizontal = Theme.spacing.medium)
+    ) {
+      Spacer(Theme.spacing.large)
+
+      Row {
+        Spacer(Theme.spacing.small)
+
+        SectionHeader(
+          "Development",
+          leftIcon = {
+            Image(
+              painter = painterResource(R.drawable._expodevclientcomponents_assets_terminalicon),
+              contentDescription = "Terminal Icon"
+            )
+          },
+          rightIcon = {
+            Image(
+              painter = painterResource(R.drawable._expodevclientcomponents_assets_infoicon),
+              contentDescription = "Terminal Icon"
+            )
+          }
+        )
+      }
+
+      Spacer(Theme.spacing.small)
+
+      RoundedSurface {
+        Column {
+          MenuButton("http://10.0.2.2:8081")
+          Divider()
+          MenuButton("Fetch development")
+          Divider()
+          Accordion("Enter URL", initialState = false) {
+            val url = remember { mutableStateOf("") }
+
+            Column {
+              Spacer(Theme.spacing.tiny)
+
+              TextField(
+                url.value,
+                onValueChange = { newValue ->
+                  url.value = newValue
+                },
+                placeholder = "http://10.0.2.2:801",
+                textStyle = Theme.typography.medium.font,
+                maxLines = 1,
+                modifier = Modifier
+                  .border(
+                    width = Theme.sizing.border.default,
+                    shape = RoundedCornerShape(Theme.sizing.borderRadius.small),
+                    color = Theme.colors.border.default
+                  )
+                  .padding(Theme.spacing.small),
+                keyboardOptions = KeyboardOptions(
+                  capitalization = KeyboardCapitalization.None,
+                  autoCorrectEnabled = false,
+                  keyboardType = KeyboardType.Uri
+                )
+              )
+
+              Spacer(Theme.spacing.tiny)
+
+              Button(onClick = {}, modifier = Modifier.fillMaxWidth()) {
+                Row(modifier = Modifier.padding(vertical = Theme.spacing.small)) {
+                  Text("Connect")
+                }
+              }
+
+              Spacer(Theme.spacing.small)
+            }
+          }
+        }
+      }
+
+      Spacer(Theme.spacing.medium)
+    }
+  }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HomeScreenPreview() {
+  HomeScreen(state = HomeScreenState("BareExpo"))
+}

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/compose/screens/Settings.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/compose/screens/Settings.kt
@@ -1,0 +1,82 @@
+package expo.modules.devlauncher.compose.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import expo.modules.devlauncher.R
+import expo.modules.devlauncher.compose.ui.SectionHeader
+import expo.modules.devmenu.compose.primitives.Divider
+import expo.modules.devmenu.compose.primitives.Heading
+import expo.modules.devmenu.compose.primitives.RoundedSurface
+import expo.modules.devmenu.compose.primitives.Spacer
+import expo.modules.devmenu.compose.primitives.Text
+import expo.modules.devmenu.compose.theme.Theme
+import expo.modules.devmenu.compose.ui.MenuButton
+import expo.modules.devmenu.compose.ui.MenuInfo
+import expo.modules.devmenu.compose.ui.MenuSwitch
+
+@Composable
+fun SettingsScreen() {
+  Column(modifier = Modifier.padding(Theme.spacing.medium)) {
+    Heading("Settings")
+    Spacer(Theme.spacing.large)
+
+    RoundedSurface {
+      MenuSwitch("Show menu as launch", icon = painterResource(R.drawable._expodevclientcomponents_assets_showmenuatlaunchicon))
+    }
+
+    Spacer(Theme.spacing.medium)
+
+    SectionHeader(
+      "Menu gestures"
+    )
+
+    Spacer(Theme.spacing.small)
+
+    RoundedSurface {
+      Column {
+        MenuButton(
+          "Shake device",
+          icon = painterResource(expo.modules.devmenu.R.drawable._expodevclientcomponents_assets_shakedeviceicon),
+          rightIcon = painterResource(R.drawable._expodevclientcomponents_assets_checkicon)
+        )
+        Divider()
+        MenuButton(
+          "Three three-finger long press",
+          icon = painterResource(R.drawable._expodevclientcomponents_assets_threefingerlongpressicon),
+          rightIcon = painterResource(R.drawable._expodevclientcomponents_assets_checkicon)
+        )
+      }
+    }
+
+    Box(modifier = Modifier.padding(Theme.spacing.small)) {
+      Text(
+        "Selected gestures will toggle the developer menu while inside a preview. The menu allows you to reload or return to home and exposes developer tools.",
+        fontSize = Theme.typography.small,
+        color = Theme.colors.text.secondary
+      )
+    }
+
+    Spacer(Theme.spacing.medium)
+
+    RoundedSurface {
+      Column {
+        MenuInfo("Version", "N/A")
+        Divider()
+        MenuInfo("Runtime version", "N/A")
+        Divider()
+        MenuButton("Tap to Copy All", icon = null, labelTextColor = Theme.colors.text.link)
+      }
+    }
+  }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun SettingsScreenPreview() {
+  SettingsScreen()
+}

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/compose/ui/AppHeader.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/compose/ui/AppHeader.kt
@@ -1,0 +1,79 @@
+package expo.modules.devlauncher.compose.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.composables.core.Icon
+import expo.modules.devlauncher.R
+import expo.modules.devmenu.compose.primitives.AppIcon
+import expo.modules.devmenu.compose.primitives.Heading
+import expo.modules.devmenu.compose.primitives.Spacer
+import expo.modules.devmenu.compose.primitives.Surface
+import expo.modules.devmenu.compose.primitives.Text
+import expo.modules.devmenu.compose.theme.Theme
+
+@Composable
+fun AppHeaderContainer(content: @Composable () -> Unit) {
+  Row(
+    verticalAlignment = Alignment.CenterVertically,
+    modifier = Modifier
+      .background(color = Theme.colors.background.default)
+      .padding(Theme.spacing.medium)
+  ) {
+    content()
+  }
+}
+
+@Composable
+fun AppHeader(
+  appName: String
+) {
+  Row(
+    verticalAlignment = Alignment.CenterVertically
+  ) {
+    AppIcon()
+    Spacer(Theme.spacing.small)
+
+    Column {
+      Heading(
+        text = appName
+      )
+
+      Spacer(Theme.spacing.tiny)
+
+      Text(
+        text = "Development Build",
+        fontSize = Theme.typography.small,
+        color = Theme.colors.text.secondary
+      )
+    }
+
+    Spacer(modifier = Modifier.weight(1f))
+
+    Surface(shape = RoundedCornerShape(Theme.sizing.borderRadius.full)) {
+      Icon(
+        painter = painterResource(R.drawable._expodevclientcomponents_assets_usericonlight),
+        contentDescription = "Expo Logo",
+        tint = Theme.colors.icon.default,
+        modifier = Modifier.padding(Theme.spacing.tiny)
+      )
+    }
+  }
+}
+
+@Composable
+@Preview(showBackground = true, widthDp = 300)
+fun AppHeaderPreview() {
+  AppHeaderContainer {
+    AppHeader(
+      appName = "BareExpo"
+    )
+  }
+}

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/compose/ui/SectionHeader.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/compose/ui/SectionHeader.kt
@@ -1,0 +1,54 @@
+package expo.modules.devlauncher.compose.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import expo.modules.devlauncher.R
+import expo.modules.devmenu.compose.primitives.Heading
+import expo.modules.devmenu.compose.primitives.Spacer
+import expo.modules.devmenu.compose.theme.Theme
+
+@Composable
+fun SectionHeader(
+  title: String,
+  leftIcon: @Composable (() -> Unit)? = null,
+  rightIcon: @Composable (() -> Unit)? = null
+) {
+  Row(verticalAlignment = Alignment.CenterVertically) {
+    leftIcon?.invoke()
+
+    if (leftIcon != null) {
+      Spacer(Theme.spacing.medium)
+    }
+
+    Heading(title, color = Theme.colors.text.secondary)
+
+    Spacer(modifier = Modifier.weight(1f))
+
+    rightIcon?.invoke()
+  }
+}
+
+@Composable
+@Preview(widthDp = 300, showBackground = true)
+fun SectionHeaderPreview() {
+  SectionHeader(
+    title = "Development",
+    leftIcon = {
+      Image(
+        painter = painterResource(R.drawable._expodevclientcomponents_assets_terminalicon),
+        contentDescription = "Terminal Icon"
+      )
+    },
+    rightIcon = {
+      Image(
+        painter = painterResource(R.drawable._expodevclientcomponents_assets_infoicon),
+        contentDescription = "Terminal Icon"
+      )
+    }
+  )
+}

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -30,35 +30,13 @@ android {
   sourceSets {
     debug {
       java {
-        srcDirs += ['../vendored/react-native-gesture-handler/android/']
         srcDirs += ['../vendored/react-native-safe-area-context/android/']
-
       }
     }
   }
   buildFeatures {
     buildConfig true
   }
-}
-
-task clenupAssets(type: Delete) {
-  // In the past, assets were placed in the `main` directory.
-  // However, this is no longer the case. To ensure a smooth transition,
-  // we’re also removing assets from the old location.
-  delete files("src/main/assets")
-}
-
-task copyAssets(type: Copy) {
-  dependsOn(clenupAssets)
-
-  from('../assets') {
-    exclude "*.ios.*"
-  }
-  into 'src/debug/assets'
-}
-
-project.afterEvaluate {
-  preBuild.dependsOn copyAssets
 }
 
 repositories {

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/DevMenuScreen.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/DevMenuScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
@@ -22,9 +23,8 @@ import expo.modules.devmenu.compose.ui.AppInfo
 import expo.modules.devmenu.compose.ui.BundlerInfo
 import expo.modules.devmenu.compose.ui.BundlerInfoState
 import expo.modules.devmenu.compose.ui.MenuButton
-import expo.modules.devmenu.compose.ui.MenuButtonContainer
+import expo.modules.devmenu.compose.ui.MenuContainer
 import expo.modules.devmenu.compose.ui.MenuInfo
-import expo.modules.devmenu.compose.ui.MenuSectionContainer
 import expo.modules.devmenu.compose.ui.MenuSwitch
 import expo.modules.devmenu.compose.ui.Warning
 
@@ -40,77 +40,77 @@ fun DevMenuContent(
       )
     )
 
-    Spacer(Modifier.size(Theme.spacing.small))
+    Column(modifier = Modifier.padding(Theme.spacing.small)) {
+      Spacer(Modifier.size(Theme.spacing.small))
 
-    MenuButtonContainer {
-      MenuButton(
-        "Reload",
-        icon = painterResource(R.drawable._expodevclientcomponents_assets_refreshicon),
-        onClick = { onAction(DevMenuAction.Reload) }
-      )
-      Divider()
-      MenuButton(
-        "Go home",
-        icon = painterResource(R.drawable._expodevclientcomponents_assets_homefilledactiveiconlight),
-        onClick = { onAction(DevMenuAction.GoHome) }
-      )
-    }
+      MenuContainer {
+        MenuButton(
+          "Reload",
+          icon = painterResource(R.drawable._expodevclientcomponents_assets_refreshicon),
+          onClick = { onAction(DevMenuAction.Reload) }
+        )
+        Divider()
+        MenuButton(
+          "Go home",
+          icon = painterResource(R.drawable._expodevclientcomponents_assets_homefilledinactiveicon),
+          onClick = { onAction(DevMenuAction.GoHome) }
+        )
+      }
 
-    Spacer(Modifier.size(Theme.spacing.small))
+      Spacer(Modifier.size(Theme.spacing.small))
 
-    MenuButtonContainer {
-      MenuButton(
-        "Toggle performance monitor",
-        icon = painterResource(R.drawable._expodevclientcomponents_assets_performanceicon),
-        onClick = { onAction(DevMenuAction.TogglePerformanceMonitor) }
-      )
-      Divider()
-      MenuButton(
-        "Toggle element inspector",
-        icon = painterResource(R.drawable._expodevclientcomponents_assets_inspectelementicon),
-        onClick = { onAction(DevMenuAction.ToggleElementInspector) }
-      )
-      Divider()
-      MenuButton(
-        "Open JS debugger",
-        icon = painterResource(R.drawable._expodevclientcomponents_assets_debugicon),
-        onClick = { onAction(DevMenuAction.OpenJSDebugger) }
-      )
-      Divider()
-      MenuSwitch(
-        "Fast Refresh",
-        icon = painterResource(R.drawable._expodevclientcomponents_assets_runicon),
-        onToggled = { newValue -> onAction(DevMenuAction.ToggleFastRefresh(newValue)) }
-      )
-    }
+      MenuContainer {
+        MenuButton(
+          "Toggle performance monitor",
+          icon = painterResource(R.drawable._expodevclientcomponents_assets_performanceicon),
+          onClick = { onAction(DevMenuAction.TogglePerformanceMonitor) }
+        )
+        Divider()
+        MenuButton(
+          "Toggle element inspector",
+          icon = painterResource(R.drawable._expodevclientcomponents_assets_inspectelementicon),
+          onClick = { onAction(DevMenuAction.ToggleElementInspector) }
+        )
+        Divider()
+        MenuButton(
+          "Open JS debugger",
+          icon = painterResource(R.drawable._expodevclientcomponents_assets_debugicon),
+          onClick = { onAction(DevMenuAction.OpenJSDebugger) }
+        )
+        Divider()
+        MenuSwitch(
+          "Fast Refresh",
+          icon = painterResource(R.drawable._expodevclientcomponents_assets_runicon),
+          onToggled = { newValue -> onAction(DevMenuAction.ToggleFastRefresh(newValue)) }
+        )
+      }
 
-    Spacer(Modifier.size(Theme.spacing.large))
+      Spacer(Modifier.size(Theme.spacing.large))
 
-    MenuSectionContainer {
       Warning("Debugging not working? Try manually reloading first")
+
+      Spacer(Modifier.size(Theme.spacing.large))
+
+      MenuContainer {
+        MenuInfo("Version", appInfo.appVersion ?: "N/A")
+        Divider()
+        MenuInfo("Runtime version", appInfo.runtimeVersion ?: "N/A")
+        Divider()
+        MenuButton("Tap to Copy All", icon = null, labelTextColor = Theme.colors.text.link)
+      }
+
+      Spacer(Modifier.size(Theme.spacing.large))
+
+      MenuContainer {
+        MenuButton(
+          "Open React Native dev menu",
+          icon = null,
+          onClick = { onAction(DevMenuAction.OpenReactNativeDevMenu) }
+        )
+      }
+
+      Spacer(Modifier.windowInsetsPadding(WindowInsets.navigationBars))
     }
-
-    Spacer(Modifier.size(Theme.spacing.large))
-
-    MenuButtonContainer {
-      MenuInfo("Version", appInfo.appVersion ?: "N/A")
-      Divider()
-      MenuInfo("Runtime version", appInfo.runtimeVersion ?: "N/A")
-      Divider()
-      MenuButton("Tap to Copy All", icon = null, labelTextColor = Theme.colors.text.link)
-    }
-
-    Spacer(Modifier.size(Theme.spacing.large))
-
-    MenuButtonContainer {
-      MenuButton(
-        "Open React Native dev menu",
-        icon = null,
-        onClick = { onAction(DevMenuAction.OpenReactNativeDevMenu) }
-      )
-    }
-
-    Spacer(Modifier.windowInsetsPadding(WindowInsets.navigationBars))
   }
 }
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/primitives/AppIcon.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/primitives/AppIcon.kt
@@ -1,0 +1,50 @@
+package expo.modules.devmenu.compose.primitives
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.graphics.drawable.toBitmap
+import expo.modules.devmenu.compose.theme.Theme
+
+@Composable
+fun AppIcon() {
+  val context = LocalContext.current
+  val icon = context.applicationInfo.icon
+
+  Surface(
+    shape = RoundedCornerShape(
+      if (icon == 0) {
+        Theme.sizing.borderRadius.medium
+      } else {
+        Theme.sizing.borderRadius.full
+      }
+    )
+  ) {
+    Box(
+      modifier = Modifier
+        .size(Theme.sizing.icon.extraLarge)
+        .background(Theme.colors.background.secondary)
+    ) {
+      if (icon != 0) {
+        // TODO(@lukmccall): It looks super weird to use the app icon as a bitmap here
+        val image = remember {
+          context.applicationInfo.loadIcon(context.packageManager).toBitmap().asImageBitmap()
+        }
+        Image(
+          image,
+          contentDescription = "App Icon",
+          modifier = Modifier
+            .fillMaxSize()
+        )
+      }
+    }
+  }
+}

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/primitives/Divider.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/primitives/Divider.kt
@@ -10,7 +10,7 @@ import expo.modules.devmenu.compose.theme.Theme
 
 @Composable
 fun Divider() {
-  val thickness = Theme.sizing.borderRadius.hairlineWidth
+  val thickness = Theme.sizing.border.hairlineWidth
   val color = Theme.colors.border.default
   Canvas(Modifier.fillMaxWidth().height(thickness)) {
     drawLine(

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/primitives/Spacer.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/primitives/Spacer.kt
@@ -1,0 +1,19 @@
+package expo.modules.devmenu.compose.primitives
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import expo.modules.devmenu.compose.theme.Theme
+
+@Composable
+fun Spacer(
+  height: Dp = Theme.spacing.medium,
+  modifier: Modifier? = null
+) {
+  androidx.compose.foundation.layout.Spacer(
+    modifier = Modifier.then(
+      modifier ?: Modifier.size(height)
+    )
+  )
+}

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/primitives/Surface.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/primitives/Surface.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -21,16 +22,35 @@ fun Surface(
   content: @Composable () -> Unit
 ) {
   Box(
-    modifier = modifier.then(
-      if (border != null) {
-        Modifier.border(border, shape)
-      } else {
-        Modifier
-      }
-    )
+    modifier = modifier
+      .then(
+        if (border != null) {
+          Modifier.border(border, shape)
+        } else {
+          Modifier
+        }
+      )
       .background(color = color, shape = shape)
-      .clip(shape)
+      .clip(shape),
+    propagateMinConstraints = true
   ) {
     content()
   }
+}
+
+@Composable
+fun RoundedSurface(
+  modifier: Modifier = Modifier,
+  shape: Shape = RoundedCornerShape(Theme.sizing.borderRadius.large),
+  color: Color = Theme.colors.background.default,
+  border: BorderStroke? = null,
+  content: @Composable () -> Unit
+) {
+  Surface(
+    modifier = modifier,
+    shape = shape,
+    color = color,
+    border = border,
+    content = content
+  )
 }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/primitives/Text.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/primitives/Text.kt
@@ -14,7 +14,7 @@ import expo.modules.devmenu.compose.theme.Theme
 @Composable
 fun Text(
   text: String,
-  fontSize: FontSize = Theme.typography.size16,
+  fontSize: FontSize = Theme.typography.medium,
   color: Color? = null,
   maxLines: Int = Int.MAX_VALUE,
   softWrap: Boolean = true,
@@ -36,7 +36,7 @@ fun Text(
 @Composable
 fun Heading(
   text: String,
-  fontSize: FontSize = Theme.typography.size18,
+  fontSize: FontSize = Theme.typography.large,
   color: Color = Theme.colors.text.default,
   maxLines: Int = Int.MAX_VALUE
 ) {

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/theme/Sizing.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/theme/Sizing.kt
@@ -4,9 +4,15 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 object Sizing {
+  object Border {
+    val hairlineWidth = Dp.Hairline
+    val default = 1.dp
+  }
+
+  val border = Border
+
   object BorderRadius {
     val none = 0.dp
-    val hairlineWidth = Dp.Hairline
     val extraSmall = 2.dp
     val small = 4.dp
     val medium = 6.dp

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/theme/Typography.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/theme/Typography.kt
@@ -12,7 +12,7 @@ import expo.modules.devmenu.R
 private const val BASE_FONT_SIZE = 16f
 
 @JvmInline
-value class FontSize(internal val font: TextStyle) {
+value class FontSize(val font: TextStyle) {
   companion object {
     internal fun create(
       fontSize: Int,

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/ui/AppInfo.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/ui/AppInfo.kt
@@ -1,33 +1,26 @@
 package expo.modules.devmenu.compose.ui
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.drawable.toBitmap
 import com.composables.core.Icon
 import com.composeunstyled.Button
 import expo.modules.devmenu.R
 import expo.modules.devmenu.compose.DevMenuAction
 import expo.modules.devmenu.compose.DevMenuActionHandler
+import expo.modules.devmenu.compose.primitives.AppIcon
 import expo.modules.devmenu.compose.primitives.Heading
-import expo.modules.devmenu.compose.primitives.Surface
 import expo.modules.devmenu.compose.primitives.Text
 import expo.modules.devmenu.compose.theme.Theme
 
@@ -38,9 +31,6 @@ fun AppInfo(
   sdkVersion: String? = null,
   onAction: DevMenuActionHandler = {}
 ) {
-  val context = LocalContext.current
-  val icon = context.applicationInfo.icon
-
   Row(
     verticalAlignment = Alignment.CenterVertically,
     modifier = Modifier
@@ -49,34 +39,7 @@ fun AppInfo(
   ) {
     Spacer(Modifier.size(Theme.spacing.medium))
 
-    Surface(
-      shape = RoundedCornerShape(
-        if (icon == 0) {
-          Theme.sizing.borderRadius.medium
-        } else {
-          Theme.sizing.borderRadius.full
-        }
-      )
-    ) {
-      Box(
-        modifier = Modifier
-          .size(Theme.sizing.icon.extraLarge)
-          .background(Theme.colors.background.secondary)
-      ) {
-        if (icon != 0) {
-          // TODO(@lukmccall): It looks super weird to use the app icon as a bitmap here
-          val image = remember {
-            context.applicationInfo.loadIcon(context.packageManager).toBitmap().asImageBitmap()
-          }
-          Image(
-            image,
-            contentDescription = "App Icon",
-            modifier = Modifier
-              .fillMaxSize()
-          )
-        }
-      }
-    }
+    AppIcon()
 
     Spacer(Modifier.size(Theme.spacing.small))
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/ui/Containers.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/ui/Containers.kt
@@ -1,36 +1,16 @@
 package expo.modules.devmenu.compose.ui
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import expo.modules.devmenu.compose.primitives.Surface
-import expo.modules.devmenu.compose.theme.Theme
+import expo.modules.devmenu.compose.primitives.RoundedSurface
 
 @Composable
-fun MenuSectionContainer(
+fun MenuContainer(
   content: @Composable () -> Unit
 ) {
-  Column(
-    modifier = Modifier
-      .padding(horizontal = Theme.spacing.small)
-  ) {
-    content()
-  }
-}
-
-@Composable
-fun MenuButtonContainer(
-  content: @Composable () -> Unit
-) {
-  MenuSectionContainer {
-    Surface(
-      shape = RoundedCornerShape(Theme.sizing.borderRadius.large)
-    ) {
-      Column {
-        content()
-      }
+  RoundedSurface {
+    Column {
+      content()
     }
   }
 }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/ui/MenuButton.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/ui/MenuButton.kt
@@ -1,5 +1,6 @@
 package expo.modules.devmenu.compose.ui
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
@@ -11,7 +12,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
-import com.composables.core.Icon
 import com.composeunstyled.Button
 import expo.modules.devmenu.R
 import expo.modules.devmenu.compose.primitives.Text
@@ -22,6 +22,7 @@ fun MenuButton(
   label: String,
   labelTextColor: Color? = null,
   icon: Painter? = null,
+  rightIcon: Painter? = null,
   onClick: () -> Unit = {}
 ) {
   Button(
@@ -34,10 +35,9 @@ fun MenuButton(
         .padding(Theme.spacing.small)
     ) {
       if (icon != null) {
-        Icon(
+        Image(
           painter = icon,
           contentDescription = label,
-          tint = Theme.colors.icon.default,
           modifier = Modifier.size(Theme.sizing.icon.small)
         )
 
@@ -50,6 +50,14 @@ fun MenuButton(
       )
 
       Spacer(Modifier.weight(1f))
+
+      if (rightIcon != null) {
+        Image(
+          painter = rightIcon,
+          contentDescription = null,
+          modifier = Modifier.size(Theme.sizing.icon.small)
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
# Why

Start migrating the dev-launcher ui to compose.
As the package is quite complex, I've decided to split the work across multiple PRs. This is the first one.

# How

Rewrite the launcher UI using compose.

# Test Plan

- compose preview ✅ 

Current state:
https://github.com/user-attachments/assets/5ec1cffa-ff5f-4ae3-8f79-68349b1c3015


