### PR TITLE
[docs] Make it explicit file extensions should be boldified

### DIFF
--- a/guides/Expo Documentation Writing Style Guide.md
+++ b/guides/Expo Documentation Writing Style Guide.md
@@ -179,9 +179,9 @@ We, sometimes, have buttons that lead to an Expo Snack. Use title case for these
 - Correct: Try this example on Snack
 - Incorrect: Try This Example On Snack
 
-### File, directory names, extensions as bold text
+### File names, directory names, file extensions as bold text
 
-File, directory names and file extensions are used as bold text in the markdown files.
+File names, directory names and file extensions are used as bold text in the markdown files.
 
 Example:
 

--- a/guides/Expo Documentation Writing Style Guide.md
+++ b/guides/Expo Documentation Writing Style Guide.md
@@ -179,9 +179,9 @@ We, sometimes, have buttons that lead to an Expo Snack. Use title case for these
 - Correct: Try this example on Snack
 - Incorrect: Try This Example On Snack
 
-### File and directory names as bold text
+### File, directory names, extensions as bold text
 
-File and directory names are used as bold text in the markdown files.
+File, directory names and file extensions are used as bold text in the markdown files.
 
 Example:
 
@@ -192,6 +192,11 @@ Example:
 
 - Correct: If you commit your **android** or **ios** directories, it won't work.
 - Incorrect: If you commit your `android` or `ios` directories, it won't work.
+
+Example:
+
+- Correct: This command should produce **.tar.gz** archive.
+- Incorrect: This command should produce .tar.gz archive.
 
 ### Capitalization
 


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/37498#discussion_r2154587352

In fact Cursor did write ".tar.gz" in plaintext, not bold, so it must have not understood the extensions should be bold too.

# How

Made it explicit.

# Test Plan

Inspect MD preview.