### PR TITLE
[docs] Update platform-specific extensions and modules guide in Expo Router

### DIFF
--- a/docs/pages/router/advanced/platform-specific-modules.mdx
+++ b/docs/pages/router/advanced/platform-specific-modules.mdx
@@ -1,11 +1,37 @@
 ---
-title: Platform-specific modules
-description: Learn how to switch modules based on the platform in Expo Router.
+title: Platform-specific extensions and module
+description: Learn how to switch modules based on the platform in Expo Router using platform-specific extensions and module.
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
 
-While building your app, you may want to show specific content based on the current platform. Platform-specific modules can make the experience more native to a given platform. The following sections describe the ways you can achieve this with Expo Router.
+While building your app, you may want to show specific content based on the current platform. Platform-specific extensions and `Platform` module can make the experience more native to a given platform. The following sections describe the ways you can achieve this with Expo Router.
+
+## Platform-specific extensions
+
+> **warning** Platform-specific extensions were added in Expo Router `3.5.x`. If you are using an older version of the library, follow instructions from [Platform-specific modules](#platform-module).
+
+Metro bundler's platform-specific extensions (for example, **.ios.tsx** or **.native.tsx**) are supported in the **app** directory only if a **non-platform version** also exists. This ensures that routes are universal across platforms for deep linking.
+
+Consider the following project structure:
+
+<FileTree
+  files={[
+    'app/_layout.tsx',
+    'app/_layout.web.tsx',
+    'app/index.tsx',
+    'app/about.tsx',
+    'app/about.web.tsx',
+  ]}
+/>
+
+In the above file structure:
+
+- **\_layout.web.tsx** file is used as a layout on the web and **\_layout.tsx** is used on all other platforms.
+- **index.tsx** file is used as the home page for all platforms.
+- **about.web.tsx** file is used as the about page for the web, and the **about.tsx** file is used on all other platforms.
+
+> **info** Providing a route file without a platform-specific extension is required to ensure every platform has a default implementation.
 
 ## Platform module
 
@@ -37,30 +63,3 @@ export default function Layout() {
   );
 }
 ```
-
-## Platform-specific extensions
-
-> **warning** Platform-specific extensions were added in Expo Router `3.5.x`. If you are using an older version of the library, follow instructions from [Platform-specific modules](#platform-module).
-
-Metro bundler's platform-specific extensions (for example, **.ios.tsx** or **.native.tsx**) are not supported in the **app** directory. This ensures that routes are universal across platforms for deep linking. However, you can create platform-specific files outside the **app** directory and use them from within the **app** directory.
-
-Consider the following project:
-
-<FileTree
-  files={[
-    'app/_layout.tsx',
-    'app/index.tsx',
-    'app/about.tsx',
-    'components/about.tsx',
-    'components/about.ios.tsx',
-    'components/about.web.tsx',
-  ]}
-/>
-
-For example, the designs require you to build different `about` screens for each platform. In that case, you can create a component for each platform in the **components** directory using platform extensions. When imported, Metro will ensure the correct component version is used based on the current platform. You can then re-export the component as a screen in the **app** directory.
-
-```tsx app/about.tsx
-export { default } from '../components/about';
-```
-
-> **info** **Best practice:** Always provide a file without a platform extension to ensure every platform has a default implementation.

--- a/docs/pages/router/advanced/platform-specific-modules.mdx
+++ b/docs/pages/router/advanced/platform-specific-modules.mdx
@@ -1,9 +1,7 @@
 ---
-title: Platform-specific Modules
+title: Platform-specific modules
 description: Learn how to switch modules based on the platform in Expo Router.
 ---
-
-> **warning** Platform specific extensions were added in Expo Router `3.5.0`. Follow this guide only if you are using an older version of Expo Router.
 
 import { FileTree } from '~/ui/components/FileTree';
 
@@ -40,7 +38,9 @@ export default function Layout() {
 }
 ```
 
-## Platform specific extensions
+## Platform-specific extensions
+
+> **warning** Platform-specific extensions were added in Expo Router `3.5.x`. If you are using an older version of the library, follow instructions from [Platform-specific modules](#platform-module).
 
 Metro bundler's platform-specific extensions (for example, **.ios.tsx** or **.native.tsx**) are not supported in the **app** directory. This ensures that routes are universal across platforms for deep linking. However, you can create platform-specific files outside the **app** directory and use them from within the **app** directory.
 

--- a/docs/pages/router/advanced/platform-specific-modules.mdx
+++ b/docs/pages/router/advanced/platform-specific-modules.mdx
@@ -31,7 +31,7 @@ In the above file structure:
 - **index.tsx** file is used as the home page for all platforms.
 - **about.web.tsx** file is used as the about page for the web, and the **about.tsx** file is used on all other platforms.
 
-> **info** Providing a route file without a platform-specific extension is required to ensure every platform has a default implementation.
+> **info** **Note:** Providing a route file without a platform-specific extension is required to ensure every platform has a default implementation.
 
 ## Platform module
 

--- a/docs/pages/router/advanced/platform-specific-modules.mdx
+++ b/docs/pages/router/advanced/platform-specific-modules.mdx
@@ -1,6 +1,6 @@
 ---
 title: Platform-specific extensions and module
-description: Learn how to switch modules based on the platform in Expo Router using platform-specific extensions and module.
+description: Learn how to switch modules based on the platform in Expo Router using platform-specific extensions and Platform module from React Native.
 ---
 
 import { FileTree } from '~/ui/components/FileTree';

--- a/docs/pages/router/advanced/platform-specific-modules.mdx
+++ b/docs/pages/router/advanced/platform-specific-modules.mdx
@@ -11,6 +11,8 @@ While building your app, you may want to show specific content based on the curr
 
 > **warning** Platform-specific extensions were added in Expo Router `3.5.x`. If you are using an older version of the library, follow instructions from [Platform-specific modules](#platform-module).
 
+There are two ways to use platform-specific extensions:
+
 ### Within app directory
 
 Metro bundler's platform-specific extensions (for example, **.android.tsx**, **.ios.tsx**, **.native.tsx**, or **.web.tsx**) are supported in the **app** directory only if a **non-platform version** also exists. This ensures that routes are universal across platforms for deep linking.

--- a/docs/pages/router/advanced/platform-specific-modules.mdx
+++ b/docs/pages/router/advanced/platform-specific-modules.mdx
@@ -11,7 +11,9 @@ While building your app, you may want to show specific content based on the curr
 
 > **warning** Platform-specific extensions were added in Expo Router `3.5.x`. If you are using an older version of the library, follow instructions from [Platform-specific modules](#platform-module).
 
-Metro bundler's platform-specific extensions (for example, **.ios.tsx** or **.native.tsx**) are supported in the **app** directory only if a **non-platform version** also exists. This ensures that routes are universal across platforms for deep linking.
+### Within app directory
+
+Metro bundler's platform-specific extensions (for example, **.android.tsx**, **.ios.tsx**, **.native.tsx**, or **.web.tsx**) are supported in the **app** directory only if a **non-platform version** also exists. This ensures that routes are universal across platforms for deep linking.
 
 Consider the following project structure:
 
@@ -31,7 +33,28 @@ In the above file structure:
 - **index.tsx** file is used as the home page for all platforms.
 - **about.web.tsx** file is used as the about page for the web, and the **about.tsx** file is used on all other platforms.
 
-> **info** **Note:** Providing a route file without a platform-specific extension is required to ensure every platform has a default implementation.
+### Outside app directory
+
+You can create platform-specific files outside the **app** directory and use them from within the **app** directory.
+
+Consider the following project structure:
+
+<FileTree
+  files={[
+    'app/_layout.tsx',
+    'app/index.tsx',
+    'app/about.tsx',
+    'components/about.tsx',
+    'components/about.ios.tsx',
+    'components/about.web.tsx',
+  ]}
+/>
+
+In the above file structure, the designs require you to build different `about` screens for each platform. In that case, you can create a component for each platform in the **components** directory using platform extensions. When imported, Metro will ensure the correct component version is used based on the current platform. You can then re-export the component as a screen in the **app** directory.
+
+```tsx app/about.tsx
+export { default } from '../components/about';
+```
 
 ## Platform module
 

--- a/docs/pages/router/advanced/platform-specific-modules.mdx
+++ b/docs/pages/router/advanced/platform-specific-modules.mdx
@@ -37,7 +37,7 @@ In the above file structure:
 
 ### Outside app directory
 
-You can create platform-specific files outside the **app** directory and use them from within the **app** directory.
+You can create platform-specific files with extensions (for example, **.android.tsx**, **.ios.tsx**, **.native.tsx**, or **.web.tsx**) outside the **app** directory and use them from within the **app** directory.
 
 Consider the following project structure:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16157

Supersedes #37453

The information about the platform-specific extensions is outdated. Vojta and Kadi pointed that the latest info about the feature was updated in this: https://github.com/expo/expo/commit/d6db31896a119ef41e9bd065000c97d2a71ecc98#diff-04c3f911c12260de6309c4052c7a1a9bb6fcd646a56896bc34dd58ce7f34ec07.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update title, description, and introduction of the page to indicate that this page covers info on both platform-specific extensions and `Platform` module
- Since platform-specific extension is the feature available in the latest Expo Router version, it should be the first section of the page. Info is copied from the diff linked above in the "why" section of this PR.
- Update file structure in the example of the platform-specific extension section to use TypeScript.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running the docs app locally and visiting: http://localhost:3002/router/advanced/platform-specific-modules/

## Preview

![CleanShot 2025-06-18 at 21 51 21](https://github.com/user-attachments/assets/8b84d0a2-b8a5-447c-a497-784c92a1dfc4)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
