### PR TITLE
[expo] fix fetch canceled error message on android

### DIFF
--- a/apps/test-suite/tests/Fetch.ts
+++ b/apps/test-suite/tests/Fetch.ts
@@ -240,6 +240,7 @@ export function test({ describe, expect, it, ...t }) {
         }
       }
       expect(error).not.toBeNull();
+      expect(error.message).toMatch(/cancell?ed/i);
       expect(hasReceivedChunk).toBe(false);
     });
   });

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
+- Fixed `expo/fetch` requests cancellation error message on Android. ([#37509](https://github.com/expo/expo/pull/37509) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
@@ -3,6 +3,7 @@
 package expo.modules.fetch
 
 import android.util.Log
+import expo.modules.core.logging.localizedMessageWithCauseLocalizedMessage
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.sharedobjects.SharedObject
 import kotlinx.coroutines.CoroutineScope
@@ -75,7 +76,7 @@ internal class NativeResponse(appContext: AppContext, private val coroutineScope
     val error = FetchRequestCancelledException()
     this.error = error
     if (state == ResponseState.BODY_STREAMING_STARTED) {
-      emit("didFailWithError", error)
+      emit("didFailWithError", error.localizedMessageWithCauseLocalizedMessage())
     }
     state = ResponseState.ERROR_RECEIVED
   }
@@ -113,7 +114,7 @@ internal class NativeResponse(appContext: AppContext, private val coroutineScope
     }
 
     if (state == ResponseState.BODY_STREAMING_STARTED) {
-      emit("didFailWithError", e)
+      emit("didFailWithError", e.localizedMessageWithCauseLocalizedMessage())
     }
     error = e
     state = ResponseState.ERROR_RECEIVED
@@ -190,7 +191,7 @@ internal class NativeResponse(appContext: AppContext, private val coroutineScope
     } catch (e: IOException) {
       this.error = e
       if (state == ResponseState.BODY_STREAMING_STARTED) {
-        emit("didFailWithError", e)
+        emit("didFailWithError", e.localizedMessageWithCauseLocalizedMessage())
       }
       state = ResponseState.ERROR_RECEIVED
     }


### PR DESCRIPTION
# Why

fix the error message when expo/fetch requests were canceled

# How

we cannot emit android exception to js, so to use string instead. this aligns to ios implementation: https://github.com/expo/expo/blob/27bd5abb6e9d10c771e40406c86fce9f734c4e9c/packages/expo/ios/Fetch/NativeResponse.swift#L65

# Test Plan

update fetch test for the case

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
