### PR TITLE
fix(expo-router): add rewrites to options schema

### DIFF
--- a/packages/expo-router/plugin/options.json
+++ b/packages/expo-router/plugin/options.json
@@ -107,6 +107,45 @@
               }
             }
           }
+        },
+        "rewrites": {
+          "description": "Enable static rewrites. Rewrites allow you to map an incoming request path to a different destination path without changing the URL.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "required": [
+              "source",
+              "destination"
+            ],
+            "properties": {
+              "source": {
+                "description": "The incoming request path pattern to match",
+                "type": "string"
+              },
+              "destination": {
+                "description": "The target path to rewrite the request to",
+                "type": "string"
+              },
+              "methods": {
+                "description": "HTTP methods that should be rewritten. Omit to rewrite all methods.",
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "GET",
+                    "POST",
+                    "PUT",
+                    "DELETE",
+                    "PATCH",
+                    "OPTIONS",
+                    "HEAD"
+                  ]
+                }
+              }
+            }
+          }
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
# Why

The documentation here demonstrates how to enable URL rewrites: https://docs.expo.dev/router/advanced/redirects/#rewrites

However this causes expo to fail to start:

```
ValidationError: Invalid options object. expo-router config plugin has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'rewrites'. These properties are valid:
   object { origin?, headOrigin?, root?, platformRoutes?, sitemap?, asyncRoutes?, partialRouteTypes?, redirects? }
```

# How

Added missing entry to options.json schema file.

# Test Plan

Tested by adding rewrite configuration in the router-e2e app.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
