### PR TITLE
chore(expo 53): upgraded @react-native-community/datetimepicker to 8.4.1

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3296,7 +3296,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNDateTimePicker (8.3.0):
+  - RNDateTimePicker (8.4.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -4445,7 +4445,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 767abb068db6ad28b5f59a129fbc9fab18b377e2
   RNCMaskedView: aac38cf7e947ff80e483996d1acd43c5ad4ab610
   RNCPicker: 9f14f7b5511d88d7608b344e9089916ff8a47298
-  RNDateTimePicker: c525b5bb1b2d9766d3fa5e178495c222d8a75c87
+  RNDateTimePicker: 60f9e986d61e42169a2716c1b51f1f93dfa82665
   RNFlashList: 30e89fd3a2a5825e2d317e27b963302b2f4a0030
   RNGestureHandler: 9d04ec6e1379b595222c2467f5e8d1c44157fcc9
   RNReanimated: 9afbfc6ca21aea3291cc058334b53b6069a2808b

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -44,7 +44,7 @@
     "@expo/dom-webview": "0.1.4",
     "@expo/styleguide-base": "^1.0.1",
     "@react-native-async-storage/async-storage": "2.2.0",
-    "@react-native-community/datetimepicker": "8.3.0",
+    "@react-native-community/datetimepicker": "8.4.1",
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "4.5.6",
     "@react-native-masked-view/masked-view": "0.3.2",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3046,7 +3046,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNDateTimePicker (8.3.0):
+  - RNDateTimePicker (8.4.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -4257,7 +4257,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 767abb068db6ad28b5f59a129fbc9fab18b377e2
   RNCMaskedView: aac38cf7e947ff80e483996d1acd43c5ad4ab610
   RNCPicker: 9f14f7b5511d88d7608b344e9089916ff8a47298
-  RNDateTimePicker: c525b5bb1b2d9766d3fa5e178495c222d8a75c87
+  RNDateTimePicker: 60f9e986d61e42169a2716c1b51f1f93dfa82665
   RNFlashList: 30e89fd3a2a5825e2d317e27b963302b2f4a0030
   RNGestureHandler: 9d04ec6e1379b595222c2467f5e8d1c44157fcc9
   RNReanimated: 9afbfc6ca21aea3291cc058334b53b6069a2808b

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -28,7 +28,7 @@
     "@gorhom/bottom-sheet": "4.4.6",
     "@graphql-codegen/introspection": "^2.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",
-    "@react-native-community/datetimepicker": "^8.3.0",
+    "@react-native-community/datetimepicker": "^8.4.1",
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "4.5.6",
     "@react-native-masked-view/masked-view": "0.3.2",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -39,7 +39,7 @@
     "@lottiefiles/dotlottie-react": "^0.10.1",
     "@lottiefiles/react-lottie-player": "^3.5.4",
     "@react-native-async-storage/async-storage": "2.2.0",
-    "@react-native-community/datetimepicker": "8.3.0",
+    "@react-native-community/datetimepicker": "8.4.1",
     "@react-native-community/netinfo": "11.4.1",
     "@react-native-community/slider": "4.5.6",
     "@react-native-masked-view/masked-view": "0.3.2",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -4,7 +4,7 @@
   "@expo/vector-icons": "^14.1.0",
   "@expo/ui": "~0.1.1-alpha.7",
   "@react-native-async-storage/async-storage": "2.2.0",
-  "@react-native-community/datetimepicker": "8.3.0",
+  "@react-native-community/datetimepicker": "8.4.1",
   "@react-native-masked-view/masked-view": "0.3.2",
   "@react-native-community/netinfo": "11.4.1",
   "@react-native-community/slider": "4.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2995,10 +2995,10 @@
   dependencies:
     merge-options "^3.0.4"
 
-"@react-native-community/datetimepicker@8.3.0", "@react-native-community/datetimepicker@^8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-8.3.0.tgz#d734a77ae5fdf9585ea2eba0d2b5cf47404c0a09"
-  integrity sha512-K/KgaJbLtjMpx4PaG4efrVIcSe6+DbLufeX1lwPB5YY8i3sq9dOh6WcAcMTLbaRTUpurebQTkl7puHPFm9GalA==
+"@react-native-community/datetimepicker@8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-8.4.1.tgz#a798c237f01ae96658d5c93292fc2955dad04a83"
+  integrity sha512-DrK+CUS5fZnz8dhzBezirkzQTcNDdaXer3oDLh0z4nc2tbdIdnzwvXCvi8IEOIvleoc9L95xS5tKUl0/Xv71Mg==
   dependencies:
     invariant "^2.2.4"
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
when using the config plugin of date time picker it creates duplicate style to edge-to-edge makes in styles.xml https://github.com/react-native-datetimepicker/datetimepicker/issues/975

and it got fixed in 8.4.1 https://github.com/react-native-datetimepicker/datetimepicker/releases/tag/v8.4.1
# How

<!--
How did you build this feature or fix this bug and why?
-->
I updated the needed version from 8.3.0 to 8.4.1 so that expo doctor or `expo install --check ` updates the version

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
run the cli and check if it suggests to upgrade or not 
# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
