### PR TITLE
[ios][audio] Move to per module component registry

### DIFF
--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3015,7 +3015,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNDateTimePicker (8.4.2):
+  - RNDateTimePicker (8.4.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3665,7 +3665,7 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../modules/@react-native-async-storage/async-storage`)"
   - "RNCMaskedView (from `../../../node_modules/@react-native-masked-view/masked-view`)"
   - "RNCPicker (from `../../../node_modules/@react-native-picker/picker`)"
-  - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
+  - "RNDateTimePicker (from `../../../node_modules/@react-native-community/datetimepicker`)"
   - "RNFlashList (from `../../../node_modules/@shopify/flash-list`)"
   - RNGestureHandler (from `../../../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../../../node_modules/react-native-reanimated`)
@@ -4025,7 +4025,7 @@ EXTERNAL SOURCES:
   RNCPicker:
     :path: "../../../node_modules/@react-native-picker/picker"
   RNDateTimePicker:
-    :path: "../node_modules/@react-native-community/datetimepicker"
+    :path: "../../../node_modules/@react-native-community/datetimepicker"
   RNFlashList:
     :path: "../../../node_modules/@shopify/flash-list"
   RNGestureHandler:

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3015,7 +3015,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNDateTimePicker (8.4.1):
+  - RNDateTimePicker (8.4.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3665,7 +3665,7 @@ DEPENDENCIES:
   - "RNCAsyncStorage (from `../modules/@react-native-async-storage/async-storage`)"
   - "RNCMaskedView (from `../../../node_modules/@react-native-masked-view/masked-view`)"
   - "RNCPicker (from `../../../node_modules/@react-native-picker/picker`)"
-  - "RNDateTimePicker (from `../../../node_modules/@react-native-community/datetimepicker`)"
+  - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
   - "RNFlashList (from `../../../node_modules/@shopify/flash-list`)"
   - RNGestureHandler (from `../../../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../../../node_modules/react-native-reanimated`)
@@ -4025,7 +4025,7 @@ EXTERNAL SOURCES:
   RNCPicker:
     :path: "../../../node_modules/@react-native-picker/picker"
   RNDateTimePicker:
-    :path: "../../../node_modules/@react-native-community/datetimepicker"
+    :path: "../node_modules/@react-native-community/datetimepicker"
   RNFlashList:
     :path: "../../../node_modules/@shopify/flash-list"
   RNGestureHandler:

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [iOS] Improve audio tap memory safety and cleanup ([#37174](https://github.com/expo/expo/pull/37174) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix unused recording permission causing app store rejection. ([#37457](https://github.com/expo/expo/pull/37457) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Prevent status updates when the player is paused. ([#37475](https://github.com/expo/expo/pull/37475) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Change component registry to be per module to prevent interference.
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [iOS] Improve audio tap memory safety and cleanup ([#37174](https://github.com/expo/expo/pull/37174) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix unused recording permission causing app store rejection. ([#37457](https://github.com/expo/expo/pull/37457) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Prevent status updates when the player is paused. ([#37475](https://github.com/expo/expo/pull/37475) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Change component registry to be per module to prevent interference.
+- [iOS] Change component registry to be per module to prevent interference. ([#37534](https://github.com/expo/expo/pull/37534) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioComponentRegistry.swift
+++ b/packages/expo-audio/ios/AudioComponentRegistry.swift
@@ -1,8 +1,6 @@
 import Foundation
 
 class AudioComponentRegistry {
-  static let shared = AudioComponentRegistry()
-
   private var players = [String: AudioPlayer]()
   #if os(iOS)
   private var recorders = [String: AudioRecorder]()
@@ -10,7 +8,7 @@ class AudioComponentRegistry {
 
   private let registryQueue = DispatchQueue(label: "expo.audio.registry", attributes: .concurrent)
 
-  private init() {}
+  init() {}
 
   func add(_ player: AudioPlayer) {
     registryQueue.async(flags: .barrier) {
@@ -42,8 +40,11 @@ class AudioComponentRegistry {
 
   func removeAll() {
     registryQueue.async(flags: .barrier) {
+      self.players.values.forEach { $0.owningRegistry = nil }
       self.players.removeAll()
+
       #if os(iOS)
+      self.recorders.values.forEach { $0.owningRegistry = nil }
       self.recorders.removeAll()
       #endif
     }

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -27,6 +27,7 @@ public class AudioPlayer: SharedRef<AVPlayer> {
   private var audioProcessor: AudioTapProcessor?
   private var tapInstalled = false
   private var shouldInstallAudioTap = false
+  weak var owningRegistry: AudioComponentRegistry?
 
   var duration: Double {
     ref.currentItem?.duration.seconds ?? 0.0
@@ -270,8 +271,7 @@ public class AudioPlayer: SharedRef<AVPlayer> {
   }
 
   public override func sharedObjectWillRelease() {
-    AudioComponentRegistry.shared.remove(self)
-
+    owningRegistry?.remove(self)
     cancellables.removeAll()
 
     if samplingEnabled {

--- a/packages/expo-audio/ios/AudioRecorder.swift
+++ b/packages/expo-audio/ios/AudioRecorder.swift
@@ -10,6 +10,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
   private var isPrepared = false
   private var recordingSession = AVAudioSession.sharedInstance()
   var allowsRecording = true
+  weak var owningRegistry: AudioComponentRegistry?
 
   override init(_ ref: AVAudioRecorder) {
     super.init(ref)
@@ -137,7 +138,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
   }
 
   override func sharedObjectWillRelease() {
-    AudioComponentRegistry.shared.remove(self)
+    owningRegistry?.remove(self)
 
     if ref.isRecording {
       ref.stop()


### PR DESCRIPTION
# Why
@chrfalch noticed the issue where audio components can interfere with each others lifecycles. This is because all modules are using a shared component registry for lifecycle management.  

# How
Make the component registry per module so each module controls it's own instance.

# Test Plan
Lifecycle methods are now called in the expected order and only affect the components that belong to the module. 

