### PR TITLE
docs: update wording related to lightning cable

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -28,7 +28,7 @@ Run the following command in your project's root directory:
 
 ### Plug in your device via USB and enable developer mode
 
-1. Connect your iOS device to your Mac using a USB to Lightning cable. Unlock the device and tap **Trust** if prompted.
+1. Connect your iOS device to your Mac using a USB cable. Unlock the device and tap **Trust** if prompted.
 
 2. Open Xcode. From the menu bar, select **Window** > **Devices and Simulators**. You will see a warning in Xcode to enable developer mode.
 


### PR DESCRIPTION
# Why

Someone left feedback related to this. Lightning cables are being phased out, modern iPhones just have USB C.

# How

- Changes `using a USB to Lightning cable` to `using a USB cable`

# Test Plan

Docs change only

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
