### PR TITLE
[workspaces] Patch react-native-macos to find correct Hermes prebuild

### DIFF
--- a/apps/bare-expo/macos/Podfile.lock
+++ b/apps/bare-expo/macos/Podfile.lock
@@ -76,6 +76,29 @@ PODS:
   - hermes-engine (0.78.2):
     - hermes-engine/Pre-built (= 0.78.2)
   - hermes-engine/Pre-built (0.78.2)
+  - lottie-ios (4.5.0)
+  - lottie-react-native (7.2.2):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - lottie-ios (= 4.5.0)
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -1704,7 +1727,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNGestureHandler (2.24.0):
+  - RNGestureHandler (2.26.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1749,6 +1772,7 @@ DEPENDENCIES:
   - fmt (from `../../../node_modules/react-native-macos/third-party-podspecs/fmt.podspec`)
   - glog (from `../../../node_modules/react-native-macos/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../../../node_modules/react-native-macos/sdks/hermes-engine/hermes-engine.podspec`)
+  - lottie-react-native (from `../../../node_modules/lottie-react-native`)
   - RCT-Folly (from `../../../node_modules/react-native-macos/third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../../../node_modules/react-native-macos/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../../../node_modules/react-native-macos/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
@@ -1817,6 +1841,10 @@ DEPENDENCIES:
   - SocketRocket (from `../../../node_modules/react-native-macos/third-party-podspecs/SocketRocket.podspec`)
   - Yoga (from `../../../node_modules/react-native-macos/ReactCommon/yoga`)
 
+SPEC REPOS:
+  trunk:
+    - lottie-ios
+
 EXTERNAL SOURCES:
   boost:
     :podspec: "../../../node_modules/react-native-macos/third-party-podspecs/boost.podspec"
@@ -1871,6 +1899,8 @@ EXTERNAL SOURCES:
   hermes-engine:
     :podspec: "../../../node_modules/react-native-macos/sdks/hermes-engine/hermes-engine.podspec"
     :tag: hermes-2025-01-13-RNv0.78.0-a942ef374897d85da38e9c8904574f8376555388
+  lottie-react-native:
+    :path: "../../../node_modules/lottie-react-native"
   RCT-Folly:
     :podspec: "../../../node_modules/react-native-macos/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -2023,6 +2053,8 @@ SPEC CHECKSUMS:
   fmt: f6af2d677a106e3e44c9536a4c0c7f03ab53c854
   glog: b7594b792ee4e02ed1f44b01d046ca25fa713e3d
   hermes-engine: 2771b98fb813fdc6f92edd7c9c0035ecabf9fee7
+  lottie-ios: a881093fab623c467d3bce374367755c272bdd59
+  lottie-react-native: 3a4dca5f080ad23c26ec9b51fc936596716c4331
   RCT-Folly: abec2d7f4af402b4957c44e86ceff8725b23c1b4
   RCTDeprecation: cf39863b43871c2031050605fb884019b6193910
   RCTRequired: 8e45f166ea2d154c59dd209c5bb710ad3ac0e752
@@ -2085,7 +2117,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 0e6b627e262ae3216aaa7735bb44853899347254
   ReactCommon: 06d6013a960cfd9223a4f6d335343ce04c0edbbe
   RNCAsyncStorage: efa02b644121f4e1f7f33e712f4f82c30aa4ff4a
-  RNGestureHandler: 9b05fab9a0b48fe48c968de7dbb9ca38a2b4f7ab
+  RNGestureHandler: 5fca159e221d84c26a24d249ef5552c0393776e2
   SocketRocket: 03f7111df1a343b162bf5b06ead333be808e1e0a
   Yoga: f89a870053f1a8fbee8c98e35a1b9eff44ce2015
 

--- a/apps/bare-expo/scripts/fixtures/macos/patches/react-native-macos+0.78.3.patch
+++ b/apps/bare-expo/scripts/fixtures/macos/patches/react-native-macos+0.78.3.patch
@@ -1,0 +1,41 @@
+diff --git a/node_modules/react-native-macos/sdks/hermes-engine/hermes-utils.rb b/node_modules/react-native-macos/sdks/hermes-engine/hermes-utils.rb
+index 1592a89..5c29959 100644
+--- a/node_modules/react-native-macos/sdks/hermes-engine/hermes-utils.rb
++++ b/node_modules/react-native-macos/sdks/hermes-engine/hermes-utils.rb
+@@ -6,6 +6,7 @@
+ require 'net/http'
+ require 'rexml/document'
+ require 'open3' # [macOS]
++require 'json' # [macOS]
+ 
+ HERMES_GITHUB_URL = "https://github.com/facebook/hermes.git"
+ ENV_BUILD_FROM_SOURCE = "RCT_BUILD_HERMES_FROM_SOURCE"
+@@ -242,22 +243,12 @@ end
+ # [macOS react-native-macos does not publish macos specific hermes artifacts
+ # so we attempt to find the latest patch version of the iOS artifacts and use that
+ def findLastestVersionWithArtifact(version)
+-    versionWithoutPatch = version.match(/^(\d+\.\d+)/)
+-    xml_data, = Open3.capture3("curl -s https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/maven-metadata.xml")
+-
+-    metadata = REXML::Document.new(xml_data)
+-    versions = metadata.elements.to_a('//metadata/versioning/versions/version')
+-
+-    # Extract version numbers and sort them
+-    filtered_versions = versions.select { |version| version.text.match?(/^#{versionWithoutPatch}\.\d+$/) }
+-    if filtered_versions.empty?
+-        return
+-    end
+-
+-    version_numbers = filtered_versions.map { |version| version.text }
+-    sorted_versions = version_numbers.sort_by { |v| Gem::Version.new(v) }
+-
+-    return sorted_versions.last
++    # See https://central.sonatype.org/search/rest-api-guide/ for details on query params
++    versionWithoutPatch = "#{version.match(/^(\d+\.\d+)/)}"
++    res, = Open3.capture3("curl -s https://search.maven.org/solrsearch/select?q=g:com.facebook.react+AND+a:react-native-artifacts+AND+v:#{versionWithoutPatch}.*&core=gav&rows=1&wt=json")
++    wt = JSON.parse(res)
++    response = wt['response']
++    return response['docs'][0]['v'] unless response['numFound'] == 0
+ end
+ # macOS]
+ 

--- a/apps/bare-expo/scripts/setup-macos-project.sh
+++ b/apps/bare-expo/scripts/setup-macos-project.sh
@@ -18,7 +18,10 @@ remove_dependencies() {
 echo " ☛  Ensuring macOS project is setup..."
 
 echo " Removing macOS incompatible dependencies..."
-remove_dependencies "react-native-reanimated" "react-native-svg" "lottie-react-native"
+remove_dependencies "react-native-reanimated" "react-native-svg"
+
+echo " Copying macOS patches..."
+cp -r ./scripts/fixtures/macos/patches/* ../../patches/
 
 RN_MACOS_VERSION=$(jq -r '.dependencies["react-native-macos"]' package.json)
 if [[ "$RN_MACOS_VERSION" != "null" ]]; then
@@ -34,3 +37,7 @@ else
 
     fi
 fi
+
+echo " Running yarn from root..."
+cd ../../
+yarn install


### PR DESCRIPTION
# Why

`react-native-macos` fails to find older versions of Hermes prebuilds because the Maven endpoint it uses does not return all versions. While a new `react-native-macos` version is not released we need to mually patch this. More context can be found in: https://github.com/microsoft/react-native-macos/issues/2499

# How

Patch `react-native-macos` to find the correct Hermes prebuild based on https://github.com/microsoft/react-native-macos/pull/2505

# Test Plan

macos CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
