### PR TITLE
[docs] Update Video icon position in SidebarLink

### DIFF
--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -71,6 +71,12 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
         )}
       />
       {children}
+      {info.hasVideoLink && !isSelected && (
+        <PlaySquareIcon className="icon-xs ml-1.5 text-icon-secondary" />
+      )}
+      {info.hasVideoLink && isSelected && (
+        <PlaySquareDuotoneIcon className="icon-xs ml-1.5 text-palette-blue11" />
+      )}
       {info.isDeprecated && !isSelected && (
         <AlertTriangleIcon className="icon-xs ml-1.5 !text-icon-warning" />
       )}
@@ -98,12 +104,6 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
           )}>
           ALPHA
         </div>
-      )}
-      {info.hasVideoLink && !isSelected && (
-        <PlaySquareIcon className="icon-xs ml-1.5 text-icon-secondary" />
-      )}
-      {info.hasVideoLink && isSelected && (
-        <PlaySquareDuotoneIcon className="icon-xs ml-1.5 text-palette-blue11" />
       )}
       {isExternal && (
         <ArrowUpRightIcon className="icon-sm ml-auto text-icon-secondary group-hover:text-icon-info" />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Video icon in Reference section shows after labels.

![CleanShot 2025-06-20 at 22 18 25](https://github.com/user-attachments/assets/f1c3df57-be9d-4914-ba29-3eb7785bf224)


# How

<!--
How did you build this feature or fix this bug and why?
-->

Change the position of the Video icon to be next to the sidebar page title.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

![CleanShot 2025-06-20 at 22 16 31](https://github.com/user-attachments/assets/65e11806-f6b9-474f-891e-3deae9580f0a)

![CleanShot 2025-06-20 at 22 16 07](https://github.com/user-attachments/assets/352db5ad-2928-4f70-9df4-227e8a5bcaa6)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
