### PR TITLE
[video] [ios] Fix Tracks Not Loading

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - [Android] Fix aspect ratio of the Picture in Picture window when auto-entering for sources with ratio different from 16:9. ([#37225](https://github.com/expo/expo/pull/37225) by [@behenate](https://github.com/behenate))
 
+- [ios] Fix tracks not loading due to checking status instead of newStatus. ([]() by [@HADeveloper](https://github.com/HADeveloper))
+
 ### 💡 Others
 
 ## 2.2.1 - 2025-06-10

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [Android] Fix aspect ratio of the Picture in Picture window when auto-entering for sources with ratio different from 16:9. ([#37225](https://github.com/expo/expo/pull/37225) by [@behenate](https://github.com/behenate))
 
-- [ios] Fix tracks not loading due to checking status instead of newStatus. ([]() by [@HADeveloper](https://github.com/HADeveloper))
+- [ios] Fix tracks not loading due to checking status instead of newStatus. ([#37546](https://github.com/expo/expo/pull/37546) by [@HADeveloper](https://github.com/HADeveloper))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -376,7 +376,7 @@ class VideoPlayerObserver: VideoSourceLoaderListener {
       status = .error
     }
 
-    if let player, !loadedCurrentItem && (status == .readyToPlay || status == .error) {
+    if let player, !loadedCurrentItem && (newStatus == .readyToPlay || newStatus == .error) {
       onLoadedPlayerItem(player: player, playerItem: playerItem)
     }
 


### PR DESCRIPTION
# Why

Audio, Video, and Subtitle tracks were no longer being set or shown as available.
Issue reported here: [#37523](https://github.com/expo/expo/issues/37523)

# How

After reviewing the code and recent changes, it appears that this was just a left over artifact in the VideoPlayerObserver.swift file. Inside the onItemStatusChanged function, there is a check of the status to see if it is .readyToPlay or .error. This is getting the wrong status, and should use the local newStatus instead.

# Test Plan

I tested this change side by side across two ios simulators (18.2 and 18.4)
(Note, it appears that @react-native-picker/picker is broken in the whole bare-expo app, but that is out of the scope of this pr)

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
