### PR TITLE
[docs] Router settings replace `initial` with `withAnchor`

### DIFF
--- a/docs/pages/router/advanced/router-settings.mdx
+++ b/docs/pages/router/advanced/router-settings.mdx
@@ -44,13 +44,13 @@ export const unstable_settings = {
 };
 ```
 
-The `initialRouteName` is only used when deep-linking to a route. During app navigation, the route you are navigating to will be the initial route. You can disable this behavior using the `initial` prop on the `<Link />` component or by passing the option to the imperative APIs.
+The `initialRouteName` is only used when deep-linking to a route. During app navigation, the route you are navigating to will be the initial route. You can disable this behavior using the `withAnchor` prop on the `<Link />` component or by passing the option to the imperative APIs.
 
 ```js
 // If this navigates to a new _layout, don't override the initial route
-<Link href="/route" initial={false} />;
+<Link href="/route" withAnchor />;
 
-router.push('/route', { overrideInitialScreen: false });
+router.push('/route', { withAnchor: true });
 ```
 
 </PaddedAPIBox>


### PR DESCRIPTION
# Why

Current [Router settings](https://docs.expo.dev/router/advanced/router-settings/) docs specify a prop to disable initial route override:

```ts
<Link href="/route" initial={false} />;

router.push('/route', { overrideInitialScreen: false });
```

However, this prop does not exist anymore and is replaced with `withAnchor`:
```ts
<Link href="/route" withAnchor />;

router.push('/route', { withAnchor: true });
```

# ~~How~~ (n/a)

# ~~Test Plan~~ (n/a)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] ~~I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)~~ (n/a)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
