### PR TITLE
[video] support for foreground service

### DIFF
--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -51,7 +51,7 @@ You can configure `expo-video` using its built-in [config plugin](/config-plugin
     {
       name: 'supportsBackgroundPlayback',
       description:
-        'A boolean value to enable background playback on iOS. If `true`, the `audio` key is added to the `UIBackgroundModes` array in the **Info.plist** file. If `false`, the key is removed. When `undefined`, the key is not modified.',
+        'On Android, a new Foreground service of type `mediaPlayback` is added to **AndroidManifest.xml**. On iOS, if `true`, the `audio` key is added to the `UIBackgroundModes` array in the **Info.plist** file. If `false`, the key is removed. When `undefined`, the key is not modified.',
       platform: 'ios',
       default: 'undefined',
     },

--- a/docs/pages/versions/v53.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/video.mdx
@@ -46,7 +46,7 @@ You can configure `expo-video` using its built-in [config plugin](/config-plugin
     {
       name: 'supportsBackgroundPlayback',
       description:
-        'On iOS, if `true`, the `audio` key is added to the `UIBackgroundModes` array in the **Info.plist** file. If `false`, the key is removed. When `undefined`, the key is not modified. On Android a new Foreground service of type `mediaPlayback` is added to `AndroidManifest.xml`.',
+        'On Android, a new Foreground service of type `mediaPlayback` is added to **AndroidManifest.xml**. On iOS, if `true`, the `audio` key is added to the `UIBackgroundModes` array in the **Info.plist** file. If `false`, the key is removed. When `undefined`, the key is not modified.',
       default: 'undefined',
     },
     {

--- a/docs/pages/versions/v53.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/video.mdx
@@ -46,8 +46,7 @@ You can configure `expo-video` using its built-in [config plugin](/config-plugin
     {
       name: 'supportsBackgroundPlayback',
       description:
-        'A boolean value to enable background playback on iOS. If `true`, the `audio` key is added to the `UIBackgroundModes` array in the **Info.plist** file. If `false`, the key is removed. When `undefined`, the key is not modified.',
-      platform: 'ios',
+        'On iOS, if `true`, the `audio` key is added to the `UIBackgroundModes` array in the **Info.plist** file. If `false`, the key is removed. When `undefined`, the key is not modified. On Android a new Foreground service of type `mediaPlayback` is added to `AndroidManifest.xml`.',
       default: 'undefined',
     },
     {

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### 🛠 Breaking changes
 
-### 🎉 New features
-
 - [Android] Support Foreground service when `showNowPlayingNotification` and `supportsBackgroundPlayback` are configured. ([#37225](https://github.com/expo/expo/pull/37566) by [@kerwanp](https://github.com/kerwanp))
 
 ### 🐛 Bug fixes

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [Android] Support Foreground service when `showNowPlayingNotification` and `supportsBackgroundPlayback` are configured. ([#37225](https://github.com/expo/expo/pull/37566) by [@kerwanp](https://github.com/kerwanp))
+
 ### 🐛 Bug fixes
 
 - [Android] Fix aspect ratio of the Picture in Picture window when auto-entering for sources with ratio different from 16:9. ([#37225](https://github.com/expo/expo/pull/37225) by [@behenate](https://github.com/behenate))

--- a/packages/expo-video/android/src/main/AndroidManifest.xml
+++ b/packages/expo-video/android/src/main/AndroidManifest.xml
@@ -8,13 +8,5 @@
       android:supportsPictureInPicture="true"
       android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"
       android:theme="@style/Fullscreen"/>
-    <service
-      android:name=".playbackService.ExpoVideoPlaybackService"
-      android:exported="false"
-      android:foregroundServiceType="mediaPlayback">
-      <intent-filter>
-        <action android:name="androidx.media3.session.MediaSessionService" />
-      </intent-filter>
-    </service>
   </application>
 </manifest>

--- a/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
@@ -121,10 +121,6 @@ class ExpoVideoPlaybackService : MediaSessionService() {
 
   @MainThread
   private fun setMostRecentInteractionSession(session: MediaSession?) {
-    if (isStateUnchanged(session)) {
-      return
-    }
-
     if (session?.player?.playWhenReady == false) {
       stopForeground(STOP_FOREGROUND_DETACH)
       isForeground = false
@@ -168,12 +164,6 @@ class ExpoVideoPlaybackService : MediaSessionService() {
   override fun onDestroy() {
     cleanup()
     super.onDestroy()
-  }
-
-  @MainThread
-  private fun isStateUnchanged(newSession: MediaSession?): Boolean {
-    val isPlaying = newSession?.player?.playWhenReady ?: false
-    return newSession == mostRecentInteractionSession && isPlaying == isForeground
   }
 
   @MainThread

--- a/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/PlaybackServiceConnection.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/PlaybackServiceConnection.kt
@@ -6,16 +6,20 @@ import android.os.IBinder
 import android.util.Log
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.Exceptions
 import expo.modules.video.player.VideoPlayer
 import java.lang.ref.WeakReference
 
 @OptIn(UnstableApi::class)
-class PlaybackServiceConnection(val player: WeakReference<VideoPlayer>) : ServiceConnection {
+class PlaybackServiceConnection(val player: WeakReference<VideoPlayer>, appContext: AppContext) : ServiceConnection {
   var playbackServiceBinder: PlaybackServiceBinder? = null
+  val appContext = WeakReference(appContext)
 
   override fun onServiceConnected(componentName: ComponentName, binder: IBinder) {
     val player = player.get() ?: return
     playbackServiceBinder = binder as? PlaybackServiceBinder
+    playbackServiceBinder?.service?.appContext = appContext.get() ?: throw Exceptions.AppContextLost()
     playbackServiceBinder?.service?.registerPlayer(player) ?: run {
       Log.w(
         "ExpoVideo",

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -64,7 +64,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
     .build()
 
   private val firstFrameEventGenerator = createFirstFrameEventGenerator()
-  val serviceConnection = PlaybackServiceConnection(WeakReference(this))
+  val serviceConnection = PlaybackServiceConnection(WeakReference(this), appContext)
   val intervalUpdateClock = IntervalUpdateClock(this)
 
   var playing by IgnoreSameSet(false) { new, old ->

--- a/packages/expo-video/plugin/build/withExpoVideo.js
+++ b/packages/expo-video/plugin/build/withExpoVideo.js
@@ -20,15 +20,50 @@ const withExpoVideo = (config, { supportsBackgroundPlayback, supportsPictureInPi
     });
     (0, config_plugins_1.withAndroidManifest)(config, (config) => {
         const activity = config_plugins_1.AndroidConfig.Manifest.getMainActivityOrThrow(config.modResults);
-        // No-op if the values are not defined
-        if (typeof supportsPictureInPicture === 'undefined') {
-            return config;
+        // Handle Picture in Picture configuration
+        if (typeof supportsPictureInPicture !== 'undefined') {
+            if (supportsPictureInPicture) {
+                activity.$['android:supportsPictureInPicture'] = 'true';
+            }
+            else {
+                delete activity.$['android:supportsPictureInPicture'];
+            }
         }
-        if (supportsPictureInPicture) {
-            activity.$['android:supportsPictureInPicture'] = 'true';
-        }
-        else {
-            delete activity.$['android:supportsPictureInPicture'];
+        // Handle background playback configuration
+        if (supportsBackgroundPlayback) {
+            // Add required permissions for foreground service
+            config_plugins_1.AndroidConfig.Permissions.ensurePermissions(config.modResults, [
+                'android.permission.FOREGROUND_SERVICE',
+                'android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK',
+            ]);
+            // Add the foreground service to the manifest
+            const application = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+            // Check if the service already exists
+            const existingService = application.service?.find((service) => service.$?.['android:name'] === 'expo.modules.video.playbackService.ExpoVideoPlaybackService');
+            if (!existingService) {
+                // Add the service if it doesn't exist
+                if (!application.service) {
+                    application.service = [];
+                }
+                application.service.push({
+                    $: {
+                        'android:name': 'expo.modules.video.playbackService.ExpoVideoPlaybackService',
+                        'android:exported': 'false',
+                        'android:foregroundServiceType': 'mediaPlayback',
+                    },
+                    'intent-filter': [
+                        {
+                            action: [
+                                {
+                                    $: {
+                                        'android:name': 'androidx.media3.session.MediaSessionService',
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                });
+            }
         }
         return config;
     });

--- a/packages/expo-video/plugin/build/withExpoVideo.js
+++ b/packages/expo-video/plugin/build/withExpoVideo.js
@@ -39,7 +39,8 @@ const withExpoVideo = (config, { supportsBackgroundPlayback, supportsPictureInPi
             // Add the foreground service to the manifest
             const application = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
             // Check if the service already exists
-            const existingService = application.service?.find((service) => service.$?.['android:name'] === 'expo.modules.video.playbackService.ExpoVideoPlaybackService');
+            const existingService = application.service?.find((service) => service.$?.['android:name'] ===
+                'expo.modules.video.playbackService.ExpoVideoPlaybackService');
             if (!existingService) {
                 // Add the service if it doesn't exist
                 if (!application.service) {

--- a/packages/expo-video/plugin/src/withExpoVideo.ts
+++ b/packages/expo-video/plugin/src/withExpoVideo.ts
@@ -39,16 +39,58 @@ const withExpoVideo: ConfigPlugin<WithExpoVideoOptions> = (
   withAndroidManifest(config, (config) => {
     const activity = AndroidConfig.Manifest.getMainActivityOrThrow(config.modResults);
 
-    // No-op if the values are not defined
-    if (typeof supportsPictureInPicture === 'undefined') {
-      return config;
+    // Handle Picture in Picture configuration
+    if (typeof supportsPictureInPicture !== 'undefined') {
+      if (supportsPictureInPicture) {
+        activity.$['android:supportsPictureInPicture'] = 'true';
+      } else {
+        delete activity.$['android:supportsPictureInPicture'];
+      }
     }
 
-    if (supportsPictureInPicture) {
-      activity.$['android:supportsPictureInPicture'] = 'true';
-    } else {
-      delete activity.$['android:supportsPictureInPicture'];
+    // Handle background playback configuration
+    if (supportsBackgroundPlayback) {
+      // Add required permissions for foreground service
+      AndroidConfig.Permissions.ensurePermissions(config.modResults, [
+        'android.permission.FOREGROUND_SERVICE',
+        'android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK',
+      ]);
+
+      // Add the foreground service to the manifest
+      const application = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+      
+      // Check if the service already exists
+      const existingService = application.service?.find(
+        (service: any) => service.$?.['android:name'] === 'expo.modules.video.playbackService.ExpoVideoPlaybackService'
+      );
+
+      if (!existingService) {
+        // Add the service if it doesn't exist
+        if (!application.service) {
+          application.service = [];
+        }
+
+        application.service.push({
+          $: {
+            'android:name': 'expo.modules.video.playbackService.ExpoVideoPlaybackService',
+            'android:exported': 'false',
+            'android:foregroundServiceType': 'mediaPlayback',
+          },
+          'intent-filter': [
+            {
+              action: [
+                {
+                  $: {
+                    'android:name': 'androidx.media3.session.MediaSessionService',
+                  },
+                },
+              ],
+            },
+          ],
+        });
+      }
     }
+
     return config;
   });
   return config;

--- a/packages/expo-video/plugin/src/withExpoVideo.ts
+++ b/packages/expo-video/plugin/src/withExpoVideo.ts
@@ -58,10 +58,12 @@ const withExpoVideo: ConfigPlugin<WithExpoVideoOptions> = (
 
       // Add the foreground service to the manifest
       const application = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
-      
+
       // Check if the service already exists
       const existingService = application.service?.find(
-        (service: any) => service.$?.['android:name'] === 'expo.modules.video.playbackService.ExpoVideoPlaybackService'
+        (service: any) =>
+          service.$?.['android:name'] ===
+          'expo.modules.video.playbackService.ExpoVideoPlaybackService'
       );
 
       if (!existingService) {


### PR DESCRIPTION
# Why

On Android, when an application is in background mode (e.g after locking screen) the internet connectivity is blocked after ~1 minute to save battery. When streaming remote content like HLS streams, the player crashes due to network error.

This can be reproduced using the following repo: https://github.com/kerwanp/expo-video-hls-repro

# How

This feature has been developed by following the [Foreground service documentation](https://developer.android.com/develop/background-work/services/fgs).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
**1. Configure `expo-video` to support background playback**
```json
{
  "plugins": [
      [
        "expo-video",
        {
          "supportsBackgroundPlayback": true,
          "supportsPictureInPicture": true
        }
      ]
  ]
}
```

**2. Run prebuild and verify the AndroidManifest.xml**
```
yarn expo prebuild --clean
```

It should contain the following service:
```xml
    <service
      android:name=".playbackService.ExpoVideoPlaybackService"
      android:exported="false"
      android:foregroundServiceType="mediaPlayback">
      <intent-filter>
        <action android:name="androidx.media3.session.MediaSessionService" />
      </intent-filter>
    </service>
```

**3. Setup the player**
The player must have `staysActiveInBackground` and `showNowPlayingNotification` set to `true`.

```tsx
import { useVideoPlayer, VideoView } from 'expo-video';

export function Player() {
  const player = useVideoPlayer(
    {
      uri: 'https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8',
    },
    (player) => {
      player.staysActiveInBackground = true;
      player.showNowPlayingNotification = true;
      player.timeUpdateEventInterval = 10;
    }
  );

  return (
    <VideoView
      allowsPictureInPicture
      startsPictureInPictureAutomatically
      allowsFullscreen
      allowsVideoFrameAnalysis
      contentFit="contain"
      player={player}
      style={{ width: '100%', aspectRatio: 16 / 9 }}
    />
  );
}
```

**4. Start the application and test the feature**

Start playing the video and lock the screen, the video should continue playing (as before) but the player should not crash after ~1 minute.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
