### PR TITLE
[image-picker][ios] Faster media selection (zero-copy picks), metadata remux shortcut

### DIFF
--- a/apps/native-component-list/src/screens/ImagePicker/ImagePickerScreen.tsx
+++ b/apps/native-component-list/src/screens/ImagePicker/ImagePickerScreen.tsx
@@ -37,7 +37,7 @@ const LAUNCH_PICKER_PARAMETERS: FunctionParameter[] = [
         ],
         platforms: ['android'],
       },
-      { name: 'quality', type: 'number', values: [0, 0.2, 0.7, 1.0] },
+      { name: 'quality', type: 'number', values: [1.0, 0.7, 0.2, 0] },
       { name: 'exif', type: 'boolean', initial: false },
       { name: 'base64', type: 'boolean', initial: false },
       { name: 'legacy', type: 'boolean', initial: false },
@@ -202,12 +202,12 @@ const LAUNCH_PICKER_PARAMETERS: FunctionParameter[] = [
         platforms: ['ios'],
         values: [
           {
-            name: 'UIImagePickerPreferredAssetRepresentationMode.Automatic',
-            value: ImagePicker.UIImagePickerPreferredAssetRepresentationMode.Automatic,
-          },
-          {
             name: 'UIImagePickerPreferredAssetRepresentationMode.Current',
             value: ImagePicker.UIImagePickerPreferredAssetRepresentationMode.Current,
+          },
+          {
+            name: 'UIImagePickerPreferredAssetRepresentationMode.Automatic',
+            value: ImagePicker.UIImagePickerPreferredAssetRepresentationMode.Automatic,
           },
           {
             name: 'UIImagePickerPreferredAssetRepresentationMode.Compatible',

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - [Web] Changed web `uri` to use blob URLs instead of base64 data URLs for better performance. The `uri` property will now be a blob URL instead of a base64 data URL, while the `base64` property behavior remains unchanged. ([#37447](https://github.com/expo/expo/pull/37447) by [@hirbod](https://github.com/hirbod))
+- [ios] The default for `preferredAssetRepresentationMode` is now `.current` instead of `.automatic`. This keeps the asset in its original container/codec (e.g. HEIC instead of JPEG) and is required for the new fast-path. Apps that relied on `.automatic` re-encoded output can pass `preferredAssetRepresentationMode: '.automatic'` to restore the old behaviour. ([#37569](https://github.com/expo/expo/pull/37569) by [@hirbod](https://github.com/hirbod))
 
 ### 🎉 New features
 
@@ -14,6 +15,9 @@
 - [Web] Corrected camera capture attributes on web where front camera was using 'environment' and back camera was using 'user'. Reversed the values to ensure proper camera selection. ([#37447](https://github.com/expo/expo/pull/37447) by [@hirbod](https://github.com/hirbod))
 
 ### 💡 Others
+
+- [ios] Images now use a _fast-path_ if possible: the original file is copied once and its size is read from the header (no full decode / re-encode). This requires `quality: 1`, `allowsEditing: false` and `preferredAssetRepresentationMode: .current` (new default) ([#37569](https://github.com/expo/expo/pull/37569) by [@hirbod](https://github.com/hirbod))
+- [ios] Videos picked with `VideoExportPreset.Passthrough` are no longer transcoded and are copied only once. ([#37569](https://github.com/expo/expo/pull/37569) by [@hirbod](https://github.com/hirbod))
 
 ## 16.1.4 — 2025-04-30
 

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -49,7 +49,7 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
       self.handlePermissionRequest(requesterClass: self.getMediaLibraryPermissionRequester(writeOnly), operationType: .ask, promise: promise)
     })
 
-    AsyncFunction("launchCameraAsync", { (options: ImagePickerOptions, promise: Promise) -> Void in
+    AsyncFunction("launchCameraAsync", { (options: ImagePickerOptions, promise: Promise) in
       guard let permissions = self.appContext?.permissions else {
         return promise.reject(PermissionsModuleNotFoundException())
       }

--- a/packages/expo-image-picker/ios/ImagePickerOptions.swift
+++ b/packages/expo-image-picker/ios/ImagePickerOptions.swift
@@ -41,7 +41,7 @@ internal struct ImagePickerOptions: Record {
   var presentationStyle: PresentationStyle = .automatic
 
   @Field
-  var preferredAssetRepresentationMode: PreferredAssetRepresentationMode = .automatic
+  var preferredAssetRepresentationMode: PreferredAssetRepresentationMode = .current
 
   @Field
   var cameraType: CameraType = .back

--- a/packages/expo-image-picker/ios/ImageUtils.swift
+++ b/packages/expo-image-picker/ios/ImageUtils.swift
@@ -1,8 +1,10 @@
 // Copyright 2024-present 650 Industries. All rights reserved.
 
+import CoreGraphics
+import ExpoModulesCore
+import ImageIO
 import Photos
 import UniformTypeIdentifiers
-import ExpoModulesCore
 
 internal struct ImageUtils {
   static func readImageFrom(mediaInfo: MediaInfo, shouldReadCroppedImage: Bool) -> UIImage? {
@@ -12,7 +14,9 @@ internal struct ImageUtils {
     if !shouldReadCroppedImage {
       return image
     }
-    guard let cropRect = mediaInfo[.cropRect] as? CGRect, let croppedImage = ImageUtils.crop(image: image, to: cropRect) else {
+    guard let cropRect = mediaInfo[.cropRect] as? CGRect,
+      let croppedImage = ImageUtils.crop(image: image, to: cropRect)
+    else {
       return nil
     }
     return croppedImage
@@ -147,7 +151,8 @@ internal struct ImageUtils {
   /**
    Reads base64 representation of the image data. If the data is `nil` fallbacks to reading the data from the url.
    */
-  static func readBase64From(imageData: Data?, orImageFileUrl url: URL, tryReadingFile: Bool) throws -> String? {
+  static func readBase64From(imageData: Data?, orImageFileUrl url: URL, tryReadingFile: Bool) throws
+    -> String? {
     if tryReadingFile {
       do {
         let data = try Data(contentsOf: url)
@@ -189,7 +194,9 @@ internal struct ImageUtils {
 
     return await withCheckedContinuation { continuation in
       asset.requestContentEditingInput(with: options) { input, _ in
-        guard let imageUrl = input?.fullSizeImageURL, let properties = CIImage(contentsOf: imageUrl)?.properties else {
+        guard let imageUrl = input?.fullSizeImageURL,
+          let properties = CIImage(contentsOf: imageUrl)?.properties
+        else {
           log.error("Could not fetch metadata for '\(imageUrl.absoluteString)'.")
           return continuation.resume(returning: nil)
         }
@@ -230,7 +237,9 @@ internal struct ImageUtils {
     let options = PHContentEditingInputRequestOptions()
     options.isNetworkAccessAllowed = true
     asset.requestContentEditingInput(with: options) { input, _ in
-      guard let imageUrl = input?.fullSizeImageURL, let properties = CIImage(contentsOf: imageUrl)?.properties else {
+      guard let imageUrl = input?.fullSizeImageURL,
+        let properties = CIImage(contentsOf: imageUrl)?.properties
+      else {
         log.error("Could not fetch metadata for '\(imageUrl.absoluteString)'.")
         return completion(nil)
       }
@@ -241,7 +250,8 @@ internal struct ImageUtils {
 
   static func readExifFrom(data: Data) -> ExifInfo? {
     if let cgImageSource = CGImageSourceCreateWithData(data as CFData, nil) {
-      if let properties = CGImageSourceCopyPropertiesAtIndex(cgImageSource, 0, nil) as? [String: Any] {
+      if let properties = CGImageSourceCopyPropertiesAtIndex(cgImageSource, 0, nil)
+        as? [String: Any] {
         return ImageUtils.readExifFrom(imageMetadata: properties)
       }
     }
@@ -278,7 +288,9 @@ internal struct ImageUtils {
       return inputData
     }
 
-    guard let sourceData = inputData, let imageSource = CGImageSourceCreateWithData(sourceData as CFData, nil) else {
+    guard let sourceData = inputData,
+      let imageSource = CGImageSourceCreateWithData(sourceData as CFData, nil)
+    else {
       throw FailedToReadImageException()
     }
 
@@ -293,11 +305,12 @@ internal struct ImageUtils {
     let gifMetadata = initialMetadata ?? gifProperties
     CGImageDestinationSetProperties(imageDestination, gifMetadata as CFDictionary?)
 
-    for frameIndex in 0 ..< frameCount {
+    for frameIndex in 0..<frameCount {
       guard var cgImage = CGImageSourceCreateImageAtIndex(imageSource, frameIndex, nil) else {
         throw FailedToCreateGifException()
       }
-      var frameProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, frameIndex, nil) as? [String: Any] ?? [:]
+      var frameProperties =
+        CGImageSourceCopyPropertiesAtIndex(imageSource, frameIndex, nil) as? [String: Any] ?? [:]
 
       if let cropRect {
         cgImage = cgImage.cropping(to: cropRect) ?? cgImage
@@ -310,5 +323,28 @@ internal struct ImageUtils {
       throw FailedToExportGifException()
     }
     return destinationData as Data
+  }
+
+  /*
+   * Extracts the pixel dimensions from an image file.
+   * This method efficiently reads metadata without loading the entire image into memory.
+   * @param url The file URL of the image to analyze
+   * @return A CGSize containing the width and height, or nil if the dimensions cannot be determined
+   */
+  static func readSizeFrom(url: URL) -> CGSize? {
+    // First, try to fetch the dimensions from the image metadata as this is the fastest way
+    if let imageSource = CGImageSourceCreateWithURL(url as CFURL, nil),
+      let properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil) as? [CFString: Any],
+      let width = properties[kCGImagePropertyPixelWidth] as? CGFloat,
+      let height = properties[kCGImagePropertyPixelHeight] as? CGFloat {
+      return CGSize(width: width, height: height)
+    }
+
+    // Fallback: minimally decode the image using UIImage when metadata is not available
+    if let img = UIImage(contentsOfFile: url.path) {
+      return CGSize(width: img.size.width, height: img.size.height)
+    }
+
+    return nil
   }
 }

--- a/packages/expo-image-picker/ios/UIImage+fixOrientation.swift
+++ b/packages/expo-image-picker/ios/UIImage+fixOrientation.swift
@@ -75,8 +75,6 @@ extension UIImage {
     guard let resultCgImage = ctx.makeImage() else {
       return nil
     }
-    let result = UIImage(cgImage: resultCgImage)
-
-    return result
+    return UIImage(cgImage: resultCgImage)
   }
 }

--- a/packages/expo-image-picker/ios/VideoUtils.swift
+++ b/packages/expo-image-picker/ios/VideoUtils.swift
@@ -1,6 +1,9 @@
 // Copyright 2024-present 650 Industries. All rights reserved.
 
 import AVFoundation
+import UniformTypeIdentifiers
+import Photos
+import ExpoModulesCore
 
 internal struct VideoUtils {
   static func tryCopyingVideo(at: URL, to: URL) throws {
@@ -75,7 +78,9 @@ internal struct VideoUtils {
 
   static func loadVideoRepresentation(provider: NSItemProvider, urlTransformer: @escaping (URL) throws -> URL) async throws -> URL {
     return try await withCheckedThrowingContinuation { continuation in
-      provider.loadFileRepresentation(forTypeIdentifier: UTType.movie.identifier) { url, error in
+      let typeId = UTType.movie.identifier
+
+      provider.loadFileRepresentation(forTypeIdentifier: typeId) { url, error in
         guard let url else {
           return continuation.resume(throwing: FailedToReadVideoException().causedBy(error))
         }
@@ -84,7 +89,6 @@ internal struct VideoUtils {
           // Since we're using it asynchronously, we need to copy the video to another location.
           let newUrl = try urlTransformer(url)
           try VideoUtils.tryCopyingVideo(at: url, to: newUrl)
-
           continuation.resume(returning: newUrl)
         } catch {
           continuation.resume(throwing: error)


### PR DESCRIPTION
# Why

Large assets - especially 4K videos and RAW images - were slow to resolve because  
1. Images were always **decoded + re-encoded** even when no edits were requested (passthrough) 
2. Videos were **copied twice** and often transcoded needlessly
3. A mere GPS/title tweak in Photos forced **minutes-long re-muxing**  
4. Multi-select processed items **sequentially**.  

A more detailed explanation can be found here.: https://github.com/expo/expo/issues/26853#issuecomment-2994238614

Fixes #26853

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

#### 1. A new fast-path for images  
* Switched to `itemProvider.loadFileRepresentation` → one sequential copy.  
* Read dimensions via Image IO header probe (`readSizeFrom`) → **no full decode, no re-encode**.  
* Optional Base64 / EXIF are read only on demand.  

_Result: 12 MP JPEG drops 80-120 ms ➜ **8-12 ms**; peak RAM 25 MB ➜ **≈1 MB**._

#### 2. Fast-/single-copy path for videos  
* Keep only one copy into our cache directory.  
* Skip `AVAssetExportSession` entirely when `videoExportPreset == Passthrough`.  

_Result: 350 MB HEVC goes 0.9 s ➜ **0.4 s** (2× faster)._  

#### 3. Metadata-only shortcut (videos)  

* Metadata changes won't cause a re-mux anymore, needs videoExportPreset passthrough though. 
If transcoding is disabled (passthrough) and we have direct access to the underlying`PHAsset`, try to copy the original/full-size video resource via `PHAssetResourceManager`. This avoids `loadFileRepresentation`, which can be noticeably slower once a user tweaks only the metadata (e.g. adjusts the capture date) because the photo service marks the asset as *adjusted* and will re-render a temporary file for us. Copying the resource bytes ourselves is dramatically faster because it just streams the already-existing file.

iOS will still remux videos that were just edited in the Photos app if they’re accessed immediately. Usually, the iPhone stitches a preview and creates the final file when the device is idle or charging. But if you access the file before a fullSizeRenderVideo exists, it will render it on the fly, and the promise will take as long as that rendering process needs. I tested this behavior with WhatsApp, Instagram, and Slack — all behave the same.

#### 4. AssetPresentationMode
* Changed default UIImagePickerPreferredAssetRepresentationMode from .automatic .current, as it's the fastest by default.

### Rough performance table

| Scenario | Before | After |
|----------|--------|-------|
| 4 MB JPEG | 80–120 ms | **8–12 ms** |
| 350 MB video (passthrough) | 0.9 s | **0.4 s** |
| 4 GB video, GPS-only edit | 80–120 s | **0.8 s** |
| 25-image multi-select | 1.8 s | **0.4 s** |

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Bare-Expo iOS 18.1, iPhone

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
