### PR TITLE
[docs] update docs for creating native module tutorial

### DIFF
--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -83,6 +83,21 @@ class ExpoSettingsModule : Module() {
 }
 ```
 
+```ts src/ExpoSettings.types.ts
+export type ExpoSettingsModuleEvents = {};
+```
+
+```ts src/ExpoSettingsModule.ts
+import { NativeModule, requireNativeModule } from 'expo';
+
+import { ExpoSettingsModuleEvents } from './ExpoSettings.types';
+
+declare class ExpoSettingsModule extends NativeModule<ExpoSettingsModuleEvents> {}
+
+// This call loads the native module object from the JSI.
+export default requireNativeModule<ExpoSettingsModule>('ExpoSettings');
+```
+
 ```ts src/index.ts
 import ExpoSettingsModule from './ExpoSettingsModule';
 
@@ -314,13 +329,20 @@ public class ExpoSettingsModule: Module {
 
 ### TypeScript module
 
+```ts src/ExpoSettings.types.ts
+export type ThemeChangeEvent = {
+  theme: Theme;
+};
+
+export type ExpoSettingsModuleEvents = {
+  onChangeTheme: (params: ThemeChangeEvent) => void;
+};
+```
+
 ```ts src/index.ts
 import { EventSubscription } from 'expo-modules-core';
 import ExpoSettingsModule from './ExpoSettingsModule';
-
-export type ThemeChangeEvent = {
-  theme: string;
-};
+import { ThemeChangeEvent } from './ExpoSettings.types';
 
 export function addThemeListener(listener: (event: ThemeChangeEvent) => void): EventSubscription {
   return ExpoSettingsModule.addListener('onChangeTheme', listener);
@@ -449,16 +471,24 @@ public class ExpoSettingsModule: Module {
 
 ### TypeScript module
 
-```ts src/index.ts
-import { EventSubscription } from 'expo-modules-core';
-
-import ExpoSettingsModule from './ExpoSettingsModule';
-
+```ts src/ExpoSettings.types.ts
 export type Theme = 'light' | 'dark' | 'system';
 
 export type ThemeChangeEvent = {
   theme: Theme;
 };
+
+export type ExpoSettingsModuleEvents = {
+  onChangeTheme: (params: ThemeChangeEvent) => void;
+};
+```
+
+```ts src/index.ts
+import { EventSubscription } from 'expo-modules-core';
+
+import ExpoSettingsModule from './ExpoSettingsModule';
+
+import { Theme, ThemeChangeEvent } from './ExpoSettingsModule';
 
 export function addThemeListener(listener: (event: ThemeChangeEvent) => void): EventSubscription {
   return ExpoSettingsModule.addListener('onChangeTheme', listener);

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -92,7 +92,9 @@ import { NativeModule, requireNativeModule } from 'expo';
 
 import { ExpoSettingsModuleEvents } from './ExpoSettings.types';
 
-declare class ExpoSettingsModule extends NativeModule<ExpoSettingsModuleEvents> {}
+declare class ExpoSettingsModule extends NativeModule<ExpoSettingsModuleEvents> {
+  getTheme: () => string;
+}
 
 // This call loads the native module object from the JSI.
 export default requireNativeModule<ExpoSettingsModule>('ExpoSettings');
@@ -218,6 +220,22 @@ public class ExpoSettingsModule: Module {
 
 ### TypeScript module
 
+Update the ExpoSettingsModule.
+
+```ts src/ExpoSettingsModule.ts
+import { NativeModule, requireNativeModule } from 'expo';
+
+import { ExpoSettingsModuleEvents } from './ExpoSettings.types';
+
+declare class ExpoSettingsModule extends NativeModule<ExpoSettingsModuleEvents> {
+  setTheme: (theme: string) => void;
+  getTheme: () => string;
+}
+
+// This call loads the native module object from the JSI.
+export default requireNativeModule<ExpoSettingsModule>('ExpoSettings');
+```
+
 Now, call your native modules from TypeScript.
 
 ```ts src/index.ts
@@ -331,7 +349,7 @@ public class ExpoSettingsModule: Module {
 
 ```ts src/ExpoSettings.types.ts
 export type ThemeChangeEvent = {
-  theme: Theme;
+  theme: string;
 };
 
 export type ExpoSettingsModuleEvents = {
@@ -483,12 +501,26 @@ export type ExpoSettingsModuleEvents = {
 };
 ```
 
+```ts src/ExpoSettingsModule.ts
+import { NativeModule, requireNativeModule } from 'expo';
+
+import { ExpoSettingsModuleEvents, Theme } from './ExpoSettings.types';
+
+declare class ExpoSettingsModule extends NativeModule<ExpoSettingsModuleEvents> {
+  setTheme: (theme: Theme) => void;
+  getTheme: () => Theme;
+}
+
+// This call loads the native module object from the JSI.
+export default requireNativeModule<ExpoSettingsModule>('ExpoSettings');
+```
+
 ```ts src/index.ts
 import { EventSubscription } from 'expo-modules-core';
 
 import ExpoSettingsModule from './ExpoSettingsModule';
 
-import { Theme, ThemeChangeEvent } from './ExpoSettingsModule';
+import { Theme, ThemeChangeEvent } from './ExpoSettings.types';
 
 export function addThemeListener(listener: (event: ThemeChangeEvent) => void): EventSubscription {
   return ExpoSettingsModule.addListener('onChangeTheme', listener);

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -220,7 +220,7 @@ public class ExpoSettingsModule: Module {
 
 ### TypeScript module
 
-Update the ExpoSettingsModule.
+Update the **ExpoSettingsModule.ts** to add a TypeScript interface for the `ExpoSettingsModule` native module to update the theme.
 
 ```ts src/ExpoSettingsModule.ts
 import { NativeModule, requireNativeModule } from 'expo';


### PR DESCRIPTION
# Why

I followed a tutorial on creating a native module using expo-modules and encountered an issue related to adding an event (I had an error as `onChangeEvent` hasn't been indentified by TypeScript) . The event should be added to the `ExpoSettingsModuleEvents` type in `ExpoSettings.types.ts`. Additionally, I believe it would be cleaner to keep all types used in this tutorial within `ExpoSettings.types.ts`.

Additionally, I've updated the `ExpoSettingsModule`  class, including the  `getTheme ` and  `setTheme`  methods, to provide proper typing and eliminate the use of  `any`  in their usage.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
