### PR TITLE
[dev-client] Remove dev-launcher imports

### DIFF
--- a/packages/expo-dev-client/build/DevClient.d.ts
+++ b/packages/expo-dev-client/build/DevClient.d.ts
@@ -1,3 +1,2 @@
-export * from 'expo-dev-launcher';
 export * from 'expo-dev-menu';
 //# sourceMappingURL=DevClient.d.ts.map

--- a/packages/expo-dev-client/build/DevClient.d.ts.map
+++ b/packages/expo-dev-client/build/DevClient.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"DevClient.d.ts","sourceRoot":"","sources":["../src/DevClient.ts"],"names":[],"mappings":"AAAA,cAAc,mBAAmB,CAAC;AAClC,cAAc,eAAe,CAAC"}
+{"version":3,"file":"DevClient.d.ts","sourceRoot":"","sources":["../src/DevClient.ts"],"names":[],"mappings":"AAAA,cAAc,eAAe,CAAC"}

--- a/packages/expo-dev-client/build/DevClient.js
+++ b/packages/expo-dev-client/build/DevClient.js
@@ -1,3 +1,2 @@
-export * from 'expo-dev-launcher';
 export * from 'expo-dev-menu';
 //# sourceMappingURL=DevClient.js.map

--- a/packages/expo-dev-client/build/DevClient.js.map
+++ b/packages/expo-dev-client/build/DevClient.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"DevClient.js","sourceRoot":"","sources":["../src/DevClient.ts"],"names":[],"mappings":"AAAA,cAAc,mBAAmB,CAAC;AAClC,cAAc,eAAe,CAAC","sourcesContent":["export * from 'expo-dev-launcher';\nexport * from 'expo-dev-menu';\n"]}
+{"version":3,"file":"DevClient.js","sourceRoot":"","sources":["../src/DevClient.ts"],"names":[],"mappings":"AAAA,cAAc,eAAe,CAAC","sourcesContent":["export * from 'expo-dev-menu';\n"]}

--- a/packages/expo-dev-client/plugin/build/withDevClient.d.ts
+++ b/packages/expo-dev-client/plugin/build/withDevClient.d.ts
@@ -1,5 +1,4 @@
-import type { PluginConfigType } from 'expo-dev-launcher/plugin/build/pluginConfig';
-type DevClientPluginConfigType = PluginConfigType & {
+type DevClientPluginConfigType = {
     addGeneratedScheme?: boolean;
 };
 declare const _default: import("expo/config-plugins").ConfigPlugin<DevClientPluginConfigType>;

--- a/packages/expo-dev-client/plugin/build/withDevClient.js
+++ b/packages/expo-dev-client/plugin/build/withDevClient.js
@@ -5,15 +5,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("expo/config-plugins");
 // @ts-expect-error missing types
-const app_plugin_1 = __importDefault(require("expo-dev-launcher/app.plugin"));
-// @ts-expect-error missing types
-const app_plugin_2 = __importDefault(require("expo-dev-menu/app.plugin"));
+const app_plugin_1 = __importDefault(require("expo-dev-menu/app.plugin"));
 const withGeneratedAndroidScheme_1 = require("./withGeneratedAndroidScheme");
 const withGeneratedIosScheme_1 = require("./withGeneratedIosScheme");
 const pkg = require('expo-dev-client/package.json');
 function withDevClient(config, props) {
-    config = (0, app_plugin_2.default)(config);
-    config = (0, app_plugin_1.default)(config, props);
+    config = (0, app_plugin_1.default)(config);
     const mySchemeProps = { addGeneratedScheme: true, ...props };
     if (mySchemeProps.addGeneratedScheme) {
         config = (0, withGeneratedAndroidScheme_1.withGeneratedAndroidScheme)(config);

--- a/packages/expo-dev-client/plugin/src/withDevClient.ts
+++ b/packages/expo-dev-client/plugin/src/withDevClient.ts
@@ -1,9 +1,6 @@
 import type { ExpoConfig } from 'expo/config';
 import { createRunOncePlugin } from 'expo/config-plugins';
 // @ts-expect-error missing types
-import withDevLauncher from 'expo-dev-launcher/app.plugin';
-import type { PluginConfigType } from 'expo-dev-launcher/plugin/build/pluginConfig';
-// @ts-expect-error missing types
 import withDevMenu from 'expo-dev-menu/app.plugin';
 
 import { withGeneratedAndroidScheme } from './withGeneratedAndroidScheme';
@@ -11,13 +8,12 @@ import { withGeneratedIosScheme } from './withGeneratedIosScheme';
 
 const pkg = require('expo-dev-client/package.json');
 
-type DevClientPluginConfigType = PluginConfigType & {
+type DevClientPluginConfigType = {
   addGeneratedScheme?: boolean;
 };
 
 function withDevClient(config: ExpoConfig, props: DevClientPluginConfigType) {
   config = withDevMenu(config);
-  config = withDevLauncher(config, props);
 
   const mySchemeProps = { addGeneratedScheme: true, ...props };
 

--- a/packages/expo-dev-client/src/DevClient.ts
+++ b/packages/expo-dev-client/src/DevClient.ts
@@ -1,2 +1,1 @@
-export * from 'expo-dev-launcher';
 export * from 'expo-dev-menu';


### PR DESCRIPTION
# Why

After #37415 , there are still `expo-dev-launcher` imports in `expo-dev-client` source. This PR removes those imports.

# Test Plan

Updates E2E dev launcher test should pass

