### PR TITLE
[ci] fix test-suite android build error

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 150
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 100
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64

--- a/.github/workflows/bare-diffs.yml
+++ b/.github/workflows/bare-diffs.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   bare-diffs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/check-issues-nightly.yml
+++ b/.github/workflows/check-issues-nightly.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   validate-pending-issues:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
   jest-ubuntu:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -171,7 +171,7 @@ jobs:
         run: yarn test:e2e --max-workers 1 --shard ${{ matrix.shard }}/${{ strategy.job-total }}
 
   playwright-ubuntu:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/client-android-eas.yml
+++ b/.github/workflows/client-android-eas.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/client-ios-eas.yml
+++ b/.github/workflows/client-ios-eas.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]') }}
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   code_review:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/commentator.yml
+++ b/.github/workflows/commentator.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   comment:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/create-expo-app.yml
+++ b/.github/workflows/create-expo-app.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/development-client-e2e.yml
+++ b/.github/workflows/development-client-e2e.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   detox_e2e:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         api-level: [34]

--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   detox_latest_e2e:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         api-level: [34]

--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   android:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         ndk-version: [21.4.7075529]

--- a/.github/workflows/docs-pr-destroy.yml
+++ b/.github/workflows/docs-pr-destroy.yml
@@ -16,7 +16,7 @@ jobs:
   docs-pr-destroy:
     if: (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview')) ||
         (github.event.action == 'unlabeled' && github.event.label.name == 'preview')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 🪣 Delete docs preview bucket
         env:

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   docs-pr:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/expotools.yml
+++ b/.github/workflows/expotools.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
       - name: 👷 Build Home app
         run: yarn expo export
         working-directory: apps/expo-go
-  
+
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/.github/workflows/issue-closed.yml
+++ b/.github/workflows/issue-closed.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   run-on-issue-accepted:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: contains(github.event.issue.labels.*.name, 'Issue accepted')
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check-if-trusted:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: 8398a7/action-slack@v3
         if: ${{ contains( env.TRUSTED_USERS, github.event.issue.user.login ) }}
@@ -35,7 +35,7 @@ jobs:
             })
 
   validate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   close-issues:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@v4
         with:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   needs-repro:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: "${{ contains(github.event.label.name, 'incomplete issue: missing or invalid repro') }}"
     steps:
       - uses: actions/github-script@v7
@@ -51,7 +51,7 @@ jobs:
             })
 
   needs-info:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: "${{ contains(github.event.label.name, 'incomplete issue: missing info') }}"
     steps:
       - uses: actions/github-script@v7
@@ -80,7 +80,7 @@ jobs:
             })
 
   issue-accepted:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
     if: github.event.label.name == 'issue accepted'
@@ -131,7 +131,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
   question:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: "${{ contains(github.event.label.name, 'invalid issue: question') }}"
     steps:
       - uses: actions/github-script@v7
@@ -159,7 +159,7 @@ jobs:
             })
 
   feature-request:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: "${{ contains(github.event.label.name, 'invalid issue: feature request') }}"
     steps:
       - uses: actions/github-script@v7
@@ -182,7 +182,7 @@ jobs:
             })
 
   third-party:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: "${{ contains(github.event.label.name, 'invalid issue: third-party library') }}"
     steps:
       - uses: actions/github-script@v7
@@ -209,7 +209,7 @@ jobs:
               state: 'closed'
             })
   react-native-core:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: "${{ contains(github.event.label.name, 'invalid issue: react-native-core') }}"
     steps:
       - uses: actions/github-script@v7
@@ -231,7 +231,7 @@ jobs:
               state: 'closed'
             })
   comments-on-closed:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: "${{ github.event.label.name == 'Comments on closed issue' }}"
     steps:
       - uses: actions/github-script@v7
@@ -253,7 +253,7 @@ jobs:
               lock_reason: 'resolved'
             })
   eas-build-troubleshooting:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: "${{ github.event.label.name == 'invalid issue: EAS Build troubleshooting' }}"
     steps:
       - uses: actions/github-script@v7
@@ -275,7 +275,7 @@ jobs:
               state: 'closed'
             })
   version-bump:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: "${{ github.event.label.name == 'Version bump PR' }}"
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   action:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: dessant/lock-threads@v5
         with:

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   test-suite-fingerprint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
     # REQUIRED: limit concurrency when pushing main(default) branch to prevent conflict for this action to update its fingerprint database
     concurrency: fingerprint-${{ github.event_name != 'pull_request' && 'main' || github.run_id }}

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   publish-canaries:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       NODE_AUTH_TOKEN: ${{ secrets.EXPO_BOT_NPM_TOKEN }}
     steps:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   check-packages:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
       - name: 🧐 Check packages
         run: |
           echo "Checking packages according to the event name: ${{ github.event_name }}"
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event.inputs.checkAll }}" == "check-all" ]] || 
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event.inputs.checkAll }}" == "check-all" ]] ||
             ${{ steps.filter.outputs.module-scripts }} == "true"; then
             # Check all packages on scheduled events or if requested by workflow_dispatch event.
             bin/expotools check-packages --all

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -149,6 +149,10 @@ jobs:
       - name: ⭐️ Create test-nightlies Project (New Architecture)
         run: yarn prepare && bun build/index.js --expo-repo ${{ github.workspace }} --no-install ${{ runner.temp }} --enable-new-architecture true
         working-directory: packages/create-expo-nightly
+      - name: 🤖 Gradle prebuild for Android project (workaround to fix build error)
+        run: |
+          cd android && ./gradlew preBuild
+        working-directory: ${{ runner.temp }}/test-nightlies
       - name: 🤖 Build Android project (New Architecture)
         run: |
           cd android && ./gradlew ":app:assemble$VARIANT"

--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -115,7 +115,7 @@ jobs:
       fail-fast: true
       matrix:
         build-type: [debug, release]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
       GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"

--- a/.github/workflows/test-suite-lint.yml
+++ b/.github/workflows/test-suite-lint.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -164,8 +164,6 @@ jobs:
       - name: ⚛️ Display React Native config
         run: yarn expo-modules-autolinking react-native-config --platform android
         working-directory: apps/bare-expo
-      - name: 🛠️ Generate dynamic macros
-        run: expotools android-generate-dynamic-macros --configuration release --bare
       - name: 🤖 Build Android project
         run: ./scripts/start-android-e2e-test.js --build
         working-directory: apps/bare-expo

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -164,6 +164,9 @@ jobs:
       - name: ⚛️ Display React Native config
         run: yarn expo-modules-autolinking react-native-config --platform android
         working-directory: apps/bare-expo
+      - name: 🤖 Gradle prebuild for Android project (workaround to fix build error)
+        run: ./gradlew preBuild
+        working-directory: apps/bare-expo/android
       - name: 🤖 Build Android project
         run: ./scripts/start-android-e2e-test.js --build
         working-directory: apps/bare-expo

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -131,7 +131,7 @@ jobs:
           author_name: Test Suite Nightly (iOS)
 
   android-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
       GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"
@@ -187,7 +187,7 @@ jobs:
 
   android-test:
     needs: android-build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         api-level: [34]

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -183,8 +183,9 @@ jobs:
       - name: ⚛️ Display React Native config
         run: yarn expo-modules-autolinking react-native-config --platform android
         working-directory: apps/bare-expo
-      - name: 🛠️ Generate dynamic macros
-        run: expotools android-generate-dynamic-macros --configuration release --bare
+      - name: 🏗️ Gradle prebuild for Android project (workaround to fix build error)
+        run: ./gradlew preBuild
+        working-directory: apps/bare-expo/android
       - name: 🏗️ Build Android project
         run: ./scripts/start-android-e2e-test.js --build
         working-directory: apps/bare-expo

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -147,7 +147,7 @@ jobs:
           author_name: Test Suite (iOS)
 
   android-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
       GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"
@@ -213,7 +213,7 @@ jobs:
 
   android-test:
     needs: android-build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         api-level: [34]

--- a/.github/workflows/validate-npm-owners.yml
+++ b/.github/workflows/validate-npm-owners.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   validate-npm-owners:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
@@ -31,4 +31,3 @@ jobs:
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
           author_name: Validate npm owners
-


### PR DESCRIPTION
# Why

fix https://github.com/expo/expo/actions/runs/15810968576/job/44571365056

# How

- [ci] seems to have some build sequence or dependency issue. not able to reproduce locally and might be ubuntu runner related. workaround to run preBuild (run codegen for autolinked modules) beforehand
- [ci] update ubuntu 24.04 runner

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
