### PR TITLE
[docs] add Keith App.js'25 talk, pin it on home

### DIFF
--- a/docs/public/static/talks.ts
+++ b/docs/public/static/talks.ts
@@ -14,6 +14,13 @@ export const TALKS = [
     home: true,
   },
   {
+    title: 'Embracing Native Code and Capabilities',
+    event: 'App.js Conf 2025',
+    description: 'Keith Kurak',
+    videoId: 'TLoHua8bzPg',
+    home: true,
+  },
+  {
     title: 'Keynote: flexibility & iteration speed',
     event: 'App.js Conf 2024',
     description: 'Charlie Cheever, James Ide',
@@ -30,7 +37,6 @@ export const TALKS = [
     event: 'App.js Conf 2024',
     description: 'Evan Bacon',
     videoId: 'BK2xbPW2uUU',
-    home: true,
   },
   {
     title: 'Launching Desktop Apps to Orbit with React Native',


### PR DESCRIPTION
# Why

The last Expo team talk from App.js'25 has been published.

# How

Add Keith App.js'25 talk to the list, pin it on home page.

# Test Plan

Visit docs home page after performing changes.

### Preview

![Screenshot 2025-06-23 at 14 48 46](https://github.com/user-attachments/assets/5bcfadfe-99b2-4088-9014-1f815f2631bd)
