### PR TITLE
[docs] Fix minor issues in native module and native view tutorials

### DIFF
--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Tutorial: Creating a native module'
+title: 'Tutorial: Create a native module'
 sidebar_title: Create a native module
 description: A tutorial on creating a native module that persists settings with Expo Modules API.
 hasVideoLink: true
@@ -40,7 +40,7 @@ First, create a new module. For this tutorial, the module is named `expo-setting
 Clean up the default module to start with a clean slate. Delete the view module since this guide does not use it.
 
 <Terminal
-  cmdCopy="cd expo-settings && rm ios/ExpoSettingsView.swift && rm android/src/main/java/expo/modules/settings/ExpoSettingsView.kt && rm src/ExpoSettingsView.tsx src/ExpoSettingsView.web.tsx src/ExpoSettingsModule.web.ts src/ExpoSettings.types.ts"
+  cmdCopy="cd expo-settings && rm ios/ExpoSettingsView.swift && rm android/src/main/java/expo/modules/settings/ExpoSettingsView.kt && rm src/ExpoSettingsView.tsx src/ExpoSettingsView.web.tsx src/ExpoSettingsModule.web.ts"
   cmd={[
     '$ cd expo-settings',
     '$ rm ios/ExpoSettingsView.swift',
@@ -51,20 +51,6 @@ Clean up the default module to start with a clean slate. Delete the view module 
 />
 
 Locate the following files and replace their contents with the provided minimal boilerplate:
-
-```swift ios/ExpoSettingsModule.swift
-import ExpoModulesCore
-
-public class ExpoSettingsModule: Module {
-  public func definition() -> ModuleDefinition {
-    Name("ExpoSettings")
-
-    Function("getTheme") { () -> String in
-      "system"
-    }
-  }
-}
-```
 
 ```kotlin android/src/main/java/expo/modules/settings/ExpoSettingsModule.kt
 package expo.modules.settings
@@ -78,6 +64,20 @@ class ExpoSettingsModule : Module() {
 
     Function("getTheme") {
       return@Function "system"
+    }
+  }
+}
+```
+
+```swift ios/ExpoSettingsModule.swift
+import ExpoModulesCore
+
+public class ExpoSettingsModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("ExpoSettings")
+
+    Function("getTheme") { () -> String in
+      "system"
     }
   }
 }

--- a/docs/pages/modules/native-view-tutorial.mdx
+++ b/docs/pages/modules/native-view-tutorial.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Tutorial: Creating a native view'
+title: 'Tutorial: Create a native view'
 sidebar_title: Create a native view
 description: A tutorial on creating a native view that renders a WebView with Expo Modules API.
 ---


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Fix minor issues in "Create a native module" and "Create a native view" tutorials under Expo Modules section.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Both tutorial titles were updated to use "Create" instead of "Creating" for consistency with the rest of the tutorials in this section.
- In the native module tutorial, the iOS Swift code block was moved after the Android Kotlin code block. The changes maintain a consistent Android-first, then iOS ordering pattern.
- Removed `src/ExpoSettings.types.ts` from the file deletion command since this file is created later in the tutorial.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
