### PR TITLE
[core] fix androidTest

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -5,7 +5,6 @@ package expo.modules.kotlin.jni
 import com.google.common.truth.Truth
 import expo.modules.kotlin.RuntimeContext
 import expo.modules.kotlin.exception.CodedException
-import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.jni.extensions.addSingleQuotes
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
@@ -198,7 +197,7 @@ class JSIAsyncFunctionsTest {
     Truth.assertThat(exception.message).contains("java.lang.IllegalStateException")
   }
 
-  @Test(expected = JavaScriptEvaluateException::class)
+  @Test(expected = PromiseException::class)
   fun should_throw_if_js_value_cannot_be_passed() = withSingleModule({
     AsyncFunction("f") { _: Int -> }
   }) {

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSISuspendableFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSISuspendableFunctionsTest.kt
@@ -5,7 +5,6 @@ package expo.modules.kotlin.jni
 import com.google.common.truth.Truth
 import expo.modules.kotlin.RuntimeContext
 import expo.modules.kotlin.exception.CodedException
-import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.jni.extensions.addSingleQuotes
 import expo.modules.kotlin.records.Field
@@ -198,7 +197,7 @@ class JSISuspendableFunctionsTest {
     Truth.assertThat(exception.message).contains("java.lang.IllegalStateException")
   }
 
-  @Test(expected = JavaScriptEvaluateException::class)
+  @Test(expected = PromiseException::class)
   fun should_throw_if_js_value_cannot_be_passed() = withSingleModule({
     AsyncFunction("f") Coroutine { _: Int -> }
   }) {


### PR DESCRIPTION
# Why

fix android insturmentation test errors: https://github.com/expo/expo/actions/runs/15843314222/job/44659923681

# How

for async and coroutine test, the exceptions are PromiseExceptions

# Test Plan

android instrumentation test passed

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - no user facing changes
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
