### PR TITLE
[calendar][iOS] Make location optional

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [iOS] Don't encode event URLs. ([#37243](https://github.com/expo/expo/pull/37243) by [@jakex7](https://github.com/jakex7))
 - [iOS] Don't require permissions for createEventInCalendarAsync. ([#37607](https://github.com/expo/expo/pull/37607) by [@jakex7](https://github.com/jakex7))
-- [iOS] Make location optional.
+- [iOS] Make location optional. ([#37612](https://github.com/expo/expo/pull/37612) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Don't encode event URLs. ([#37243](https://github.com/expo/expo/pull/37243) by [@jakex7](https://github.com/jakex7))
 - [iOS] Don't require permissions for createEventInCalendarAsync. ([#37607](https://github.com/expo/expo/pull/37607) by [@jakex7](https://github.com/jakex7))
+- [iOS] Make location optional.
 
 ### 💡 Others
 

--- a/packages/expo-calendar/ios/Records/CalendarRecords.swift
+++ b/packages/expo-calendar/ios/Records/CalendarRecords.swift
@@ -45,7 +45,7 @@ struct Event: Record {
   @Field
   var title: String
   @Field
-  var location: String
+  var location: String?
   @Field
   var creationDate: Either<String, Double>?
   @Field


### PR DESCRIPTION
# Why

I've noticed that if `location` in `createEventInCalendarAsync` is not provided, it uses an empty string instead of nil, therefore making it a bit confusing as the location should not be set at all.

| Before | After |
| --- | --- |
| <img width="368" alt="image" src="https://github.com/user-attachments/assets/f758d8eb-3efd-4f86-a288-3730603efec4" /> | <img width="368" alt="image" src="https://github.com/user-attachments/assets/4b4ecccf-f70a-4020-af03-e9d3cbabe23a" /> |
 
# How

Make location optional

# Test Plan

```ts
Calendar.createEventInCalendarAsync({
  title: 'Test Event',
  startDate: (() => {
    const date = new Date();
    date.setDate(date.getDate() + 1); // Set to tomorrow
    return date;
  })(),
  endDate: (() => {
    const date = new Date();
    date.setDate(date.getDate() + 1); // Set to tomorrow
    date.setHours(date.getHours() + 1); // Set to one hour later
    return date;
  })(),
});
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
