### PR TITLE
[file-system][next] Add directory size and disk space properties for android

### DIFF
--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemDirectory.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemDirectory.kt
@@ -20,6 +20,12 @@ class FileSystemDirectory(file: File) : FileSystemPath(file) {
     return file.isDirectory
   }
 
+  val size: Long get() {
+    validatePermission(Permission.READ)
+    validateType()
+    return file.walkTopDown().filter { it.isFile }.map { it.length() }.sum()
+  }
+
   fun create(options: CreateOptions = CreateOptions()) {
     validateType()
     validatePermission(Permission.WRITE)

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemNextModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemNextModule.kt
@@ -37,7 +37,7 @@ class FileSystemNextModule : Module() {
     }
 
     Property("availableDiskSpace") {
-     File(context.filesDir.path).freeSpace
+      File(context.filesDir.path).freeSpace
     }
 
     AsyncFunction("downloadFileAsync") Coroutine { url: URI, to: FileSystemPath, options: DownloadOptionsNext? ->

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemNextModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemNextModule.kt
@@ -32,6 +32,14 @@ class FileSystemNextModule : Module() {
       "bundleDirectory" to "asset:///"
     )
 
+    Property("totalDiskSpace") {
+      File(context.filesDir.path).totalSpace
+    }
+
+    Property("availableDiskSpace") {
+     File(context.filesDir.path).freeSpace;
+    }
+
     AsyncFunction("downloadFileAsync") Coroutine { url: URI, to: FileSystemPath, options: DownloadOptionsNext? ->
       to.validatePermission(Permission.WRITE)
       val requestBuilder = Request.Builder().url(url.toURL())
@@ -207,6 +215,10 @@ class FileSystemNextModule : Module() {
 
       Property("uri") { directory ->
         directory.asString()
+      }
+
+      Property("size") { directory ->
+        directory.size
       }
 
       // this function is internal and will be removed in the future (when returning arrays of shared objects is supported)

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemNextModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemNextModule.kt
@@ -37,7 +37,7 @@ class FileSystemNextModule : Module() {
     }
 
     Property("availableDiskSpace") {
-     File(context.filesDir.path).freeSpace;
+     File(context.filesDir.path).freeSpace
     }
 
     AsyncFunction("downloadFileAsync") Coroutine { url: URI, to: FileSystemPath, options: DownloadOptionsNext? ->


### PR DESCRIPTION
# Why

Adds size functions for filesystem for android.

# How

Same as iOS in the previous stacked PR

# Test Plan

Unit tests must pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
