### PR TITLE
[docs] Add missing import reference for Directory in expo-file-system/next

### DIFF
--- a/docs/pages/versions/unversioned/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem-next.mdx
@@ -42,7 +42,7 @@ try {
 Using `downloadFileAsync`:
 
 ```ts example.ts
-import { File, Paths } from 'expo-file-system/next';
+import { Directory, File, Paths } from 'expo-file-system/next';
 
 const url = 'https://pdfobject.com/pdf/sample.pdf';
 const destination = new Directory(Paths.cache, 'pdfs');

--- a/docs/pages/versions/unversioned/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem-next.mdx
@@ -107,7 +107,7 @@ const response = await fetch('https://example.com', {
 ### Moving and copying files
 
 ```ts example.ts
-import { File, Paths } from 'expo-file-system/next';
+import { Directory, File, Paths } from 'expo-file-system/next';
 
 try {
   const file = new File(Paths.document, 'example.txt');

--- a/docs/pages/versions/unversioned/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem-next.mdx
@@ -70,7 +70,7 @@ src.write(await response.bytes());
 
 ### Uploading files using `expo/fetch`
 
-You can upload files as blobs directly with fetch built into the Expo package:
+You can upload files as blobs directly with `fetch` built into the Expo package:
 
 ```ts example.ts
 import { fetch } from 'expo/fetch';

--- a/docs/pages/versions/v52.0.0/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/filesystem-next.mdx
@@ -58,7 +58,7 @@ try {
 ### Moving and copying files
 
 ```ts example.ts
-import { File, Paths } from 'expo-file-system/next';
+import { Directory, File, Paths } from 'expo-file-system/next';
 
 try {
   const file = new File(Paths.document, 'example.txt');

--- a/docs/pages/versions/v52.0.0/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/filesystem-next.mdx
@@ -41,7 +41,7 @@ try {
 ### Downloading files
 
 ```ts example.ts
-import { File, Paths } from 'expo-file-system/next';
+import { Directory, File, Paths } from 'expo-file-system/next';
 
 const url = 'https://pdfobject.com/pdf/sample.pdf';
 const destination = new Directory(Paths.cache, 'pdfs');

--- a/docs/pages/versions/v53.0.0/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/filesystem-next.mdx
@@ -42,7 +42,7 @@ try {
 Using `downloadFileAsync`:
 
 ```ts example.ts
-import { File, Paths } from 'expo-file-system/next';
+import { Directory, File, Paths } from 'expo-file-system/next';
 
 const url = 'https://pdfobject.com/pdf/sample.pdf';
 const destination = new Directory(Paths.cache, 'pdfs');

--- a/docs/pages/versions/v53.0.0/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/filesystem-next.mdx
@@ -107,7 +107,7 @@ const response = await fetch('https://example.com', {
 ### Moving and copying files
 
 ```ts example.ts
-import { File, Paths } from 'expo-file-system/next';
+import { Directory, File, Paths } from 'expo-file-system/next';
 
 try {
   const file = new File(Paths.document, 'example.txt');

--- a/docs/pages/versions/v53.0.0/sdk/filesystem-next.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/filesystem-next.mdx
@@ -70,7 +70,7 @@ src.write(await response.bytes());
 
 ### Uploading files using `expo/fetch`
 
-You can upload files as blobs directly with fetch built into the Expo package:
+You can upload files as blobs directly with `fetch` built into the Expo package:
 
 ```ts example.ts
 import { fetch } from 'expo/fetch';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16233

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update multiple import statements in examples where `Directory` is used.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs app locally and visiting FileSystem (next) reference doc.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
