### PR TITLE
[ios][core] Support throwing errors in shared object constructor

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,7 +22,7 @@
 - [Android] Changed how nullable types are converted. ([#37055](https://github.com/expo/expo/pull/37055) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Reduce the number of conversions needed to call a function from the native module. ([#37099](https://github.com/expo/expo/pull/37099) by [@lukmccall](https://github.com/lukmccall))
 - Updated `ExpoComposeView` to support virtual view. ([#36255](https://github.com/expo/expo/pull/36255) by [@kudo](https://github.com/kudo))
-- [iOS] Support throwing errors in shared object constructor.
+- [iOS] Support throwing errors in shared object constructor. ([#37618](https://github.com/expo/expo/pull/37618) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 2.4.0 - 2025-06-04
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Android] Changed how nullable types are converted. ([#37055](https://github.com/expo/expo/pull/37055) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Reduce the number of conversions needed to call a function from the native module. ([#37099](https://github.com/expo/expo/pull/37099) by [@lukmccall](https://github.com/lukmccall))
 - Updated `ExpoComposeView` to support virtual view. ([#36255](https://github.com/expo/expo/pull/36255) by [@kudo](https://github.com/kudo))
+- [iOS] Support throwing errors in shared object constructor.
 
 ## 2.4.0 - 2025-06-04
 

--- a/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
@@ -68,14 +68,14 @@ public final class ClassDefinition: ObjectDefinition {
       } catch let error as Exception {
         let exception = NSException(
           name: NSExceptionName("ExpoClassConstructorException"),
-          reason: "Call to function '\(self.name).constructor' has been rejected.\n→ Caused by: \(error.description)",
+          reason: error.description,
           userInfo: ["code": error.code]
         )
         exception.raise()
       } catch {
         let exception = NSException(
           name: NSExceptionName("ExpoClassConstructorException"),
-          reason: "Call to function '\(self.name).constructor' has been rejected.\n→ Caused by: \(error.localizedDescription)",
+          reason: error.localizedDescription,
           userInfo: nil
         )
         exception.raise()

--- a/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
@@ -45,17 +45,40 @@ public final class ClassDefinition: ObjectDefinition {
 
   public override func build(appContext: AppContext) throws -> JavaScriptObject {
     let constructorBlock: ClassConstructorBlock = { [weak self, weak appContext] this, arguments in
-      guard let self = self, let appContext else {
-        // TODO: Throw an exception? (@tsapeta)
+      guard let self, let appContext else {
+        let exception = NSException(
+          name: NSExceptionName("ExpoClassConstructorException"),
+          reason: "Call to function '\(String(describing: self?.name)).constructor' has been rejected.\n→ Caused by: App context was lost",
+          userInfo: nil
+        )
+        exception.raise()
         return
       }
 
       // Call the native constructor when defined.
-      let result = try? self.constructor?.call(by: this, withArguments: arguments, appContext: appContext)
+      do {
+        if let constructor {
+          let result = try constructor.call(by: this, withArguments: arguments, appContext: appContext)
 
-      // Register the shared object if returned by the constructor.
-      if let result = result as? SharedObject {
-        appContext.sharedObjectRegistry.add(native: result, javaScript: this)
+          // Register the shared object if returned by the constructor.
+          if let result = result as? SharedObject {
+            appContext.sharedObjectRegistry.add(native: result, javaScript: this)
+          }
+        }
+      } catch let error as Exception {
+        let exception = NSException(
+          name: NSExceptionName("ExpoClassConstructorException"),
+          reason: "Call to function '\(self.name).constructor' has been rejected.\n→ Caused by: \(error.description)",
+          userInfo: ["code": error.code]
+        )
+        exception.raise()
+      } catch {
+        let exception = NSException(
+          name: NSExceptionName("ExpoClassConstructorException"),
+          reason: "Call to function '\(self.name).constructor' has been rejected.\n→ Caused by: \(error.localizedDescription)",
+          userInfo: nil
+        )
+        exception.raise()
       }
     }
 
@@ -81,12 +104,12 @@ public final class ClassDefinition: ObjectDefinition {
     try decorateWithClasses(object: prototype, appContext: appContext)
     try decorateWithProperties(object: prototype, appContext: appContext)
   }
-  
+
   private func createClass(appContext: AppContext, name: String, consturctor: @escaping ClassConstructorBlock) throws -> JavaScriptObject {
     if isSharedRef {
       return try appContext.runtime.createSharedRefClass(name, constructor: consturctor)
     }
-    
+
     return try appContext.runtime.createSharedObjectClass(name, constructor: consturctor)
   }
 }

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -164,7 +164,26 @@ typedef jsi::Function (^InstanceFactory)(jsi::Runtime& runtime, NSString * name,
     NSArray<EXJavaScriptValue *> *arguments = expo::convertJSIValuesToNSArray(self, args, count);
 
     // Returning something else than `this` is not supported in native constructors.
-    constructor(caller, arguments);
+    @try {
+      constructor(caller, arguments);
+    } @catch (NSException *exception) {
+      jsi::String jsMessage = expo::convertNSStringToJSIString(runtime, exception.reason ?: @"Constructor failed");
+      jsi::Value error = runtime
+        .global()
+        .getProperty(runtime, "Error")
+        .asObject(runtime)
+        .asFunction(runtime)
+        .callAsConstructor(runtime, {
+          jsi::Value(runtime, jsMessage)
+        });
+      
+      if (exception.userInfo[@"code"]) {
+        jsi::String jsCode = expo::convertNSStringToJSIString(runtime, exception.userInfo[@"code"]);
+        error.asObject(runtime).setProperty(runtime, "code", jsi::Value(runtime, jsCode));
+      }
+      
+      throw jsi::JSError(runtime, jsi::Value(runtime, error));
+    }
 
     return jsi::Value(runtime, thisValue);
   };

--- a/packages/expo-modules-core/ios/Tests/ExceptionsSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ExceptionsSpec.swift
@@ -130,19 +130,19 @@ final class ExceptionsSpec: ExpoSpec {
   }
 }
 
-class TestException: Exception {
+final class TestException: Exception {
   override var reason: String {
     "This is the test exception"
   }
 }
 
-class TestExceptionCause: Exception {
+final class TestExceptionCause: Exception {
   override var reason: String {
     "This is the cause of the test exception"
   }
 }
 
-class TestCodedException: Exception {
+final class TestCodedException: Exception {
   init() {
     super.init(name: "TestException",
                description: "This is a test Exception with a code",


### PR DESCRIPTION
# Why
Currently on iOS, we can't throw an error from the shared object constructor. Instead, we just silently fail to create the object leaving the user with no way of knowing there was an issue.

# How
Throw an NSException in the constructor block so this can be caught by c++ and convert it to an error. Used the same  format of message we use on Android. 

# Test Plan
Bare-expo. Tested with expo-audio

![Simulator Screenshot - iPhone 16 Pro - 2025-06-24 at 14 45 22](https://github.com/user-attachments/assets/32519f8d-3e60-4c86-be41-eca66e93d644)
