### PR TITLE
[Android][menu] Bind ViewModel to the current activity

### DIFF
--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuPackage.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/DevMenuPackage.kt
@@ -7,6 +7,8 @@ import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
@@ -18,6 +20,7 @@ import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.ReactActivityHandler
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.devmenu.compose.BindingView
+import expo.modules.devmenu.compose.DevMenuViewModel
 
 class DevMenuPackage : Package, ReactPackage {
   override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
@@ -60,7 +63,7 @@ class DevMenuPackage : Package, ReactPackage {
       object : ReactActivityHandler {
         override fun createReactRootViewContainer(activity: Activity): ViewGroup {
           return FrameLayout(activity).apply {
-            addView(BindingView(activity))
+            addView(BindingView(activity, lazyViewModel = (activity as AppCompatActivity).viewModels<DevMenuViewModel>()))
           }
         }
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/BindingView.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/BindingView.kt
@@ -1,12 +1,14 @@
 package expo.modules.devmenu.compose
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.widget.LinearLayout
 import androidx.compose.ui.platform.ComposeView
 import expo.modules.devmenu.compose.theme.AppTheme
 
-class BindingView(context: Context) : LinearLayout(context) {
-  val viewModel = DevMenuViewModel()
+@SuppressLint("ViewConstructor")
+class BindingView(context: Context, lazyViewModel: Lazy<DevMenuViewModel>) : LinearLayout(context) {
+  val viewModel by lazyViewModel
 
   init {
     addView(

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/DevMenuViewModel.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/compose/DevMenuViewModel.kt
@@ -1,9 +1,10 @@
 package expo.modules.devmenu.compose
 
 import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
 import expo.modules.devmenu.DevMenuManager
 
-class DevMenuViewModel {
+class DevMenuViewModel : ViewModel() {
   private val _state = mutableStateOf<DevMenuState>(DevMenuState())
 
   val state


### PR DESCRIPTION
# Why

Binds dev menu view model to the current activity.
It's a good practice and will simplify subscribing to changing data later.

# Test Plan

- bare-expo ✅ 