### PR TITLE
[mail-composer][android] Replace LabeledIntent with Intent in composeAsync

### DIFF
--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [android] Replace LabeledIntent with Intent in composeAsync ([#37624](https://github.com/expo/expo/pull/37624) by [@Ubax](https://github.com/Ubax))
+
 ### 💡 Others
 
 ## 14.1.4 — 2025-04-30

--- a/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailComposerModule.kt
+++ b/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/MailComposerModule.kt
@@ -1,7 +1,6 @@
 package expo.modules.mailcomposer
 
 import android.content.Intent
-import android.content.pm.LabeledIntent
 import android.net.Uri
 import android.os.Bundle
 import expo.modules.kotlin.Promise
@@ -49,13 +48,7 @@ class MailComposerModule : Module() {
           .putSubject(Intent.EXTRA_SUBJECT)
           .putBody(Intent.EXTRA_TEXT, options.isHtml == true)
           .putAttachments(Intent.EXTRA_STREAM, application)
-
-        LabeledIntent(
-          mailIntentBuilder.build(),
-          info.activityInfo.packageName,
-          info.loadLabel(context.packageManager),
-          info.icon
-        )
+        mailIntentBuilder.build()
       }.toMutableList()
 
       val primaryIntent = mailIntents.removeAt(mailIntents.size - 1)


### PR DESCRIPTION
# Why
Closes #35898

# How

Replaced `LabeledIntent` with `mailIntentBuilder.build()`. LabeledIntent was using default icon and label, so it should be safe to use just `Intent`

# Test Plan

1. Manually tested on Android 15 and 16 simulators, as well as older physical devices 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
