### PR TITLE
[docs] Add clarity about free plan credits in Billing

### DIFF
--- a/docs/pages/billing/faq.mdx
+++ b/docs/pages/billing/faq.mdx
@@ -34,6 +34,10 @@ To upgrade from the Free plan to the Starter plan, see [Upgrade to a new plan](/
 
 To downgrade from the Starter to a Free plan, see [Cancel a plan](/billing/manage/#cancel-a-plan).
 
+### Can I transfer my unused free plan credits when upgrading to a paid subscription?
+
+No, your free plan credits are not transferable to another subscription plan. All paid plans provide credits to enable priority builds for EAS Build and broader access to EAS Update through more monthly active users and extra bandwidth.
+
 ## Billing
 
 ### When does a billing period start for a plan?

--- a/docs/pages/billing/plans.mdx
+++ b/docs/pages/billing/plans.mdx
@@ -10,7 +10,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 [Expo Application Services (EAS)](/eas/) offers [free access](https://expo.dev/eas/fair-use#commercial-usage) to a limited quantity of low-priority builds on [EAS Build](/build/introduction/) and free updates with [EAS Update](/eas-update/introduction/). These limits reset monthly.
 
-Beyond the Free plan, there are different subscription plans to cater to various customers and their needs. Each plan offers credits to enable priority builds for EAS Build and broader access to EAS Update through more monthly active users and extra bandwidth. We also offer add-ons that complement subscriptions and enable opt-in features to amplify customer needs.
+Beyond the Free plan, there are different subscription plans to cater to various customers and their needs. Each paid plan offers credits to enable priority builds for EAS Build and broader access to EAS Update through more monthly active users and extra bandwidth. We also offer add-ons that complement subscriptions and enable opt-in features to amplify customer needs.
 
 This page lists different subscription-based plans and available add-ons.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16029

# How
 
<!--
How did you build this feature or fix this bug and why?
-->

After a recent conversation, we found that there is a lack of context in Billing docs about free plan credits. This PR updates the documentation for Expo's billing and subscription plans, clarifying credit usage and adding a new FAQ entry. The changes aim to improve user understanding of plan features and limitations.

* Added a new FAQ entry explaining that unused free plan credits cannot be transferred when upgrading to a paid subscription. The entry also highlights the benefits of paid plans, such as priority builds and broader access to EAS Update. 

* Updated the description of subscription plans to specify that only paid plans provide credits for priority builds and extended access to EAS Update.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs app locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
