### PR TITLE
[updates] Add basic support for macOS

### DIFF
--- a/apps/bare-expo/macos/BareExpo-macOS.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/macos/BareExpo-macOS.xcodeproj/project.pbxproj
@@ -32,6 +32,20 @@
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		C02466F72E09DA4C00F9B72D /* Supporting */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		514201462437B4B30078DB4F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -81,6 +95,7 @@
 				514201572437B4B40078DB4F /* main.m */,
 				514201592437B4B40078DB4F /* BareExpo-macOS.entitlements */,
 				6E6919923BB3CB3F3071FB08 /* PrivacyInfo.xcprivacy */,
+				C02466F72E09DA4C00F9B72D /* Supporting */,
 			);
 			path = "BareExpo-macOS";
 			sourceTree = "<group>";
@@ -142,6 +157,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				C02466F72E09DA4C00F9B72D /* Supporting */,
 			);
 			name = "BareExpo-macOS";
 			productName = ExpoMacOS;

--- a/apps/bare-expo/macos/BareExpo-macOS/Supporting/Expo.plist
+++ b/apps/bare-expo/macos/BareExpo-macOS/Supporting/Expo.plist
@@ -16,6 +16,6 @@
       <string>production</string>
     </dict>
     <key>EXUpdatesURL</key>
-    <string>https://u.expo.dev/a611132f-6ee2-4d2d-8fdd-2ddca08750f9</string>
+    <string>https://u.expo.dev/2c28de10-a2cd-11e6-b8ce-59d1587e6774</string>
   </dict>
 </plist>

--- a/apps/bare-expo/macos/BareExpo-macOS/Supporting/Expo.plist
+++ b/apps/bare-expo/macos/BareExpo-macOS/Supporting/Expo.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>EXUpdatesCheckOnLaunch</key>
+    <string>ALWAYS</string>
+    <key>EXUpdatesEnabled</key>
+    <true />
+    <key>EXUpdatesLaunchWaitMs</key>
+    <integer>0</integer>
+    <key>EXUpdatesRuntimeVersion</key>
+    <string>1.0.0</string>
+    <key>EXUpdatesRequestHeaders</key>
+    <dict>
+      <key>expo-channel-name</key>
+      <string>production</string>
+    </dict>
+    <key>EXUpdatesURL</key>
+    <string>https://u.expo.dev/a611132f-6ee2-4d2d-8fdd-2ddca08750f9</string>
+  </dict>
+</plist>

--- a/apps/bare-expo/macos/Podfile.lock
+++ b/apps/bare-expo/macos/Podfile.lock
@@ -1,7 +1,11 @@
 PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
+  - EASClient (0.14.3):
+    - ExpoModulesCore
   - EXConstants (17.1.6):
+    - ExpoModulesCore
+  - EXManifests (0.16.5):
     - ExpoModulesCore
   - Expo (53.0.9):
     - DoubleConversion
@@ -69,6 +73,36 @@ PODS:
     - ExpoModulesCore
   - ExpoWebBrowser (14.1.6):
     - ExpoModulesCore
+  - EXStructuredHeaders (4.1.0)
+  - EXUpdates (0.28.13):
+    - DoubleConversion
+    - EASClient
+    - EXManifests
+    - ExpoModulesCore
+    - EXStructuredHeaders
+    - EXUpdatesInterface
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - ReachabilitySwift
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - EXUpdatesInterface (1.1.0):
+    - ExpoModulesCore
   - fast_float (6.1.4)
   - FBLazyVector (0.78.3)
   - fmt (11.0.2)
@@ -101,6 +135,7 @@ PODS:
     - FBLazyVector (= 0.78.3)
     - RCTRequired (= 0.78.3)
     - React-Core (= 0.78.3)
+  - ReachabilitySwift (5.2.4)
   - React (0.78.3):
     - React-Core (= 0.78.3)
     - React-Core/DevSupport (= 0.78.3)
@@ -1731,7 +1766,9 @@ PODS:
 DEPENDENCIES:
   - boost (from `../../../node_modules/react-native-macos/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../../../node_modules/react-native-macos/third-party-podspecs/DoubleConversion.podspec`)
+  - EASClient (from `../../../packages/expo-eas-client/ios`)
   - EXConstants (from `../../../packages/expo-constants/ios`)
+  - EXManifests (from `../../../packages/expo-manifests/ios`)
   - Expo (from `../../../node_modules/expo`)
   - ExpoAsset (from `../../../packages/expo-asset/ios`)
   - ExpoCrypto (from `../../../packages/expo-crypto/ios`)
@@ -1744,6 +1781,9 @@ DEPENDENCIES:
   - ExpoModulesCore (from `../../../packages/expo-modules-core`)
   - ExpoSQLite (from `../../../packages/expo-sqlite/ios`)
   - ExpoWebBrowser (from `../../../packages/expo-web-browser/ios`)
+  - EXStructuredHeaders (from `../../../packages/expo-structured-headers/ios`)
+  - EXUpdates (from `../../../packages/expo-updates/ios`)
+  - EXUpdatesInterface (from `../../../packages/expo-updates-interface/ios`)
   - fast_float (from `../../../node_modules/react-native-macos/third-party-podspecs/fast_float.podspec`)
   - FBLazyVector (from `../../../node_modules/react-native-macos/Libraries/FBLazyVector`)
   - fmt (from `../../../node_modules/react-native-macos/third-party-podspecs/fmt.podspec`)
@@ -1817,14 +1857,24 @@ DEPENDENCIES:
   - SocketRocket (from `../../../node_modules/react-native-macos/third-party-podspecs/SocketRocket.podspec`)
   - Yoga (from `../../../node_modules/react-native-macos/ReactCommon/yoga`)
 
+SPEC REPOS:
+  trunk:
+    - ReachabilitySwift
+
 EXTERNAL SOURCES:
   boost:
     :podspec: "../../../node_modules/react-native-macos/third-party-podspecs/boost.podspec"
   DoubleConversion:
     :podspec: "../../../node_modules/react-native-macos/third-party-podspecs/DoubleConversion.podspec"
+  EASClient:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-eas-client/ios"
   EXConstants:
     inhibit_warnings: false
     :path: "../../../packages/expo-constants/ios"
+  EXManifests:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-manifests/ios"
   Expo:
     :path: "../../../node_modules/expo"
   ExpoAsset:
@@ -1860,6 +1910,15 @@ EXTERNAL SOURCES:
   ExpoWebBrowser:
     inhibit_warnings: false
     :path: "../../../packages/expo-web-browser/ios"
+  EXStructuredHeaders:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-structured-headers/ios"
+  EXUpdates:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-updates/ios"
+  EXUpdatesInterface:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-updates-interface/ios"
   fast_float:
     :podspec: "../../../node_modules/react-native-macos/third-party-podspecs/fast_float.podspec"
   FBLazyVector:
@@ -2005,7 +2064,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 7d49a506d1ac47358fea28558d184dd6431170ca
   DoubleConversion: 10f51d3e1238973c033faac2d84c0ea114942f53
+  EASClient: 81d62c389f7385bee733cd028f3aeb0b700bc900
   EXConstants: be238322d57d084dc055dbd5d6fe6479510504ce
+  EXManifests: 18dc175e0df41ce726d456dc13489e60e6a742a3
   Expo: a83417971ce4165d6fff913a381224abc1831762
   ExpoAsset: 3ea3275cca6a7793b3d36fbf1075c590f803fbcb
   ExpoCrypto: fc94a8865ce0e06c68c10c3993f9ac9a6424d0c2
@@ -2018,6 +2079,9 @@ SPEC CHECKSUMS:
   ExpoModulesCore: 81aba1cc8072d3ea46125d8276bc414b7be67aec
   ExpoSQLite: c092c9454ad72ba09e29c494470a4fe41996f741
   ExpoWebBrowser: 8aa522ab60113768d4dc5691c36d3315cc3b297b
+  EXStructuredHeaders: 1c799cb91e8057e0671610635e5b2109fa295114
+  EXUpdates: b3101fd5478a983781ddccbfab37d6a31d11871d
+  EXUpdatesInterface: b941371be742ef272f2fa7d6f46ee9fdf8c73c60
   fast_float: 44983b3bddb2d2ed3021a98be86f60ec8abc9ffd
   FBLazyVector: b61b46a4137164b884a21e2ae3e289e1ccef5700
   fmt: f6af2d677a106e3e44c9536a4c0c7f03ab53c854
@@ -2027,6 +2091,7 @@ SPEC CHECKSUMS:
   RCTDeprecation: cf39863b43871c2031050605fb884019b6193910
   RCTRequired: 8e45f166ea2d154c59dd209c5bb710ad3ac0e752
   RCTTypeSafety: 28651c7820ad239ac978b3a0cca1f1486a19408a
+  ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
   React: e470b63f0ff02464f52a526d7989f533467e725a
   React-callinvoker: cdbf74bfa1e78c0a41d43bbd5f34b6e22e093368
   React-Core: 3cc4c4a445a9cd3f978d4fa78cf1f8635b372308

--- a/packages/expo-eas-client/CHANGELOG.md
+++ b/packages/expo-eas-client/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add support for macOS. ([#37629](https://github.com/expo/expo/pull/37629) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-eas-client/ios/EASClient.podspec
+++ b/packages/expo-eas-client/ios/EASClient.podspec
@@ -12,7 +12,8 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '15.1',
-    :tvos => '15.1'
+    :tvos => '15.1',
+    :osx => '11.0'
   }
   s.swift_version  = '5.4'
   s.source         = { git: '' }

--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add support for macOS. ([#37629](https://github.com/expo/expo/pull/37629) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-manifests/ios/EXManifests.podspec
+++ b/packages/expo-manifests/ios/EXManifests.podspec
@@ -12,7 +12,8 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '15.1',
-    :tvos => '15.1'
+    :tvos => '15.1',
+    :osx => '11.0'
   }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-manifests/ios/EXManifests/Manifest.swift
+++ b/packages/expo-manifests/ios/EXManifests/Manifest.swift
@@ -4,8 +4,10 @@
 // swiftlint:disable unavailable_function
 
 import Foundation
-import UIKit
 
+#if os(iOS) || os(tvOS)
+import UIKit
+#endif
 /**
  Uses objective-c NSExceptions for field validation. This is to maintain
  backwards compatibility with the previous objective-c implementation so that we don't need to do
@@ -274,13 +276,17 @@ public class Manifest: NSObject {
   }
 
   public func iosSplashImageUrl() -> String? {
+    var paths = [["ios", "splash", "imageUrl"], ["splash", "imageUrl"]]
+#if os(iOS) || os(tvOS)
+    if UIDevice.current.userInterfaceIdiom == UIUserInterfaceIdiom.pad {
+      paths.insert(contentsOf: [
+        ["ios", "splash", "tabletImageUrl"],
+        ["splash", "tabletImageUrl"]
+      ], at: 0)
+    }
+#endif
     return expoClientConfigRootObject().let { it in
-      Manifest.string(fromManifest: it, atPaths: [
-        UIDevice.current.userInterfaceIdiom == UIUserInterfaceIdiom.pad
-          ? ["ios", "splash", "tabletImageUrl"] : [],
-        ["ios", "splash", "imageUrl"],
-        ["splash", "imageUrl"]
-      ])
+      Manifest.string(fromManifest: it, atPaths: paths)
     }
   }
 

--- a/packages/expo-structured-headers/CHANGELOG.md
+++ b/packages/expo-structured-headers/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add support for macOS. ([#37629](https://github.com/expo/expo/pull/37629) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-structured-headers/ios/EXStructuredHeaders.podspec
+++ b/packages/expo-structured-headers/ios/EXStructuredHeaders.podspec
@@ -12,7 +12,8 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '15.1',
-    :tvos => '15.1'
+    :tvos => '15.1',
+    :osx => '11.0'
   }
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add support for macOS. ([#37629](https://github.com/expo/expo/pull/37629) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface.podspec
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface.podspec
@@ -12,7 +12,8 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '15.1',
-    :tvos => '15.1'
+    :tvos => '15.1',
+    :osx => '11.0'
   }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add experimental support for macOS. ([#37629](https://github.com/expo/expo/pull/37629) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -30,7 +30,8 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '15.1',
-    :tvos => '15.1'
+    :tvos => '15.1',
+    :osx => '11.0'
   }
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -40,16 +40,11 @@ public final class EmbeddedAppLoader: AppLoader {
 
     let frameworkBundle = Bundle(for: EmbeddedAppLoader.self)
     if let resourceUrl = frameworkBundle.resourceURL,
-      let bundle = Bundle(url: resourceUrl.appendingPathComponent("EXUpdates.bundle")) {
-#if os(iOS) || os(tvOS)
+      let bundle = Bundle(url: resourceUrl.appendingPathComponent("EXUpdates.bundle")),
       let path = bundle.path(
         forResource: EmbeddedAppLoader.EXUpdatesEmbeddedManifestName,
         ofType: EmbeddedAppLoader.EXUpdatesEmbeddedManifestType
-      )
-#else
-      let manifestURL = bundle.bundleURL.appendingPathComponent("app.manifest")
-      let path = manifestURL.path
-#endif
+      ) {
       manifestNSData = NSData(contentsOfFile: path)
     }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -40,11 +40,16 @@ public final class EmbeddedAppLoader: AppLoader {
 
     let frameworkBundle = Bundle(for: EmbeddedAppLoader.self)
     if let resourceUrl = frameworkBundle.resourceURL,
-      let bundle = Bundle(url: resourceUrl.appendingPathComponent("EXUpdates.bundle")),
+      let bundle = Bundle(url: resourceUrl.appendingPathComponent("EXUpdates.bundle")) {
+#if os(iOS) || os(tvOS)
       let path = bundle.path(
         forResource: EmbeddedAppLoader.EXUpdatesEmbeddedManifestName,
         ofType: EmbeddedAppLoader.EXUpdatesEmbeddedManifestType
-      ) {
+      )
+#else
+      let manifestURL = bundle.bundleURL.appendingPathComponent("app.manifest")
+      let path = manifestURL.path
+#endif
       manifestNSData = NSData(contentsOfFile: path)
     }
 

--- a/packages/expo-updates/scripts/create-updates-resources-ios.sh
+++ b/packages/expo-updates/scripts/create-updates-resources-ios.sh
@@ -39,5 +39,15 @@ cd "$PROJECT_ROOT" || exit
 # We should get the physical path (/var/folders -> /private/var/folders) for metro to resolve correct files
 PROJECT_ROOT="$(pwd -P)"
 
-"${EXPO_UPDATES_PACKAGE_DIR}/scripts/with-node.sh" "${EXPO_UPDATES_PACKAGE_DIR}/utils/build/createUpdatesResources.js" ios "$PROJECT_ROOT" "$DEST/$RESOURCE_BUNDLE_NAME" "$CREATE_UPDATES_RESOURCES_MODE" "$ENTRY_FILE"
+if [ "$BUNDLE_FORMAT" == "shallow" ]; then
+  RESOURCE_DEST="$DEST/$RESOURCE_BUNDLE_NAME"
+elif [ "$BUNDLE_FORMAT" == "deep" ]; then
+  RESOURCE_DEST="$DEST/$RESOURCE_BUNDLE_NAME/Contents/Resources"
+  mkdir -p "$RESOURCE_DEST"
+else
+  echo "Unsupported bundle format: $BUNDLE_FORMAT"
+  exit 1
+fi
+
+"${EXPO_UPDATES_PACKAGE_DIR}/scripts/with-node.sh" "${EXPO_UPDATES_PACKAGE_DIR}/utils/build/createUpdatesResources.js" ios "$PROJECT_ROOT" "$RESOURCE_DEST" "$CREATE_UPDATES_RESOURCES_MODE" "$ENTRY_FILE"
 


### PR DESCRIPTION
# Why

Closes ENG-15307

# How

- Add podspec macOS support to:
  - expo-eas-client
  - expo-structured-headers
  - expo-updates-interface
  - expo-manifest (just need to add one os check for splash)
- Add a supporting folder to macOS bare-expo
- Implement support for macOS (still having a race condition sometimes where `appController(_ appController: AppControllerInterface, didStartWithSuccess success: Bool)` is called before the main window is created)


# Test Plan

Run BareExpo macos locally 

![image](https://github.com/user-attachments/assets/dd73bbb2-691f-4b2c-9a42-6387f94fb637)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
