### PR TITLE
refactor(expotools): output the full spawn logs when encountering errors during yarning stage

### DIFF
--- a/tools/bin/expotools.js
+++ b/tools/bin/expotools.js
@@ -22,6 +22,17 @@ function createLogModifier(modifier) {
     }
   };
 }
+
+/**
+ * Extract the complete spawn output, by line.
+ * This is useful for outputting errors encountered in spawn commands.
+ *
+ * @param {import('@expo/spawn-async').SpawnResult} result
+ */
+function getSpawnOutputLines(result) {
+  return result.output.map((line) => line.split('\n')).flat();
+}
+
 /**
  * Importing chalk directly may lead to errors
  * if it's not yet available on the machine.
@@ -52,7 +63,14 @@ async function maybeRebuildAndRun() {
     try {
       await spawnAsync('yarn', ['install'], { cwd: ROOT_PATH });
     } catch (error) {
-      console.error(LogModifiers.error(` 💥 Yarning failed: ${error.stack}`));
+      console.error(LogModifiers.error(` 💥 Yarning failed:`));
+      console.error(
+        LogModifiers.error(
+          getSpawnOutputLines(error)
+            .map((line) => `    ${line}`)
+            .join('\n')
+        )
+      );
       process.exit(1);
     }
   }
@@ -66,7 +84,14 @@ async function maybeRebuildAndRun() {
       await spawnAsync('yarn', ['run', 'build'], { cwd: ROOT_PATH });
       state.schema = await getCommandsSchemaAsync();
     } catch (error) {
-      console.error(LogModifiers.error(` 💥 Rebuilding failed: ${error.stack}`));
+      console.error(LogModifiers.error(` 💥 Rebuilding failed:`));
+      console.error(
+        LogModifiers.error(
+          getSpawnOutputLines(error)
+            .map((line) => `    ${line}`)
+            .join('\n')
+        )
+      );
       process.exit(1);
     }
     console.log(` ✨ Successfully built ${LogModifiers.name('expotools')}\n`);


### PR DESCRIPTION
# Why

PR #37486 broke `et` in non-obvious ways due to the `undici` update. The updates E2E tests were still suing Node 18, causing workflows to fail without proper reason:

<img width="1028" alt="image" src="https://github.com/user-attachments/assets/edd6c90a-ee16-4a5b-8ffc-e2d20c987fc6" />

# How

Old errors | New errors
--- | ---
![image](https://github.com/user-attachments/assets/df6b99a1-9d67-41e0-9a37-d9c24bf9c8df) | ![image](https://github.com/user-attachments/assets/dddb1a6b-941e-4a80-89cb-a274e550860b)


# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
