### PR TITLE
refactor(expotools): drop `undici` as its not necessary

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -62,7 +62,6 @@
     "tar": "^7.4.3",
     "terminal-link": "^2.1.1",
     "typedoc": "0.27.6",
-    "undici": "^7.10.0",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/tools/src/commands/ClientInstall.ts
+++ b/tools/src/commands/ClientInstall.ts
@@ -3,10 +3,8 @@ import chalk from 'chalk';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { Readable } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
+import { Writable } from 'node:stream';
 import { extract as tarExtract } from 'tar';
-import { fetch } from 'undici';
 
 import * as AndroidDevice from '../AndroidDevice';
 import * as Simulator from '../IOSSimulator';
@@ -124,7 +122,7 @@ async function downloadExpoGoAsync({
   if (!resp.ok || !resp.body) {
     throw new Error(`Failed to download Expo Go from ${downloadUrl}`);
   }
-  await pipeline(Readable.fromWeb(resp.body), stream);
+  await resp.body.pipeTo(Writable.toWeb(stream));
   return downloadFilePath;
 }
 

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -9,7 +9,6 @@ import inquirer from 'inquirer';
 import os from 'os';
 import path from 'path';
 import semver from 'semver';
-import { fetch } from 'undici';
 import { v4 as uuidv4 } from 'uuid';
 
 import { EXPO_DIR, EXPO_GO_IOS_DIR } from '../Constants';

--- a/tools/src/commands/PublishProdExpoHomeCommand.ts
+++ b/tools/src/commands/PublishProdExpoHomeCommand.ts
@@ -10,9 +10,7 @@ import fs from 'fs/promises';
 import nullthrows from 'nullthrows';
 import os from 'os';
 import path from 'path';
-import { Readable } from 'stream';
-import { pipeline } from 'stream/promises';
-import { fetch, type Response } from 'undici';
+import { Writable } from 'stream';
 
 import { EXPO_GO_ANDROID_DIR, EXPO_GO_IOS_DIR } from '../Constants';
 import { deepCloneObject } from '../Utils';
@@ -171,10 +169,8 @@ async function fetchManifestAndBundleAsync(
   await fs.writeFile(path.resolve(manifestPath), JSON.stringify(manifest));
 
   const bundlePath = platform === 'ios' ? iosPublishBundlePath : androidPublishBundlePath;
-  await pipeline(
-    Readable.fromWeb(bundleResponse.body),
-    createWriteStream(path.resolve(bundlePath))
-  );
+  const stream = createWriteStream(path.resolve(bundlePath));
+  await bundleResponse.body.pipeTo(Writable.toWeb(stream));
 }
 
 /**

--- a/tools/src/commands/SyncBundledNativeModules.ts
+++ b/tools/src/commands/SyncBundledNativeModules.ts
@@ -4,7 +4,6 @@ import chalk from 'chalk';
 import inquirer from 'inquirer';
 import path from 'path';
 import semver from 'semver';
-import { fetch } from 'undici';
 
 import { EXPO_DIR, LOCAL_API_HOST } from '../Constants';
 import logger from '../Logger';

--- a/tools/src/dynamic-macros/macros.ts
+++ b/tools/src/dynamic-macros/macros.ts
@@ -9,7 +9,6 @@ import crypto from 'crypto';
 import { lanNetwork } from 'lan-network';
 import os from 'os';
 import path from 'path';
-import { fetch, type Response } from 'undici';
 
 import { EXPO_GO_DIR, EXPO_GO_DEV_SERVER_PORT } from '../Constants';
 import { getExpoRepositoryRootDir } from '../Directories';

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -5781,11 +5781,6 @@ undici-types@~6.20.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
-undici@^7.10.0:
-  version "7.10.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.10.0.tgz#8ae17a976acc6593b13c9ff3342840bea9b24670"
-  integrity sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==
-
 unfetch@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"


### PR DESCRIPTION
# Why

Stacked on top of #37636

This drops `undici` from `et`, we can just rely on the global fetch within Node instead. Dropping `undici` also [fixes updates E2E issues](https://github.com/expo/expo/pull/37635) as we still default to Node 18 on EAS.

# How

- Drop `undici` from `expotools`

# Test Plan

- Start up the iOS simulator
- `et client-install -p ios`
- Should work fine

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
