### PR TITLE
Fix mixed up sentence in map view docks

### DIFF
--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -106,7 +106,7 @@ const styles = StyleSheet.create({
 <Step label="4">
 #### Add the API key to your project
 
-- Copy your **API Key** into your **.env** file and then add it to your **app.json** under the `android.config.googleMaps.apiKey` as follows:
+- Copy your **API Key** into your **.env** file and then add it to your **app.json** under the `android.config.googleMaps.apiKey` field or copy:
 
 ```json
     "android": {
@@ -150,7 +150,7 @@ const styles = StyleSheet.create({
 <Step label="3">
 #### Add the API key to your project
 
-- Copy your **API Key** into your your to either a **.env** file and then add it to your **app.json** under the `ios.config.googleMapsApiKey` field like or copy it:
+- Copy your **API Key** into your **.env** file and then add it to your **app.json** under the `ios.config.googleMaps.apiKey` field or copy:
 
 ```json
     "ios": {

--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -106,7 +106,7 @@ const styles = StyleSheet.create({
 <Step label="4">
 #### Add the API key to your project
 
-- Copy your **API Key** into your your to either a **.env** file and then add it to your **app.json** under the `android.config.googleMaps.apiKey` field like or copy it:
+- Copy your **API Key** into your **.env** file and then add it to your **app.json** under the `android.config.googleMaps.apiKey` as follows:
 
 ```json
     "android": {


### PR DESCRIPTION
# Why

Text is wrong.

# How

Fixed the sentence.

# Test Plan

No testing needed apart from re-proofreading.

I checked the style of the sentence against the documentation rules, and found that `*API Key*` should not be bolded according to the rules. However, to maintain consistency across the file, where `*API Key*` is used standard, I decided to keep it.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
