### PR TITLE
chore: disable `D:` drive on Windows playwright tests

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -246,17 +246,17 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1, 2]
-    env:
-      # Change bun, npm, and yarn caches to the much faster D:\ drive
-      # See: https://github.com/twpayne/chezmoi/pull/4064
-      BUN_INSTALL_CACHE_DIR: D:\_temp\bun
-      NPM_CACHE_LOCATION: D:\_temp\npm
-      YARN_CACHE_FOLDER: D:\_temp\yarn
-      # Change playwright browser cache to the much faster D:\ drive
-      PLAYWRIGHT_BROWSERS_PATH: D:\_temp\playwright-browsers
-      # Change the Expo E2E project directory to the same drive as the repository,
-      # allowing to run Expo from source (avoiding Metro's multi-drive limitation)
-      EXPO_E2E_TEMP_DIR: D:\_temp\expo-e2e
+    # env:
+    #   # Change bun, npm, and yarn caches to the much faster D:\ drive
+    #   # See: https://github.com/twpayne/chezmoi/pull/4064
+    #   BUN_INSTALL_CACHE_DIR: D:\_temp\bun
+    #   NPM_CACHE_LOCATION: D:\_temp\npm
+    #   YARN_CACHE_FOLDER: D:\_temp\yarn
+    #   # Change playwright browser cache to the much faster D:\ drive
+    #   PLAYWRIGHT_BROWSERS_PATH: D:\_temp\playwright-browsers
+    #   # Change the Expo E2E project directory to the same drive as the repository,
+    #   # allowing to run Expo from source (avoiding Metro's multi-drive limitation)
+    #   EXPO_E2E_TEMP_DIR: D:\_temp\expo-e2e
     steps:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -246,17 +246,17 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1, 2]
-    # env:
-    #   # Change bun, npm, and yarn caches to the much faster D:\ drive
-    #   # See: https://github.com/twpayne/chezmoi/pull/4064
-    #   BUN_INSTALL_CACHE_DIR: D:\_temp\bun
-    #   NPM_CACHE_LOCATION: D:\_temp\npm
-    #   YARN_CACHE_FOLDER: D:\_temp\yarn
-    #   # Change playwright browser cache to the much faster D:\ drive
-    #   PLAYWRIGHT_BROWSERS_PATH: D:\_temp\playwright-browsers
-    #   # Change the Expo E2E project directory to the same drive as the repository,
-    #   # allowing to run Expo from source (avoiding Metro's multi-drive limitation)
-    #   EXPO_E2E_TEMP_DIR: D:\_temp\expo-e2e
+    env:
+      # Change bun, npm, and yarn caches to the much faster D:\ drive
+      # See: https://github.com/twpayne/chezmoi/pull/4064
+      BUN_INSTALL_CACHE_DIR: D:\_temp\bun
+      NPM_CACHE_LOCATION: D:\_temp\npm
+      YARN_CACHE_FOLDER: D:\_temp\yarn
+      # Change playwright browser cache to the much faster D:\ drive
+      # PLAYWRIGHT_BROWSERS_PATH: D:\_temp\playwright-browsers
+      # Change the Expo E2E project directory to the same drive as the repository,
+      # allowing to run Expo from source (avoiding Metro's multi-drive limitation)
+      EXPO_E2E_TEMP_DIR: D:\_temp\expo-e2e
     steps:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
@@ -316,7 +316,7 @@ jobs:
         uses: actions/cache@v4
         id: playwright-browser-cache
         with:
-          path: ${{ steps.playwright-info.outputs.dir }}
+          path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-info.outputs.version }}
       - name: 🎭 Install Playwright Browsers
         run: bun playwright install --with-deps chromium


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
