### PR TITLE
[CI][expo-updates] dev client updates E2E Maestro test

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
@@ -121,16 +121,17 @@ jobs:
           JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
         run: |
           yarn maestro:android:debug:build
-      - name: Run Maestro test 1 (debug)
-        id: testdebug1
-        env:
-          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
-        working_directory: ../../../updates-e2e
-        run: |
-          # start packager
-          yarn start:dev-client
-          ./maestro/maestro-test-executor.sh ./maestro/tests/devClient_runUpdate.yml android debug
-      - name: Run Maestro test 2 (debug)
+      ###### This test works on Android in local testing, but not in Linux workers
+      # - name: Run Maestro test (debug) (load update through dev client)
+      #   id: testdebug1
+      #   env:
+      #     JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+      #   working_directory: ../../../updates-e2e
+      #   run: |
+      #     # start packager
+      #     yarn start:dev-client
+      #     ./maestro/maestro-test-executor.sh ./maestro/tests/devClient_runUpdate.yml android debug
+      - name: Run Maestro test (debug) (verify state)
         id: testdebug2
         env:
           JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
@@ -1,0 +1,141 @@
+name: Updates E2E (dev client)
+
+on:
+  push:
+    branches: [main, 'sdk-*']
+    paths:
+      - apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
+      - packages/expo-asset/**
+      - packages/expo-manifests/**
+      - packages/expo-updates-interface/**
+      - packages/expo-updates/**
+      - packages/expo-dev-client/**
+      - packages/expo-dev-menu/**
+      - packages/expo-dev-launcher/**
+      - templates/expo-template-bare-minimum/**
+  pull_request:
+    branches: [main]
+    paths:
+      - apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
+      - packages/expo-asset/**
+      - packages/expo-manifests/**
+      - packages/expo-updates-interface/**
+      - packages/expo-updates/**
+      - packages/expo-dev-client/**
+      - packages/expo-dev-menu/**
+      - packages/expo-dev-launcher/**
+      - templates/expo-template-bare-minimum/**
+  schedule:
+    - cron: '0 19 * * SUN' # 18:00 UTC every Sunday
+
+defaults:
+  tools:
+    node: 22.14.0
+    yarn: 1.22.22
+
+jobs:
+  ios:
+    runs_on: macos-large
+    image: latest
+    steps:
+      - name: Install applesimutils
+        id: ios_simulator
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          /opt/homebrew/bin/brew tap wix/brew
+          /opt/homebrew/bin/brew install applesimutils
+          xcrun simctl list
+      - uses: eas/install_maestro
+      - uses: eas/checkout
+      - uses: eas/use_npm_token
+      - uses: eas/install_node_modules
+      - name: Set up Updates E2E disabled project
+        id: setup
+        working_directory: ../..        
+        env:
+          UPDATES_HOST: localhost
+          UPDATES_PORT: "4747"
+        run: |
+          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-dev-client-eas-project.ts
+          ls -la ../updates-e2e
+      - name: Prepare E2E project
+        id: prepare
+        working_directory: ../../../updates-e2e
+        run: |
+          yarn generate-test-update-bundles ios test-update-1
+          npx pod-install
+      - name: Build E2E test app (debug)
+        id: builddebug
+        working_directory: ../../../updates-e2e
+        run: |
+          yarn maestro:ios:debug:build
+      - uses: eas/start_ios_simulator
+        with:
+          device_identifier: iPhone 16
+      - name: Run Maestro tests (debug)
+        id: testdebug
+        working_directory: ../../../updates-e2e
+        run: |
+          # start packager
+          yarn start:dev-client
+          ./maestro/maestro-test-executor.sh ./maestro/tests/updates-e2e-dev-client.yml ios debug
+  android:
+    runs_on: linux-large-nested-virtualization
+    image: latest
+    steps:
+      - name: Set up JDK 17 and Android dependencies
+        id: setuptools
+        env:
+          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+        run: |
+          sudo apt-get --quiet update --yes
+          sudo apt-get --quiet install openjdk-17-jdk openjdk-17-jre libc6 libdbus-1-3 libfontconfig1 libgcc1 libpulse0 libtinfo5 libx11-6 libxcb1 libxdamage1 libnss3 libxcomposite1 libxcursor1 libxi6 libxext6 libxfixes3 zlib1g libgl1 pulseaudio socat --yes
+      - uses: eas/install_maestro
+      - uses: eas/checkout
+      - uses: eas/use_npm_token
+      - uses: eas/install_node_modules
+      - name: Set up Updates E2E disabled project
+        id: setup
+        working_directory: ../..        
+        env:
+          UPDATES_HOST: localhost
+          UPDATES_PORT: "4747"
+        run: |
+          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-dev-client-eas-project.ts
+          ls -la ../updates-e2e
+      - name: Prepare E2E project
+        id: prepare
+        working_directory: ../../../updates-e2e
+        env:
+          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+        run: |
+          yarn generate-test-update-bundles android test-update-1
+      - uses: eas/start_android_emulator
+        with:
+          device_name: pixel_4
+      - name: Build E2E test app (debug)
+        id: builddebug
+        working_directory: ../../../updates-e2e
+        env:
+          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+        run: |
+          yarn maestro:android:debug:build
+      - name: Run Maestro test 1 (debug)
+        id: testdebug1
+        env:
+          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+        working_directory: ../../../updates-e2e
+        run: |
+          # start packager
+          yarn start:dev-client
+          ./maestro/maestro-test-executor.sh ./maestro/tests/devClient_runUpdate.yml android debug
+      - name: Run Maestro test 2 (debug)
+        id: testdebug2
+        env:
+          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+        working_directory: ../../../updates-e2e
+        run: |
+          # start packager
+          yarn start:dev-client
+          ./maestro/maestro-test-executor.sh ./maestro/tests/devClient_verifyState.yml android debug

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-old-arch.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-old-arch.yml
@@ -65,52 +65,53 @@ jobs:
         run: |
           # run same tests as the updates E2E enabled tests
           ./maestro/maestro-test-executor.sh ./maestro/tests/updates-e2e-enabled.yml ios release
-  android:
-    runs_on: linux-large-nested-virtualization
-    image: latest
-    steps:
-      - name: Set up JDK 17 and Android dependencies
-        id: setuptools
-        env:
-          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
-        run: |
-          sudo apt-get --quiet update --yes
-          sudo apt-get --quiet install openjdk-17-jdk openjdk-17-jre libc6 libdbus-1-3 libfontconfig1 libgcc1 libpulse0 libtinfo5 libx11-6 libxcb1 libxdamage1 libnss3 libxcomposite1 libxcursor1 libxi6 libxext6 libxfixes3 zlib1g libgl1 pulseaudio socat --yes
-      - uses: eas/install_maestro
-      - uses: eas/checkout
-      - uses: eas/use_npm_token
-      - uses: eas/install_node_modules
-      - name: Set up Updates E2E old arch project
-        id: setup
-        working_directory: ../..        
-        env:
-          UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
-        run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project-old-arch.ts
-          ls -la ../updates-e2e
-      - name: Prepare E2E project
-        id: prepare
-        working_directory: ../../../updates-e2e
-        env:
-          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
-        run: |
-          yarn generate-test-update-bundles android
-      - uses: eas/start_android_emulator
-        with:
-          device_name: pixel_4
-      - name: Build E2E test app (release)
-        id: buildrelease
-        working_directory: ../../../updates-e2e
-        env:
-          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
-        run: |
-          yarn maestro:android:release:build
-      - name: Run Maestro tests (release)
-        id: testrelease
-        env:
-          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
-        working_directory: ../../../updates-e2e
-        run: |
-          # run same tests as the updates E2E enabled tests
-          ./maestro/maestro-test-executor.sh ./maestro/tests/updates-e2e-enabled.yml android release
+######### Old arch test is working on Android locally, but not in Linux workers, so we disable this for now
+#  android:
+#    runs_on: linux-large-nested-virtualization
+#    image: latest
+#    steps:
+#      - name: Set up JDK 17 and Android dependencies
+#        id: setuptools
+#        env:
+#          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+#        run: |
+#          sudo apt-get --quiet update --yes
+#          sudo apt-get --quiet install openjdk-17-jdk openjdk-17-jre libc6 libdbus-1-3 libfontconfig1 libgcc1 libpulse0 libtinfo5 libx11-6 libxcb1 libxdamage1 libnss3 libxcomposite1 libxcursor1 libxi6 libxext6 libxfixes3 zlib1g libgl1 pulseaudio socat --yes
+#      - uses: eas/install_maestro
+#      - uses: eas/checkout
+#      - uses: eas/use_npm_token
+#      - uses: eas/install_node_modules
+#      - name: Set up Updates E2E old arch project
+#        id: setup
+#        working_directory: ../..        
+#        env:
+#          UPDATES_HOST: localhost
+#          UPDATES_PORT: "4747"
+#        run: |
+#          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project-old-arch.ts
+#          ls -la ../updates-e2e
+#      - name: Prepare E2E project
+#        id: prepare
+#        working_directory: ../../../updates-e2e
+#        env:
+#          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+#        run: |
+#          yarn generate-test-update-bundles android
+#      - uses: eas/start_android_emulator
+#        with:
+#          device_name: pixel_4
+#      - name: Build E2E test app (release)
+#        id: buildrelease
+#        working_directory: ../../../updates-e2e
+#        env:
+#          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+#        run: |
+#          yarn maestro:android:release:build
+#      - name: Run Maestro tests (release)
+#        id: testrelease
+#        env:
+#          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+#        working_directory: ../../../updates-e2e
+#        run: |
+#          # run same tests as the updates E2E enabled tests
+#          ./maestro/maestro-test-executor.sh ./maestro/tests/updates-e2e-enabled.yml android release

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/maestro-test-executor.sh
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/maestro-test-executor.sh
@@ -51,6 +51,7 @@ function beforeAll() {
   startUpdatesServerIfNeeded
   if [[ "$MAESTRO_PLATFORM" == "android" ]]; then
     adb reverse tcp:$MAESTRO_UPDATES_SERVER_PORT tcp:$MAESTRO_UPDATES_SERVER_PORT
+    adb reverse tcp:8081 tcp:8081
   fi
 }
 

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
@@ -1,0 +1,42 @@
+appId: dev.expo.updatese2e
+onFlowStart:
+  - runFlow:
+      file: beforeEach.yml
+---
+# Use dev client to load a bundle from updates server
+- evalScript:
+    script:  ${output.api.serveManifest('test-update-basic', MAESTRO_PLATFORM)}
+    label: Setup updates server to serve a basic update
+    env:
+      MAESTRO_PLATFORM: ${MAESTRO_PLATFORM}
+- launchApp
+- tapOn:
+    label: Tap on "Enter URL manually"
+    text: Enter URL manually
+- tapOn:
+    label: Tap on "Updates URL" text field
+    below: Enter URL manually
+- inputText:
+    label: Input local update server URL
+    text: "http://localhost:4747/update\n"
+- tapOn:
+    label: Tap on "Connect" button
+    text: Connect
+    optional: true
+- tapOn:
+    label: Tap on "Connect" button
+    text: Connect
+    optional: true
+- tapOn:
+    label: Tap on "Continue" to clear onboarding menu
+    text: Continue
+    optional: true
+- tapOn:
+    label: Tap on reload
+    text: Reload
+- copyTextFrom:
+    label: Copy text from update string
+    id: updateString
+- assertTrue:
+    condition: ${maestro.copiedText == "test-update-1"}
+    label: Assert update string is from update bundle

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_verifyState.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_verifyState.yml
@@ -1,0 +1,41 @@
+appId: dev.expo.updatese2e
+onFlowStart:
+  - runFlow:
+      file: beforeEach.yml
+---
+# Check that state is correct on a dev client build with updates enabled
+- launchApp
+- tapOn:
+    label: Tap on local URL
+    below: Development servers
+- tapOn:
+    label: Tap on "Continue" to clear onboarding menu
+    text: Continue
+    optional: true
+- tapOn:
+    label: Tap on reload
+    text: Reload
+- copyTextFrom:
+    label: Copy text from update string
+    id: updateString
+- assertTrue:
+    condition: ${maestro.copiedText == "test"}
+    label: Assert update string is from embedded bundle
+- copyTextFrom:
+    label: Copy text from updateID
+    id: updateID
+- assertTrue:
+    condition: ${maestro.copiedText != ""}
+    label: Assert updateID is not empty
+- copyTextFrom:
+    label: Copy text from isEmbeddedLaunch
+    id: isEmbeddedLaunch
+- assertTrue:
+    condition: ${maestro.copiedText == "false"}
+    label: Assert isEmbeddedLaunch is false
+- copyTextFrom:
+    label: Copy text from availableUpdateID
+    id: availableUpdateID
+- assertTrue:
+    condition: ${maestro.copiedText == "undefined"}
+    label: Assert availableUpdateID is undefined

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/updates-e2e-dev-client.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/updates-e2e-dev-client.yml
@@ -1,0 +1,6 @@
+appId: dev.expo.updatese2e
+---
+- runFlow:
+    file: devClient_verifyState.yml
+- runFlow:
+    file: devClient_runUpdate.yml

--- a/packages/expo-updates/e2e/setup/create-dev-client-eas-project.ts
+++ b/packages/expo-updates/e2e/setup/create-dev-client-eas-project.ts
@@ -2,7 +2,12 @@
 
 import path from 'path';
 
-import { initAsync, repoRoot, setupUpdatesDevClientE2EAppAsync } from './project';
+import {
+  initAsync,
+  repoRoot,
+  setupUpdatesDevClientE2EAppAsync,
+  transformAppJsonForE2EWithDevClient,
+} from './project';
 
 const workingDir = path.resolve(repoRoot, '..');
 const runtimeVersion = '1.0.0';
@@ -30,9 +35,10 @@ const runtimeVersion = '1.0.0';
     runtimeVersion,
     localCliBin,
     configureE2E: true,
-    shouldGenerateTestUpdateBundles: false,
-    shouldConfigureCodeSigning: false,
+    shouldGenerateTestUpdateBundles: true,
+    shouldConfigureCodeSigning: true,
     includeDevClient: true,
+    transformAppJson: transformAppJsonForE2EWithDevClient,
   });
 
   await setupUpdatesDevClientE2EAppAsync(projectRoot, { localCliBin, repoRoot });

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -336,6 +336,7 @@ async function preparePackageJson(
         'tvos:build':
           'xcodebuild -workspace ios/updatese2e.xcworkspace -scheme updatese2e -configuration Debug -sdk appletvsimulator -arch arm64 -derivedDataPath ios/build | npx @expo/xcpretty',
         postinstall: 'patch-package',
+        'start:dev-client': 'npx expo start --private-key-path ./keys/private-key.pem > /dev/null 2>&1 &',
         ...extraScriptsGenerateTestUpdateBundlesPart,
       }
     : extraScriptsAssetExclusion;
@@ -571,6 +572,25 @@ export function transformAppJsonForE2EWithFingerprint(
       },
     },
   };
+}
+
+/**
+ * Modifies app.json in the E2E test app to add the properties we need, and turns off updates native debug
+ */
+export function transformAppJsonForE2EWithDevClient(
+  appJson: any,
+  projectName: string,
+  runtimeVersion: string,
+  isTV: boolean
+) {
+  const transformedForE2E = transformAppJsonForE2EWithFallbackToCacheTimeout(
+    appJson,
+    projectName,
+    runtimeVersion,
+    isTV
+  );
+  delete transformedForE2E.expo.updates.useNativeDebug;
+  return transformedForE2E;
 }
 
 export function transformAppJsonForE2EWithBrickingMeasuresDisabled(


### PR DESCRIPTION
# Why

- There was a script to set up the test project for updates E2E dev client, but no test was implemented in Detox
- This implements the test in Maestro:
  - Verify state when updates and dev client are both enabled
  - Load and run an update from the test update server with the dev client UI

# Test Plan

CI should pass. Both tests are passing on iOS, but Android will not load from the update server (investigating).

I have pushed a commit to disable the Android tests that work locally, but not in Linux workers. Once we have a fix for this, these tests can be reenabled. The issue with Linux workers is tracked in ENG-16303.