### PR TITLE
fix(expo-linking): Fix cold booting iOS apps with a universal link

### DIFF
--- a/apps/router-e2e/.env
+++ b/apps/router-e2e/.env
@@ -4,3 +4,7 @@ EXPO_SKIP_MANIFEST_VALIDATION_TOKEN=0
 EXPO_NO_TELEMETRY=1
 EXPO_USE_FAST_RESOLVER=1
 TEST_SECRET_VALUE=test-secret
+
+APPLE_BUNDLE_ID=com.expo.routere2e
+# Create a .env.local file with your Apple Team ID to make testing easier.
+# APPLE_TEAM_ID=

--- a/apps/router-e2e/__e2e__/universal-linking/app/+native-intent.ts
+++ b/apps/router-e2e/__e2e__/universal-linking/app/+native-intent.ts
@@ -1,0 +1,14 @@
+export function redirectSystemPath({ path, initial }: { path: string; initial: boolean }): string {
+  console.log('redirectSystemPath', { path, initial });
+  try {
+    // Handle App Clip default page redirection.
+    // If path matches https://appclip.apple.com/id?p=com.evanbacon.pillarvalley.clip (with any query parameters), then redirect to `/` path.
+    const url = new URL(path);
+    if (url.hostname === 'appclip.apple.com') {
+      return '/?ref=' + encodeURIComponent(path);
+    }
+    return path;
+  } catch {
+    return path;
+  }
+}

--- a/apps/router-e2e/__e2e__/universal-linking/app/.well-known/apple-app-site-association+api.ts
+++ b/apps/router-e2e/__e2e__/universal-linking/app/.well-known/apple-app-site-association+api.ts
@@ -1,0 +1,31 @@
+// Support dynamically generating the AASA file for testing purposes.
+const { APPLE_TEAM_ID, APPLE_BUNDLE_ID } = process.env;
+
+const ID = `${APPLE_TEAM_ID}.${APPLE_BUNDLE_ID}`;
+
+export function GET() {
+  return Response.json({
+    applinks: {
+      details: [
+        {
+          appIDs: [ID],
+          components: [
+            {
+              '/': '*',
+              comment: 'Matches all routes',
+            },
+          ],
+        },
+      ],
+    },
+    activitycontinuation: {
+      apps: [ID],
+    },
+    webcredentials: {
+      apps: [ID],
+    },
+    appclips: {
+      apps: [`${ID}.clip`],
+    },
+  });
+}

--- a/apps/router-e2e/__e2e__/universal-linking/app/index.tsx
+++ b/apps/router-e2e/__e2e__/universal-linking/app/index.tsx
@@ -1,0 +1,5 @@
+import { Text } from 'react-native';
+
+export default function Post() {
+  return <Text>Index Route</Text>;
+}

--- a/apps/router-e2e/__e2e__/universal-linking/app/post/[post].tsx
+++ b/apps/router-e2e/__e2e__/universal-linking/app/post/[post].tsx
@@ -1,0 +1,7 @@
+import { useLocalSearchParams } from 'expo-router';
+import { Text } from 'react-native';
+
+export default function Post() {
+  const { post } = useLocalSearchParams();
+  return <Text>Post: "{post}"</Text>;
+}

--- a/apps/router-e2e/app.config.js
+++ b/apps/router-e2e/app.config.js
@@ -1,4 +1,7 @@
 const path = require('node:path');
+
+const subdomain = process.env.EXPO_TUNNEL_SUBDOMAIN ?? 'expo-e2e-universal-linking';
+
 /** @type {import('expo/config').ExpoConfig} */
 module.exports = {
   name: 'Router E2E',
@@ -11,7 +14,13 @@ module.exports = {
   userInterfaceStyle: 'automatic',
   ios: {
     supportsTablet: true,
-    bundleIdentifier: 'dev.expo.routere2e',
+    appleTeamId: process.env.APPLE_TEAM_ID,
+    bundleIdentifier: process.env.APPLE_BUNDLE_ID ?? 'com.expo.routere2e',
+    associatedDomains: [
+      `applinks:${subdomain}.ngrok.io`,
+      `webcredentials:${subdomain}.ngrok.io`,
+      `activitycontinuation:${subdomain}.ngrok.io`,
+    ],
   },
   android: {
     package: 'dev.expo.routere2e',

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -19,7 +19,7 @@
     "start:link-preview": "E2E_ROUTER_SRC=link-preview expo start",
     "ios:link-preview": "E2E_ROUTER_SRC=link-preview expo run:ios",
     "start:universal-linking": "EXPO_USE_STATIC=server EXPO_TUNNEL_SUBDOMAIN=expo-e2e-universal-linking E2E_ROUTER_SRC=universal-linking expo start --tunnel",
-    "open:universal-linking": "npx uri-scheme open https://expo-e2e-universal-linking.ngrok.io/post/123 --ios",
+    "open:universal-linking": "xcrun simctl terminate booted com.expo.routere2e && npx uri-scheme open https://expo-e2e-universal-linking.ngrok.io/post/123 --ios",
     "dom:run:ios": "E2E_ROUTER_SRC=dom-components expo run:ios",
     "start:headless": "E2E_ROUTER_SRC=headless expo",
     "android": "expo run:android",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -18,6 +18,8 @@
     "start:dom": "E2E_ROUTER_SRC=dom-components expo start -d",
     "start:link-preview": "E2E_ROUTER_SRC=link-preview expo start",
     "ios:link-preview": "E2E_ROUTER_SRC=link-preview expo run:ios",
+    "start:universal-linking": "EXPO_USE_STATIC=server EXPO_TUNNEL_SUBDOMAIN=expo-e2e-universal-linking E2E_ROUTER_SRC=universal-linking expo start --tunnel",
+    "open:universal-linking": "npx uri-scheme open https://expo-e2e-universal-linking.ngrok.io",
     "dom:run:ios": "E2E_ROUTER_SRC=dom-components expo run:ios",
     "start:headless": "E2E_ROUTER_SRC=headless expo",
     "android": "expo run:android",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -19,7 +19,7 @@
     "start:link-preview": "E2E_ROUTER_SRC=link-preview expo start",
     "ios:link-preview": "E2E_ROUTER_SRC=link-preview expo run:ios",
     "start:universal-linking": "EXPO_USE_STATIC=server EXPO_TUNNEL_SUBDOMAIN=expo-e2e-universal-linking E2E_ROUTER_SRC=universal-linking expo start --tunnel",
-    "open:universal-linking": "npx uri-scheme open https://expo-e2e-universal-linking.ngrok.io",
+    "open:universal-linking": "npx uri-scheme open https://expo-e2e-universal-linking.ngrok.io/post/123 --ios",
     "dom:run:ios": "E2E_ROUTER_SRC=dom-components expo run:ios",
     "start:headless": "E2E_ROUTER_SRC=headless expo",
     "android": "expo run:android",

--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix cold booting iOS apps from a universal link.
+
 ### 💡 Others
 
 - Deprecate `useURL` in favor of `useLinkingURL`. ([#37005](https://github.com/expo/expo/pull/37005) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix cold booting iOS apps from a universal link.
+- Fix cold booting iOS apps from a universal link. ([#37647](https://github.com/expo/expo/pull/37647) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift
+++ b/packages/expo-linking/ios/LinkingAppDelegateSubscriber.swift
@@ -1,14 +1,6 @@
 import ExpoModulesCore
 
 public class LinkingAppDelegateSubscriber: ExpoAppDelegateSubscriber {
-  private static let isAppClip: Bool = {
-    // Having an NSAppClip key is not technically required but it's how App Clips are generated and
-    // there was no other clear indicator without knowing the child bundle identifier ahead of time.
-    if let infoPlist = Bundle.main.infoDictionary, infoPlist["NSAppClip"] != nil {
-      return true
-    }
-    return false
-  }()
 
 #if os(iOS) || os(tvOS)
   public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
@@ -33,8 +25,9 @@ public class LinkingAppDelegateSubscriber: ExpoAppDelegateSubscriber {
   ) -> Bool {
     // The URL can be nullish when launching App Clips from Test Flight without custom invocations set.
     if userActivity.activityType == NSUserActivityTypeBrowsingWeb, let url = userActivity.webpageURL {
-      // App Clips don't appear to invoke application:open:options: so we'll use this first request to assume the initial URL.
-      if ExpoLinkingRegistry.shared.initialURL == nil && LinkingAppDelegateSubscriber.isAppClip {
+      // App Clips and cold universal link launches don't appear to invoke application:open:options: 
+      // so we'll use this first request to assume the initial URL.
+      if ExpoLinkingRegistry.shared.initialURL == nil {
         ExpoLinkingRegistry.shared.initialURL = url
       }
       NotificationCenter.default.post(name: onURLReceivedNotification, object: self, userInfo: ["url": url])


### PR DESCRIPTION
# Why

- @Titozzz identified an issue where the initial launch of an iOS app with a universal link will direct to the index route `/`. The issue stems from iOS inconsistently calling app delegate methods with the initial URL. 
- We can reuse the hack I added for App Clip support to identify the first URL from the incoming web URL if no initial URL has been found yet. This could lead to issues where an app is launched from the home screen and the "initial" URL is later set by launching a universal link. 
- Due to weird undocumented bug in universal links, I've changed the bundle identifier of router-e2e to use `com.` instead of `dev.`

# Test Plan

I added a manual e2e test runner in apps/router-e2e to confirm the behavior and test against:
- define credentials in the `.env.local` file
- `yarn start:universal-linking`
- `npx expo run:ios`
- Should see the `.well-known` hit in the server when the app installs.
- Terminate the app to ensure it launches from a cold boot.
- Open: https://expo-e2e-universal-linking.ngrok.io/post/123 -> launch app to correct location. (`yarn open:universal-linking`).
