### PR TITLE
[ios][dev-menu] Fix button press on scroll

### DIFF
--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuMainView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuMainView.swift
@@ -5,43 +5,40 @@ struct DevMenuMainView: View {
 
   var body: some View {
     ScrollView {
-      LazyVStack(spacing: 0, pinnedViews: []) {
-        if let hostUrl = viewModel.appInfo?.hostUrl {
-          HostUrl(
-            hostUrl: hostUrl,
-            onCopy: viewModel.copyToClipboard,
-            copiedMessage: viewModel.hostUrlCopiedMessage
-          )
-        }
-
-        if !viewModel.registeredCallbacks.isEmpty {
-          CustomItems(
-            callbacks: viewModel.registeredCallbacks,
-            onFireCallback: viewModel.fireCallback
-          )
-        }
-
-        DevMenuActions(
-          isDevLauncherInstalled: viewModel.isDevLauncherInstalled,
-          onReload: viewModel.reload,
-          onGoHome: viewModel.goHome
+      if let hostUrl = viewModel.appInfo?.hostUrl {
+        HostUrl(
+          hostUrl: hostUrl,
+          onCopy: viewModel.copyToClipboard,
+          copiedMessage: viewModel.hostUrlCopiedMessage
         )
-
-        DevMenuDeveloperTools()
-          .environmentObject(viewModel)
-
-        if viewModel.appInfo?.engine == "Hermes" {
-          HermesWarning()
-        }
-
-        DevMenuAppInfo()
-          .environmentObject(viewModel)
-
-        DevMenuRNDevMenu(onOpenRNDevMenu: viewModel.openRNDevMenu)
-
-        Spacer(minLength: 32)
       }
+
+      if !viewModel.registeredCallbacks.isEmpty {
+        CustomItems(
+          callbacks: viewModel.registeredCallbacks,
+          onFireCallback: viewModel.fireCallback
+        )
+      }
+
+      DevMenuActions(
+        isDevLauncherInstalled: viewModel.isDevLauncherInstalled,
+        onReload: viewModel.reload,
+        onGoHome: viewModel.goHome
+      )
+
+      DevMenuDeveloperTools()
+
+      if viewModel.appInfo?.engine == "Hermes" {
+        HermesWarning()
+      }
+
+      DevMenuAppInfo()
+
+      DevMenuRNDevMenu(onOpenRNDevMenu: viewModel.openRNDevMenu)
+
+      Spacer(minLength: 32)
     }
+    .environmentObject(viewModel)
   }
 }
 


### PR DESCRIPTION
# Why
Button presses were not cancelled on scroll when using the dev menu.

# How
It was caused by adding a LazyVStack around the scroll view content. Removing it fixes the issue. The view will never be large enough there to require a lazy stack anyway.

# Test Plan
Bare-expo. Button presses are cancelled on scroll
