### PR TITLE
[ui][ios] Make datepicker label hidden if empty, remove default value.

### DIFF
--- a/apps/native-component-list/src/screens/UI/DateTimePickerScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/DateTimePickerScreen.ios.tsx
@@ -36,6 +36,7 @@ export default function DatePickerScreen() {
               displayedComponents={
                 typeOptions[typeIndex] as DateTimePickerProps['displayedComponents']
               }
+              title="Select date"
               initialDate={selectedDate.toISOString()}
               variant={displayOptions[selectedIndex] as DateTimePickerProps['variant']}
               style={{ height: Platform.select({ android: 520, ios: undefined }) }}

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 💡 Others
 
-- Make `DateTimePicker` label hidden if empty.
+- Make `DateTimePicker` label hidden if empty. ([#37665](https://github.com/expo/expo/pull/37665) by [@aleqsio](https://github.com/aleqsio))
 - Fixed `ExpoComposeView` breaking change errors. ([#36256](https://github.com/expo/expo/pull/36256) by [@kudo](https://github.com/kudo))
 
 ## 0.1.1-alpha.9 - 2025-06-08

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 💡 Others
 
+- Make `DateTimePicker` label hidden if empty.
 - Fixed `ExpoComposeView` breaking change errors. ([#36256](https://github.com/expo/expo/pull/36256) by [@kudo](https://github.com/kudo))
 
 ## 0.1.1-alpha.9 - 2025-06-08

--- a/packages/expo-ui/ios/DateTimePickerView.swift
+++ b/packages/expo-ui/ios/DateTimePickerView.swift
@@ -2,7 +2,7 @@ import ExpoModulesCore
 import SwiftUI
 
 final class DateTimePickerProps: ExpoSwiftUI.ViewProps {
-  @Field var title: String = "Select Date"
+  @Field var title: String?
   @Field var initialDate: Date?
   @Field var variant: PickerStyle = .automatic
   @Field var displayedComponents: DisplayedComponents = .date
@@ -24,13 +24,14 @@ struct DateTimePickerView: ExpoSwiftUI.View {
     #else
     let displayedComponents = props.displayedComponents.toDatePickerComponent()
 
-    DatePicker(props.title, selection: $date, displayedComponents: displayedComponents)
+    DatePicker(props.title ?? "", selection: $date, displayedComponents: displayedComponents)
       .onAppear {
         date = props.initialDate ?? Date()
       }
       .onChange(of: date, perform: { newDate in
         props.onDateSelected(["date": newDate.timeIntervalSince1970 * 1000])
       })
+      .if(props.title == nil, { $0.labelsHidden() })
       .applyDatePickerStyle(for: props.variant)
       .tint(props.color)
       .foregroundStyle(props.color ?? .accentColor)


### PR DESCRIPTION
# Why

https://expo.canny.io/feature-requests/p/expo-ui-ios-datetimepicker-hide-title

This PR enhances the `DateTimePicker` component by making the label hidden when the title is empty, providing a cleaner UI when no title is needed.

# How

- Modified the `DateTimePickerView.swift` file to make the `title` property optional

# Test Plan

1. Run the native-component-list app on iOS
2. Navigate to the DateTimePicker screen
3. Verify that the "Select date" title appears correctly
4. Test with and without a title to ensure labels are hidden appropriately when no title is provided

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)