### PR TITLE
[audio] Fix issue with currentTime when seeking

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -26,6 +26,8 @@
 - [iOS] Change component registry to be per module to prevent interference. ([#37534](https://github.com/expo/expo/pull/37534) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix metering issues when recording. ([#37556](https://github.com/expo/expo/pull/37556) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix issues with audio focus management. ([#37698](https://github.com/expo/expo/pull/37698) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix connected bluetooth devices not playing back recordings. ([#37580](https://github.com/expo/expo/pull/37580) by [@alanjhughes](https://github.com/alanjhughes))
+- Fix issue where the currentTime is out of sync when seeking before playing.
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Fix metering issues when recording. ([#37556](https://github.com/expo/expo/pull/37556) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix issues with audio focus management. ([#37698](https://github.com/expo/expo/pull/37698) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix connected bluetooth devices not playing back recordings. ([#37580](https://github.com/expo/expo/pull/37580) by [@alanjhughes](https://github.com/alanjhughes))
-- Fix issue where the currentTime is out of sync when seeking before playing.
+- Fix issue where the currentTime is out of sync when seeking before playing. ([#37668](https://github.com/expo/expo/pull/37668) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -415,7 +415,7 @@ class AudioModule : Module() {
       }
 
       AsyncFunction("seekTo") { player: AudioPlayer, seekTime: Double ->
-        player.ref.seekTo((seekTime * 1000L).toLong())
+        player.seekTo(seekTime)
       }.runOnQueue(Queues.MAIN)
 
       Function("setPlaybackRate") { player: AudioPlayer, rate: Float ->

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -145,6 +145,13 @@ class AudioPlayer(
     }
   }
 
+  fun seekTo(seekTime: Double) {
+    ref.seekTo((seekTime * 1000L).toLong())
+    playerScope.launch {
+      sendPlayerUpdate()
+    }
+  }
+
   private fun extractAmplitudes(chunk: ByteArray): List<Float> = chunk.map { byte ->
     val unsignedByte = byte.toInt() and 0xFF
     ((unsignedByte - 128).toDouble() / 128.0).toFloat()

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -186,12 +186,7 @@ public class AudioModule: Module {
       }
 
       AsyncFunction("seekTo") { (player: AudioPlayer, seconds: Double) in
-        await player.ref.currentItem?.seek(
-          to: CMTime(
-            seconds: seconds,
-            preferredTimescale: CMTimeScale(NSEC_PER_SEC)
-          )
-        )
+        await player.seekTo(seconds: seconds)
       }
     }
 

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -106,6 +106,18 @@ public class AudioPlayer: SharedRef<AVPlayer> {
     }
     self.emit(event: AudioConstants.playbackStatus, arguments: arguments)
   }
+  
+  func seekTo(seconds: Double) async {
+    await ref.currentItem?.seek(
+      to: CMTime(
+        seconds: seconds,
+        preferredTimescale: CMTimeScale(NSEC_PER_SEC)
+      )
+    )
+    updateStatus(with: [
+      "currentTime": currentTime
+    ])
+  }
 
   private func setupPublisher() {
     ref.publisher(for: \.currentItem?.status)

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -106,7 +106,7 @@ public class AudioPlayer: SharedRef<AVPlayer> {
     }
     self.emit(event: AudioConstants.playbackStatus, arguments: arguments)
   }
-  
+
   func seekTo(seconds: Double) async {
     await ref.currentItem?.seek(
       to: CMTime(


### PR DESCRIPTION
# Why
Closes #37653

# How
The time observers are only emitting when the player is playing. This means that if you seek while the player is not playing, the time gets out of sync. To fix it, we should emit a status update when seeking.

# Test Plan
Bare-expo. The `currentTime` stays in sync when seeking when the player isn't actively playing. 

