### PR TITLE
chore: revert `node: 20` upgrade for Windows workflows due to RSC and async components

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -116,7 +116,9 @@ jobs:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # NOTE(cedric): Node 20+ crashes on Windows when rendering async components through `expo export:embed` with RSC enabled
+          # We need to keep this on Node 18 in order for our tests to pass
+          node-version: 18
 
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -261,7 +263,9 @@ jobs:
       - name: 🏗️ Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # NOTE(cedric): Node 20+ crashes on Windows when rendering async components through `expo export:embed` with RSC enabled
+          # We need to keep this on Node 18 in order for our tests to pass
+          node-version: 18
 
       - name: 🏗️ Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
# Why

On Windows and Node 20+, it seems that (pre)rendering an async component with RSC enabled causes Node to fully crash. This error is related to the findings of #37663, you can use that command to reproduce.

The error is specific to the [`<Pokemon>` component being rendered](https://github.com/expo/expo/blob/67fe94985eaf889392beaa4f05b2f495b00b344d/apps/router-e2e/__e2e__/01-rsc/app/index.tsx#L33). When disabling this component, `expo export:embed` with RSC completes normally.

The bug coincides with the `flushCompletedChunks` from `react-server-dom-webpack`, right at that function Node abruptly stops.

### Node 18

![image](https://github.com/user-attachments/assets/8ed951fd-ba67-4e9e-8d10-01393d405d74)

### Node 20+

![image](https://github.com/user-attachments/assets/e7f3b3d5-f01c-4908-b3ee-4a4f41ef94b9)


# How

- Reverted the Node 20 upgrade for Windows CLI E2E tests

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
