### PR TITLE
[ios][video] set tolerance to 0 when seeking with setting player.currentTime 

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Setting `player.currentTime` doesn't seek to the correct time on some videos. ([#37672](https://github.com/expo/expo/pull/37300) by [@petrkonecny2](https://github.com/petrkonecny2))
+
 ### 💡 Others
 
 ## 2.2.2 - 2025-06-18

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -52,7 +52,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
         return
       }
 
-      ref.seek(to: timeToSeek)
+      ref.seek(to: timeToSeek, toleranceBefore: .zero, toleranceAfter: .zero)
     }
   }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
After change introduced in https://github.com/expo/expo/pull/36308 setting player.currentTime no longer seeks to an exact position by ms but instead seeks with very low tolerance of approximately 5s. This breaks some use cases like trying to seek to a specific frame in the video. Also mentioned in issue https://github.com/expo/expo/issues/37299#issuecomment-2955752530. 

Fixes https://github.com/expo/expo/issues/37794
Fixes https://github.com/expo/expo/issues/37299

# How

<!--
How did you build this feature or fix this bug and why?
-->
Reverting back to original seek function implementation with tolerances set to zero as it has been before restores the functionality that is described in the docs https://docs.expo.dev/versions/latest/sdk/video/#currenttime. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested in Bare-Expo FlatList of videos. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
