### PR TITLE
[docs] Update Sitemap config

### DIFF
--- a/docs/scripts/create-sitemap.js
+++ b/docs/scripts/create-sitemap.js
@@ -29,7 +29,7 @@ export default function createSitemap({ pathMap, domain, output, pathsPriority, 
   // Get a list of URLs from the pathMap that we can use in the sitemap
   const urls = Object.keys(pathMap)
     .filter(url => !IGNORED_PAGES.has(url) && !pathsHidden.some(hidden => url.startsWith(hidden)))
-    .map(pathWithTrailingSlash)
+    .map(pathWithoutTrailingSlash)
     .sort((a, b) => pathSortedByPriority(a, b, pathsPriority));
 
   const target = fs.createWriteStream(output);
@@ -50,8 +50,9 @@ export default function createSitemap({ pathMap, domain, output, pathsPriority, 
   return urls;
 }
 
-function pathWithTrailingSlash(url) {
-  return !path.extname(url) && !url.endsWith('/') ? `${url}/` : url;
+function pathWithoutTrailingSlash(url) {
+  // Remove trailing slash except for the root path
+  return url === '/' ? url : url.replace(/\/$/, '');
 }
 
 function pathWithStartingSlash(url) {

--- a/docs/scripts/create-sitemap.js
+++ b/docs/scripts/create-sitemap.js
@@ -1,5 +1,4 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { SitemapStream } from 'sitemap';
 
 const IGNORED_PAGES = new Set([


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

[Sitemap](https://docs.expo.dev/sitemap.xml) still contains trailing slashes which is affecting Algolia search. This PR should update the sitemap.xml file by removing trailing slash from sitemap configuration.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run `yarn build`
- Go to `out/sitemap.xml` and links generated inside this file should not contain trailing slash.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
