### PR TITLE
[docs] Update react-compiler.mdx (Change compilationMode value)

### DIFF
--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -169,7 +169,7 @@ module.exports = function (api) {
         {
           'react-compiler': {
             // Passed directly to the React Compiler Babel plugin.
-            compilationMode: 'strict',
+            compilationMode: 'annotation',
             panicThreshold: 'all_errors',
           },
           web: {


### PR DESCRIPTION
I've updated the babel.config.js code example in the react-compiler page.

The `compilationMode` option does not include `strict`.

See:
https://github.com/facebook/react/blob/4db4b21c63ebc4edc508c5f7674f9df50d8f9744/compiler/packages/babel-plugin-react-compiler/src/Entrypoint/Options.ts#L179-L197

