### PR TITLE
[tools] Throw error when attempting publishing specific packages as canaries.

### DIFF
--- a/tools/src/commands/PublishPackages.ts
+++ b/tools/src/commands/PublishPackages.ts
@@ -222,6 +222,17 @@ function tasksForOptions(options: CommandOptions): Task<TaskArgs>[] {
     return [assignTagForSdkRelease];
   }
   if (options.canary) {
+    if (!process.env.CI) {
+      logger.info(
+        `🛠️ You can also use the CI action instead: https://github.com/expo/expo/actions/workflows/publish-canaries.yml`
+      );
+    }
+    if (options.packageNames) {
+      logger.error(
+        '⚠️  Do not pass package names with the --canary flag - canary tags do not support semver ranges, so this would likely cause duplicate expo package versions.'
+      );
+      throw Error('Passing package names with the --canary flag is not allowed.');
+    }
     return [publishCanaryPipeline];
   }
   return [publishPackagesPipeline];


### PR DESCRIPTION
# Why

There is a major bug in the publish canaries script when calling it with package names (it publishes templates with the sdk-53 tag).

This option also won't work due to npm/semver constraints.

# How

Added an error (plus a reminder to prefer CI instead)

# Test Plan

Tested that it correctly errors if package names are passed in.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
