### PR TITLE
sync SDK 53 changelogs

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### 🐛 Bug fixes
 
+### 💡 Others
+
+## 3.4.3 - 2025-06-26
+
+### 🐛 Bug fixes
+
 - Update to `getenv@2.0.0` to support upper case boolean environment variables ([#36688](https://github.com/expo/expo/pull/36688) by [@stephenlacy](https://github.com/stephenlacy))
 
 ### 💡 Others

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix connected bluetooth devices not playing back recordings. ([#37580](https://github.com/expo/expo/pull/37580) by [@alanjhughes](https://github.com/alanjhughes))
+
+### 💡 Others
+
+## 0.4.7 - 2025-06-26
+
+### 🐛 Bug fixes
+
 - [iOS] Fixed status property bug when track finishes ([#37389](https://github.com/expo/expo/pull/37389) by [@adiktiv](https://github.com/adiktiv))
 - [iOS] Fix inconsistent audio sampling. ([#37154](https://github.com/expo/expo/pull/37154) by [@alanjhughes](https://github.com/alanjhughes))
 - Add automatic interruption handling. ([#37153](https://github.com/expo/expo/pull/37153) by [@alanjhughes](https://github.com/alanjhughes))
@@ -17,7 +25,6 @@
 - [Android] Prevent status updates when the player is paused. ([#37475](https://github.com/expo/expo/pull/37475) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Change component registry to be per module to prevent interference. ([#37534](https://github.com/expo/expo/pull/37534) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix metering issues when recording. ([#37556](https://github.com/expo/expo/pull/37556) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix connected bluetooth devices not playing back recordings. ([#37580](https://github.com/expo/expo/pull/37580) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 - [Android] Bumped MLKit barcode scanner to 17.3.0 for Android 16KB page size support. ([#37454](https://github.com/expo/expo/pull/37454) by [@kudo](https://github.com/kudo))
 
+## 16.1.9 - 2025-06-26
+
+_This version does not introduce any user-facing changes._
+
 ## 16.1.8 - 2025-06-10
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 5.2.2 - 2025-06-26
+
+_This version does not introduce any user-facing changes._
+
 ## 5.2.1 - 2025-06-18
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,8 +10,6 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix missing launch args from pending intent extras. ([#37172](https://github.com/expo/expo/pull/37172) by [@coolsoftwaretyler](https://github.com/coolsoftwaretyler))
-- [Android] Fix missing intent extras when handling external intents. ([#37307](https://github.com/expo/expo/pull/37307) by [@coolsoftwaretyler](https://github.com/coolsoftwaretyler))
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
@@ -21,6 +19,13 @@
 ### ⚠️ Notices
 
 - Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
+## 5.1.14 - 2025-06-26
+
+### 🐛 Bug fixes
+
+- [Android] Fix missing launch args from pending intent extras. ([#37172](https://github.com/expo/expo/pull/37172) by [@coolsoftwaretyler](https://github.com/coolsoftwaretyler))
+- [Android] Fix missing intent extras when handling external intents. ([#37307](https://github.com/expo/expo/pull/37307) by [@coolsoftwaretyler](https://github.com/coolsoftwaretyler))
 
 ## 5.1.13 - 2025-06-18
 

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -8,9 +8,13 @@
 
 ### 🐛 Bug fixes
 
-- [android] Replace LabeledIntent with Intent in composeAsync ([#37624](https://github.com/expo/expo/pull/37624) by [@Ubax](https://github.com/Ubax))
-
 ### 💡 Others
+
+## 14.1.5 - 2025-06-27
+
+### 🐛 Bug fixes
+
+- [android] Replace LabeledIntent with Intent in composeAsync ([#37624](https://github.com/expo/expo/pull/37624) by [@Ubax](https://github.com/Ubax))
 
 ## 14.1.4 — 2025-04-30
 

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 4.1.8 - 2025-06-26
+
+_This version does not introduce any user-facing changes._
+
 ## 4.1.7 — 2025-05-08
 
 ### 🎉 New features

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -10,14 +10,18 @@
 
 ### 🐛 Bug fixes
 
+### 💡 Others
+
+- Create href preview component ([#37335](https://github.com/expo/expo/pull/37335) by [@Ubax](https://github.com/Ubax))
+
+## 5.1.1 - 2025-06-26
+
+### 🐛 Bug fixes
+
 - Fork StackRouter getStateFromAction to fix freezing screens ([#37086](https://github.com/expo/expo/pull/37086) by [@marklawlor](https://github.com/marklawlor))
 - Fix inconsistent global param decoding ([#36973](https://github.com/expo/expo/pull/36973) by [@marklawlor](https://github.com/marklawlor))
 - Prevent error when using `<Screen options />` with prefetching ([#36866](https://github.com/expo/expo/pull/36866) by [@marklawlor](https://github.com/marklawlor))
 - Fix static redirects ([#36962](https://github.com/expo/expo/pull/36962) by [@marklawlor](https://github.com/marklawlor))
-
-### 💡 Others
-
-- Create href preview component ([#37335](https://github.com/expo/expo/pull/37335) by [@Ubax](https://github.com/Ubax))
 
 ## 5.1.0 - 2025-06-11
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 - Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
+## 53.0.13 - 2025-06-26
+
+_This version does not introduce any user-facing changes._
+
 ## 53.0.12 - 2025-06-18
 
 _This version does not introduce any user-facing changes._


### PR DESCRIPTION
# Why

sync changelogs from sdk-53

# How

- `et sync-sdk-branch-changelogs --branch sdk-53` 

# Test Plan

n/a

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
