### PR TITLE
[file-system][next] Update `exists` logic to align with documentation

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Update exists logic to align with documentation ([#37692](https://github.com/expo/expo/pull/37692) by [@Wenszel](https://github.com/Wenszel))
 - Fix memory usage issue in getInfoAsync ([#37417](https://github.com/expo/expo/pull/37417) by [@Wenszel](https://github.com/Wenszel))
 - Improved type safety in the FileSystem module to support tsconfig setups with stricter rules than the default. ([#37107](https://github.com/expo/expo/pull/37107) by [@hirbod](https://github.com/hirbod))
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemDirectory.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemDirectory.kt
@@ -16,8 +16,11 @@ class FileSystemDirectory(file: File) : FileSystemPath(file) {
   }
 
   val exists: Boolean get() {
-    validatePermission(Permission.READ)
-    return file.isDirectory
+    return if (checkPermission(Permission.READ)) {
+      file.isDirectory
+    } else {
+      false
+    }
   }
 
   fun create(options: CreateOptions = CreateOptions()) {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemFile.kt
@@ -26,8 +26,11 @@ class FileSystemFile(file: File) : FileSystemPath(file) {
   }
 
   val exists: Boolean get() {
-    validatePermission(Permission.READ)
-    return file.isFile
+    return if (checkPermission(Permission.READ)) {
+      file.isFile
+    } else {
+      false
+    }
   }
 
   fun create(options: CreateOptions = CreateOptions()) {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemPath.kt
@@ -63,12 +63,15 @@ abstract class FileSystemPath(public var file: File) : SharedObject() {
     return destination.file
   }
 
-  fun validatePermission(permission: Permission): Boolean {
-    val permissions = appContext?.filePermission?.getPathPermissions(appContext?.reactContext, file.path) ?: EnumSet.noneOf(Permission::class.java)
-    if (permissions.contains(permission)) {
-      return true
+  fun validatePermission(permission: Permission) {
+    if (!checkPermission(permission)) {
+      throw InvalidPermissionException(permission)
     }
-    throw InvalidPermissionException(permission)
+  }
+
+  fun checkPermission(permission: Permission): Boolean {
+    val permissions = appContext?.filePermission?.getPathPermissions(appContext?.reactContext, file.path) ?: EnumSet.noneOf(Permission::class.java)
+    return permissions.contains(permission)
   }
 
   fun validateCanCreate(options: CreateOptions) {

--- a/packages/expo-file-system/ios/Next/FileSystemDirectory.swift
+++ b/packages/expo-file-system/ios/Next/FileSystemDirectory.swift
@@ -28,12 +28,9 @@ internal final class FileSystemDirectory: FileSystemPath {
   }
 
   override var exists: Bool {
-    do {
-      try validatePermission(.read)
-    } catch {
+    guard checkPermission(.read) else {
       return false
     }
-
     var isDirectory: ObjCBool = false
     if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) {
       return isDirectory.boolValue

--- a/packages/expo-file-system/ios/Next/FileSystemFile.swift
+++ b/packages/expo-file-system/ios/Next/FileSystemFile.swift
@@ -33,15 +33,14 @@ internal final class FileSystemFile: FileSystemPath {
   }
 
   override var exists: Bool {
-    get throws {
-      try validatePermission(.read)
-
-      var isDirectory: ObjCBool = false
-      if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) {
-        return !isDirectory.boolValue
-      }
+    guard checkPermission(.read) else {
       return false
     }
+    var isDirectory: ObjCBool = false
+    if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) {
+      return !isDirectory.boolValue
+    }
+    return false
   }
 
   // TODO: Move to the constructor once error is rethrowed

--- a/packages/expo-file-system/ios/Next/FileSystemPath.swift
+++ b/packages/expo-file-system/ios/Next/FileSystemPath.swift
@@ -13,6 +13,13 @@ internal class FileSystemPath: SharedObject {
     try ensurePathPermission(appContext, path: url.path, flag: flag)
   }
 
+  func checkPermission(_ flag: EXFileSystemPermissionFlags) -> Bool {
+    guard let permissionsManager: EXFilePermissionModuleInterface = appContext?.legacyModule(implementing: EXFilePermissionModuleInterface.self) else {
+      return false
+    }
+    return permissionsManager.getPathPermissions(url.path).contains(flag)
+  }
+
   func validateCanCreate(_ options: CreateOptions) throws {
     if try !options.overwrite && exists {
       throw FileAlreadyExistsException("File already exists")


### PR DESCRIPTION
# Why
According to the documentation, `exists` returns a boolean and never throws an error. Previously, `exists` threw an error if the path was forbidden. 

# How

Fixed `exists` to match the documentation output type.
Added the `checkPermission` method used in `exists`, which returns a false instead of throwing an error. 
Changed `validatePermission` to return void.

# Test Plan

Tested in bare-expo
