### PR TITLE
[android][expo] Guards against null React instance manager

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
 - Fixed `expo/fetch` requests cancellation error message on Android. ([#37509](https://github.com/expo/expo/pull/37509) by [@kudo](https://github.com/kudo))
+- [Android] Guards against null React instance manager ([#37693](https://github.com/expo/expo/pull/37693) by [@huextrat](https://github.com/huextrat))
 
 ### 💡 Others
 

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -204,7 +204,19 @@ class ReactActivityDelegateWrapper(
     reactActivityLifecycleListeners.forEach { listener ->
       listener.onPause(activity)
     }
-    return invokeDelegateMethod("onPause")
+
+    // Prevent crashes when React instance is not available,
+    // as this seems to happen in some edge cases
+    val reactInstanceManager = try {
+      delegate.reactInstanceManager
+    } catch (e: Exception) {
+      null
+    }
+    if (reactInstanceManager != null) {
+      return invokeDelegateMethod("onPause")
+    } else {
+      return
+    }
   }
 
   override fun onUserLeaveHint() {


### PR DESCRIPTION
# Why

fixes: https://github.com/expo/expo/issues/35676
/claim #35676

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Prevents crashes when the React instance manager is not available during the `onPause` lifecycle event. This addresses an edge case where the instance manager can be null, leading to unexpected errors when using `expo-updates`.

The error manifests as:
```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference
    at com.facebook.react.ReactInstanceManager.onHostPause(ReactInstanceManager.java:647)
```

This fix prevents the crash by safely checking if the React instance manager exists before calling the delegate's `onPause` method.

## Stacktrace

```
java.lang.RuntimeException: Unable to pause activity {X/X.MainActivity}: java.lang.reflect.InvocationTargetException
    at android.app.ActivityThread.performPauseActivityIfNeeded(ActivityThread.java:4957)
    at android.app.ActivityThread.performPauseActivity(ActivityThread.java:4908)
    at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:4860)
    at android.app.servertransaction.PauseActivityItem.execute(PauseActivityItem.java:46)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2261)
    at android.os.Handler.dispatchMessage(Handler.java:107)
    at android.os.Looper.loop(Looper.java:237)
    at android.app.ActivityThread.main(ActivityThread.java:8107)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:496)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1100)
java.lang.reflect.InvocationTargetException: null
    at java.lang.reflect.Method.invoke(Method.java)
    at expo.modules.ReactActivityDelegateWrapper.invokeDelegateMethod(ReactActivityDelegateWrapper.kt:352)
    at expo.modules.ReactActivityDelegateWrapper.onPause(ReactActivityDelegateWrapper.kt:210)
    at com.facebook.react.ReactActivity.onPause(ReactActivity.java:53)
    at android.app.Activity.performPause(Activity.java:8144)
    at android.app.Instrumentation.callActivityOnPause(Instrumentation.java:1508)
    at android.app.ActivityThread.performPauseActivityIfNeeded(ActivityThread.java:4947)
    at android.app.ActivityThread.performPauseActivity(ActivityThread.java:4908)
    at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:4860)
    at android.app.servertransaction.PauseActivityItem.execute(PauseActivityItem.java:46)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2261)
    at android.os.Handler.dispatchMessage(Handler.java:107)
    at android.os.Looper.loop(Looper.java:237)
    at android.app.ActivityThread.main(ActivityThread.java:8107)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:496)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1100)
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference
    at com.facebook.react.ReactInstanceManager.onHostPause(ReactInstanceManager.java:647)
    at com.facebook.react.ReactDelegate.onHostPause(ReactDelegate.java:142)
    at com.facebook.react.ReactActivityDelegate.onPause(ReactActivityDelegate.java:175)
    at java.lang.reflect.Method.invoke(Method.java)
    at expo.modules.ReactActivityDelegateWrapper.invokeDelegateMethod(ReactActivityDelegateWrapper.kt:352)
    at expo.modules.ReactActivityDelegateWrapper.onPause(ReactActivityDelegateWrapper.kt:210)
    at com.facebook.react.ReactActivity.onPause(ReactActivity.java:53)
    at android.app.Activity.performPause(Activity.java:8144)
    at android.app.Instrumentation.callActivityOnPause(Instrumentation.java:1508)
    at android.app.ActivityThread.performPauseActivityIfNeeded(ActivityThread.java:4947)
    at android.app.ActivityThread.performPauseActivity(ActivityThread.java:4908)
    at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:4860)
    at android.app.servertransaction.PauseActivityItem.execute(PauseActivityItem.java:46)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2261)
    at android.os.Handler.dispatchMessage(Handler.java:107)
    at android.os.Looper.loop(Looper.java:237)
    at android.app.ActivityThread.main(ActivityThread.java:8107)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:496)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1100)
```

# How

Added a null check in `ReactActivityDelegateWrapper.onPause()` that:
1. Safely retrieves the reactInstanceManager from the delegate using a try-catch block
2. Only calls invokeDelegateMethod("onPause") if the instance manager is not null
3. Returns early if the instance manager is unavailable, preventing the crash

The fix maintains the existing logic for handling delayed `loadApp` scenarios while adding protection against any case where the React instance is not available.

This approach is consistent with the existing pattern used for `shouldEmitPendingResume` but handles additional edge cases where the React instance manager is null for reasons other than delayed initialization.

Before (crashes):

1. onPause() called
2. invokeDelegateMethod("onPause") called
3. ReactActivityDelegate.onPause() called
4. ReactDelegate.onHostPause() called
5. ReactInstanceManager.onHostPause() called
6. CRASH - NullPointerException because reactInstanceManager is null

After (safe):

1. onPause() called
2. Check if reactInstanceManager is null
3. If null → return early (no crash)
4. If not null → proceed safely

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Need a repo where we can reproduce the issue easily, as for now we don't have reproducer

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
