### PR TITLE
[ios][expo-mail-composer] Prevent duplicate values in LSApplicationQueriesSchemes

### DIFF
--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [ios] Prevent duplicate values in LSApplicationQueriesSchemes
+- [ios] Prevent duplicate values in LSApplicationQueriesSchemes ([#37697](https://github.com/expo/expo/pull/37697) by [@huextrat](https://github.com/huextrat))
 
 ### 💡 Others
 

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Prevent duplicate values in LSApplicationQueriesSchemes
+
 ### 💡 Others
 
 ## 14.1.5 - 2025-06-27

--- a/packages/expo-mail-composer/plugin/build/withMailComposer.js
+++ b/packages/expo-mail-composer/plugin/build/withMailComposer.js
@@ -31,10 +31,13 @@ const mailClientURLs = [
 ];
 const withMailComposer = (config) => {
     return (0, config_plugins_1.withInfoPlist)(config, (config) => {
-        config.modResults.LSApplicationQueriesSchemes = [
-            ...(config.modResults.LSApplicationQueriesSchemes ?? []),
-            ...mailClientURLs,
+        const existingSchemes = config.modResults.LSApplicationQueriesSchemes ?? [];
+        const existingSet = new Set(existingSchemes);
+        const newSchemes = [
+            ...existingSchemes,
+            ...mailClientURLs.filter((scheme) => !existingSet.has(scheme)),
         ];
+        config.modResults.LSApplicationQueriesSchemes = newSchemes;
         return config;
     });
 };

--- a/packages/expo-mail-composer/plugin/build/withMailComposer.js
+++ b/packages/expo-mail-composer/plugin/build/withMailComposer.js
@@ -32,11 +32,7 @@ const mailClientURLs = [
 const withMailComposer = (config) => {
     return (0, config_plugins_1.withInfoPlist)(config, (config) => {
         const existingSchemes = config.modResults.LSApplicationQueriesSchemes ?? [];
-        const existingSet = new Set(existingSchemes);
-        const newSchemes = [
-            ...existingSchemes,
-            ...mailClientURLs.filter((scheme) => !existingSet.has(scheme)),
-        ];
+        const newSchemes = [...new Set([...existingSchemes, ...mailClientURLs])];
         config.modResults.LSApplicationQueriesSchemes = newSchemes;
         return config;
     });

--- a/packages/expo-mail-composer/plugin/src/withMailComposer.ts
+++ b/packages/expo-mail-composer/plugin/src/withMailComposer.ts
@@ -32,11 +32,13 @@ const mailClientURLs: string[] = [
 
 const withMailComposer: ConfigPlugin = (config) => {
   return withInfoPlist(config, (config) => {
-    config.modResults.LSApplicationQueriesSchemes = [
-      ...(config.modResults.LSApplicationQueriesSchemes ?? []),
-      ...mailClientURLs,
+    const existingSchemes = config.modResults.LSApplicationQueriesSchemes ?? [];
+    const existingSet = new Set(existingSchemes);
+    const newSchemes = [
+      ...existingSchemes,
+      ...mailClientURLs.filter((scheme) => !existingSet.has(scheme)),
     ];
-
+    config.modResults.LSApplicationQueriesSchemes = newSchemes;
     return config;
   });
 };

--- a/packages/expo-mail-composer/plugin/src/withMailComposer.ts
+++ b/packages/expo-mail-composer/plugin/src/withMailComposer.ts
@@ -33,11 +33,7 @@ const mailClientURLs: string[] = [
 const withMailComposer: ConfigPlugin = (config) => {
   return withInfoPlist(config, (config) => {
     const existingSchemes = config.modResults.LSApplicationQueriesSchemes ?? [];
-    const existingSet = new Set(existingSchemes);
-    const newSchemes = [
-      ...existingSchemes,
-      ...mailClientURLs.filter((scheme) => !existingSet.has(scheme)),
-    ];
+    const newSchemes = [...new Set([...existingSchemes, ...mailClientURLs])];
     config.modResults.LSApplicationQueriesSchemes = newSchemes;
     return config;
   });


### PR DESCRIPTION
# Why

fixes: https://github.com/expo/expo/issues/37695

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The expo-mail-composer plugin was unconditionally appending all mail client URL schemes to the `LSApplicationQueriesSchemes` array in the iOS Info.plist, which could result in duplicate values when other plugins also add schemes. This could lead to unnecessary bloat in the Info.plist and potential conflicts.

# How

- Extract existing schemes with fallback to empty array
- Create a Set for efficient duplicate checking
- Filter mailClientURLs to only include schemes not already present
- Preserve existing array order while appending new values

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
