### PR TITLE
[android][audio] Fix focus management issues

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -25,7 +25,7 @@
 - [Android] Prevent status updates when the player is paused. ([#37475](https://github.com/expo/expo/pull/37475) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Change component registry to be per module to prevent interference. ([#37534](https://github.com/expo/expo/pull/37534) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix metering issues when recording. ([#37556](https://github.com/expo/expo/pull/37556) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fix issues with audio focus management.
+- [Android] Fix issues with audio focus management. ([#37698](https://github.com/expo/expo/pull/37698) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [Android] Prevent status updates when the player is paused. ([#37475](https://github.com/expo/expo/pull/37475) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Change component registry to be per module to prevent interference. ([#37534](https://github.com/expo/expo/pull/37534) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix metering issues when recording. ([#37556](https://github.com/expo/expo/pull/37556) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fix issues with audio focus management.
 
 ### 💡 Others
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -226,7 +226,7 @@ class AudioModule : Module() {
         if (hasPlayersToResume) {
           requestAudioFocus()
         }
-        
+
         players.values.forEach { player ->
           if (player.isPaused) {
             player.isPaused = false
@@ -387,10 +387,6 @@ class AudioModule : Module() {
       Function("pause") { player: AudioPlayer ->
         runOnMain {
           player.ref.pause()
-
-          if (shouldReleaseFocus()) {
-            releaseAudioFocus()
-          }
         }
       }
 
@@ -432,10 +428,6 @@ class AudioModule : Module() {
 
       Function("remove") { player: AudioPlayer ->
         players.remove(player.id)
-
-        if (shouldReleaseFocus()) {
-          releaseAudioFocus()
-        }
       }
     }
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -80,7 +80,10 @@ class AudioModule : Module() {
         AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
           if (interruptionMode == InterruptionMode.DUCK_OTHERS) {
             players.values.forEach { player ->
-              player.ref.volume /= 2f
+              if (player.previousVolume != player.ref.volume) {
+                player.previousVolume = player.ref.volume
+              }
+              player.ref.volume = player.previousVolume * 0.5f
             }
           } else {
             players.values.forEach { player ->
@@ -123,7 +126,7 @@ class AudioModule : Module() {
           AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK
         }
       } ?: AudioManager.AUDIOFOCUS_GAIN
-      val audioFocusRequest = AudioFocusRequest.Builder(requestType).run {
+      audioFocusRequest = AudioFocusRequest.Builder(requestType).run {
         setAudioAttributes(
           AudioAttributes.Builder()
             .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
@@ -149,6 +152,10 @@ class AudioModule : Module() {
   }
 
   private fun releaseAudioFocus() {
+    if (!focusAcquired) {
+      return
+    }
+
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       audioFocusRequest?.let {
         audioManager.abandonAudioFocusRequest(it)
@@ -215,7 +222,11 @@ class AudioModule : Module() {
 
     OnActivityEntersForeground {
       if (!staysActiveInBackground) {
-        requestAudioFocus()
+        val hasPlayersToResume = players.values.any { it.isPaused }
+        if (hasPlayersToResume) {
+          requestAudioFocus()
+        }
+        
         players.values.forEach { player ->
           if (player.isPaused) {
             player.isPaused = false
@@ -258,6 +269,11 @@ class AudioModule : Module() {
             mediaSource,
             updateInterval
           )
+          player.onPlaybackStateChange = { isPlaying ->
+            if (!isPlaying && shouldReleaseFocus()) {
+              releaseAudioFocus()
+            }
+          }
           players[player.id] = player
           player
         }
@@ -415,10 +431,9 @@ class AudioModule : Module() {
       }
 
       Function("remove") { player: AudioPlayer ->
-        val wasPlaying = player.ref.isPlaying
         players.remove(player.id)
 
-        if (wasPlaying && shouldReleaseFocus()) {
+        if (shouldReleaseFocus()) {
           releaseAudioFocus()
         }
       }

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -48,6 +48,7 @@ class AudioPlayer(
   var isPaused = false
   var isMuted = false
   var previousVolume = 1f
+  var onPlaybackStateChange: ((Boolean) -> Unit)? = null
 
   private var playerScope = CoroutineScope(Dispatchers.Default)
   private var samplingEnabled = false
@@ -105,6 +106,7 @@ class AudioPlayer(
       playerScope.launch {
         sendPlayerUpdate(mapOf("playing" to isPlaying))
       }
+      onPlaybackStateChange?.invoke(isPlaying)
     }
 
     override fun onIsLoadingChanged(isLoading: Boolean) {


### PR DESCRIPTION
# Why
Closes #37694

# How
The main issue was we were shadowing the `audioFocusRequest` instead of storing it on the module. This caused releasing focus to fail because you must use the same request object to release. I noticed some other small issue when working on this
- OnActivityEntersForeground would request focus regardless of it we needed it or not, interrupting any playing audio when the app launched.
- When the player state would change, we did not notify the audio module and kept the audio focus regardless of if it was needed or not.

# Test Plan
Tested on a real device using spotify.
- Bare expo no longer interrupts on launch
- `duckOthers` and `doNotMix` both work correctly. In the case of ducking, spotify app volume is lowered while our player is playing and restored when paused. 

The issue mentioned av working correctly but it seems completely broken in my testing.

