### PR TITLE
[ios][expo-mail-composer] Removes retired appcenter URL scheme

### DIFF
--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [ios] Remove `appcenter` from `LSApplicationQueriesSchemes` as it's now retired
+
 ## 14.1.5 - 2025-06-27
 
 ### 🐛 Bug fixes

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [ios] Remove `appcenter` from `LSApplicationQueriesSchemes` as it's now retired
+- [ios] Remove `appcenter` from `LSApplicationQueriesSchemes` as it's now retired ([#37699](https://github.com/expo/expo/pull/37699) by [@huextrat](https://github.com/huextrat))
 
 ## 14.1.5 - 2025-06-27
 

--- a/packages/expo-mail-composer/plugin/build/withMailComposer.js
+++ b/packages/expo-mail-composer/plugin/build/withMailComposer.js
@@ -26,7 +26,6 @@ const mailClientURLs = [
     'x-webdemail-netid-v1',
     'ymail',
     'yandexmail',
-    'appcenter-f45b4c0b-75c9-2d01-7ab6-41f6a6015be2',
     'mymail-mailto',
 ];
 const withMailComposer = (config) => {

--- a/packages/expo-mail-composer/plugin/src/withMailComposer.ts
+++ b/packages/expo-mail-composer/plugin/src/withMailComposer.ts
@@ -26,7 +26,6 @@ const mailClientURLs: string[] = [
   'x-webdemail-netid-v1',
   'ymail',
   'yandexmail',
-  'appcenter-f45b4c0b-75c9-2d01-7ab6-41f6a6015be2',
   'mymail-mailto',
 ];
 


### PR DESCRIPTION
Removes the retired `appcenter` URL scheme from the list of `LSApplicationQueriesSchemes` in the iOS configuration.

# Why

AppCenter is now retired: https://learn.microsoft.com/en-us/appcenter/retirement

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
