### PR TITLE
[docs]: clarify KeyboardAwareScrollView recommendation

### DIFF
--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -154,9 +154,20 @@ export default function RootLayout() {
 
 ### Handling multiple inputs
 
-The [`KeyboardAvoidingView`](#keyboard-avoiding-view) component is excellent for prototyping but requires platform-specific configuration and is not very customizable. To achieve the same functionality, you can use [`KeyboardAwareScrollView`](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/components/keyboard-aware-scroll-view), which automatically scrolls to focused `TextInput` and provides a native-like performance, we recommend using `KeyboardAwareScrollView` for simple screens with not many elements.
+The [`KeyboardAvoidingView`](#keyboard-avoiding-view) component is excellent for
+prototyping, but it requires platform-specific configuration and is not very
+customizable.
 
-For screens with multiple inputs, the Keyboard Controller provides `KeyboardAwareScrollView` and `KeyboardToolbar` components. These components handle input navigation and prevent the keyboard from covering the screen without custom configuration:
+As a more powerful alternative, you can use the
+[`KeyboardAwareScrollView`](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/components/keyboard-aware-scroll-view)
+component. It automatically scrolls to a focused `TextInput` and provides
+native-like performance. For simple screens with only a few elements, using
+`KeyboardAwareScrollView` is a great approach.
+
+For screens with multiple inputs, the Keyboard Controller library also provides a
+`KeyboardToolbar` component to use alongside `KeyboardAwareScrollView`.
+Together, these components handle input navigation and prevent the keyboard from
+covering the screen without custom configuration:
 
 ```tsx FormScreen.tsx
 import { TextInput, View, StyleSheet } from 'react-native';

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -154,20 +154,11 @@ export default function RootLayout() {
 
 ### Handling multiple inputs
 
-The [`KeyboardAvoidingView`](#keyboard-avoiding-view) component is excellent for
-prototyping, but it requires platform-specific configuration and is not very
-customizable.
+The [`KeyboardAvoidingView`](#keyboard-avoiding-view) component is excellent for prototyping, but it requires platform-specific configuration and is not very customizable.
 
-As a more powerful alternative, you can use the
-[`KeyboardAwareScrollView`](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/components/keyboard-aware-scroll-view)
-component. It automatically scrolls to a focused `TextInput` and provides
-native-like performance. For simple screens with only a few elements, using
-`KeyboardAwareScrollView` is a great approach.
+As a more powerful alternative, you can use the [`KeyboardAwareScrollView`](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/components/keyboard-aware-scroll-view) component. It automatically scrolls to a focused `TextInput` and provides native-like performance. For simple screens with only a few elements, using `KeyboardAwareScrollView` is a great approach.
 
-For screens with multiple inputs, the Keyboard Controller library also provides a
-`KeyboardToolbar` component to use alongside `KeyboardAwareScrollView`.
-Together, these components handle input navigation and prevent the keyboard from
-covering the screen without custom configuration:
+For screens with multiple inputs, the Keyboard Controller library also provides a `KeyboardToolbar` component to use alongside `KeyboardAwareScrollView`. Together, these components handle input navigation and prevent the keyboard from covering the screen without custom configuration:
 
 ```tsx FormScreen.tsx
 import { TextInput, View, StyleSheet } from 'react-native';


### PR DESCRIPTION
Rewrites the section for better readability and to align with the style guide by removing first-person phrasing and splitting a long sentence.

File changed: docs/pages/guides/keyboard-handling.mdx

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
As I was reading [this expo](https://docs.expo.dev/guides/keyboard-handling/) documentation page myself I got confused with the wording and the sentence structure, particularly the following:

> To achieve the same functionality, you can use [KeyboardAwareScrollView](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/components/keyboard-aware-scroll-view), which automatically scrolls to focused TextInput and provides a native-like performance, we recommend using KeyboardAwareScrollView for simple screens with not many elements.


As you can see there should be at least a dot before the `we recommend using` part. Furthermore, after reading the writing style guide, I noticed that the use of `we` is discouraged unless it is something directly communicated by the Expo team or it is some important message.

After this sentence, the following follows:
> For screens with multiple inputs, the Keyboard Controller provides KeyboardAwareScrollView and KeyboardToolbar components. 

Continuing. So in the very previous sentence we have:
> ...we recommend using KeyboardAwareScrollView for simple screens with not many elements.

Which is immediately followed by: 
> For screens with multiple inputs, the Keyboard Controller provides KeyboardAwareScrollView...

Even though it is followed by `KeyboardToolbar` and your goal is to recommend the `KeyboardToolbar` to the developer, it still reads hard and is quite confusing. 

# How

<!--
How did you build this feature or fix this bug and why?
-->
Please consider the following phrasing, which I think reads better:
> The [`KeyboardAvoidingView`](#keyboard-avoiding-view) component is excellent for
prototyping, but it requires platform-specific configuration and is not very
customizable.

> As a more powerful alternative, you can use the
[`KeyboardAwareScrollView`](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/components/keyboard-aware-scroll-view)
component. It automatically scrolls to a focused `TextInput` and provides
native-like performance. For simple screens with only a few elements, using
`KeyboardAwareScrollView` is a great approach.

> For screens with multiple inputs, the Keyboard Controller library also provides a
`KeyboardToolbar` component to use alongside `KeyboardAwareScrollView`.
Together, these components handle input navigation and prevent the keyboard from
covering the screen without custom configuration:

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
No tests were made as this is purely text edit in a very small area in the docs
Here is the diff from the GitHub's preview:
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/e23aeaa5-e24c-4a7c-aecc-6b60c4c33d8a" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
