### PR TITLE
[expo] fix delay load app handler on new arch

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
 - Fixed `expo/fetch` requests cancellation error message on Android. ([#37509](https://github.com/expo/expo/pull/37509) by [@kudo](https://github.com/kudo))
+- [Android] Fixed delay load app handler on new architecture mode. ([#37706](https://github.com/expo/expo/pull/37706) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -77,6 +77,8 @@ dependencies { dependencyHandler ->
   testImplementation 'androidx.test:core:1.5.0'
   testImplementation "com.google.truth:truth:1.1.2"
   testImplementation 'io.mockk:mockk:1.13.5'
+  testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2'
+  testImplementation 'org.robolectric:robolectric:4.15.1'
 
   if (useLegacyAutolinking) {
     // Link expo modules as dependencies of the adapter. It uses `api` configuration so they all will be visible for the app as well.

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -1,13 +1,20 @@
 package expo.modules
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.content.res.Configuration
+import android.os.Build
+import android.os.Build.VERSION
 import android.os.Bundle
+import android.util.Log
 import android.view.KeyEvent
 import android.view.ViewGroup
+import androidx.annotation.VisibleForTesting
 import androidx.collection.ArrayMap
+import androidx.lifecycle.lifecycleScope
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.ReactDelegate
@@ -18,17 +25,22 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactRootView
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.core.PermissionListener
+import expo.modules.core.interfaces.ReactActivityHandler.DelayLoadAppHandler
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.kotlin.Utils
 import expo.modules.rncompatibility.ReactNativeFeatureFlags
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 class ReactActivityDelegateWrapper(
   private val activity: ReactActivity,
   private val isNewArchitectureEnabled: Boolean,
-  private var delegate: ReactActivityDelegate
+  @get:VisibleForTesting internal var delegate: ReactActivityDelegate
 ) : ReactActivityDelegate(activity, null) {
   constructor(activity: ReactActivity, delegate: ReactActivityDelegate) :
     this(activity, false, delegate)
@@ -44,9 +56,14 @@ class ReactActivityDelegateWrapper(
   private val _reactHost: ReactHost? by lazy {
     delegate.reactHost
   }
+  private val delayLoadAppHandler: DelayLoadAppHandler? by lazy {
+    reactActivityHandlers.asSequence()
+      .mapNotNull { it.getDelayLoadAppHandler(activity, reactNativeHost) }
+      .firstOrNull()
+  }
 
   /**
-   * When the app delay for `loadApp`, the ReactInstanceManager's lifecycle will be disrupted.
+   * When the app delay for `loadApp`, the React Native lifecycle will be disrupted.
    * This flag indicates we should emit `onResume` after `loadApp`.
    */
   private var shouldEmitPendingResume = false
@@ -82,53 +99,12 @@ class ReactActivityDelegateWrapper(
   }
 
   override fun loadApp(appKey: String?) {
-    // Give modules a chance to wrap the ReactRootView in a container ViewGroup. If some module
-    // wants to do this, we override the functionality of `loadApp` and call `setContentView` with
-    // the new container view instead.
-    val rootViewContainer = reactActivityHandlers.asSequence()
-      .mapNotNull { it.createReactRootViewContainer(activity) }
-      .firstOrNull()
-    if (rootViewContainer != null) {
-      val mReactDelegate = ReactActivityDelegate::class.java.getDeclaredField("mReactDelegate")
-      mReactDelegate.isAccessible = true
-      val reactDelegate = mReactDelegate[delegate] as ReactDelegate
-
-      reactDelegate.loadApp(appKey)
-      val reactRootView = reactDelegate.reactRootView
-      (reactRootView?.parent as? ViewGroup)?.removeView(reactRootView)
-      rootViewContainer.addView(reactRootView, ViewGroup.LayoutParams.MATCH_PARENT)
-      activity.setContentView(rootViewContainer)
-      reactActivityLifecycleListeners.forEach { listener ->
-        listener.onContentChanged(activity)
-      }
-      return
-    }
-
-    val delayLoadAppHandler = reactActivityHandlers.asSequence()
-      .mapNotNull { it.getDelayLoadAppHandler(activity, reactNativeHost) }
-      .firstOrNull()
-    if (delayLoadAppHandler != null) {
-      shouldEmitPendingResume = true
-      delayLoadAppHandler.whenReady {
-        Utils.assertMainThread()
-        invokeDelegateMethod<Unit, String?>("loadApp", arrayOf(String::class.java), arrayOf(appKey))
-        reactActivityLifecycleListeners.forEach { listener ->
-          listener.onContentChanged(activity)
-        }
-        if (shouldEmitPendingResume) {
-          shouldEmitPendingResume = false
-          onResume()
-        }
-      }
-      return
-    }
-
-    invokeDelegateMethod<Unit, String?>("loadApp", arrayOf(String::class.java), arrayOf(appKey))
-    reactActivityLifecycleListeners.forEach { listener ->
-      listener.onContentChanged(activity)
+    activity.lifecycleScope.launch(start = CoroutineStart.UNDISPATCHED) {
+      loadAppImpl(appKey, supportsDelayLoad = true)
     }
   }
 
+  @SuppressLint("DiscouragedPrivateApi")
   override fun onCreate(savedInstanceState: Bundle?) {
     // Give handlers a chance as early as possible to replace the wrapped delegate object.
     // If they do, we call the new wrapped delegate's `onCreate` instead of overriding it here.
@@ -144,38 +120,49 @@ class ReactActivityDelegateWrapper(
       mDelegateField.set(activity, newDelegate)
       delegate = newDelegate
 
-      invokeDelegateMethod<Unit, Bundle?>("onCreate", arrayOf(Bundle::class.java), arrayOf(savedInstanceState))
+      delegate.onCreate(savedInstanceState)
     } else {
       // Since we just wrap `ReactActivityDelegate` but not inherit it, in its `onCreate`,
       // the calls to `createRootView()` or `getMainComponentName()` have no chances to be our wrapped methods.
       // Instead we intercept `ReactActivityDelegate.onCreate` and replace the `mReactDelegate` with our version.
       // That's not ideal but works.
-      val launchOptions = composeLaunchOptions()
-      val reactDelegate: ReactDelegate
-      if (ReactNativeFeatureFlags.enableBridgelessArchitecture) {
-        reactDelegate = ReactDelegate(
-          plainActivity,
-          reactHost,
-          mainComponentName,
-          launchOptions
-        )
-      } else {
-        reactDelegate = object : ReactDelegate(
-          plainActivity,
-          reactNativeHost,
-          mainComponentName,
-          launchOptions
-        ) {
-          override fun createRootView(): ReactRootView {
-            return this@ReactActivityDelegateWrapper.createRootView() ?: super.createRootView()
+
+      activity.lifecycleScope.launch(start = CoroutineStart.UNDISPATCHED) {
+        awaitDelayLoadAppWhenReady(delayLoadAppHandler)
+
+        if (VERSION.SDK_INT >= Build.VERSION_CODES.O && isWideColorGamutEnabled) {
+          activity.window.colorMode = ActivityInfo.COLOR_MODE_WIDE_COLOR_GAMUT
+        }
+
+        val launchOptions = composeLaunchOptions()
+        val reactDelegate: ReactDelegate
+        if (ReactNativeFeatureFlags.enableBridgelessArchitecture) {
+          reactDelegate = ReactDelegate(
+            plainActivity,
+            reactHost,
+            mainComponentName,
+            launchOptions
+          )
+        } else {
+          reactDelegate = object : ReactDelegate(
+            plainActivity,
+            reactNativeHost,
+            mainComponentName,
+            launchOptions,
+            isFabricEnabled
+          ) {
+            override fun createRootView(): ReactRootView {
+              return this@ReactActivityDelegateWrapper.createRootView() ?: super.createRootView()
+            }
           }
         }
-      }
-      val mReactDelegate = ReactActivityDelegate::class.java.getDeclaredField("mReactDelegate")
-      mReactDelegate.isAccessible = true
-      mReactDelegate.set(delegate, reactDelegate)
-      if (mainComponentName != null) {
-        loadApp(mainComponentName)
+
+        val mReactDelegate = ReactActivityDelegate::class.java.getDeclaredField("mReactDelegate")
+        mReactDelegate.isAccessible = true
+        mReactDelegate.set(delegate, reactDelegate)
+        if (mainComponentName != null) {
+          loadAppImpl(mainComponentName, supportsDelayLoad = false)
+        }
       }
     }
 
@@ -188,7 +175,7 @@ class ReactActivityDelegateWrapper(
     if (shouldEmitPendingResume) {
       return
     }
-    invokeDelegateMethod<Unit>("onResume")
+    delegate.onResume()
     reactActivityLifecycleListeners.forEach { listener ->
       listener.onResume(activity)
     }
@@ -204,14 +191,26 @@ class ReactActivityDelegateWrapper(
     reactActivityLifecycleListeners.forEach { listener ->
       listener.onPause(activity)
     }
-    return invokeDelegateMethod("onPause")
+    if (delayLoadAppHandler != null) {
+      try {
+        // For the delay load case, we may enter a different call flow than react-native.
+        // For example, Activity stopped before delay load finished.
+        // We stop before the ReactActivityDelegate gets a chance to set up.
+        // In this case, we should catch the exceptions.
+        delegate.onPause()
+      } catch (e: Exception) {
+        Log.e(TAG, "Exception occurred during onPause with delayed app loading", e)
+      }
+    } else {
+      delegate.onPause()
+    }
   }
 
   override fun onUserLeaveHint() {
     reactActivityLifecycleListeners.forEach { listener ->
       listener.onUserLeaveHint(activity)
     }
-    return invokeDelegateMethod("onUserLeaveHint")
+    delegate.onUserLeaveHint()
   }
 
   override fun onDestroy() {
@@ -224,7 +223,19 @@ class ReactActivityDelegateWrapper(
     reactActivityLifecycleListeners.forEach { listener ->
       listener.onDestroy(activity)
     }
-    return invokeDelegateMethod("onDestroy")
+    if (delayLoadAppHandler != null) {
+      try {
+        // For the delay load case, we may enter a different call flow than react-native.
+        // For example, Activity stopped before delay load finished.
+        // We stop before the ReactActivityDelegate gets a chance to set up.
+        // In this case, we should catch the exceptions.
+        delegate.onDestroy()
+      } catch (e: Exception) {
+        Log.e(TAG, "Exception occurred during onDestroy with delayed app loading", e)
+      }
+    } else {
+      delegate.onDestroy()
+    }
   }
 
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -318,6 +329,10 @@ class ReactActivityDelegateWrapper(
     return invokeDelegateMethod("isFabricEnabled")
   }
 
+  override fun isWideColorGamutEnabled(): Boolean {
+    return invokeDelegateMethod("isWideColorGamutEnabled")
+  }
+
   override fun composeLaunchOptions(): Bundle? {
     return invokeDelegateMethod("composeLaunchOptions")
   }
@@ -341,8 +356,9 @@ class ReactActivityDelegateWrapper(
     return method!!.invoke(delegate) as T
   }
 
+  @VisibleForTesting
   @Suppress("UNCHECKED_CAST")
-  private fun <T, A> invokeDelegateMethod(
+  internal fun <T, A> invokeDelegateMethod(
     name: String,
     argTypes: Array<Class<*>>,
     args: Array<A>
@@ -356,5 +372,68 @@ class ReactActivityDelegateWrapper(
     return method!!.invoke(delegate, *args) as T
   }
 
+  private suspend fun loadAppImpl(appKey: String?, supportsDelayLoad: Boolean) {
+    // Give modules a chance to wrap the ReactRootView in a container ViewGroup. If some module
+    // wants to do this, we override the functionality of `loadApp` and call `setContentView` with
+    // the new container view instead.
+    val rootViewContainer = reactActivityHandlers.asSequence()
+      .mapNotNull { it.createReactRootViewContainer(activity) }
+      .firstOrNull()
+    if (rootViewContainer != null) {
+      val mReactDelegate = ReactActivityDelegate::class.java.getDeclaredField("mReactDelegate")
+      mReactDelegate.isAccessible = true
+      val reactDelegate = mReactDelegate[delegate] as ReactDelegate
+
+      reactDelegate.loadApp(appKey)
+      val reactRootView = reactDelegate.reactRootView
+      (reactRootView?.parent as? ViewGroup)?.removeView(reactRootView)
+      rootViewContainer.addView(reactRootView, ViewGroup.LayoutParams.MATCH_PARENT)
+      activity.setContentView(rootViewContainer)
+      reactActivityLifecycleListeners.forEach { listener ->
+        listener.onContentChanged(activity)
+      }
+      return
+    }
+
+    if (supportsDelayLoad) {
+      awaitDelayLoadAppWhenReady(delayLoadAppHandler)
+      invokeDelegateMethod<Unit, String?>("loadApp", arrayOf(String::class.java), arrayOf(appKey))
+      reactActivityLifecycleListeners.forEach { listener ->
+        listener.onContentChanged(activity)
+      }
+      if (shouldEmitPendingResume) {
+        shouldEmitPendingResume = false
+        onResume()
+      }
+      return
+    }
+
+    invokeDelegateMethod<Unit, String?>("loadApp", arrayOf(String::class.java), arrayOf(appKey))
+    reactActivityLifecycleListeners.forEach { listener ->
+      listener.onContentChanged(activity)
+    }
+    if (shouldEmitPendingResume) {
+      shouldEmitPendingResume = false
+      onResume()
+    }
+  }
+
+  private suspend fun awaitDelayLoadAppWhenReady(delayLoadAppHandler: DelayLoadAppHandler?) {
+    if (delayLoadAppHandler == null) {
+      return
+    }
+    shouldEmitPendingResume = true
+    suspendCoroutine { continuation ->
+      delayLoadAppHandler.whenReady {
+        Utils.assertMainThread()
+        continuation.resume(Unit)
+      }
+    }
+  }
+
   //endregion
+
+  companion object {
+    private val TAG = ReactActivityDelegate::class.simpleName
+  }
 }

--- a/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperDelayLoadTest.kt
+++ b/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperDelayLoadTest.kt
@@ -1,0 +1,336 @@
+package expo.modules
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import com.facebook.react.ReactActivity
+import com.facebook.react.ReactActivityDelegate
+import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
+import com.facebook.react.ReactNativeHost
+import com.facebook.react.ReactRootView
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
+import com.facebook.react.defaults.DefaultReactActivityDelegate
+import com.facebook.react.interfaces.fabric.ReactSurface
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
+import com.facebook.soloader.SoLoader
+import expo.modules.core.interfaces.Package
+import expo.modules.core.interfaces.ReactActivityHandler
+import expo.modules.core.interfaces.ReactActivityHandler.DelayLoadAppHandler
+import expo.modules.core.interfaces.ReactActivityLifecycleListener
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.android.controller.ActivityController
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = MockApplication::class)
+internal class ReactActivityDelegateWrapperDelayLoadTest {
+  @RelaxedMockK
+  private lateinit var delayLoadAppHandler: DelayLoadAppHandler
+
+  private lateinit var mockPackageWithDelay: MockPackageWithDelayHandler
+  private lateinit var mockPackageWithoutDelay: MockPackageWithoutDelayHandler
+  private lateinit var activityController: ActivityController<MockActivity>
+  private val activity: MockActivity
+    get() = activityController.get()
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Before
+  fun setUp() {
+    SoLoader.setInTestMode()
+    mockkObject(ExpoModulesPackage.Companion)
+    mockkStatic(ReactNativeFeatureFlags::class)
+    every { ReactNativeFeatureFlags.enableBridgelessArchitecture() } returns true
+    every { ReactNativeFeatureFlags.enableFabricRenderer() } returns true
+    Dispatchers.setMain(UnconfinedTestDispatcher())
+
+    MockKAnnotations.init(this)
+
+    mockPackageWithDelay = MockPackageWithDelayHandler(delayLoadAppHandler)
+    mockPackageWithoutDelay = MockPackageWithoutDelayHandler()
+  }
+
+  @After
+  fun tearDown() {
+    unmockkAll()
+  }
+
+  @Test
+  fun `should proceed loadApp immediately when no delayLoadAppHandler`() = runTest {
+    every { ExpoModulesPackage.Companion.packageList } returns listOf(mockPackageWithoutDelay)
+
+    activityController = Robolectric.buildActivity(MockActivity::class.java)
+      .also {
+        val activity = it.get()
+        (activity.application as MockApplication).bindCurrentActivity(activity)
+      }
+      .setup()
+    val spyDelegateWrapper = activity.reactActivityDelegate as ReactActivityDelegateWrapper
+    verify { spyDelegateWrapper.invokeDelegateMethod("loadApp", arrayOf(String::class.java), arrayOf("main")) }
+  }
+
+  @Test
+  fun `should block loadApp until delayLoadAppHandler finished`() = runTest {
+    every { ExpoModulesPackage.Companion.packageList } returns listOf(mockPackageWithDelay)
+
+    val callbackSlot = slot<Runnable>()
+    every { delayLoadAppHandler.whenReady(capture(callbackSlot)) } answers {
+      // Don't call the callback immediately to simulate delay
+    }
+
+    activityController = Robolectric.buildActivity(MockActivity::class.java)
+      .also {
+        val activity = it.get()
+        (activity.application as MockApplication).bindCurrentActivity(activity)
+      }
+      .setup()
+
+    val spyDelegateWrapper = activity.reactActivityDelegate as ReactActivityDelegateWrapper
+
+    verify(exactly = 0) { spyDelegateWrapper.invokeDelegateMethod("loadApp", arrayOf(String::class.java), arrayOf("main")) }
+    callbackSlot.captured.run()
+    verify(exactly = 1) { spyDelegateWrapper.invokeDelegateMethod("loadApp", arrayOf(String::class.java), arrayOf("main")) }
+  }
+
+  @Test
+  fun `should call lifecycle methods in correct order with delay load`() = runTest {
+    every { ExpoModulesPackage.Companion.packageList } returns listOf(mockPackageWithDelay)
+
+    val callbackSlot = slot<Runnable>()
+    every { delayLoadAppHandler.whenReady(capture(callbackSlot)) } answers {
+      // Don't call the callback immediately to simulate delay
+    }
+
+    activityController = Robolectric.buildActivity(MockActivity::class.java)
+      .also {
+        val activity = it.get()
+        (activity.application as MockApplication).bindCurrentActivity(activity)
+      }
+      .setup()
+    val spyDelegateWrapper = activity.reactActivityDelegate as ReactActivityDelegateWrapper
+    val spyDelegate = spyDelegateWrapper.delegate
+
+    verify(exactly = 1) { spyDelegateWrapper.onCreate(any()) }
+    verify(exactly = 1) { spyDelegateWrapper.onResume() }
+    verify(exactly = 0) { spyDelegate.onResume() }
+
+    callbackSlot.captured.run()
+    verify(exactly = 2) { spyDelegateWrapper.onResume() }
+    verify(exactly = 1) { spyDelegate.onResume() }
+    verify(exactly = 0) { spyDelegateWrapper.onPause() }
+    verify(exactly = 0) { spyDelegateWrapper.onDestroy() }
+    verify(exactly = 0) { spyDelegate.onPause() }
+    verify(exactly = 0) { spyDelegate.onDestroy() }
+
+    activityController.pause().stop().destroy()
+    verify(exactly = 1) { spyDelegateWrapper.onPause() }
+    verify(exactly = 1) { spyDelegateWrapper.onDestroy() }
+    verify(exactly = 1) { spyDelegate.onPause() }
+    verify(exactly = 1) { spyDelegate.onDestroy() }
+  }
+
+  @Test
+  fun `should have normal lifecycle when no delayLoadHandler`() = runTest {
+    every { ExpoModulesPackage.Companion.packageList } returns listOf(mockPackageWithoutDelay)
+
+    activityController = Robolectric.buildActivity(MockActivity::class.java)
+      .also {
+        val activity = it.get()
+        (activity.application as MockApplication).bindCurrentActivity(activity)
+      }
+      .setup()
+    val spyDelegateWrapper = activity.reactActivityDelegate as ReactActivityDelegateWrapper
+    val spyDelegate = spyDelegateWrapper.delegate
+
+    verify(exactly = 1) { spyDelegateWrapper.onCreate(any()) }
+    verify(exactly = 1) { spyDelegateWrapper.onResume() }
+    verify(exactly = 1) { spyDelegate.onResume() }
+
+    activityController.pause().stop().destroy()
+    verify(exactly = 1) { spyDelegateWrapper.onPause() }
+    verify(exactly = 1) { spyDelegateWrapper.onDestroy() }
+    verify(exactly = 1) { spyDelegate.onPause() }
+    verify(exactly = 1) { spyDelegate.onDestroy() }
+  }
+
+  @Test
+  fun `should cancel pending resume if activity pause before delay load finished`() = runTest {
+    every { ExpoModulesPackage.Companion.packageList } returns listOf(mockPackageWithDelay)
+
+    val callbackSlot = slot<Runnable>()
+    every { delayLoadAppHandler.whenReady(capture(callbackSlot)) } answers {
+      // Don't call the callback immediately to simulate delay
+    }
+
+    activityController = Robolectric.buildActivity(MockActivity::class.java)
+      .also {
+        val activity = it.get()
+        (activity.application as MockApplication).bindCurrentActivity(activity)
+      }
+      .setup()
+    val spyDelegateWrapper = activity.reactActivityDelegate as ReactActivityDelegateWrapper
+    val spyDelegate = spyDelegateWrapper.delegate
+
+    verify(exactly = 1) { spyDelegateWrapper.onCreate(any()) }
+    verify(exactly = 1) { spyDelegateWrapper.onResume() }
+    verify(exactly = 0) { spyDelegate.onResume() }
+
+    activityController.pause()
+    callbackSlot.captured.run()
+    verify(exactly = 0) { spyDelegate.onResume() }
+  }
+
+  @Test
+  fun `should cancel pending resume if activity stop before delay load finished`() = runTest {
+    every { ExpoModulesPackage.Companion.packageList } returns listOf(mockPackageWithDelay)
+
+    val callbackSlot = slot<Runnable>()
+    every { delayLoadAppHandler.whenReady(capture(callbackSlot)) } answers {
+      // Don't call the callback immediately to simulate delay
+    }
+
+    activityController = Robolectric.buildActivity(MockActivity::class.java)
+      .also {
+        val activity = it.get()
+        (activity.application as MockApplication).bindCurrentActivity(activity)
+      }
+      .setup()
+    val spyDelegateWrapper = activity.reactActivityDelegate as ReactActivityDelegateWrapper
+    val spyDelegate = spyDelegateWrapper.delegate
+
+    verify(exactly = 1) { spyDelegateWrapper.onCreate(any()) }
+    verify(exactly = 1) { spyDelegateWrapper.onResume() }
+    verify(exactly = 0) { spyDelegate.onResume() }
+
+    activityController.pause().stop()
+    callbackSlot.captured.run()
+    verify(exactly = 0) { spyDelegate.onResume() }
+  }
+
+  @Test
+  fun `should cancel pending resume if activity destroy before delay load finished`() = runTest {
+    every { ExpoModulesPackage.Companion.packageList } returns listOf(mockPackageWithDelay)
+
+    val callbackSlot = slot<Runnable>()
+    every { delayLoadAppHandler.whenReady(capture(callbackSlot)) } answers {
+      // Don't call the callback immediately to simulate delay
+    }
+
+    activityController = Robolectric.buildActivity(MockActivity::class.java)
+      .also {
+        val activity = it.get()
+        (activity.application as MockApplication).bindCurrentActivity(activity)
+      }
+      .setup()
+    val spyDelegateWrapper = activity.reactActivityDelegate as ReactActivityDelegateWrapper
+    val spyDelegate = spyDelegateWrapper.delegate
+
+    verify(exactly = 1) { spyDelegateWrapper.onCreate(any()) }
+    verify(exactly = 1) { spyDelegateWrapper.onResume() }
+    verify(exactly = 0) { spyDelegate.onResume() }
+
+    activityController.pause().stop().destroy()
+    callbackSlot.captured.run()
+    verify(exactly = 0) { spyDelegate.onResume() }
+  }
+}
+
+internal class MockPackageWithDelayHandler(delayHandler: DelayLoadAppHandler) : Package {
+  private val reactActivityLifecycleListener = mockk<ReactActivityLifecycleListener>(relaxed = true)
+  private val reactActivityHandler = mockk<ReactActivityHandler>(relaxed = true)
+
+  init {
+    every { reactActivityHandler.createReactRootViewContainer(any()) } returns null
+    every { reactActivityHandler.onDidCreateReactActivityDelegate(any(), any()) } returns null
+    every { reactActivityHandler.getDelayLoadAppHandler(any(), any()) } returns delayHandler
+  }
+
+  override fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener> {
+    return listOf(reactActivityLifecycleListener)
+  }
+
+  override fun createReactActivityHandlers(activityContext: Context?): List<ReactActivityHandler> {
+    return listOf(reactActivityHandler)
+  }
+}
+
+internal class MockPackageWithoutDelayHandler : Package {
+  private val reactActivityLifecycleListener = mockk<ReactActivityLifecycleListener>(relaxed = true)
+  private val reactActivityHandler = mockk<ReactActivityHandler>(relaxed = true)
+
+  init {
+    every { reactActivityHandler.createReactRootViewContainer(any()) } returns null
+    every { reactActivityHandler.onDidCreateReactActivityDelegate(any(), any()) } returns null
+    every { reactActivityHandler.getDelayLoadAppHandler(any(), any()) } returns null
+  }
+
+  override fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener> {
+    return listOf(reactActivityLifecycleListener)
+  }
+
+  override fun createReactActivityHandlers(activityContext: Context?): List<ReactActivityHandler> {
+    return listOf(reactActivityHandler)
+  }
+}
+
+internal class MockApplication : Application(), ReactApplication {
+  private var currentActivity: Activity? = null
+
+  override fun onCreate() {
+    super.onCreate()
+    setTheme(androidx.appcompat.R.style.Theme_AppCompat)
+  }
+
+  internal fun bindCurrentActivity(activity: Activity?) {
+    currentActivity = activity
+  }
+
+  override val reactNativeHost: ReactNativeHost = mockk<ReactNativeHost>(relaxed = true)
+
+  override val reactHost: ReactHost by lazy {
+    mockk<ReactHost>(relaxed = true)
+      .also {
+        val mockReactSurface = mockk<ReactSurface>(relaxed = true)
+        every { mockReactSurface.view } returns ReactRootView(currentActivity)
+        every { it.createSurface(any(), any(), any()) } returns mockReactSurface
+      }
+  }
+}
+
+internal class MockActivity : ReactActivity() {
+  override fun getMainComponentName(): String = "main"
+
+  override fun createReactActivityDelegate(): ReactActivityDelegate = spyk(
+    ReactActivityDelegateWrapper(
+      this,
+      BuildConfig.IS_NEW_ARCHITECTURE_ENABLED,
+      spyk(
+        object : DefaultReactActivityDelegate(
+          this,
+          mainComponentName,
+          fabricEnabled
+        ) {}
+      )
+    )
+  )
+}


### PR DESCRIPTION
# Why

fixes #35676

# How

- the delay load has been broken since new arch. updates still loads on main thread from [this line](https://github.com/expo/expo/blob/857df579d707b08e3925b6bbb04517baff8324b0/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt#L37-L39)
- this pr tries to fix the delay load to support new arch. it should block the `ReactHost` creation when the delay load app is ready. i moved the delay load point from `loadApp()` to `onCreate()`.
- add `isWideColorGamutEnabled` support from upstream. we missed this from react-native upgrades
- remove reflection from `delegate.onResume`, `onPause` and so on. these methods are public now and don't need to use reflection calls.
- also try to fix the [issue](https://github.com/expo/expo/issues/15298#issuecomment-2669425544) as well. to catch the exceptions when delay load is enabled

# Test Plan

- test this new code on sdk53 with updates
- add android unit tests for the delay load behaviors

# Checklist

- [x]  I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
