### PR TITLE
[updates] remove detox workaround

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [CI] convert E2E (fingerprint and startup) tests to Maestro. ([#37592](https://github.com/expo/expo/pull/37592) by [@douglowder](https://github.com/douglowder))
 - [CI] convert E2E (old arch, custom init, error recovery, bricking measures disabled) tests to Maestro. ([#37600](https://github.com/expo/expo/pull/37600) by [@douglowder](https://github.com/douglowder))
 - Bump Express and types to `express@5`. ([#37635](https://github.com/expo/expo/pull/37635) by [@byCedric](https://github.com/byCedric))
+- Removed Detox testing workaround code on Android. ([#37707](https://github.com/expo/expo/pull/37707) by [@kudo](https://github.com/kudo))
 
 ## 0.28.15 - 2025-06-18
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -1,6 +1,5 @@
 package expo.modules.updates
 
-import android.app.Application
 import android.content.Context
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
@@ -8,7 +7,6 @@ import com.facebook.react.ReactActivity
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
-import expo.modules.core.interfaces.ApplicationLifecycleListener
 import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.ReactActivityHandler
 import expo.modules.core.interfaces.ReactNativeHostHandler
@@ -92,30 +90,6 @@ class UpdatesPackage : Package {
     }
 
     return listOf(handler)
-  }
-
-  override fun createApplicationLifecycleListeners(context: Context): List<ApplicationLifecycleListener> {
-    val handler = object : ApplicationLifecycleListener {
-      override fun onCreate(application: Application) {
-        super.onCreate(application)
-        if (isRunningAndroidTest()) {
-          // Preload updates to prevent Detox ANR
-          UpdatesController.initialize(context)
-          UpdatesController.instance.launchAssetFile
-        }
-      }
-    }
-
-    return listOf(handler)
-  }
-
-  private fun isRunningAndroidTest(): Boolean {
-    try {
-      Class.forName("androidx.test.espresso.Espresso")
-      return true
-    } catch (_: ClassNotFoundException) {
-    }
-    return false
   }
 
   companion object {


### PR DESCRIPTION
# Why

thanks to the updates e2e maestro migration. we can't remove the detox workaround in updates

# How

remove the main thread workaround for detox. and align the updates behavior for delay load

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
