### PR TITLE
Chore(i18n): add isRTL code snippet

### DIFF
--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -327,6 +327,11 @@ export default Text;
 
 If you need to use different icons for LTR/RTL or change styles based on this setting, you can use `I18nManager.isRTL` to get the current layout direction.
 
+```tsx
+import { I18nManager } from 'react-native';
+const isRTL = I18nManager.isRTL;
+```
+
 ## Locale settings and units
 
 Expo provides the `expo-localization` library to allow you to read the user's locale and other preferences. You can use synchronous `getLocales()` and `getCalendars()` methods to get the current locale settings of the user device:

--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -325,7 +325,7 @@ export default Text;
 
 ### Selecting assets based on locale direction
 
-If you need to use different icons for LTR/RTL or change styles based on this setting, you can use `I18nManager.isRTL` to get the current layout direction.
+If you need to use different icons for LTR/RTL or change styles based on this setting, you can use [`I18nManager.isRTL`](https://reactnative.dev/docs/next/i18nmanager#isrtl) to get the current layout direction.
 
 ```tsx
 import { I18nManager } from 'react-native';


### PR DESCRIPTION
# Why

The code snippet was not provided directly, it's easier to copy paste it, instead of looking where to find the i18nmanager
# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
