### PR TITLE
Fix invalid check for publishing canary packages.

### DIFF
--- a/tools/src/commands/PublishPackages.ts
+++ b/tools/src/commands/PublishPackages.ts
@@ -227,7 +227,7 @@ function tasksForOptions(options: CommandOptions): Task<TaskArgs>[] {
         `🛠️ You can also use the CI action instead: https://github.com/expo/expo/actions/workflows/publish-canaries.yml`
       );
     }
-    if (options.packageNames) {
+    if (options.packageNames.length > 0) {
       logger.error(
         '⚠️  Do not pass package names with the --canary flag - canary tags do not support semver ranges, so this would likely cause duplicate expo package versions.'
       );


### PR DESCRIPTION
# Why

Left out this commit from my previous PR: https://github.com/expo/expo/pull/37687

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
