### PR TITLE
Add local package mocks for expofont to allow reverting #36586

### DIFF
--- a/apps/jest-expo-mock-generator/App.tsx
+++ b/apps/jest-expo-mock-generator/App.tsx
@@ -3,6 +3,9 @@ import { setStringAsync } from 'expo-clipboard';
 import React, { useEffect, useState } from 'react';
 import { Button, StyleSheet, Text, View } from 'react-native';
 
+// const whitelist = /^(Expo(?:nent)?|AIR|CTK|Lottie|Reanimated|RN|NativeUnimoduleProxy)(?![a-z])/;
+const blacklist = ['ExpoCrypto', 'ExpoClipboard', 'ExpoLocalization', 'ExpoLinking', 'ExpoFont'];
+
 type ModuleRegistrySchema = [
   {
     name: string;
@@ -110,8 +113,6 @@ THE TEXT WAS ALSO COPIED TO YOUR CLIPBOARD
   );
 }
 
-// const whitelist = /^(Expo(?:nent)?|AIR|CTK|Lottie|Reanimated|RN|NativeUnimoduleProxy)(?![a-z])/;
-const blacklist = ['ExpoCrypto', 'ExpoClipboard', 'ExpoLocalization', 'ExpoLinking'];
 async function _getExpoModuleSpecsAsync() {
   const schemaString = await CoreModule.getModulesSchema();
   const schema = JSON.parse(schemaString) as ModuleRegistrySchema;

--- a/packages/expo-font/mocks/ExpoFontLoader.ts
+++ b/packages/expo-font/mocks/ExpoFontLoader.ts
@@ -1,0 +1,5 @@
+export function getLoadedFonts(): string[] {
+  return [];
+}
+
+export async function loadAsync(fontFamilyAlias: string, localUri: string): Promise<void> {}

--- a/packages/expo-font/mocks/ExpoFontUtils.ts
+++ b/packages/expo-font/mocks/ExpoFontUtils.ts
@@ -1,0 +1,8 @@
+export type RenderToImageOptions = any;
+
+export async function renderToImageAsync(
+  glyphs: string,
+  options: RenderToImageOptions
+): Promise<string> {
+  return '';
+}

--- a/packages/jest-expo/src/preset/moduleMocks/expoModules.js
+++ b/packages/jest-expo/src/preset/moduleMocks/expoModules.js
@@ -259,13 +259,6 @@ module.exports = {
           { name: 'evalJsForWebViewAsync', argumentsCount: 2, key: 'evalJsForWebViewAsync' },
         ],
         ExpoFetchModule: [],
-        ExpoFontLoader: [
-          { name: 'getLoadedFonts', argumentsCount: 0, key: 'getLoadedFonts' },
-          { name: 'loadAsync', argumentsCount: 2, key: 'loadAsync' },
-        ],
-        ExpoFontUtils: [
-          { name: 'renderToImageAsync', argumentsCount: 2, key: 'renderToImageAsync' },
-        ],
         ExpoGo: [{ name: 'getModulesSchema', argumentsCount: 0, key: 'getModulesSchema' }],
         ExpoHaptics: [
           { name: 'impactAsync', argumentsCount: 1, key: 'impactAsync' },
@@ -906,17 +899,6 @@ module.exports = {
         ExpoFetchModule: {
           addListener: { type: 'function' },
           removeListeners: { type: 'function' },
-        },
-        ExpoFontLoader: {
-          addListener: { type: 'function' },
-          getLoadedFonts: { type: 'function' },
-          loadAsync: { type: 'function' },
-          removeListeners: { type: 'function' },
-        },
-        ExpoFontUtils: {
-          addListener: { type: 'function' },
-          removeListeners: { type: 'function' },
-          renderToImageAsync: { type: 'function' },
         },
         ExpoGo: {
           addListener: { type: 'function' },


### PR DESCRIPTION
# Why

Should allow us to revert https://github.com/expo/expo/pull/36586.

# How

- Added `ExpoFont` to the blacklist in the mock generator app to prevent auto-generation
- Generated dedicated mock files for `ExpoFontLoader` and `ExpoFontUtils` in the `expo-font` package and adjusted return types.
- Removed the auto-generated mock implementations from `jest-expo/src/preset/moduleMocks/expoModules.js`

# Test Plan

- Verified that the new mock implementations provide the expected functionality
- Ensured that the blacklist in the mock generator app correctly excludes `ExpoFont`
- Confirmed that the mock implementations match the API signatures of the actual modules

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)