### PR TITLE
[go] Improve landscape mode support

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
@@ -1,7 +1,9 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 package host.exp.exponent.experience
 
+import android.annotation.SuppressLint
 import android.content.Intent
+import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Debug
@@ -47,6 +49,7 @@ import host.exp.exponent.kernel.ExperienceKey
 import host.exp.exponent.kernel.Kernel.KernelStartedRunningEvent
 import host.exp.exponent.utils.ExperienceActivityUtils
 import host.exp.exponent.utils.ExperienceRTLManager
+import host.exp.exponent.utils.currentDeviceIsAPhone
 import org.json.JSONException
 
 open class HomeActivity : BaseExperienceActivity() {
@@ -54,6 +57,13 @@ open class HomeActivity : BaseExperienceActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     configureSplashScreen(installSplashScreen())
     enableEdgeToEdge()
+
+    if (currentDeviceIsAPhone(this)) {
+      // Like on iOS, we lock the orientation only for phones
+      @SuppressLint("SourceLockedOrientationActivity")
+      requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+    }
+
     super.onCreate(savedInstanceState)
 
     NativeModuleDepsProvider.instance.inject(HomeActivity::class.java, this)

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/DeviceSizeUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/DeviceSizeUtils.kt
@@ -1,0 +1,18 @@
+package host.exp.exponent.utils
+
+import android.content.Context
+import android.util.DisplayMetrics
+import kotlin.math.min
+
+internal fun currentDeviceIsAPhone(context: Context): Boolean {
+  val displayMetrics: DisplayMetrics = context.resources.displayMetrics
+  val dpHeight = displayMetrics.heightPixels / displayMetrics.density
+  val dpWidth = displayMetrics.widthPixels / displayMetrics.density
+
+  // We can be pretty sure that if the smaller dimension is larger than 600dp we are not dealing with a phone
+  // https://developer.android.com/develop/ui/compose/layouts/adaptive/use-window-size-classes
+  if (min(dpHeight, dpWidth) >= 600) {
+    return false
+  }
+  return true
+}

--- a/apps/expo-go/app.json
+++ b/apps/expo-go/app.json
@@ -7,7 +7,6 @@
     "privacy": "unlisted",
     "sdkVersion": "53.0.0",
     "version": "53.0.0",
-    "orientation": "portrait",
     "platforms": [
       "ios",
       "android"

--- a/apps/expo-go/src/components/Views.tsx
+++ b/apps/expo-go/src/components/Views.tsx
@@ -1,11 +1,12 @@
 import { useTheme } from '@react-navigation/native';
 import * as React from 'react';
-import { ScrollViewProps, View } from 'react-native';
+import { ScrollViewProps, useWindowDimensions, View, ViewStyle } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 
 import Colors, { ColorTheme } from '../constants/Colors';
 
 type ViewProps = View['props'];
+
 interface Props extends ViewProps {
   lightBackgroundColor?: string;
   darkBackgroundColor?: string;
@@ -24,6 +25,7 @@ function useThemeName(): ColorTheme {
   const theme = useTheme();
   return theme.dark ? ColorTheme.DARK : ColorTheme.LIGHT;
 }
+
 function useThemeBackgroundColor(props: Props | StyledScrollViewProps, colorName: ThemedColors) {
   const themeName = useThemeName();
   const colorFromProps =
@@ -84,3 +86,36 @@ export const StyledView = (props: Props) => {
     />
   );
 };
+
+/**
+ * View used to limit the content width to stay at most as wide as the screen is wide.
+ * Usually this makes the content look better in landscape mode.
+ */
+export function CappedWidthContainerView(
+  props: ViewProps & { wrapperStyle?: ViewStyle | ViewStyle[] }
+) {
+  const { height: screenHeight } = useWindowDimensions();
+  return (
+    <View
+      style={[
+        {
+          flex: 1,
+          alignItems: 'center',
+          width: '100%',
+        },
+        props.wrapperStyle,
+      ]}>
+      <View
+        {...props}
+        style={[
+          {
+            flex: 1,
+            width: '100%',
+            maxWidth: Math.max(screenHeight, 600),
+          },
+          props.style,
+        ]}
+      />
+    </View>
+  );
+}

--- a/apps/expo-go/src/navigation/defaultNavigationOptions.tsx
+++ b/apps/expo-go/src/navigation/defaultNavigationOptions.tsx
@@ -1,14 +1,39 @@
 import { darkTheme, lightTheme } from '@expo/styleguide-native';
-import { StackNavigationOptions, HeaderStyleInterpolators } from '@react-navigation/stack';
-import { Platform, StyleSheet } from 'react-native';
+import {
+  StackNavigationOptions,
+  HeaderStyleInterpolators,
+  Header,
+  StackHeaderProps,
+} from '@react-navigation/stack';
+import { Platform, StyleSheet, ViewStyle } from 'react-native';
 
+import { CappedWidthContainerView } from '../components/Views';
 import { ColorTheme } from '../constants/Colors';
 
 export default (theme: ColorTheme): StackNavigationOptions => {
+  const androidHeader = (props: StackHeaderProps) => (
+    <CappedWidthContainerView
+      wrapperStyle={[
+        props.options.headerStyle as ViewStyle,
+        {
+          flex: 0,
+          borderBottomWidth: StyleSheet.hairlineWidth,
+          borderBottomColor:
+            theme === 'dark' ? darkTheme.border.default : lightTheme.border.default,
+        },
+      ]}
+      style={{ flex: 0 }}>
+      <Header {...props} />
+    </CappedWidthContainerView>
+  );
+
   return {
+    // On iOS the header title is centered by default so we can skip adding padding to it
+    header: Platform.OS === 'android' ? androidHeader : undefined,
     headerStyle: {
       elevation: 0,
-      borderBottomWidth: StyleSheet.hairlineWidth,
+      // On android the border is added in the `androidHeader` component above
+      borderBottomWidth: Platform.OS === 'android' ? 0 : StyleSheet.hairlineWidth,
       borderBottomColor: theme === 'dark' ? darkTheme.border.default : lightTheme.border.default,
       backgroundColor:
         theme === 'dark' ? darkTheme.background.default : lightTheme.background.default,

--- a/apps/expo-go/src/screens/AccountModal/ModalHeader.tsx
+++ b/apps/expo-go/src/screens/AccountModal/ModalHeader.tsx
@@ -6,6 +6,8 @@ import { Platform, StyleSheet } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { CappedWidthContainerView } from '../../components/Views';
+
 export function ModalHeader() {
   const theme = useExpoTheme();
   const navigation = useNavigation();
@@ -22,15 +24,25 @@ export function ModalHeader() {
         borderBottomWidth: StyleSheet.hairlineWidth,
         borderBottomColor: theme.border.default,
       }}>
-      <Text type="InterBold" size="large">
-        Account
-      </Text>
-      <TouchableOpacity
-        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-        style={{ padding: spacing[2], marginRight: -8 }}
-        onPress={() => navigation.goBack()}>
-        <XIcon size={iconSize.regular} color={theme.icon.default} />
-      </TouchableOpacity>
+      <CappedWidthContainerView
+        style={{
+          flex: 0,
+          width: '100%',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignContent: 'center',
+          alignItems: 'center',
+        }}>
+        <Text type="InterBold" size="large">
+          Account
+        </Text>
+        <TouchableOpacity
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          style={{ padding: spacing[2], marginRight: -8 }}
+          onPress={() => navigation.goBack()}>
+          <XIcon size={iconSize.regular} color={theme.icon.default} />
+        </TouchableOpacity>
+      </CappedWidthContainerView>
     </Row>
   );
 }

--- a/apps/expo-go/src/screens/AccountModal/index.tsx
+++ b/apps/expo-go/src/screens/AccountModal/index.tsx
@@ -8,6 +8,7 @@ import { TouchableOpacity } from 'react-native-gesture-handler';
 import { LoggedInAccountView } from './LoggedInAccountView';
 import { LoggedOutAccountView } from './LoggedOutAccountView';
 import { ModalHeader } from './ModalHeader';
+import { CappedWidthContainerView } from '../../components/Views';
 import { useHome_CurrentUserActorQuery } from '../../graphql/types';
 
 export function AccountModal() {
@@ -32,7 +33,7 @@ export function AccountModal() {
     console.error(error);
 
     return (
-      <View flex="1" style={{ backgroundColor: theme.background.screen }}>
+      <CappedWidthContainerView wrapperStyle={{ backgroundColor: theme.background.screen }}>
         {Platform.OS === 'ios' && <ModalHeader />}
         <View padding="medium">
           <View
@@ -77,7 +78,7 @@ export function AccountModal() {
             </TouchableOpacity>
           </View>
         </View>
-      </View>
+      </CappedWidthContainerView>
     );
   }
 
@@ -86,15 +87,17 @@ export function AccountModal() {
   return (
     <View flex="1" style={{ backgroundColor: theme.background.screen }}>
       <ModalHeader />
-      {data?.meUserActor?.accounts ? (
-        <LoggedInAccountView accounts={data.meUserActor.accounts} />
-      ) : (
-        <LoggedOutAccountView
-          refetch={async () => {
-            await refetch();
-          }}
-        />
-      )}
+      <CappedWidthContainerView>
+        {data?.meUserActor?.accounts ? (
+          <LoggedInAccountView accounts={data.meUserActor.accounts} />
+        ) : (
+          <LoggedOutAccountView
+            refetch={async () => {
+              await refetch();
+            }}
+          />
+        )}
+      </CappedWidthContainerView>
     </View>
   );
 }

--- a/apps/expo-go/src/screens/BranchDetailsScreen/BranchDetailsView.tsx
+++ b/apps/expo-go/src/screens/BranchDetailsScreen/BranchDetailsView.tsx
@@ -10,6 +10,7 @@ import { BranchHeader } from './BranchHeader';
 import { EmptySection } from './EmptySection';
 import { SectionHeader } from '../../components/SectionHeader';
 import { UpdateListItem } from '../../components/UpdateListItem';
+import { CappedWidthContainerView } from '../../components/Views';
 import { BranchDetailsQuery } from '../../graphql/types';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
 import { useThrottle } from '../../utils/useThrottle';
@@ -58,23 +59,25 @@ export function BranchDetailsView({ error, data, refetch, branchName, networkSta
   return (
     <View style={{ flex: 1, backgroundColor: theme.background.screen }}>
       <BranchHeader name={branchName} latestUpdate={data.app.byId.updateBranchByName.updates[0]} />
-      <FlatList
-        data={data.app.byId.updateBranchByName.updates}
-        refreshControl={<RefreshControl onRefresh={refetch} refreshing={refetching} />}
-        ListHeaderComponent={<SectionHeader header="Updates" style={{ paddingTop: 0 }} />}
-        keyExtractor={(update) => update.id}
-        contentContainerStyle={{ padding: spacing[4] }}
-        ItemSeparatorComponent={() => <Divider style={{ height: 1 }} />}
-        ListEmptyComponent={() => <EmptySection />}
-        renderItem={({ item: update, index }) => (
-          <UpdateListItem
-            key={update.id}
-            update={update}
-            first={index === 0}
-            last={index === (data.app.byId.updateBranchByName?.updates ?? []).length - 1}
-          />
-        )}
-      />
+      <CappedWidthContainerView>
+        <FlatList
+          data={data.app.byId.updateBranchByName.updates}
+          refreshControl={<RefreshControl onRefresh={refetch} refreshing={refetching} />}
+          ListHeaderComponent={<SectionHeader header="Updates" style={{ paddingTop: 0 }} />}
+          keyExtractor={(update) => update.id}
+          contentContainerStyle={{ padding: spacing[4] }}
+          ItemSeparatorComponent={() => <Divider style={{ height: 1 }} />}
+          ListEmptyComponent={() => <EmptySection />}
+          renderItem={({ item: update, index }) => (
+            <UpdateListItem
+              key={update.id}
+              update={update}
+              first={index === 0}
+              last={index === (data.app.byId.updateBranchByName?.updates ?? []).length - 1}
+            />
+          )}
+        />
+      </CappedWidthContainerView>
     </View>
   );
 }

--- a/apps/expo-go/src/screens/BranchDetailsScreen/BranchHeader.tsx
+++ b/apps/expo-go/src/screens/BranchDetailsScreen/BranchHeader.tsx
@@ -1,5 +1,5 @@
 import { BranchIcon, iconSize, spacing } from '@expo/styleguide-native';
-import { Row, useExpoTheme, View, Text, Spacer } from 'expo-dev-client-components';
+import { Row, useExpoTheme, Text, Spacer, padding } from 'expo-dev-client-components';
 import * as React from 'react';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import { BranchDetailsQuery } from 'src/graphql/types';
@@ -7,6 +7,8 @@ import {
   isUpdateCompatibleWithThisExpoGo,
   openUpdateManifestPermalink,
 } from 'src/utils/UpdateUtils';
+
+import { CappedWidthContainerView } from '../../components/Views';
 
 type Props = {
   name: string;
@@ -36,12 +38,16 @@ export function BranchHeader(props: Props) {
     ) : null;
 
   return (
-    <View
-      bg="default"
-      padding="medium"
+    <CappedWidthContainerView
       style={{
+        flex: 0,
+      }}
+      wrapperStyle={{
+        flex: 0,
+        backgroundColor: theme.background.default,
         borderColor: theme.border.default,
         borderBottomWidth: 1,
+        ...padding.padding.medium,
       }}>
       <Row align="center" justify="between">
         <Row align="center">
@@ -53,6 +59,6 @@ export function BranchHeader(props: Props) {
         </Row>
         {openButton}
       </Row>
-    </View>
+    </CappedWidthContainerView>
   );
 }

--- a/apps/expo-go/src/screens/BranchListScreen/BranchListView.tsx
+++ b/apps/expo-go/src/screens/BranchListScreen/BranchListView.tsx
@@ -1,10 +1,11 @@
 import { ApolloQueryResult } from '@apollo/client';
 import { spacing } from '@expo/styleguide-native';
-import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
+import { Divider, useExpoTheme } from 'expo-dev-client-components';
 import * as React from 'react';
 import { FlatList, ActivityIndicator, View as RNView } from 'react-native';
 
 import { BranchListItem } from '../../components/BranchListItem';
+import { CappedWidthContainerView } from '../../components/Views';
 import { BranchesForProjectQuery } from '../../graphql/types';
 
 export type BranchManifest = {
@@ -92,9 +93,8 @@ function BranchList({ data, appId, loadMoreAsync }: Props) {
   );
 
   return (
-    <View
-      flex="1"
-      style={{
+    <CappedWidthContainerView
+      wrapperStyle={{
         backgroundColor: theme.background.screen,
       }}>
       <FlatList
@@ -106,6 +106,6 @@ function BranchList({ data, appId, loadMoreAsync }: Props) {
         onEndReached={handleLoadMoreAsync}
         onEndReachedThreshold={0.2}
       />
-    </View>
+    </CappedWidthContainerView>
   );
 }

--- a/apps/expo-go/src/screens/DiagnosticsScreen/index.tsx
+++ b/apps/expo-go/src/screens/DiagnosticsScreen/index.tsx
@@ -13,6 +13,7 @@ import { DiagnosticButton } from './DiagnosticsButton';
 import GeofencingScreen from './GeofencingDiagnosticsScreen';
 import LocationDiagnosticsScreen from './LocationDiagnosticsScreen';
 import ScrollView from '../../components/NavigationScrollView';
+import { CappedWidthContainerView } from '../../components/Views';
 import { ColorTheme } from '../../constants/Colors';
 import { DiagnosticsStackRoutes } from '../../navigation/Navigation.types';
 import defaultNavigationOptions from '../../navigation/defaultNavigationOptions';
@@ -65,16 +66,18 @@ function DiagnosticsScreen({
 }: StackScreenProps<DiagnosticsStackRoutes, 'Diagnostics'>) {
   return (
     <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingHorizontal: spacing[4] }}>
-      <Spacer.Vertical size="large" />
-      <AudioDiagnostic navigation={navigation} />
-      <Spacer.Vertical size="large" />
-      {Environment.IsIOSRestrictedBuild ? (
-        <ForegroundLocationDiagnostic navigation={navigation} />
-      ) : (
-        <BackgroundLocationDiagnostic navigation={navigation} />
-      )}
-      <Spacer.Vertical size="large" />
-      <GeofencingDiagnostic navigation={navigation} />
+      <CappedWidthContainerView>
+        <Spacer.Vertical size="large" />
+        <AudioDiagnostic navigation={navigation} />
+        <Spacer.Vertical size="large" />
+        {Environment.IsIOSRestrictedBuild ? (
+          <ForegroundLocationDiagnostic navigation={navigation} />
+        ) : (
+          <BackgroundLocationDiagnostic navigation={navigation} />
+        )}
+        <Spacer.Vertical size="large" />
+        <GeofencingDiagnostic navigation={navigation} />
+      </CappedWidthContainerView>
     </ScrollView>
   );
 }

--- a/apps/expo-go/src/screens/HomeScreen/HomeScreenHeader.tsx
+++ b/apps/expo-go/src/screens/HomeScreen/HomeScreenHeader.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { StyleSheet } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
+import { CappedWidthContainerView } from '../../components/Views';
 import { HomeScreenDataQuery } from '../../graphql/types';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
 import { useTheme } from '../../utils/useTheme';
@@ -72,34 +73,42 @@ export function HomeScreenHeader({ currentAccount }: Props) {
         borderBottomWidth: StyleSheet.hairlineWidth,
         borderBottomColor: theme.border.default,
       }}>
-      <Row align="center">
-        <View
-          align="centered"
-          rounded="medium"
-          shadow="button"
-          height="xl"
-          width="xl"
-          bg={themeType === 'dark' ? 'secondary' : 'default'}
-          style={{
-            marginRight: spacing[2],
-            elevation: themeType === 'light' ? 1 : 0,
-          }}>
-          <Image
-            size="xl"
-            source={require('../../assets/client-logo.png')}
+      <CappedWidthContainerView
+        style={{
+          flex: 0,
+          width: '100%',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+        }}>
+        <Row align="center">
+          <View
+            align="centered"
+            rounded="medium"
+            shadow="button"
+            height="xl"
+            width="xl"
+            bg={themeType === 'dark' ? 'secondary' : 'default'}
             style={{
-              tintColor: theme.text.default,
-              width: 15.3,
-              height: 17.19,
-              resizeMode: 'contain',
-            }}
-          />
-        </View>
-        <Text type="InterBold" color="default">
-          Expo Go
-        </Text>
-      </Row>
-      {rightContent}
+              marginRight: spacing[2],
+              elevation: themeType === 'light' ? 1 : 0,
+            }}>
+            <Image
+              size="xl"
+              source={require('../../assets/client-logo.png')}
+              style={{
+                tintColor: theme.text.default,
+                width: 15.3,
+                height: 17.19,
+                resizeMode: 'contain',
+              }}
+            />
+          </View>
+          <Text type="InterBold" color="default">
+            Expo Go
+          </Text>
+        </Row>
+        {rightContent}
+      </CappedWidthContainerView>
     </Row>
   );
 }

--- a/apps/expo-go/src/screens/HomeScreen/HomeScreenView.tsx
+++ b/apps/expo-go/src/screens/HomeScreen/HomeScreenView.tsx
@@ -30,6 +30,7 @@ import ScrollView from '../../components/NavigationScrollView';
 import { SectionHeader } from '../../components/SectionHeader';
 import ThemedStatusBar from '../../components/ThemedStatusBar';
 import UserReviewSection from '../../components/UserReviewSection';
+import { CappedWidthContainerView } from '../../components/Views';
 import {
   AppPlatform,
   HomeScreenDataDocument,
@@ -106,79 +107,81 @@ export class HomeScreenView extends React.Component<Props, State> {
     return (
       <View style={styles.container}>
         <HomeScreenHeader currentAccount={data} />
-        <ScrollView
-          refreshControl={
-            <RefreshControl refreshing={isRefreshing} onRefresh={this._handleRefreshAsync} />
-          }
-          bounces
-          key={Platform.OS === 'ios' ? this.props.allHistory.count() : 'scroll-view'}
-          style={styles.container}
-          contentContainerStyle={[styles.contentContainer]}>
-          <UserReviewSection apps={data?.apps} snacks={data?.snacks} />
-          <DevelopmentServersHeader onHelpPress={this._handlePressHelpProjects} />
-          {projects?.length ? (
-            <View bg="default" rounded="large" border="default" overflow="hidden">
-              {projects.map((project, i) => (
-                <React.Fragment key={`${project.description}${project.url}`}>
-                  <DevelopmentServerListItem
-                    url={project.url}
-                    image={
-                      project.source === 'desktop'
-                        ? require('../../assets/cli.png')
-                        : require('../../assets/snack.png')
-                    }
-                    imageStyle={styles.projectImageStyle}
-                    title={project.description}
-                    platform={project.platform}
-                    subtitle={project.url}
-                  />
-                  {projects.length > 1 && i !== projects.length - 1 ? (
-                    <Divider style={{ height: 1 }} />
-                  ) : null}
-                </React.Fragment>
-              ))}
-              {FeatureFlags.ENABLE_PROJECT_TOOLS && FeatureFlags.ENABLE_QR_CODE_BUTTON ? (
-                <DevelopmentServersOpenQR />
-              ) : null}
-              {FeatureFlags.ENABLE_PROJECT_TOOLS && FeatureFlags.ENABLE_CLIPBOARD_BUTTON ? (
-                <DevelopmentServersOpenURL />
-              ) : null}
-            </View>
-          ) : (
-            <DevelopmentServersPlaceholder isAuthenticated={this.props.isAuthenticated} />
-          )}
-          {this.props.recentHistory.count() ? (
-            <>
-              <Spacer.Vertical size="medium" />
-              <RecentlyOpenedHeader onClearPress={this._handlePressClearHistory} />
-              <RecentlyOpenedSection recentHistory={this.props.recentHistory} />
-            </>
-          ) : null}
+        <CappedWidthContainerView>
+          <ScrollView
+            refreshControl={
+              <RefreshControl refreshing={isRefreshing} onRefresh={this._handleRefreshAsync} />
+            }
+            bounces
+            key={Platform.OS === 'ios' ? this.props.allHistory.count() : 'scroll-view'}
+            style={styles.container}
+            contentContainerStyle={[styles.contentContainer]}>
+            <UserReviewSection apps={data?.apps} snacks={data?.snacks} />
+            <DevelopmentServersHeader onHelpPress={this._handlePressHelpProjects} />
+            {projects?.length ? (
+              <View bg="default" rounded="large" border="default" overflow="hidden">
+                {projects.map((project, i) => (
+                  <React.Fragment key={`${project.description}${project.url}`}>
+                    <DevelopmentServerListItem
+                      url={project.url}
+                      image={
+                        project.source === 'desktop'
+                          ? require('../../assets/cli.png')
+                          : require('../../assets/snack.png')
+                      }
+                      imageStyle={styles.projectImageStyle}
+                      title={project.description}
+                      platform={project.platform}
+                      subtitle={project.url}
+                    />
+                    {projects.length > 1 && i !== projects.length - 1 ? (
+                      <Divider style={{ height: 1 }} />
+                    ) : null}
+                  </React.Fragment>
+                ))}
+                {FeatureFlags.ENABLE_PROJECT_TOOLS && FeatureFlags.ENABLE_QR_CODE_BUTTON ? (
+                  <DevelopmentServersOpenQR />
+                ) : null}
+                {FeatureFlags.ENABLE_PROJECT_TOOLS && FeatureFlags.ENABLE_CLIPBOARD_BUTTON ? (
+                  <DevelopmentServersOpenURL />
+                ) : null}
+              </View>
+            ) : (
+              <DevelopmentServersPlaceholder isAuthenticated={this.props.isAuthenticated} />
+            )}
+            {this.props.recentHistory.count() ? (
+              <>
+                <Spacer.Vertical size="medium" />
+                <RecentlyOpenedHeader onClearPress={this._handlePressClearHistory} />
+                <RecentlyOpenedSection recentHistory={this.props.recentHistory} />
+              </>
+            ) : null}
 
-          {data?.apps.length && this.props.accountName ? (
-            <>
-              <Spacer.Vertical size="medium" />
-              <SectionHeader header="Projects" />
-              <ProjectsSection
-                accountName={this.props.accountName}
-                apps={data.apps.slice(0, 3)}
-                showMore={data.apps.length > 3}
-              />
-            </>
-          ) : null}
+            {data?.apps.length && this.props.accountName ? (
+              <>
+                <Spacer.Vertical size="medium" />
+                <SectionHeader header="Projects" />
+                <ProjectsSection
+                  accountName={this.props.accountName}
+                  apps={data.apps.slice(0, 3)}
+                  showMore={data.apps.length > 3}
+                />
+              </>
+            ) : null}
 
-          {data?.snacks.length && this.props.accountName ? (
-            <>
-              <Spacer.Vertical size="medium" />
-              <SectionHeader header="Snacks" />
-              <SnacksSection
-                accountName={this.props.accountName}
-                snacks={data.snacks.slice(0, 3)}
-                showMore={data.snacks.length > 3}
-              />
-            </>
-          ) : null}
-        </ScrollView>
+            {data?.snacks.length && this.props.accountName ? (
+              <>
+                <Spacer.Vertical size="medium" />
+                <SectionHeader header="Snacks" />
+                <SnacksSection
+                  accountName={this.props.accountName}
+                  snacks={data.snacks.slice(0, 3)}
+                  showMore={data.snacks.length > 3}
+                />
+              </>
+            ) : null}
+          </ScrollView>
+        </CappedWidthContainerView>
         <ThemedStatusBar />
       </View>
     );

--- a/apps/expo-go/src/screens/ProjectScreen/ProjectHeader.tsx
+++ b/apps/expo-go/src/screens/ProjectScreen/ProjectHeader.tsx
@@ -1,19 +1,21 @@
-import { Row, useExpoTheme, View, Text } from 'expo-dev-client-components';
+import { Row, useExpoTheme, View, Text, padding } from 'expo-dev-client-components';
 import * as React from 'react';
 
+import { CappedWidthContainerView } from '../../components/Views';
 import { ProjectsQuery } from '../../graphql/types';
 
 type ProjectPageApp = ProjectsQuery['app']['byId'];
 
 export function ProjectHeader(props: { app: ProjectPageApp }) {
   const theme = useExpoTheme();
+  console.log(padding.padding.medium);
   return (
-    <View
-      bg="default"
-      padding="medium"
-      style={{
+    <CappedWidthContainerView
+      wrapperStyle={{
+        backgroundColor: theme.background.default,
         borderColor: theme.border.default,
         borderBottomWidth: 1,
+        ...padding.padding.medium,
       }}>
       <Row align="center">
         <View>
@@ -28,6 +30,6 @@ export function ProjectHeader(props: { app: ProjectPageApp }) {
           </Text>
         </View>
       </Row>
-    </View>
+    </CappedWidthContainerView>
   );
 }

--- a/apps/expo-go/src/screens/ProjectScreen/ProjectView.tsx
+++ b/apps/expo-go/src/screens/ProjectScreen/ProjectView.tsx
@@ -1,7 +1,7 @@
 import { spacing } from '@expo/styleguide-native';
 import { StackScreenProps } from '@react-navigation/stack';
 import dedent from 'dedent';
-import { Spacer, Text, useExpoTheme, View } from 'expo-dev-client-components';
+import { padding, Spacer, Text, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
 import { ActivityIndicator } from 'react-native';
 import { SectionHeader } from 'src/components/SectionHeader';
@@ -10,6 +10,7 @@ import { EASUpdateLaunchSection } from './EASUpdateLaunchSection';
 import { ProjectHeader } from './ProjectHeader';
 import ScrollView from '../../components/NavigationScrollView';
 import ShareProjectButton from '../../components/ShareProjectButton';
+import { CappedWidthContainerView } from '../../components/Views';
 import { ProjectsQuery } from '../../graphql/types';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
 
@@ -50,11 +51,11 @@ export function ProjectView({ loading, error, data, navigation }: Props) {
     contents = (
       <ScrollView style={{ flex: 1 }}>
         <ProjectHeader app={app} />
-        <View padding="medium">
+        <CappedWidthContainerView style={padding.padding.medium}>
           <SectionHeader header="Branches" style={{ paddingTop: 0 }} />
           <EASUpdateLaunchSection app={app} />
           <Spacer.Vertical size="xl" />
-        </View>
+        </CappedWidthContainerView>
       </ScrollView>
     );
   }

--- a/apps/expo-go/src/screens/ProjectsListScreen/ProjectList.tsx
+++ b/apps/expo-go/src/screens/ProjectsListScreen/ProjectList.tsx
@@ -1,12 +1,13 @@
 import { spacing } from '@expo/styleguide-native';
 import dedent from 'dedent';
-import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
+import { Divider, useExpoTheme } from 'expo-dev-client-components';
 import * as React from 'react';
 import { FlatList, ActivityIndicator, ListRenderItem, View as RNView } from 'react-native';
 
 import PrimaryButton from '../../components/PrimaryButton';
 import { ProjectsListItem } from '../../components/ProjectsListItem';
 import { StyledText } from '../../components/Text';
+import { CappedWidthContainerView } from '../../components/Views';
 import SharedStyles from '../../constants/SharedStyles';
 import { CommonAppDataFragment } from '../../graphql/types';
 
@@ -45,15 +46,15 @@ export function ProjectList(props: Props) {
 
   if (!isReady) {
     return (
-      <RNView
+      <CappedWidthContainerView
+        wrapperStyle={{ backgroundColor: theme.background.screen }}
         style={{
           flex: 1,
           padding: 30,
           alignItems: 'center',
-          backgroundColor: theme.background.screen,
         }}>
         <ActivityIndicator color={theme.highlight.accent} />
-      </RNView>
+      </CappedWidthContainerView>
     );
   }
 
@@ -144,9 +145,8 @@ function ProjectListView({ data, loadMoreAsync }: Props) {
   );
 
   return (
-    <View
-      flex="1"
-      style={{
+    <CappedWidthContainerView
+      wrapperStyle={{
         backgroundColor: theme.background.screen,
       }}>
       <FlatList
@@ -158,6 +158,6 @@ function ProjectListView({ data, loadMoreAsync }: Props) {
         onEndReachedThreshold={0.2}
         onEndReached={handleLoadMoreAsync}
       />
-    </View>
+    </CappedWidthContainerView>
   );
 }

--- a/apps/expo-go/src/screens/SettingsScreen/index.tsx
+++ b/apps/expo-go/src/screens/SettingsScreen/index.tsx
@@ -1,4 +1,4 @@
-import { Spacer, View } from 'expo-dev-client-components';
+import { padding, Spacer } from 'expo-dev-client-components';
 import * as Tracking from 'expo-tracking-transparency';
 import * as React from 'react';
 import { Platform, StyleSheet } from 'react-native';
@@ -9,6 +9,7 @@ import { DeleteAccountSection } from './DeleteAccountSection';
 import { DevMenuGestureSection } from './DevMenuGestureSection';
 import { ThemeSection } from './ThemeSection';
 import { TrackingSection } from './TrackingSection';
+import { CappedWidthContainerView } from '../../components/Views';
 import { useHome_CurrentUserActorQuery } from '../../graphql/types';
 
 export function SettingsScreen() {
@@ -19,7 +20,7 @@ export function SettingsScreen() {
       style={styles.container}
       keyboardShouldPersistTaps="always"
       keyboardDismissMode="on-drag">
-      <View flex="1" padding="medium">
+      <CappedWidthContainerView style={padding.padding.medium}>
         <ThemeSection />
         <Spacer.Vertical size="medium" />
         {Platform.OS === 'ios' && <DevMenuGestureSection />}
@@ -31,7 +32,7 @@ export function SettingsScreen() {
             <DeleteAccountSection />
           </>
         ) : null}
-      </View>
+      </CappedWidthContainerView>
     </KeyboardAwareScrollView>
   );
 }

--- a/apps/expo-go/src/screens/SnacksListScreen/SnackList.tsx
+++ b/apps/expo-go/src/screens/SnacksListScreen/SnackList.tsx
@@ -1,9 +1,10 @@
 import { spacing } from '@expo/styleguide-native';
-import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
+import { Divider, useExpoTheme } from 'expo-dev-client-components';
 import * as React from 'react';
 import { FlatList, ActivityIndicator, View as RNView } from 'react-native';
 
 import { SnacksListItem } from '../../components/SnacksListItem';
+import { CappedWidthContainerView } from '../../components/Views';
 import { CommonSnackDataFragment } from '../../graphql/types';
 
 type Props = {
@@ -26,7 +27,10 @@ export function SnackListView(props: Props) {
 
   if (!isReady) {
     return (
-      <RNView
+      <CappedWidthContainerView
+        wrapperStyle={{
+          backgroundColor: theme.background.screen,
+        }}
         style={{
           flex: 1,
           padding: 30,
@@ -34,7 +38,7 @@ export function SnackListView(props: Props) {
           backgroundColor: theme.background.screen,
         }}>
         <ActivityIndicator />
-      </RNView>
+      </CappedWidthContainerView>
     );
   }
 
@@ -84,9 +88,8 @@ function SnackList({ data, loadMoreAsync }: Props) {
   );
 
   return (
-    <View
-      flex="1"
-      style={{
+    <CappedWidthContainerView
+      wrapperStyle={{
         backgroundColor: theme.background.screen,
       }}>
       <FlatList
@@ -98,6 +101,6 @@ function SnackList({ data, loadMoreAsync }: Props) {
         onEndReachedThreshold={0.2}
         onEndReached={handleLoadMoreAsync}
       />
-    </View>
+    </CappedWidthContainerView>
   );
 }

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -144,7 +144,6 @@
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
             android:exported="true"
             android:launchMode="singleTask"
-            android:screenOrientation="portrait"
             android:theme="@style/Theme.Exponent.HomeActivity">
             <!-- START HOME INTENT FILTERS -->
             <intent-filter>
@@ -205,7 +204,6 @@
 
         <activity
             android:name=".experience.ErrorActivity"
-            android:screenOrientation="portrait"
             android:theme="@style/Theme.Exponent.Dark" />
 
         <service


### PR DESCRIPTION
# Why

Meta Quest allows for free window resize. Currently the activity is locked in portrait orientation, which leads to black bars on the side of the window. When the orientation lock is disabled the app can look kind of awkward with everything stretched out so wide.

# How

Allowed landscape orientation on Android tablets (on iPads it's already enabled). When in landscape, most of the elements of the app are now limited to be laid out at most as wide as the device is tall (actually it's max(windowHeight, 600). This makes the UI look significantly better, especially at more extreme aspect ratios. (See comparisons below)

# Test Plan

Tested in ExpoGo on Android phone and tablet, iOS phone and tabled and the Meta Quest

| No Padding  | Padding |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/fc6b86c9-0f83-4d9f-8bce-749b965346c9"/> |  <video src="https://github.com/user-attachments/assets/87d2cfad-2b6a-49e3-9401-052168696a53"/> |
|<video src="https://github.com/user-attachments/assets/4985d58d-ced1-467f-a815-5d73159ea7f8"/>|<video src="https://github.com/user-attachments/assets/6d043182-1ef4-4c91-bdcc-d29941d01700"/>|
|<video src="https://github.com/user-attachments/assets/a396004f-0093-4b56-b2ac-f0a9c098e027"/>|<video src="https://github.com/user-attachments/assets/3672630e-4ca7-4d9a-9e4d-f416e16289b1"/>|

