### PR TITLE
[go] Meta Quest support - [1/n] - Add product flavors

### DIFF
--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -41,7 +41,7 @@
         "EAS_BUILD_PROFILE": "versioned-client"
       },
       "android": {
-        "gradleCommand": ":app:assembleDebug",
+        "gradleCommand": ":app:assembleMobileDebug",
         "withoutCredentials": true
       },
       "ios": {
@@ -62,14 +62,14 @@
         "EAS_BUILD_PROFILE": "unversioned-client"
       },
       "android": {
-        "gradleCommand": ":app:assembleDebug",
+        "gradleCommand": ":app:assembleMobileDebug",
         "withoutCredentials": true
       },
       "ios": {
         "scheme": "Expo Go",
         "simulator": true,
         "buildConfiguration": "Release"
-      }
+      },
     },
     "release-client": {
       "extends": "versioned-client",
@@ -82,7 +82,7 @@
           "disabled": true
         },
         "withoutCredentials": false,
-        "gradleCommand": ":app:bundleRelease"
+        "gradleCommand": ":app:bundleMobileRelease"
       },
       "ios": {
         "autoIncrement": "buildNumber",
@@ -104,7 +104,7 @@
           "disabled": true
         },
         "withoutCredentials": false,
-        "gradleCommand": ":app:assembleRelease"
+        "gradleCommand": ":app:assembleMobileRelease"
       },
       "ios": {
         "resourceClass": "large",
@@ -113,6 +113,39 @@
           "disabled": true
         },
         "simulator": true
+      }
+    },
+    "versioned-quest-client": {
+      "extends": "versioned-client",
+      "android": {
+        "gradleCommand": ":app:assembleQuestDebug"
+      }
+    },
+    "versioned-quest-client-add-sdk": {
+      "extends": "versioned-quest-client",
+      "env": {
+        "EAS_BUILD_PROFILE": "versioned-client-add-sdk"
+      }
+    },
+    "unversioned-quest-client": {
+      "extends": "unversioned-client",
+      "android": {
+        "gradleCommand": ":app:assembleQuestDebug"
+      }
+    },
+    "release-quest-client": {
+      "extends": "release-client",
+      "env": {
+        "EAS_BUILD_PROFILE": "release-client"
+      },
+      "android": {
+        "gradleCommand": ":app:bundleQuestRelease"
+      }
+    },
+    "publish-quest-client": {
+      "extends": "publish-client",
+      "android": {
+        "gradleCommand": ":app:assembleQuestRelease"
       }
     }
   },

--- a/apps/expo-go/android/app/build.gradle
+++ b/apps/expo-go/android/app/build.gradle
@@ -35,7 +35,7 @@ react {
   codegenDir = new File(projectRoot, "../../react-native-lab/react-native/packages/react-native-codegen")
 
   // Expo Go does not require JS bundling from build, we set all variants as debuggableVariants
-  debuggableVariants = ["debug", "release"]
+  debuggableVariants = ["mobileDebug", "mobileRelease", "questDebug", "questRelease"]
 
   cliFile = new File(["node", "--print", "require.resolve('@expo/cli')"].execute(null, rootDir).text.trim())
   bundleCommand = "export:embed"
@@ -62,6 +62,12 @@ android {
         'appAuthRedirectScheme': 'host.exp.exponent',
         'appLabel': '@string/versioned_app_name'
     ]
+  }
+
+  flavorDimensions += "device"
+  productFlavors {
+    quest { dimension "device" }
+    mobile { dimension "device" }
   }
 
   signingConfigs {

--- a/template-files/android-paths.json
+++ b/template-files/android-paths.json
@@ -1,6 +1,8 @@
 {
   "paths": {
     "AndroidManifest.xml": "apps/expo-go/android/app/src/main/AndroidManifest.xml",
+    "mobile/AndroidManifest.xml": "apps/expo-go/android/app/src/mobile/AndroidManifest.xml",
+    "quest/AndroidManifest.xml": "apps/expo-go/android/app/src/quest/AndroidManifest.xml",
     "google-services.json": "apps/expo-go/android/app/google-services.json"
   }
 }

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -12,13 +12,11 @@
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <!-- ADD PERMISSIONS HERE -->
     <!-- BEGIN OPTIONAL PERMISSIONS -->
     <uses-permission android:name="android.permission.READ_INTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
@@ -30,16 +28,10 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.READ_CONTACTS" />
-    <uses-permission android:name="android.permission.READ_CALENDAR" />
-    <uses-permission android:name="android.permission.WRITE_CALENDAR" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
-    <!-- END OPTIONAL PERMISSIONS -->
 
-    <uses-permission android:name="android.permission.WRITE_CONTACTS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
     <uses-feature
@@ -144,7 +136,6 @@
             android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
             android:exported="true"
             android:launchMode="singleTask"
-            android:screenOrientation="portrait"
             android:theme="@style/Theme.Exponent.HomeActivity">
             <!-- START HOME INTENT FILTERS -->
             <intent-filter>
@@ -205,7 +196,6 @@
 
         <activity
             android:name=".experience.ErrorActivity"
-            android:screenOrientation="portrait"
             android:theme="@style/Theme.Exponent.Dark" />
 
         <service
@@ -268,23 +258,5 @@
             android:name="com.canhub.cropper.CropImageActivity"
             android:theme="@style/Base.Theme.AppCompat" />
 
-        <!-- ADD GOOGLE MAPS CONFIG HERE -->
-        <!-- BEGIN GOOGLE MAPS CONFIG -->
-        <meta-data
-            android:name="com.google.android.geo.API_KEY"
-            android:value="${GOOGLE_MAPS_API_KEY}"/>
-        <!-- END GOOGLE MAPS CONFIG -->
-
-        <!-- ADD GOOGLE MOBILE ADS CONFIG HERE -->
-        <!-- BEGIN GOOGLE MOBILE ADS CONFIG -->
-        <meta-data
-            android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="ca-app-pub-3940256099942544~3347511713" />
-        <meta-data
-            android:name="com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT"
-            android:value="true" />
-        <!-- END GOOGLE MOBILE ADS CONFIG -->
-
     </application>
 </manifest>
-

--- a/template-files/android/mobile/AndroidManifest.xml
+++ b/template-files/android/mobile/AndroidManifest.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- These are required permissions to make the app run -->
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+
+    <!-- ADD PERMISSIONS HERE -->
+    <!-- BEGIN OPTIONAL PERMISSIONS -->
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+
+    <!-- These require runtime permissions on M -->
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
+    <uses-permission android:name="android.permission.WRITE_CALENDAR" />
+    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
+    <uses-permission android:name="android.permission.WRITE_CONTACTS" />
+
+    <!-- END OPTIONAL PERMISSIONS -->
+
+    <application>
+        <!-- ADD GOOGLE MAPS CONFIG HERE -->
+        <!-- BEGIN GOOGLE MAPS CONFIG -->
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="${GOOGLE_MAPS_API_KEY}"/>
+        <!-- END GOOGLE MAPS CONFIG -->
+
+        <!-- ADD GOOGLE MOBILE ADS CONFIG HERE -->
+        <!-- BEGIN GOOGLE MOBILE ADS CONFIG -->
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713" />
+        <meta-data
+            android:name="com.google.android.gms.ads.DELAY_APP_MEASUREMENT_INIT"
+            android:value="true" />
+        <!-- END GOOGLE MOBILE ADS CONFIG -->
+    </application>
+</manifest>

--- a/template-files/android/quest/AndroidManifest.xml
+++ b/template-files/android/quest/AndroidManifest.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
+          android:installLocation="auto">
+
+    <meta-data android:name="com.oculus.supportedDevices" android:value="quest2|questpro|quest3|quest3s" />
+
+    <!-- ADD PERMISSIONS HERE -->
+    <!-- BEGIN OPTIONAL PERMISSIONS -->
+    <uses-feature android:name="android.hardware.vr.headtracking" android:required="true" android:version="1"/>
+    <uses-feature android:name="oculus.software.overlay_keyboard"  android:required="true"/>
+    <uses-feature android:name="com.oculus.feature.VIRTUAL_KEYBOARD" android:required="true" />
+    <uses-permission android:name="horizonos.permission.HEADSET_CAMERA"/>
+
+    <!-- Override any prohibited permissions added by the libraries -->
+    <uses-permission android:name="android.permission.ACCEPT_HANDOVER" tools:node="remove" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" tools:node="remove" />
+    <uses-permission android:name="android.permission.ACCESS_CHECKIN_PROPERTIES" tools:node="remove" />
+    <uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS" tools:node="remove" />
+    <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" tools:node="remove" />
+    <uses-permission android:name="android.permission.ACCOUNT_MANAGER" tools:node="remove" />
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" tools:node="remove" />
+    <uses-permission android:name="com.android.voicemail.permission.ADD_VOICEMAIL" tools:node="remove" />
+    <uses-permission android:name="android.permission.ANSWER_PHONE_CALLS" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_ACCESSIBILITY_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_APPWIDGET" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_AUTOFILL_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_CALL_REDIRECTION_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_CARRIER_MESSAGING_CLIENT_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_CARRIER_MESSAGING_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_CARRIER_SERVICES" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_CHOOSER_TARGET_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_CONDITION_PROVIDER_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_CONTROLS" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_DEVICE_ADMIN" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_DREAM_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_INCALL_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_INPUT_METHOD" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_MIDI_DEVICE_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_NFC_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_PRINT_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_QUICK_ACCESS_WALLET_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_QUICK_SETTINGS_TILE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_REMOTEVIEWS" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_SCREENING_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_TELECOM_CONNECTION_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_TEXT_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_TV_INPUT" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_VISUAL_VOICEMAIL_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_VOICE_INTERACTION" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_VR_LISTENER_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.BIND_WALLPAPER" tools:node="remove" />
+    <uses-permission android:name="android.permission.BLUETOOTH_PRIVILEGED" tools:node="remove" />
+    <uses-permission android:name="android.permission.BODY_SENSORS" tools:node="remove" />
+    <uses-permission android:name="android.permission.BROADCAST_PACKAGE_REMOVED" tools:node="remove" />
+    <uses-permission android:name="android.permission.BROADCAST_SMS" tools:node="remove" />
+    <uses-permission android:name="android.permission.BROADCAST_WAP_PUSH" tools:node="remove" />
+    <uses-permission android:name="android.permission.CALL_PHONE" tools:node="remove" />
+    <uses-permission android:name="android.permission.CALL_PRIVILEGED" tools:node="remove" />
+    <uses-permission android:name="android.permission.CAPTURE_AUDIO_OUTPUT" tools:node="remove" />
+    <uses-permission android:name="android.permission.CHANGE_COMPONENT_ENABLED_STATE" tools:node="remove" />
+    <uses-permission android:name="android.permission.CHANGE_CONFIGURATION" tools:node="remove" />
+    <uses-permission android:name="android.permission.CLEAR_APP_CACHE" tools:node="remove" />
+    <uses-permission android:name="android.permission.CONTROL_LOCATION_UPDATES" tools:node="remove" />
+    <uses-permission android:name="android.permission.DELETE_CACHE_FILES" tools:node="remove" />
+    <uses-permission android:name="android.permission.DELETE_PACKAGES" tools:node="remove" />
+    <uses-permission android:name="android.permission.DIAGNOSTIC" tools:node="remove" />
+    <uses-permission android:name="android.permission.DUMP" tools:node="remove" />
+    <uses-permission android:name="android.permission.FACTORY_TEST" tools:node="remove" />
+    <uses-permission android:name="android.permission.GET_ACCOUNTS" tools:node="remove" />
+    <uses-permission android:name="android.permission.GET_ACCOUNTS_PRIVILEGED" tools:node="remove" />
+    <uses-permission android:name="android.permission.INSTALL_LOCATION_PROVIDER" tools:node="remove" />
+    <uses-permission android:name="android.permission.INSTALL_PACKAGES" tools:node="remove" />
+    <uses-permission android:name="android.permission.INSTANT_APP_FOREGROUND_SERVICE" tools:node="remove" />
+    <uses-permission android:name="android.permission.LOADER_USAGE_STATS" tools:node="remove" />
+    <uses-permission android:name="android.permission.LOCATION_HARDWARE" tools:node="remove" />
+    <uses-permission android:name="android.permission.MANAGE_DOCUMENTS" tools:node="remove" />
+    <uses-permission android:name="android.permission.MANAGE_MEDIA" tools:node="remove" />
+    <uses-permission android:name="android.permission.MANAGE_ONGOING_CALLS" tools:node="remove" />
+    <uses-permission android:name="android.permission.MASTER_CLEAR" tools:node="remove" />
+    <uses-permission android:name="android.permission.MEDIA_CONTENT_CONTROL" tools:node="remove" />
+    <uses-permission android:name="android.permission.MODIFY_PHONE_STATE" tools:node="remove" />
+    <uses-permission android:name="android.permission.MOUNT_FORMAT_FILESYSTEMS" tools:node="remove" />
+    <uses-permission android:name="android.permission.MOUNT_UNMOUNT_FILESYSTEMS" tools:node="remove" />
+    <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS" tools:node="remove" />
+    <uses-permission android:name="android.permission.PROCESS_OUTGOING_CALLS" tools:node="remove" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_CALENDAR" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_CALL_LOG" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_CONTACTS" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_INPUT_STATE" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_LOGS" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_PRECISE_PHONE_STATE" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_SMS" tools:node="remove" />
+    <uses-permission android:name="com.android.voicemail.permission.READ_VOICEMAIL" tools:node="remove" />
+    <uses-permission android:name="android.permission.REBOOT" tools:node="remove" />
+    <uses-permission android:name="android.permission.RECEIVE_MMS" tools:node="remove" />
+    <uses-permission android:name="android.permission.RECEIVE_SMS" tools:node="remove" />
+    <uses-permission android:name="android.permission.RECEIVE_WAP_PUSH" tools:node="remove" />
+    <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" tools:node="remove" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove" />
+    <uses-permission android:name="android.permission.SEND_RESPOND_VIA_MESSAGE" tools:node="remove" />
+    <uses-permission android:name="android.permission.SEND_SMS" tools:node="remove" />
+    <uses-permission android:name="android.permission.SET_ALWAYS_FINISH" tools:node="remove" />
+    <uses-permission android:name="android.permission.SET_ANIMATION_SCALE" tools:node="remove" />
+    <uses-permission android:name="android.permission.SET_DEBUG_APP" tools:node="remove" />
+    <uses-permission android:name="android.permission.SET_PROCESS_LIMIT" tools:node="remove" />
+    <uses-permission android:name="android.permission.SET_TIME" tools:node="remove" />
+    <uses-permission android:name="android.permission.SET_TIME_ZONE" tools:node="remove" />
+    <uses-permission android:name="android.permission.SIGNAL_PERSISTENT_PROCESSES" tools:node="remove" />
+    <uses-permission android:name="android.permission.SMS_FINANCIAL_TRANSACTIONS" tools:node="remove" />
+    <uses-permission android:name="android.permission.START_FOREGROUND_SERVICES_FROM_BACKGROUND" tools:node="remove" />
+    <uses-permission android:name="android.permission.START_VIEW_PERMISSION_USAGE" tools:node="remove" />
+    <uses-permission android:name="android.permission.STATUS_BAR" tools:node="remove" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" tools:node="remove" />
+    <uses-permission android:name="com.android.launcher.permission.UNINSTALL_SHORTCUT" tools:node="remove" />
+    <uses-permission android:name="android.permission.UPDATE_DEVICE_STATS" tools:node="remove" />
+    <uses-permission android:name="android.permission.USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER" tools:node="remove" />
+    <uses-permission android:name="android.permission.USE_SIP" tools:node="remove" />
+    <uses-permission android:name="android.permission.UWB_RANGING" tools:node="remove" />
+    <uses-permission android:name="android.permission.WRITE_APN_SETTINGS" tools:node="remove" />
+    <uses-permission android:name="android.permission.WRITE_CALENDAR" tools:node="remove" />
+    <uses-permission android:name="android.permission.WRITE_CALL_LOG" tools:node="remove" />
+    <uses-permission android:name="android.permission.WRITE_CONTACTS" tools:node="remove" />
+    <uses-permission android:name="android.permission.WRITE_GSERVICES" tools:node="remove" />
+    <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" tools:node="remove" />
+    <uses-permission android:name="android.permission.WRITE_SETTINGS" tools:node="remove" />
+    <uses-permission android:name="com.android.voicemail.permission.WRITE_VOICEMAIL" tools:node="remove" />
+    <uses-permission android:name="android.permission.USB_CAMERA" tools:node="remove" />
+    <application>
+        <!-- android:excludeFromRecents is required for submission to the Quest store -->
+        <activity
+                android:name=".LauncherActivity"
+                android:excludeFromRecents="true">
+            <layout android:defaultHeight="640dp" android:defaultWidth="1024dp" />
+        </activity>
+
+        <activity
+                android:name=".experience.ExperienceActivity"
+                android:excludeFromRecents="true">
+            <layout android:defaultHeight="640dp" android:defaultWidth="1024dp" />
+        </activity>
+
+        <activity
+                android:name=".experience.HomeActivity"
+                android:excludeFromRecents="true"
+                android:windowSoftInputMode="adjustResize">
+            <layout android:defaultHeight="640dp" android:defaultWidth="1024dp" />
+        </activity>
+
+        <activity
+                android:name=".experience.TvActivity"
+                android:excludeFromRecents="true"
+                android:windowSoftInputMode="adjustResize">
+        </activity>
+
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:excludeFromRecents="true"/>
+
+        <activity
+                android:name="net.openid.appauth.RedirectUriReceiverActivity"
+                android:excludeFromRecents="true">
+        </activity>
+
+        <activity
+                android:name=".experience.ErrorActivity"
+                android:excludeFromRecents="true">
+            <layout android:defaultHeight="640dp" android:defaultWidth="1024dp" />
+        </activity>
+    </application>
+</manifest>

--- a/tools/src/dynamic-macros/generateDynamicMacros.ts
+++ b/tools/src/dynamic-macros/generateDynamicMacros.ts
@@ -122,7 +122,7 @@ async function copyTemplateFileAsync(
     );
   }
 
-  if (configuration === 'debug') {
+  if (configuration === 'debug' || configuration === 'mobileDebug') {
     // We need these permissions when testing but don't want them
     // ending up in our release.
     currentSourceFile = currentSourceFile.replace(
@@ -132,6 +132,8 @@ async function copyTemplateFileAsync(
   }
 
   if (currentSourceFile !== currentDestFile) {
+    const destDir = path.dirname(dest);
+    await fs.mkdir(destDir, { recursive: true });
     await fs.writeFile(dest, currentSourceFile, 'utf8');
   }
 }


### PR DESCRIPTION
# Why

This is the first part of PRs that add support for the Meta Quest to Expo Go. We need slightly different android manifests for mobile devices and the quest. The best way of getting that is adding product flavors.

# How

Added mobile and quest flavors. 

Updated `eas.json` of expo go to run gradle commands with flavors

The common manifest in `template-files/android/AndroidManifest.xml` now contains only properties shared across the platforms. The manifest in `template-files/android/mobile/AndroidManifest.xml` contains properties used on mobile but not used on the quest. The same for `template-files/android/quest/AndroidManifest.xml`

Modified the generate-dynamic-macros script to create the desitination directories if they don't exist (`/quest` and `/mobile` won't exist). Also updated the `WRITE_CONTACTS` permission injection to also check for the `mobileDebug` variant. 

# Test Plan

Tested on a local build of Expo-Go with the mobile and quest variants.
