### PR TITLE
[core] Meta Quest support - [2/n] Add VR utilities

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [Android] Support object arrays in type converters. ([#37276](https://github.com/expo/expo/pull/37276) by [@jakex7](https://github.com/jakex7))
 - [Android] Add `testID` support to `ExpoComposeView`. ([#38005](https://github.com/expo/expo/pull/38005) by [@mateoguzmana](https://github.com/mateoguzmana))
 - [iOS] Return proper dynamic type for AnyEither. ([#38072](https://github.com/expo/expo/pull/38072) by [@jakex7](https://github.com/jakex7))
+- [Android] Add VRUtilities for VR-related values and utils ([#37744](https://github.com/expo/expo/pull/37744) by [@behenate](https://github.com/behenate))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/utilities/VRUtilities.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/utilities/VRUtilities.kt
@@ -1,0 +1,13 @@
+package expo.modules.core.utilities
+
+import android.os.Build
+
+class VRUtilities {
+  companion object {
+    const val HZOS_CAMERA_PERMISSION = "horizonos.permission.HEADSET_CAMERA"
+
+    fun isQuest(): Boolean {
+      return (Build.MANUFACTURER.equals("Oculus", ignoreCase = true) || Build.MANUFACTURER.equals("Meta", ignoreCase = true)) && Build.MODEL.contains("Quest")
+    }
+  }
+}


### PR DESCRIPTION
# Why

We need a place to store horizon os permissions that we are requesting as well as a common way to check if the current device is a quest headset.

# How

Added VRUtilities.kt file that stores the camera permission constant as well as a simple function that allows us to check if the current device is a quest at runtime.

# Test Plan

Tested in Expo Go when adding support for the Quest
