### PR TITLE
[build-properties] Add Android buildFromSource option

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `android.buildFromSource` option ([#37745](https://github.com/expo/expo/pull/37745) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-build-properties/build/android.d.ts
+++ b/packages/expo-build-properties/build/android.d.ts
@@ -21,3 +21,8 @@ export declare function updateAndroidProguardRules(contents: string, newProguard
 export declare const withAndroidCleartextTraffic: ConfigPlugin<PluginConfigType>;
 export declare const withAndroidQueries: ConfigPlugin<PluginConfigType>;
 export declare const withAndroidDayNightTheme: ConfigPlugin<PluginConfigType>;
+export declare const withAndroidSettingsGradle: ConfigPlugin<PluginConfigType>;
+export declare function updateAndroidSettingsGradle({ contents, buildFromSource, }: {
+    contents: string;
+    buildFromSource?: boolean;
+}): string;

--- a/packages/expo-build-properties/build/android.js
+++ b/packages/expo-build-properties/build/android.js
@@ -3,8 +3,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.withAndroidDayNightTheme = exports.withAndroidQueries = exports.withAndroidCleartextTraffic = exports.withAndroidPurgeProguardRulesOnce = exports.withAndroidProguardRules = exports.withAndroidBuildProperties = void 0;
+exports.withAndroidSettingsGradle = exports.withAndroidDayNightTheme = exports.withAndroidQueries = exports.withAndroidCleartextTraffic = exports.withAndroidPurgeProguardRulesOnce = exports.withAndroidProguardRules = exports.withAndroidBuildProperties = void 0;
 exports.updateAndroidProguardRules = updateAndroidProguardRules;
+exports.updateAndroidSettingsGradle = updateAndroidSettingsGradle;
 const config_plugins_1 = require("expo/config-plugins");
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
@@ -247,3 +248,32 @@ const withAndroidDayNightTheme = (config, props) => {
     });
 };
 exports.withAndroidDayNightTheme = withAndroidDayNightTheme;
+const withAndroidSettingsGradle = (config, props) => {
+    return (0, config_plugins_1.withSettingsGradle)(config, (config) => {
+        config.modResults.contents = updateAndroidSettingsGradle({
+            contents: config.modResults.contents,
+            buildFromSource: props.android?.buildFromSource,
+        });
+        return config;
+    });
+};
+exports.withAndroidSettingsGradle = withAndroidSettingsGradle;
+function updateAndroidSettingsGradle({ contents, buildFromSource, }) {
+    let newContents = contents;
+    if (buildFromSource === true) {
+        const addCodeBlock = [
+            '', // new line
+            'includeBuild(expoAutolinking.reactNative) {',
+            '  dependencySubstitution {',
+            '    substitute(module("com.facebook.react:react-android")).using(project(":packages:react-native:ReactAndroid"))',
+            '    substitute(module("com.facebook.react:react-native")).using(project(":packages:react-native:ReactAndroid"))',
+            '    substitute(module("com.facebook.react:hermes-android")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))',
+            '    substitute(module("com.facebook.react:hermes-engine")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))',
+            '  }',
+            '}',
+            '', // new line
+        ];
+        newContents += addCodeBlock.join('\n');
+    }
+    return newContents;
+}

--- a/packages/expo-build-properties/build/pluginConfig.d.ts
+++ b/packages/expo-build-properties/build/pluginConfig.d.ts
@@ -147,6 +147,12 @@ export interface PluginConfigTypeAndroid {
      * @default false
      */
     enableBundleCompression?: boolean;
+    /**
+     * Enable building React Native from source. Turning this on will significantly increase the build times.
+     *
+     * @default false
+     */
+    buildFromSource?: boolean;
 }
 /**
  * @platform android

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -137,6 +137,7 @@ const schema = {
                     nullable: true,
                 },
                 enableBundleCompression: { type: 'boolean', nullable: true },
+                buildFromSource: { type: 'boolean', nullable: true },
             },
             nullable: true,
         },

--- a/packages/expo-build-properties/build/withBuildProperties.js
+++ b/packages/expo-build-properties/build/withBuildProperties.js
@@ -14,6 +14,7 @@ const withBuildProperties = (config, props) => {
     config = (0, android_1.withAndroidBuildProperties)(config, pluginConfig);
     config = (0, android_1.withAndroidProguardRules)(config, pluginConfig);
     config = (0, android_1.withAndroidCleartextTraffic)(config, pluginConfig);
+    config = (0, android_1.withAndroidSettingsGradle)(config, pluginConfig);
     config = (0, android_1.withAndroidQueries)(config, pluginConfig);
     // Assuming `withBuildProperties` could be called multiple times from different config-plugins,
     // the `withAndroidProguardRules` always appends new rules by default.

--- a/packages/expo-build-properties/src/android.ts
+++ b/packages/expo-build-properties/src/android.ts
@@ -6,6 +6,7 @@ import {
   withAndroidManifest,
   withAndroidStyles,
   withDangerousMod,
+  withSettingsGradle,
 } from 'expo/config-plugins';
 import fs from 'fs';
 import path from 'path';
@@ -301,3 +302,40 @@ export const withAndroidDayNightTheme: ConfigPlugin<PluginConfigType> = (config,
     return config;
   });
 };
+
+export const withAndroidSettingsGradle: ConfigPlugin<PluginConfigType> = (config, props) => {
+  return withSettingsGradle(config, (config) => {
+    config.modResults.contents = updateAndroidSettingsGradle({
+      contents: config.modResults.contents,
+      buildFromSource: props.android?.buildFromSource,
+    });
+    return config;
+  });
+};
+
+export function updateAndroidSettingsGradle({
+  contents,
+  buildFromSource,
+}: {
+  contents: string;
+  buildFromSource?: boolean;
+}) {
+  let newContents = contents;
+  if (buildFromSource === true) {
+    const addCodeBlock = [
+      '', // new line
+      'includeBuild(expoAutolinking.reactNative) {',
+      '  dependencySubstitution {',
+      '    substitute(module("com.facebook.react:react-android")).using(project(":packages:react-native:ReactAndroid"))',
+      '    substitute(module("com.facebook.react:react-native")).using(project(":packages:react-native:ReactAndroid"))',
+      '    substitute(module("com.facebook.react:hermes-android")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))',
+      '    substitute(module("com.facebook.react:hermes-engine")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))',
+      '  }',
+      '}',
+      '', // new line
+    ];
+    newContents += addCodeBlock.join('\n');
+  }
+
+  return newContents;
+}

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -172,6 +172,13 @@ export interface PluginConfigTypeAndroid {
    * @default false
    */
   enableBundleCompression?: boolean;
+
+  /**
+   * Enable building React Native from source. Turning this on will significantly increase the build times.
+   *
+   * @default false
+   */
+  buildFromSource?: boolean;
 }
 
 // @docsMissing
@@ -639,6 +646,7 @@ const schema: JSONSchemaType<PluginConfigType> = {
           nullable: true,
         },
         enableBundleCompression: { type: 'boolean', nullable: true },
+        buildFromSource: { type: 'boolean', nullable: true },
       },
       nullable: true,
     },

--- a/packages/expo-build-properties/src/withBuildProperties.ts
+++ b/packages/expo-build-properties/src/withBuildProperties.ts
@@ -7,6 +7,7 @@ import {
   withAndroidCleartextTraffic,
   withAndroidQueries,
   withAndroidDayNightTheme,
+  withAndroidSettingsGradle,
 } from './android';
 import { withIosBuildProperties, withIosDeploymentTarget } from './ios';
 import { PluginConfigType, validateConfig } from './pluginConfig';
@@ -23,6 +24,7 @@ export const withBuildProperties: ConfigPlugin<PluginConfigType> = (config, prop
 
   config = withAndroidProguardRules(config, pluginConfig);
   config = withAndroidCleartextTraffic(config, pluginConfig);
+  config = withAndroidSettingsGradle(config, pluginConfig);
   config = withAndroidQueries(config, pluginConfig);
   // Assuming `withBuildProperties` could be called multiple times from different config-plugins,
   // the `withAndroidProguardRules` always appends new rules by default.


### PR DESCRIPTION
# Why

Whenever you need to patch/debug code inside react-native on Android it's necessary to build from source and users should be able to easily enable this through a build property 

# How

Add a `withAndroidSettingsGradle` block to the plugin that adds the necessary code to build from source

# Test Plan

Ran prebuild inside `sandbox` with and without the `buildFromSource` option

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
