### PR TITLE
[go] Meta Quest support - [3/n] - Add scoped HZOS camera permissions

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.kt
@@ -6,6 +6,7 @@ import android.content.DialogInterface
 import android.content.pm.PackageManager
 import android.provider.Settings
 import com.facebook.react.modules.core.PermissionListener
+import expo.modules.core.utilities.VRUtilities
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.experience.ReactNativeActivity
 import host.exp.exponent.kernel.ExperienceKey
@@ -123,8 +124,14 @@ class ScopedPermissionsRequester(private val experienceKey: ExperienceKey) {
   }
 
   private fun permissionToResId(permission: String): Int {
+    // Manifest.permission.CAMERA Asks for the front (avatar) camera on Horizon OS
+    val cameraMessageId = if (VRUtilities.isQuest()) {
+      R.string.perm_hzos_use_avatar_camera
+    } else {
+      R.string.perm_camera
+    }
     return when (permission) {
-      Manifest.permission.CAMERA -> R.string.perm_camera
+      Manifest.permission.CAMERA -> cameraMessageId
       Manifest.permission.READ_CONTACTS -> R.string.perm_contacts_read
       Manifest.permission.WRITE_CONTACTS -> R.string.perm_contacts_write
       Manifest.permission.READ_EXTERNAL_STORAGE -> R.string.perm_camera_roll_read
@@ -140,6 +147,7 @@ class ScopedPermissionsRequester(private val experienceKey: ExperienceKey) {
       Manifest.permission.READ_PHONE_STATE -> R.string.perm_read_phone_state
       Manifest.permission.READ_MEDIA_AUDIO -> R.string.perm_read_media_audio
       Manifest.permission.POST_NOTIFICATIONS -> R.string.perm_notifications
+      VRUtilities.HZOS_CAMERA_PERMISSION -> R.string.perm_hzos_use_headset_camera
       else -> -1
     }
   }

--- a/apps/expo-go/android/expoview/src/main/res/values/strings.xml
+++ b/apps/expo-go/android/expoview/src/main/res/values/strings.xml
@@ -33,6 +33,8 @@
   <string name="perm_read_media_audio">reading audio files from external storage</string>
   <string name="perm_notifications">posting notifications</string>
   <string name="perm_system_brightness">system brightness</string>
+  <string name="perm_hzos_use_avatar_camera">accessing the avatar camera</string>
+  <string name="perm_hzos_use_headset_camera">accessing the headset camera</string>
   <string name="default_notification_channel_group">Default</string>
   <string name="persistent_notification_channel_group">Expo</string>
   <string name="persistent_notification_channel_name">Experience notifications</string>


### PR DESCRIPTION
# Why

Adds support for the Quest passthrough camera permission (equivalent of the back camera of a phone) to the scoped permissions.

# How

Added the permission into the ScopedPermissionsRequester, as well as updated the string constants.

# Test Plan

Tested in Expo Go home app and NCL running through Expo Go

