### PR TITLE
[camera] Meta Quest support - [4/n] - Add support for the passthrough camera

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [Android] Add support for Meta Quest passthrough camera ([#37748](https://github.com/expo/expo/pull/37748) by [@behenate](https://github.com/behenate))
+
 ### 🐛 Bug fixes
 
 - [iOS] Fixes returning `PictureRef` objects.([#37393](https://github.com/expo/expo/pull/37393) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
@@ -22,6 +22,7 @@ import expo.modules.camera.tasks.ResolveTakenPicture
 import expo.modules.camera.tasks.writeStreamToFile
 import expo.modules.core.errors.ModuleDestroyedException
 import expo.modules.core.utilities.EmulatorUtilities
+import expo.modules.core.utilities.VRUtilities
 import expo.modules.interfaces.imageloader.ImageLoaderInterface
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.kotlin.Promise
@@ -47,6 +48,15 @@ val cameraEvents = arrayOf(
   "onAvailableLensesChanged"
 )
 
+val cameraPermissions = if (VRUtilities.isQuest()) {
+  arrayOf(
+    Manifest.permission.CAMERA,
+    VRUtilities.HZOS_CAMERA_PERMISSION
+  )
+} else {
+  arrayOf(Manifest.permission.CAMERA)
+}
+
 class CameraViewModule : Module() {
   private val moduleScope = CoroutineScope(Dispatchers.Main)
 
@@ -57,8 +67,9 @@ class CameraViewModule : Module() {
 
     // Aligned with iOS which has the same property. Will always be true on Android since
     // the Google code scanner's min sdk is 21 - and our min sdk is currently 24.
+    // False on Horizon OS, as there is no google services.
     Property("isModernBarcodeScannerAvailable") {
-      true
+      !VRUtilities.isQuest()
     }
 
     // Again, aligned with iOS.
@@ -70,7 +81,7 @@ class CameraViewModule : Module() {
       Permissions.askForPermissionsWithPermissionsManager(
         permissionsManager,
         promise,
-        Manifest.permission.CAMERA
+        *cameraPermissions
       )
     }
 
@@ -86,7 +97,7 @@ class CameraViewModule : Module() {
       Permissions.getPermissionsWithPermissionsManager(
         permissionsManager,
         promise,
-        Manifest.permission.CAMERA
+        *cameraPermissions
       )
     }
 


### PR DESCRIPTION
# Why

We want expo-camera to be able to access headset's back camera in order to be able to scan QR codes and just use it like the back camera of a phone

# How

We need to add appropriate permissions, when granted the camera will show up like a regular phone back camera.

# Test Plan

Tested in Expo Go and NCL

