### PR TITLE
[cli] Meta Quest Support - [5/n] - Add Quest support in `resolvePlatrofm.ts`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -36,6 +36,7 @@
 - simplify/optimize web-modal tests ([#38025](https://github.com/expo/expo/pull/38025) by [@hirbod](https://github.com/hirbod))
 - Fix e2e start-test for local runs ([#38066](https://github.com/expo/expo/pull/38066) by [@Ubax](https://github.com/Ubax))
 - Switch Metro imports to `@expo/metro` wrapper package ([#38166](https://github.com/expo/expo/pull/38166) by [@kitten](https://github.com/kitten))
+- Treat Meta Quest devices as Android devices in `resolvePlatformFromUserAgentHeader` ([#37749](https://github.com/expo/expo/pull/37749) by [@behenate](https://github.com/behenate))
 
 ### ⚠️ Notices
 

--- a/packages/@expo/cli/src/start/server/middleware/resolvePlatform.ts
+++ b/packages/@expo/cli/src/start/server/middleware/resolvePlatform.ts
@@ -32,6 +32,10 @@ export function resolvePlatformFromUserAgentHeader(req: ServerRequest): string |
   if (userAgent?.match(/Android/i)) {
     platform = 'android';
   }
+  // For now we match the quest headsets as Android. We can add a separate platform when needed.
+  if (userAgent?.match(/OculusBrowser|Quest/i)) {
+    platform = 'android';
+  }
   if (userAgent?.match(/iPhone|iPad/i)) {
     platform = 'ios';
   }

--- a/packages/@expo/cli/src/start/server/middleware/resolvePlatform.ts
+++ b/packages/@expo/cli/src/start/server/middleware/resolvePlatform.ts
@@ -32,7 +32,6 @@ export function resolvePlatformFromUserAgentHeader(req: ServerRequest): string |
   if (userAgent?.match(/Android/i)) {
     platform = 'android';
   }
-  // For now we match the quest headsets as Android. We can add a separate platform when needed.
   if (userAgent?.match(/OculusBrowser|Quest/i)) {
     platform = 'android';
   }


### PR DESCRIPTION
# Why

When opening a project with expo-go on a Quest, the website with "development build / Expo Go" picker would fail to load with an error about an unknown platform.

# How

In the `resolvePlatformFromUserAgentHeader` method I have added a matcher that matches to Quest devices and returns the platform for them as `Android` (I think we don't need any special treatment for the Quest for now)

# Test Plan

Tested in Expo Go

