### PR TITLE
[sandbox] Bump react-native to 0.80.0

### DIFF
--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -15,7 +15,7 @@
     "expo-router": "^5.0.7",
     "expo-splash-screen": "~0.30.8",
     "react": "19.1.0",
-    "react-native": "0.80.0-rc.5",
+    "react-native": "0.80.0",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "4.11.1-nightly-20250611-8b82e081e"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13212,7 +13212,7 @@ react-native-webview@13.13.5:
     escape-string-regexp "^4.0.0"
     invariant "2.2.4"
 
-react-native@0.80.0, react-native@0.80.0-rc.5:
+react-native@0.80.0:
   version "0.80.0"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.80.0.tgz#574bf976c1e03d27191100179a8e9ec0f19d42ef"
   integrity sha512-b9K1ygb2MWCBtKAodKmE3UsbUuC29Pt4CrJMR0ocTA8k+8HJQTPleBPDNKL4/p0P01QO9aL/gZUddoxHempLow==


### PR DESCRIPTION
# Why

While working on https://github.com/expo/expo/pull/37745 I noticed that the sanbox app was still on react-native 0.80.0-rc.5

# How

Bump sandbox app to 0.80.0

# Test Plan

Run sandbox app locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
