### PR TITLE
[expo] Remove outdated TODO comment from ExpoAppDelegate

### DIFF
--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -9,8 +9,6 @@ import ReactAppDependencyProvider
  by forwarding `UIApplicationDelegate` events to the subscribers.
 
  Keep functions and markers in sync with https://developer.apple.com/documentation/uikit/uiapplicationdelegate
-
- TODO vonovak check macOS support once RN macOS 78 goes out
  */
 @objc(EXExpoAppDelegate)
 open class ExpoAppDelegate: NSObject, ReactNativeFactoryProvider, UIApplicationDelegate {


### PR DESCRIPTION
# Why

RN macOS 78 is out for quite a while now and this is working as expected 

# How

Remove outdated TODO comment from ExpoAppDelegate

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
