### PR TITLE
[docs] Remove deprecated library from in-app purchases

### DIFF
--- a/docs/pages/guides/in-app-purchases.mdx
+++ b/docs/pages/guides/in-app-purchases.mdx
@@ -46,22 +46,6 @@ The following libraries provide robust support for in-app purchase functionality
 <BoxLink
   title={
     <>
-      <CODE>react-native-iap</CODE> (deprecated)
-    </>
-  }
-  description={
-    <>
-      A legacy React Native library for in-app purchases. Superseded by <CODE>expo-iap</CODE> for
-      Expo apps.
-    </>
-  }
-  href="https://github.com/hyochan/react-native-iap"
-  Icon={GithubIcon}
-/>
-
-<BoxLink
-  title={
-    <>
       <CODE>expo-iap</CODE>
     </>
   }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Our in-app purchases guide lists a deprecated library (`react-native-iap`). We should remove it since now the official announcement has been made by the library maintainer: https://x.com/hyodotdev/status/1939420943665049961.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

By running docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
