### PR TITLE
docs(guide): clarify disabling New Architecture on iOS

### DIFF
--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -148,7 +148,7 @@ You can configure the React Native Directory check in your **package.json** file
 If you are using Expo SDK 53 or higher, it will be enabled by default. The following instructions apply to older projects.
 
 - **Android**: Set `newArchEnabled=true` in the **gradle.properties** file.
-- **iOS**: If your project has a **Podfile.properties.json** file (which is created by `npx create-expo-app` or `npx expo prebuild`), you can enable the New Architecture by setting the `newArchEnabled` property to `"true"` in the **Podfile.properties.json** file. Otherwise, refer to the ["Enable the New Architecture for Apps"](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/enable-apps.md) section of the React Native New Architecture working group.
+- **iOS**: If your project has a **Podfile.properties.json** file (which is created by `npx create-expo-app` or `npx expo prebuild`), you can disable the New Architecture by setting the `newArchEnabled` property to `"true"` in the **Podfile.properties.json** file. Otherwise, refer to the ["Enable the New Architecture for Apps"](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/enable-apps.md) section of the React Native New Architecture working group.
 
 </Collapsible>
 

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -148,7 +148,7 @@ You can configure the React Native Directory check in your **package.json** file
 If you are using Expo SDK 53 or higher, it will be enabled by default. The following instructions apply to older projects.
 
 - **Android**: Set `newArchEnabled=true` in the **gradle.properties** file.
-- **iOS**: If your project has a **Podfile.properties.json** file (which is created by `npx create-expo-app` or `npx expo prebuild`), you can disable the New Architecture by setting the `newArchEnabled` property to `"true"` in the **Podfile.properties.json** file. Otherwise, refer to the ["Enable the New Architecture for Apps"](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/enable-apps.md) section of the React Native New Architecture working group.
+- **iOS**: If your project has a **Podfile.properties.json** file (which is created by `npx create-expo-app` or `npx expo prebuild`), you can enable the New Architecture by setting the `newArchEnabled` property to `"true"` in the **Podfile.properties.json** file. Otherwise, refer to the ["Enable the New Architecture for Apps"](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/enable-apps.md) section of the React Native New Architecture working group.
 
 </Collapsible>
 
@@ -169,7 +169,7 @@ If you want to opt out of using the New Architecture, set the `newArchEnabled` p
 <Collapsible summary="Are you disabling the New Architecture in a bare React Native app?">
 
 - **Android**: Set `newArchEnabled=false` in the **gradle.properties** file.
-- **iOS**: If your project has a **Podfile.properties.json** file (which is created by `npx create-expo-app` or `npx expo prebuild`), you can enable the New Architecture by setting the `newArchEnabled` property to `"false"` in the **Podfile.properties.json** file. Otherwise, refer to the ["Enable the New Architecture for Apps"](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/enable-apps.md) section of the React Native New Architecture working group.
+- **iOS**: If your project has a **Podfile.properties.json** file (which is created by `npx create-expo-app` or `npx expo prebuild`), you can disable the New Architecture by setting the `newArchEnabled` property to `"false"` in the **Podfile.properties.json** file. Otherwise, refer to the ["Enable the New Architecture for Apps"](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/enable-apps.md) section of the React Native New Architecture working group.
 
 </Collapsible>
 


### PR DESCRIPTION
In the iOS section, change wording from \"enable\" to \"disable\" for newArchEnabled, so the guidance now correctly instructs setting it to \"false\" when disabling the New Architecture.

# Why

This fixes a documentation mistake that could confuse users. The original line stated that you can enable the New Architecture by setting newArchEnabled to "false", which is incorrect. This PR clarifies that setting the value to "false" disables the New Architecture on iOS, aligning it with the Android instructions above.

# How

This is a simple copy edit to the Expo guide. Only the word "enable" was changed to "disable" in the iOS section discussing Podfile.properties.json.

# Test Plan

Manually reviewed the guide to confirm that the change now provides accurate information. No additional testing is needed as this is a documentation-only update.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
