### PR TITLE
[ios][cli] Skip pod installation when running binary

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - add modal component ([#37365](https://github.com/expo/expo/pull/37365) by [@Ubax](https://github.com/Ubax))
 - Bumped `playwright` version to 1.53.1. ([#37631](https://github.com/expo/expo/pull/37631) by [@kudo](https://github.com/kudo))
-- Skip pod installation when running with a pre-built binary to speed up launch time
+- Skip pod installation when running with a pre-built binary to speed up launch time ([#37766](https://github.com/expo/expo/pull/37766) by [@robingullo](https://github.com/robingullo))
 
 ### ⚠️ Notices
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - add modal component ([#37365](https://github.com/expo/expo/pull/37365) by [@Ubax](https://github.com/Ubax))
 - Bumped `playwright` version to 1.53.1. ([#37631](https://github.com/expo/expo/pull/37631) by [@kudo](https://github.com/kudo))
+- Skip pod installation when running with a pre-built binary to speed up launch time
 
 ### ⚠️ Notices
 

--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -33,10 +33,7 @@ export async function runIosAsync(projectRoot: string, options: Options) {
   assertPlatform();
 
   const install = !!options.install;
-
-  if ((await ensureNativeProjectAsync(projectRoot, { platform: 'ios', install })) && install) {
-    await maybePromptToSyncPodsAsync(projectRoot);
-  }
+  const hadToPrebuild = await ensureNativeProjectAsync(projectRoot, { platform: 'ios', install });
 
   // Resolve the CLI arguments into useable options.
   const props = await profile(resolveOptionsAsync)(projectRoot, options);
@@ -118,6 +115,10 @@ export async function runIosAsync(projectRoot: string, options: Options) {
           platform: 'ios',
         })
       );
+    }
+
+    if (hadToPrebuild && install) {
+      await maybePromptToSyncPodsAsync(projectRoot);
     }
 
     // Spawn the `xcodebuild` process to create the app binary.


### PR DESCRIPTION
# Why

With new build cache provider feature, Pod installation is no longer needed if a cached build is used. This can drastically improve `expo run:ios` performance (up to 4x times in my tests).

# How

Pod installation is delayed to the last moment, just before building with XCode.

# Test Plan

I tested `npx expo run:ios` on bare expo with a [custom cache provider](https://gist.github.com/robingullo/9024b0146e26d69bbb6f2869912437aa) storing builds locally.
If I delete the Pods folder, `npx expo run:ios` still works with or without a cache hit.

I ran a perf test with the custom local build cache provider. The new implementation is equivalent to forcing  `--no-install` with a cache hit, so I ran:
```bash
hyperfine "npx expo run:ios --no-bundler --no-install" "npx expo run:ios --no-bundler" --prepare "rm -rf ios/Pods"
```

Here are the results on my Mac M1:

<img width="637" alt="Capture d’écran 2025-07-01 à 12 10 50" src="https://github.com/user-attachments/assets/851a98fd-c9bd-4219-ad40-4509c37aa63b" />


# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
