### PR TITLE
fix(cli): allow fast resolver to resolve nested `node_modules` packages in monorepos

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Support SSR imports of internal node builtins such as `_http_agent`. ([#37494](https://github.com/expo/expo/pull/37494) by [@EvanBacon](https://github.com/EvanBacon))
 - Allow anonymous sessions even when `projectId` is set ([#36874](https://github.com/expo/expo/pull/36874) by [@kadikraman](https://github.com/kadikraman))
+- Allow fast resolver to resolve nested `node_modules` packages in monorepos. ([#37769](https://github.com/expo/expo/pull/37769) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/createExpoMetroResolver.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/createExpoMetroResolver.test.ts
@@ -1,6 +1,7 @@
 import { getBareExtensions } from '@expo/config/paths';
 import assert from 'assert';
 import fs from 'fs';
+import type { SourceFileResolution } from 'metro-resolver/src/types';
 import path from 'path';
 
 import { createFastResolver, FailedToResolvePathError } from '../createExpoMetroResolver';
@@ -54,7 +55,7 @@ const createContext = ({
       : isServer
         ? ['main', 'module']
         : ['browser', 'module', 'main'],
-    nodeModulesPaths: ['node_modules', ...nodeModulesPaths],
+    nodeModulesPaths,
     originModulePath: origin,
     preferNativePlatform,
     sourceExts,
@@ -223,6 +224,35 @@ describe(createFastResolver, () => {
     });
 
     assert(results.type === 'sourceFile');
+  });
+
+  // This tests the `node_modules/react-native/node_modules/promise` structure
+  // If this changes, another example of a nested package should be picked
+  it('resolves nested `node_modules` packages', () => {
+    const resolver = createFastResolver({ preserveSymlinks: true, blockList: [] });
+
+    const indexPath = path.join(originProjectRoot, 'index.js');
+    const platform = 'ios';
+    const nodeModulesPaths = [
+      path.join(originProjectRoot, 'node_modules'),
+      path.join(originProjectRoot, '../../node_modules'),
+    ];
+
+    // First resolve `react-native`
+    const nclContext = createContext({ platform, origin: indexPath, nodeModulesPaths });
+    const nclResult = resolver(nclContext, 'react-native', platform);
+    expect(nclResult).toMatchObject({ type: 'sourceFile', filePath: expect.any(String) });
+
+    // Then resolve `promise` within `react-native`
+    const rnEntryFile = (nclResult as SourceFileResolution).filePath;
+    const rnContext = createContext({ platform, origin: rnEntryFile, nodeModulesPaths });
+    const rnResult = resolver(rnContext, 'promise', platform);
+    expect(rnResult).toMatchObject({ type: 'sourceFile', filePath: expect.any(String) });
+
+    // Ensure the resolved path of `promise` is within React Native's `node_modules`
+    expect(rnResult).toMatchObject({
+      filePath: expect.stringContaining('node_modules/react-native/node_modules/promise'),
+    });
   });
 
   describe('ios', () => {

--- a/packages/@expo/cli/src/start/server/metro/createExpoMetroResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoMetroResolver.ts
@@ -146,9 +146,7 @@ export function createFastResolver({
         blockList,
         enablePackageExports: context.unstable_enablePackageExports,
         basedir: path.dirname(context.originModulePath),
-        moduleDirectory: context.nodeModulesPaths.length
-          ? (context.nodeModulesPaths as string[])
-          : undefined,
+        paths: context.nodeModulesPaths.length ? (context.nodeModulesPaths as string[]) : undefined,
         extensions,
         conditions,
         realpathSync(file: string): string {

--- a/packages/@expo/cli/src/start/server/metro/createExpoMetroResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoMetroResolver.ts
@@ -146,7 +146,9 @@ export function createFastResolver({
         blockList,
         enablePackageExports: context.unstable_enablePackageExports,
         basedir: path.dirname(context.originModulePath),
-        paths: context.nodeModulesPaths.length ? (context.nodeModulesPaths as string[]) : undefined,
+        moduleDirectory: context.nodeModulesPaths.length
+          ? (context.nodeModulesPaths as string[])
+          : undefined,
         extensions,
         conditions,
         realpathSync(file: string): string {


### PR DESCRIPTION
Blocked by #37770

# Why

Fixes #37734

Looking at the bug described in #37734, it turns out that we didn't configure `resolve` (used by our fast resolver) properly when using monorepos.

TL;DR;
- Fast resolver is now enabled when using React canaries
- When using monorepos, we explicitly configure [`nodeModulesPaths`](https://metrobundler.dev/docs/configuration/#nodemodulespaths)
- The `nodeModulesPaths` is then passed to the `resolve` package as `moduleDirectory`
- The `moduleDirectory` property is not identical to Metro
  - Instead, this is the folder name (or names) that should be searched recursively when resolving from specific directories.
- Because the `moduleDirectory` was set incorrectly, nested resolutions started misbehaving (see #37734)

I used the repro from #37734, and looked how the Node module resolution paths were generated:

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/be7dddbd-2d24-4bf2-b005-ba1a38a4ac0f) | ![image](https://github.com/user-attachments/assets/a43a2ff6-05d6-4c09-bada-49ef21d99b22)


# How

Looking at the documentation for `resolve`, there is a property called [`paths`](https://github.com/browserify/resolve/tree/06bfa9190190760511720cf74efb7f00a1a40a9d?tab=readme-ov-file#resolveid-opts-cb), which actually resembles the functionality Metro provides through `nodeModulesPaths`.

<img width="787" alt="image" src="https://github.com/user-attachments/assets/09e46932-f998-4f69-8e1a-041f6ed6a5b0" />

<img width="976" alt="image" src="https://github.com/user-attachments/assets/973085fb-251c-44b7-98de-e2eaadbcc802" />

> [!IMPORTANT]
> Notice how both features explains this as:
> - **resolve**:  .. _if nothing is found_ on the normal `node_modules` recursive walk ..
> - **Metro**: .. _After_ after looking through all `node_modules` directories. ..

# Test Plan

See added unit test and #37734

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
