### PR TITLE
[image][iOS] Use specified cache type when no transformation is applied

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [Android] Fix animation resuming by casting image to GifDrawable. ([#37363](https://github.com/expo/expo/pull/37363) by [@Wenszel](https://github.com/Wenszel))
 - [Web] Fix `alt` as an alias for `accessibilityLabel` ([#37682](https://github.com/expo/expo/pull/37682) by [@huextrat](https://github.com/huextrat))
-- [iOS] Use specified cache type when no transformation is applied
+- [iOS] Use specified cache type when no transformation is applied ([#37777](https://github.com/expo/expo/pull/37777) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] Fix animation resuming by casting image to GifDrawable. ([#37363](https://github.com/expo/expo/pull/37363) by [@Wenszel](https://github.com/Wenszel))
 - [Web] Fix `alt` as an alias for `accessibilityLabel` ([#37682](https://github.com/expo/expo/pull/37682) by [@huextrat](https://github.com/huextrat))
+- [iOS] Use specified cache type when no transformation is applied
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -192,6 +192,8 @@ func createSDWebImageContext(forSource source: ImageSource, cachePolicy: ImageCa
     let sdCacheType = cachePolicy.toSdCacheType().rawValue
     context[.originalQueryCacheType] = sdCacheType
     context[.originalStoreCacheType] = sdCacheType
+    context[.queryCacheType] = sdCacheType
+    context[.storeCacheType] = sdCacheType
   } else {
     context[.originalQueryCacheType] = SDImageCacheType.none.rawValue
     context[.originalStoreCacheType] = SDImageCacheType.none.rawValue

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -155,7 +155,9 @@ public final class ImageView: ExpoView {
     // Cancel currently running load requests.
     cancelPendingOperation()
 
-    context[.imageTransformer] = createTransformPipeline()
+    if blurRadius > 0 {
+      context[.imageTransformer] = createTransformPipeline()
+    }
 
     // It seems that `UIImageView` can't tint some vector graphics. If the `tintColor` prop is specified,
     // we tell the SVG coder to decode to a bitmap instead. This will become useless when we switch to SVGNative coder.
@@ -357,9 +359,6 @@ public final class ImageView: ExpoView {
   // MARK: - Processing
 
   private func createTransformPipeline() -> SDImagePipelineTransformer? {
-    if blurRadius <= 0 {
-      return nil
-    }
     let transformers: [SDImageTransformer] = [
       SDImageBlurTransformer(radius: blurRadius)
     ]


### PR DESCRIPTION
# Why

Fixes #37705

Our cache policy is not applied when no transformations are applied. After a previous optimizations, when blur is not applied, we do not create a transform pipeline, and as a result, its output will not be cached.

# How

Apply cache type to query and store cache.

# Test Plan

- `"disk" and "Image loaded"` should be visible after initial render.
- `"disk" and "Image loaded"` should be visible directly after the animation has ended. 


<details>
<summary>JSX test</summary>

```tsx

import { Image } from 'expo-image';
import * as React from 'react';
import { Button, View } from 'react-native';
import Animated, {
  useAnimatedStyle,
  useSharedValue,
  withRepeat,
  withTiming,
} from 'react-native-reanimated';

const AnimatedImage = Animated.createAnimatedComponent(Image);

export default function ImageComparisonScreen() {
  const sv = useSharedValue(0);

  const animatedStyle = useAnimatedStyle(() => ({
    width: 100 + sv.value * 100,
    height: 100 + sv.value * 100,
  }));

  return (
    <View style={{ flex: 1, justifyContent: 'center' }}>
      <AnimatedImage
        source={{
          uri: `https://jakubgrzywacz.pl/10000.png`,
        }}
        style={[{ height: 100, width: 100 }, animatedStyle]}
        onLoad={(e) => console.log(e.cacheType)}
        onLoadEnd={() => console.log('Image loaded')}
      />
      <Button
        onPress={() => {
          sv.value = withRepeat(withTiming(1, { duration: 1000 }), 4, true);
        }}
        title="Animate"
      />
    </View>
  );
}
```

</details>


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
