### PR TITLE
[Android][core] Fix `Value is undefined, expected an Object` in the `JNIUtils::emitEventOnJSIObject`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fix `Value is undefined, expected an Object` in the `JNIUtils::emitEventOnJSIObject`.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fix `Value is undefined, expected an Object` in the `JNIUtils::emitEventOnJSIObject`.
+- [Android] Fix `Value is undefined, expected an Object` in the `JNIUtils::emitEventOnJSIObject`. ([#37778](https://github.com/expo/expo/pull/37778) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/cpp/JNIUtils.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIUtils.cpp
@@ -187,7 +187,13 @@ void JNIUtils::emitEventOnJSIObject(
     // TODO(@lukmccall): refactor when jsInvoker receives a runtime as a parameter
     jsi::Runtime &rt = jsiContext->runtimeHolder->get();
 
-    jsi::Object jsThis = jsWeakThis->lock(rt).asObject(rt);
+    jsi::Value unpackedValue = jsWeakThis->lock(rt);
+    if (unpackedValue.isUndefined()) {
+      // The JS object was deallocated - we can ignore emitting an event
+      return;
+    }
+
+    jsi::Object jsThis = unpackedValue.asObject(rt);
     EventEmitter::emitEvent(rt, jsThis, name, argsProvider(rt));
   });
 }


### PR DESCRIPTION
# Why

Fixes: `Value is undefined, expected an Object`.

# How

Handled the case where `jsiThis` was deallocated, and we can emit the event. 

# Test Plan

- constantly allocating and deallocating video players with event listeners ✅  
