### PR TITLE
[docs] Update rollout docs to better details how to revert a per-update rollout

### DIFF
--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -13,7 +13,7 @@ EAS provides **per-update and branch-based rollout mechanisms** depending on you
 
 This rollout mechanism allows you to specify a percentage of users that should receive a new update when you publish it, and then increase that percentage gradually afterwards.
 
-### Starting a rollout
+### Starting
 
 To start an update-based rollout, add the `--rollout-percentage` flag to your normal `eas update` command:
 
@@ -21,7 +21,7 @@ To start an update-based rollout, add the `--rollout-percentage` flag to your no
 
 In this example, when published, the update will only be available to 10% of your end users.
 
-### Progressing a rollout
+### Progressing
 
 To edit the percentage of an update-based rollout:
 
@@ -29,24 +29,26 @@ To edit the percentage of an update-based rollout:
 
 You will be guided through the process of selecting the update to edit and asked for the new percentage.
 
-### Ending a rollout
+### Ending
 
 When ending an update-based rollout, you have two options:
 
 - **Roll out fully**: To accomplish this end state, progress the rollout as detailed above and set the percentage to 100.
-- **Revert**: To accomplish this end state, republish the previous update by using the `eas update:republish` command.
+- **Revert back to previous state**: To accomplish this, run `eas update:revert-update-rollout` which will guide you through reverting back to the previous state.
 
-### Working with rollouts
+### Additional notes
 
 - Only one update can be rolled out on a branch at one time.
 - When a rollout is in progress, it must be ended using one of the options above before a new update (with the same runtime version) can be published. This prevents accidentally clobbering the rollout.
 - To see the state of the rollout, use the `eas update:list` or `eas update:view` commands.
+- Reverting a rollout that is created on a branch with an existing update will republish the control update. This ensures that all clients are reverted back to the previous state.
+- A rollout can be started on a branch with no current update, in which case the first update will be rolled out to the specified percentage of users. When reverted, a rollback-to-embedded update will be created, which will revert the clients to their previous state (embedded update).
 
 ## Branch-based rollouts
 
 This rollout mechanism allows you to incrementally roll out a set of updates on a new branch to a percentage of end users and leave the remaining percentage of users on the current branch.
 
-### Starting a rollout
+### Starting
 
 To start a branch-based rollout, run the following EAS CLI command:
 
@@ -54,14 +56,14 @@ To start a branch-based rollout, run the following EAS CLI command:
 
 In the terminal, an interactive guide will assist you in selecting a channel, choosing a branch for the rollout, and setting the percentage of users for the rollout. To increase or decrease the rollout amount, run the command again and choose the `Edit` option to adjust the rollout percentage.
 
-### Ending a rollout
+### Ending
 
 Two methods are available to end a rollout when you choose the `End` option in the interactive guide:
 
 - **Republish and revert:** Use this option when you are confident with the state of the new branch. This will republish the latest update from the new branch to the old branch, and all users will be pointed to the old branch.
 - **Revert:** Choose to disregard the updates on the new branch and return users to the old branch.
 
-### Working with rollouts
+### Additional notes
 
 - Only one branch can be rolled out on a channel at a single time.
 - To see the state of the rollout, use the `eas channel:rollout` command.


### PR DESCRIPTION
# Why

This corrects the per-update rollout revert documentation. It was previously incorrect.

# How

The new `eas update:revert-update-rollout` command should be used to revert an update-based rollout.

# Test Plan

Proofread.