### PR TITLE
[docs] Add doc for EAS Update request proxying

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -512,6 +512,7 @@ export const eas = [
       makePage('eas-update/code-signing.mdx'),
       makePage('eas-update/asset-selection.mdx'),
       makePage('eas-update/standalone-service.mdx'),
+      makePage('eas-update/request-proxying.mdx'),
       makePage('eas-update/codepush.mdx'),
       makePage('eas-update/migrate-from-classic-updates.mdx'),
       makePage('eas-update/trace-update-id-expo-dashboard.mdx'),

--- a/docs/pages/eas-update/request-proxying.mdx
+++ b/docs/pages/eas-update/request-proxying.mdx
@@ -1,6 +1,7 @@
 ---
-title: Request Proxying
+title: Request proxying
 description: Proxy requests to the EAS Update server through your own server.
+hideTOC: true
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
@@ -18,20 +19,23 @@ EAS Update supports request proxying, which allows you to proxy requests to the 
      - This must forward requests to `u.expo.dev`, the EAS Update server.
      - This must pass-through all URL contents (path, query parameters, and so on).
      - This must pass-through all headers prefixed with `expo-` or `eas-`.
-1. Add the following fields to your `eas.json` configuration file, replacing the placeholders with your actual proxy server URLs:
-   ```json
+1. Add the following fields to your **eas.json** configuration file, replacing the placeholders with your actual proxy server URLs:
+   
+   {/* prettier-ignore */}
+   ```json eas.json
    {
      "cli": {
-       ...
+       /* @hide ... */ /* @end */
        "updateAssetHostOverride": "updates-asset-proxy.example.com",
        "updateManifestHostOverride": "updates-manifest-proxy.example.com"
      }
    }
    ```
+
 1. Run the following command to apply the changes:
    <Terminal cmd={['$ eas update:configure']} />
 1. Publish an update to test the proxying:
    <Terminal cmd={['$ eas update']} />
 1. Verify by navigating to the update group on the [EAS Update dashboard](https://expo.dev/accounts/[account]/projects/[project]/updates) and clicking "View Metadata" for one of the platforms.
-   - `manifest.json` should show the overridden `manifestHostOverride`.
+   - **manifest.json** should show the overridden `manifestHostOverride`.
    - Other assets should show the overridden `assetHostOverride`.

--- a/docs/pages/eas-update/request-proxying.mdx
+++ b/docs/pages/eas-update/request-proxying.mdx
@@ -20,7 +20,7 @@ EAS Update supports request proxying, which allows you to proxy requests to the 
      - This must pass-through all URL contents (path, query parameters, and so on).
      - This must pass-through all headers prefixed with `expo-` or `eas-`.
 1. Add the following fields to your **eas.json** configuration file, replacing the placeholders with your actual proxy server URLs:
-   
+
    {/* prettier-ignore */}
    ```json eas.json
    {

--- a/docs/pages/eas-update/request-proxying.mdx
+++ b/docs/pages/eas-update/request-proxying.mdx
@@ -1,0 +1,37 @@
+---
+title: Request Proxying
+description: Proxy requests to the EAS Update server through your own server.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+EAS Update supports request proxying, which allows you to proxy requests to the EAS Update server through your own server. This can be useful for various reasons, such as adding custom headers, logging requests, or implementing additional security or request IP anonymization measures.
+
+## Enabling request proxying
+
+1. Create two proxy servers that will handle the requests:
+   - One for the update asset requests (JavaScript bundles, images, and so on).
+     - This must forward requests to `assets.eascdn.net`, the EAS Update asset server.
+     - This must pass-through all URL contents (path, query parameters, and so on).
+     - This must pass-through all headers prefixed with `expo-` or `eas-`.
+   - One for the update manifest requests.
+     - This must forward requests to `u.expo.dev`, the EAS Update server.
+     - This must pass-through all URL contents (path, query parameters, and so on).
+     - This must pass-through all headers prefixed with `expo-` or `eas-`.
+1. Add the following fields to your `eas.json` configuration file, replacing the placeholders with your actual proxy server URLs:
+   ```json
+   {
+     "cli": {
+       ...
+       "updateAssetHostOverride": "updates-asset-proxy.example.com",
+       "updateManifestHostOverride": "updates-manifest-proxy.example.com"
+     }
+   }
+   ```
+1. Run the following command to apply the changes:
+   <Terminal cmd={['$ eas update:configure']} />
+1. Publish an update to test the proxying:
+   <Terminal cmd={['$ eas update']} />
+1. Verify by navigating to the update group on the [EAS Update dashboard](https://expo.dev/accounts/[account]/projects/[project]/updates) and clicking "View Metadata" for one of the platforms.
+   - `manifest.json` should show the overridden `manifestHostOverride`.
+   - Other assets should show the overridden `assetHostOverride`.


### PR DESCRIPTION
# Why

We're launching EAS Update request proxying fully. This adds the public docs for the feature.

# How

Add doc.

# Test Plan

`yarn dev`, preview at http://localhost:3002/eas-update/request-proxying/.