### PR TITLE
[dev-launcher][Android] Strings in UI should match those on iOS

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Use same strings in UI as iOS. ([#37786](https://github.com/expo/expo/pull/37786) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/primitives/Accordion.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/primitives/Accordion.kt
@@ -91,7 +91,7 @@ fun Accordion(
 @Composable
 @Preview(showBackground = true, heightDp = 200)
 fun AccordionVariantPreview() {
-  Accordion(text = "Enter URL") {
+  Accordion(text = "Enter URL manually") {
     Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ac nisl interdum, mattis purus a, consequat ipsum. Aliquam sem mauris, egestas a elit a, lacinia efficitur nisi. Maecenas scelerisque erat nisi, ac interdum mauris volutpat vel. Proin sed lectus at purus interdum porta. Ut mollis feugiat dignissim.")
   }
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/Home.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/Home.kt
@@ -49,7 +49,7 @@ fun HomeScreen(state: DevLauncherState, onProfileClick: () -> Unit) {
         Spacer(Theme.spacing.small)
 
         SectionHeader(
-          "Development",
+          "Development servers",
           leftIcon = {
             Image(
               painter = painterResource(R.drawable._expodevclientcomponents_assets_terminalicon),
@@ -78,7 +78,7 @@ fun HomeScreen(state: DevLauncherState, onProfileClick: () -> Unit) {
             Divider()
           }
 
-          Accordion("Enter URL", initialState = false) {
+          Accordion("Enter URL manually", initialState = false) {
             val url = remember { mutableStateOf("") }
 
             Column {
@@ -89,7 +89,7 @@ fun HomeScreen(state: DevLauncherState, onProfileClick: () -> Unit) {
                 onValueChange = { newValue ->
                   url.value = newValue
                 },
-                placeholder = "http://10.0.2.2:801",
+                placeholder = "http://10.0.2.2:8081",
                 textStyle = Theme.typography.medium.font,
                 maxLines = 1,
                 modifier = Modifier

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/SectionHeader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/SectionHeader.kt
@@ -37,7 +37,7 @@ fun SectionHeader(
 @Preview(widthDp = 300, showBackground = true)
 fun SectionHeaderPreview() {
   SectionHeader(
-    title = "Development",
+    title = "Development servers",
     leftIcon = {
       Image(
         painter = painterResource(R.drawable._expodevclientcomponents_assets_terminalicon),


### PR DESCRIPTION
# Why

After #37696 , the updates E2E dev client test is failing on Android, because the strings in the UI ("Development servers", etc.) are no longer the same as the ones on iOS.

# How

Changed the affected strings to match those on iOS.

# Test Plan

CI should pass

