### PR TITLE
[ios][audio] Fix ducking behaviour

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix connected bluetooth devices not playing back recordings. ([#37580](https://github.com/expo/expo/pull/37580) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix ducking behaviour.
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix connected bluetooth devices not playing back recordings. ([#37580](https://github.com/expo/expo/pull/37580) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix ducking behaviour.
+- [iOS] Fix ducking behaviour. ([#37788](https://github.com/expo/expo/pull/37788) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -488,11 +488,13 @@ public class AudioModule: Module {
   private func activateSession() throws {
     try AVAudioSession.sharedInstance().setActive(true, options: [.notifyOthersOnDeactivation])
   }
-  
+
   private func deactivateSession() {
     // We need to give isPlaying time to update before running this
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-      guard let self = self else { return }
+      guard let self else {
+        return
+      }
       let hasActivePlayers = self.registry.allPlayers.values.contains { $0.isPlaying }
       if !hasActivePlayers {
         do {

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -476,7 +476,7 @@ public class AudioModule: Module {
       }
 
       if category == .playAndRecord {
-        categoryOptions.insert(.allowBluetoothHFP)
+        categoryOptions.insert(.allowBluetooth)
       }
 
       sessionOptions = categoryOptions

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -28,6 +28,7 @@ public class AudioPlayer: SharedRef<AVPlayer> {
   private var tapInstalled = false
   private var shouldInstallAudioTap = false
   weak var owningRegistry: AudioComponentRegistry?
+  var onPlaybackComplete: (() -> Void)?
 
   var duration: Double {
     ref.currentItem?.duration.seconds ?? 0.0
@@ -262,6 +263,7 @@ public class AudioPlayer: SharedRef<AVPlayer> {
           "currentTime": self.duration,
           "didJustFinish": true
         ])
+        self.onPlaybackComplete?()
       }
     }
   }


### PR DESCRIPTION
# Why
Closes #37776
Similar to #37698, we need to handle the audio modes correctly

# How
Setting audio modes did not align with the behaviour in expo-av. Activating the session immediately in `setAudioModeAsync` causes the session to be affected before the audio is played. So if you set `duckOthers` for example, any playing audio from another app will be ducked immediately, even before playback begins. Activating the session as we are about to begin playing is the correct way to do this and also deactivating when we have no more active players. iOS automatically handles restoring other affected audio to the settings it had before we interrupted it which is the correct behaviour. 

# Test Plan
Bare-expo
