### PR TITLE
feat(html): improve code font and add svg to the babel transform

### DIFF
--- a/packages/html-elements/CHANGELOG.md
+++ b/packages/html-elements/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Use modern monospace font for web and iOS.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/html-elements/CHANGELOG.md
+++ b/packages/html-elements/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Use modern monospace font for web and iOS.
+- Use modern monospace font for web and iOS. ([#37789](https://github.com/expo/expo/pull/37789) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/html-elements/src/elements/Text.tsx
+++ b/packages/html-elements/src/elements/Text.tsx
@@ -81,7 +81,11 @@ const styles = StyleSheet.create({
     fontStyle: 'italic',
   },
   code: {
-    fontFamily: Platform.select({ default: 'Courier', ios: 'Courier New', android: 'monospace' }),
+    fontFamily: Platform.select({
+      default: `SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace`,
+      ios: 'ui-monospace',
+      android: 'monospace',
+    }),
     fontWeight: '500',
   },
   pre: {

--- a/packages/html-elements/src/elements/__tests__/__snapshots__/Text.test.ios.tsx.snap.ios
+++ b/packages/html-elements/src/elements/__tests__/__snapshots__/Text.test.ios.tsx.snap.ios
@@ -37,7 +37,7 @@ exports[`renders Code 1`] = `
 <Text
   style={
     {
-      "fontFamily": "Courier New",
+      "fontFamily": "ui-monospace",
       "fontWeight": "500",
     }
   }
@@ -108,7 +108,7 @@ exports[`renders Pre 1`] = `
 <Text
   style={
     {
-      "fontFamily": "Courier New",
+      "fontFamily": "ui-monospace",
       "fontWeight": "500",
       "marginVertical": 32,
     }


### PR DESCRIPTION
# Why

- Improve the code font to use the newer iOS font and a more refined web font. 
- SVG is an easy win for automatically transforming.
