### PR TITLE
[image][ios] Speed up displaying local assets.

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Speed up displaying local assets.
 - [Android] Fix animation resuming by casting image to GifDrawable. ([#37363](https://github.com/expo/expo/pull/37363) by [@Wenszel](https://github.com/Wenszel))
 - [Web] Fix `alt` as an alias for `accessibilityLabel` ([#37682](https://github.com/expo/expo/pull/37682) by [@huextrat](https://github.com/huextrat))
 - [iOS] Use specified cache type when no transformation is applied ([#37777](https://github.com/expo/expo/pull/37777) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Speed up displaying local assets.
+- [iOS] Speed up displaying local assets. ([#37795](https://github.com/expo/expo/pull/37795) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Fix animation resuming by casting image to GifDrawable. ([#37363](https://github.com/expo/expo/pull/37363) by [@Wenszel](https://github.com/Wenszel))
 - [Web] Fix `alt` as an alias for `accessibilityLabel` ([#37682](https://github.com/expo/expo/pull/37682) by [@huextrat](https://github.com/huextrat))
 - [iOS] Use specified cache type when no transformation is applied ([#37777](https://github.com/expo/expo/pull/37777) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -12,6 +12,8 @@ typealias SDWebImageContext = [SDWebImageContextOption: Any]
 public final class ImageView: ExpoView {
   static let contextSourceKey = SDWebImageContextOption(rawValue: "source")
   static let screenScaleKey = SDWebImageContextOption(rawValue: "screenScale")
+  static let contentFitKey = SDWebImageContextOption(rawValue: "contentFit")
+  static let frameSizeKey = SDWebImageContextOption(rawValue: "frameSize")
 
   let sdImageView = SDAnimatedImageView(frame: .zero)
 
@@ -171,6 +173,8 @@ public final class ImageView: ExpoView {
 
     // Some loaders (e.g. PhotoLibraryAssetLoader) may need to know the screen scale.
     context[ImageView.screenScaleKey] = screenScale
+    context[ImageView.frameSizeKey] = frame.size
+    context[ImageView.contentFitKey] = contentFit
 
     // Do it here so we don't waste resources trying to fetch from a remote URL
     if maybeRenderLocalAsset(from: source) {

--- a/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
+++ b/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
@@ -107,9 +107,24 @@ private func requestAsset(
     }
   }
 
+  var targetSize = PHImageManagerMaximumSize
+
+  // We compute the minimal size required to display the image to avoid having to downsample it later
+  if let scale = context?[ImageView.screenScaleKey] as? Double,
+     let containerSize = context?[ImageView.frameSizeKey] as? CGSize,
+     let contentFit = context?[ImageView.contentFitKey] as? ContentFit {
+
+    let targetSize = idealSize(
+        contentPixelSize: CGSize(width: asset.pixelWidth, height: asset.pixelHeight),
+        containerSize: containerSize,
+        scale: scale,
+        contentFit: contentFit
+    ).rounded(.up) * scale
+  }
+
   return PHImageManager.default().requestImage(
     for: asset,
-    targetSize: PHImageManagerMaximumSize,
+    targetSize: targetSize,
     contentMode: .aspectFit,
     options: options,
     resultHandler: { image, info in

--- a/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
+++ b/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
@@ -113,7 +113,6 @@ private func requestAsset(
   if let scale = context?[ImageView.screenScaleKey] as? Double,
      let containerSize = context?[ImageView.frameSizeKey] as? CGSize,
      let contentFit = context?[ImageView.contentFitKey] as? ContentFit {
-
     let targetSize = idealSize(
         contentPixelSize: CGSize(width: asset.pixelWidth, height: asset.pixelHeight),
         containerSize: containerSize,

--- a/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
+++ b/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
@@ -114,10 +114,10 @@ private func requestAsset(
     let containerSize = context?[ImageView.frameSizeKey] as? CGSize,
     let contentFit = context?[ImageView.contentFitKey] as? ContentFit {
     let targetSize = idealSize(
-        contentPixelSize: CGSize(width: asset.pixelWidth, height: asset.pixelHeight),
-        containerSize: containerSize,
-        scale: scale,
-        contentFit: contentFit
+      contentPixelSize: CGSize(width: asset.pixelWidth, height: asset.pixelHeight),
+      containerSize: containerSize,
+      scale: scale,
+      contentFit: contentFit
     ).rounded(.up) * scale
   }
 

--- a/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
+++ b/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
@@ -111,8 +111,8 @@ private func requestAsset(
 
   // We compute the minimal size required to display the image to avoid having to downsample it later
   if let scale = context?[ImageView.screenScaleKey] as? Double,
-     let containerSize = context?[ImageView.frameSizeKey] as? CGSize,
-     let contentFit = context?[ImageView.contentFitKey] as? ContentFit {
+    let containerSize = context?[ImageView.frameSizeKey] as? CGSize,
+    let contentFit = context?[ImageView.contentFitKey] as? ContentFit {
     let targetSize = idealSize(
         contentPixelSize: CGSize(width: asset.pixelWidth, height: asset.pixelHeight),
         containerSize: containerSize,


### PR DESCRIPTION
# Why

Fixes a reported issue with gallery apps crashing in ios.

After testing loading ph assets takes up a few gb of memory.

# How

Optimize image loading from the photo library by calculating the ideal target size based on the container dimensions, content fit, and screen scale. This prevents loading unnecessarily large images that would need to be downsampled later.

This mostly repeats what would happen later at a downsampling stage, but avoids loading the entire image into memory and is thus far more efficient.

Tested this works well with resizing and caching.

# Test Plan

Tested in a repro app that this now behaves similarly to RN's Image.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)