### PR TITLE
[expo-image][android] Add generateBlurhashAsync

### DIFF
--- a/apps/native-component-list/src/screens/Image/ImageBlurhash.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageBlurhash.tsx
@@ -1,0 +1,49 @@
+import { StyleSheet, View, Text } from 'react-native';
+import { Image } from 'expo-image';
+import { comparisonImages } from '../../constants/ComparisonImages';
+import { useState } from 'react';
+
+export default function ImageBlurhash() {
+  const image = comparisonImages[0];
+  const [generatedSource, setGeneratedSource] = useState<{ blurhash: string }>();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Image:</Text>
+      <Image
+        source={image.source.uri}
+        style={styles.image}
+        onDisplay={async () => {
+          const blurhash = await Image.generateBlurhashAsync(image.source.uri ?? '', [9, 9]);
+          if (blurhash) {
+            setGeneratedSource({
+              blurhash: blurhash,
+            });
+          }
+        }}
+      />
+      {generatedSource && (
+        <>
+          <Text style={styles.header}>Blurhash image:</Text>
+          <Image source={generatedSource} style={styles.image} />
+          <Text style={styles.header}>Blurhash:</Text>
+          <Text style={styles.image}>{generatedSource.blurhash}</Text>
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  image: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  header: {
+    marginTop: 10,
+    fontWeight: 'bold',
+  },
+});

--- a/apps/native-component-list/src/screens/Image/ImageScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageScreen.tsx
@@ -36,6 +36,13 @@ export const ImageScreens = [
     },
   },
   {
+    name: 'Blurhash',
+    route: 'image/blurhash',
+    getComponent() {
+      return optionalRequire(() => require('./ImageBlurhash'));
+    },
+  },
+  {
     name: 'Image formats',
     route: 'image/formats',
     getComponent() {

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -19,6 +19,7 @@ import com.bumptech.glide.request.target.Target
 import com.github.penfeizhou.animation.apng.APNGDrawable
 import com.github.penfeizhou.animation.gif.GifDrawable
 import com.github.penfeizhou.animation.webp.WebPDrawable
+import expo.modules.image.blurhash.BlurhashEncoder
 import expo.modules.image.enums.ContentFit
 import expo.modules.image.enums.Priority
 import expo.modules.image.records.CachePolicy
@@ -110,6 +111,13 @@ class ExpoImageModule : Module() {
 
     AsyncFunction("loadAsync") Coroutine { source: SourceMap, options: ImageLoadOptions? ->
       ImageLoadTask(appContext, source, options ?: ImageLoadOptions()).load()
+    }
+
+    AsyncFunction("generateBlurhashAsync") { url: String, numberOfComponents: Pair<Int, Int> ->
+      val context = appContext.reactContext ?: throw Exception()
+      val bitmap = Glide.with(context).asBitmap().load(url).submit()
+      val blurHash = BlurhashEncoder.encode(bitmap.get(), numberOfComponents)
+      blurHash
     }
 
     Class(Image::class) {

--- a/packages/expo-image/android/src/main/java/expo/modules/image/blurhash/BlurhashDecoder.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/blurhash/BlurhashDecoder.kt
@@ -74,16 +74,7 @@ object BlurhashDecoder {
     val r = colorEnc shr 16
     val g = (colorEnc shr 8) and 255
     val b = colorEnc and 255
-    return floatArrayOf(srgbToLinear(r), srgbToLinear(g), srgbToLinear(b))
-  }
-
-  private fun srgbToLinear(colorEnc: Int): Float {
-    val v = colorEnc / 255f
-    return if (v <= 0.04045f) {
-      (v / 12.92f)
-    } else {
-      ((v + 0.055f) / 1.055f).pow(2.4f)
-    }
+    return floatArrayOf(BlurhashHelpers.srgbToLinear(r), BlurhashHelpers.srgbToLinear(g), BlurhashHelpers.srgbToLinear(b))
   }
 
   private fun decodeAc(value: Int, maxAc: Float): FloatArray {

--- a/packages/expo-image/android/src/main/java/expo/modules/image/blurhash/BlurhashEncoder.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/blurhash/BlurhashEncoder.kt
@@ -1,0 +1,114 @@
+package expo.modules.image.blurhash
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import kotlin.math.*
+
+/**
+ * Rewritten in kotlin from https://github.com/woltapp/blurhash/blob/master/Swift/BlurHashEncode.swift
+ */
+object BlurhashEncoder {
+  fun encode(image: Bitmap, numberOfComponents: Pair<Int, Int>): String {
+    val pixels = IntArray(image.width * image.height)
+    image.getPixels(pixels, 0, image.width, 0, 0, image.width, image.height)
+
+    val factors = calculateBlurFactors(pixels, image.width, image.height, numberOfComponents)
+
+    val dc = factors.first()
+    val ac = factors.drop(1)
+    val hashBuilder = StringBuilder()
+
+    encodeFlag(numberOfComponents, hashBuilder)
+    val maximumValue = encodeMaximumValue(ac, hashBuilder)
+    hashBuilder.append(encode83(encodeDC(dc), 4))
+    for (factor in ac) {
+      hashBuilder.append(encode83(encodeAC(factor, maximumValue), 2))
+    }
+
+    return hashBuilder.toString()
+  }
+
+  private fun encodeFlag(numberOfComponents: Pair<Int, Int>, hashBuilder: StringBuilder) {
+    val sizeFlag = (numberOfComponents.first - 1) + (numberOfComponents.second - 1) * 9
+    hashBuilder.append(encode83(sizeFlag, 1))
+  }
+
+  private fun encodeMaximumValue(ac: List<Triple<Float, Float, Float>>, hash: StringBuilder): Float {
+    val maximumValue: Float
+    if (ac.isNotEmpty()) {
+      val actualMaximumValue = ac.maxOf { t -> max(max(abs(t.first), abs(t.second)), abs(t.third)) }
+      val quantisedMaximumValue = max(0f, min(82f, floor(actualMaximumValue * 166f - 0.5f))).toInt()
+      maximumValue = (quantisedMaximumValue + 1).toFloat() / 166f
+      hash.append(encode83(quantisedMaximumValue, 1))
+    } else {
+      maximumValue = 1f
+      hash.append(encode83(0, 1))
+    }
+    return maximumValue
+  }
+
+  private fun calculateBlurFactors(pixels: IntArray, width: Int, height: Int, numberOfComponents: Pair<Int, Int>): List<Triple<Float, Float, Float>> {
+    val factors = mutableListOf<Triple<Float, Float, Float>>()
+    for (y in 0 until numberOfComponents.second) {
+      for (x in 0 until numberOfComponents.first) {
+        val normalisation = if (x == 0 && y == 0) 1f else 2f
+        val factor = multiplyBasisFunction(pixels, width, height, x, y, normalisation)
+        factors.add(factor)
+      }
+    }
+    return factors
+  }
+
+  private fun encode83(value: Int, length: Int): String {
+    var result = ""
+    for (i in 1..length) {
+      val digit = (value / 83f.pow((length - i).toFloat())) % 83f
+      result += ENCODE_CHARACTERS[digit.toInt()]
+    }
+    return result
+  }
+
+  private const val ENCODE_CHARACTERS =
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#$%*+,-.:;=?@[]^_{|}~"
+
+  private fun encodeDC(value: Triple<Float, Float, Float>): Int {
+    val roundedR = BlurhashHelpers.linearTosRGB(value.first)
+    val roundedG = BlurhashHelpers.linearTosRGB(value.second)
+    val roundedB = BlurhashHelpers.linearTosRGB(value.third)
+    return (roundedR shl 16) + (roundedG shl 8) + roundedB
+  }
+
+  private fun encodeAC(value: Triple<Float, Float, Float>, maximumValue: Float): Int {
+    val quantR = max(0f, min(18f, floor(BlurhashHelpers.signPow(value.first / maximumValue, 0.5f) * 9f + 9.5f)))
+    val quantG = max(0f, min(18f, floor(BlurhashHelpers.signPow(value.second / maximumValue, 0.5f) * 9f + 9.5f)))
+    val quantB = max(0f, min(18f, floor(BlurhashHelpers.signPow(value.third / maximumValue, 0.5f) * 9f + 9.5f)))
+
+    return (quantR * 19f * 19f + quantG * 19f + quantB).toInt()
+  }
+
+  private fun multiplyBasisFunction(pixels: IntArray, width: Int, height: Int, x: Int, y: Int, normalisation: Float): Triple<Float, Float, Float> {
+    var r = 0f
+    var g = 0f
+    var b = 0f
+
+    for (j in 0 until height) {
+      for (i in 0 until width) {
+        val basis = normalisation *
+          cos(PI.toFloat() * x * i / width) *
+          cos(PI.toFloat() * y * j / height)
+
+        val pixel = pixels[i + j * width]
+        val pr = BlurhashHelpers.srgbToLinear(Color.red(pixel))
+        val pg = BlurhashHelpers.srgbToLinear(Color.green(pixel))
+        val pb = BlurhashHelpers.srgbToLinear(Color.blue(pixel))
+
+        r += basis * pr
+        g += basis * pg
+        b += basis * pb
+      }
+    }
+
+    val scale = 1f / (width * height)
+    return Triple(r * scale, g * scale, b * scale)
+  }
+}

--- a/packages/expo-image/android/src/main/java/expo/modules/image/blurhash/BlurhashHelpers.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/blurhash/BlurhashHelpers.kt
@@ -1,0 +1,38 @@
+package expo.modules.image.blurhash
+
+import android.graphics.Bitmap
+import kotlin.math.*
+
+object BlurhashHelpers {
+  fun srgbToLinear(colorEnc: Int): Float {
+    val v = colorEnc / 255f
+    return if (v <= 0.04045f) {
+      (v / 12.92f)
+    } else {
+      ((v + 0.055f) / 1.055f).pow(2.4f)
+    }
+  }
+
+  fun linearTosRGB(value: Float): Int {
+    val v = max(0f, min(1f, value))
+    return if (v <= 0.0031308) {
+      (v * 12.92 * 255 + 0.5).toInt()
+    } else {
+      (1.055 * (v.pow(1f / 2.4f) - 0.055) * 255 + 0.5).toInt()
+    }
+  }
+
+  fun signPow(value: Float, exp: Float): Float {
+    return abs(value).pow(exp) * sign(value)
+  }
+
+  fun getBitsPerPixel(bitmap: Bitmap): Int {
+    return when (bitmap.config) {
+      Bitmap.Config.ARGB_8888 -> 32
+      Bitmap.Config.RGB_565 -> 16
+      Bitmap.Config.ALPHA_8 -> 8
+      Bitmap.Config.ARGB_4444 -> 16
+      else -> 0
+    }
+  }
+}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
