### PR TITLE
[autolinking][Android] Improve error message when Kotlin version provided by the user is not supported

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed local aar files is not being linked correctly. ([#37280](https://github.com/expo/expo/pull/37280) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Improved erorr message when we don't support Kotlin version provided by the user.
+- [Android] Improved erorr message when we don't support Kotlin version provided by the user. ([#37802](https://github.com/expo/expo/pull/37802) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed local aar files is not being linked correctly. ([#37280](https://github.com/expo/expo/pull/37280) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Improved erorr message when we don't support Kotlin version provided by the user.
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Improves error message when Kotlin version provided by the user is not supported.

# How

This should help users debug problems in their setup.

# Test Plan

- bare-expo ✅ 