### PR TITLE
Update `expo-maps` homepage on package.json

### DIFF
--- a/packages/expo-maps/package.json
+++ b/packages/expo-maps/package.json
@@ -13,7 +13,7 @@
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module"
   },
-  "homepage": "https://docs.expo.dev/versions/latest/sdk/ui/",
+  "homepage": "https://docs.expo.dev/versions/latest/sdk/maps/",
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git",


### PR DESCRIPTION
# Why

This will ensures that `https://npmjs.com/package/expo-maps` is pointing to `https://docs.expo.dev/versions/latest/sdk/maps/`, instead of the UI page

# How

Just fixing the link

# Test Plan

n/a

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
