### PR TITLE
[docs] improve .fingerprintignore doc

### DIFF
--- a/docs/pages/versions/unversioned/sdk/fingerprint.mdx
+++ b/docs/pages/versions/unversioned/sdk/fingerprint.mdx
@@ -6,7 +6,6 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/@expo/fingerprin
 packageName: '@expo/fingerprint'
 iconUrl: '/static/images/packages/expo-fingerprint.png'
 platforms: ['node']
-isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';
@@ -34,17 +33,24 @@ If you wish to use `@expo/fingerprint` as a standalone package, you can install 
 
 ### .fingerprintignore
 
-Placed in your project root, **.fingerprintignore** is a [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format)-like ignore mechanism used to exclude files from hash calculation. It behaves similarly but instead uses `minimatch` for pattern matching which has some [limitations](#options) (see documentation for `ignorePaths` under [Options](#options)).
+Placed in your project root, **.fingerprintignore** is a [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format)-like ignore mechanism used to exclude files from hash calculation. All pattern paths are relative to the project root. It behaves similarly but instead uses `minimatch` for pattern matching which has some [limitations](#options) (see documentation for `ignorePaths` under [Options](#options)).
 
-For example, to skip a folder but keep some files:
+Here is an example **.fingerprintignore** configuration:
 
-```ignore
-# Ignore the entire /app/ios folder
-/app/ios/**/*
+```ignore .fingerprintignore
+# Ignore the entire android directory
+android/**/*
 
-# But still keep /app/ios/Podfile and /app/ios/Podfile.lock
-!/app/ios/Podfile
-!/app/ios/Podfile.lock
+# Ignore the entire ios directory but still keep ios/Podfile and ios/Podfile.lock
+ios/**/*
+!ios/Podfile
+!ios/Podfile.lock
+
+# Ignore specific package in node_modules
+node_modules/some-package/**/*
+
+# Same as above but having broader scope because packages may be nested
+**/node_modules/some-package/**/*
 ```
 
 ### fingerprint.config.js

--- a/docs/pages/versions/v52.0.0/sdk/fingerprint.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/fingerprint.mdx
@@ -34,17 +34,24 @@ If you wish to use `@expo/fingerprint` as a standalone package, you can install 
 
 ### .fingerprintignore
 
-Placed in your project root, **.fingerprintignore** is a [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format)-like ignore mechanism used to exclude files from hash calculation. It behaves similarly but instead uses `minimatch` for pattern matching which has some [limitations](#options) (see documentation for `ignorePaths` under [Options](#options)).
+Placed in your project root, **.fingerprintignore** is a [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format)-like ignore mechanism used to exclude files from hash calculation. All pattern paths are relative to the project root. It behaves similarly but instead uses `minimatch` for pattern matching which has some [limitations](#options) (see documentation for `ignorePaths` under [Options](#options)).
 
-For example, to skip a folder but keep some files:
+Here is an example **.fingerprintignore** configuration:
 
-```ignore
-# Ignore the entire /app/ios folder
-/app/ios/**/*
+```ignore .fingerprintignore
+# Ignore the entire android directory
+android/**/*
 
-# But still keep /app/ios/Podfile and /app/ios/Podfile.lock
-!/app/ios/Podfile
-!/app/ios/Podfile.lock
+# Ignore the entire ios directory but still keep ios/Podfile and ios/Podfile.lock
+ios/**/*
+!ios/Podfile
+!ios/Podfile.lock
+
+# Ignore specific package in node_modules
+node_modules/some-package/**/*
+
+# Same as above but having broader scope because packages may be nested
+**/node_modules/some-package/**/*
 ```
 
 ### fingerprint.config.js

--- a/docs/pages/versions/v53.0.0/sdk/fingerprint.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/fingerprint.mdx
@@ -34,17 +34,24 @@ If you wish to use `@expo/fingerprint` as a standalone package, you can install 
 
 ### .fingerprintignore
 
-Placed in your project root, **.fingerprintignore** is a [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format)-like ignore mechanism used to exclude files from hash calculation. It behaves similarly but instead uses `minimatch` for pattern matching which has some [limitations](#options) (see documentation for `ignorePaths` under [Options](#options)).
+Placed in your project root, **.fingerprintignore** is a [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format)-like ignore mechanism used to exclude files from hash calculation. All pattern paths are relative to the project root. It behaves similarly but instead uses `minimatch` for pattern matching which has some [limitations](#options) (see documentation for `ignorePaths` under [Options](#options)).
 
-For example, to skip a folder but keep some files:
+Here is an example **.fingerprintignore** configuration:
 
-```ignore
-# Ignore the entire /app/ios folder
-/app/ios/**/*
+```ignore .fingerprintignore
+# Ignore the entire android directory
+android/**/*
 
-# But still keep /app/ios/Podfile and /app/ios/Podfile.lock
-!/app/ios/Podfile
-!/app/ios/Podfile.lock
+# Ignore the entire ios directory but still keep ios/Podfile and ios/Podfile.lock
+ios/**/*
+!ios/Podfile
+!ios/Podfile.lock
+
+# Ignore specific package in node_modules
+node_modules/some-package/**/*
+
+# Same as above but having broader scope because packages may be nested
+**/node_modules/some-package/**/*
 ```
 
 ### fingerprint.config.js


### PR DESCRIPTION
# Why

the original **.fingerprintignore** patterns are confusing because they use absolute paths which doesn't work most of time.

# How

- rewrite the example to use relative paths
- also remove the `isNew` for unversioned doc. it's not new.
![Screenshot 2025-07-03 at 12 30 35 PM](https://github.com/user-attachments/assets/baf12e49-3ef6-4114-b24d-7edafbb53e83)


# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
