### PR TITLE
[build-properties] Add `android.buildArchs` option

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Added support for prebuilt React Native iOS dependencies via `ios.buildFromSource: false` in the iOS build properties. When `buildFromSource` is disabled, it sets `ENV['RCT_USE_RN_DEP'] = '1'` in the Podfile to use prebuilt third-party dependencies, as described in the [React Native 0.80 release blog post](https://reactnative.dev/blog/2025/06/12/react-native-0.80#experimental---react-native-ios-dependencies-are-now-prebuilt). ([#37678](https://github.com/expo/expo/pull/37678) by [@huextrat](https://github.com/huextrat))
-- Add `android.reactNativeArchitectures` option ([#37831](https://github.com/expo/expo/pull/37831) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add `android.buildArchs` option to override the default `reactNativeArchitectures` value in gradle.properties ([#37831](https://github.com/expo/expo/pull/37831) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Added support for prebuilt React Native iOS dependencies via `ios.buildFromSource: false` in the iOS build properties. When `buildFromSource` is disabled, it sets `ENV['RCT_USE_RN_DEP'] = '1'` in the Podfile to use prebuilt third-party dependencies, as described in the [React Native 0.80 release blog post](https://reactnative.dev/blog/2025/06/12/react-native-0.80#experimental---react-native-ios-dependencies-are-now-prebuilt). ([#37678](https://github.com/expo/expo/pull/37678) by [@huextrat](https://github.com/huextrat))
+- Add `android.reactNativeArchitectures` option ([#37831](https://github.com/expo/expo/pull/37831) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-build-properties/build/android.js
+++ b/packages/expo-build-properties/build/android.js
@@ -98,6 +98,10 @@ exports.withAndroidBuildProperties = createBuildGradlePropsConfigPlugin([
         propName: 'android.enableBundleCompression',
         propValueGetter: (config) => config.android?.enableBundleCompression?.toString(),
     },
+    {
+        propName: 'reactNativeArchitectures',
+        propValueGetter: (config) => config.android?.reactNativeArchitectures?.join(','),
+    },
 ], 'withAndroidBuildProperties');
 /**
  * Appends `props.android.extraProguardRules` content into `android/app/proguard-rules.pro`

--- a/packages/expo-build-properties/build/android.js
+++ b/packages/expo-build-properties/build/android.js
@@ -100,7 +100,7 @@ exports.withAndroidBuildProperties = createBuildGradlePropsConfigPlugin([
     },
     {
         propName: 'reactNativeArchitectures',
-        propValueGetter: (config) => config.android?.reactNativeArchitectures?.join(','),
+        propValueGetter: (config) => config.android?.buildArchs?.join(','),
     },
 ], 'withAndroidBuildProperties');
 /**

--- a/packages/expo-build-properties/build/pluginConfig.d.ts
+++ b/packages/expo-build-properties/build/pluginConfig.d.ts
@@ -153,6 +153,19 @@ export interface PluginConfigTypeAndroid {
      * @default false
      */
     buildFromSource?: boolean;
+    /**
+     * Override the default `reactNativeArchitectures` value in **gradle.properties**. A list of ABIs to build.
+     *
+     * @see [Android documentation](https://developer.android.com/ndk/guides/abis) for more information.
+     *
+     * @example
+     * ```json
+     * ["arm64-v8a", "x86_64"]
+     * ```
+     *
+     * @default ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
+     */
+    reactNativeArchitectures?: string[];
 }
 /**
  * @platform android

--- a/packages/expo-build-properties/build/pluginConfig.d.ts
+++ b/packages/expo-build-properties/build/pluginConfig.d.ts
@@ -154,7 +154,7 @@ export interface PluginConfigTypeAndroid {
      */
     buildFromSource?: boolean;
     /**
-     * Override the default `reactNativeArchitectures` value in **gradle.properties**. A list of ABIs to build.
+     * Override the default `reactNativeArchitectures` list of ABIs to build in **gradle.properties**.
      *
      * @see [Android documentation](https://developer.android.com/ndk/guides/abis) for more information.
      *
@@ -165,7 +165,7 @@ export interface PluginConfigTypeAndroid {
      *
      * @default ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
      */
-    reactNativeArchitectures?: string[];
+    buildArchs?: string[];
 }
 /**
  * @platform android

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -138,6 +138,7 @@ const schema = {
                 },
                 enableBundleCompression: { type: 'boolean', nullable: true },
                 buildFromSource: { type: 'boolean', nullable: true },
+                reactNativeArchitectures: { type: 'array', items: { type: 'string' }, nullable: true },
             },
             nullable: true,
         },

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -138,7 +138,7 @@ const schema = {
                 },
                 enableBundleCompression: { type: 'boolean', nullable: true },
                 buildFromSource: { type: 'boolean', nullable: true },
-                reactNativeArchitectures: { type: 'array', items: { type: 'string' }, nullable: true },
+                buildArchs: { type: 'array', items: { type: 'string' }, nullable: true },
             },
             nullable: true,
         },

--- a/packages/expo-build-properties/src/__tests__/withBuildProperties-test.ts
+++ b/packages/expo-build-properties/src/__tests__/withBuildProperties-test.ts
@@ -229,9 +229,9 @@ describe(withBuildProperties, () => {
     });
   });
 
-  it('generates the reactNativeArchitectures property', async () => {
+  it('generates the android.buildArchs property', async () => {
     const pluginProps: PluginConfigType = {
-      android: { reactNativeArchitectures: ['armeabi-v7a', 'arm64-v8a'] },
+      android: { buildArchs: ['armeabi-v7a', 'arm64-v8a'] },
     };
 
     const { modResults: androidModResults } = await compileMockModWithResultsAsync<

--- a/packages/expo-build-properties/src/__tests__/withBuildProperties-test.ts
+++ b/packages/expo-build-properties/src/__tests__/withBuildProperties-test.ts
@@ -228,4 +228,28 @@ describe(withBuildProperties, () => {
       'ios.buildFromSource': 'true',
     });
   });
+
+  it('generates the reactNativeArchitectures property', async () => {
+    const pluginProps: PluginConfigType = {
+      android: { reactNativeArchitectures: ['armeabi-v7a', 'arm64-v8a'] },
+    };
+
+    const { modResults: androidModResults } = await compileMockModWithResultsAsync<
+      AndroidConfig.Properties.PropertiesItem[],
+      PluginConfigType
+    >(
+      {},
+      {
+        plugin: withBuildProperties,
+        pluginProps,
+        mod: withGradleProperties,
+        modResults: [],
+      }
+    );
+    expect(androidModResults).toContainEqual({
+      type: 'property',
+      key: 'reactNativeArchitectures',
+      value: 'armeabi-v7a,arm64-v8a',
+    });
+  });
 });

--- a/packages/expo-build-properties/src/android.ts
+++ b/packages/expo-build-properties/src/android.ts
@@ -109,6 +109,10 @@ export const withAndroidBuildProperties = createBuildGradlePropsConfigPlugin<Plu
       propName: 'android.enableBundleCompression',
       propValueGetter: (config) => config.android?.enableBundleCompression?.toString(),
     },
+    {
+      propName: 'reactNativeArchitectures',
+      propValueGetter: (config) => config.android?.reactNativeArchitectures?.join(','),
+    },
   ],
   'withAndroidBuildProperties'
 );

--- a/packages/expo-build-properties/src/android.ts
+++ b/packages/expo-build-properties/src/android.ts
@@ -111,7 +111,7 @@ export const withAndroidBuildProperties = createBuildGradlePropsConfigPlugin<Plu
     },
     {
       propName: 'reactNativeArchitectures',
-      propValueGetter: (config) => config.android?.reactNativeArchitectures?.join(','),
+      propValueGetter: (config) => config.android?.buildArchs?.join(','),
     },
   ],
   'withAndroidBuildProperties'

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -180,7 +180,7 @@ export interface PluginConfigTypeAndroid {
    */
   buildFromSource?: boolean;
   /**
-   * Override the default `reactNativeArchitectures` value in **gradle.properties**. A list of ABIs to build.
+   * Override the default `reactNativeArchitectures` list of ABIs to build in **gradle.properties**.
    *
    * @see [Android documentation](https://developer.android.com/ndk/guides/abis) for more information.
    *
@@ -191,7 +191,7 @@ export interface PluginConfigTypeAndroid {
    *
    * @default ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
    */
-  reactNativeArchitectures?: string[];
+  buildArchs?: string[];
 }
 
 // @docsMissing
@@ -671,7 +671,7 @@ const schema: JSONSchemaType<PluginConfigType> = {
         },
         enableBundleCompression: { type: 'boolean', nullable: true },
         buildFromSource: { type: 'boolean', nullable: true },
-        reactNativeArchitectures: { type: 'array', items: { type: 'string' }, nullable: true },
+        buildArchs: { type: 'array', items: { type: 'string' }, nullable: true },
       },
       nullable: true,
     },

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -179,6 +179,19 @@ export interface PluginConfigTypeAndroid {
    * @default false
    */
   buildFromSource?: boolean;
+  /**
+   * Override the default `reactNativeArchitectures` value in **gradle.properties**. A list of ABIs to build.
+   *
+   * @see [Android documentation](https://developer.android.com/ndk/guides/abis) for more information.
+   *
+   * @example
+   * ```json
+   * ["arm64-v8a", "x86_64"]
+   * ```
+   *
+   * @default ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
+   */
+  reactNativeArchitectures?: string[];
 }
 
 // @docsMissing
@@ -658,6 +671,7 @@ const schema: JSONSchemaType<PluginConfigType> = {
         },
         enableBundleCompression: { type: 'boolean', nullable: true },
         buildFromSource: { type: 'boolean', nullable: true },
+        reactNativeArchitectures: { type: 'array', items: { type: 'string' }, nullable: true },
       },
       nullable: true,
     },


### PR DESCRIPTION
# Why

Closes ENG-16331

# How

Add support for customizing Android's `reactNativeArchitectures` gradle property 


# Test Plan

Added tests and ran prebuild inside `sandbox` with and without the `reactNativeArchitectures` option



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
