### PR TITLE
[github] Update macOS build workflow trigger to include all supported packages

### DIFF
--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -10,15 +10,21 @@ on:
       - packages/expo-asset/**
       - packages/expo-constants/**
       - packages/expo-crypto/**
+      - packages/expo-eas-client/**
       - packages/expo-file-system/**
       - packages/expo-font/**
       - packages/expo-keep-awake/**
       - packages/expo-linking/**
       - packages/expo-local-authentication/**
+      - packages/expo-manifests/**
       - packages/expo-mesh-gradient/**
       - packages/expo-modules-autolinking/**
       - packages/expo-modules-core/**
       - packages/expo-sqlite/**
+      - packages/expo-structured-headers/**
+      - packages/expo-updates/**
+      - packages/expo-updates-interface/**
+      - packages/expo-web-browser/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION

# Why

Now that we've added support for more macOS libraries, we need to update `pull_request.paths` in test-suite-macos to prevent breaking macOS compatibility 

# How

Update macOS build workflow trigger to include missing macOS-supported packages

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
