### PR TITLE
feat(router-e2e): Fast CSS-Modules Refresh E2E Coverage

### DIFF
--- a/apps/router-e2e/__e2e__/fast-refresh/app/FastRefresh.module.css
+++ b/apps/router-e2e/__e2e__/fast-refresh/app/FastRefresh.module.css
@@ -1,0 +1,13 @@
+.container {
+    background-color: #888;
+    padding: 10px;
+    margin-top: auto;
+}
+
+.test {
+    color: red;
+}
+
+.green {
+    color: green;
+}

--- a/apps/router-e2e/__e2e__/fast-refresh/app/_layout.tsx
+++ b/apps/router-e2e/__e2e__/fast-refresh/app/_layout.tsx
@@ -21,7 +21,14 @@ export default function Layout() {
       <Head>
         <meta name="expo-nested-layout" content={layoutValue} />
       </Head>
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <View
+        style={{
+          width: '100%',
+          height: '100%',
+          maxWidth: 320,
+          marginLeft: 'auto',
+          marginRight: 'auto',
+        }}>
         <Text testID="layout-value">{layoutValue}</Text>
         <Tabs />
       </View>

--- a/apps/router-e2e/__e2e__/fast-refresh/app/index.tsx
+++ b/apps/router-e2e/__e2e__/fast-refresh/app/index.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { Button, Text } from 'react-native';
+import { Button, Text, View } from 'react-native';
+
+// @ts-expect-error - CSS module is not typed in our test environment
+import styles, { unstable_styles } from './FastRefresh.module.css';
 
 export default function Page() {
   const [index, setIndex] = React.useState(0);
@@ -11,6 +14,11 @@ export default function Page() {
       <Button testID="index-increment" onPress={() => setIndex((i) => i + 1)} title="increment" />
       <Text testID="index-count">{index}</Text>
       <Text testID="index-text">{input}</Text>
+      <View style={unstable_styles.container} testID="css-module-container">
+        <p className={styles.test} data-testid="css-module">
+          CSS Module
+        </p>
+      </View>
     </>
   );
 }

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Bumped `playwright` version to 1.53.1. ([#37631](https://github.com/expo/expo/pull/37631) by [@kudo](https://github.com/kudo))
 - Use Vaul for modals and sheets on web with a custom stack ([#37767](https://github.com/expo/expo/pull/37767) by [@hirbod](https://github.com/hirbod))
 - fix web back/forward buttons ([#37747](https://github.com/expo/expo/pull/37747) by [@Ubax](https://github.com/Ubax))
+- Added CSS-Modules Fast Refresh E2E Coverage ([#37845](https://github.com/expo/expo/pull/37845) by [@hirbod](https://github.com/hirbod))
 
 ### ⚠️ Notices
 


### PR DESCRIPTION
# Why

Fast-refresh tests didn’t cover CSS-Module style updates, so regressions could slip through.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Added a CSS module (FastRefresh.module.css) to the existing fast-refresh test
- Updated the sample page to use these styles and added new test ids
- Extended fast-refresh.test.ts with two new Playwright tests:
  - Edit CSS file (red → blue) and assert style change + state preservation.
  - Swap className (styles.test → styles.green) and assert new color + state preservation.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

```bash
playwright test e2e/playwright/dev/fast-refresh.test.ts --ui
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
