### PR TITLE
[image-picker][ios]: Enhance image reading logic to prioritize cropped images and improve orientation handling

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Prevent external applications from accessing the CropImageActivity ([#37223](https://github.com/expo/expo/pull/37223) by [@aladine](https://github.com/aladine))
 - [Web] Corrected camera capture attributes on web where front camera was using 'environment' and back camera was using 'user'. Reversed the values to ensure proper camera selection. ([#37447](https://github.com/expo/expo/pull/37447) by [@hirbod](https://github.com/hirbod))
+- [ios]: Enhance image reading logic to prioritize cropped images and improve orientation handling ([#37846](https://github.com/expo/expo/pull/37846) by [@hirbod](https://github.com/hirbod))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Images whose EXIF orientation ≠ `.up` (e.g. TIFF data saved with “.jpg”) were cropped incorrectly when `allowsEditing = true`, because we  
1. rotated the original bitmap first (`fixOrientation()`), then  
2. applied the `cropRect` that is defined in the *pre-rotation* coordinate space.  

This mismatch offset the crop and produced visibly wrong results.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

`readImageFrom(...)` now:

1. **Fast-path** – if the picker supplies `info[.editedImage]` (always true after the system crop UI):
   • return that image and just call `fixOrientation()` to normalize metadata.
   → We reuse UIKit’s already-cropped, already-oriented bitmap.

2. **Fallback** – when `.editedImage` isn’t available (edge cases):
   • take `.originalImage`,
   • apply `cropRect` *before* any rotation,
   • then run `fixOrientation()`.

No other behaviour changes; APIs and outputs stay the same, but crops are now correct across all formats and orientations. Editing should be faster too, as we skip a few calls in the fast-path.

Fixes #37810

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

bare-expo, a bunch of image files, and some modified files with different extensions

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
