### PR TITLE
[expo] fix delay load crash on android 10

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
+- Fixed NPE of `onWindowFocusChanged` on Android 10. ([#37819](https://github.com/expo/expo/pull/37819) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -470,6 +470,15 @@ class ReactActivityDelegateWrapper(
     }
   }
 
+  /**
+   * Set the [loadAppReady] to completed state.
+   * This is only for unit tests when a test setups mocks and skips the [Activity] lifecycle.
+   */
+  @VisibleForTesting
+  internal fun setLoadAppReadyForTesting() {
+    loadAppReady.complete(Unit)
+  }
+
   //endregion
 
   companion object {

--- a/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperDelayLoadTest.kt
+++ b/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperDelayLoadTest.kt
@@ -135,7 +135,7 @@ internal class ReactActivityDelegateWrapperDelayLoadTest {
     verify(exactly = 0) { spyDelegate.onResume() }
 
     callbackSlot.captured.run()
-    verify(exactly = 2) { spyDelegateWrapper.onResume() }
+    verify(exactly = 1) { spyDelegateWrapper.onResume() }
     verify(exactly = 1) { spyDelegate.onResume() }
     verify(exactly = 0) { spyDelegateWrapper.onPause() }
     verify(exactly = 0) { spyDelegateWrapper.onDestroy() }

--- a/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperTest.kt
+++ b/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperTest.kt
@@ -20,9 +20,9 @@ import org.junit.Before
 import org.junit.Test
 
 internal class ReactActivityDelegateWrapperTest {
-  lateinit var mockPackage0: MockPackage
+  private lateinit var mockPackage0: MockPackage
 
-  lateinit var mockPackage1: MockPackage
+  private lateinit var mockPackage1: MockPackage
 
   @RelaxedMockK
   lateinit var activity: ReactActivity
@@ -47,6 +47,7 @@ internal class ReactActivityDelegateWrapperTest {
   @Test
   fun `onBackPressed should call each handler's callback just once`() {
     val delegateWrapper = ReactActivityDelegateWrapper(activity, delegate)
+    delegateWrapper.setLoadAppReadyForTesting()
     every { mockPackage0.reactActivityLifecycleListener.onBackPressed() } returns true
 
     delegateWrapper.onBackPressed()
@@ -59,6 +60,7 @@ internal class ReactActivityDelegateWrapperTest {
   @Test
   fun `onBackPressed should return true if someone returns true`() {
     val delegateWrapper = ReactActivityDelegateWrapper(activity, delegate)
+    delegateWrapper.setLoadAppReadyForTesting()
     every { mockPackage0.reactActivityLifecycleListener.onBackPressed() } returns false
     every { mockPackage1.reactActivityLifecycleListener.onBackPressed() } returns true
     every { delegate.onBackPressed() } returns false
@@ -71,6 +73,7 @@ internal class ReactActivityDelegateWrapperTest {
   fun `onNewIntent should call each handler's callback just once`() {
     val intent = mockk<Intent>()
     val delegateWrapper = ReactActivityDelegateWrapper(activity, delegate)
+    delegateWrapper.setLoadAppReadyForTesting()
     every { mockPackage0.reactActivityLifecycleListener.onNewIntent(intent) } returns false
     every { mockPackage1.reactActivityLifecycleListener.onNewIntent(intent) } returns true
     every { delegate.onNewIntent(intent) } returns false
@@ -86,6 +89,7 @@ internal class ReactActivityDelegateWrapperTest {
   fun `onNewIntent should return true if someone returns true`() {
     val intent = mockk<Intent>()
     val delegateWrapper = ReactActivityDelegateWrapper(activity, delegate)
+    delegateWrapper.setLoadAppReadyForTesting()
     every { mockPackage0.reactActivityLifecycleListener.onNewIntent(intent) } returns false
     every { mockPackage1.reactActivityLifecycleListener.onNewIntent(intent) } returns true
     every { delegate.onNewIntent(intent) } returns false
@@ -97,7 +101,7 @@ internal class ReactActivityDelegateWrapperTest {
 
 internal class MockPackage : Package {
   val reactActivityLifecycleListener = mockk<ReactActivityLifecycleListener>(relaxed = true)
-  val reactActivityHandler = mockk<ReactActivityHandler>(relaxed = true)
+  private val reactActivityHandler = mockk<ReactActivityHandler>(relaxed = true)
 
   override fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener> {
     return listOf(reactActivityLifecycleListener)


### PR DESCRIPTION
# Why

fixes #37819

# How

- on android 10, some callbacks like `onWindowFocusChanged` are called on early stage before the delay app loading ready. we should queue its event like `onResume`. this pr tries to use a coroutine to queue most event calls by a `CompletableDeferred`.
- some callbacks with synchronous return value, like `onKeyDown` are not queued. they return false when `loadAppReady` is not ready. the behavior aligns react-native: when react instance is not ready. it returns false.

# Test Plan

- tested repro from https://github.com/huextrat/expo-android-10-crash on android 10 emulator
- ci passed (especially **ReactActivityDelegateWrapperDelayLoadTest**)

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
