### PR TITLE
[image-picker][android] fix:  Adjust video metadata extraction to account for rotation

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Prevent external applications from accessing the CropImageActivity ([#37223](https://github.com/expo/expo/pull/37223) by [@aladine](https://github.com/aladine))
 - [Web] Corrected camera capture attributes on web where front camera was using 'environment' and back camera was using 'user'. Reversed the values to ensure proper camera selection. ([#37447](https://github.com/expo/expo/pull/37447) by [@hirbod](https://github.com/hirbod))
 - [ios]: Enhance image reading logic to prioritize cropped images and improve orientation handling ([#37846](https://github.com/expo/expo/pull/37846) by [@hirbod](https://github.com/hirbod))
+- [android] Adjust video metadata extraction to account for rotation ([#37849](https://github.com/expo/expo/pull/37849) by [@hirbod](https://github.com/hirbod))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/MediaHandler.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/MediaHandler.kt
@@ -101,16 +101,32 @@ internal class MediaHandler(
       val fileData = getAdditionalFileData(sourceUri)
       val mimeType = getType(context.contentResolver, sourceUri)
 
+      // Extract basic metadata
+      var width = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)
+      var height = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)
+      val rotation = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)
+
+      // Android returns the encoded width/height which do not take the display rotation into
+      // account. For videos recorded in portrait mode the encoded dimensions are often landscape
+      // (e.g. 1920x1080) paired with a 90°/270° rotation flag.  iOS adjusts these values before
+      // reporting them, so to keep the behaviour consistent across platforms we swap the width
+      // and height when the rotation indicates the video should be displayed in portrait.
+      if (rotation % 180 != 0) {
+        val tmp = width
+        width = height
+        height = tmp
+      }
+
       return ImagePickerAsset(
         type = MediaType.VIDEO,
         uri = outputUri.toString(),
-        width = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH),
-        height = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT),
+        width = width,
+        height = height,
         fileName = fileData?.fileName,
         fileSize = fileData?.fileSize,
         mimeType = mimeType,
         duration = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_DURATION),
-        rotation = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION),
+        rotation = rotation,
         assetId = sourceUri.getMediaStoreAssetId()
       )
     } catch (cause: FailedToExtractVideoMetadataException) {

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/MediaHandler.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/MediaHandler.kt
@@ -112,9 +112,7 @@ internal class MediaHandler(
       // reporting them, so to keep the behaviour consistent across platforms we swap the width
       // and height when the rotation indicates the video should be displayed in portrait.
       if (rotation % 180 != 0) {
-        val tmp = width
-        width = height
-        height = tmp
+        width = height.also { height = width }
       }
 
       return ImagePickerAsset(


### PR DESCRIPTION
# Why

MediaMetadataRetriever reports the encoded frame size, which is often landscape (e.g. 1920 × 1080) even for portrait clips that are meant to be displayed with a 90°/270° rotation flag.
  - iOS, on the other hand, derives the size from AVAssetTrack.naturalSize.applying(preferredTransform) which already compensates for rotation, so it returns 1080 × 1920 for the same file.
  - Therefore when rotation % 180 ≠ 0 the width/height values must be swapped to be semantically consistent with iOS and with what developers expect to see.


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Updated MediaHandler to extract video width and height while considering the rotation metadata.
- Ensured consistent behavior across platforms by swapping width and height for portrait videos.

Fixes #37657

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

bare-expo and 6-7 different video files, and the repro file

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
