### PR TITLE
Cleanup `isStartSamplingProfilerOnInit` needed for 0.81

### DIFF
--- a/packages/expo-dev-menu/android/src/main/java/com/facebook/react/devsupport/DevMenuSettingsBase.kt
+++ b/packages/expo-dev-menu/android/src/main/java/com/facebook/react/devsupport/DevMenuSettingsBase.kt
@@ -33,7 +33,7 @@ abstract class DevMenuSettingsBase(
   override var isJSMinifyEnabled: Boolean = mPreferences.getBoolean("js_minify_debug", false)
 
   override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
-    if (this.listener != null && ("fps_debug" == key || "js_dev_mode_debug" == key || "start_sampling_profiler_on_init" == key || "js_minify_debug" == key)) {
+    if (this.listener != null && ("fps_debug" == key || "js_dev_mode_debug" == key || "js_minify_debug" == key)) {
       listener.onInternalSettingsChanged()
     }
   }
@@ -53,9 +53,6 @@ abstract class DevMenuSettingsBase(
     set(remoteJSDebugEnabled) {
       mPreferences.edit().putBoolean("remote_js_debug", remoteJSDebugEnabled).apply()
     }
-
-  override var isStartSamplingProfilerOnInit: Boolean =
-    mPreferences.getBoolean("start_sampling_profiler_on_init", false)
 
   override fun addMenuItem(title: String) {
   }


### PR DESCRIPTION
# Why

See:
- https://github.com/facebook/react-native/pull/52405

This is needed when you eventually integrate Expo with React Native 0.81

# How

CI will be red till you folks integrate with 0.81 I suppose.
Feel free to cherry-pick this commit on a different branch if needed.

# Test Plan

CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
