### PR TITLE
[tools] Make the publish script recommend patch on SDK branches.

### DIFF
--- a/tools/src/publish-packages/helpers.ts
+++ b/tools/src/publish-packages/helpers.ts
@@ -242,7 +242,9 @@ export async function resolveReleaseTypeAndVersion(parcel: Parcel, options: Comm
   } else if (sdkBranch != null) {
     state.releaseType = ReleaseType.PATCH;
     if (highestReleaseType !== ReleaseType.PATCH) {
-      explainer = `Based on changes made in this package, it should normally be released as ${highestReleaseType}, but when releasing from an SDK branch (currently ${sdkBranch}) a patch bump is recommended instead.`;
+      explainer = chalk.dim(
+        `Based on changes made in this package, it should normally be released as ${chalk.blue(highestReleaseType)}, but when releasing from an SDK branch (currently ${chalk.blue(sdkBranch)}) a ${chalk.blue('patch')} bump is recommended instead.`
+      );
     }
   } else {
     // Set the release type depending on changes made in the package.

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -55,7 +55,7 @@ export const prepareCanaries = new Task<TaskArgs>(
       const { pkg, state, pkgView } = parcel;
       const baseVersion = SDK_CONSTRAINED_PACKAGES.includes(pkg.packageName)
         ? nextSdkVersion
-        : resolveReleaseTypeAndVersion(parcel, options);
+        : await resolveReleaseTypeAndVersion(parcel, options);
 
       // Strip any pre-release tag from the baseVersion
       // For example, convert "5.0.0-rc.0" or "5.0.0-preview.0" to "5.0.0"

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -55,7 +55,7 @@ export const prepareCanaries = new Task<TaskArgs>(
       const { pkg, state, pkgView } = parcel;
       const baseVersion = SDK_CONSTRAINED_PACKAGES.includes(pkg.packageName)
         ? nextSdkVersion
-        : await resolveReleaseTypeAndVersion(parcel, options);
+        : (await resolveReleaseTypeAndVersion(parcel, options)).releaseVersion;
 
       // Strip any pre-release tag from the baseVersion
       // For example, convert "5.0.0-rc.0" or "5.0.0-preview.0" to "5.0.0"

--- a/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
+++ b/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
@@ -131,7 +131,7 @@ async function promptToPublishParcel(
     {
       type: 'list',
       name: 'action',
-      message: `Do you want to publish ${green.bold(packageName)} as ${cyan.bold(releaseVersion)}?${explainer ? ` ${explainer}` : ''}`,
+      message: `Do you want to publish ${green.bold(packageName)} as ${cyan.bold(releaseVersion)}?${explainer ? `\n${explainer}` : ''}`,
       choices,
       default: lastAction || 'yes',
     },

--- a/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
+++ b/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
@@ -97,7 +97,7 @@ async function promptToPublishParcel(
 ): Promise<boolean | 'back' | 'skip'> {
   const customVersionId = 'custom-version';
   const packageName = parcel.pkg.packageName;
-  const releaseVersion = resolveReleaseTypeAndVersion(parcel, options);
+  const releaseVersion = await resolveReleaseTypeAndVersion(parcel, options);
 
   if (process.env.CI) {
     parcel.state.releaseVersion = releaseVersion;

--- a/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
+++ b/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
@@ -97,7 +97,7 @@ async function promptToPublishParcel(
 ): Promise<boolean | 'back' | 'skip'> {
   const customVersionId = 'custom-version';
   const packageName = parcel.pkg.packageName;
-  const releaseVersion = await resolveReleaseTypeAndVersion(parcel, options);
+  const { releaseVersion, explainer } = await resolveReleaseTypeAndVersion(parcel, options);
 
   if (process.env.CI) {
     parcel.state.releaseVersion = releaseVersion;
@@ -131,7 +131,7 @@ async function promptToPublishParcel(
     {
       type: 'list',
       name: 'action',
-      message: `Do you want to publish ${green.bold(packageName)} as ${cyan.bold(releaseVersion)}?`,
+      message: `Do you want to publish ${green.bold(packageName)} as ${cyan.bold(releaseVersion)}?${explainer ? ` ${explainer}` : ''}`,
       choices,
       default: lastAction || 'yes',
     },


### PR DESCRIPTION
# Why

When publishing from sdk branches, it's safer to publish new package versions as PATCH, even if these changes were listed as new features in changelogs. It's not strictly semver compliant, but publishing minors has it's own problems (dependencies don't get automatically bumped, so we need to immediately publish all packages that pull in the new minor – if we omit some it causes dependency conflicts, we also need to update version endpoints).

# How

By checking the sdk version during version recomendation and suggesting patch releases if on sdk-XX branch.

# Test Plan

Tested by pulling in a "new feature" change to sdk branch and dry publishing with this commit and without.

Without:
```
expo-mesh-gradient, current version 0.3.4
Do you want to publish expo-mesh-gradient as 0.4.0?
```

With:
```
expo-mesh-gradient, current version 0.3.4
Do you want to publish expo-mesh-gradient as 0.3.5?
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
