### PR TITLE
[launcher][Android] Add `AsyncImage` component

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/primitives/Asyncimage.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/primitives/Asyncimage.kt
@@ -1,0 +1,40 @@
+package expo.modules.devlauncher.compose.primitives
+
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import expo.modules.devlauncher.services.ImageLoaderService
+import expo.modules.devlauncher.services.inject
+import kotlinx.coroutines.launch
+
+@Composable
+fun AsyncImage(
+  url: String
+) {
+  val imageLoaderService = inject<ImageLoaderService>()
+  val scope = rememberCoroutineScope()
+  var imageBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
+
+  LaunchedEffect(url) {
+    scope.launch {
+      val image = imageLoaderService.loadImage(url)
+      if (image != null) {
+        imageBitmap = image.asImageBitmap()
+      }
+    }
+  }
+
+  imageBitmap?.let {
+    Image(
+      bitmap = it,
+      contentDescription = url
+    )
+  }
+}

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/DependencyInjection.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/DependencyInjection.kt
@@ -1,6 +1,7 @@
 package expo.modules.devlauncher.services
 
 import android.content.Context
+import androidx.compose.runtime.Composable
 import androidx.lifecycle.ViewModel
 
 /**
@@ -9,6 +10,12 @@ import androidx.lifecycle.ViewModel
  */
 object DependencyInjection {
   var wasInitialized: Boolean = false
+    private set
+
+  var httpClientService: HttpClientService? = null
+    private set
+
+  var imageLoaderService: ImageLoaderService? = null
     private set
 
   var sessionService: SessionService? = null
@@ -24,6 +31,15 @@ object DependencyInjection {
 
     wasInitialized = true
 
+    val httpClient = HttpClientService()
+
+    httpClientService = httpClient
+
+    imageLoaderService = ImageLoaderService(
+      context = context.applicationContext,
+      httpClientService = httpClient
+    )
+
     val apolloClient = ApolloClientService()
 
     apolloClientService = apolloClient
@@ -35,11 +51,22 @@ object DependencyInjection {
   }
 }
 
-@Suppress("UNCHECKED_CAST")
-inline fun <reified T> ViewModel.inject(): T {
+@PublishedApi
+internal inline fun <reified T> injectService(): T {
   return when (T::class) {
     SessionService::class -> DependencyInjection.sessionService
     ApolloClientService::class -> DependencyInjection.apolloClientService
+    ImageLoaderService::class -> DependencyInjection.imageLoaderService
+    HttpClientService::class -> DependencyInjection.httpClientService
     else -> throw IllegalArgumentException("Unknown service type: ${T::class}")
   } as T
+}
+
+inline fun <reified T> ViewModel.inject(): T {
+  return injectService<T>()
+}
+
+@Composable
+inline fun <reified T> inject(): T {
+  return injectService<T>()
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/HttpClientService.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/HttpClientService.kt
@@ -1,0 +1,9 @@
+package expo.modules.devlauncher.services
+
+import okhttp3.OkHttpClient
+
+class HttpClientService {
+  val httpClient = OkHttpClient
+    .Builder()
+    .build()
+}

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/ImageLoaderService.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/ImageLoaderService.kt
@@ -1,0 +1,69 @@
+package expo.modules.devlauncher.services
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.webkit.URLUtil
+import expo.modules.devlauncher.helpers.await
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Request
+import java.io.File
+import java.io.FileOutputStream
+
+class ImageLoaderService(
+  context: Context,
+  private val httpClientService: HttpClientService
+) {
+  private val imageDirector = context
+    .cacheDir
+    .resolve(".expo-dev-launcher")
+    .apply {
+      if (!exists()) {
+        mkdirs()
+      }
+    }
+
+  suspend fun loadImage(url: String): Bitmap? = withContext(Dispatchers.IO) {
+    val fileName = URLUtil.guessFileName(url, null, null)
+    val imageFile = imageDirector.resolve(fileName)
+    if (imageFile.exists()) {
+      return@withContext loadFromFile(imageFile)
+    }
+
+    if (downloadImage(url, imageFile)) {
+      return@withContext loadFromFile(imageFile)
+    }
+
+    return@withContext null
+  }
+
+  private fun loadFromFile(file: File): Bitmap {
+    return BitmapFactory.decodeFile(file.path)
+  }
+
+  private suspend fun downloadImage(url: String, to: File): Boolean {
+    val request = Request
+      .Builder()
+      .url(url)
+      .build()
+
+    val response = request.await(httpClientService.httpClient)
+    if (!response.isSuccessful) {
+      return false
+    }
+
+    val responseBody = response.body
+    if (responseBody == null) {
+      return false
+    }
+
+    responseBody.byteStream().use { inputStream ->
+      FileOutputStream(to).use { outputStream ->
+        inputStream.copyTo(outputStream)
+      }
+    }
+
+    return true
+  }
+}


### PR DESCRIPTION
# Why

Adds basic `AsyncImage` component.
I don't want to include coil or glide as a dependency, so I decided to implement a simple image loading service with disk cache. It's a very basic implementation, but should be sufficient for our use case. 	

# Test Plan

- bare-expo ✅ 