### PR TITLE
[build-properties] Add android.exclusiveMavenMirror option

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added support for prebuilt React Native iOS dependencies via `ios.buildFromSource: false` in the iOS build properties. When `buildFromSource` is disabled, it sets `ENV['RCT_USE_RN_DEP'] = '1'` in the Podfile to use prebuilt third-party dependencies, as described in the [React Native 0.80 release blog post](https://reactnative.dev/blog/2025/06/12/react-native-0.80#experimental---react-native-ios-dependencies-are-now-prebuilt). ([#37678](https://github.com/expo/expo/pull/37678) by [@huextrat](https://github.com/huextrat))
 - Add `android.buildArchs` option to override the default `reactNativeArchitectures` value in gradle.properties ([#37831](https://github.com/expo/expo/pull/37831) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add support for setting Android's exclusiveMavenMirror gradle property ([#37864](https://github.com/expo/expo/pull/37864) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-build-properties/build/android.js
+++ b/packages/expo-build-properties/build/android.js
@@ -102,6 +102,10 @@ exports.withAndroidBuildProperties = createBuildGradlePropsConfigPlugin([
         propName: 'reactNativeArchitectures',
         propValueGetter: (config) => config.android?.buildArchs?.join(','),
     },
+    {
+        propName: 'exclusiveEnterpriseRepository',
+        propValueGetter: (config) => config.android?.exclusiveMavenMirror,
+    },
 ], 'withAndroidBuildProperties');
 /**
  * Appends `props.android.extraProguardRules` content into `android/app/proguard-rules.pro`

--- a/packages/expo-build-properties/build/pluginConfig.d.ts
+++ b/packages/expo-build-properties/build/pluginConfig.d.ts
@@ -166,6 +166,13 @@ export interface PluginConfigTypeAndroid {
      * @default ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
      */
     buildArchs?: string[];
+    /**
+     * Specifies a single Maven repository to be used as an exclusive mirror for all dependency resolution.
+     * When set, all other Maven repositories will be ignored and only this repository will be used to fetch dependencies.
+     *
+     * @see [Using a Maven Mirror](https://reactnative.dev/docs/build-speed#using-a-maven-mirror-android-only)
+     */
+    exclusiveMavenMirror?: string;
 }
 /**
  * @platform android

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -139,6 +139,7 @@ const schema = {
                 enableBundleCompression: { type: 'boolean', nullable: true },
                 buildFromSource: { type: 'boolean', nullable: true },
                 buildArchs: { type: 'array', items: { type: 'string' }, nullable: true },
+                exclusiveEnterpriseRepository: { type: 'string', nullable: true },
             },
             nullable: true,
         },

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -139,7 +139,7 @@ const schema = {
                 enableBundleCompression: { type: 'boolean', nullable: true },
                 buildFromSource: { type: 'boolean', nullable: true },
                 buildArchs: { type: 'array', items: { type: 'string' }, nullable: true },
-                exclusiveEnterpriseRepository: { type: 'string', nullable: true },
+                exclusiveMavenMirror: { type: 'string', nullable: true },
             },
             nullable: true,
         },

--- a/packages/expo-build-properties/src/__tests__/withBuildProperties-test.ts
+++ b/packages/expo-build-properties/src/__tests__/withBuildProperties-test.ts
@@ -252,4 +252,28 @@ describe(withBuildProperties, () => {
       value: 'armeabi-v7a,arm64-v8a',
     });
   });
+
+  it('generates the android.exclusiveMavenMirror property', async () => {
+    const pluginProps: PluginConfigType = {
+      android: { exclusiveMavenMirror: 'https://my.internal.proxy.net/' },
+    };
+
+    const { modResults: androidModResults } = await compileMockModWithResultsAsync<
+      AndroidConfig.Properties.PropertiesItem[],
+      PluginConfigType
+    >(
+      {},
+      {
+        plugin: withBuildProperties,
+        pluginProps,
+        mod: withGradleProperties,
+        modResults: [],
+      }
+    );
+    expect(androidModResults).toContainEqual({
+      type: 'property',
+      key: 'exclusiveEnterpriseRepository',
+      value: 'https://my.internal.proxy.net/',
+    });
+  });
 });

--- a/packages/expo-build-properties/src/android.ts
+++ b/packages/expo-build-properties/src/android.ts
@@ -113,6 +113,10 @@ export const withAndroidBuildProperties = createBuildGradlePropsConfigPlugin<Plu
       propName: 'reactNativeArchitectures',
       propValueGetter: (config) => config.android?.buildArchs?.join(','),
     },
+    {
+      propName: 'exclusiveEnterpriseRepository',
+      propValueGetter: (config) => config.android?.exclusiveMavenMirror,
+    },
   ],
   'withAndroidBuildProperties'
 );

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -192,6 +192,13 @@ export interface PluginConfigTypeAndroid {
    * @default ["armeabi-v7a", "arm64-v8a", "x86", "x86_64"]
    */
   buildArchs?: string[];
+  /**
+   * Specifies a single Maven repository to be used as an exclusive mirror for all dependency resolution.
+   * When set, all other Maven repositories will be ignored and only this repository will be used to fetch dependencies.
+   *
+   * @see [Using a Maven Mirror](https://reactnative.dev/docs/build-speed#using-a-maven-mirror-android-only)
+   */
+  exclusiveMavenMirror?: string;
 }
 
 // @docsMissing
@@ -672,6 +679,7 @@ const schema: JSONSchemaType<PluginConfigType> = {
         enableBundleCompression: { type: 'boolean', nullable: true },
         buildFromSource: { type: 'boolean', nullable: true },
         buildArchs: { type: 'array', items: { type: 'string' }, nullable: true },
+        exclusiveMavenMirror: { type: 'string', nullable: true },
       },
       nullable: true,
     },


### PR DESCRIPTION
# Why

https://github.com/facebook/react-native/pull/52378 introduced a new gradle property called `exclusiveEnterpriseRepository`, allowing users to remove all the existing Maven repositories and only use the specified internal mirror. We should support customizing it through expo-build-properties

# How

Add support for setting Android's exclusiveMavenMirror gradle property

# Test Plan

Added tests and ran prebuild inside sandbox with and without the exclusiveMavenMirror option

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
