### PR TITLE
Fix expo-constants version mismatch

### DIFF
--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -48,7 +48,7 @@
     "assert": "^2.0.0",
     "badgin": "^1.1.5",
     "expo-application": "~6.1.4",
-    "expo-constants": "~17.1.6"
+    "expo-constants": "~17.1.7"
   },
   "devDependencies": {
     "expo-module-scripts": "^4.1.7",


### PR DESCRIPTION
# Why
Fixes #37867 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
