### PR TITLE
[docs] fixed example of local android building for production

### DIFF
--- a/docs/public/static/diffs/android-release-build.diff
+++ b/docs/public/static/diffs/android-release-build.diff
@@ -17,10 +17,12 @@ index c50bf0c..8dd1626 100644
      }
      buildTypes {
          debug {
+             signingConfig signingConfigs.debug
+         }
+         release {
 @@ -110,6 +118,7 @@ android {
              // Caution! In production, you need to generate your own keystore file.
              // see https://reactnative.dev/docs/signed-apk-android.
-             signingConfig signingConfigs.debug
 +            signingConfig signingConfigs.release
              shrinkResources (findProperty('android.enableShrinkResourcesInReleaseBuilds')?.toBoolean() ?: false)
              minifyEnabled enableProguardInReleaseBuilds


### PR DESCRIPTION
# Why

I followed guide (https://docs.expo.dev/guides/local-app-production/) to build the app localy, but when I uploaded the `.aab` file to Google Play Console, I received an error stating that the file needs to be signed using the release signature.

# How

I fixed a small issue in the example section where you need to specify the signature configuration.

# Test Plan

Before:

<img width="1308" alt="Screenshot 2025-07-06 at 17 37 23" src="https://github.com/user-attachments/assets/7669c414-5491-4450-ac2b-27366bdb7ff6" />

After:

<img width="1307" alt="Screenshot 2025-07-06 at 17 37 53" src="https://github.com/user-attachments/assets/f5ac5e9b-d77b-4951-b443-c93fe565df34" />


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
