### PR TITLE
[docs] Added docs for deep link handling with conflicting scheme

### DIFF
--- a/docs/pages/linking/into-your-app.mdx
+++ b/docs/pages/linking/into-your-app.mdx
@@ -27,7 +27,9 @@ To provide a link to your app, add a custom string to the [`scheme`](/versions/l
 
 After adding a custom scheme to your app, you need to [create a new development build](/develop/development-builds/create-a-build/). Once the app is installed on a device, you can open links within your app using `myapp://`.
 
-If the **custom scheme is not defined**, the app will use `android.package` and `ios.bundleIdentifier` as the default schemes in both development and production builds. This is because [Expo Prebuild](/workflow/prebuild/) automatically adds these properties as custom schemes for Android and iOS.
+If the **custom scheme is not defined**, the app will use `android.package` and `ios.bundleIdentifier` as the default schemes in both development and production builds. This is because [Expo Prebuild](/workflow/prebuild/) automatically adds these properties as custom schemes for Android and iOS. To avoid this, uninstall Expo Go or any other conflicting apps so only your development build handles the deep link.
+
+> **Tip:** You might encounter a “Select an app to open this link” prompt if multiple apps on your device are registered for the same deep link scheme (for example, both Expo Go and your custom development build). To avoid this, uninstall other apps that use the same scheme so your app can handle the link automatically.
 
 ## Test the deep link
 


### PR DESCRIPTION
# Why
When a user installs both Expo Go and a custom development build with the same deep link scheme, they may see a system prompt asking which app to use to open the link. This behavior is confusing for developers testing deep linking. Adding a tip in the documentation helps clarify why this happens and how to address it.


# How
Added a documentation tip explaining that if the “Select an app to open this link” prompt appears, it is because multiple apps are registered for the same scheme. The note advises uninstalling other apps using the same scheme so the link resolves automatically. This provides more predictable behavior when testing deep linking in a development build.


# Test Plan
Verified the change by running yarn dev to preview the updated documentation. Confirmed the tip displays correctly and follows Expo’s style guidelines.

# Checklist
- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
