### PR TITLE
[ios][core] Bump to swift 5.9

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -4183,83 +4183,83 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  BenchmarkingModule: 9e58a2f29c4fdd9a07d97ef766ce7fd7edb7c287
+  BenchmarkingModule: 0f4a9e453d7a5e94d1b97b3bffd5c8e8e1ad873d
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EASClient: 81d62c389f7385bee733cd028f3aeb0b700bc900
-  EXApplication: b28de982d44768fc593de9d19ca5a7a0e49685b1
+  EASClient: cca4fa0bf58b32a99476e9d9f80cbeebcb57df90
+  EXApplication: 2da4660569e086f4f18722758b52d7e7792631ab
   EXAV: 0809cbb31eba2111d5413f2dbb547ba9727478ee
-  EXConstants: be238322d57d084dc055dbd5d6fe6479510504ce
+  EXConstants: 72e8e04dc4d7d97c74a618d44753ea4a7437a2b6
   EXImageLoader: ab4fcf9240cf3636a83c00e3fc5229d692899428
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: 18dc175e0df41ce726d456dc13489e60e6a742a3
+  EXManifests: bf76658edfbfa3e3fb67f940ade98d7803490789
   EXNotifications: f0f1c97d04f06c51ea073d7b2396431e5611c1ea
   Expo: 449fa5f24115c93d2573a8f012ace3187e3b02a5
   expo-dev-client: b32e7e9c0a420a5256e38b12e8eebbf14a7031ed
   expo-dev-launcher: 4c8515fc532ea0926817c5b4fdc6b9a19b42363e
   expo-dev-menu: 547f393e5fbcd62bb2f8357998af38d697fa1b98
   expo-dev-menu-interface: 609c35ae8b97479cdd4c9e23c8cf6adc44beea0e
-  ExpoAppleAuthentication: 7e358fcbcbacb7685cddb0bbeede0acd677e58f6
-  ExpoAsset: 3ea3275cca6a7793b3d36fbf1075c590f803fbcb
-  ExpoAudio: 58670fa530972e56145c4f26dee8bc39416ed78b
+  ExpoAppleAuthentication: 69a48d4633024124a33fda650dba706c216d6c76
+  ExpoAsset: b5bfc6425d1e9a09e8e1368646b98fe5ae7ed074
+  ExpoAudio: f6bcc6868e643e6fa74b6e20fd7d20ecc89b4e28
   ExpoBackgroundFetch: 76c48b3cd9a4ee46e5267614a30fac804de6f33e
   ExpoBackgroundTask: 9296d983f3d612359419e015ded65ebe9de30ba2
-  ExpoBattery: 2bdb40a8943dae1cbab23ccaaab09d0cc78de0ae
+  ExpoBattery: 6229d981d12dffb00c9e8e48181162729febb541
   ExpoBlur: 5d95f7ca771a0f3b9618466525dd68e46dc95f3a
   ExpoBrightness: 05e750736f8886dcf235212b0caf85b0f605fc88
   ExpoCalendar: 660542dc1c5ef98f46bedcc8745aa707df5d501a
   ExpoCamera: e88fc30631e63e5504ce19d52c563a6ec49e17d2
-  ExpoCellular: 040f1a7a3dc3a6f573f2b077a7911bdbe3aeb923
-  ExpoClipboard: c187b3101e5f38cce4c6321788e0047f1c29e152
+  ExpoCellular: 9310e19e8052da7d861b31450e46b1db4821b20c
+  ExpoClipboard: 77842a5542aa7ad5dcd9cc03d34442b1b2d857ea
   ExpoContacts: 870a98e359ee83ab9fa15eee40c66d15731747a8
-  ExpoCrypto: fc94a8865ce0e06c68c10c3993f9ac9a6424d0c2
-  ExpoDevice: 7a961caede6638aa0d37d0d3aa884ab957a2e3d3
-  ExpoDocumentPicker: d1bb0c63fc686a74455bd7c2cd54545fa6231b66
-  ExpoDomWebView: d97348ddd1e1981e30f052d58a4bcb7bfbb737f5
-  ExpoFileSystem: 3a98ca2a6f13674ecfd97327d1b44a8ace444cbd
-  ExpoFont: 312c73403bbd4f98e1d6a5330641a56292583cd2
+  ExpoCrypto: d79e7fb137efb093a9c144974d7a165009a1b11f
+  ExpoDevice: 3a4e4dc5cca31c1c731731cf11717dc3f7fff211
+  ExpoDocumentPicker: 0b9848ccbb414d27491a478a013ea9d434613d84
+  ExpoDomWebView: 290738a4948cf54d58a70191f31aedce6113a9a6
+  ExpoFileSystem: 3ee0f53b719c928eb179fc67467f89ffce4472ed
+  ExpoFont: 370a9897880ac279fbd4e478dede18ec4f723d1a
   ExpoGL: 8f7f43291e400621ef9aeb7af347816c2051ddc7
-  ExpoHaptics: 68c215e070f660e0a29c45dcda4f60eeff08aefb
-  ExpoImage: 23fd11d3f2c4b04dc0b5e97fb41e9ead278bd0c8
-  ExpoImageManipulator: 094b748056f2654d5d7813370c910e20ef3d79b4
-  ExpoImagePicker: d2fff488a0738343a3cc21e98544ee9feafaa0e6
-  ExpoInsights: 58e0fb0aa39cabc674cf950942d241903fc94406
-  ExpoKeepAwake: e8dedc115d9f6f24b153ccd2d1d8efcdfd68a527
-  ExpoLinearGradient: 42e58f6db5ebc20b6fbbf7d31013264644ab12a4
+  ExpoHaptics: 581bbb680c566b8afef68fd50f1efb883972b150
+  ExpoImage: 736d4bf4e14437d0e0c7dafdd3aa169c17d447a7
+  ExpoImageManipulator: 8d088059bf4f6287edb451925cc280b0d12b7627
+  ExpoImagePicker: 235489a513df4c70c402f2a49a47fdd94053d63d
+  ExpoInsights: 657d71d1bef38f0b832cfc9c8ea0dde28068dbfd
+  ExpoKeepAwake: 95037f8576ba678db79cbf558b933400c81997a7
+  ExpoLinearGradient: 110244a240361e3351756225e5fcc4c6c07f5431
   ExpoLinking: 5d151d4a497d7e375308602f0a89b4e8acf7b5f8
-  ExpoLivePhoto: b47b0598f335a979749ec76d4b3e5a4f9fa84150
-  ExpoLocalAuthentication: fd8b38cdb709f6c327995668223529763619a5c6
-  ExpoLocalization: 7cd94f24bc3ff2f263cb4258fe1e86a97bc1ea64
+  ExpoLivePhoto: e2d46bcd19046da559d4a690244382ad1c6bd699
+  ExpoLocalAuthentication: def09053225f6395574fbff9b385ff707a870f2b
+  ExpoLocalization: 3d73d7d77ec4277b533cbc19b74ac0f009151985
   ExpoLocation: afc197fce1045ac7325f095b0c149308e1653aab
-  ExpoMailComposer: e0340cff1246b9c9c493f9a0f9549d92c53d7950
-  ExpoMaps: f7f4cd0a94ca57eed995a4b749f757f2c716a5fe
+  ExpoMailComposer: 502cb45610367987f741db89ad5e1e45497b52b0
+  ExpoMaps: 11e31ba05d35cefd551731b18d3cb8703f715727
   ExpoMediaLibrary: ad61cd80ca07da02be3d676e3d9b04b311a82c2c
-  ExpoMeshGradient: ee97f0bfd80356910ca4fc2b67663ea0d9e14a41
-  ExpoModulesCore: 0b7a0299baa6c8de3b9331869d61df3e7c2f5e0f
-  ExpoModulesTestCore: c87ba2da38070e3483a3049453a4dc898b972eb2
+  ExpoMeshGradient: d0c68837d2abe38a7ed9b9c800f084be0f03ed1b
+  ExpoModulesCore: 07e528408e8a9c8328788b80e88c50ab3fada70a
+  ExpoModulesTestCore: eb1c0976fd260b9b56f1224c4508522e3acd3e03
   ExpoNetwork: 9fdbef259f313a1ba7ede5fa977ee3dfed6fe653
-  ExpoPrint: 187f43f5d16bc8db93fb6609707ed40b8e90d3a6
-  ExpoScreenCapture: 4de83d2f4e377a60ac246548212fa3cb91863a90
-  ExpoScreenOrientation: c0ea1650e8e1959b855711f6674cd570e5928c8b
-  ExpoSecureStore: 3148869ad24ab94f9e0c5777c7941d7a37d60399
-  ExpoSensors: a997847b03472f79eabb7989446088bd8f791657
-  ExpoSharing: 04b346bdd7c8ea1fa87047ac7bba65c37bde4f51
-  ExpoSMS: de195632beeb7ef00556750da10da667596d8967
-  ExpoSpeech: fceabf6bf31aa9530ef0696e6793571edb702068
+  ExpoPrint: ad01049aadc3a5315afc95e483548d8cce4192d1
+  ExpoScreenCapture: dc8bd55d68fac61ae677c1cc31fa1bc1f6c6913e
+  ExpoScreenOrientation: 1bc5cc538bfebf7578429439fdb8e957681dab42
+  ExpoSecureStore: b2b179bc106f683f7a1ce61a46dd2dce6a6c715f
+  ExpoSensors: 391133ad6430712d61a7797454ae326e0e8755e0
+  ExpoSharing: 4390db7ff14bc5db4d41879d529d729230204f91
+  ExpoSMS: 78241dca635906b6aefcfa9d3d2e499b7fa8d05f
+  ExpoSpeech: f7b35627d6665edec6580144d8070316b261eea6
   ExpoSplashScreen: c39151354ff0fa6d0f5e7dde07a234abd5550e69
   ExpoSQLite: c092c9454ad72ba09e29c494470a4fe41996f741
-  ExpoStoreReview: bed43bea90a5876a6a480504f95fea1521dacaa7
-  ExpoSymbols: b5dbeee7d8d901d15016d4084a7096b64644e3bb
-  ExpoSystemUI: 5ae7571742a69d0fc29145b6512f53879a3f42e5
-  ExpoTrackingTransparency: 843029c42d70de59bb0503f6fc747b9d2fe67f7b
-  ExpoUI: 4a03c3af5dd55144c788dfa3370bd244c21645ec
-  ExpoVideo: 54ce43735b4ceb6b3828e3eec3b750b0fe10314c
-  ExpoVideoThumbnails: 4280333bee3bd4d69b3b139bd50a8b7c967095ae
-  ExpoWebBrowser: 8aa522ab60113768d4dc5691c36d3315cc3b297b
+  ExpoStoreReview: d8004651736a31ed37cb69e4799d0f18fd6e362b
+  ExpoSymbols: c5fd6904f2adda427e4a5ac1a4cbad060dec6f53
+  ExpoSystemUI: b9294916cc916a704d21c8bb745d6e27871fdbb7
+  ExpoTrackingTransparency: 37880a2e6f317c938f1b50cd05c094571e317ba5
+  ExpoUI: 3aa8b32e10230a7b2aca7b3e8199f4e2461c3267
+  ExpoVideo: 0e9cd59d0bd301e0f33a8fa7b0e3f1a497f60f81
+  ExpoVideoThumbnails: 1381bba1a0ef61c80d6f3eae6e0ffcc198de648b
+  ExpoWebBrowser: 41dc1db6ed9185a3b80a9f917ba3c62dafd22eec
   EXStructuredHeaders: 1c799cb91e8057e0671610635e5b2109fa295114
   EXTaskManager: 0128b9f39a088b0c762d8d1c42017e6d44200b29
-  EXUpdates: 4050ade8f457ff720be67180430f85a4e5d95e2a
-  EXUpdatesInterface: b941371be742ef272f2fa7d6f46ee9fdf8c73c60
+  EXUpdates: 90ae8de78856383eec69dba4b30149e195a9f2bd
+  EXUpdatesInterface: d6c802a2d1d11867523d03a95397957f9ba3d1c7
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 09f03e4b6f42f955734b64a118f86509cc719427
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd

--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingModule.podspec
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingModule.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1',
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4047,73 +4047,73 @@ SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EASClient: 81d62c389f7385bee733cd028f3aeb0b700bc900
-  EXApplication: b28de982d44768fc593de9d19ca5a7a0e49685b1
+  EASClient: cca4fa0bf58b32a99476e9d9f80cbeebcb57df90
+  EXApplication: 2da4660569e086f4f18722758b52d7e7792631ab
   EXAV: 0809cbb31eba2111d5413f2dbb547ba9727478ee
-  EXConstants: be238322d57d084dc055dbd5d6fe6479510504ce
+  EXConstants: 72e8e04dc4d7d97c74a618d44753ea4a7437a2b6
   EXImageLoader: ab4fcf9240cf3636a83c00e3fc5229d692899428
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: 18dc175e0df41ce726d456dc13489e60e6a742a3
+  EXManifests: bf76658edfbfa3e3fb67f940ade98d7803490789
   EXNotifications: f0f1c97d04f06c51ea073d7b2396431e5611c1ea
   Expo: 449fa5f24115c93d2573a8f012ace3187e3b02a5
-  ExpoAppleAuthentication: 7e358fcbcbacb7685cddb0bbeede0acd677e58f6
-  ExpoAsset: 3ea3275cca6a7793b3d36fbf1075c590f803fbcb
-  ExpoAudio: 58670fa530972e56145c4f26dee8bc39416ed78b
+  ExpoAppleAuthentication: 69a48d4633024124a33fda650dba706c216d6c76
+  ExpoAsset: b5bfc6425d1e9a09e8e1368646b98fe5ae7ed074
+  ExpoAudio: f6bcc6868e643e6fa74b6e20fd7d20ecc89b4e28
   ExpoBackgroundFetch: 76c48b3cd9a4ee46e5267614a30fac804de6f33e
   ExpoBackgroundTask: 9296d983f3d612359419e015ded65ebe9de30ba2
-  ExpoBattery: 2bdb40a8943dae1cbab23ccaaab09d0cc78de0ae
+  ExpoBattery: 6229d981d12dffb00c9e8e48181162729febb541
   ExpoBlur: 5d95f7ca771a0f3b9618466525dd68e46dc95f3a
   ExpoBrightness: 05e750736f8886dcf235212b0caf85b0f605fc88
   ExpoCalendar: 660542dc1c5ef98f46bedcc8745aa707df5d501a
   ExpoCamera: e88fc30631e63e5504ce19d52c563a6ec49e17d2
-  ExpoCellular: 040f1a7a3dc3a6f573f2b077a7911bdbe3aeb923
-  ExpoClipboard: c187b3101e5f38cce4c6321788e0047f1c29e152
+  ExpoCellular: 9310e19e8052da7d861b31450e46b1db4821b20c
+  ExpoClipboard: 77842a5542aa7ad5dcd9cc03d34442b1b2d857ea
   ExpoContacts: 870a98e359ee83ab9fa15eee40c66d15731747a8
-  ExpoCrypto: fc94a8865ce0e06c68c10c3993f9ac9a6424d0c2
-  ExpoDevice: 7a961caede6638aa0d37d0d3aa884ab957a2e3d3
-  ExpoDocumentPicker: d1bb0c63fc686a74455bd7c2cd54545fa6231b66
-  ExpoDomWebView: d97348ddd1e1981e30f052d58a4bcb7bfbb737f5
-  ExpoFileSystem: 3a98ca2a6f13674ecfd97327d1b44a8ace444cbd
-  ExpoFont: 312c73403bbd4f98e1d6a5330641a56292583cd2
+  ExpoCrypto: d79e7fb137efb093a9c144974d7a165009a1b11f
+  ExpoDevice: 3a4e4dc5cca31c1c731731cf11717dc3f7fff211
+  ExpoDocumentPicker: 0b9848ccbb414d27491a478a013ea9d434613d84
+  ExpoDomWebView: 290738a4948cf54d58a70191f31aedce6113a9a6
+  ExpoFileSystem: 3ee0f53b719c928eb179fc67467f89ffce4472ed
+  ExpoFont: 370a9897880ac279fbd4e478dede18ec4f723d1a
   ExpoGL: 8f7f43291e400621ef9aeb7af347816c2051ddc7
-  ExpoHaptics: 68c215e070f660e0a29c45dcda4f60eeff08aefb
-  ExpoHead: 0383e7f76b7b7047a03efd200619b9b972bbfb86
-  ExpoImage: 23fd11d3f2c4b04dc0b5e97fb41e9ead278bd0c8
-  ExpoImageManipulator: 094b748056f2654d5d7813370c910e20ef3d79b4
-  ExpoImagePicker: d2fff488a0738343a3cc21e98544ee9feafaa0e6
-  ExpoKeepAwake: e8dedc115d9f6f24b153ccd2d1d8efcdfd68a527
-  ExpoLinearGradient: 42e58f6db5ebc20b6fbbf7d31013264644ab12a4
+  ExpoHaptics: 581bbb680c566b8afef68fd50f1efb883972b150
+  ExpoHead: f96648632e137de2488710fc32d12bb886dd6c97
+  ExpoImage: 736d4bf4e14437d0e0c7dafdd3aa169c17d447a7
+  ExpoImageManipulator: 8d088059bf4f6287edb451925cc280b0d12b7627
+  ExpoImagePicker: 235489a513df4c70c402f2a49a47fdd94053d63d
+  ExpoKeepAwake: 95037f8576ba678db79cbf558b933400c81997a7
+  ExpoLinearGradient: 110244a240361e3351756225e5fcc4c6c07f5431
   ExpoLinking: 5d151d4a497d7e375308602f0a89b4e8acf7b5f8
-  ExpoLivePhoto: b47b0598f335a979749ec76d4b3e5a4f9fa84150
-  ExpoLocalAuthentication: fd8b38cdb709f6c327995668223529763619a5c6
-  ExpoLocalization: 7cd94f24bc3ff2f263cb4258fe1e86a97bc1ea64
+  ExpoLivePhoto: e2d46bcd19046da559d4a690244382ad1c6bd699
+  ExpoLocalAuthentication: def09053225f6395574fbff9b385ff707a870f2b
+  ExpoLocalization: 3d73d7d77ec4277b533cbc19b74ac0f009151985
   ExpoLocation: afc197fce1045ac7325f095b0c149308e1653aab
-  ExpoMailComposer: e0340cff1246b9c9c493f9a0f9549d92c53d7950
+  ExpoMailComposer: 502cb45610367987f741db89ad5e1e45497b52b0
   ExpoMediaLibrary: ad61cd80ca07da02be3d676e3d9b04b311a82c2c
-  ExpoMeshGradient: ee97f0bfd80356910ca4fc2b67663ea0d9e14a41
-  ExpoModulesCore: 0b7a0299baa6c8de3b9331869d61df3e7c2f5e0f
-  ExpoModulesTestCore: c87ba2da38070e3483a3049453a4dc898b972eb2
+  ExpoMeshGradient: d0c68837d2abe38a7ed9b9c800f084be0f03ed1b
+  ExpoModulesCore: 07e528408e8a9c8328788b80e88c50ab3fada70a
+  ExpoModulesTestCore: eb1c0976fd260b9b56f1224c4508522e3acd3e03
   ExpoNetwork: 9fdbef259f313a1ba7ede5fa977ee3dfed6fe653
-  ExpoPrint: 187f43f5d16bc8db93fb6609707ed40b8e90d3a6
-  ExpoScreenCapture: 4de83d2f4e377a60ac246548212fa3cb91863a90
-  ExpoScreenOrientation: c0ea1650e8e1959b855711f6674cd570e5928c8b
-  ExpoSecureStore: 3148869ad24ab94f9e0c5777c7941d7a37d60399
-  ExpoSensors: a997847b03472f79eabb7989446088bd8f791657
-  ExpoSharing: 04b346bdd7c8ea1fa87047ac7bba65c37bde4f51
-  ExpoSMS: de195632beeb7ef00556750da10da667596d8967
-  ExpoSpeech: fceabf6bf31aa9530ef0696e6793571edb702068
+  ExpoPrint: ad01049aadc3a5315afc95e483548d8cce4192d1
+  ExpoScreenCapture: dc8bd55d68fac61ae677c1cc31fa1bc1f6c6913e
+  ExpoScreenOrientation: 1bc5cc538bfebf7578429439fdb8e957681dab42
+  ExpoSecureStore: b2b179bc106f683f7a1ce61a46dd2dce6a6c715f
+  ExpoSensors: 391133ad6430712d61a7797454ae326e0e8755e0
+  ExpoSharing: 4390db7ff14bc5db4d41879d529d729230204f91
+  ExpoSMS: 78241dca635906b6aefcfa9d3d2e499b7fa8d05f
+  ExpoSpeech: f7b35627d6665edec6580144d8070316b261eea6
   ExpoSQLite: c092c9454ad72ba09e29c494470a4fe41996f741
-  ExpoStoreReview: bed43bea90a5876a6a480504f95fea1521dacaa7
-  ExpoSymbols: b5dbeee7d8d901d15016d4084a7096b64644e3bb
-  ExpoSystemUI: 5ae7571742a69d0fc29145b6512f53879a3f42e5
-  ExpoTrackingTransparency: 843029c42d70de59bb0503f6fc747b9d2fe67f7b
-  ExpoVideo: 54ce43735b4ceb6b3828e3eec3b750b0fe10314c
-  ExpoVideoThumbnails: 4280333bee3bd4d69b3b139bd50a8b7c967095ae
-  ExpoWebBrowser: 8aa522ab60113768d4dc5691c36d3315cc3b297b
+  ExpoStoreReview: d8004651736a31ed37cb69e4799d0f18fd6e362b
+  ExpoSymbols: c5fd6904f2adda427e4a5ac1a4cbad060dec6f53
+  ExpoSystemUI: b9294916cc916a704d21c8bb745d6e27871fdbb7
+  ExpoTrackingTransparency: 37880a2e6f317c938f1b50cd05c094571e317ba5
+  ExpoVideo: 0e9cd59d0bd301e0f33a8fa7b0e3f1a497f60f81
+  ExpoVideoThumbnails: 1381bba1a0ef61c80d6f3eae6e0ffcc198de648b
+  ExpoWebBrowser: 41dc1db6ed9185a3b80a9f917ba3c62dafd22eec
   EXStructuredHeaders: 1c799cb91e8057e0671610635e5b2109fa295114
   EXTaskManager: 0128b9f39a088b0c762d8d1c42017e6d44200b29
-  EXUpdates: 81d596f00b284d0541ce45e690329d9a4c6ab2ae
-  EXUpdatesInterface: b941371be742ef272f2fa7d6f46ee9fdf8c73c60
+  EXUpdates: a8427b57ecd860a4391ee838c73903e76055f3f7
+  EXUpdatesInterface: d6c802a2d1d11867523d03a95397957f9ba3d1c7
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 09f03e4b6f42f955734b64a118f86509cc719427
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
@@ -4131,7 +4131,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 66cb589c7fa7f501251dd11ff307fa6ac73309c4
+  hermes-engine: a3ec960e841e867d0c120fb8722d1bad078789e9
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8

--- a/packages/@expo/dom-webview/ios/ExpoDomWebView.podspec
+++ b/packages/@expo/dom-webview/ios/ExpoDomWebView.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms       = {
     :ios => '15.1',
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
   s.dependency 'ExpoModulesCore'

--- a/packages/expo-apple-authentication/ios/ExpoAppleAuthentication.podspec
+++ b/packages/expo-apple-authentication/ios/ExpoAppleAuthentication.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-application/ios/EXApplication.podspec
+++ b/packages/expo-application/ios/EXApplication.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-asset/ios/ExpoAsset.podspec
+++ b/packages/expo-asset/ios/ExpoAsset.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     :osx => '11.0',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-audio/ios/ExpoAudio.podspec
+++ b/packages/expo-audio/ios/ExpoAudio.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-battery/ios/ExpoBattery.podspec
+++ b/packages/expo-battery/ios/ExpoBattery.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-cellular/ios/ExpoCellular.podspec
+++ b/packages/expo-cellular/ios/ExpoCellular.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-clipboard/ios/ExpoClipboard.podspec
+++ b/packages/expo-clipboard/ios/ExpoClipboard.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-constants/ios/EXConstants.podspec
+++ b/packages/expo-constants/ios/EXConstants.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     :osx => '11.0',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-crypto/ios/ExpoCrypto.podspec
+++ b/packages/expo-crypto/ios/ExpoCrypto.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     :tvos => '15.1',
     :osx => '11.0'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-device/ios/ExpoDevice.podspec
+++ b/packages/expo-device/ios/ExpoDevice.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-document-picker/ios/ExpoDocumentPicker.podspec
+++ b/packages/expo-document-picker/ios/ExpoDocumentPicker.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-eas-client/ios/EASClient.podspec
+++ b/packages/expo-eas-client/ios/EASClient.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     :tvos => '15.1',
     :osx => '11.0'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: '' }
   s.static_framework = true
 

--- a/packages/expo-file-system/ios/ExpoFileSystem.podspec
+++ b/packages/expo-file-system/ios/ExpoFileSystem.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     :osx => '11.0',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { :git => 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-font/ios/ExpoFont.podspec
+++ b/packages/expo-font/ios/ExpoFont.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     :osx => '11.0',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-haptics/ios/ExpoHaptics.podspec
+++ b/packages/expo-haptics/ios/ExpoHaptics.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-image-manipulator/ios/ExpoImageManipulator.podspec
+++ b/packages/expo-image-manipulator/ios/ExpoImageManipulator.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-image-picker/ios/ExpoImagePicker.podspec
+++ b/packages/expo-image-picker/ios/ExpoImagePicker.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-image/ios/ExpoImage.podspec
+++ b/packages/expo-image/ios/ExpoImage.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-insights/ios/ExpoInsights.podspec
+++ b/packages/expo-insights/ios/ExpoInsights.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-keep-awake/ios/ExpoKeepAwake.podspec
+++ b/packages/expo-keep-awake/ios/ExpoKeepAwake.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     :osx => '11.0',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-linear-gradient/ios/ExpoLinearGradient.podspec
+++ b/packages/expo-linear-gradient/ios/ExpoLinearGradient.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-live-photo/ios/ExpoLivePhoto.podspec
+++ b/packages/expo-live-photo/ios/ExpoLivePhoto.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1',
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-local-authentication/ios/ExpoLocalAuthentication.podspec
+++ b/packages/expo-local-authentication/ios/ExpoLocalAuthentication.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :osx => '11.0'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-localization/ios/ExpoLocalization.podspec
+++ b/packages/expo-localization/ios/ExpoLocalization.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-mail-composer/ios/ExpoMailComposer.podspec
+++ b/packages/expo-mail-composer/ios/ExpoMailComposer.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-manifests/ios/EXManifests.podspec
+++ b/packages/expo-manifests/ios/EXManifests.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     :tvos => '15.1',
     :osx => '11.0'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-mesh-gradient/ios/ExpoMeshGradient.podspec
+++ b/packages/expo-mesh-gradient/ios/ExpoMeshGradient.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     :tvos => '15.1',
     :osx => '11.0',
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-module-template/ios/{%- project.name %}.podspec
+++ b/packages/expo-module-template/ios/{%- project.name %}.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: '<%- repo %>' }
   s.static_framework = true
 

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -55,7 +55,7 @@ Pod::Spec.new do |s|
     :osx => '11.0',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
   s.header_dir     = 'ExpoModulesCore'

--- a/packages/expo-modules-test-core/ios/ExpoModulesTestCore.podspec
+++ b/packages/expo-modules-test-core/ios/ExpoModulesTestCore.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
   s.header_dir     = 'ExpoModulesTestCore'

--- a/packages/expo-print/ios/ExpoPrint.podspec
+++ b/packages/expo-print/ios/ExpoPrint.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   }
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
 
   s.dependency 'ExpoModulesCore'
 

--- a/packages/expo-router/ios/ExpoHead.podspec
+++ b/packages/expo-router/ios/ExpoHead.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-screen-capture/ios/ExpoScreenCapture.podspec
+++ b/packages/expo-screen-capture/ios/ExpoScreenCapture.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-screen-orientation/ios/ExpoScreenOrientation.podspec
+++ b/packages/expo-screen-orientation/ios/ExpoScreenOrientation.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-secure-store/ios/ExpoSecureStore.podspec
+++ b/packages/expo-secure-store/ios/ExpoSecureStore.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :tvos => '15.1',
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-sensors/ios/ExpoSensors.podspec
+++ b/packages/expo-sensors/ios/ExpoSensors.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-sharing/ios/ExpoSharing.podspec
+++ b/packages/expo-sharing/ios/ExpoSharing.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-sms/ios/ExpoSMS.podspec
+++ b/packages/expo-sms/ios/ExpoSMS.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-speech/ios/ExpoSpeech.podspec
+++ b/packages/expo-speech/ios/ExpoSpeech.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-store-review/ios/ExpoStoreReview.podspec
+++ b/packages/expo-store-review/ios/ExpoStoreReview.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-symbols/ios/ExpoSymbols.podspec
+++ b/packages/expo-symbols/ios/ExpoSymbols.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-system-ui/ios/ExpoSystemUI.podspec
+++ b/packages/expo-system-ui/ios/ExpoSystemUI.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-tracking-transparency/ios/ExpoTrackingTransparency.podspec
+++ b/packages/expo-tracking-transparency/ios/ExpoTrackingTransparency.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :tvos => '15.1',
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-ui/ios/ExpoUI.podspec
+++ b/packages/expo-ui/ios/ExpoUI.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface.podspec
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     :tvos => '15.1',
     :osx => '11.0'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
   s.source_files = 'EXUpdatesInterface/**/*.{h,m,swift}'

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
     :tvos => '15.1',
     :osx => '11.0'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
   s.dependency 'ExpoModulesCore'

--- a/packages/expo-video-thumbnails/ios/ExpoVideoThumbnails.podspec
+++ b/packages/expo-video-thumbnails/ios/ExpoVideoThumbnails.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-video/ios/ExpoVideo.podspec
+++ b/packages/expo-video/ios/ExpoVideo.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :tvos => '15.1'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/packages/expo-web-browser/ios/ExpoWebBrowser.podspec
+++ b/packages/expo-web-browser/ios/ExpoWebBrowser.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     :ios => '15.1',
     :osx => '11.0'
   }
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
 

--- a/template-files/ios/ExpoKit.podspec
+++ b/template-files/ios/ExpoKit.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.author = "650 Industries, Inc."
   s.requires_arc = true
   s.platform = :ios, "13.0"
-  s.swift_version  = '5.4'
+  s.swift_version  = '5.9'
   s.default_subspec = "Core"
   s.source = { :git => "http://github.com/expo/expo.git" }
   s.compiler_flags = folly_compiler_flags + ' ' + boost_compiler_flags

--- a/yarn.lock
+++ b/yarn.lock
@@ -14229,12 +14229,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-sf-symbols-typescript@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/sf-symbols-typescript/-/sf-symbols-typescript-2.0.0.tgz#52548c84d124914faed1868c55bb71bffac472f1"
-  integrity sha512-Fc8Uhhl2plqXMw7GQ8q83t/zj1xhNCJvteDNJUDULaH/4a/Eqw5aW1UYEznyEIgkokw7QYXuQ9hOw8jhBLXL0A==
-
-sf-symbols-typescript@^2.1.0:
+sf-symbols-typescript@^2.0.0, sf-symbols-typescript@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/sf-symbols-typescript/-/sf-symbols-typescript-2.1.0.tgz#50a2d7b36edd6809606f0b0a36322fc1fdd7cfde"
   integrity sha512-ezT7gu/SHTPIOEEoG6TF+O0m5eewl0ZDAO4AtdBi5HjsrUI6JdCG17+Q8+aKp0heM06wZKApRCn5olNbs0Wb/A==


### PR DESCRIPTION
# Why
Xcode 16 is the minimum version of xcode an app can use to build for the store. We can safely bump our swift version to 5.9 as it has been supported since xcode 15.

# How
Bump podspecs

# Test Plan
bare expo ✅
expo go ✅
native tests ✅
