### PR TITLE
sync changelog from sdk-53 [skip ci]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,13 +15,10 @@
 
 - Support SSR imports of internal node builtins such as `_http_agent`. ([#37494](https://github.com/expo/expo/pull/37494) by [@EvanBacon](https://github.com/EvanBacon))
 - Allow anonymous sessions even when `projectId` is set ([#36874](https://github.com/expo/expo/pull/36874) by [@kadikraman](https://github.com/kadikraman))
-- Allow fast resolver to resolve nested `node_modules` packages in monorepos. ([#37769](https://github.com/expo/expo/pull/37769) by [@byCedric](https://github.com/byCedric))
-- Rewrite React canary resolution to rely on normal Node module resolution. ([#37770](https://github.com/expo/expo/pull/37770) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 
 - add modal component ([#37365](https://github.com/expo/expo/pull/37365) by [@Ubax](https://github.com/Ubax))
-- Bumped `playwright` version to 1.53.1. ([#37631](https://github.com/expo/expo/pull/37631) by [@kudo](https://github.com/kudo))
 - Use Vaul for modals and sheets on web with a custom stack ([#37767](https://github.com/expo/expo/pull/37767) by [@hirbod](https://github.com/hirbod))
 - fix web back/forward buttons ([#37747](https://github.com/expo/expo/pull/37747) by [@Ubax](https://github.com/Ubax))
 - Added CSS-Modules Fast Refresh E2E Coverage ([#37845](https://github.com/expo/expo/pull/37845) by [@hirbod](https://github.com/hirbod))
@@ -29,6 +26,19 @@
 ### ⚠️ Notices
 
 - Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
+## 0.24.19 - 2025-07-07
+
+### 🐛 Bug fixes
+
+- Allow fast resolver to resolve nested `node_modules` packages in monorepos. ([#37769](https://github.com/expo/expo/pull/37769) by [@byCedric](https://github.com/byCedric))
+- Rewrite React canary resolution to rely on normal Node module resolution. ([#37770](https://github.com/expo/expo/pull/37770) by [@byCedric](https://github.com/byCedric))
+
+## 0.24.17 - 2025-07-02
+
+### 💡 Others
+
+- Bumped `playwright` version to 1.53.1. ([#37631](https://github.com/expo/expo/pull/37631) by [@kudo](https://github.com/kudo))
 
 ## 0.24.16 - 2025-07-01
 

--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -6,13 +6,21 @@
 
 ### 🎉 New features
 
-- Add android config plugin for app name translation. ([#37202](https://github.com/expo/expo/pull/37202) by [@aleqsio](https://github.com/aleqsio))
-
 ### 🐛 Bug fixes
 
 - [Android] Fix build failures when localized strings contain single quotes by wrapping string values in quotes in `strings.xml`. ([#37828](https://github.com/expo/expo/pull/37828) by [@huextrat](https://github.com/huextrat))
 
 ### 💡 Others
+
+## 10.1.1 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
+## 10.1.0 - 2025-07-01
+
+### 🎉 New features
+
+- Add android config plugin for app name translation. ([#37202](https://github.com/expo/expo/pull/37202) by [@aleqsio](https://github.com/aleqsio))
 
 ## 10.0.3 - 2025-06-18
 

--- a/packages/@expo/config/CHANGELOG.md
+++ b/packages/@expo/config/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 11.0.12 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 11.0.11 - 2025-07-01
 
 ### 🐛 Bug fixes

--- a/packages/@expo/env/CHANGELOG.md
+++ b/packages/@expo/env/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 1.0.7 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 1.0.6 - 2025-07-01
 
 ### 🐛 Bug fixes

--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 0.13.4 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 0.13.3 - 2025-07-01
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/image-utils/CHANGELOG.md
+++ b/packages/@expo/image-utils/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 0.7.6 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 0.7.5 - 2025-07-01
 
 ### 🐛 Bug fixes

--- a/packages/@expo/json-file/CHANGELOG.md
+++ b/packages/@expo/json-file/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 9.1.5 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 9.1.4 — 2025-04-30
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -10,10 +10,19 @@
 
 ### 🐛 Bug fixes
 
-- Fix require path of assets with RSC client references ([#37663](https://github.com/expo/expo/pull/37663) by [@byCedric](https://github.com/byCedric))
 - Fix Fast Refresh on web by calling `module.hot.accept()` in the transformer. ([#37767](https://github.com/expo/expo/pull/37767) by [@hirbod](https://github.com/hirbod))
 
 ### 💡 Others
+
+## 0.20.17 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
+## 0.20.16 - 2025-07-02
+
+### 🐛 Bug fixes
+
+- Fix require path of assets with RSC client references ([#37663](https://github.com/expo/expo/pull/37663) by [@byCedric](https://github.com/byCedric))
 
 ## 0.20.15 - 2025-06-18
 

--- a/packages/@expo/osascript/CHANGELOG.md
+++ b/packages/@expo/osascript/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 2.2.5 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 2.2.4 — 2025-04-30
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/package-manager/CHANGELOG.md
+++ b/packages/@expo/package-manager/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 1.8.6 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 1.8.5 - 2025-07-01
 
 ### 💡 Others

--- a/packages/@expo/pkcs12/CHANGELOG.md
+++ b/packages/@expo/pkcs12/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 0.2.5 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 0.2.4 — 2025-04-30
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/plist/CHANGELOG.md
+++ b/packages/@expo/plist/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 0.3.5 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 0.3.4 — 2025-04-30
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### 🎉 New features
 
-- Add android config plugin for app name translation. ([#37202](https://github.com/expo/expo/pull/37202) by [@aleqsio](https://github.com/aleqsio))
 - Support Liquid Glass app icons. ([#37609](https://github.com/expo/expo/pull/37609) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
@@ -16,6 +15,16 @@
 ### ⚠️ Notices
 
 - Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
+## 9.0.10 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
+## 9.0.9 - 2025-07-02
+
+### 🎉 New features
+
+- Add android config plugin for app name translation. ([#37202](https://github.com/expo/expo/pull/37202) by [@aleqsio](https://github.com/aleqsio))
 
 ## 9.0.7 - 2025-06-18
 

--- a/packages/@expo/schemer/CHANGELOG.md
+++ b/packages/@expo/schemer/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 1.6.5 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 1.6.4 — 2025-04-30
 
 _This version does not introduce any user-facing changes._

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -17,6 +17,14 @@
 
 - Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
+## 13.2.3 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
+## 13.2.2 - 2025-07-02
+
+_This version does not introduce any user-facing changes._
+
 ## 13.2.1 - 2025-06-18
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### 💡 Others
 
+## 11.1.7 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 11.1.6 - 2025-07-01
 
 ### 💡 Others

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -6,19 +6,26 @@
 
 ### 🎉 New features
 
-- [iOS] Support setting seek tolerences when calling `seekTo` on the player. ([#37669](https://github.com/expo/expo/pull/37669) by [@alanjhughes](https://github.com/alanjhughes))
-
 ### 🐛 Bug fixes
 
 - [iOS] Fix connected bluetooth devices not playing back recordings. ([#37580](https://github.com/expo/expo/pull/37580) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix ducking behaviour. ([#37788](https://github.com/expo/expo/pull/37788) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fix issues with audio focus management. ([#37698](https://github.com/expo/expo/pull/37698) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix connected bluetooth devices not playing back recordings. ([#37580](https://github.com/expo/expo/pull/37580) by [@alanjhughes](https://github.com/alanjhughes))
-- Fix issue where the currentTime is out of sync when seeking before playing. ([#37668](https://github.com/expo/expo/pull/37668) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 
 - Fix resolving issues with AudioEventKeys on webpack. Export mark types export with `type`. ([#37421](https://github.com/expo/expo/pull/37421) by [@behenate](https://github.com/behenate))
+
+## 0.4.8 - 2025-07-03
+
+### 🎉 New features
+
+- [iOS] Support setting seek tolerences when calling `seekTo` on the player. ([#37669](https://github.com/expo/expo/pull/37669) by [@alanjhughes](https://github.com/alanjhughes))
+
+### 🐛 Bug fixes
+
+- [Android] Fix issues with audio focus management. ([#37698](https://github.com/expo/expo/pull/37698) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix connected bluetooth devices not playing back recordings. ([#37580](https://github.com/expo/expo/pull/37580) by [@alanjhughes](https://github.com/alanjhughes))
+- Fix issue where the currentTime is out of sync when seeking before playing. ([#37668](https://github.com/expo/expo/pull/37668) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix ducking behaviour. ([#37788](https://github.com/expo/expo/pull/37788) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.4.7 - 2025-06-26
 

--- a/packages/expo-auth-session/CHANGELOG.md
+++ b/packages/expo-auth-session/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 6.2.1 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 6.2.0 - 2025-06-04
 
 ### 🎉 New features

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ### 💡 Others
 
+## 17.1.7 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 17.1.6 — 2025-05-06
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-client-components/CHANGELOG.md
+++ b/packages/expo-dev-client-components/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 2.1.5 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 2.1.4 — 2025-04-30
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -10,6 +10,14 @@
 
 ### 💡 Others
 
+## 5.2.4 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
+## 5.2.3 - 2025-07-02
+
+_This version does not introduce any user-facing changes._
+
 ## 5.2.2 - 2025-06-26
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -21,6 +21,14 @@
 
 - Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
+## 5.1.16 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
+## 5.1.15 - 2025-07-02
+
+_This version does not introduce any user-facing changes._
+
 ## 5.1.14 - 2025-06-26
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -21,6 +21,14 @@
 
 - Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
+## 6.1.14 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
+## 6.1.13 - 2025-07-02
+
+_This version does not introduce any user-facing changes._
+
 ## 6.1.12 - 2025-06-18
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 1.13.5 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 1.13.4 - 2025-07-01
 
 ### 🐛 Bug fixes

--- a/packages/expo-eas-client/CHANGELOG.md
+++ b/packages/expo-eas-client/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### 💡 Others
 
+## 0.14.4 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 0.14.3 — 2025-04-30
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-env-info/CHANGELOG.md
+++ b/packages/expo-env-info/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 1.3.4 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 1.3.3 — 2025-04-30
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -11,11 +11,16 @@
 - [iOS] Speed up displaying local assets. ([#37795](https://github.com/expo/expo/pull/37795) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Fix animation resuming by casting image to GifDrawable. ([#37363](https://github.com/expo/expo/pull/37363) by [@Wenszel](https://github.com/Wenszel))
 - [Web] Fix `alt` as an alias for `accessibilityLabel` ([#37682](https://github.com/expo/expo/pull/37682) by [@huextrat](https://github.com/huextrat))
-- [iOS] Use specified cache type when no transformation is applied ([#37777](https://github.com/expo/expo/pull/37777) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 
 ### 📚 3rd party library updates
+
+## 2.3.2 - 2025-07-01
+
+### 🐛 Bug fixes
+
+- [iOS] Use specified cache type when no transformation is applied ([#37777](https://github.com/expo/expo/pull/37777) by [@jakex7](https://github.com/jakex7))
 
 ## 2.3.1 - 2025-07-01
 

--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -8,9 +8,13 @@
 
 ### 🐛 Bug fixes
 
-- Fix cold booting iOS apps from a universal link. ([#37647](https://github.com/expo/expo/pull/37647) by [@EvanBacon](https://github.com/EvanBacon))
-
 ### 💡 Others
+
+## 7.1.7 - 2025-07-03
+
+### 🐛 Bug fixes
+
+- Fix cold booting iOS apps from a universal link. ([#37647](https://github.com/expo/expo/pull/37647) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 7.1.6 - 2025-07-01
 

--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### 💡 Others
 
+## 0.16.6 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 0.16.5 — 2025-05-08
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 4.1.9 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 4.1.8 - 2025-06-26
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,11 +8,16 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed local aar files is not being linked correctly. ([#37280](https://github.com/expo/expo/pull/37280) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Improved erorr message when we don't support Kotlin version provided by the user. ([#37802](https://github.com/expo/expo/pull/37802) by [@lukmccall](https://github.com/lukmccall))
-- Fixed breaking change for local AAR autolinking. ([#37882](https://github.com/expo/expo/pull/37882) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
+
+## 2.1.14 - 2025-07-07
+
+### 🐛 Bug fixes
+
+- Fixed breaking change for local AAR autolinking. ([#37882](https://github.com/expo/expo/pull/37882) by [@kudo](https://github.com/kudo))
+- [Android] Fixed local aar files is not being linked correctly. ([#37280](https://github.com/expo/expo/pull/37280) by [@lukmccall](https://github.com/lukmccall))
 
 ## 2.1.13 - 2025-07-01
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,7 +14,6 @@
 
 - [Android] Mark either converters as non-trivial. ([#37836](https://github.com/expo/expo/pull/37836) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fix `Value is undefined, expected an Object` in the `JNIUtils::emitEventOnJSIObject`. ([#37778](https://github.com/expo/expo/pull/37778) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 
@@ -25,6 +24,12 @@
 - Updated `ExpoComposeView` to support virtual view. ([#36255](https://github.com/expo/expo/pull/36255) by [@kudo](https://github.com/kudo))
 - [iOS] Support throwing errors in shared object constructor. ([#37618](https://github.com/expo/expo/pull/37618) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Remove boilerplate from function factories. ([#37884](https://github.com/expo/expo/pull/37884) by [@alanjhughes](https://github.com/alanjhughes))
+
+## 2.4.2 - 2025-07-02
+
+### 🐛 Bug fixes
+
+- [Android] Fix `Value is undefined, expected an Object` in the `JNIUtils::emitEventOnJSIObject`. ([#37778](https://github.com/expo/expo/pull/37778) by [@lukmccall](https://github.com/lukmccall))
 
 ## 2.4.1 - 2025-07-01
 

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 - Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
+## 4.2.7 - 2025-07-02
+
+_This version does not introduce any user-facing changes._
+
 ## 4.2.6 - 2025-06-18
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### 💡 Others
 
+## 0.31.4 - 2025-07-05
+
+_This version does not introduce any user-facing changes._
+
 ## 0.31.3 - 2025-06-04
 
 ### 🐛 Bug fixes
@@ -683,11 +687,9 @@ _This version does not introduce any user-facing changes._
 - Changed class responsible for handling Firebase events from `FirebaseMessagingService` to `.service.NotificationsService` on Android. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override `FirebaseMessagingService` to implement some custom handling logic.
-
 - Changed how you can override ways in which a notification is reinterpreted from a [`StatusBarNotification`](https://developer.android.com/reference/android/service/notification/StatusBarNotification) and in which a [`Notification`](https://developer.android.com/reference/android/app/Notification.html?hl=en) is built from defining an `expo.modules.notifications#NotificationsScoper` meta-data value in `AndroidManifest.xml` to implementing a `BroadcastReceiver` subclassing `NotificationsService` delegating those responsibilities to your custom `PresentationDelegate` instance. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override those methods to implement some custom handling logic.
-
 - Removed `removeAllNotificationListeners` method. You can (and should) still remove listeners using `remove` method on `Subscription` objects returned by `addNotification…Listener`. ([#10883](https://github.com/expo/expo/pull/10883) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier being used to fetch Expo push token being backed up on Android which resulted in multiple devices having the same `deviceId` (and eventually, Expo push token). ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier used when fetching Expo push token being different than `Constants.installationId` in managed workflow apps which resulted in different Expo push tokens returned for the same experience across old and new Expo API and the device push token not being automatically updated on Expo push servers which lead to Expo push tokens corresponding to outdated Firebase tokens. ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -15,12 +15,17 @@
 
 ### 🐛 Bug fixes
 
-- fix web back/forward buttons ([#37747](https://github.com/expo/expo/pull/37747) by [@Ubax](https://github.com/Ubax))
 - fix link with preview on web and Android ([#37800](https://github.com/expo/expo/pull/37800) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 
 - Create href preview component ([#37335](https://github.com/expo/expo/pull/37335) by [@Ubax](https://github.com/Ubax))
+
+## 5.1.3 - 2025-07-03
+
+### 🐛 Bug fixes
+
+- fix web back/forward buttons ([#37747](https://github.com/expo/expo/pull/37747) by [@Ubax](https://github.com/Ubax))
 
 ## 5.1.1 - 2025-06-26
 

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ### 💡 Others
 
+## 0.30.10 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 0.30.9 - 2025-06-04
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -9,11 +9,16 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix nullability of binding params. ([#37200](https://github.com/expo/expo/pull/37200) by [@lukmccall](https://github.com/lukmccall))
-- Fixed unnecessary database reopen from `SQLiteProvider` with same options. ([#37872](https://github.com/expo/expo/pull/37872) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 
 ### 📚 3rd party library updates
+
+## 15.2.14 - 2025-07-07
+
+### 🐛 Bug fixes
+
+- Fixed unnecessary database reopen from `SQLiteProvider` with same options. ([#37872](https://github.com/expo/expo/pull/37872) by [@kudo](https://github.com/kudo))
 
 ## 15.2.13 - 2025-07-01
 

--- a/packages/expo-system-ui/CHANGELOG.md
+++ b/packages/expo-system-ui/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 - Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
+## 5.0.10 - 2025-07-02
+
+_This version does not introduce any user-facing changes._
+
 ## 5.0.9 - 2025-06-18
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -21,6 +21,10 @@
 - [CI] Removed Detox testing workaround code on Android. ([#37707](https://github.com/expo/expo/pull/37707) by [@kudo](https://github.com/kudo))
 - [CI] Removed Detox dependency and unused files in E2E code. ([#37751](https://github.com/expo/expo/pull/37751) by [@douglowder](https://github.com/douglowder))
 
+## 0.28.16 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 0.28.15 - 2025-06-18
 
 ### 🐛 Bug fixes

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
-- Fixed NPE of `onWindowFocusChanged` on Android 10. ([#37819](https://github.com/expo/expo/pull/37819) by [@kudo](https://github.com/kudo))
+- Fixed NPE of `onWindowFocusChanged` on Android 10. ([#37847](https://github.com/expo/expo/pull/37847) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,13 +12,26 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
-- Fixed NPE of `onWindowFocusChanged` on Android 10. ([#37847](https://github.com/expo/expo/pull/37847) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 
 ### ⚠️ Notices
 
 - Added support for React Native 0.80.x. ([#37400](https://github.com/expo/expo/pull/37400) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
+## 53.0.18 - 2025-07-07
+
+### 🐛 Bug fixes
+
+- Fixed NPE of `onWindowFocusChanged` on Android 10. ([#37847](https://github.com/expo/expo/pull/37847) by [@kudo](https://github.com/kudo))
+
+## 53.0.17 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
+## 53.0.16 - 2025-07-02
+
+_This version does not introduce any user-facing changes._
 
 ## 53.0.15 - 2025-07-01
 

--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 0.12.8 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 0.12.7 - 2025-07-01
 
 ### 💡 Others

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -15,6 +15,10 @@
 - add experimental link preview ([#37336](https://github.com/expo/expo/pull/37336) by [@Ubax](https://github.com/Ubax))
 - Add ExpoFont to ignorelist. ([#37736](https://github.com/expo/expo/pull/37736) by [@aleqsio](https://github.com/aleqsio))
 
+## 53.0.9 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 53.0.8 - 2025-07-01
 
 _This version does not introduce any user-facing changes._

--- a/packages/patch-project/CHANGELOG.md
+++ b/packages/patch-project/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 0.2.9 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 0.2.8 - 2025-07-01
 
 ### 🐛 Bug fixes

--- a/packages/pod-install/CHANGELOG.md
+++ b/packages/pod-install/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 0.3.10 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 0.3.9 — 2025-04-30
 
 _This version does not introduce any user-facing changes._

--- a/packages/uri-scheme/CHANGELOG.md
+++ b/packages/uri-scheme/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### 💡 Others
 
+## 1.4.9 - 2025-07-03
+
+_This version does not introduce any user-facing changes._
+
 ## 1.4.8 - 2025-07-01
 
 ### 💡 Others


### PR DESCRIPTION
# Why

sync the changelog from sdk-53

# How

`et ssbc -b sdk-53`

# Test Plan

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
