### PR TITLE
[ios][dev-menu] Prevent RN dev menu from responding to commands

### DIFF
--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -16,7 +16,7 @@ class DevMenuPackagerConnectionHandler {
     // It shouldn't diverge, because of the definition of `RCT_DEV`.
 #if DEBUG
     self.swizzleRCTDevMenuShow()
-    
+
     RCTPackagerConnection
       .shared()
       .addNotificationHandler(
@@ -34,7 +34,7 @@ class DevMenuPackagerConnectionHandler {
       )
 #endif
   }
-  
+
   private func swizzleRCTDevMenuShow() {
     // [@alan] HACK: We are only doing this to prevent the RN dev menu from showing except when called from
     // our dev menu. Without this, it will still respond to commands coming from the packager. I could not
@@ -44,19 +44,19 @@ class DevMenuPackagerConnectionHandler {
     guard let originalMethod = class_getInstanceMethod(devMenuClass, originalSelector) else {
       return
     }
-    
+
     let originalImplementation = method_getImplementation(originalMethod)
 
     let block: @convention(block) (AnyObject) -> Void = { devMenuInstance in
       if DevMenuPackagerConnectionHandler.suppressRNDevMenu {
         return
       }
-      
+
       typealias ShowFunction = @convention(c) (AnyObject, Selector) -> Void
       let showFunc = unsafeBitCast(originalImplementation, to: ShowFunction.self)
       showFunc(devMenuInstance, originalSelector)
     }
-    
+
     let blockImpl = imp_implementationWithBlock(block)
     method_setImplementation(originalMethod, blockImpl)
   }
@@ -90,7 +90,7 @@ class DevMenuPackagerConnectionHandler {
   func devMenuNotificationHanlder(_ parames: [String: Any]) {
     self.manager?.toggleMenu()
   }
-  
+
   static func allowRNDevMenuTemporarily() {
     suppressRNDevMenu = false
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {

--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -39,7 +39,9 @@ class DevMenuPackagerConnectionHandler {
     // [@alan] HACK: We are only doing this to prevent the RN dev menu from showing except when called from
     // our dev menu. Without this, it will still respond to commands coming from the packager. I could not
     // find an easier way to do this until we have a proper api.
-    guard let devMenuClass = NSClassFromString("RCTDevMenu") else { return }
+    guard let devMenuClass = NSClassFromString("RCTDevMenu") else {
+      return
+    }
     let originalSelector = NSSelectorFromString("show")
     guard let originalMethod = class_getInstanceMethod(devMenuClass, originalSelector) else {
       return

--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -5,6 +5,7 @@ import React
 
 class DevMenuPackagerConnectionHandler {
   weak var manager: DevMenuManager?
+  private static var suppressRNDevMenu = true
 
   init(manager: DevMenuManager) {
     self.manager = manager
@@ -14,6 +15,8 @@ class DevMenuPackagerConnectionHandler {
     // `RCT_DEV` isn't available in Swift, that's why we used `DEBUG` instead.
     // It shouldn't diverge, because of the definition of `RCT_DEV`.
 #if DEBUG
+    self.swizzleRCTDevMenuShow()
+    
     RCTPackagerConnection
       .shared()
       .addNotificationHandler(
@@ -30,6 +33,32 @@ class DevMenuPackagerConnectionHandler {
         forMethod: "devMenu"
       )
 #endif
+  }
+  
+  private func swizzleRCTDevMenuShow() {
+    // [@alan] HACK: We are only doing this to prevent the RN dev menu from showing except when called from
+    // our dev menu. Without this, it will still respond to commands coming from the packager. I could not
+    // find an easier way to do this until we have a proper api.
+    guard let devMenuClass = NSClassFromString("RCTDevMenu") else { return }
+    let originalSelector = NSSelectorFromString("show")
+    guard let originalMethod = class_getInstanceMethod(devMenuClass, originalSelector) else {
+      return
+    }
+    
+    let originalImplementation = method_getImplementation(originalMethod)
+
+    let block: @convention(block) (AnyObject) -> Void = { devMenuInstance in
+      if DevMenuPackagerConnectionHandler.suppressRNDevMenu {
+        return
+      }
+      
+      typealias ShowFunction = @convention(c) (AnyObject, Selector) -> Void
+      let showFunc = unsafeBitCast(originalImplementation, to: ShowFunction.self)
+      showFunc(devMenuInstance, originalSelector)
+    }
+    
+    let blockImpl = imp_implementationWithBlock(block)
+    method_setImplementation(originalMethod, blockImpl)
   }
 
   @objc
@@ -60,5 +89,12 @@ class DevMenuPackagerConnectionHandler {
   @objc
   func devMenuNotificationHanlder(_ parames: [String: Any]) {
     self.manager?.toggleMenu()
+  }
+  
+  static func allowRNDevMenuTemporarily() {
+    suppressRNDevMenu = false
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+      suppressRNDevMenu = true
+    }
   }
 }

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
@@ -101,9 +101,8 @@ class DevMenuViewModel: ObservableObject {
     }
 
     devMenuManager.closeMenu {
-      DispatchQueue.main.async {
-        rctDevMenu.show()
-      }
+      DevMenuPackagerConnectionHandler.allowRNDevMenuTemporarily()
+      rctDevMenu.show()
     }
   }
 


### PR DESCRIPTION
# Why
We need to prevent the RN dev menu from showing except when called from our menu. This works without this for the hotkeys but we cannot prevent it from responding to commands coming from the packager.

# How
Swizzle `RCTDevMenu.show` and only call the original method when we call it. 

# Test Plan
Bare expo ✅
