### PR TITLE
[docs] Add `searchRank` to improve config plugins related pages ranking in search UI

### DIFF
--- a/docs/pages/config-plugins/introduction.mdx
+++ b/docs/pages/config-plugins/introduction.mdx
@@ -2,6 +2,7 @@
 title: Introduction to config plugins
 description: An introduction to Expo config plugins.
 sidebar_title: Introduction
+searchRank: 5
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';

--- a/docs/pages/config-plugins/plugins.mdx
+++ b/docs/pages/config-plugins/plugins.mdx
@@ -2,6 +2,7 @@
 title: Create and use config plugins
 description: Learn how to create and use a config plugins in your Expo project.
 sidebar_title: Create a plugin
+searchRank: 4
 ---
 
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';

--- a/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
+++ b/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
@@ -2,6 +2,7 @@
 title: 'Tutorial: Create a module with a config plugin'
 sidebar_title: Create a module with a config plugin
 description: A tutorial on creating a native module with a config plugin using Expo modules API.
+searchRank: 3
 ---
 
 import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16428

Currently, when searching for "config plugins", the introduction and create a config plugin page are shown as 3rd and 2nd results in the search UI:

![CleanShot 2025-07-07 at 23 23 27@2x](https://github.com/user-attachments/assets/d705adf6-5fc5-4e44-ba75-6d6ea5a8ea2e)


# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds `searchRank` property to the metadata of:
- https://docs.expo.dev/config-plugins/introduction/
- https://docs.expo.dev/config-plugins/plugins/
- https://docs.expo.dev/modules/config-plugin-and-native-module-tutorial/

such that these pages are shown in the above order.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

After applying these changes, the search UI will show the following order:

![CleanShot 2025-07-07 at 23 43 51@2x](https://github.com/user-attachments/assets/f3bc5a2f-caeb-4a7d-84d1-921dc9d7e516)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
