### PR TITLE
[expo] fix ReactActivityDelegateWrapper reentrant issue

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
+- Fixed `ReactActivityDelegateWrapper` lifecycle atomic issue. ([#37895](https://github.com/expo/expo/pull/37895) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -35,6 +35,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
@@ -70,6 +72,14 @@ class ReactActivityDelegateWrapper(
    * A deferred that indicates when the app loading is ready
    */
   private val loadAppReady = CompletableDeferred<Unit>()
+
+  /**
+   * A mutex to ensure all coroutines in a scope are running in atomic way.
+   *
+   * This is to act like [Activity] lifecycle,
+   * e.g. all work in [onResume] should be executed after all work in [onCreate] finished.
+   */
+  private val mutex = Mutex()
 
   /**
    * A [CoroutineScope] that binds its lifecycle as [ReactActivityDelegateWrapper].
@@ -110,7 +120,7 @@ class ReactActivityDelegateWrapper(
   }
 
   override fun loadApp(appKey: String?) {
-    activity.lifecycleScope.launch(start = CoroutineStart.UNDISPATCHED) {
+    launchLifecycleScopeWithLock(start = CoroutineStart.UNDISPATCHED) {
       loadAppImpl(appKey, supportsDelayLoad = true)
     }
   }
@@ -138,7 +148,7 @@ class ReactActivityDelegateWrapper(
       // Instead we intercept `ReactActivityDelegate.onCreate` and replace the `mReactDelegate` with our version.
       // That's not ideal but works.
 
-      activity.lifecycleScope.launch(start = CoroutineStart.UNDISPATCHED) {
+      launchLifecycleScopeWithLock(start = CoroutineStart.UNDISPATCHED) {
         awaitDelayLoadAppWhenReady(delayLoadAppHandler)
         loadAppReady.complete(Unit)
 
@@ -184,7 +194,7 @@ class ReactActivityDelegateWrapper(
   }
 
   override fun onResume() {
-    activity.lifecycleScope.launch {
+    launchLifecycleScopeWithLock {
       loadAppReady.await()
       delegate.onResume()
       reactActivityLifecycleListeners.forEach { listener ->
@@ -194,7 +204,7 @@ class ReactActivityDelegateWrapper(
   }
 
   override fun onPause() {
-    activity.lifecycleScope.launch {
+    launchLifecycleScopeWithLock {
       if (!loadAppReady.isCompleted) {
         loadAppReady.completeExceptionally(CancellationException("Activity paused before app loaded"))
       }
@@ -219,7 +229,7 @@ class ReactActivityDelegateWrapper(
   }
 
   override fun onUserLeaveHint() {
-    activity.lifecycleScope.launch {
+    launchLifecycleScopeWithLock {
       loadAppReady.await()
       reactActivityLifecycleListeners.forEach { listener ->
         listener.onUserLeaveHint(activity)
@@ -232,26 +242,28 @@ class ReactActivityDelegateWrapper(
     // Note: use our `coroutineScope` for onDestroy here
     // because the lifecycleScope destroyed before the executions.
     applicationCoroutineScope.launch {
-      if (!loadAppReady.isCompleted) {
-        // Cancel loadAppReady so any waiting coroutines are notified
-        loadAppReady.completeExceptionally(CancellationException("Activity destroyed before app loaded"))
-      }
-      loadAppReady.await()
-      reactActivityLifecycleListeners.forEach { listener ->
-        listener.onDestroy(activity)
-      }
-      if (delayLoadAppHandler != null) {
-        try {
-          // For the delay load case, we may enter a different call flow than react-native.
-          // For example, Activity stopped before delay load finished.
-          // We stop before the ReactActivityDelegate gets a chance to set up.
-          // In this case, we should catch the exceptions.
-          delegate.onDestroy()
-        } catch (e: Exception) {
-          Log.e(TAG, "Exception occurred during onDestroy with delayed app loading", e)
+      mutex.withLock {
+        if (!loadAppReady.isCompleted) {
+          // Cancel loadAppReady so any waiting coroutines are notified
+          loadAppReady.completeExceptionally(CancellationException("Activity destroyed before app loaded"))
         }
-      } else {
-        delegate.onDestroy()
+        loadAppReady.await()
+        reactActivityLifecycleListeners.forEach { listener ->
+          listener.onDestroy(activity)
+        }
+        if (delayLoadAppHandler != null) {
+          try {
+            // For the delay load case, we may enter a different call flow than react-native.
+            // For example, Activity stopped before delay load finished.
+            // We stop before the ReactActivityDelegate gets a chance to set up.
+            // In this case, we should catch the exceptions.
+            delegate.onDestroy()
+          } catch (e: Exception) {
+            Log.e(TAG, "Exception occurred during onDestroy with delayed app loading", e)
+          }
+        } else {
+          delegate.onDestroy()
+        }
       }
     }
   }
@@ -270,7 +282,7 @@ class ReactActivityDelegateWrapper(
      *
      * TODO (@bbarthec): fix it upstream?
      */
-    activity.lifecycleScope.launch {
+    launchLifecycleScopeWithLock {
       loadAppReady.await()
       if (!ReactNativeFeatureFlags.enableBridgelessArchitecture && delegate.reactInstanceManager.currentReactContext == null) {
         val reactContextListener = object : ReactInstanceEventListener {
@@ -279,7 +291,9 @@ class ReactActivityDelegateWrapper(
             delegate.onActivityResult(requestCode, resultCode, data)
           }
         }
-        return@launch delegate.reactInstanceManager.addReactInstanceEventListener(reactContextListener)
+        return@launchLifecycleScopeWithLock delegate.reactInstanceManager.addReactInstanceEventListener(
+          reactContextListener
+        )
       }
 
       delegate.onActivityResult(requestCode, resultCode, data)
@@ -342,21 +356,21 @@ class ReactActivityDelegateWrapper(
   }
 
   override fun onWindowFocusChanged(hasFocus: Boolean) {
-    activity.lifecycleScope.launch {
+    launchLifecycleScopeWithLock {
       loadAppReady.await()
       delegate.onWindowFocusChanged(hasFocus)
     }
   }
 
   override fun requestPermissions(permissions: Array<out String>?, requestCode: Int, listener: PermissionListener?) {
-    activity.lifecycleScope.launch {
+    launchLifecycleScopeWithLock {
       loadAppReady.await()
       delegate.requestPermissions(permissions, requestCode, listener)
     }
   }
 
   override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?, grantResults: IntArray?) {
-    activity.lifecycleScope.launch {
+    launchLifecycleScopeWithLock {
       loadAppReady.await()
       delegate.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
@@ -383,7 +397,7 @@ class ReactActivityDelegateWrapper(
   }
 
   override fun onConfigurationChanged(newConfig: Configuration?) {
-    activity.lifecycleScope.launch {
+    launchLifecycleScopeWithLock {
       loadAppReady.await()
       delegate.onConfigurationChanged(newConfig)
     }
@@ -466,6 +480,17 @@ class ReactActivityDelegateWrapper(
       delayLoadAppHandler.whenReady {
         Utils.assertMainThread()
         continuation.resume(Unit)
+      }
+    }
+  }
+
+  private fun launchLifecycleScopeWithLock(
+    start: CoroutineStart = CoroutineStart.DEFAULT,
+    block: suspend CoroutineScope.() -> Unit
+  ) {
+    activity.lifecycleScope.launch(start = start) {
+      mutex.withLock {
+        block()
       }
     }
   }

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -29,7 +29,6 @@ import expo.modules.core.interfaces.ReactActivityHandler.DelayLoadAppHandler
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.kotlin.Utils
 import expo.modules.rncompatibility.ReactNativeFeatureFlags
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart

--- a/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperDelayLoadTest.kt
+++ b/packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperDelayLoadTest.kt
@@ -174,60 +174,6 @@ internal class ReactActivityDelegateWrapperDelayLoadTest {
   }
 
   @Test
-  fun `should cancel pending resume if activity pause before delay load finished`() = runTest {
-    every { ExpoModulesPackage.Companion.packageList } returns listOf(mockPackageWithDelay)
-
-    val callbackSlot = slot<Runnable>()
-    every { delayLoadAppHandler.whenReady(capture(callbackSlot)) } answers {
-      // Don't call the callback immediately to simulate delay
-    }
-
-    activityController = Robolectric.buildActivity(MockActivity::class.java)
-      .also {
-        val activity = it.get()
-        (activity.application as MockApplication).bindCurrentActivity(activity)
-      }
-      .setup()
-    val spyDelegateWrapper = activity.reactActivityDelegate as ReactActivityDelegateWrapper
-    val spyDelegate = spyDelegateWrapper.delegate
-
-    verify(exactly = 1) { spyDelegateWrapper.onCreate(any()) }
-    verify(exactly = 1) { spyDelegateWrapper.onResume() }
-    verify(exactly = 0) { spyDelegate.onResume() }
-
-    activityController.pause()
-    callbackSlot.captured.run()
-    verify(exactly = 0) { spyDelegate.onResume() }
-  }
-
-  @Test
-  fun `should cancel pending resume if activity stop before delay load finished`() = runTest {
-    every { ExpoModulesPackage.Companion.packageList } returns listOf(mockPackageWithDelay)
-
-    val callbackSlot = slot<Runnable>()
-    every { delayLoadAppHandler.whenReady(capture(callbackSlot)) } answers {
-      // Don't call the callback immediately to simulate delay
-    }
-
-    activityController = Robolectric.buildActivity(MockActivity::class.java)
-      .also {
-        val activity = it.get()
-        (activity.application as MockApplication).bindCurrentActivity(activity)
-      }
-      .setup()
-    val spyDelegateWrapper = activity.reactActivityDelegate as ReactActivityDelegateWrapper
-    val spyDelegate = spyDelegateWrapper.delegate
-
-    verify(exactly = 1) { spyDelegateWrapper.onCreate(any()) }
-    verify(exactly = 1) { spyDelegateWrapper.onResume() }
-    verify(exactly = 0) { spyDelegate.onResume() }
-
-    activityController.pause().stop()
-    callbackSlot.captured.run()
-    verify(exactly = 0) { spyDelegate.onResume() }
-  }
-
-  @Test
   fun `should cancel pending resume if activity destroy before delay load finished`() = runTest {
     every { ExpoModulesPackage.Companion.packageList } returns listOf(mockPackageWithDelay)
 


### PR DESCRIPTION
# Why

fixes https://github.com/expo/expo/issues/37819#issuecomment-3045876504

# How

- my hypothesis is that the coroutine scope supports concurrent jobs (even it's on main thread). some onCreate/onResume lifecycle work is interrupt to not executed in correct order. this pr tries to add lock and makes sure the coroutines run in atomic order. (`onCreate` -> `onResume`)
- also remove the `onPause` / `onDestory` `loadAppReady` cancelation. i now feel that we should still send `onResume` -> `onPause` in sequence even it's delayed on `onStop` already. that would move us away from breaking the assumption of the state machine in react instance management. 

# Test Plan

can only repro https://github.com/huextrat/expo-android-10-crash on real device. the coroutine interrupt logic is not quite deterministic and not able to write an unit test for it. 

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
