### PR TITLE
fix(jest-expo): reconfigure Jest React Canary resolver to use identical method as Metro

### DIFF
--- a/packages/jest-expo/config/react-canaries-resolver.js
+++ b/packages/jest-expo/config/react-canaries-resolver.js
@@ -1,13 +1,14 @@
 const path = require('path');
 const canariesDir = path.join(require.resolve('@expo/cli/package.json'), '../static/canary-full');
 
+/** @type {import('jest-resolve').SyncResolver} */
 function customResolver(request, options) {
   // TODO: Remove this when we have React 19 in the expo/expo monorepo.
   if (
     // Change the node modules path for react and react-dom to use the vendor in Expo CLI.
     /^(react|react\/.*|react-dom|react-dom\/.*)$/.test(request)
   ) {
-    options.moduleDirectory = [canariesDir];
+    options.basedir = canariesDir;
   }
 
   // Fall back to Jest's default resolver


### PR DESCRIPTION
# Why

This was supposed to be part of #37770, to fix #37734 through #37769. I think the Expo Router CI might not have triggered correctly, and let CI turn green before me merging the change.

# How

- Used Jest's `basedir` resolver option, similar to `originModulePath` in Metro

# Test Plan

See if Expo Router (and other packages with RSC tests) turn green on CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
