### PR TITLE
[docs] Add LLMs page to the sidebar navigation

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -150,7 +150,7 @@ export const home = [
     makePage('deploy/web.mdx'),
   ]),
   makeSection('Monitor', [makePage('monitoring/services.mdx')]),
-  makeSection('More', [makePage('core-concepts.mdx'), makePage('faq.mdx')]),
+  makeSection('More', [makePage('core-concepts.mdx'), makePage('faq.mdx'), makePage('llms.mdx')]),
 ];
 
 export const general = [

--- a/docs/pages/llms.mdx
+++ b/docs/pages/llms.mdx
@@ -1,7 +1,9 @@
 ---
 title: Documentation for LLMs
+sidebar_title: LLMs
 description: A list of Expo and EAS documentation files available for large language models (LLMs) and apps that use them.
 hideTOC: true
+hideFromSearch: true
 ---
 
 At Expo, we support the [llms.txt](https://llmstxt.org/) initiative to provide documentation for large language models (LLMs) and apps that use them. Below is a list of documentation files available:


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Internal feedback shared abot LLMs page not being available in the docs sidebar.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add /llms to the docs sidebar
- Hide this page from docs search
- Add an appropriate sidebar title

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run dev` and visit http://localhost:3002/llms/.

## Preview

![CleanShot 2025-07-08 at 01 10 46@2x](https://github.com/user-attachments/assets/ba333821-2e19-427f-ab54-6608fe246aa4)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
