### PR TITLE
[docs] Update internal and external links

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -490,7 +490,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/eas/workflows/reference/e2e-tests/': '/eas/workflows/examples/e2e-tests/',
 
   // After moving e2e-tests to eas/workflows/reference
-  '/build-reference/e2e-tests/': '/eas/workflows/reference/e2e-tests/',
+  '/build-reference/e2e-tests/': '/eas/workflows/examples/e2e-tests/',
 
   // After merging EAS environment variables guides
   '/eas/using-environment-variables/': '/eas/environment-variables/',

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -318,7 +318,7 @@ redirects[eas/workflows/examples/#deploy-to-production-workflow]=eas/workflows/e
 redirects[eas/workflows/reference/e2e-tests/]=eas/workflows/examples/e2e-tests
 
 # After moving e2e-tests to eas/workflows/reference
-redirects[build-reference/e2e-tests]=eas/workflows/reference/e2e-tests
+redirects[build-reference/e2e-tests]=eas/workflows/examples/e2e-tests
 
 # After adding distribution section under EAS
 redirects[distribution/publishing-websites]=guides/publishing-websites

--- a/docs/pages/archive/e2e-tests.mdx
+++ b/docs/pages/archive/e2e-tests.mdx
@@ -10,7 +10,7 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-> **warning** **Deprecated:** This is an old and archived version of our EAS Build E2E tests guide. [See the latest version of the guide here](/eas/workflows/reference/e2e-tests/).
+> **warning** **Deprecated:** This is an old and archived version of our EAS Build E2E tests guide. [See the latest version of the guide here](/eas/workflows/examples/e2e-tests/).
 
 In this guide, you will learn how to create and run E2E tests on EAS Build using [Maestro](https://maestro.dev/), which is one of the most popular tools for running E2E tests in mobile apps.
 

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -51,7 +51,7 @@ Any EAS CLI command can be built on your local machine with the `--local` flag. 
 | **Windows** | <YesIcon/> (\*\*) | <NoIcon />    | <NoIcon />      |
 | **Linux**   | <YesIcon/>        | <NoIcon />    | <NoIcon />      |
 
-(\*) All builds that run on an iPhone device require a paid [Apple Developer](developer.apple.com) account for build signing.
+(\*) All builds that run on an iPhone device require a paid [Apple Developer](https://developer.apple.com) account for build signing.
 
 (\*\*) No first-class support, but possible with [WSL](http://expo.fyi/wsl.md).
 

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -248,7 +248,7 @@ It's all about preferences, and it is up to you to decide how you want to organi
 
 ## Snapshot test
 
-> **info** **Note:** For UI testing, we recommend end-to-end tests instead of snapshot unit tests. See the [E2E tests with Maestro](/eas/workflows/reference/e2e-tests/) guide.
+> **info** **Note:** For UI testing, we recommend end-to-end tests instead of snapshot unit tests. See the [E2E tests with Maestro](/eas/workflows/examples/e2e-tests/) guide.
 
 A [snapshot test](https://jestjs.io/docs/en/snapshot-testing) is used to make sure that UI stays consistent, especially when a project is working with global styles that are potentially shared across components.
 
@@ -334,7 +334,7 @@ For more information, see [CLI Options](https://jestjs.io/docs/en/cli) in Jest d
 <BoxLink
   title="E2E tests with EAS Workflows"
   description="Learn how to set up and run E2E tests on EAS Workflows with Maestro."
-  href="/eas/workflows/reference/e2e-tests/"
+  href="/eas/workflows/examples/e2e-tests/"
   Icon={Dataflow03Icon}
 />
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -53,7 +53,7 @@ If the command fails, refer to the [Installing Expo modules](/bare/installing-ex
 
 If you created your project with `npx create-expo-app`, or you don't call `registerRootComponent` in your app at all (for example, it's handled by Expo Router), then you are all set. The following applies to projects created with other tools, such as React Native Community CLI.
 
-We recommend that apps using EAS Update use Expo's [`registerRootComponent`](/versions/latest/sdk/register-root-component.mdx) instead of React Native's `registerApplication`. This will ensure that Expo is able to configure React Native to load assets, such as images, that are included in updates. If you do not use `registerRootComponent`, you may find that your assets will not be available in release builds.
+We recommend that apps using EAS Update use Expo's [`registerRootComponent`](/versions/latest/sdk/expo/#registerrootcomponentcomponent) instead of React Native's `registerApplication`. This will ensure that Expo is able to configure React Native to load assets, such as images, that are included in updates. If you do not use `registerRootComponent`, you may find that your assets will not be available in release builds.
 
 In a simple app created with React Native Community CLI, the diff would look like this:
 

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -21,7 +21,7 @@ Ensure you install the version of `expo` that works for your currently installed
 
 ## Update the entry file
 
-Modify the entry file to use [`registerRootComponent`](/versions/latest/sdk/register-root-component) instead of `AppRegistry.registerComponent`:
+Modify the entry file to use [`registerRootComponent`](/versions/latest/sdk/expo/#registerrootcomponentcomponent) instead of `AppRegistry.registerComponent`:
 
 ```diff
 + import {registerRootComponent} from 'expo';

--- a/docs/pages/troubleshooting/application-has-not-been-registered.mdx
+++ b/docs/pages/troubleshooting/application-has-not-been-registered.mdx
@@ -34,7 +34,7 @@ Look at your logs before this error message to see what may have caused it. A fr
 
 Another possibility is that there is a mismatch between the `AppKey` being provided to [`AppRegistry.registerComponent`](https://reactnative.dev/docs/appregistry#registercomponent), and the `AppKey` being registered on the native iOS or Android side.
 
-In managed projects, the default behavior is to use "main" as the `AppKey`. This is handled for you automatically, and as long as you don't change the `"main"` field in your **package.json** from the default value then this will just work. If you want to customize the app entry point, see [registerRootComponent](/versions/latest/sdk/register-root-component) API reference.
+In managed projects, the default behavior is to use "main" as the `AppKey`. This is handled for you automatically, and as long as you don't change the `"main"` field in your **package.json** from the default value then this will just work. If you want to customize the app entry point, see [registerRootComponent](/versions/latest/sdk/expo/#registerrootcomponentcomponent) API reference.
 
 In projects with native code, you will see something like this in your **index.js** by default:
 

--- a/docs/pages/versions/v51.0.0/config/metro.mdx
+++ b/docs/pages/versions/v51.0.0/config/metro.mdx
@@ -347,7 +347,7 @@ This can be used to emulate `externals` with custom imports. For example, if you
 
 > Transformations are heavily cached in Metro. If you update something, use the `--clear` flag to see updates. For example, `npx expo start --clear`.
 
-Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the [**babel.config.js**](../config/babel/) and caller object to customize the transformation.
+Metro doesn't have a very expressive plugin system for transforming files, instead opt to use the **babel.config.js** and caller object to customize the transformation.
 
 ```js babel.config.js
 module.exports = function (api) {

--- a/docs/pages/workflow/web.mdx
+++ b/docs/pages/workflow/web.mdx
@@ -71,7 +71,7 @@ If you haven't added Expo to your React Native app yet, you can either [install 
 
 <Terminal cmd={['$ npm install expo']} />
 
-2. Modify the entry file to use [`registerRootComponent`](/versions/latest/sdk/register-root-component#registerrootcomponentcomponent) instead of `AppRegistry.registerComponent`:
+2. Modify the entry file to use [`registerRootComponent`](/versions/latest/sdk/expo/#registerrootcomponentcomponent) instead of `AppRegistry.registerComponent`:
 
 ```diff
 + import {registerRootComponent} from 'expo';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Update internal and external 404 links as per Algolia's report:

![CleanShot 2025-07-08 at 17 20 33@2x](https://github.com/user-attachments/assets/951a5674-2cd0-4387-9024-703dc66cb649)


# How

<!--
How did you build this feature or fix this bug and why?
-->

- By manually updating and verifying links.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs app locally and go through diff to see up to date links.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
