### PR TITLE
[docs] Fix code annotation now showing up when hovering over a highlight

### DIFF
--- a/docs/common/code-utilities.ts
+++ b/docs/common/code-utilities.ts
@@ -168,12 +168,12 @@ export function parseValue(value: string) {
 export function findNodeByPropInChildren<T>(
   element: ReactElement,
   propToFind: string
-): PropsWithChildren<Record<string, T>> | T | null {
+): PropsWithChildren<{ [propToFind]: T }> | T | null {
   if (!element || typeof element !== 'object') {
     return null;
   }
 
-  if (isValidElement<PropsWithChildren<Record<string, T>>>(element)) {
+  if (isValidElement<PropsWithChildren<{ [propToFind]: T }>>(element)) {
     return element.props;
   }
 
@@ -202,7 +202,7 @@ export function getCodeBlockDataFromChildren(children?: ReactNode, className?: s
       language: className ? className.split('-')[1] : 'jsx',
     };
   }
-  const codeNode = findNodeByPropInChildren<{ className: string }>(
+  const codeNode = findNodeByPropInChildren<PropsWithChildren<{ className: string }>>(
     children as ReactElement,
     'className'
   );

--- a/docs/common/code-utilities.ts
+++ b/docs/common/code-utilities.ts
@@ -168,12 +168,12 @@ export function parseValue(value: string) {
 export function findNodeByPropInChildren<T>(
   element: ReactElement,
   propToFind: string
-): PropsWithChildren<{ [propToFind]: T }> | T | null {
+): PropsWithChildren<Record<string, T>> | T | null {
   if (!element || typeof element !== 'object') {
     return null;
   }
 
-  if (isValidElement<PropsWithChildren<{ [propToFind]: T }>>(element)) {
+  if (isValidElement<PropsWithChildren<Record<string, T>>>(element)) {
     return element.props;
   }
 
@@ -202,7 +202,7 @@ export function getCodeBlockDataFromChildren(children?: ReactNode, className?: s
       language: className ? className.split('-')[1] : 'jsx',
     };
   }
-  const codeNode = findNodeByPropInChildren<PropsWithChildren<{ className: string }>>(
+  const codeNode = findNodeByPropInChildren<{ className: string }>(
     children as ReactElement,
     'className'
   );

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -3,7 +3,7 @@ import { FileCode01Icon } from '@expo/styleguide-icons/outline/FileCode01Icon';
 import { LayoutAlt01Icon } from '@expo/styleguide-icons/outline/LayoutAlt01Icon';
 import { Server03Icon } from '@expo/styleguide-icons/outline/Server03Icon';
 import { useEffect, useRef, useState, type PropsWithChildren } from 'react';
-import tippy, { roundArrow } from 'tippy.js';
+import tippy, { roundArrow, type Instance } from 'tippy.js';
 
 import {
   cleanCopyValue,
@@ -55,14 +55,16 @@ export function Code({ className, children, title }: CodeProps) {
 
   useEffect(() => {
     const tippyFunc = testTippy ?? tippy;
-    let codeAnnotationInstances: any = null;
-    let tutorialAnnotationInstances: any = null;
+    let codeAnnotationInstances: Instance | Instance[] | null = null;
+    let tutorialAnnotationInstances: Instance | Instance[] | null = null;
     let observer: MutationObserver | null = null;
 
     function initializeTippy() {
       if (codeAnnotationInstances) {
         if (Array.isArray(codeAnnotationInstances)) {
-          codeAnnotationInstances.forEach((instance: any) => instance.destroy());
+          codeAnnotationInstances.forEach((instance: Instance) => {
+            instance.destroy();
+          });
         } else {
           codeAnnotationInstances.destroy();
         }
@@ -70,7 +72,9 @@ export function Code({ className, children, title }: CodeProps) {
 
       if (tutorialAnnotationInstances) {
         if (Array.isArray(tutorialAnnotationInstances)) {
-          tutorialAnnotationInstances.forEach((instance: any) => instance.destroy());
+          tutorialAnnotationInstances.forEach((instance: Instance) => {
+            instance.destroy();
+          });
         } else {
           tutorialAnnotationInstances.destroy();
         }
@@ -143,13 +147,17 @@ export function Code({ className, children, title }: CodeProps) {
       }
 
       if (Array.isArray(codeAnnotationInstances)) {
-        codeAnnotationInstances.forEach((instance: any) => instance.destroy());
+        codeAnnotationInstances.forEach((instance: Instance) => {
+          instance.destroy();
+        });
       } else if (codeAnnotationInstances) {
         codeAnnotationInstances.destroy();
       }
 
       if (Array.isArray(tutorialAnnotationInstances)) {
-        tutorialAnnotationInstances.forEach((instance: any) => instance.destroy());
+        tutorialAnnotationInstances.forEach((instance: Instance) => {
+          instance.destroy();
+        });
       } else if (tutorialAnnotationInstances) {
         tutorialAnnotationInstances.destroy();
       }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16441

# How

<!--
How did you build this feature or fix this bug and why?
-->

* Added a new `didMount` state to track component mounting, simplifying the effect dependencies and improving clarity. 
* Refactored the `useEffect` hook to separate block height calculations from tooltip initialization, ensuring better organization and performance.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally and visit a page that contains code/tutorial code annotations, such as: http://localhost:3002/tutorial/create-your-first-app/.

## Preview


https://github.com/user-attachments/assets/9538dc48-d8fc-403e-997e-1580cafa0b7b



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
