### PR TITLE
[cli] Use scheme from expo config for managed projects

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Enable async require by default. ([#36405](https://github.com/expo/expo/pull/36405) by [@EvanBacon](https://github.com/EvanBacon))
 - Support JSON output for install check. ([#37318](https://github.com/expo/expo/pull/37318) by [@betomoedano](https://github.com/betomoedano))
+- Use scheme from expo config for managed projects. ([#37920](https://github.com/expo/expo/pull/37920) by [@jhhayashi](https://github.com/jhhayashi))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/utils/scheme.ts
+++ b/packages/@expo/cli/src/utils/scheme.ts
@@ -97,6 +97,13 @@ export async function getOptionalDevClientSchemeAsync(
 
   // Allow managed projects
   if (!hasIos && !hasAndroid) {
+    // First check if the expo config has a scheme defined
+    const { exp } = getConfig(projectRoot);
+    if (exp.scheme) {
+      const scheme = Array.isArray(exp.scheme) ? exp.scheme[0] : exp.scheme;
+      return { scheme, resolution: 'config' };
+    }
+    // Fall back to the default managed dev client scheme
     return { scheme: await getManagedDevClientSchemeAsync(projectRoot), resolution: 'config' };
   }
 


### PR DESCRIPTION
Managed projects currently use the default scheme (exp+slug), which can
cause issues if a device has multiple builds installed (e,g, a dev
client and a production build).

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Referenced #27241


# Test Plan

If the expo team agrees with this change, I will add jest tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
