### PR TITLE
[video][android] Fix accessing `player.loop` causes app to crash

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix accessing player.loop causes app to crash.
+- [Android] Fix accessing player.loop causes app to crash. ([#37928](https://github.com/expo/expo/pull/37928) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Setting `player.currentTime` doesn't seek to the correct time on some videos. ([#37672](https://github.com/expo/expo/pull/37300) by [@petrkonecny2](https://github.com/petrkonecny2))
 
 ### 💡 Others

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix accessing player.loop causes app to crash.
 - [iOS] Setting `player.currentTime` doesn't seek to the correct time on some videos. ([#37672](https://github.com/expo/expo/pull/37300) by [@petrkonecny2](https://github.com/petrkonecny2))
 
 ### 💡 Others

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -225,7 +225,9 @@ class VideoModule : Module() {
 
       Property("loop")
         .get { ref: VideoPlayer ->
-          ref.player.repeatMode == REPEAT_MODE_ONE
+          runBlocking(appContext.mainQueue.coroutineContext) {
+            ref.player.repeatMode == REPEAT_MODE_ONE
+          }
         }
         .set { ref: VideoPlayer, loop: Boolean ->
           appContext.mainQueue.launch {


### PR DESCRIPTION
# Why

fixes [#34493](https://github.com/expo/expo/issues/34493)

# How
The issue was caused by accessing a video player getter outside the main thread, so I moved this operation to the main thread.

# Test Plan
Tested on bare-expo on android
