### PR TITLE
[ios][audio] Throw when attempting to record without allowing

### DIFF
--- a/apps/native-component-list/src/screens/Audio/expo-audio/Recorder.tsx
+++ b/apps/native-component-list/src/screens/Audio/expo-audio/Recorder.tsx
@@ -80,7 +80,7 @@ export default function Recorder({ onDone, style }: RecorderProps) {
         audioRecorder.record();
       }
     } catch (error) {
-      Alert.alert('Error', error);
+      Alert.alert('Error', error.message);
     }
   };
 

--- a/apps/native-component-list/src/screens/Audio/expo-audio/Recorder.tsx
+++ b/apps/native-component-list/src/screens/Audio/expo-audio/Recorder.tsx
@@ -55,7 +55,13 @@ export default function Recorder({ onDone, style }: RecorderProps) {
 
   const recorderState = useAudioRecorderState(audioRecorder);
 
-  const record = () => audioRecorder.record();
+  const record = () => {
+    try {
+      audioRecorder.record();
+    } catch (error) {
+      Alert.alert('Error', error.message);
+    }
+  };
 
   const renderOptionsButton = (title: string, options: RecordingOptions) => {
     return (
@@ -67,10 +73,14 @@ export default function Recorder({ onDone, style }: RecorderProps) {
   };
 
   const togglePause = () => {
-    if (audioRecorder.isRecording) {
-      audioRecorder.pause();
-    } else {
-      audioRecorder.record();
+    try {
+      if (audioRecorder.isRecording) {
+        audioRecorder.pause();
+      } else {
+        audioRecorder.record();
+      }
+    } catch (error) {
+      Alert.alert('Error', error);
     }
   };
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - Fix resolving issues with AudioEventKeys on webpack. Export mark types export with `type`. ([#37421](https://github.com/expo/expo/pull/37421) by [@behenate](https://github.com/behenate))
-- [iOS] Throw an error when attempting to record when recording is not allowed.
+- [iOS] Throw an error when attempting to record when recording is not allowed. ([#37929](https://github.com/expo/expo/pull/37929) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.4.8 - 2025-07-03
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Fix resolving issues with AudioEventKeys on webpack. Export mark types export with `type`. ([#37421](https://github.com/expo/expo/pull/37421) by [@behenate](https://github.com/behenate))
+- [iOS] Throw an error when attempting to record when recording is not allowed.
 
 ## 0.4.8 - 2025-07-03
 

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -232,7 +232,7 @@ public class AudioModule: Module {
 
       Function("record") { (recorder: AudioRecorder) -> [String: Any] in
         try checkPermissions()
-        return recorder.startRecording()
+        return try recorder.startRecording()
       }
 
       Function("pause") { recorder in
@@ -384,7 +384,7 @@ public class AudioModule: Module {
 #if os(iOS)
     registry.allRecorders.values.forEach { recorder in
       if recorder.allowsRecording && !recorder.isRecording {
-        _ = recorder.startRecording()
+        _ = try? recorder.startRecording()
       }
     }
 #endif

--- a/packages/expo-audio/ios/AudioRecorder.swift
+++ b/packages/expo-audio/ios/AudioRecorder.swift
@@ -99,10 +99,9 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     totalRecordedDuration = 0
   }
 
-  func startRecording() -> [String: Any] {
+  func startRecording() throws -> [String: Any] {
     guard allowsRecording else {
-      log.info("Recording is currently disabled")
-      return [:]
+      throw RecordingDisabledException()
     }
 
     guard currentState == .prepared || currentState == .paused else {


### PR DESCRIPTION
# Why
Currently, when you attempt to start a recording without setting `allowsRecording: true`, we silently fail.  

# How
Throw an error when `record` is called but the current audio mode does not allow recording.

# Test Plan
Bare-expo ✅

