### PR TITLE
[template] fix: make react logo visible by specifying width/height

### DIFF
--- a/templates/expo-template-default/app/(tabs)/explore.tsx
+++ b/templates/expo-template-default/app/(tabs)/explore.tsx
@@ -50,7 +50,10 @@ export default function TabTwoScreen() {
           <ThemedText type="defaultSemiBold">@3x</ThemedText> suffixes to provide files for
           different screen densities
         </ThemedText>
-        <Image source={require('@/assets/images/react-logo.png')} style={{ alignSelf: 'center' }} />
+        <Image
+          source={require('@/assets/images/react-logo.png')}
+          style={{ width: 100, height: 100, alignSelf: 'center' }}
+        />
         <ExternalLink href="https://reactnative.dev/docs/images">
           <ThemedText type="link">Learn more</ThemedText>
         </ExternalLink>


### PR DESCRIPTION
# Why

In the default template, the React logo in the Explore Tab does not display on Web, iOS, or Android.

# How

By specifying width/height. It seems that in expo-image, static images require specifying width/height, which might differ from the behavior of the React Native Image component. I'm a beginner, so I could be misunderstanding this.

# Test Plan

I tested on Web, iOS and Android, it looks fine now.

Before: 
<img width="482" alt="image" src="https://github.com/user-attachments/assets/9f284cd7-47ac-483e-8beb-a9dca693a50b" />

After:
<img width="482" alt="image" src="https://github.com/user-attachments/assets/e04e34d7-6389-4be0-9752-c500e9566de2" />

