### PR TITLE
[ios][audio] Fix: setting allowBluetooth raises the min os version for tv

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix connected bluetooth devices not playing back recordings. ([#37580](https://github.com/expo/expo/pull/37580) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Exclude setting `.allowBluetooth` on tvOS.
+- [iOS] Exclude setting `.allowBluetooth` on tvOS. ([#37950](https://github.com/expo/expo/pull/37950) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix connected bluetooth devices not playing back recordings. ([#37580](https://github.com/expo/expo/pull/37580) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Exclude setting `.allowBluetooth` on tvOS.
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -475,9 +475,11 @@ public class AudioModule: Module {
         categoryOptions.insert(.mixWithOthers)
       }
 
+#if !os(tvOS)
       if category == .playAndRecord {
         categoryOptions.insert(.allowBluetooth)
       }
+#endif
 
       sessionOptions = categoryOptions
     }


### PR DESCRIPTION
# Why
https://github.com/expo/expo/pull/37580#issuecomment-3053108313 I missed that this would require a higher os version on tv

# How
Exclude setting the option in tvOS

# Test Plan
Bare-expo ✅

