### PR TITLE
[android][updates] Migrate loader and file downloader to coroutines

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -21,7 +21,7 @@
 - [CI] Removed Detox testing workaround code on Android. ([#37707](https://github.com/expo/expo/pull/37707) by [@kudo](https://github.com/kudo))
 - [CI] Removed Detox dependency and unused files in E2E code. ([#37751](https://github.com/expo/expo/pull/37751) by [@douglowder](https://github.com/douglowder))
 - Updates imports from `@expo/config`, `@expo/config-plugins` to `expo/config`, `expo/config-plugins`. ([#37860](https://github.com/expo/expo/pull/37860) by [@aleqsio](https://github.com/aleqsio))
-- [Android] Migrate loaders and file downloader to coroutines.
+- [Android] Migrate loaders and file downloader to coroutines. ([#37959](https://github.com/expo/expo/pull/37959) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.28.16 - 2025-07-03
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [CI] Removed Detox testing workaround code on Android. ([#37707](https://github.com/expo/expo/pull/37707) by [@kudo](https://github.com/kudo))
 - [CI] Removed Detox dependency and unused files in E2E code. ([#37751](https://github.com/expo/expo/pull/37751) by [@douglowder](https://github.com/douglowder))
 - Updates imports from `@expo/config`, `@expo/config-plugins` to `expo/config`, `expo/config-plugins`. ([#37860](https://github.com/expo/expo/pull/37860) by [@aleqsio](https://github.com/aleqsio))
+- [Android] Migrate loaders and file downloader to coroutines.
 
 ## 0.28.16 - 2025-07-03
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/TestUtils.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/TestUtils.kt
@@ -1,6 +1,5 @@
 package expo.modules.updates
 
-import expo.modules.updates.TestUtils.asResponseBody
 import okhttp3.Headers
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
@@ -10,13 +10,14 @@ import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
-import expo.modules.updates.launcher.Launcher.LauncherCallback
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.selectionpolicy.SelectionPolicy
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
-import io.mockk.verify
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert
@@ -24,7 +25,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
-import java.util.*
+import java.util.Date
+import java.util.UUID
 
 @RunWith(AndroidJUnit4ClassRunner::class)
 class DatabaseLauncherTest {
@@ -43,7 +45,7 @@ class DatabaseLauncherTest {
   }
 
   @Test
-  fun testLaunch_MarkUpdateAccessed() {
+  fun testLaunch_MarkUpdateAccessed() = runTest {
     val testUpdate = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey", JSONObject("{}"))
     testUpdate.lastAccessed = Date(Date().time - DateUtils.DAY_IN_MILLIS) // yesterday
     db.updateDao().insertUpdate(testUpdate)
@@ -70,19 +72,16 @@ class DatabaseLauncherTest {
         mockk(),
         mockk()
       ),
-      UpdatesLogger(context.filesDir)
+      UpdatesLogger(context.filesDir),
+      TestScope()
     )
     val spyLauncher = spyk(launcher)
     every { spyLauncher.getLaunchableUpdate(any()) } returns db.updateDao().loadUpdateWithId(testUpdate.id)
 
     val mockedFile = File(context.cacheDir, "test")
-    every { spyLauncher.ensureAssetExists(any(), any(), any(), any()) } returns mockedFile
+    coEvery { spyLauncher.ensureAssetExists(any(), any(), any(), any()) } returns mockedFile
 
-    val mockedCallback = mockk<LauncherCallback>(relaxed = true)
-
-    spyLauncher.launch(db, mockedCallback)
-
-    verify { mockedCallback.onSuccess() }
+    spyLauncher.launch(db)
 
     val sameUpdate = db.updateDao().loadUpdateWithId(testUpdate.id)!!
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
@@ -13,7 +13,6 @@ import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import kotlinx.coroutines.test.TestScope

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
@@ -76,7 +76,7 @@ class DatabaseLauncherTest {
       TestScope()
     )
     val spyLauncher = spyk(launcher)
-    every { spyLauncher.getLaunchableUpdate(any()) } returns db.updateDao().loadUpdateWithId(testUpdate.id)
+    coEvery { spyLauncher.getLaunchableUpdate(any()) } returns db.updateDao().loadUpdateWithId(testUpdate.id)
 
     val mockedFile = File(context.cacheDir, "test")
     coEvery { spyLauncher.ensureAssetExists(any(), any(), any(), any()) } returns mockedFile

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
@@ -10,7 +10,7 @@ import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.db.enums.UpdateStatus
-import expo.modules.updates.loader.Loader.LoaderCallback
+import kotlinx.coroutines.test.runTest
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.EmbeddedUpdate
 import expo.modules.updates.manifest.Update
@@ -36,7 +36,6 @@ class EmbeddedLoaderTest {
   private lateinit var loader: EmbeddedLoader
   private lateinit var loaderWithCopyAssets: EmbeddedLoader
   private lateinit var mockLoaderFiles: LoaderFiles
-  private lateinit var mockCallback: LoaderCallback
 
   @Before
   @Throws(JSONException::class)
@@ -75,18 +74,16 @@ class EmbeddedLoaderTest {
 
     every { mockLoaderFiles.readEmbeddedUpdate(any(), any()) } returns manifest
     every { mockLoaderFiles.copyAssetAndGetHash(any(), any(), any()) } answers { callOriginal() } // test for exception cases
-
-    mockCallback = mockk(relaxUnitFun = true)
-    every { mockCallback.onUpdateResponseLoaded(any()) } returns Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
   }
 
   @Test
   @Throws(IOException::class, NoSuchAlgorithmException::class)
-  fun testEmbeddedLoader_SimpleCase() {
-    loader.start(mockCallback)
+  fun testEmbeddedLoader_SimpleCase() = runTest {
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
 
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
+    Assert.assertNotNull(result.updateEntity)
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())
@@ -98,7 +95,7 @@ class EmbeddedLoaderTest {
 
   @Test
   @Throws(JSONException::class, IOException::class, NoSuchAlgorithmException::class)
-  fun testEmbeddedLoader_MultipleScales() {
+  fun testEmbeddedLoader_MultipleScales() = runTest {
     val multipleScalesManifest: Update = EmbeddedUpdate.fromEmbeddedManifest(
       EmbeddedManifest(JSONObject("{\"id\":\"d26d7f92-c7a6-4c44-9ada-4804eda7e6e2\",\"commitTime\":1630435460610,\"assets\":[{\"name\":\"robot-dev\",\"type\":\"png\",\"scale\":1,\"packagerHash\":\"54da1e9816c77e30ebc5920e256736f2\",\"subdirectory\":\"/assets\",\"scales\":[1,2,3],\"resourcesFilename\":\"robotdev\",\"resourcesFolder\":\"drawable\"},{\"name\":\"robot-dev\",\"type\":\"png\",\"scale\":2,\"packagerHash\":\"4ecff55cf37460b7f768dc7b72bcea6b\",\"subdirectory\":\"/assets\",\"scales\":[1,2,3],\"resourcesFilename\":\"robotdev\",\"resourcesFolder\":\"drawable\"}]}")),
       configuration
@@ -106,10 +103,11 @@ class EmbeddedLoaderTest {
 
     every { mockLoaderFiles.readEmbeddedUpdate(any(), any()) } returns multipleScalesManifest
 
-    loader.start(mockCallback)
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
 
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
+    Assert.assertNotNull(result.updateEntity)
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())
@@ -121,7 +119,7 @@ class EmbeddedLoaderTest {
 
   @Test
   @Throws(JSONException::class, IOException::class, NoSuchAlgorithmException::class)
-  fun testEmbeddedLoader_MultipleScales_ReverseOrder() {
+  fun testEmbeddedLoader_MultipleScales_ReverseOrder() = runTest {
     val multipleScalesManifest: Update = EmbeddedUpdate.fromEmbeddedManifest(
       EmbeddedManifest(JSONObject("{\"id\":\"d26d7f92-c7a6-4c44-9ada-4804eda7e6e2\",\"commitTime\":1630435460610,\"assets\":[{\"name\":\"robot-dev\",\"type\":\"png\",\"scale\":2,\"packagerHash\":\"4ecff55cf37460b7f768dc7b72bcea6b\",\"subdirectory\":\"/assets\",\"scales\":[1,2],\"resourcesFilename\":\"robotdev\",\"resourcesFolder\":\"drawable\"},{\"name\":\"robot-dev\",\"type\":\"png\",\"scale\":1,\"packagerHash\":\"54da1e9816c77e30ebc5920e256736f2\",\"subdirectory\":\"/assets\",\"scales\":[1,2],\"resourcesFilename\":\"robotdev\",\"resourcesFolder\":\"drawable\"}]}")),
       configuration
@@ -129,10 +127,11 @@ class EmbeddedLoaderTest {
 
     every { mockLoaderFiles.readEmbeddedUpdate(any(), any()) } returns multipleScalesManifest
 
-    loader.start(mockCallback)
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
 
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
+    Assert.assertNotNull(result.updateEntity)
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())
@@ -144,18 +143,21 @@ class EmbeddedLoaderTest {
 
   @Test
   @Throws(IOException::class, NoSuchAlgorithmException::class)
-  fun testEmbeddedLoaderWithCopyAssets_FailureToCopyAssets() {
+  fun testEmbeddedLoaderWithCopyAssets_FailureToCopyAssets() = runTest {
     every { mockLoaderFiles.copyAssetAndGetHash(any(), any(), any()) } throws IOException("mock failed to copy asset")
 
-    loaderWithCopyAssets.start(mockCallback)
+    try {
+      loaderWithCopyAssets.load { _ ->
+        Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+      }
+    } catch (e: Exception) {
+      Assert.assertEquals("mock failed to copy asset", e.message)
+    }
 
-    verify(exactly = 0) { mockCallback.onSuccess(any()) }
-    verify { mockCallback.onFailure(any()) }
-    verify(exactly = 2) { mockLoaderFiles.copyAssetAndGetHash(any(), any(), any()) }
+    verify(atLeast = 1) { mockLoaderFiles.copyAssetAndGetHash(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())
-    // status embedded indicates the update wasn't able to be fully copied to the expo-updates cache
     Assert.assertEquals(UpdateStatus.EMBEDDED, updates[0].status)
 
     val assets = db.assetDao().loadAllAssets()
@@ -164,7 +166,7 @@ class EmbeddedLoaderTest {
 
   @Test
   @Throws(IOException::class, NoSuchAlgorithmException::class)
-  fun testEmbeddedLoaderWithCopyAssets_AssetExists_BothDbAndDisk() {
+  fun testEmbeddedLoaderWithCopyAssets_AssetExists_BothDbAndDisk() = runTest {
     // return true when asked if file 54da1e9816c77e30ebc5920e256736f2 exists
     every { mockLoaderFiles.fileExists(any(), any(), any()) } answers {
       thirdArg<String>().contains("54da1e9816c77e30ebc5920e256736f2")
@@ -174,10 +176,11 @@ class EmbeddedLoaderTest {
     existingAsset.relativePath = "54da1e9816c77e30ebc5920e256736f2.png"
     db.assetDao().insertAssetForTest(existingAsset)
 
-    loaderWithCopyAssets.start(mockCallback)
+    val result = loaderWithCopyAssets.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
 
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
+    Assert.assertNotNull(result.updateEntity)
 
     // only 1 asset (bundle) should be copied since the other asset already exists
     verify(exactly = 1) { mockLoaderFiles.copyAssetAndGetHash(any(), any(), any()) }
@@ -192,7 +195,7 @@ class EmbeddedLoaderTest {
 
   @Test
   @Throws(IOException::class, NoSuchAlgorithmException::class)
-  fun testEmbeddedLoaderWithCopyAssets_AssetExists_DbOnly() {
+  fun testEmbeddedLoaderWithCopyAssets_AssetExists_DbOnly() = runTest {
     // return true when asked if file 54da1e9816c77e30ebc5920e256736f2 exists
     every { mockLoaderFiles.fileExists(any(), any(), any()) } returns false
 
@@ -200,10 +203,11 @@ class EmbeddedLoaderTest {
     existingAsset.relativePath = "54da1e9816c77e30ebc5920e256736f2.png"
     db.assetDao().insertAssetForTest(existingAsset)
 
-    loaderWithCopyAssets.start(mockCallback)
+    val result = loaderWithCopyAssets.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
 
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
+    Assert.assertNotNull(result.updateEntity)
 
     // both assets should be copied regardless of what the database says
     verify(exactly = 2) { mockLoaderFiles.copyAssetAndGetHash(any(), any(), any()) }
@@ -220,7 +224,7 @@ class EmbeddedLoaderTest {
 
   @Test
   @Throws(IOException::class, NoSuchAlgorithmException::class)
-  fun testEmbeddedLoaderWithCopyAssets_AssetExists_DiskOnly() {
+  fun testEmbeddedLoaderWithCopyAssets_AssetExists_DiskOnly() = runTest {
     // return true when asked if file 54da1e9816c77e30ebc5920e256736f2 exists
     every { mockLoaderFiles.fileExists(any(), any(), any()) } answers {
       thirdArg<String>().contains("54da1e9816c77e30ebc5920e256736f2")
@@ -228,10 +232,11 @@ class EmbeddedLoaderTest {
 
     Assert.assertEquals(0, db.assetDao().loadAllAssets().size.toLong())
 
-    loaderWithCopyAssets.start(mockCallback)
+    val result = loaderWithCopyAssets.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
 
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
+    Assert.assertNotNull(result.updateEntity)
 
     // only 1 asset (bundle) should be copied since the other asset already exists
     verify(exactly = 1) { mockLoaderFiles.copyAssetAndGetHash(any(), any(), any()) }
@@ -247,7 +252,7 @@ class EmbeddedLoaderTest {
 
   @Test
   @Throws(IOException::class, NoSuchAlgorithmException::class)
-  fun testEmbeddedLoader_UpdateExists_Ready() {
+  fun testEmbeddedLoader_UpdateExists_Ready() = runTest {
     val update = UpdateEntity(
       manifest.updateEntity!!.id,
       manifest.updateEntity!!.commitTime,
@@ -258,10 +263,11 @@ class EmbeddedLoaderTest {
     update.status = UpdateStatus.READY
     db.updateDao().insertUpdate(update)
 
-    loader.start(mockCallback)
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
 
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
+    Assert.assertNotNull(result.updateEntity)
     verify(exactly = 0) { mockLoaderFiles.copyAssetAndGetHash(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
@@ -271,7 +277,7 @@ class EmbeddedLoaderTest {
 
   @Test
   @Throws(IOException::class, NoSuchAlgorithmException::class)
-  fun testEmbeddedLoader_UpdateExists_Pending() {
+  fun testEmbeddedLoader_UpdateExists_Pending() = runTest {
     val update = UpdateEntity(
       manifest.updateEntity!!.id,
       manifest.updateEntity!!.commitTime,
@@ -282,10 +288,11 @@ class EmbeddedLoaderTest {
     update.status = UpdateStatus.PENDING
     db.updateDao().insertUpdate(update)
 
-    loader.start(mockCallback)
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
 
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
+    Assert.assertNotNull(result.updateEntity)
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
@@ -6,19 +6,19 @@ import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
 import expo.modules.manifests.core.ExpoUpdatesManifest
 import expo.modules.updates.UpdatesConfiguration
+import expo.modules.updates.codesigning.*
 import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
-import expo.modules.updates.codesigning.*
 import expo.modules.updates.db.enums.UpdateStatus
-import expo.modules.updates.loader.FileDownloader.AssetDownloadCallback
-import expo.modules.updates.loader.Loader.LoaderCallback
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.ExpoUpdatesUpdate
 import expo.modules.updates.manifest.Update
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
+import kotlinx.coroutines.test.runTest
 import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Assert
@@ -38,11 +38,10 @@ class RemoteLoaderTest {
   private lateinit var loader: RemoteLoader
   private lateinit var mockLoaderFiles: LoaderFiles
   private lateinit var mockFileDownloader: FileDownloader
-  private lateinit var mockCallback: LoaderCallback
 
   @Before
   @Throws(JSONException::class)
-  fun setup() {
+  fun setup() = runTest {
     val configMap = mapOf<String, Any>(
       "updateUrl" to Uri.parse("https://exp.host/@test/test"),
       "runtimeVersion" to "1.0"
@@ -67,34 +66,26 @@ class RemoteLoaderTest {
     val manifestString = CertificateFixtures.testExpoUpdatesManifestBody
     manifest = ExpoUpdatesUpdate.fromExpoUpdatesManifest(ExpoUpdatesManifest(JSONObject(manifestString)), null, configuration)
 
-    every { mockFileDownloader.downloadRemoteUpdate(any(), any()) } answers {
-      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(1)
-      callback.onSuccess(
-        UpdateResponse(
-          responseHeaderData = null,
-          manifestUpdateResponsePart = UpdateResponsePart.ManifestUpdateResponsePart(manifest),
-          directiveUpdateResponsePart = null
-        )
-      )
-    }
+    coEvery { mockFileDownloader.downloadRemoteUpdate(any()) } returns UpdateResponse(
+      responseHeaderData = null,
+      manifestUpdateResponsePart = UpdateResponsePart.ManifestUpdateResponsePart(manifest),
+      directiveUpdateResponsePart = null
+    )
 
-    every { mockFileDownloader.downloadAsset(any(), any(), any(), any()) } answers {
+    coEvery { mockFileDownloader.downloadAsset(any(), any(), any()) } answers {
       val asset = firstArg<AssetEntity>()
-      val callback = arg<AssetDownloadCallback>(3)
-      callback.onSuccess(asset, true)
+      FileDownloader.AssetDownloadResult(asset, true)
     }
-
-    mockCallback = mockk(relaxUnitFun = true)
-    every { mockCallback.onUpdateResponseLoaded(any()) } returns Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
   }
 
   @Test
-  fun testRemoteLoader_SimpleCase() {
-    loader.start(mockCallback)
+  fun testRemoteLoader_SimpleCase() = runTest {
+    val result = loader.load {
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
 
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    Assert.assertNotNull(result.updateEntity)
+    coVerify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -104,18 +95,18 @@ class RemoteLoaderTest {
   }
 
   @Test
-  fun testRemoteLoader_FailureToDownloadAssets() {
-    every { mockFileDownloader.downloadAsset(any(), any(), any(), any()) } answers {
-      val asset = firstArg<AssetEntity>()
-      val callback = arg<AssetDownloadCallback>(3)
-      callback.onFailure(IOException("mock failed to download asset"), asset)
+  fun testRemoteLoader_FailureToDownloadAssets() = runTest {
+    coEvery { mockFileDownloader.downloadAsset(any(), any(), any()) } throws IOException("mock failed to download asset")
+
+    try {
+      loader.load { _ ->
+        Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+      }
+    } catch (e: IOException) {
+      Assert.assertEquals("mock failed to download asset", e.message)
     }
 
-    loader.start(mockCallback)
-
-    verify(exactly = 0) { mockCallback.onSuccess(any()) }
-    verify { mockCallback.onFailure(any()) }
-    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    coVerify(atLeast = 1) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -125,7 +116,7 @@ class RemoteLoaderTest {
   }
 
   @Test
-  fun testRemoteLoader_AssetExists_BothDbAndDisk() {
+  fun testRemoteLoader_AssetExists_BothDbAndDisk() = runTest {
     // return true when asked if file 54da1e9816c77e30ebc5920e256736f2 exists on disk
     every { mockLoaderFiles.fileExists(any(), any(), any()) } answers {
       thirdArg<String>().contains("489ea2f19fa850b65653ab445637a181")
@@ -134,13 +125,15 @@ class RemoteLoaderTest {
     val existingAsset = AssetEntity("489ea2f19fa850b65653ab445637a181.jpg", ".jpg")
     existingAsset.relativePath = "489ea2f19fa850b65653ab445637a181.jpg"
     db.assetDao().insertAssetForTest(existingAsset)
-    loader.start(mockCallback)
 
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
+
+    Assert.assertNotNull(result.updateEntity)
 
     // only 1 asset (bundle) should be downloaded since the other asset already exists
-    verify(exactly = 1) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    coVerify(exactly = 1) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -153,7 +146,7 @@ class RemoteLoaderTest {
   }
 
   @Test
-  fun testRemoteLoader_AssetExists_DbOnly() {
+  fun testRemoteLoader_AssetExists_DbOnly() = runTest {
     // return false when asked if file 489ea2f19fa850b65653ab445637a181 exists on disk
     every { mockLoaderFiles.fileExists(any(), any(), any()) } returns false
 
@@ -161,13 +154,15 @@ class RemoteLoaderTest {
     existingAsset.relativePath = "489ea2f19fa850b65653ab445637a181.jpg"
     existingAsset.url = Uri.parse("http://example.com")
     db.assetDao().insertAssetForTest(existingAsset)
-    loader.start(mockCallback)
 
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
+
+    Assert.assertNotNull(result.updateEntity)
 
     // both assets should be downloaded regardless of what the database says
-    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    coVerify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -183,7 +178,7 @@ class RemoteLoaderTest {
   }
 
   @Test
-  fun testRemoteLoader_UpdateExists_Ready() {
+  fun testRemoteLoader_UpdateExists_Ready() = runTest {
     val update = UpdateEntity(
       manifest.updateEntity!!.id,
       manifest.updateEntity!!.commitTime,
@@ -193,11 +188,13 @@ class RemoteLoaderTest {
     )
     update.status = UpdateStatus.READY
     db.updateDao().insertUpdate(update)
-    loader.start(mockCallback)
 
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
+
+    Assert.assertNotNull(result.updateEntity)
+    coVerify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -205,7 +202,7 @@ class RemoteLoaderTest {
   }
 
   @Test
-  fun testRemoteLoader_UpdateExists_Pending() {
+  fun testRemoteLoader_UpdateExists_Pending() = runTest {
     val update = UpdateEntity(
       manifest.updateEntity!!.id,
       manifest.updateEntity!!.commitTime,
@@ -215,13 +212,15 @@ class RemoteLoaderTest {
     )
     update.status = UpdateStatus.PENDING
     db.updateDao().insertUpdate(update)
-    loader.start(mockCallback)
 
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
+
+    Assert.assertNotNull(result.updateEntity)
 
     // missing assets should still be downloaded
-    verify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    coVerify(exactly = 2) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -231,7 +230,7 @@ class RemoteLoaderTest {
   }
 
   @Test
-  fun testRemoteLoader_UpdateExists_DifferentScopeKey() {
+  fun testRemoteLoader_UpdateExists_DifferentScopeKey() = runTest {
     val update = UpdateEntity(
       manifest.updateEntity!!.id,
       manifest.updateEntity!!.commitTime,
@@ -241,11 +240,13 @@ class RemoteLoaderTest {
     )
     update.status = UpdateStatus.READY
     db.updateDao().insertUpdate(update)
-    loader.start(mockCallback)
 
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
+
+    Assert.assertNotNull(result.updateEntity)
+    coVerify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -255,27 +256,23 @@ class RemoteLoaderTest {
 
   @Test
   @Throws(JSONException::class)
-  fun testRemoteLoader_DevelopmentModeManifest() {
+  fun testRemoteLoader_DevelopmentModeManifest() = runTest {
     val manifestString =
       "{\"metadata\":{},\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"url\":\"https://url.to/bundle.js\",\"contentType\":\"application/javascript\"},\"extra\":{\"expoGo\":{\"developer\":{\"tool\":\"expo-cli\",\"projectRoot\":\"/Users/eric/expo/updates-unit-test-template\"},\"packagerOpts\":{\"scheme\":null,\"hostType\":\"lan\",\"lanType\":\"ip\",\"dev\":true,\"minify\":false,\"urlRandomness\":null,\"https\":false}}}}"
     manifest = ExpoUpdatesUpdate.fromExpoUpdatesManifest(ExpoUpdatesManifest(JSONObject(manifestString)), null, configuration)
 
-    every { mockFileDownloader.downloadRemoteUpdate(any(), any()) } answers {
-      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(1)
-      callback.onSuccess(
-        UpdateResponse(
-          responseHeaderData = null,
-          manifestUpdateResponsePart = UpdateResponsePart.ManifestUpdateResponsePart(manifest),
-          directiveUpdateResponsePart = null
-        )
-      )
+    coEvery { mockFileDownloader.downloadRemoteUpdate(any()) } returns UpdateResponse(
+      responseHeaderData = null,
+      manifestUpdateResponsePart = UpdateResponsePart.ManifestUpdateResponsePart(manifest),
+      directiveUpdateResponsePart = null
+    )
+
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
     }
 
-    loader.start(mockCallback)
-
-    verify { mockCallback.onSuccess(any()) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    Assert.assertNotNull(result.updateEntity)
+    coVerify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size)
@@ -283,24 +280,21 @@ class RemoteLoaderTest {
   }
 
   @Test
-  fun testRemoteLoader_RollBackDirective() {
+  fun testRemoteLoader_RollBackDirective() = runTest {
     val updateDirective = UpdateDirective.RollBackToEmbeddedUpdateDirective(commitTime = Date(), signingInfo = null)
-    every { mockFileDownloader.downloadRemoteUpdate(any(), any()) } answers {
-      val callback = arg<FileDownloader.RemoteUpdateDownloadCallback>(1)
-      callback.onSuccess(
-        UpdateResponse(
-          responseHeaderData = null,
-          manifestUpdateResponsePart = null,
-          directiveUpdateResponsePart = UpdateResponsePart.DirectiveUpdateResponsePart(updateDirective)
-        )
-      )
+    coEvery { mockFileDownloader.downloadRemoteUpdate(any()) } returns UpdateResponse(
+      responseHeaderData = null,
+      manifestUpdateResponsePart = null,
+      directiveUpdateResponsePart = UpdateResponsePart.DirectiveUpdateResponsePart(updateDirective)
+    )
+
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
     }
 
-    loader.start(mockCallback)
-
-    verify { mockCallback.onSuccess(Loader.LoaderResult(null, updateDirective)) }
-    verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any(), any()) }
+    Assert.assertEquals(updateDirective, result.updateDirective)
+    Assert.assertNull(result.updateEntity)
+    coVerify(exactly = 0) { mockFileDownloader.downloadAsset(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(0, updates.size)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.Bundle
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
+import expo.modules.easclient.EASClientID
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.toCodedException
 import expo.modules.updates.db.BuildData
@@ -55,12 +56,14 @@ class EnabledUpdatesController(
   private val logger = UpdatesLogger(context.filesDir)
   override val eventManager: IUpdatesEventManager = UpdatesEventManager(logger)
 
-  private val fileDownloader = FileDownloader(context, updatesConfiguration, logger)
   private val selectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy(
     updatesConfiguration.getRuntimeVersion()
   )
   private val stateMachine = UpdatesStateMachine(logger, eventManager, UpdatesStateValue.entries.toSet())
   private val controllerScope = CoroutineScope(Dispatchers.IO)
+  private val fileDownloader by lazy {
+    FileDownloader(context.filesDir, EASClientID(context).uuid.toString(), updatesConfiguration, logger)
+  }
   private val databaseHolder = DatabaseHolder(UpdatesDatabase.getInstance(context, Dispatchers.IO))
   private val startupFinishedDeferred = CompletableDeferred<Unit>()
   private val startupFinishedMutex = Mutex()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -30,7 +30,6 @@ import expo.modules.updatesinterface.UpdatesInterface
 import expo.modules.updatesinterface.UpdatesInterfaceCallbacks
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.json.JSONObject

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -1,11 +1,11 @@
 package expo.modules.updates
 
 import android.content.Context
-import android.os.AsyncTask
-import android.os.Bundle
 import android.net.Uri
+import android.os.Bundle
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
+import expo.modules.easclient.EASClientID
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.updates.db.DatabaseHolder
 import expo.modules.updates.db.Reaper
@@ -19,7 +19,6 @@ import expo.modules.updates.loader.FileDownloader
 import expo.modules.updates.loader.Loader
 import expo.modules.updates.loader.RemoteLoader
 import expo.modules.updates.loader.UpdateDirective
-import expo.modules.updates.loader.UpdateResponse
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.selectionpolicy.LauncherSelectionPolicySingleUpdate
@@ -29,7 +28,10 @@ import expo.modules.updates.selectionpolicy.SelectionPolicyFactory
 import expo.modules.updates.statemachine.UpdatesStateContext
 import expo.modules.updatesinterface.UpdatesInterface
 import expo.modules.updatesinterface.UpdatesInterfaceCallbacks
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.json.JSONObject
 import java.io.File
@@ -63,6 +65,7 @@ class UpdatesDevLauncherController(
   private var updatesConfiguration: UpdatesConfiguration? = initialUpdatesConfiguration
 
   private val databaseHolder = DatabaseHolder(UpdatesDatabase.getInstance(context, Dispatchers.IO))
+  private val controllerScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
   private var mSelectionPolicy: SelectionPolicy? = null
   private var defaultSelectionPolicy: SelectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy(
@@ -151,7 +154,7 @@ class UpdatesDevLauncherController(
 
     setDevelopmentSelectionPolicy()
 
-    val fileDownloader = FileDownloader(context, updatesConfiguration!!, logger)
+    val fileDownloader = FileDownloader(context.filesDir, EASClientID(context).uuid.toString(), updatesConfiguration!!, logger)
     val loader = RemoteLoader(
       context,
       updatesConfiguration!!,
@@ -161,47 +164,44 @@ class UpdatesDevLauncherController(
       updatesDirectory,
       null
     )
-    loader.start(object : Loader.LoaderCallback {
-      override fun onFailure(e: Exception) {
-        // reset controller's configuration to what it was before this request
-        updatesConfiguration = previousUpdatesConfiguration
-        callback.onFailure(e)
+    controllerScope.launch {
+      val progressJob = launch {
+        loader.progressFlow.collect { progress ->
+          callback.onProgress(progress.successfulAssetCount, progress.failedAssetCount, progress.totalAssetCount)
+        }
       }
 
-      override fun onSuccess(loaderResult: Loader.LoaderResult) {
+      try {
+        val loaderResult = loader.load { updateResponse ->
+          val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
+          if (updateDirective != null) {
+            return@load Loader.OnUpdateResponseLoadedResult(
+              shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
+                is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
+                is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
+              }
+            )
+          }
+
+          val update = updateResponse.manifestUpdateResponsePart?.update
+            ?: return@load Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
+          Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = callback.onManifestLoaded(update.manifest.getRawJson()))
+        }
+
         // the dev launcher doesn't handle roll back to embedded commands
         if (loaderResult.updateEntity == null) {
           callback.onSuccess(null)
-          return
+          return@launch
         }
         launchUpdate(loaderResult.updateEntity, updatesConfiguration!!, fileDownloader, callback)
+      } catch (e: Exception) {
+        // reset controller's configuration to what it was before this request
+        updatesConfiguration = previousUpdatesConfiguration
+        callback.onFailure(e)
+      } finally {
+        progressJob.cancel()
       }
-
-      override fun onAssetLoaded(
-        asset: AssetEntity,
-        successfulAssetCount: Int,
-        failedAssetCount: Int,
-        totalAssetCount: Int
-      ) {
-        callback.onProgress(successfulAssetCount, failedAssetCount, totalAssetCount)
-      }
-
-      override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
-        val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
-        if (updateDirective != null) {
-          return Loader.OnUpdateResponseLoadedResult(
-            shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
-              is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
-              is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
-            }
-          )
-        }
-
-        val update = updateResponse.manifestUpdateResponsePart?.update
-          ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
-        return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = callback.onManifestLoaded(update.manifest.getRawJson()))
-      }
-    })
+    }
   }
 
   override fun isValidUpdatesConfiguration(configuration: HashMap<String, Any>): Boolean {
@@ -249,7 +249,7 @@ class UpdatesDevLauncherController(
     resetSelectionPolicyToDefault()
   }
 
-  private fun launchUpdate(
+  private suspend fun launchUpdate(
     update: UpdateEntity,
     configuration: UpdatesConfiguration,
     fileDownloader: FileDownloader,
@@ -275,35 +275,30 @@ class UpdatesDevLauncherController(
       updatesDirectory!!,
       fileDownloader,
       selectionPolicy,
-      logger
+      logger,
+      controllerScope
     )
-    launcher.launch(
-      databaseHolder.database,
-      object : Launcher.LauncherCallback {
-        override fun onFailure(e: Exception) {
-          // reset controller's configuration to what it was before this request
-          updatesConfiguration = previousUpdatesConfiguration
-          callback.onFailure(e)
-        }
-
-        override fun onSuccess() {
-          this@UpdatesDevLauncherController.launcher = launcher
-          callback.onSuccess(object : UpdatesInterface.Update {
-            override val manifest: JSONObject
-              get() = launcher.launchedUpdate!!.manifest
-            override val launchAssetPath: String
-              get() = launcher.launchAssetFile!!
-          })
-          runReaper()
-        }
-      }
-    )
+    try {
+      launcher.launch(databaseHolder.database)
+      this@UpdatesDevLauncherController.launcher = launcher
+      callback.onSuccess(object : UpdatesInterface.Update {
+        override val manifest: JSONObject
+          get() = launcher.launchedUpdate!!.manifest
+        override val launchAssetPath: String
+          get() = launcher.launchAssetFile!!
+      })
+      runReaper()
+    } catch (e: Exception) {
+      // reset controller's configuration to what it was before this request
+      updatesConfiguration = previousUpdatesConfiguration
+      callback.onFailure(e)
+    }
   }
 
   private fun getDatabase(): UpdatesDatabase = databaseHolder.database
 
   private fun runReaper() {
-    AsyncTask.execute {
+    controllerScope.launch {
       updatesConfiguration?.let {
         val databaseLocal = getDatabase()
         Reaper.reapUnusedUpdates(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -65,7 +65,7 @@ class UpdatesDevLauncherController(
   private var updatesConfiguration: UpdatesConfiguration? = initialUpdatesConfiguration
 
   private val databaseHolder = DatabaseHolder(UpdatesDatabase.getInstance(context, Dispatchers.IO))
-  private val controllerScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+  private val controllerScope = CoroutineScope(Dispatchers.IO)
 
   private var mSelectionPolicy: SelectionPolicy? = null
   private var defaultSelectionPolicy: SelectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -118,7 +118,7 @@ class DatabaseLauncher(
 
     localAssetFiles = embeddedAssetFileMap().apply {
       val downloadJobs = mutableListOf<Deferred<Pair<AssetEntity, File?>>>()
-      
+
       for (asset in assetEntities) {
         if (asset.id == launchAsset.id) {
           // we took care of this one above
@@ -135,7 +135,7 @@ class DatabaseLauncher(
           this[asset] = filename
         }
       }
-      
+
       downloadJobs.awaitAll().forEach { (asset, assetFile) ->
         if (assetFile != null) {
           this[asset] = Uri.fromFile(assetFile).toString()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -10,9 +10,7 @@ import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.db.enums.UpdateStatus
-import expo.modules.updates.launcher.Launcher.LauncherCallback
 import expo.modules.updates.loader.FileDownloader
-import expo.modules.updates.loader.FileDownloader.AssetDownloadCallback
 import expo.modules.updates.loader.LoaderFiles
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
@@ -21,6 +19,10 @@ import expo.modules.updates.manifest.EmbeddedUpdate
 import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import expo.modules.updates.utils.AndroidResourceAssetUtils
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import org.json.JSONObject
 import java.io.File
 
@@ -48,6 +50,7 @@ class DatabaseLauncher(
   private val fileDownloader: FileDownloader,
   private val selectionPolicy: SelectionPolicy,
   private val logger: UpdatesLogger,
+  private val scope: CoroutineScope,
   private val shouldCopyEmbeddedAssets: Boolean = BuildConfig.EX_UPDATES_COPY_EMBEDDED_ASSETS
 ) : Launcher {
   private val loaderFiles: LoaderFiles = LoaderFiles()
@@ -62,40 +65,32 @@ class DatabaseLauncher(
   override val isUsingEmbeddedAssets: Boolean
     get() = localAssetFiles == null
 
-  private var assetsToDownload = 0
-  private var assetsToDownloadFinished = 0
   private var launchAssetException: Exception? = null
-  private var callback: LauncherCallback? = null
+  private var hasLaunched = false
 
-  @Synchronized
-  fun launch(database: UpdatesDatabase, callback: LauncherCallback?) {
-    if (this.callback != null) {
+  suspend fun launch(database: UpdatesDatabase) {
+    if (hasLaunched) {
       throw AssertionError("DatabaseLauncher has already started. Create a new instance in order to launch a new version.")
     }
-    this.callback = callback
+    hasLaunched = true
 
     launchedUpdate = getLaunchableUpdate(database)
     if (launchedUpdate == null) {
-      this.callback!!.onFailure(Exception("No launchable update was found. If this is a generic app, ensure expo-updates is configured correctly."))
-      return
+      throw Exception("No launchable update was found. If this is a generic app, ensure expo-updates is configured correctly.")
     }
 
     database.updateDao().markUpdateAccessed(launchedUpdate!!)
     if (launchedUpdate!!.status == UpdateStatus.DEVELOPMENT) {
-      this.callback!!.onSuccess()
       return
     }
 
     // verify that we have all assets on disk
     // according to the database, we should, but something could have gone wrong on disk
     val launchAsset = database.updateDao().loadLaunchAssetForUpdate(launchedUpdate!!.id)
-    if (launchAsset == null) {
-      this.callback!!.onFailure(Exception("Launch asset not found for update; this should never happen. Debug info: ${launchedUpdate!!.debugInfo()}"))
-      return
-    }
+      ?: throw Exception("Launch asset not found for update; this should never happen. Debug info: ${launchedUpdate!!.debugInfo()}")
 
     if (launchAsset.relativePath == null) {
-      this.callback!!.onFailure(Exception("Launch asset relative path should not be null. Debug info: ${launchedUpdate!!.debugInfo()}"))
+      throw Exception("Launch asset relative path should not be null. Debug info: ${launchedUpdate!!.debugInfo()}")
     }
 
     val embeddedUpdate = EmbeddedManifestUtils.getEmbeddedUpdate(context, configuration)
@@ -115,11 +110,15 @@ class DatabaseLauncher(
     val launchAssetFile = embeddedLaunchAsset ?: ensureAssetExists(launchAsset, database, embeddedUpdate, extraHeaders)
     if (launchAssetFile != null) {
       this.launchAssetFile = launchAssetFile.toString()
+    } else {
+      throw launchAssetException ?: Exception("Launch asset file was null after download attempt")
     }
 
     val assetEntities = database.assetDao().loadAssetsForUpdate(launchedUpdate!!.id)
 
     localAssetFiles = embeddedAssetFileMap().apply {
+      val downloadJobs = mutableListOf<Deferred<Pair<AssetEntity, File?>>>()
+      
       for (asset in assetEntities) {
         if (asset.id == launchAsset.id) {
           // we took care of this one above
@@ -127,26 +126,25 @@ class DatabaseLauncher(
         }
         val filename = asset.relativePath ?: continue
         if (!AndroidResourceAssetUtils.isAndroidResourceAsset(filename)) {
-          val assetFile = ensureAssetExists(asset, database, embeddedUpdate, extraHeaders)
-          if (assetFile != null) {
-            this[asset] = Uri.fromFile(assetFile).toString()
+          val job = scope.async {
+            val assetFile = ensureAssetExists(asset, database, embeddedUpdate, extraHeaders)
+            Pair(asset, assetFile)
           }
+          downloadJobs.add(job)
         } else {
           this[asset] = filename
         }
       }
-    }
-
-    if (assetsToDownload == 0) {
-      if (this.launchAssetFile == null) {
-        this.callback!!.onFailure(Exception("Launch asset file was null with no assets to download reported; this should never happen. Debug info: ${launchedUpdate!!.debugInfo()}"))
-      } else {
-        this.callback!!.onSuccess()
+      
+      downloadJobs.awaitAll().forEach { (asset, assetFile) ->
+        if (assetFile != null) {
+          this[asset] = Uri.fromFile(assetFile).toString()
+        }
       }
     }
   }
 
-  fun getLaunchableUpdate(database: UpdatesDatabase): UpdateEntity? {
+  suspend fun getLaunchableUpdate(database: UpdatesDatabase): UpdateEntity? {
     val launchableUpdates = database.updateDao().loadLaunchableUpdatesForScope(configuration.scopeKey)
 
     // We can only run an update marked as embedded if it's actually the update embedded in the
@@ -207,7 +205,7 @@ class DatabaseLauncher(
   }
 
   @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-  fun ensureAssetExists(
+  suspend fun ensureAssetExists(
     asset: AssetEntity,
     database: UpdatesDatabase,
     embeddedUpdate: EmbeddedUpdate?,
@@ -244,53 +242,25 @@ class DatabaseLauncher(
 
     return if (!assetFileExists) {
       // we still don't have the asset locally, so try downloading it remotely
-      assetsToDownload++
+      try {
+        val result = fileDownloader.downloadAsset(
+          asset,
+          updatesDirectory,
+          extraHeaders
+        )
 
-      fileDownloader.downloadAsset(
-        asset,
-        updatesDirectory,
-        extraHeaders,
-        object : AssetDownloadCallback {
-          override fun onFailure(e: Exception, assetEntity: AssetEntity) {
-            logger.error("Failed to load asset from disk or network", e, UpdatesErrorCode.AssetsFailedToLoad)
-            if (assetEntity.isLaunchAsset) {
-              launchAssetException = e
-            }
-            maybeFinish(assetEntity, null)
-          }
-
-          override fun onSuccess(assetEntity: AssetEntity, isNew: Boolean) {
-            database.assetDao().updateAsset(assetEntity)
-            val assetFileLocal = File(updatesDirectory, assetEntity.relativePath!!)
-            maybeFinish(assetEntity, if (assetFileLocal.exists()) assetFileLocal else null)
-          }
+        database.assetDao().updateAsset(result.assetEntity)
+        val assetFileLocal = File(updatesDirectory, result.assetEntity.relativePath!!)
+        if (assetFileLocal.exists()) assetFileLocal else null
+      } catch (e: Exception) {
+        logger.error("Failed to load asset from disk or network", e, UpdatesErrorCode.AssetsFailedToLoad)
+        if (asset.isLaunchAsset) {
+          launchAssetException = e
         }
-      )
-      null
+        null
+      }
     } else {
       assetFile
-    }
-  }
-
-  @Synchronized
-  private fun maybeFinish(asset: AssetEntity, assetFile: File?) {
-    assetsToDownloadFinished++
-    if (asset.isLaunchAsset) {
-      launchAssetFile = assetFile?.toString()
-    } else {
-      if (assetFile != null) {
-        localAssetFiles!![asset] = assetFile.toString()
-      }
-    }
-    if (assetsToDownloadFinished == assetsToDownload) {
-      if (launchAssetFile == null) {
-        if (launchAssetException == null) {
-          launchAssetException = Exception("Launcher launch asset file is unexpectedly null")
-        }
-        callback!!.onFailure(launchAssetException!!)
-      } else {
-        callback!!.onSuccess()
-      }
     }
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.kt
@@ -43,9 +43,9 @@ class NoDatabaseLauncher @JvmOverloads constructor(
 
     private const val ERROR_LOG_FILENAME = "expo-error.log"
 
-    fun consumeErrorLog(context: Context, logger: UpdatesLogger): String? {
+    fun consumeErrorLog(filesDir: File, logger: UpdatesLogger): String? {
       return try {
-        val errorLogFile = File(context.filesDir, ERROR_LOG_FILENAME)
+        val errorLogFile = File(filesDir, ERROR_LOG_FILENAME)
         if (!errorLogFile.exists()) {
           return null
         }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
@@ -5,8 +5,6 @@ import expo.modules.updates.BuildConfig
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.UpdatesDatabase
-import expo.modules.updates.loader.FileDownloader.AssetDownloadCallback
-import expo.modules.updates.loader.FileDownloader.RemoteUpdateDownloadCallback
 import expo.modules.updates.UpdatesUtils
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.logging.UpdatesLogger
@@ -52,40 +50,35 @@ class EmbeddedLoader internal constructor(
     updatesDirectory: File
   ) : this(context, configuration, logger, database, updatesDirectory, LoaderFiles())
 
-  override fun loadRemoteUpdate(
+  override suspend fun loadRemoteUpdate(
     database: UpdatesDatabase,
-    configuration: UpdatesConfiguration,
-    callback: RemoteUpdateDownloadCallback
-  ) {
+    configuration: UpdatesConfiguration
+  ): UpdateResponse {
     val update = loaderFiles.readEmbeddedUpdate(this.context, this.configuration)
-    if (update != null) {
-      callback.onSuccess(
-        UpdateResponse(
-          responseHeaderData = null,
-          manifestUpdateResponsePart = UpdateResponsePart.ManifestUpdateResponsePart(update),
-          directiveUpdateResponsePart = null
-        )
+    return if (update != null) {
+      UpdateResponse(
+        responseHeaderData = null,
+        manifestUpdateResponsePart = UpdateResponsePart.ManifestUpdateResponsePart(update),
+        directiveUpdateResponsePart = null
       )
     } else {
-      callback.onFailure(Exception("Embedded manifest is null"))
+      throw Exception("Embedded manifest is null")
     }
   }
 
-  override fun loadAsset(
+  override suspend fun loadAsset(
     assetEntity: AssetEntity,
     updatesDirectory: File?,
     configuration: UpdatesConfiguration,
     requestedUpdate: UpdateEntity?,
-    embeddedUpdate: UpdateEntity?,
-    callback: AssetDownloadCallback
-  ) {
+    embeddedUpdate: UpdateEntity?
+  ): FileDownloader.AssetDownloadResult {
     if (!shouldCopyEmbeddedAssets) {
       assetEntity.downloadTime = Date()
       assetEntity.relativePath = AndroidResourceAssetUtils.createEmbeddedFilenameForAsset(assetEntity)
       // Passing `isNew=true` aka `AssetLoadResult.FINISHED` to the callback,
       // because we assume embedded asset is always existed without filesystem out of sync.
-      callback.onSuccess(assetEntity, true)
-      return
+      return FileDownloader.AssetDownloadResult(assetEntity, true)
     }
 
     val filename = UpdatesUtils.createFilenameForAsset(assetEntity)
@@ -93,20 +86,18 @@ class EmbeddedLoader internal constructor(
 
     if (loaderFiles.fileExists(context, updatesDirectory, filename)) {
       assetEntity.relativePath = filename
-      callback.onSuccess(assetEntity, false)
+      return FileDownloader.AssetDownloadResult(assetEntity, false)
     } else {
       try {
         assetEntity.hash = loaderFiles.copyAssetAndGetHash(assetEntity, destination, context)
         assetEntity.downloadTime = Date()
         assetEntity.relativePath = filename
-        callback.onSuccess(assetEntity, true)
+        return FileDownloader.AssetDownloadResult(assetEntity, true)
       } catch (e: FileNotFoundException) {
         throw AssertionError(
           "APK bundle must contain the expected embedded asset " +
             if (assetEntity.embeddedAssetFilename != null) assetEntity.embeddedAssetFilename else assetEntity.resourcesFilename
         )
-      } catch (e: Exception) {
-        callback.onFailure(e, assetEntity)
       }
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -543,7 +543,7 @@ class FileDownloader(
   }
 
   companion object {
-    suspend fun getExtraHeadersForRemoteUpdateRequest(
+    fun getExtraHeadersForRemoteUpdateRequest(
       database: UpdatesDatabase,
       configuration: UpdatesConfiguration,
       launchedUpdate: UpdateEntity?,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -1,40 +1,53 @@
 package expo.modules.updates.loader
 
-import android.content.Context
+import com.facebook.react.common.annotations.VisibleForTesting
 import expo.modules.jsonutils.require
+import expo.modules.structuredheaders.Dictionary
+import expo.modules.structuredheaders.OuterList
+import expo.modules.structuredheaders.StringItem
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.UpdatesUtils
+import expo.modules.updates.UpdatesUtils.parseContentDispositionNameParameter
+import expo.modules.updates.codesigning.ValidationResult
+import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
-import expo.modules.structuredheaders.Dictionary
+import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.launcher.NoDatabaseLauncher
+import expo.modules.updates.logging.UpdatesErrorCode
+import expo.modules.updates.logging.UpdatesLogger
+import expo.modules.updates.manifest.ManifestMetadata
+import expo.modules.updates.manifest.ResponseHeaderData
+import expo.modules.updates.manifest.ResponsePartHeaderData
+import expo.modules.updates.manifest.ResponsePartInfo
+import expo.modules.updates.manifest.UpdateFactory
 import expo.modules.updates.selectionpolicy.SelectionPolicies
-import okhttp3.*
+import okhttp3.Cache
+import okhttp3.Headers
+import okhttp3.MultipartReader
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
 import okhttp3.brotli.BrotliInterceptor
 import org.json.JSONObject
 import java.io.File
 import java.io.IOException
-import java.util.*
-import kotlin.math.min
-import kotlin.math.max
-import expo.modules.easclient.EASClientID
-import expo.modules.structuredheaders.OuterList
-import expo.modules.structuredheaders.StringItem
-import expo.modules.updates.UpdatesUtils.parseContentDispositionNameParameter
-import expo.modules.updates.codesigning.ValidationResult
-import expo.modules.updates.db.UpdatesDatabase
-import expo.modules.updates.db.entity.UpdateEntity
-import expo.modules.updates.logging.UpdatesErrorCode
-import expo.modules.updates.logging.UpdatesLogger
-import expo.modules.updates.manifest.*
 import java.security.cert.CertificateException
+import java.util.Date
 import java.util.concurrent.TimeUnit
+import kotlin.math.max
+import kotlin.math.min
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * Utility class that holds all the logic for downloading data and files, such as update manifests
  * and assets, using an instance of [OkHttpClient].
  */
 class FileDownloader(
-  private val context: Context,
+  private val filesDirectory: File,
+  private val easClientID: String,
   private val configuration: UpdatesConfiguration,
   private val logger: UpdatesLogger
 ) {
@@ -42,7 +55,7 @@ class FileDownloader(
   // we should use that as the timeout. For example, let's say launchWaitMs is 20 seconds,
   // the HTTP timeout should be at least 20 seconds.
   private var client: OkHttpClient = OkHttpClient.Builder()
-    .cache(getCache(context))
+    .cache(getCache())
     .connectTimeout(max(configuration.launchWaitMs.toLong(), 10_000L), TimeUnit.MILLISECONDS)
     .readTimeout(max(configuration.launchWaitMs.toLong(), 10_000L), TimeUnit.MILLISECONDS)
     .addInterceptor(BrotliInterceptor)
@@ -51,65 +64,46 @@ class FileDownloader(
   /**
    * Constructor for tests
    */
-  constructor(context: Context, configuration: UpdatesConfiguration, logger: UpdatesLogger, client: OkHttpClient) : this(context, configuration, logger) {
+  constructor(filesDirectory: File, easClientID: String, configuration: UpdatesConfiguration, logger: UpdatesLogger, client: OkHttpClient) : this(filesDirectory, easClientID, configuration, logger) {
     this.client = client
   }
 
-  interface FileDownloadCallback {
-    fun onFailure(e: Exception)
-    fun onSuccess(file: File, hash: ByteArray)
-  }
+  data class FileDownloadResult(val file: File, val hash: ByteArray)
+  data class AssetDownloadResult(val assetEntity: AssetEntity, val isNew: Boolean)
 
-  interface RemoteUpdateDownloadCallback {
-    fun onFailure(e: Exception)
-    fun onSuccess(updateResponse: UpdateResponse)
-  }
-
-  interface AssetDownloadCallback {
-    fun onFailure(e: Exception, assetEntity: AssetEntity)
-    fun onSuccess(assetEntity: AssetEntity, isNew: Boolean)
-  }
-
-  private fun downloadAssetAndVerifyHashAndWriteToPath(
+  private suspend fun downloadAssetAndVerifyHashAndWriteToPath(
     request: Request,
     expectedBase64URLEncodedSHA256Hash: String?,
-    destination: File,
-    callback: FileDownloadCallback
-  ) {
-    downloadData(
-      request,
-      object : Callback {
-        override fun onFailure(call: Call, e: IOException) {
-          val message = "Failed to download asset from URL ${request.url}"
-          logger.error(message, e, UpdatesErrorCode.AssetsFailedToLoad)
-          callback.onFailure(IOException(message, e))
-        }
+    destination: File
+  ): FileDownloadResult {
+    try {
+      val response = downloadData(request)
 
-        @Throws(IOException::class)
-        override fun onResponse(call: Call, response: Response) {
-          if (!response.isSuccessful) {
-            val message = "Asset download request not successful"
-            val cause = IOException(response.body!!.string())
-            logger.error(message, cause, UpdatesErrorCode.AssetsFailedToLoad)
-            callback.onFailure(IOException(message, cause))
-            return
-          }
-          try {
-            response.body!!.byteStream().use { inputStream ->
-              val hash = UpdatesUtils.verifySHA256AndWriteToFile(inputStream, destination, expectedBase64URLEncodedSHA256Hash)
-              callback.onSuccess(destination, hash)
-            }
-          } catch (e: Exception) {
-            val message = "Failed to write asset file from ${request.url} to destination $destination"
-            logger.error(message, e, UpdatesErrorCode.AssetsFailedToLoad)
-            callback.onFailure(IOException(message, e))
-          }
-        }
+      if (!response.isSuccessful) {
+        val message = "Asset download request not successful"
+        val cause = IOException(response.body?.string() ?: "Unknown error")
+        logger.error(message, cause, UpdatesErrorCode.AssetsFailedToLoad)
+        throw IOException(message, cause)
       }
-    )
+
+      try {
+        response.body!!.byteStream().use { inputStream ->
+          val hash = UpdatesUtils.verifySHA256AndWriteToFile(inputStream, destination, expectedBase64URLEncodedSHA256Hash)
+          return FileDownloadResult(destination, hash)
+        }
+      } catch (e: Exception) {
+        val message = "Failed to write asset file from ${request.url} to destination $destination"
+        logger.error(message, e, UpdatesErrorCode.AssetsFailedToLoad)
+        throw IOException(message, e)
+      }
+    } catch (e: IOException) {
+      val message = "Failed to download asset from URL ${request.url}"
+      logger.error(message, e, UpdatesErrorCode.AssetsFailedToLoad)
+      throw IOException(message, e)
+    }
   }
 
-  internal fun parseRemoteUpdateResponse(response: Response, callback: RemoteUpdateDownloadCallback) {
+  internal fun parseRemoteUpdateResponse(response: Response): UpdateResponse {
     val responseHeaders = response.headers
     val responseHeaderData = ResponseHeaderData(
       protocolVersionRaw = responseHeaders["expo-protocol-version"],
@@ -122,26 +116,22 @@ class FileDownloader(
       // If the protocol version greater than 0, we support returning a 204 and no body to mean no-op.
       // A 204 has no content-type.
       if (responseHeaderData.protocolVersion != null && responseHeaderData.protocolVersion > 0) {
-        callback.onSuccess(
-          UpdateResponse(
-            responseHeaderData = responseHeaderData,
-            manifestUpdateResponsePart = null,
-            directiveUpdateResponsePart = null
-          )
+        return UpdateResponse(
+          responseHeaderData = responseHeaderData,
+          manifestUpdateResponsePart = null,
+          directiveUpdateResponsePart = null
         )
-        return
       }
 
       val message = "Invalid update response"
       val cause = IOException("Empty body")
       logger.error(message, cause, UpdatesErrorCode.UpdateFailedToLoad)
-      callback.onFailure(IOException(message, cause))
-      return
+      throw IOException(message, cause)
     }
 
     val isMultipart = responseBody.contentType()?.type == "multipart"
     if (isMultipart) {
-      parseMultipartRemoteUpdateResponse(response, responseBody, responseHeaderData, callback)
+      return parseMultipartRemoteUpdateResponse(response, responseBody, responseHeaderData)
     } else {
       val manifestResponseInfo = ResponsePartInfo(
         responseHeaderData = responseHeaderData,
@@ -151,30 +141,21 @@ class FileDownloader(
         body = response.body!!.string()
       )
 
-      parseManifest(
+      val manifestUpdateResponsePart = parseManifest(
         manifestResponseInfo,
         null,
-        null,
-        object : ParseManifestCallback {
-          override fun onFailure(e: Exception) {
-            callback.onFailure(e)
-          }
+        null
+      )
 
-          override fun onSuccess(manifestUpdateResponsePart: UpdateResponsePart.ManifestUpdateResponsePart) {
-            callback.onSuccess(
-              UpdateResponse(
-                responseHeaderData = responseHeaderData,
-                manifestUpdateResponsePart = manifestUpdateResponsePart,
-                directiveUpdateResponsePart = null
-              )
-            )
-          }
-        }
+      return UpdateResponse(
+        responseHeaderData = responseHeaderData,
+        manifestUpdateResponsePart = manifestUpdateResponsePart,
+        directiveUpdateResponsePart = null
       )
     }
   }
 
-  private fun parseMultipartRemoteUpdateResponse(response: Response, responseBody: ResponseBody, responseHeaderData: ResponseHeaderData, callback: RemoteUpdateDownloadCallback) {
+  private fun parseMultipartRemoteUpdateResponse(response: Response, responseBody: ResponseBody, responseHeaderData: ResponseHeaderData): UpdateResponse {
     var manifestPartBodyAndHeaders: Pair<String, Headers>? = null
     var extensionsBody: String? = null
     var certificateChainString: String? = null
@@ -209,8 +190,7 @@ class FileDownloader(
         // okhttp multipart reader doesn't support empty multipart bodies, but our spec does
         val message = "Error while reading multipart remote update response"
         logger.error(message, e, UpdatesErrorCode.UpdateFailedToLoad)
-        callback.onFailure(IOException(message, e))
-        return
+        throw IOException(message, e)
       }
     }
 
@@ -219,8 +199,7 @@ class FileDownloader(
     } catch (e: Exception) {
       val message = "Failed to parse multipart remote update extensions part"
       logger.error(message, e, UpdatesErrorCode.UpdateFailedToLoad)
-      callback.onFailure(IOException(message, e))
-      return
+      throw IOException(message, e)
     }
 
     // in v0 compatibility mode require a manifest
@@ -228,8 +207,7 @@ class FileDownloader(
       val message = "Invalid update response"
       val cause = IOException("Multipart response missing manifest part. Manifest is required in version 0 of the expo-updates protocol. This may be due to the response being for a different protocol version.")
       logger.error(message, cause, UpdatesErrorCode.UpdateFailedToLoad)
-      callback.onFailure(IOException(message, cause))
-      return
+      throw IOException(message, cause)
     }
 
     val manifestResponseInfo = manifestPartBodyAndHeaders?.let {
@@ -257,423 +235,315 @@ class FileDownloader(
       }
     }
 
-    var parseManifestResponse: UpdateResponsePart.ManifestUpdateResponsePart? = null
-    var parseDirectiveResponse: UpdateResponsePart.DirectiveUpdateResponsePart? = null
-    var didError = false
-
-    // need to parse the directive and manifest in parallel, to do so use this common callback.
-    // would be a great place to have better coroutine stuff
-    val maybeFinish = {
-      if (!didError) {
-        val isManifestDone = manifestResponseInfo == null || parseManifestResponse != null
-        val isDirectiveDone = directiveResponseInfo == null || parseDirectiveResponse != null
-
-        if (isManifestDone && isDirectiveDone) {
-          callback.onSuccess(
-            UpdateResponse(
-              responseHeaderData = responseHeaderData,
-              manifestUpdateResponsePart = parseManifestResponse,
-              directiveUpdateResponsePart = parseDirectiveResponse
-            )
-          )
-        }
-      }
+    val parseManifestResponse = manifestResponseInfo?.let {
+      parseManifest(it, extensions, certificateChainString)
+    }
+    val parseDirectiveResponse = directiveResponseInfo?.let {
+      parseDirective(it, certificateChainString)
     }
 
-    if (directiveResponseInfo != null) {
-      parseDirective(
-        directiveResponseInfo,
-        certificateChainString,
-        object : ParseDirectiveCallback {
-          override fun onFailure(e: Exception) {
-            if (!didError) {
-              didError = true
-              callback.onFailure(e)
-            }
-          }
-
-          override fun onSuccess(directiveUpdateResponsePart: UpdateResponsePart.DirectiveUpdateResponsePart) {
-            parseDirectiveResponse = directiveUpdateResponsePart
-            maybeFinish()
-          }
-        }
-      )
-    }
-
-    if (manifestResponseInfo != null) {
-      parseManifest(
-        manifestResponseInfo,
-        extensions,
-        certificateChainString,
-        object : ParseManifestCallback {
-          override fun onFailure(e: Exception) {
-            if (!didError) {
-              didError = true
-              callback.onFailure(e)
-            }
-          }
-          override fun onSuccess(manifestUpdateResponsePart: UpdateResponsePart.ManifestUpdateResponsePart) {
-            parseManifestResponse = manifestUpdateResponsePart
-            maybeFinish()
-          }
-        }
-      )
-    }
-
-    // if both parts are empty, we still want to finish
-    if (manifestResponseInfo == null && directiveResponseInfo == null) {
-      maybeFinish()
-    }
-  }
-
-  interface ParseDirectiveCallback {
-    fun onFailure(e: Exception)
-    fun onSuccess(directiveUpdateResponsePart: UpdateResponsePart.DirectiveUpdateResponsePart)
+    return UpdateResponse(
+      responseHeaderData = responseHeaderData,
+      manifestUpdateResponsePart = parseManifestResponse,
+      directiveUpdateResponsePart = parseDirectiveResponse
+    )
   }
 
   private fun parseDirective(
     directiveResponsePartInfo: ResponsePartInfo,
-    certificateChainFromManifestResponse: String?,
-    callback: ParseDirectiveCallback
-  ) {
+    certificateChainFromManifestResponse: String?
+  ): UpdateResponsePart.DirectiveUpdateResponsePart {
+    val body = directiveResponsePartInfo.body
+
+    // check code signing if code signing is configured
+    // 1. verify the code signing signature (throw if invalid)
+    // 2. then, if the code signing certificate is only valid for a particular project, verify that the directive
+    //    has the correct info for code signing. If the code signing certificate doesn't specify a particular
+    //    project, it is assumed to be valid for all projects
+    // 3. consider the directive verified if both of these pass
     try {
-      val body = directiveResponsePartInfo.body
+      configuration.codeSigningConfiguration?.let { codeSigningConfiguration ->
+        val signatureValidationResult = codeSigningConfiguration.validateSignature(
+          directiveResponsePartInfo.responsePartHeaderData.signature,
+          body.toByteArray(),
+          certificateChainFromManifestResponse
+        )
+        if (signatureValidationResult.validationResult == ValidationResult.INVALID) {
+          throw IOException("Incorrect signature")
+        }
 
-      // check code signing if code signing is configured
-      // 1. verify the code signing signature (throw if invalid)
-      // 2. then, if the code signing certificate is only valid for a particular project, verify that the directive
-      //    has the correct info for code signing. If the code signing certificate doesn't specify a particular
-      //    project, it is assumed to be valid for all projects
-      // 3. consider the directive verified if both of these pass
-      try {
-        configuration.codeSigningConfiguration?.let { codeSigningConfiguration ->
-          val signatureValidationResult = codeSigningConfiguration.validateSignature(
-            directiveResponsePartInfo.responsePartHeaderData.signature,
-            body.toByteArray(),
-            certificateChainFromManifestResponse
-          )
-          if (signatureValidationResult.validationResult == ValidationResult.INVALID) {
-            throw IOException("Incorrect signature")
-          }
-
-          if (signatureValidationResult.validationResult != ValidationResult.SKIPPED) {
-            val directiveForProjectInformation = UpdateDirective.fromJSONString(body)
-            signatureValidationResult.expoProjectInformation?.let { expoProjectInformation ->
-              if (expoProjectInformation.projectId != directiveForProjectInformation.signingInfo?.easProjectId ||
-                expoProjectInformation.scopeKey != directiveForProjectInformation.signingInfo.scopeKey
-              ) {
-                throw CertificateException("Code signing certificate project ID or scope key does not match project ID or scope key in response part")
-              }
+        if (signatureValidationResult.validationResult != ValidationResult.SKIPPED) {
+          val directiveForProjectInformation = UpdateDirective.fromJSONString(body)
+          signatureValidationResult.expoProjectInformation?.let { expoProjectInformation ->
+            if (expoProjectInformation.projectId != directiveForProjectInformation.signingInfo?.easProjectId ||
+              expoProjectInformation.scopeKey != directiveForProjectInformation.signingInfo.scopeKey
+            ) {
+              throw CertificateException("Code signing certificate project ID or scope key does not match project ID or scope key in response part")
             }
           }
         }
-      } catch (e: Exception) {
-        val message = "Code signing verification failed for directive"
-        logger.error(message, e, UpdatesErrorCode.UpdateCodeSigningError)
-        callback.onFailure(IOException(message, e))
-        return
       }
-
-      callback.onSuccess(UpdateResponsePart.DirectiveUpdateResponsePart(UpdateDirective.fromJSONString(body)))
     } catch (e: Exception) {
-      val message = "Failed to construct directive from response"
-      logger.error(message, e, UpdatesErrorCode.UpdateFailedToLoad)
-      callback.onFailure(IOException(message, e))
+      val message = "Code signing verification failed for directive"
+      logger.error(message, e, UpdatesErrorCode.UpdateCodeSigningError)
+      throw IOException(message, e)
     }
-  }
 
-  interface ParseManifestCallback {
-    fun onFailure(e: Exception)
-    fun onSuccess(manifestUpdateResponsePart: UpdateResponsePart.ManifestUpdateResponsePart)
+    return UpdateResponsePart.DirectiveUpdateResponsePart(UpdateDirective.fromJSONString(body))
   }
 
   private fun parseManifest(
     manifestResponseInfo: ResponsePartInfo,
     extensions: JSONObject?,
-    certificateChainFromManifestResponse: String?,
-    callback: ParseManifestCallback
-  ) {
-    try {
-      checkCodeSigningAndCreateManifest(
-        bodyString = manifestResponseInfo.body,
-        preManifest = JSONObject(manifestResponseInfo.body),
-        responseHeaderData = manifestResponseInfo.responseHeaderData,
-        responsePartHeaderData = manifestResponseInfo.responsePartHeaderData,
-        extensions = extensions,
-        certificateChainFromManifestResponse = certificateChainFromManifestResponse,
-        configuration = configuration,
-        logger = logger,
-        callback = callback
-      )
-    } catch (e: Exception) {
-      val message = "Failed to construct manifest from response"
-      logger.error(message, e, UpdatesErrorCode.UpdateFailedToLoad)
-      callback.onFailure(IOException(message, e))
-    }
+    certificateChainFromManifestResponse: String?
+  ): UpdateResponsePart.ManifestUpdateResponsePart {
+    return checkCodeSigningAndCreateManifest(
+      bodyString = manifestResponseInfo.body,
+      preManifest = JSONObject(manifestResponseInfo.body),
+      responseHeaderData = manifestResponseInfo.responseHeaderData,
+      responsePartHeaderData = manifestResponseInfo.responsePartHeaderData,
+      extensions = extensions,
+      certificateChainFromManifestResponse = certificateChainFromManifestResponse,
+      configuration = configuration,
+      logger = logger
+    )
   }
 
-  fun downloadRemoteUpdate(
-    extraHeaders: JSONObject?,
-    callback: RemoteUpdateDownloadCallback
-  ) {
+  suspend fun downloadRemoteUpdate(
+    extraHeaders: JSONObject?
+  ): UpdateResponse {
     try {
-      downloadData(
-        createRequestForRemoteUpdate(extraHeaders, configuration, logger, context),
-        object : Callback {
-          override fun onFailure(call: Call, e: IOException) {
-            val message = "Failed to download remote update"
-            logger.error(message, e, UpdatesErrorCode.UpdateFailedToLoad)
-            callback.onFailure(IOException(message, e))
-          }
-
-          @Throws(IOException::class)
-          override fun onResponse(call: Call, response: Response) {
-            if (!response.isSuccessful) {
-              val message = "Remote update request not successful"
-              val underlyingError = IOException(response.body!!.string())
-              logger.error(message, underlyingError, UpdatesErrorCode.UpdateFailedToLoad)
-              callback.onFailure(IOException(message, underlyingError))
-              return
-            }
-
-            parseRemoteUpdateResponse(response, callback)
-          }
-        }
+      val response = downloadData(
+        createRequestForRemoteUpdate(extraHeaders, configuration, logger)
       )
+
+      if (!response.isSuccessful) {
+        val message = "Remote update request not successful"
+        val underlyingError = IOException(response.body?.string() ?: "Unknown error")
+        logger.error(message, underlyingError, UpdatesErrorCode.UpdateFailedToLoad)
+        throw IOException(message, underlyingError)
+      }
+
+      return parseRemoteUpdateResponse(response)
     } catch (e: Exception) {
       val message = "Failed to download remote update"
       logger.error(message, e, UpdatesErrorCode.UpdateFailedToLoad)
-      callback.onFailure(IOException(message, e))
+      throw IOException(message, e)
     }
   }
 
-  fun downloadAsset(
+  suspend fun downloadAsset(
     asset: AssetEntity,
     destinationDirectory: File?,
-    extraHeaders: JSONObject,
-    callback: AssetDownloadCallback
-  ) {
+    extraHeaders: JSONObject
+  ): AssetDownloadResult {
     if (asset.url == null) {
       val message = "Failed to download asset ${asset.key}"
       val error = Exception("Asset missing URL")
       logger.error(message, error, UpdatesErrorCode.AssetsFailedToLoad)
-      callback.onFailure(IOException(message, error), asset)
-      return
+      throw IOException(message, error)
     }
+
     val filename = UpdatesUtils.createFilenameForAsset(asset)
     val path = File(destinationDirectory, filename)
+
     if (path.exists()) {
       asset.relativePath = filename
-      callback.onSuccess(asset, false)
+      return AssetDownloadResult(asset, false)
     } else {
       try {
-        downloadAssetAndVerifyHashAndWriteToPath(
-          createRequestForAsset(asset, extraHeaders, configuration, context),
+        val downloadResult = downloadAssetAndVerifyHashAndWriteToPath(
+          createRequestForAsset(asset, extraHeaders, configuration),
           asset.expectedHash,
-          path,
-          object : FileDownloadCallback {
-            override fun onFailure(e: Exception) {
-              callback.onFailure(e, asset)
-            }
-
-            override fun onSuccess(file: File, hash: ByteArray) {
-              asset.downloadTime = Date()
-              asset.relativePath = filename
-              asset.hash = hash
-              callback.onSuccess(asset, true)
-            }
-          }
+          path
         )
+
+        asset.downloadTime = Date()
+        asset.relativePath = filename
+        asset.hash = downloadResult.hash
+        return AssetDownloadResult(asset, true)
       } catch (e: Exception) {
         val message = "Failed to download asset ${asset.key}"
         logger.error(message, e, UpdatesErrorCode.AssetsFailedToLoad)
-        callback.onFailure(IOException(message, e), asset)
+        throw IOException(message, e)
       }
     }
   }
 
-  private fun downloadData(request: Request, callback: Callback) {
-    downloadData(request, callback, false)
+  private suspend fun downloadData(request: Request): Response = suspendCancellableCoroutine { continuation ->
+    val call = client.newCall(request)
+    
+    continuation.invokeOnCancellation {
+      call.cancel()
+    }
+    
+    try {
+      val response = call.execute()
+      continuation.resume(response)
+    } catch (e: Exception) {
+      continuation.resumeWithException(e)
+    }
   }
 
-  private fun downloadData(request: Request, callback: Callback, isRetry: Boolean) {
-    client.newCall(request).enqueue(object : Callback {
-      override fun onFailure(call: Call, e: IOException) {
-        if (isRetry) {
-          callback.onFailure(call, e)
-        } else {
-          downloadData(request, callback, true)
+  private fun getCache(): Cache {
+    val cacheSize = 50 * 1024 * 1024 // 50 MiB
+    return Cache(getCacheDirectory(), cacheSize.toLong())
+  }
+
+  private fun getCacheDirectory(): File {
+    return File(filesDirectory, "okhttp")
+  }
+
+  @VisibleForTesting
+  fun createRequestForAsset(
+    assetEntity: AssetEntity,
+    extraHeaders: JSONObject,
+    configuration: UpdatesConfiguration
+  ): Request {
+    return Request.Builder()
+      .url(assetEntity.url!!.toString())
+      .addHeadersFromJSONObject(assetEntity.extraRequestHeaders)
+      .addHeadersFromJSONObject(extraHeaders)
+      .header("Expo-Platform", "android")
+      .header("Expo-Protocol-Version", "1")
+      .header("Expo-API-Version", "1")
+      .header("Expo-Updates-Environment", "BARE")
+      .header("EAS-Client-ID", easClientID)
+      .apply {
+        for ((key, value) in configuration.requestHeaders) {
+          header(key, value)
         }
       }
-
-      @Throws(IOException::class)
-      override fun onResponse(call: Call, response: Response) {
-        callback.onResponse(call, response)
-      }
-    })
+      .build()
   }
 
-  companion object {
-    private fun checkCodeSigningAndCreateManifest(
-      bodyString: String,
-      preManifest: JSONObject,
-      responseHeaderData: ResponseHeaderData,
-      responsePartHeaderData: ResponsePartHeaderData,
-      extensions: JSONObject?,
-      certificateChainFromManifestResponse: String?,
-      configuration: UpdatesConfiguration,
-      logger: UpdatesLogger,
-      callback: ParseManifestCallback
-    ) {
-      // Set the isVerified field in the manifest itself so that it is stored in the database.
-      // Note that this is not considered for code signature verification.
-      // currently this is only used by Expo Go, but moving it out of the library would require
-      // also storing the signature so database-loaded-update validity could be derived at load
-      // time.
-      preManifest.put("isVerified", false)
+  private fun checkCodeSigningAndCreateManifest(
+    bodyString: String,
+    preManifest: JSONObject,
+    responseHeaderData: ResponseHeaderData,
+    responsePartHeaderData: ResponsePartHeaderData,
+    extensions: JSONObject?,
+    certificateChainFromManifestResponse: String?,
+    configuration: UpdatesConfiguration,
+    logger: UpdatesLogger
+  ): UpdateResponsePart.ManifestUpdateResponsePart {
+    // Set the isVerified field in the manifest itself so that it is stored in the database.
+    // Note that this is not considered for code signature verification.
+    // currently this is only used by Expo Go, but moving it out of the library would require
+    // also storing the signature so database-loaded-update validity could be derived at load
+    // time.
+    preManifest.put("isVerified", false)
 
-      // check code signing if code signing is configured
-      // 1. verify the code signing signature (throw if invalid)
-      // 2. then, if the code signing certificate is only valid for a particular project, verify that the manifest
-      //    has the correct info for code signing. If the code signing certificate doesn't specify a particular
-      //    project, it is assumed to be valid for all projects
-      // 3. mark the manifest as verified if both of these pass
-      try {
-        configuration.codeSigningConfiguration?.let { codeSigningConfiguration ->
-          val signatureValidationResult = codeSigningConfiguration.validateSignature(
-            responsePartHeaderData.signature,
-            bodyString.toByteArray(),
-            certificateChainFromManifestResponse
-          )
-          if (signatureValidationResult.validationResult == ValidationResult.INVALID) {
-            throw IOException("Incorrect signature")
-          }
+    // check code signing if code signing is configured
+    // 1. verify the code signing signature (throw if invalid)
+    // 2. then, if the code signing certificate is only valid for a particular project, verify that the manifest
+    //    has the correct info for code signing. If the code signing certificate doesn't specify a particular
+    //    project, it is assumed to be valid for all projects
+    // 3. mark the manifest as verified if both of these pass
+    try {
+      configuration.codeSigningConfiguration?.let { codeSigningConfiguration ->
+        val signatureValidationResult = codeSigningConfiguration.validateSignature(
+          responsePartHeaderData.signature,
+          bodyString.toByteArray(),
+          certificateChainFromManifestResponse
+        )
+        if (signatureValidationResult.validationResult == ValidationResult.INVALID) {
+          throw IOException("Incorrect signature")
+        }
 
-          if (signatureValidationResult.validationResult != ValidationResult.SKIPPED) {
-            val manifestForProjectInformation = UpdateFactory.getUpdate(
-              preManifest,
-              responseHeaderData,
-              extensions,
-              configuration
-            ).manifest
-            signatureValidationResult.expoProjectInformation?.let { expoProjectInformation ->
-              if (expoProjectInformation.projectId != manifestForProjectInformation.getEASProjectID() ||
-                expoProjectInformation.scopeKey != manifestForProjectInformation.getScopeKey()
-              ) {
-                throw CertificateException("Code signing certificate project ID or scope key does not match project ID or scope key in response")
-              }
+        if (signatureValidationResult.validationResult != ValidationResult.SKIPPED) {
+          val manifestForProjectInformation = UpdateFactory.getUpdate(
+            preManifest,
+            responseHeaderData,
+            extensions,
+            configuration
+          ).manifest
+          signatureValidationResult.expoProjectInformation?.let { expoProjectInformation ->
+            if (expoProjectInformation.projectId != manifestForProjectInformation.getEASProjectID() ||
+              expoProjectInformation.scopeKey != manifestForProjectInformation.getScopeKey()
+            ) {
+              throw CertificateException("Code signing certificate project ID or scope key does not match project ID or scope key in response")
             }
-
-            logger.info("Manifest code signing signature verified successfully")
-            preManifest.put("isVerified", true)
           }
-        }
-      } catch (e: Exception) {
-        val message = "Code signing verification failed for manifest"
-        logger.error(message, e, UpdatesErrorCode.UpdateCodeSigningError)
-        callback.onFailure(IOException(message, e))
-        return
-      }
 
-      val update = UpdateFactory.getUpdate(preManifest, responseHeaderData, extensions, configuration)
-      if (!SelectionPolicies.matchesFilters(update.updateEntity!!, responseHeaderData.manifestFilters)) {
-        callback.onFailure(Exception("Manifest filters do not match manifest content for downloaded manifest"))
-      } else {
-        callback.onSuccess(UpdateResponsePart.ManifestUpdateResponsePart(update))
+          logger.info("Manifest code signing signature verified successfully")
+          preManifest.put("isVerified", true)
+        }
       }
+    } catch (e: Exception) {
+      val message = "Code signing verification failed for manifest"
+      logger.error(message, e, UpdatesErrorCode.UpdateCodeSigningError)
+      throw IOException(message, e)
     }
 
-    private fun Request.Builder.addHeadersFromJSONObject(headers: JSONObject?): Request.Builder {
-      if (headers == null) {
-        return this
-      }
+    val update = UpdateFactory.getUpdate(preManifest, responseHeaderData, extensions, configuration)
+    if (!SelectionPolicies.matchesFilters(update.updateEntity!!, responseHeaderData.manifestFilters)) {
+      throw Exception("Manifest filters do not match manifest content for downloaded manifest")
+    } else {
+      return UpdateResponsePart.ManifestUpdateResponsePart(update)
+    }
+  }
 
-      headers.keys().asSequence().forEach { key ->
-        header(key, headers.require<Any>(key).toString())
-      }
+  private fun Request.Builder.addHeadersFromJSONObject(headers: JSONObject?): Request.Builder {
+    if (headers == null) {
       return this
     }
 
-    internal fun createRequestForAsset(
-      assetEntity: AssetEntity,
-      extraHeaders: JSONObject,
-      configuration: UpdatesConfiguration,
-      context: Context
-    ): Request {
-      return Request.Builder()
-        .url(assetEntity.url!!.toString())
-        .addHeadersFromJSONObject(assetEntity.extraRequestHeaders)
-        .addHeadersFromJSONObject(extraHeaders)
-        .header("Expo-Platform", "android")
-        .header("Expo-Protocol-Version", "1")
-        .header("Expo-API-Version", "1")
-        .header("Expo-Updates-Environment", "BARE")
-        .header("EAS-Client-ID", EASClientID(context).uuid.toString())
-        .apply {
-          for ((key, value) in configuration.requestHeaders) {
-            header(key, value)
-          }
-        }
-        .build()
+    headers.keys().asSequence().forEach { key ->
+      header(key, headers.require<Any>(key).toString())
     }
+    return this
+  }
 
-    internal fun createRequestForRemoteUpdate(
-      extraHeaders: JSONObject?,
-      configuration: UpdatesConfiguration,
-      logger: UpdatesLogger,
-      context: Context
-    ): Request {
-      return Request.Builder()
-        .url(configuration.updateUrl.toString())
-        .addHeadersFromJSONObject(extraHeaders)
-        .header("Accept", "multipart/mixed,application/expo+json,application/json")
-        .header("Expo-Platform", "android")
-        .header("Expo-Protocol-Version", "1")
-        .header("Expo-API-Version", "1")
-        .header("Expo-Updates-Environment", "BARE")
-        .header("Expo-JSON-Error", "true")
-        .header("EAS-Client-ID", EASClientID(context).uuid.toString())
-        .apply {
-          val runtimeVersion = configuration.runtimeVersionRaw
-          if (!runtimeVersion.isNullOrEmpty()) {
-            header("Expo-Runtime-Version", runtimeVersion)
-          }
+  @VisibleForTesting
+  fun createRequestForRemoteUpdate(
+    extraHeaders: JSONObject?,
+    configuration: UpdatesConfiguration,
+    logger: UpdatesLogger
+  ): Request {
+    return Request.Builder()
+      .url(configuration.updateUrl.toString())
+      .addHeadersFromJSONObject(extraHeaders)
+      .header("Accept", "multipart/mixed,application/expo+json,application/json")
+      .header("Expo-Platform", "android")
+      .header("Expo-Protocol-Version", "1")
+      .header("Expo-API-Version", "1")
+      .header("Expo-Updates-Environment", "BARE")
+      .header("Expo-JSON-Error", "true")
+      .header("EAS-Client-ID", easClientID)
+      .apply {
+        val runtimeVersion = configuration.runtimeVersionRaw
+        if (!runtimeVersion.isNullOrEmpty()) {
+          header("Expo-Runtime-Version", runtimeVersion)
         }
-        .apply {
-          val previousFatalError = NoDatabaseLauncher.consumeErrorLog(context, logger)
-          if (previousFatalError != null) {
-            // some servers can have max length restrictions for headers,
-            // so we restrict the length of the string to 1024 characters --
-            // this should satisfy the requirements of most servers
-            header(
-              "Expo-Fatal-Error",
-              previousFatalError.substring(0, min(1024, previousFatalError.length))
-            )
-          }
+      }
+      .apply {
+        val previousFatalError = NoDatabaseLauncher.consumeErrorLog(filesDirectory, logger)
+        if (previousFatalError != null) {
+          // some servers can have max length restrictions for headers,
+          // so we restrict the length of the string to 1024 characters --
+          // this should satisfy the requirements of most servers
+          header(
+            "Expo-Fatal-Error",
+            previousFatalError.substring(0, min(1024, previousFatalError.length))
+          )
         }
-        .apply {
-          for ((key, value) in configuration.requestHeaders) {
-            header(key, value)
-          }
+      }
+      .apply {
+        for ((key, value) in configuration.requestHeaders) {
+          header(key, value)
         }
-        .apply {
-          configuration.codeSigningConfiguration?.let {
-            header("expo-expect-signature", it.getAcceptSignatureHeader())
-          }
+      }
+      .apply {
+        configuration.codeSigningConfiguration?.let {
+          header("expo-expect-signature", it.getAcceptSignatureHeader())
         }
-        .build()
-    }
+      }
+      .build()
+  }
 
-    private fun getCache(context: Context): Cache {
-      val cacheSize = 50 * 1024 * 1024 // 50 MiB
-      return Cache(getCacheDirectory(context), cacheSize.toLong())
-    }
-
-    private fun getCacheDirectory(context: Context): File {
-      return File(context.cacheDir, "okhttp")
-    }
-
-    fun getExtraHeadersForRemoteUpdateRequest(
+  companion object {
+    suspend fun getExtraHeadersForRemoteUpdateRequest(
       database: UpdatesDatabase,
       configuration: UpdatesConfiguration,
       launchedUpdate: UpdateEntity?,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -372,11 +372,11 @@ class FileDownloader(
 
   private suspend fun downloadData(request: Request): Response = suspendCancellableCoroutine { continuation ->
     val call = client.newCall(request)
-    
+
     continuation.invokeOnCancellation {
       call.cancel()
     }
-    
+
     try {
       val response = call.execute()
       continuation.resume(response)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -7,12 +7,18 @@ import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.db.enums.UpdateStatus
-import expo.modules.updates.loader.FileDownloader.AssetDownloadCallback
-import expo.modules.updates.loader.FileDownloader.RemoteUpdateDownloadCallback
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.Deferred
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.manifest.Update
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import java.io.File
 import java.io.IOException
 import java.util.*
@@ -30,117 +36,73 @@ abstract class Loader protected constructor(
   protected val logger: UpdatesLogger,
   private val database: UpdatesDatabase,
   private val updatesDirectory: File,
-  private val loaderFiles: LoaderFiles
+  private val loaderFiles: LoaderFiles,
+  private var scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 ) {
   private var updateResponse: UpdateResponse? = null
   private var updateEntity: UpdateEntity? = null
-  private var callback: LoaderCallback? = null
   private var assetTotal = 0
   private var erroredAssetList = mutableListOf<AssetEntity>()
   private var existingAssetList = mutableListOf<AssetEntity>()
   private var finishedAssetList = mutableListOf<AssetEntity>()
+  private val _progressFlow = MutableSharedFlow<AssetLoadProgress>()
+  val progressFlow: Flow<AssetLoadProgress> = _progressFlow.asSharedFlow()
 
   data class LoaderResult(val updateEntity: UpdateEntity?, val updateDirective: UpdateDirective?)
 
   data class OnUpdateResponseLoadedResult(val shouldDownloadManifestIfPresentInResponse: Boolean)
 
-  interface LoaderCallback {
-    fun onFailure(e: Exception)
-    fun onSuccess(loaderResult: LoaderResult)
-
-    /**
-     * Called when an asset has either been successfully downloaded or failed to download.
-     *
-     * @param asset Entity representing the asset that was either just downloaded or failed
-     * @param successfulAssetCount The number of assets that have so far been loaded successfully
-     * (including any that were found to already exist on disk)
-     * @param failedAssetCount The number of assets that have so far failed to load
-     * @param totalAssetCount The total number of assets that comprise the update
-     */
-    fun onAssetLoaded(
-      asset: AssetEntity,
-      successfulAssetCount: Int,
-      failedAssetCount: Int,
-      totalAssetCount: Int
-    )
-
-    /**
-     * Called when a response has been downloaded. The calling class should determine whether or not
-     * the RemoteLoader should continue to download the manifest in the manifest part of the update response,
-     * based on (for example) whether or not it already has the update downloaded locally.
-     *
-     * @param updateResponse Response downloaded by Loader
-     * @return true if Loader should download the manifest described in the manifest part of the update response,
-     * false if not.
-     */
-    fun onUpdateResponseLoaded(updateResponse: UpdateResponse): OnUpdateResponseLoadedResult
-  }
-
-  protected abstract fun loadRemoteUpdate(
-    database: UpdatesDatabase,
-    configuration: UpdatesConfiguration,
-    callback: RemoteUpdateDownloadCallback
+  data class AssetLoadProgress(
+    val asset: AssetEntity,
+    val successfulAssetCount: Int,
+    val failedAssetCount: Int,
+    val totalAssetCount: Int
   )
 
-  protected abstract fun loadAsset(
+  protected abstract suspend fun loadRemoteUpdate(
+    database: UpdatesDatabase,
+    configuration: UpdatesConfiguration
+  ): UpdateResponse
+
+  protected abstract suspend fun loadAsset(
     assetEntity: AssetEntity,
     updatesDirectory: File?,
     configuration: UpdatesConfiguration,
     requestedUpdate: UpdateEntity?,
-    embeddedUpdate: UpdateEntity?,
-    callback: AssetDownloadCallback
-  )
+    embeddedUpdate: UpdateEntity?
+  ): FileDownloader.AssetDownloadResult
 
-  // lifecycle methods for class
-  fun start(callback: LoaderCallback) {
-    if (this.callback != null) {
-      callback.onFailure(Exception("RemoteLoader has already started. Create a new instance in order to load multiple URLs in parallel."))
-      return
-    }
-    this.callback = callback
+  suspend fun load(updateResponseDecision: (UpdateResponse) -> OnUpdateResponseLoadedResult): LoaderResult {
+    try {
+      val updateResponse = loadRemoteUpdate(database, configuration)
+      this@Loader.updateResponse = updateResponse
+      val update = updateResponse.manifestUpdateResponsePart?.update
+      val onUpdateResponseLoadedResult = updateResponseDecision(updateResponse)
 
-    loadRemoteUpdate(
-      database,
-      configuration,
-      object : RemoteUpdateDownloadCallback {
-        override fun onFailure(e: Exception) {
-          finishWithException(e)
-        }
-
-        override fun onSuccess(updateResponse: UpdateResponse) {
-          this@Loader.updateResponse = updateResponse
-          val update = updateResponse.manifestUpdateResponsePart?.update
-          val onUpdateResponseLoadedResult = this@Loader.callback!!.onUpdateResponseLoaded(updateResponse)
-          if (update !== null && onUpdateResponseLoadedResult.shouldDownloadManifestIfPresentInResponse) {
-            // if onUpdateResponseLoaded returns true that is a sign that the delegate wants the update manifest
-            // to be processed/downloaded, and therefore the update needs to exist
-            processUpdate(update)
-          } else {
-            updateEntity = null
-            finishWithSuccess()
-          }
-        }
+      if (update !== null && onUpdateResponseLoadedResult.shouldDownloadManifestIfPresentInResponse) {
+        // if onUpdateResponseLoaded returns true that is a sign that the delegate wants the update manifest
+        // to be processed/downloaded, and therefore the update needs to exist
+        return processUpdate(update)
+      } else {
+        updateEntity = null
+        return finish()
       }
-    )
+    } catch (e: Exception) {
+      logger.error("Load error", e, UpdatesErrorCode.UpdateFailedToLoad)
+      throw e
+    }
   }
 
   private fun reset() {
     updateResponse = null
     updateEntity = null
-    callback = null
     assetTotal = 0
     erroredAssetList = mutableListOf()
     existingAssetList = mutableListOf()
     finishedAssetList = mutableListOf()
   }
 
-  private fun finishWithSuccess() {
-    if (callback == null) {
-      val cause = Exception("Null callback in finishWithSuccess")
-      logger.error("${this.javaClass.simpleName} tried to finish but it already finished or was never initialized.", cause, UpdatesErrorCode.UpdateFailedToLoad)
-      return
-    }
-
+  private fun finish(): LoaderResult {
     // store the header data even if only a message was included in the response
     updateResponse!!.responseHeaderData?.let {
       ManifestMetadata.saveMetadata(it, database, configuration)
@@ -148,35 +110,24 @@ abstract class Loader protected constructor(
 
     val updateDirective = updateResponse!!.directiveUpdateResponsePart?.updateDirective
 
-    callback!!.onSuccess(
-      LoaderResult(
-        updateEntity = this.updateEntity,
-        updateDirective = updateDirective
-      )
+    val result = LoaderResult(
+      updateEntity = this.updateEntity,
+      updateDirective = updateDirective
     )
     reset()
-  }
-
-  private fun finishWithException(e: Exception) {
-    logger.error("Load error", e, UpdatesErrorCode.UpdateFailedToLoad)
-    if (callback == null) {
-      logger.error("${this.javaClass.simpleName} tried to finish but it already finished or was never initialized.", e, UpdatesErrorCode.UpdateFailedToLoad)
-      return
-    }
-    callback!!.onFailure(e)
-    reset()
+    return result
   }
 
   // private helper methods
-  private fun processUpdate(update: Update) {
+  private suspend fun processUpdate(update: Update): LoaderResult {
     if (update.isDevelopmentMode) {
       // insert into database but don't try to load any assets;
       // the RN runtime will take care of that and we don't want to cache anything
       val updateEntity = update.updateEntity
       database.updateDao().insertUpdate(updateEntity!!)
       database.updateDao().markUpdateFinished(updateEntity)
-      finishWithSuccess()
-      return
+      this.updateEntity = updateEntity
+      return finish()
     }
 
     val newUpdateEntity = update.updateEntity
@@ -195,7 +146,7 @@ abstract class Loader protected constructor(
     if (existingUpdateEntity != null && existingUpdateEntity.status == UpdateStatus.READY) {
       // hooray, we already have this update downloaded and ready to go!
       updateEntity = existingUpdateEntity
-      finishWithSuccess()
+      return finish()
     } else {
       if (existingUpdateEntity == null) {
         // no update already exists with this ID, so we need to insert it and download everything.
@@ -206,7 +157,7 @@ abstract class Loader protected constructor(
         // however, it's not ready, so we should try to download all the assets again.
         updateEntity = existingUpdateEntity
       }
-      downloadAllAssets(update)
+      return downloadAllAssets(update)
     }
   }
 
@@ -216,11 +167,13 @@ abstract class Loader protected constructor(
     ERRORED
   }
 
-  private fun downloadAllAssets(update: Update) {
+  private suspend fun downloadAllAssets(update: Update): LoaderResult {
     val assetList = update.assetEntityList
     assetTotal = assetList.size
 
     val embeddedUpdate = loaderFiles.readEmbeddedUpdate(context, configuration)
+    val assetDownloadJobs = mutableListOf<Deferred<AssetLoadResult>>()
+
     for (assetEntityCur in assetList) {
       var assetEntity = assetEntityCur
 
@@ -240,87 +193,72 @@ abstract class Loader protected constructor(
         continue
       }
 
-      loadAsset(
-        assetEntity,
-        updatesDirectory,
-        configuration,
-        requestedUpdate = update.updateEntity,
-        embeddedUpdate = embeddedUpdate?.updateEntity,
-        object : AssetDownloadCallback {
-          override fun onFailure(e: Exception, assetEntity: AssetEntity) {
-            val identifier = if (assetEntity.hash != null) {
-              "hash " + UpdatesUtils.bytesToHex(
-                assetEntity.hash!!
-              )
-            } else {
-              "key " + assetEntity.key
-            }
-            logger.error("Failed to download asset with $identifier", e)
-            handleAssetDownloadCompleted(assetEntity, AssetLoadResult.ERRORED)
-          }
+      val job = scope.async {
+        val result = loadAsset(
+          assetEntity,
+          updatesDirectory,
+          configuration,
+          requestedUpdate = update.updateEntity,
+          embeddedUpdate = embeddedUpdate?.updateEntity
+        )
 
-          override fun onSuccess(assetEntity: AssetEntity, isNew: Boolean) {
-            handleAssetDownloadCompleted(
-              assetEntity,
-              if (isNew) AssetLoadResult.FINISHED else AssetLoadResult.ALREADY_EXISTS
-            )
-          }
-        }
-      )
+        handleAssetDownloadCompleted(
+          result.assetEntity,
+          if (result.isNew) AssetLoadResult.FINISHED else AssetLoadResult.ALREADY_EXISTS
+        )
+      }
+      assetDownloadJobs.add(job)
     }
+
+    // Wait for all asset downloads to complete - this will throw the first exception that occurs
+    assetDownloadJobs.awaitAll()
+
+    try {
+      for (asset in existingAssetList) {
+        val existingAssetFound = database.assetDao()
+          .addExistingAssetToUpdate(updateEntity!!, asset, asset.isLaunchAsset)
+        if (!existingAssetFound) {
+          // the database and filesystem have gotten out of sync
+          // do our best to create a new entry for this file even though it already existed on disk
+          // TODO: we should probably get rid of this assumption that if an asset exists on disk with the same filename, it's the same asset
+          var hash: ByteArray? = null
+          try {
+            hash = UpdatesUtils.sha256(File(updatesDirectory, asset.relativePath))
+          } catch (_: Exception) {
+          }
+          asset.downloadTime = Date()
+          asset.hash = hash
+          finishedAssetList.add(asset)
+        }
+      }
+
+      database.assetDao().insertAssets(finishedAssetList, updateEntity!!)
+      database.updateDao().markUpdateFinished(updateEntity!!)
+    } catch (e: Exception) {
+      throw IOException("Error while adding new update to database", e)
+    }
+
+    return finish()
   }
 
-  @Synchronized
-  private fun handleAssetDownloadCompleted(assetEntity: AssetEntity, result: AssetLoadResult) {
+  private suspend fun handleAssetDownloadCompleted(assetEntity: AssetEntity, result: AssetLoadResult): AssetLoadResult {
     when (result) {
       AssetLoadResult.FINISHED -> finishedAssetList.add(assetEntity)
       AssetLoadResult.ALREADY_EXISTS -> existingAssetList.add(assetEntity)
       AssetLoadResult.ERRORED -> erroredAssetList.add(assetEntity)
     }
 
-    callback!!.onAssetLoaded(
-      assetEntity,
-      finishedAssetList.size + existingAssetList.size,
-      erroredAssetList.size,
-      assetTotal
+    // Emit progress update through Flow
+    _progressFlow.emit(
+      AssetLoadProgress(
+        asset = assetEntity,
+        successfulAssetCount = finishedAssetList.size + existingAssetList.size,
+        failedAssetCount = erroredAssetList.size,
+        totalAssetCount = assetTotal
+      )
     )
 
-    if (finishedAssetList.size + erroredAssetList.size + existingAssetList.size == assetTotal) {
-      try {
-        for (asset in existingAssetList) {
-          val existingAssetFound = database.assetDao()
-            .addExistingAssetToUpdate(updateEntity!!, asset, asset.isLaunchAsset)
-          if (!existingAssetFound) {
-            // the database and filesystem have gotten out of sync
-            // do our best to create a new entry for this file even though it already existed on disk
-            // TODO: we should probably get rid of this assumption that if an asset exists on disk with the same filename, it's the same asset
-            var hash: ByteArray? = null
-            try {
-              hash = UpdatesUtils.sha256(File(updatesDirectory, asset.relativePath))
-            } catch (_: Exception) {
-            }
-            asset.downloadTime = Date()
-            asset.hash = hash
-            finishedAssetList.add(asset)
-          }
-        }
-
-        database.assetDao().insertAssets(finishedAssetList, updateEntity!!)
-
-        if (erroredAssetList.size == 0) {
-          database.updateDao().markUpdateFinished(updateEntity!!)
-        }
-      } catch (e: Exception) {
-        finishWithException(IOException("Error while adding new update to database", e))
-        return
-      }
-
-      if (erroredAssetList.size > 0) {
-        finishWithException(Exception("Failed to load all assets"))
-      } else {
-        finishWithSuccess()
-      }
-    }
+    return result
   }
 
   companion object {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -5,14 +5,17 @@ import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
-import expo.modules.updates.loader.FileDownloader.AssetDownloadCallback
-import expo.modules.updates.loader.FileDownloader.RemoteUpdateDownloadCallback
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.EmbeddedManifestUtils
 import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import java.io.File
+
+data class ProcessSuccessLoaderResult(
+  val availableUpdate: UpdateEntity?,
+  val didRollBackToEmbedded: Boolean
+)
 
 /**
  * Subclass of [Loader] which handles downloading updates from a remote server.
@@ -41,32 +44,30 @@ class RemoteLoader internal constructor(
     launchedUpdate: UpdateEntity?
   ) : this(context, configuration, logger, database, fileDownloader, updatesDirectory, launchedUpdate, LoaderFiles())
 
-  override fun loadRemoteUpdate(
+  override suspend fun loadRemoteUpdate(
     database: UpdatesDatabase,
-    configuration: UpdatesConfiguration,
-    callback: RemoteUpdateDownloadCallback
-  ) {
+    configuration: UpdatesConfiguration
+  ): UpdateResponse {
     val embeddedUpdate = loaderFiles.readEmbeddedUpdate(context, configuration)?.updateEntity
     val extraHeaders = FileDownloader.getExtraHeadersForRemoteUpdateRequest(database, configuration, launchedUpdate, embeddedUpdate)
-    mFileDownloader.downloadRemoteUpdate(extraHeaders, callback)
+    return mFileDownloader.downloadRemoteUpdate(extraHeaders)
   }
 
-  override fun loadAsset(
+  override suspend fun loadAsset(
     assetEntity: AssetEntity,
     updatesDirectory: File?,
     configuration: UpdatesConfiguration,
     requestedUpdate: UpdateEntity?,
-    embeddedUpdate: UpdateEntity?,
-    callback: AssetDownloadCallback
-  ) {
+    embeddedUpdate: UpdateEntity?
+  ): FileDownloader.AssetDownloadResult {
     val extraHeaders = FileDownloader.getExtraHeadersForRemoteAssetRequest(launchedUpdate, embeddedUpdate, requestedUpdate)
-    mFileDownloader.downloadAsset(assetEntity, updatesDirectory, extraHeaders, callback)
+    return mFileDownloader.downloadAsset(assetEntity, updatesDirectory, extraHeaders)
   }
 
   companion object {
     private val TAG = RemoteLoader::class.java.simpleName
 
-    fun processSuccessLoaderResult(
+    suspend fun processSuccessLoaderResult(
       context: Context,
       configuration: UpdatesConfiguration,
       logger: UpdatesLogger,
@@ -74,18 +75,16 @@ class RemoteLoader internal constructor(
       selectionPolicy: SelectionPolicy,
       directory: File,
       launchedUpdate: UpdateEntity?,
-      loaderResult: LoaderResult,
-      onComplete: (availableUpdate: UpdateEntity?, didRollBackToEmbedded: Boolean) -> Unit
-    ) {
+      loaderResult: LoaderResult
+    ): ProcessSuccessLoaderResult {
       val updateEntity = loaderResult.updateEntity
       val updateDirective = loaderResult.updateDirective
 
-      if (updateDirective != null && updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) {
-        processRollBackToEmbeddedDirective(context, configuration, logger, database, selectionPolicy, directory, launchedUpdate, updateDirective) { didRollBackToEmbedded ->
-          onComplete(null, didRollBackToEmbedded)
-        }
+      return if (updateDirective != null && updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) {
+        val didRollBackToEmbedded = processRollBackToEmbeddedDirective(context, configuration, logger, database, selectionPolicy, directory, launchedUpdate, updateDirective)
+        ProcessSuccessLoaderResult(null, didRollBackToEmbedded)
       } else {
-        onComplete(updateEntity, false)
+        ProcessSuccessLoaderResult(updateEntity, false)
       }
     }
 
@@ -95,7 +94,7 @@ class RemoteLoader internal constructor(
      * so that the selection policy will choose it. That way future updates can continue to be applied
      * over this roll back, but older ones won't.
      */
-    private fun processRollBackToEmbeddedDirective(
+    private suspend fun processRollBackToEmbeddedDirective(
       context: Context,
       configuration: UpdatesConfiguration,
       logger: UpdatesLogger,
@@ -103,52 +102,34 @@ class RemoteLoader internal constructor(
       selectionPolicy: SelectionPolicy,
       directory: File,
       launchedUpdate: UpdateEntity?,
-      updateDirective: UpdateDirective.RollBackToEmbeddedUpdateDirective,
-      onComplete: (didRollBackToEmbedded: Boolean) -> Unit
-    ) {
+      updateDirective: UpdateDirective.RollBackToEmbeddedUpdateDirective
+    ): Boolean {
       if (!configuration.hasEmbeddedUpdate) {
-        onComplete(false)
-        return
+        return false
       }
 
       val embeddedUpdate = EmbeddedManifestUtils.getEmbeddedUpdate(context, configuration)!!.updateEntity
       val manifestFilters = ManifestMetadata.getManifestFilters(database, configuration)
       if (!selectionPolicy.shouldLoadRollBackToEmbeddedDirective(updateDirective, embeddedUpdate, launchedUpdate, manifestFilters)) {
-        onComplete(false)
-        return
+        return false
       }
 
       // update the embedded update commit time in the in-memory embedded update since it is a singleton
       embeddedUpdate.commitTime = updateDirective.commitTime
 
       // update the embedded update commit time in the database (requires loading and then updating)
-      EmbeddedLoader(context, configuration, logger, database, directory).start(object : LoaderCallback {
-        /**
-         * This should never happen since we check for the embedded update above
-         */
-        override fun onFailure(e: Exception) {
-          logger.error("Embedded update erroneously null when applying roll back to embedded directive", e, UpdatesErrorCode.UpdateFailedToLoad)
-          onComplete(false)
+      return try {
+        val embeddedLoader = EmbeddedLoader(context, configuration, logger, database, directory)
+        val loaderResult = embeddedLoader.load {
+          OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
         }
-
-        override fun onSuccess(loaderResult: LoaderResult) {
-          val embeddedUpdateToLoad = loaderResult.updateEntity
-          database.updateDao().setUpdateCommitTime(embeddedUpdateToLoad!!, updateDirective.commitTime)
-          onComplete(true)
-        }
-
-        override fun onAssetLoaded(
-          asset: AssetEntity,
-          successfulAssetCount: Int,
-          failedAssetCount: Int,
-          totalAssetCount: Int
-        ) {
-        }
-
-        override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): OnUpdateResponseLoadedResult {
-          return OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
-        }
-      })
+        val embeddedUpdateToLoad = loaderResult.updateEntity
+        database.updateDao().setUpdateCommitTime(embeddedUpdateToLoad!!, updateDirective.commitTime)
+        true
+      } catch (e: Exception) {
+        logger.error("Embedded update erroneously null when applying roll back to embedded directive", e, UpdatesErrorCode.UpdateFailedToLoad)
+        false
+      }
     }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/CheckForUpdateProcedure.kt
@@ -14,10 +14,8 @@ import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.EmbeddedManifestUtils
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import expo.modules.updates.statemachine.UpdatesStateEvent
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.CancellationException
 import org.json.JSONObject
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 class CheckForUpdateProcedure(
   private val context: Context,
@@ -52,25 +50,12 @@ class CheckForUpdateProcedure(
     }
   }
 
-  private suspend fun downloadRemoteUpdate(extraHeaders: JSONObject) = suspendCancellableCoroutine { continuation ->
-
-    val callback = object : FileDownloader.RemoteUpdateDownloadCallback {
-      override fun onFailure(e: Exception) {
-        if (continuation.isActive) {
-          continuation.resumeWithException(e)
-        }
-      }
-
-      override fun onSuccess(updateResponse: UpdateResponse) {
-        if (continuation.isActive) {
-          continuation.resume(updateResponse)
-        }
-      }
-    }
-    fileDownloader.downloadRemoteUpdate(extraHeaders, callback)
-
-    continuation.invokeOnCancellation {
+  private suspend fun downloadRemoteUpdate(extraHeaders: JSONObject): UpdateResponse {
+    try {
+      return fileDownloader.downloadRemoteUpdate(extraHeaders)
+    } catch (e: CancellationException) {
       updatesLogger.info("Download cancelled for remote update check")
+      throw e
     }
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/FetchUpdateProcedure.kt
@@ -5,20 +5,16 @@ import expo.modules.updates.IUpdatesController
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.DatabaseHolder
 import expo.modules.updates.db.UpdatesDatabase
-import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.loader.FileDownloader
 import expo.modules.updates.loader.Loader
 import expo.modules.updates.loader.RemoteLoader
 import expo.modules.updates.loader.UpdateDirective
-import expo.modules.updates.loader.UpdateResponse
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.selectionpolicy.SelectionPolicy
 import expo.modules.updates.statemachine.UpdatesStateEvent
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.CancellationException
 import java.io.File
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 class FetchUpdateProcedure(
   private val context: Context,
@@ -51,70 +47,50 @@ class FetchUpdateProcedure(
     }
   }
 
-  private suspend fun startRemoteLoader(database: UpdatesDatabase): Loader.LoaderResult =
-    suspendCancellableCoroutine { continuation ->
-      val remoteLoader = RemoteLoader(
-        context,
-        updatesConfiguration,
-        logger,
-        database,
-        fileDownloader,
-        updatesDirectory,
-        launchedUpdate
-      )
-      remoteLoader.start(
-        object : Loader.LoaderCallback {
-          override fun onFailure(e: Exception) {
-            if (continuation.isActive) {
-              continuation.resumeWithException(e)
+  private suspend fun startRemoteLoader(database: UpdatesDatabase): Loader.LoaderResult {
+    val remoteLoader = RemoteLoader(
+      context,
+      updatesConfiguration,
+      logger,
+      database,
+      fileDownloader,
+      updatesDirectory,
+      launchedUpdate
+    )
+
+    try {
+      val result = remoteLoader.load { updateResponse ->
+        val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
+        if (updateDirective != null) {
+          return@load Loader.OnUpdateResponseLoadedResult(
+            shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
+              is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
+              is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
             }
-          }
-
-          override fun onAssetLoaded(
-            asset: AssetEntity,
-            successfulAssetCount: Int,
-            failedAssetCount: Int,
-            totalAssetCount: Int
-          ) = Unit
-
-          override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
-            val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
-            if (updateDirective != null) {
-              return Loader.OnUpdateResponseLoadedResult(
-                shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
-                  is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
-                  is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
-                }
-              )
-            }
-
-            val update = updateResponse.manifestUpdateResponsePart?.update
-              ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
-
-            return Loader.OnUpdateResponseLoadedResult(
-              shouldDownloadManifestIfPresentInResponse = selectionPolicy.shouldLoadNewUpdate(
-                update.updateEntity,
-                launchedUpdate,
-                updateResponse.responseHeaderData?.manifestFilters
-              )
-            )
-          }
-
-          override fun onSuccess(loaderResult: Loader.LoaderResult) {
-            if (continuation.isActive) {
-              continuation.resume(loaderResult)
-            }
-          }
+          )
         }
-      )
 
-      continuation.invokeOnCancellation {
-        logger.info("Remote loader cancelled during fetch update procedure")
+        val update = updateResponse.manifestUpdateResponsePart?.update
+          ?: return@load Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
+
+        Loader.OnUpdateResponseLoadedResult(
+          shouldDownloadManifestIfPresentInResponse = selectionPolicy.shouldLoadNewUpdate(
+            update.updateEntity,
+            launchedUpdate,
+            updateResponse.responseHeaderData?.manifestFilters
+          )
+        )
       }
-    }
 
-  private fun processSuccessLoaderResult(loaderResult: Loader.LoaderResult, procedureContext: ProcedureContext) {
-    RemoteLoader.processSuccessLoaderResult(
+      return result
+    } catch (e: CancellationException) {
+      logger.info("Remote loader cancelled during fetch update procedure")
+      throw e
+    }
+  }
+
+  private suspend fun processSuccessLoaderResult(loaderResult: Loader.LoaderResult, procedureContext: ProcedureContext) {
+    val result = RemoteLoader.processSuccessLoaderResult(
       context,
       updatesConfiguration,
       logger,
@@ -123,18 +99,19 @@ class FetchUpdateProcedure(
       updatesDirectory,
       launchedUpdate,
       loaderResult
-    ) { availableUpdate, didRollBackToEmbedded ->
-      if (didRollBackToEmbedded) {
-        procedureContext.processStateEvent(UpdatesStateEvent.DownloadCompleteWithRollback())
-        callback(IUpdatesController.FetchUpdateResult.RollBackToEmbedded())
+    )
+    val (availableUpdate, didRollBackToEmbedded) = result
+
+    if (didRollBackToEmbedded) {
+      procedureContext.processStateEvent(UpdatesStateEvent.DownloadCompleteWithRollback())
+      callback(IUpdatesController.FetchUpdateResult.RollBackToEmbedded())
+    } else {
+      if (availableUpdate == null) {
+        procedureContext.processStateEvent(UpdatesStateEvent.DownloadComplete())
+        callback(IUpdatesController.FetchUpdateResult.Failure())
       } else {
-        if (availableUpdate == null) {
-          procedureContext.processStateEvent(UpdatesStateEvent.DownloadComplete())
-          callback(IUpdatesController.FetchUpdateResult.Failure())
-        } else {
-          procedureContext.processStateEvent(UpdatesStateEvent.DownloadCompleteWithUpdate(availableUpdate.manifest))
-          callback(IUpdatesController.FetchUpdateResult.Success(availableUpdate))
-        }
+        procedureContext.processStateEvent(UpdatesStateEvent.DownloadCompleteWithUpdate(availableUpdate.manifest))
+        callback(IUpdatesController.FetchUpdateResult.Success(availableUpdate))
       }
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -16,7 +16,6 @@ import expo.modules.updates.loader.Loader
 import expo.modules.updates.loader.LoaderTask
 import expo.modules.updates.loader.RemoteLoader
 import expo.modules.updates.loader.UpdateDirective
-import expo.modules.updates.loader.UpdateResponse
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.Update
@@ -197,7 +196,8 @@ class StartupProcedure(
         }
         errorRecovery.notifyNewRemoteLoadStatus(remoteLoadStatus)
       }
-    }
+    },
+    procedureScope
   )
 
   override suspend fun run(procedureContext: ProcedureContext) {
@@ -240,13 +240,23 @@ class StartupProcedure(
         }
         remoteLoadStatus = ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADING
         val remoteLoader = RemoteLoader(context, updatesConfiguration, logger, databaseHolder.database, fileDownloader, updatesDirectory, launchedUpdate)
-        remoteLoader.start(object : Loader.LoaderCallback {
-          override fun onFailure(e: Exception) {
-            logger.error("UpdatesController loadRemoteUpdate onFailure", e, UpdatesErrorCode.UpdateFailedToLoad, launchedUpdate?.loggingId, null)
-            setRemoteLoadStatus(ErrorRecoveryDelegate.RemoteLoadStatus.IDLE)
-          }
+        procedureScope.launch {
+          try {
+            val loaderResult = remoteLoader.load { updateResponse ->
+              val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
+              if (updateDirective != null) {
+                return@load Loader.OnUpdateResponseLoadedResult(
+                  shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
+                    is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
+                    is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
+                  }
+                )
+              }
 
-          override fun onSuccess(loaderResult: Loader.LoaderResult) {
+              val update = updateResponse.manifestUpdateResponsePart?.update ?: return@load Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
+              Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = selectionPolicy.shouldLoadNewUpdate(update.updateEntity, launchedUpdate, updateResponse.responseHeaderData?.manifestFilters))
+            }
+
             setRemoteLoadStatus(
               if (loaderResult.updateEntity != null || loaderResult.updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) {
                 ErrorRecoveryDelegate.RemoteLoadStatus.NEW_UPDATE_LOADED
@@ -254,25 +264,11 @@ class StartupProcedure(
                 ErrorRecoveryDelegate.RemoteLoadStatus.IDLE
               }
             )
+          } catch (e: Exception) {
+            logger.error("UpdatesController loadRemoteUpdate onFailure", e, UpdatesErrorCode.UpdateFailedToLoad, launchedUpdate?.loggingId, null)
+            setRemoteLoadStatus(ErrorRecoveryDelegate.RemoteLoadStatus.IDLE)
           }
-
-          override fun onAssetLoaded(asset: AssetEntity, successfulAssetCount: Int, failedAssetCount: Int, totalAssetCount: Int) { }
-
-          override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
-            val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
-            if (updateDirective != null) {
-              return Loader.OnUpdateResponseLoadedResult(
-                shouldDownloadManifestIfPresentInResponse = when (updateDirective) {
-                  is UpdateDirective.RollBackToEmbeddedUpdateDirective -> false
-                  is UpdateDirective.NoUpdateAvailableUpdateDirective -> false
-                }
-              )
-            }
-
-            val update = updateResponse.manifestUpdateResponsePart?.update ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
-            return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = selectionPolicy.shouldLoadNewUpdate(update.updateEntity, launchedUpdate, updateResponse.responseHeaderData?.manifestFilters))
-          }
-        })
+        }
       }
 
       override fun relaunch(callback: Launcher.LauncherCallback) {

--- a/packages/expo-updates/e2e/README.md
+++ b/packages/expo-updates/e2e/README.md
@@ -54,7 +54,7 @@ yarn maestro:ios:debug:build
 
 ```bash
 yarn maestro:android:debug:build
-./maestro/maestro-test-executor.sh ./maestro/tests/updates-e2e-enabled.yml ios debug
+./maestro/maestro-test-executor.sh ./maestro/tests/updates-e2e-enabled.yml android debug
 ```
 
 - For either the iOS or Android tests, you can optionally run the test updates server separately for debugging purposes.


### PR DESCRIPTION
# Why
Continues migration of `expo-updates` to coroutines. 

# How
This one is kind of large but it was impossible to break up without having multiple PRs in a broken state.
The intention was to focus on the file downloader which then impacted the loaders and procedures. Most of the changes are relatively straight forward. The largest change is to the `FileDownloader` class.

# Test Plan
Local e2e ✅
Native tests ✅
CI 

