### PR TITLE
[docs] note vector icons migration in the docs

### DIFF
--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -5,11 +5,13 @@ description: Learn how to use various types of icons in your Expo app, including
 
 import { SnackInline } from '~/ui/components/Snippet';
 
-Not every app needs to use emojis for icons. You can use a popular icon set through an icon font such as FontAwesome, Glyphicons, or Ionicons, or choose PNGs from [The Noun Project](https://thenounproject.com/). This guide explains various ways to use icons in your Expo app.
+You can use popular icon sets through icon fonts such as FontAwesome, Glyphicons, or Ionicons, or choose PNGs from [The Noun Project](https://thenounproject.com/). This guide explains various ways to use icons in your Expo app.
 
 ## `@expo/vector-icons`
 
-The `@expo/vector-icons` library is installed by default on the template project using `npx create-expo-app` and is part of the `expo` package. It is built on top of [`react-native-vector-icons`](https://github.com/oblador/react-native-vector-icons) and uses a similar API. It includes popular icon sets you can browse at [icons.expo.fyi](https://icons.expo.fyi).
+> **warning** `@expo/vector-icons` is deprecated. [Learn more](https://expo.fyi/migrating-from-expo-vector-icons) about migrating to `@react-native-vector-icons`.
+
+The `@expo/vector-icons` library is built on top of [`react-native-vector-icons`](https://github.com/oblador/react-native-vector-icons) and uses a similar API. It includes popular icon sets you can browse at [icons.expo.fyi](https://icons.expo.fyi).
 
 The component loads the `Ionicons` font and renders a checkmark icon in the following example:
 


### PR DESCRIPTION
# Why

https://github.com/expo/vector-icons/pull/335/

Add a deprecation warning for `@expo/vector-icons` in the documentation and update the description to reflect its current status.

# How

Added a warning box to the icons documentation page that informs users that `@expo/vector-icons` is deprecated and provides a link to migration resources. Also removed the statement about the library being installed by default in template projects.

# Test Plan


# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)