### PR TITLE
[templates] remove @expo/vector-icons from default template

### DIFF
--- a/templates/expo-template-default/components/ui/IconSymbol.tsx
+++ b/templates/expo-template-default/components/ui/IconSymbol.tsx
@@ -1,6 +1,6 @@
 // Fallback for using MaterialIcons on Android and web.
 
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import MaterialIcons from '@react-native-vector-icons/material-icons';
 import { SymbolWeight, SymbolViewProps } from 'expo-symbols';
 import { ComponentProps } from 'react';
 import { OpaqueColorValue, type StyleProp, type TextStyle } from 'react-native';

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -12,7 +12,7 @@
     "lint": "expo lint"
   },
   "dependencies": {
-    "@expo/vector-icons": "^14.1.0",
+	"@react-native-vector-icons/material-icons": "^12.2.0",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",


### PR DESCRIPTION
# Why

edit: the package is gone from the templates already

Remove the `@expo/vector-icons` dependency from the default Expo template since it's now included in the `expo` package by default.

# How

Removed the `@expo/vector-icons` entry from the dependencies section in the default template's package.json file.

# Test Plan

1. Create a new project using the default template
2. Verify that vector icons still work correctly despite removing the explicit dependency
3. Confirm that the app builds and runs without any errors related to missing vector icons

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)