### PR TITLE
Update ExpoGL docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/gl-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/gl-view.mdx
@@ -97,7 +97,7 @@ To use this API inside Reanimated worklet, you need to pass the GL context ID to
 ```jsx
 import { View } from 'react-native';
 import { runOnUI } from 'react-native-reanimated';
-import { GLView } from 'expo-gl';
+import { GLView, getWorkletContext } from 'expo-gl';
 
 function render(gl) {
   'worklet';
@@ -107,7 +107,7 @@ function render(gl) {
 function onContextCreate(gl) {
   runOnUI((contextId: number) => {
     'worklet';
-    const gl = GLView.getWorkletContext(contextId);
+    const gl = getWorkletContext(contextId);
     render(gl);
   })(gl.contextId);
 }


### PR DESCRIPTION
# Why

`GLView.getWorkletContext` is deprecated and doesn't work inside of the worklets with new reanimated versions.
https://github.com/expo/expo/blob/20a35eda39cba5c9f98d36a07f090953a84fce16/packages/expo-gl/build/GLView.d.ts#L41 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
