### PR TITLE
[docs] Improve search page ranking for environment variable pages

### DIFF
--- a/docs/pages/eas/environment-variables.mdx
+++ b/docs/pages/eas/environment-variables.mdx
@@ -2,6 +2,7 @@
 title: Environment variables in EAS
 sidebar_title: Environment variables
 description: Learn how to use and manage environment variables in EAS with examples.
+searchRank: 8
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/eas/hosting/environment-variables.mdx
+++ b/docs/pages/eas/hosting/environment-variables.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_title: Environment variables
-title: Environment variables
-description: Learn how to use environment variables in your project.
+title: Environment variables in EAS Hosting
+description: Learn how to use environment variables in your project when using EAS Hosting.
+searchRank: 7
 ---
 
 An Expo Router web project may include client-side and server-side environment variables. The client-side environment variables are embedded in the app and inlined in the JavaScript bundle when you run `npx expo export`. The server-side environment variables are kept securely on the server and are deployed with the API routes code when you run `eas deploy`.

--- a/docs/pages/get-started/set-up-your-environment.mdx
+++ b/docs/pages/get-started/set-up-your-environment.mdx
@@ -2,6 +2,7 @@
 title: Set up your environment
 description: Learn how to set up your development environment to start building with Expo.
 hideTOC: true
+searchRank: 3
 ---
 
 import { DevelopmentEnvironmentInstructions } from '~/scenes/get-started/set-up-your-environment/DevelopmentEnvironmentInstructions';

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -2,6 +2,7 @@
 title: Environment variables in Expo
 sidebar_title: Environment variables
 description: Learn how to use environment variables in an Expo project.
+searchRank: 10
 ---
 
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16459 ENG-16458

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Increasing `searchRank` to all three environment variable pages
- Decreasing `searchRank` for set up your environment page
- Add missing context to EAS Hosting environment variable guide's title and description.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Applied these ranks to the specific URL of these pages in Algolia crawler configuration.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
