### PR TITLE
[docs] Fix SnackInline copy action for a code block

### DIFF
--- a/docs/common/code-utilities.ts
+++ b/docs/common/code-utilities.ts
@@ -2,6 +2,8 @@ import partition from 'lodash/partition';
 import { Language, Prism } from 'prism-react-renderer';
 import { Children, ReactElement, ReactNode, PropsWithChildren, isValidElement } from 'react';
 
+import { toString } from './utilities';
+
 // Read more: https://github.com/FormidableLabs/prism-react-renderer#custom-language-support
 async function initPrismAsync() {
   (typeof global !== 'undefined' ? global : window).Prism = Prism;
@@ -206,7 +208,7 @@ export function getCodeBlockDataFromChildren(children?: ReactNode, className?: s
     children as ReactElement,
     'className'
   );
-  const code = parseValue(codeNode?.children?.toString() ?? '');
+  const code = parseValue(toString(codeNode?.children));
   const codeLanguage =
     typeof codeNode?.className === 'string' ? codeNode.className.split('-')[1] : 'jsx';
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Fix ENG-16473 #37956

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Replaced the inline `.toString()` method with the `toString` utility function in the `getCodeBlockDataFromChildren` function, simplifying the code block parsing logic.
- Remove fallback since the output will always be a string.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview


https://github.com/user-attachments/assets/4479cf5c-ac27-46f8-91c1-bede4f1344ef



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
