### PR TITLE
[docs] fix rendering type fields metadata when content is empty

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -2611,7 +2611,7 @@ sign-out operation.
     </div>
     <br />
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class=""
     >
       <div
         class="flex flex-row items-start gap-2 mb-2.5 [table_&]:last:mb-0"
@@ -3101,7 +3101,7 @@ for more details.
       </blockquote>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class=""
     />
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
@@ -3602,7 +3602,7 @@ may be
       </p>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class=""
     />
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
@@ -3670,11 +3670,11 @@ may be
             <td
               class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <span
+              <div
                 class="text-quaternary"
               >
                 -
-              </span>
+              </div>
             </td>
           </tr>
           <tr
@@ -3713,11 +3713,11 @@ may be
             <td
               class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <span
+              <div
                 class="text-quaternary"
               >
                 -
-              </span>
+              </div>
             </td>
           </tr>
           <tr
@@ -3756,11 +3756,11 @@ may be
             <td
               class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <span
+              <div
                 class="text-quaternary"
               >
                 -
-              </span>
+              </div>
             </td>
           </tr>
           <tr
@@ -3799,11 +3799,11 @@ may be
             <td
               class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <span
+              <div
                 class="text-quaternary"
               >
                 -
-              </span>
+              </div>
             </td>
           </tr>
           <tr
@@ -3842,11 +3842,11 @@ may be
             <td
               class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <span
+              <div
                 class="text-quaternary"
               >
                 -
-              </span>
+              </div>
             </td>
           </tr>
           <tr
@@ -3885,11 +3885,11 @@ may be
             <td
               class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <span
+              <div
                 class="text-quaternary"
               >
                 -
-              </span>
+              </div>
             </td>
           </tr>
         </tbody>
@@ -4222,7 +4222,7 @@ for more details.
       </blockquote>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class=""
     />
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
@@ -4409,11 +4409,11 @@ OAuth 2.0 protocol
             <td
               class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <span
+              <div
                 class="text-quaternary"
               >
                 -
-              </span>
+              </div>
             </td>
           </tr>
         </tbody>
@@ -4553,7 +4553,7 @@ for more details.
       </blockquote>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class=""
     />
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
@@ -4904,7 +4904,7 @@ for more details.
       </blockquote>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class=""
     />
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
@@ -5017,11 +5017,11 @@ OAuth 2.0 protocol
             <td
               class="border-r border-secondary p-4 text-left last:border-r-0"
             >
-              <span
+              <div
                 class="text-quaternary"
               >
                 -
-              </span>
+              </div>
             </td>
           </tr>
         </tbody>
@@ -6099,7 +6099,7 @@ for more details.
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class=""
     />
     <div
       class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"
@@ -8438,10 +8438,10 @@ After calling this function, the listener will no longer receive any events from
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class=""
     />
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class=""
     />
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
@@ -8579,7 +8579,7 @@ After calling this function, the listener will no longer receive any events from
     </div>
     <div>
       <div
-        class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+        class=""
       />
       <div
         class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
@@ -8849,7 +8849,7 @@ After calling this function, the listener will no longer receive any events from
       </p>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class=""
     />
     <div
       class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
@@ -9142,7 +9142,7 @@ in order to enable/disable the permission.
       </h3>
     </div>
     <div
-      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+      class=""
     />
     <div
       class="border-t border-t-palette-gray4 px-4 pb-0 pt-3 [&_h4]:mb-0.5"

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -48,7 +48,7 @@ const renderTypeDeclarationTable = (
     {index && index > 0 ? (
       <CALLOUT
         className={mergeClasses(STYLES_SECONDARY, 'border-t border-palette-gray4 px-4 py-3')}>
-        Or object shaped as below:
+        Or <CODE className="text-default">object</CODE> shaped as below:
       </CALLOUT>
     ) : undefined}
     <APICommentTextBlock comment={comment} />

--- a/docs/components/plugins/api/components/APICommentTextBlock.tsx
+++ b/docs/components/plugins/api/components/APICommentTextBlock.tsx
@@ -44,10 +44,6 @@ export const APICommentTextBlock = ({
 }: Props) => {
   const content = comment?.summary ? getCommentContent(comment.summary) : undefined;
 
-  if (emptyCommentFallback && !content?.length) {
-    return <span className="text-quaternary">{emptyCommentFallback}</span>;
-  }
-
   const paramTags = content ? getParamTags(content) : undefined;
   const parsedContent = (
     <ReactMarkdown components={mdComponents} remarkPlugins={[remarkGfm, remarkSupsub]}>
@@ -118,6 +114,9 @@ export const APICommentTextBlock = ({
         </>
       )}
       {beforeContent}
+      {emptyCommentFallback && !content?.length && (
+        <span className="text-quaternary">{emptyCommentFallback}</span>
+      )}
       {parsedContent}
       {afterContent}
       {afterContent && !exampleContent && <br />}

--- a/docs/components/plugins/api/components/APICommentTextBlock.tsx
+++ b/docs/components/plugins/api/components/APICommentTextBlock.tsx
@@ -43,8 +43,9 @@ export const APICommentTextBlock = ({
   emptyCommentFallback,
 }: Props) => {
   const content = comment?.summary ? getCommentContent(comment.summary) : undefined;
+  const hasContent = Boolean(content?.length);
 
-  const paramTags = content ? getParamTags(content) : undefined;
+  const paramTags = hasContent ? getParamTags(content) : undefined;
   const parsedContent = (
     <ReactMarkdown components={mdComponents} remarkPlugins={[remarkGfm, remarkSupsub]}>
       {parseCommentContent(paramTags ? content?.replaceAll(PARAM_TAGS_REGEX, '') : content)}
@@ -98,7 +99,11 @@ export const APICommentTextBlock = ({
   const hasPlatforms = (getAllTagData('platform', comment)?.length || 0) > 0;
 
   return (
-    <div className={mergeClasses(includeSpacing && 'px-4 [table_&]:!mb-0 [table_&]:px-0')}>
+    <div
+      className={mergeClasses(
+        includeSpacing && hasContent && 'px-4 [table_&]:!mb-0 [table_&]:px-0',
+        emptyCommentFallback && !hasContent && 'text-quaternary'
+      )}>
       {includePlatforms && hasPlatforms && (
         <APISectionPlatformTags
           comment={comment}
@@ -114,9 +119,7 @@ export const APICommentTextBlock = ({
         </>
       )}
       {beforeContent}
-      {emptyCommentFallback && !content?.length && (
-        <span className="text-quaternary">{emptyCommentFallback}</span>
-      )}
+      {Boolean(emptyCommentFallback) && !hasContent && emptyCommentFallback}
       {parsedContent}
       {afterContent}
       {afterContent && !exampleContent && <br />}

--- a/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
+++ b/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
@@ -165,7 +165,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
 exports[`APICommentTextBlock no comment 1`] = `
 <div>
   <div
-    class="px-4 [table_&]:!mb-0 [table_&]:px-0"
+    class=""
   />
 </div>
 `;


### PR DESCRIPTION
# Why

Fixes ENG-16476

# How

Do not bail out early from rendering type field description when there is no text content. Looks like that in very rare cases we include some metadata tags but no description, and with the current logic we skipped rendering them unintentionally.

I have removed early bail-out and moved the empty comment fallback inside the final comment block.

In the process, I have also find small formatting inconsistency, which also has been addressed.

# Test Plan

1. Run docs app locally, or visit the PR preview.
2. Navigate to http://localhost:3002/versions/latest/sdk/notifications/#pushnotificationtrigger and make sure that platform tags are present in the table with `PushNotificationTrigger` properties. 

### Preview

<img width="2274" height="626" alt="Screenshot 2025-07-10 at 21 29 05" src="https://github.com/user-attachments/assets/7fb8f2b7-2eb9-4517-b017-b1e58417f80e" />

