### PR TITLE
[script] run `npx` through `pnpm exec` when appropriate

### DIFF
--- a/packages/expo-module-scripts/bin/npx
+++ b/packages/expo-module-scripts/bin/npx
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
-# Runs `npx` through Yarn if necessary so that the environment variables are set up similarly across
-# Yarn and npm.
+# Runs `npx` through Yarn or pnpm if necessary so that the environment variables are set up similarly across
+# Yarn, pnpm and npm.
 
 # shellcheck disable=SC2154
-if [[ ! "$npm_config_user_agent" =~ yarn ]] && [ -x "$(command -v yarn)" ]; then
+if [[ "$npm_config_user_agent" =~ yarn ]] && [ -x "$(command -v yarn)" ]; then
   yarn exec -- npx "$@"
+elif [[ "$npm_config_user_agent" =~ pnpm ]] && [ -x "$(command -v pnpm)" ]; then
+  pnpm exec -- npx "$@"
 else
   npx "$@"
 fi


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
In our module package inside of a pnpm monorepo, we saw failures installing during prepare
```
packages/net-notifications prepare$ expo-module prepare
packages/net-notifications prepare: Configuring module
packages/net-notifications prepare: expo-module-scripts: README.md exists, not updating
packages/net-notifications prepare: error This project's package.json defines "packageManager": "yarn@pnpm@9.14.2". However the current global version of Yarn is 1.22.22.
packages/net-notifications prepare: Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
packages/net-notifications prepare: Corepack must currently be enabled by running corepack enable in your terminal. For more information, check out https://yarnpkg.com/corepack.
packages/net-notifications prepare: Failed
 ELIFECYCLE  Command failed with exit code 1.
```

# How

<!--
How did you build this feature or fix this bug and why?
-->
I created a local patch and this fixed it. I have no context on what this stuff is really even doing, but this seems reasonable.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Try installing a expo module in pnpm monorepo, it should work.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
