### PR TITLE
Fix limitation link in fingerprint.mdx

### DIFF
--- a/docs/pages/versions/unversioned/sdk/fingerprint.mdx
+++ b/docs/pages/versions/unversioned/sdk/fingerprint.mdx
@@ -33,7 +33,7 @@ If you wish to use `@expo/fingerprint` as a standalone package, you can install 
 
 ### .fingerprintignore
 
-Placed in your project root, **.fingerprintignore** is a [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format)-like ignore mechanism used to exclude files from hash calculation. All pattern paths are relative to the project root. It behaves similarly but instead uses `minimatch` for pattern matching which has some [limitations](#options) (see documentation for `ignorePaths` under [Options](#options)).
+Placed in your project root, **.fingerprintignore** is a [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format)-like ignore mechanism used to exclude files from hash calculation. All pattern paths are relative to the project root. It behaves similarly but instead uses `minimatch` for pattern matching which has some [limitations](#limitations) (see documentation for `ignorePaths` under [Options](#options)).
 
 Here is an example **.fingerprintignore** configuration:
 

--- a/docs/pages/versions/v52.0.0/sdk/fingerprint.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/fingerprint.mdx
@@ -34,7 +34,7 @@ If you wish to use `@expo/fingerprint` as a standalone package, you can install 
 
 ### .fingerprintignore
 
-Placed in your project root, **.fingerprintignore** is a [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format)-like ignore mechanism used to exclude files from hash calculation. All pattern paths are relative to the project root. It behaves similarly but instead uses `minimatch` for pattern matching which has some [limitations](#options) (see documentation for `ignorePaths` under [Options](#options)).
+Placed in your project root, **.fingerprintignore** is a [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format)-like ignore mechanism used to exclude files from hash calculation. All pattern paths are relative to the project root. It behaves similarly but instead uses `minimatch` for pattern matching which has some [limitations](#limitations) (see documentation for `ignorePaths` under [Options](#options)).
 
 Here is an example **.fingerprintignore** configuration:
 

--- a/docs/pages/versions/v53.0.0/sdk/fingerprint.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/fingerprint.mdx
@@ -34,7 +34,7 @@ If you wish to use `@expo/fingerprint` as a standalone package, you can install 
 
 ### .fingerprintignore
 
-Placed in your project root, **.fingerprintignore** is a [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format)-like ignore mechanism used to exclude files from hash calculation. All pattern paths are relative to the project root. It behaves similarly but instead uses `minimatch` for pattern matching which has some [limitations](#options) (see documentation for `ignorePaths` under [Options](#options)).
+Placed in your project root, **.fingerprintignore** is a [**.gitignore**](https://git-scm.com/docs/gitignore#_pattern_format)-like ignore mechanism used to exclude files from hash calculation. All pattern paths are relative to the project root. It behaves similarly but instead uses `minimatch` for pattern matching which has some [limitations](#limitations) (see documentation for `ignorePaths` under [Options](#options)).
 
 Here is an example **.fingerprintignore** configuration:
 


### PR DESCRIPTION
# Why

Link in doc was redirecting to incorrect section

# How

Changed link

# Test Plan

Follow `#limitations` link on prod app to ensure it works as expected 

# Checklist

- [ N/A ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
