### PR TITLE
[video][android] Fix duration property resetting to 0 on video repeat

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix duration property resetting to 0 on video repeat.
+- [Android] Fix duration property resetting to 0 on video repeat. ([#37984](https://github.com/expo/expo/pull/37984) by [@Wenszel](https://github.com/Wenszel))
 - [Android] Fix accessing player.loop causes app to crash. ([#37928](https://github.com/expo/expo/pull/37928) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Setting `player.currentTime` doesn't seek to the correct time on some videos. ([#37672](https://github.com/expo/expo/pull/37300) by [@petrkonecny2](https://github.com/petrkonecny2))
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix duration property resetting to 0 on video repeat.
 - [Android] Fix accessing player.loop causes app to crash. ([#37928](https://github.com/expo/expo/pull/37928) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Setting `player.currentTime` doesn't seek to the correct time on some videos. ([#37672](https://github.com/expo/expo/pull/37300) by [@petrkonecny2](https://github.com/petrkonecny2))
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -385,13 +385,13 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
   }
 
   private fun refreshPlaybackInfo() {
-    this@VideoPlayer.duration = this@VideoPlayer.player.duration / 1000f
-    this@VideoPlayer.isLive = this@VideoPlayer.player.isCurrentMediaItemLive
+    duration = player.duration / 1000f
+    isLive = player.isCurrentMediaItemLive
   }
 
   private fun resetPlaybackInfo() {
-    this@VideoPlayer.duration = 0f
-    this@VideoPlayer.isLive = false
+    duration = 0f
+    isLive = false
   }
 
   fun addListener(videoPlayerListener: VideoPlayerListener) {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -235,10 +235,13 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
     }
 
     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-      this@VideoPlayer.duration = 0f
-      this@VideoPlayer.isLive = false
       if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT) {
         sendEvent(PlayerEvent.PlayedToEnd())
+      } else {
+        // New playback info is set in the onPlaybackStateChanged event, which occurs after mediaItemTransition.
+        // The onPlaybackStateChanged is not triggered if the video repeats (since the state remains STATE_READY)
+        // That is why the playback info is not reset when the transition reason is MEDIA_ITEM_TRANSITION_REASON_REPEAT.
+        resetPlaybackInfo()
       }
       subtitles.setSubtitlesEnabled(false)
       super.onMediaItemTransition(mediaItem, reason)
@@ -249,8 +252,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
         return
       }
       if (playbackState == Player.STATE_READY) {
-        this@VideoPlayer.duration = this@VideoPlayer.player.duration / 1000f
-        this@VideoPlayer.isLive = this@VideoPlayer.player.isCurrentMediaItemLive
+        refreshPlaybackInfo()
       }
       setStatus(playerStateToPlayerStatus(playbackState), null)
       super.onPlaybackStateChanged(playbackState)
@@ -269,8 +271,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
 
     override fun onPlayerErrorChanged(error: PlaybackException?) {
       error?.let {
-        this@VideoPlayer.duration = 0f
-        this@VideoPlayer.isLive = false
+        resetPlaybackInfo()
         setStatus(ERROR, error)
       } ?: run {
         setStatus(playerStateToPlayerStatus(player.playbackState), null)
@@ -381,6 +382,16 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
     if (this.status != oldStatus) {
       sendEvent(PlayerEvent.StatusChanged(status, oldStatus, playbackError))
     }
+  }
+
+  private fun refreshPlaybackInfo() {
+    this@VideoPlayer.duration = this@VideoPlayer.player.duration / 1000f
+    this@VideoPlayer.isLive = this@VideoPlayer.player.isCurrentMediaItemLive
+  }
+
+  private fun resetPlaybackInfo() {
+    this@VideoPlayer.duration = 0f
+    this@VideoPlayer.isLive = false
   }
 
   fun addListener(videoPlayerListener: VideoPlayerListener) {


### PR DESCRIPTION
# Why

Fixes [#34700](https://github.com/expo/expo/issues/34700)

# How
This situation occurs because on repeat the player remains in `STATE_READY`, and the duration is not refreshed after being set to 0 in onMediaTransition.  
Removed resetting the duration on `MEDIA_ITEM_TRANSITION_REASON_REPEAT` because the duration does not change on video repeat.

# Test Plan

Tested on bare-expo using the code from the issue.

