### PR TITLE
[image][ios] Fix some operations were incorrectly cancelled

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [iOS] Speed up displaying local assets. ([#37795](https://github.com/expo/expo/pull/37795) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Fix animation resuming by casting image to GifDrawable. ([#37363](https://github.com/expo/expo/pull/37363) by [@Wenszel](https://github.com/Wenszel))
 - [Web] Fix `alt` as an alias for `accessibilityLabel` ([#37682](https://github.com/expo/expo/pull/37682) by [@huextrat](https://github.com/huextrat))
-- [iOS] Fix some operation were incorrectly cancelled.
+- [iOS] Fix some operation were incorrectly cancelled. ([#37987](https://github.com/expo/expo/pull/37987) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [iOS] Speed up displaying local assets. ([#37795](https://github.com/expo/expo/pull/37795) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Fix animation resuming by casting image to GifDrawable. ([#37363](https://github.com/expo/expo/pull/37363) by [@Wenszel](https://github.com/Wenszel))
 - [Web] Fix `alt` as an alias for `accessibilityLabel` ([#37682](https://github.com/expo/expo/pull/37682) by [@huextrat](https://github.com/huextrat))
+- [iOS] Fix some operation were incorrectly cancelled.
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -121,12 +121,10 @@ public final class ImageView: ExpoView {
     if window == nil {
       // Cancel pending requests when the view is unmounted.
       cancelPendingOperation()
-    } else if !bounds.isEmpty {
-      // Reload the image after mounting the view with non-empty bounds.
-      reload()
-    } else {
-      loadPlaceholderIfNecessary()
+      return
     }
+    
+    loadPlaceholderIfNecessary()
   }
 
   public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -123,7 +123,7 @@ public final class ImageView: ExpoView {
       cancelPendingOperation()
       return
     }
-    
+
     loadPlaceholderIfNecessary()
   }
 


### PR DESCRIPTION
# Why

Fixes operations were cancelled incorrectly.
When the view was moved to the window, we were cancelling and starting the same SDWebImage operation, leading to weird delays. We no longer reload the image when the view is mounted. It may appear that we're loading the incorrect image when the view starts with a bounding box of `.zero`. It's not true, we are triggering reload when the bounding box changes.

# Test Plan

- external app ✅ 