### PR TITLE
[sdk54][0.81.0.rc-0] Added support for using React Native prebuilt XCFramework in 0.81.0

### DIFF
--- a/packages/expo-modules-core/ios/Core/ExpoBridgeModule.h
+++ b/packages/expo-modules-core/ios/Core/ExpoBridgeModule.h
@@ -1,6 +1,10 @@
 // Copyright 2024-present 650 Industries. All rights reserved.
 
+#if __has_include(<React/React-Core-umbrella.h>)
 #import <React/React-Core-umbrella.h>
+#else
+#import <React_Core/React_Core-umbrella.h>
+#endif
 #import <ExpoModulesCore/EXNativeModulesProxy.h>
 #import <ExpoModulesCore/EXModuleRegistry.h>
 
@@ -8,9 +12,9 @@
 
 @interface ExpoBridgeModule : NSObject <RCTBridgeModule>
 
-@property (nonatomic, nullable, strong) EXAppContext *appContext;
+@property(nonatomic, nullable, strong) EXAppContext *appContext;
 
-- (nonnull instancetype)initWithAppContext:(nonnull EXAppContext *) appContext; 
+- (nonnull instancetype)initWithAppContext:(nonnull EXAppContext *)appContext;
 
 - (void)legacyProxyDidSetBridge:(nonnull EXNativeModulesProxy *)moduleProxy
            legacyModuleRegistry:(nonnull EXModuleRegistry *)moduleRegistry;

--- a/packages/expo-modules-core/ios/EXAppDefines.m
+++ b/packages/expo-modules-core/ios/EXAppDefines.m
@@ -1,7 +1,11 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
 #import <ExpoModulesCore/EXAppDefines.h>
-#import <React/React-Core-umbrella.h>
+#if __has_include(<React/React-Core-umbrella.h>)
+  #import <React/React-Core-umbrella.h>
+#else
+  #import <React_Core/React_Core-umbrella.h>
+#endif
 
 @implementation EXAppDefines
 

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
@@ -4,7 +4,11 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 
+#if __has_include(<React/React-Core-umbrella.h>)
 #import <React/React-Core-umbrella.h>
+#else
+#import <React_Core/React_Core-umbrella.h>
+#endif
 
 #ifdef __cplusplus
 
@@ -20,7 +24,7 @@
 @end
 
 #endif // __cplusplus
-#else // Paper
+#else  // Paper
 
 @interface ExpoFabricViewObjC : RCTView
 @end
@@ -38,7 +42,7 @@
 
 - (void)viewDidUpdateProps;
 
-- (void)setShadowNodeSize:(float) width height:(float) height;
+- (void)setShadowNodeSize:(float)width height:(float)height;
 
 - (BOOL)supportsPropWithName:(nonnull NSString *)name;
 

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
@@ -10,7 +10,11 @@
 #import <ExpoModulesCore/ExpoViewComponentDescriptor.h>
 #import <ExpoModulesCore/Swift.h>
 
-#import <React/React-Core-umbrella.h>
+#if __has_include(<React/React-Core-umbrella.h>)
+  #import <React/React-Core-umbrella.h>
+#else
+  #import <React_Core/React_Core-umbrella.h>
+#endif
 
 #import <string.h>
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.h
@@ -5,7 +5,11 @@
 #import <Foundation/Foundation.h>
 
 #import <jsi/jsi.h>
+#if __has_include(<React/React-Core-umbrella.h>)
 #import <React/React-Core-umbrella.h>
+#else
+#import <React_Core/React_Core-umbrella.h>
+#endif
 
 using namespace facebook;
 using namespace react;
@@ -13,33 +17,34 @@ using namespace react;
 @class EXJavaScriptValue;
 @class EXJavaScriptRuntime;
 
-namespace expo {
+namespace expo
+{
 
-jsi::Value convertNSNumberToJSIBoolean(jsi::Runtime &runtime, NSNumber *value);
+    jsi::Value convertNSNumberToJSIBoolean(jsi::Runtime &runtime, NSNumber *value);
 
-jsi::Value convertNSNumberToJSINumber(jsi::Runtime &runtime, NSNumber *value);
+    jsi::Value convertNSNumberToJSINumber(jsi::Runtime &runtime, NSNumber *value);
 
-jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *value);
+    jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *value);
 
-jsi::Object convertNSDictionaryToJSIObject(jsi::Runtime &runtime, NSDictionary *value);
+    jsi::Object convertNSDictionaryToJSIObject(jsi::Runtime &runtime, NSDictionary *value);
 
-jsi::Array convertNSArrayToJSIArray(jsi::Runtime &runtime, NSArray *value);
+    jsi::Array convertNSArrayToJSIArray(jsi::Runtime &runtime, NSArray *value);
 
-std::vector<jsi::Value> convertNSArrayToStdVector(jsi::Runtime &runtime, NSArray *value);
+    std::vector<jsi::Value> convertNSArrayToStdVector(jsi::Runtime &runtime, NSArray *value);
 
-jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value);
+    jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value);
 
-NSString *convertJSIStringToNSString(jsi::Runtime &runtime, const jsi::String &value);
+    NSString *convertJSIStringToNSString(jsi::Runtime &runtime, const jsi::String &value);
 
-NSArray *convertJSIArrayToNSArray(jsi::Runtime &runtime, const jsi::Array &value, std::shared_ptr<CallInvoker> jsInvoker);
+    NSArray *convertJSIArrayToNSArray(jsi::Runtime &runtime, const jsi::Array &value, std::shared_ptr<CallInvoker> jsInvoker);
 
-NSArray<EXJavaScriptValue *> *convertJSIValuesToNSArray(EXJavaScriptRuntime *runtime, const jsi::Value *values, size_t count);
+    NSArray<EXJavaScriptValue *> *convertJSIValuesToNSArray(EXJavaScriptRuntime *runtime, const jsi::Value *values, size_t count);
 
-NSDictionary *convertJSIObjectToNSDictionary(jsi::Runtime &runtime, const jsi::Object &value, std::shared_ptr<CallInvoker> jsInvoker);
+    NSDictionary *convertJSIObjectToNSDictionary(jsi::Runtime &runtime, const jsi::Object &value, std::shared_ptr<CallInvoker> jsInvoker);
 
-id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value, std::shared_ptr<CallInvoker> jsInvoker);
+    id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value, std::shared_ptr<CallInvoker> jsInvoker);
 
-RCTResponseSenderBlock convertJSIFunctionToCallback(jsi::Runtime &runtime, const jsi::Function &value, std::shared_ptr<CallInvoker> jsInvoker);
+    RCTResponseSenderBlock convertJSIFunctionToCallback(jsi::Runtime &runtime, const jsi::Function &value, std::shared_ptr<CallInvoker> jsInvoker);
 
 } // namespace expo
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.h
@@ -1,6 +1,10 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#if __has_include(<React/React-Core-umbrella.h>)
 #import <React/React-Core-umbrella.h>
+#else
+#import <React_Core/React_Core-umbrella.h>
+#endif
 
 // Swift classes need forward-declaration in the headers.
 @class EXAppContext;
@@ -13,7 +17,7 @@
 /**
  Property name of the core object in the global scope of the Expo JS runtime.
  */
-extern NSString * _Nonnull const EXGlobalCoreObjectPropertyName;
+extern NSString *_Nonnull const EXGlobalCoreObjectPropertyName;
 
 @interface EXJavaScriptRuntimeManager : NSObject
 
@@ -36,7 +40,7 @@ extern NSString * _Nonnull const EXGlobalCoreObjectPropertyName;
 /**
  Installs the base class for shared objects, i.e. `global.expo.SharedObject`.
  */
-+ (void)installSharedObjectClass:(nonnull EXRuntime *)runtime releaser:(void(^)(long))releaser;
++ (void)installSharedObjectClass:(nonnull EXRuntime *)runtime releaser:(void (^)(long))releaser;
 
 /**
  Installs the base class for shared refs, i.e. `global.expo.SharedRef`.

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
@@ -6,46 +6,51 @@
 
 #import <jsi/jsi.h>
 #import <React/RCTBridgeModule.h>
+#if __has_include(<React/React-Core-umbrella.h>)
 #import <React/React-Core-umbrella.h>
+#else
+#import <React_Core/React_Core-umbrella.h>
+#endif
 #import <ReactCommon/TurboModuleUtils.h>
 #import <ExpoModulesCore/ObjectDeallocator.h>
 
 namespace jsi = facebook::jsi;
 namespace react = facebook::react;
 
-namespace expo {
+namespace expo
+{
 
 #pragma mark - Promises
 
-using PromiseInvocationBlock = void (^)(RCTPromiseResolveBlock resolveWrapper, RCTPromiseRejectBlock rejectWrapper);
+    using PromiseInvocationBlock = void (^)(RCTPromiseResolveBlock resolveWrapper, RCTPromiseRejectBlock rejectWrapper);
 
-void callPromiseSetupWithBlock(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> jsInvoker, std::shared_ptr<react::Promise> promise, PromiseInvocationBlock setupBlock);
+    void callPromiseSetupWithBlock(jsi::Runtime &runtime, std::shared_ptr<react::CallInvoker> jsInvoker, std::shared_ptr<react::Promise> promise, PromiseInvocationBlock setupBlock);
 
 #pragma mark - Weak objects
 
-/**
- Checks whether the `WeakRef` class is available in the given runtime.
- According to the docs, it is unimplemented in JSC prior to iOS 14.5.
- As of the time of writing this comment it's also unimplemented in Hermes
- where you should use `jsi::WeakObject` instead.
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef
- */
-bool isWeakRefSupported(jsi::Runtime &runtime);
+    /**
+     Checks whether the `WeakRef` class is available in the given runtime.
+     According to the docs, it is unimplemented in JSC prior to iOS 14.5.
+     As of the time of writing this comment it's also unimplemented in Hermes
+     where you should use `jsi::WeakObject` instead.
+     https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef
+     */
+    bool isWeakRefSupported(jsi::Runtime &runtime);
 
-/**
- Creates the `WeakRef` with given JSI object. You should first use `isWeakRefSupported`
- to check whether this feature is supported by the runtime.
- */
-std::shared_ptr<jsi::Object> createWeakRef(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> object);
+    /**
+     Creates the `WeakRef` with given JSI object. You should first use `isWeakRefSupported`
+     to check whether this feature is supported by the runtime.
+     */
+    std::shared_ptr<jsi::Object> createWeakRef(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> object);
 
-/**
- Returns the `WeakRef` object's target object, or an empty pointer if the target object has been reclaimed.
- */
-std::shared_ptr<jsi::Object> derefWeakRef(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> object);
+    /**
+     Returns the `WeakRef` object's target object, or an empty pointer if the target object has been reclaimed.
+     */
+    std::shared_ptr<jsi::Object> derefWeakRef(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> object);
 
 #pragma mark - Errors
 
-jsi::Value makeCodedError(jsi::Runtime &runtime, NSString *code, NSString *message);
+    jsi::Value makeCodedError(jsi::Runtime &runtime, NSString *code, NSString *message);
 
 } // namespace expo
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
@@ -2,7 +2,11 @@
 
 #import <sstream>
 
-#import <React/React-Core-umbrella.h>
+#if __has_include(<React/React-Core-umbrella.h>)
+  #import <React/React-Core-umbrella.h>
+#else
+  #import <React_Core/React_Core-umbrella.h>
+#endif
 #import <ExpoModulesCore/EXJSIConversions.h>
 #import <ExpoModulesCore/EXJSIUtils.h>
 #import <ExpoModulesCore/JSIUtils.h>

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -3,7 +3,11 @@
 #import <Foundation/Foundation.h>
 #import <ExpoModulesCore/EXJavaScriptValue.h>
 #import <ExpoModulesCore/EXJavaScriptObject.h>
+#if __has_include(<React/React-Core-umbrella.h>)
 #import <React/React-Core-umbrella.h>
+#else
+#import <React_Core/React_Core-umbrella.h>
+#endif
 
 #ifdef __cplusplus
 
@@ -17,20 +21,20 @@ namespace react = facebook::react;
 
 typedef void (^JSRuntimeExecutionBlock)(void);
 
-typedef void (^JSAsyncFunctionBlock)(EXJavaScriptValue * _Nonnull thisValue,
-                                     NSArray<EXJavaScriptValue *> * _Nonnull arguments,
+typedef void (^JSAsyncFunctionBlock)(EXJavaScriptValue *_Nonnull thisValue,
+                                     NSArray<EXJavaScriptValue *> *_Nonnull arguments,
                                      RCTPromiseResolveBlock _Nonnull resolve,
                                      RCTPromiseRejectBlock _Nonnull reject);
 
-typedef EXJavaScriptValue * _Nullable (^JSSyncFunctionBlock)(EXJavaScriptValue * _Nonnull thisValue,
-                                                             NSArray<EXJavaScriptValue *> * _Nonnull arguments,
-                                                             NSError * _Nullable __autoreleasing * _Nullable error);
+typedef EXJavaScriptValue *_Nullable (^JSSyncFunctionBlock)(EXJavaScriptValue *_Nonnull thisValue,
+                                                            NSArray<EXJavaScriptValue *> *_Nonnull arguments,
+                                                            NSError *_Nullable __autoreleasing *_Nullable error);
 
 #ifdef __cplusplus
 typedef jsi::Value (^JSHostFunctionBlock)(jsi::Runtime &runtime,
                                           std::shared_ptr<react::CallInvoker> callInvoker,
-                                          EXJavaScriptValue * _Nonnull thisValue,
-                                          NSArray<EXJavaScriptValue *> * _Nonnull arguments);
+                                          EXJavaScriptValue *_Nonnull thisValue,
+                                          NSArray<EXJavaScriptValue *> *_Nonnull arguments);
 #endif // __cplusplus
 
 NS_SWIFT_NAME(JavaScriptRuntime)
@@ -94,7 +98,7 @@ NS_SWIFT_NAME(JavaScriptRuntime)
 
 #pragma mark - Classes
 
-typedef void (^ClassConstructorBlock)(EXJavaScriptObject * _Nonnull thisValue, NSArray<EXJavaScriptValue *> * _Nonnull arguments);
+typedef void (^ClassConstructorBlock)(EXJavaScriptObject *_Nonnull thisValue, NSArray<EXJavaScriptValue *> *_Nonnull arguments);
 
 - (nonnull EXJavaScriptObject *)createClass:(nonnull NSString *)name
                                 constructor:(nonnull ClassConstructorBlock)constructor;

--- a/packages/expo-modules-core/ios/Legacy/EXBridgeModule.h
+++ b/packages/expo-modules-core/ios/Legacy/EXBridgeModule.h
@@ -1,15 +1,18 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#if __has_include(<React/React-Core-umbrella.h>)
 #import <React/React-Core-umbrella.h>
+#else
+#import <React_Core/React_Core-umbrella.h>
+#endif
 
 // Escape hatch for modules that both have to depend on React Native
 // and want to be exported as an internal universal module.
-#define EX_RCT_REGISTER_MODULE(external_name) \
-  + (const NSString *)moduleName { return @#external_name; } \
-  EX_EXPORT_MODULE_WITH_CUSTOM_LOAD(external_name, \
-    RCT_EXTERN void RCTRegisterModule(Class); \
-    RCTRegisterModule(self); \
-  )
+#define EX_RCT_REGISTER_MODULE(external_name)                                 \
+  +(const NSString *)moduleName { return @ #external_name; }                  \
+  EX_EXPORT_MODULE_WITH_CUSTOM_LOAD(external_name,                            \
+                                    RCT_EXTERN void RCTRegisterModule(Class); \
+                                    RCTRegisterModule(self);)
 
 @protocol EXBridgeModule <RCTBridgeModule>
 

--- a/packages/expo-modules-core/ios/Legacy/ModuleRegistryAdapter/EXModuleRegistryAdapter.h
+++ b/packages/expo-modules-core/ios/Legacy/ModuleRegistryAdapter/EXModuleRegistryAdapter.h
@@ -1,6 +1,11 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#if __has_include(<React/React-Core-umbrella.h>)
 #import <React/React-Core-umbrella.h>
+#else
+#import <React_Core/React_Core-umbrella.h>
+#endif
+
 #import <ExpoModulesCore/EXModuleRegistryProvider.h>
 
 // An "adapter" over module registry, for given RCTBridge and NSString
@@ -11,14 +16,14 @@
 NS_SWIFT_NAME(ModuleRegistryAdapter)
 @interface EXModuleRegistryAdapter : NSObject
 
-@property (nonnull, nonatomic, readonly) EXModuleRegistryProvider *moduleRegistryProvider;
+@property(nonnull, nonatomic, readonly) EXModuleRegistryProvider *moduleRegistryProvider;
 
 - (nonnull instancetype)initWithModuleRegistryProvider:(nonnull EXModuleRegistryProvider *)moduleRegistryProvider
-__deprecated_msg("Expo modules are now automatically registered. You can remove this method call.");
+    __deprecated_msg("Expo modules are now automatically registered. You can remove this method call.");
 
 - (nonnull NSArray<id<RCTBridgeModule>> *)extraModulesForModuleRegistry:(nonnull EXModuleRegistry *)moduleRegistry;
 
 - (nonnull NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(nonnull RCTBridge *)bridge
-__deprecated_msg("Expo modules are now automatically registered. You can replace this with an empty array.");
+    __deprecated_msg("Expo modules are now automatically registered. You can replace this with an empty array.");
 
 @end

--- a/packages/expo-modules-core/ios/Legacy/ModuleRegistryAdapter/EXModuleRegistryHolderReactModule.h
+++ b/packages/expo-modules-core/ios/Legacy/ModuleRegistryAdapter/EXModuleRegistryHolderReactModule.h
@@ -1,6 +1,10 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#if __has_include(<React/React-Core-umbrella.h>)
 #import <React/React-Core-umbrella.h>
+#else
+#import <React_Core/React_Core-umbrella.h>
+#endif
 
 #import <ExpoModulesCore/EXModuleRegistry.h>
 

--- a/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.h
+++ b/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.h
@@ -1,6 +1,10 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#if __has_include(<React/React-Core-umbrella.h>)
 #import <React/React-Core-umbrella.h>
+#else
+#import <React_Core/React_Core-umbrella.h>
+#endif
 
 #import <ExpoModulesCore/EXInternalModule.h>
 #import <ExpoModulesCore/EXModuleRegistry.h>
@@ -26,7 +30,7 @@ NS_SWIFT_NAME(ModulesProxyConfig)
 NS_SWIFT_NAME(LegacyNativeModulesProxy)
 @interface EXNativeModulesProxy : NSObject <RCTBridgeModule>
 
-@property (nonatomic, strong, readonly) EXModulesProxyConfig *nativeModulesConfig;
+@property(nonatomic, strong, readonly) EXModulesProxyConfig *nativeModulesConfig;
 
 - (nonnull instancetype)init;
 - (nonnull instancetype)initWithModuleRegistry:(nullable EXModuleRegistry *)moduleRegistry;

--- a/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
+++ b/packages/expo-modules-core/ios/Legacy/NativeModulesProxy/EXNativeModulesProxy.mm
@@ -2,7 +2,12 @@
 
 #import <objc/runtime.h>
 
-#import <React/React-Core-umbrella.h>
+#if __has_include(<React/React-Core-umbrella.h>)
+  #import <React/React-Core-umbrella.h>
+#else
+  #import <React_Core/React_Core-umbrella.h>
+#endif
+
 #import <React/RCTComponentViewFactory.h> // Allows non-umbrella since it's coming from React-RCTFabric
 
 #import <jsi/jsi.h>
@@ -141,7 +146,7 @@ RCT_EXPORT_MODULE(NativeUnimoduleProxy)
   if (_nativeModulesConfig) {
     return _nativeModulesConfig;
   }
-  
+
   NSMutableDictionary <NSString *, id> *exportedModulesConstants = [NSMutableDictionary dictionary];
   // Grab all the constants exported by modules
   for (EXExportedModule *exportedModule in [_exModuleRegistry getAllExportedModules]) {
@@ -167,13 +172,13 @@ RCT_EXPORT_MODULE(NativeUnimoduleProxy)
     }];
     [self assignExportedMethodsKeys:exportedMethodsNamesAccumulator[exportedModuleName] forModuleName:exportedModuleName];
   }
-  
+
   EXModulesProxyConfig *config = [[EXModulesProxyConfig alloc] initWithConstants:exportedModulesConstants
                                                                      methodNames:exportedMethodsNamesAccumulator
                                                                     viewManagers:[NSMutableDictionary new]];
   // decorate legacy config with sweet expo-modules config
   [config addEntriesFromConfig:[_appContext expoModulesConfig]];
-  
+
   _nativeModulesConfig = config;
   return config;
 }

--- a/packages/expo-modules-core/ios/Legacy/Services/EXReactLogHandler.m
+++ b/packages/expo-modules-core/ios/Legacy/Services/EXReactLogHandler.m
@@ -1,6 +1,10 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <React/React-Core-umbrella.h>
+#if __has_include(<React/React-Core-umbrella.h>)
+  #import <React/React-Core-umbrella.h>
+#else
+  #import <React_Core/React_Core-umbrella.h>
+#endif
 
 #import <ExpoModulesCore/EXReactLogHandler.h>
 #import <ExpoModulesCore/EXDefines.h>

--- a/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.h
+++ b/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.h
@@ -1,6 +1,10 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#if __has_include(<React/React-Core-umbrella.h>)
 #import <React/React-Core-umbrella.h>
+#else
+#import <React_Core/React_Core-umbrella.h>
+#endif
 
 #import <ExpoModulesCore/EXUIManager.h>
 #import <ExpoModulesCore/EXInternalModule.h>

--- a/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.mm
+++ b/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeAdapter.mm
@@ -2,7 +2,12 @@
 
 #import <JavaScriptCore/JavaScriptCore.h>
 
-#import <React/React-Core-umbrella.h>
+#if __has_include(<React/React-Core-umbrella.h>)
+  #import <React/React-Core-umbrella.h>
+#else
+  #import <React_Core/React_Core-umbrella.h>
+#endif
+
 #import <ExpoModulesCore/EXReactNativeAdapter.h>
 #import <ExpoModulesCore/ExpoFabricViewObjC.h>
 

--- a/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeEventEmitter.h
+++ b/packages/expo-modules-core/ios/Legacy/Services/EXReactNativeEventEmitter.h
@@ -1,6 +1,10 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#if __has_include(<React/React-Core-umbrella.h>)
 #import <React/React-Core-umbrella.h>
+#else
+#import <React_Core/React_Core-umbrella.h>
+#endif
 
 #import <ExpoModulesCore/EXInternalModule.h>
 #import <ExpoModulesCore/EXEventEmitterService.h>
@@ -13,6 +17,6 @@
 
 @interface EXReactNativeEventEmitter : RCTEventEmitter <EXInternalModule, EXBridgeModule, EXModuleRegistryConsumer, EXEventEmitterService>
 
-@property (nonatomic, strong) EXAppContext *appContext;
+@property(nonatomic, strong) EXAppContext *appContext;
 
 @end

--- a/packages/expo-modules-core/ios/RCTComponentData+Privates.h
+++ b/packages/expo-modules-core/ios/RCTComponentData+Privates.h
@@ -1,6 +1,10 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
+#if __has_include(<React/React-Core-umbrella.h>)
 #import <React/React-Core-umbrella.h>
+#else
+#import <React_Core/React_Core-umbrella.h>
+#endif
 
 typedef void (^RCTPropBlockAlias)(id<RCTComponent> _Nonnull view, id _Nullable json);
 

--- a/packages/expo-modules-core/ios/RCTComponentData+Privates.m
+++ b/packages/expo-modules-core/ios/RCTComponentData+Privates.m
@@ -1,7 +1,11 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
 #import <ExpoModulesCore/RCTComponentData+Privates.h>
-#import <React/React-Core-umbrella.h>
+#if __has_include(<React/React-Core-umbrella.h>)
+  #import <React/React-Core-umbrella.h>
+#else
+  #import <React_Core/React_Core-umbrella.h>
+#endif
 
 @implementation RCTComponentDataSwiftAdapter
 

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -1,6 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-import React_RCTAppDelegate
+import React
 
 public class ExpoReactNativeFactory: RCTReactNativeFactory {
   private let reactDelegate = ExpoReactDelegate(handlers: ExpoAppDelegateSubscriberRepository.reactDelegateHandlers)

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactoryDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactoryDelegate.swift
@@ -1,4 +1,4 @@
-import React_RCTAppDelegate
+import React
 
 open class ExpoReactNativeFactoryDelegate: RCTDefaultReactNativeFactoryDelegate {
   open override func customize(_ rootView: UIView) {


### PR DESCRIPTION
# Why

SDK54 - Upgrade to React Native 0.81.0.rc.0

# How

Resolved imports and added __has_includes statement where the imports differs between RN built from source and RN using prebuilt.

The difference lies in the umbrella files - which will be different (there is actually no way to make them equal). Umbrella files are the public API of the package, but the location of the umbrella files are not - so this should be a valid solution for now.

# Test Plan

Build ExpoGo/BareExpo on Android/iOS

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
