### PR TITLE
[docs] Add react-native-keyboard-controller to third-party libraries

### DIFF
--- a/docs/pages/versions/unversioned/sdk/keyboard-controller.mdx
+++ b/docs/pages/versions/unversioned/sdk/keyboard-controller.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/kirillzyusko/react-native-keyboard-controller
 packageName: react-native-keyboard-controller
 platforms: ['android', 'ios']
 inExpoGo: true
+isNew: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';

--- a/docs/pages/versions/unversioned/sdk/keyboard-controller.mdx
+++ b/docs/pages/versions/unversioned/sdk/keyboard-controller.mdx
@@ -81,6 +81,7 @@ const styles = StyleSheet.create({
 </SnackInline>
 
 ## Additional resources
+
 <BoxLink
   title="Advanced keyboard handling"
   description="Learn more about advanced keyboard handling examples with Keyboard Controller"

--- a/docs/pages/versions/unversioned/sdk/keyboard-controller.mdx
+++ b/docs/pages/versions/unversioned/sdk/keyboard-controller.mdx
@@ -1,0 +1,89 @@
+---
+title: react-native-keyboard-controller
+description: A library that provides a Keyboard manager that works in an identical way on Android and iOS
+sourceCodeUrl: 'https://github.com/kirillzyusko/react-native-keyboard-controller'
+packageName: react-native-keyboard-controller
+platforms: ['android', 'ios']
+inExpoGo: true
+---
+
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { SnackInline } from '~/ui/components/Snippet';
+
+`react-native-keyboard-controller` offers additional functionality beyond the built-in React Native keyboard APIs, providing consistency across Android and iOS with minimal configuration and offering the native feel users expect.
+
+## Installation
+
+<APIInstallSection
+  packageName="react-native-keyboard-controller"
+  href="https://github.com/lottie-react-native/lottie-react-native#installing"
+/>
+
+## Example
+
+<SnackInline
+  label="KeyboardController"
+  dependencies={['react-native-keyboard-controller']}>
+
+```tsx
+import { TextInput, View, StyleSheet } from 'react-native';
+import { KeyboardAwareScrollView, KeyboardToolbar } from 'react-native-keyboard-controller';
+
+export default function FormScreen() {
+  return (
+    <>
+      <KeyboardAwareScrollView bottomOffset={62} contentContainerStyle={styles.container}>
+        <View>
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+        </View>
+        <TextInput placeholder="Type a message..." style={styles.textInput} />
+        <View>
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+          <TextInput placeholder="Type a message..." style={styles.textInput} />
+        </View>
+        <TextInput placeholder="Type a message..." style={styles.textInput} />
+      </KeyboardAwareScrollView>
+      <KeyboardToolbar />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 16,
+    padding: 16,
+  },
+  listStyle: {
+    padding: 16,
+    gap: 16,
+  },
+  textInput: {
+    width: 'auto',
+    flexGrow: 1,
+    flexShrink: 1,
+    height: 45,
+    borderWidth: 1,
+    borderRadius: 8,
+    borderColor: '#d8d8d8',
+    backgroundColor: '#fff',
+    padding: 8,
+    marginBottom: 8,
+  },
+});
+```
+
+</SnackInline>
+
+## Learn more
+
+<BoxLink
+  title="Visit official documentation"
+  description="Get full information on API and its usage."
+  Icon={BookOpen02Icon}
+  href="https://kirillzyusko.github.io/react-native-keyboard-controller/"
+/>

--- a/docs/pages/versions/unversioned/sdk/keyboard-controller.mdx
+++ b/docs/pages/versions/unversioned/sdk/keyboard-controller.mdx
@@ -23,7 +23,7 @@ import { SnackInline } from '~/ui/components/Snippet';
   href="https://github.com/lottie-react-native/lottie-react-native#installing"
 />
 
-## Example
+## Usage
 
 <SnackInline
   label="KeyboardController"
@@ -80,7 +80,13 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-## Learn more
+## Additional resources
+<BoxLink
+  title="Advanced keyboard handling"
+  description="Learn more about advanced keyboard handling examples with Keyboard Controller"
+  Icon={BookOpen02Icon}
+  href="/guides/keyboard-handling/#advanced-keyboard-handling-with-keyboard-controller"
+/>
 
 <BoxLink
   title="Visit official documentation"


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/37942

# How

Add react-native-keyboard-controller to third-party libraries

# Test Plan

Run docs locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
