### PR TITLE
test(cli): pass login e2e test when rate limited

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/login-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/login-test.ts
@@ -66,5 +66,10 @@ it('runs `npx expo login` and throws due to invalid credentials', async () => {
     executeExpoAsync(projectRoot, ['login', '--username=bacon', '--password=invalid'], {
       verbose: false,
     })
-  ).rejects.toThrow(/Your username, email, or password was incorrect/);
+  ).rejects.toThrow(
+    // Account for the normal error, or the rate limiting error:
+    // - Your username, email, or password was incorrect
+    // - ApiV2Error: Exceeded maximum login attempts. Try again later.
+    /(Your username, email, or password was incorrect|Exceeded maximum login attempts)/
+  );
 });


### PR DESCRIPTION
# Why

Sometimes the CLI E2E tests are failing due to the login E2E test being rate limited. It doesn't make sense to fail the test suit on, e.g.:

- https://github.com/expo/expo/actions/runs/16119592374/job/45481703173#step:12:25

# How

- Added the rate limit error as passable error

> Could also verify the error a bit more, and then log a warning if needed. But, this test is just to test if the login was attempted, and the error propagates properly - which the rate limit is actualy one potential error of, thus passing the test.

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
