### PR TITLE
fix: ESLint warning by using named import for Checkbox from expo-checkbox

### DIFF
--- a/docs/pages/versions/unversioned/sdk/checkbox.mdx
+++ b/docs/pages/versions/unversioned/sdk/checkbox.mdx
@@ -21,7 +21,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 <SnackInline label='Basic Checkbox usage' dependencies={['expo-checkbox']} platforms={['android', 'web']}>
 
 ```tsx
-import Checkbox from 'expo-checkbox';
+import { Checkbox } from 'expo-checkbox';
 import { useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
@@ -75,7 +75,7 @@ const styles = StyleSheet.create({
 ## API
 
 ```js
-import Checkbox from 'expo-checkbox';
+import { Checkbox } from 'expo-checkbox';
 ```
 
 <APISection packageName="expo-checkbox" apiName="Checkbox" />


### PR DESCRIPTION
# Why

This fixes an ESLint warning `import/no-named-as-default` caused by using a named export (`Checkbox`) as a default import from the `expo-checkbox` package.

According to the [Expo Checkbox documentation](https://docs.expo.dev/versions/latest/sdk/checkbox/), `Checkbox` is a named export, not a default export. Using a default import causes linting issues and may lead to unexpected behaviour during bundling.


<img width="867" height="201" alt="Screenshot 2025-07-12 at 2 58 07 AM" src="https://github.com/user-attachments/assets/cb5851df-16cc-4143-8596-8e0db2cfc0a7" />

Here are my ESLint and tsconfig files

<img width="3568" height="1768" alt="image" src="https://github.com/user-attachments/assets/ab3b131a-f018-4757-8552-e5262b2980f3" />

<img width="2764" height="1768" alt="image" src="https://github.com/user-attachments/assets/79e80df7-acad-47cf-99b7-ad113ee11034" />


# How

- Replaced default import:

```ts
- import Checkbox from "expo-checkbox";
+ import { Checkbox } from "expo-checkbox";
```

This change ensures compatibility with ESLint rules and aligns with the official Expo SDK structure.

# Test Plan

* Verified the import works correctly in the app without any runtime errors.
* Confirmed the ESLint warning (`import/no-named-as-default`) is resolved.
* Functionality using `<Checkbox />` still behaves as expected.

# Checklist

* [x] Fixed ESLint `import/no-named-as-default` warning.
* [x] Matches official Expo documentation.
* [x] Tested rendering and interaction of the Checkbox component.
* [x] This diff will work correctly for `npx expo prebuild` & EAS Build.
* [x] Conforms with the [Expo Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
