### PR TITLE
[templates] Enable gradle parallel execution

### DIFF
--- a/templates/expo-template-bare-minimum/android/gradle.properties
+++ b/templates/expo-template-bare-minimum/android/gradle.properties
@@ -15,7 +15,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
 
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK


### PR DESCRIPTION
# Why 

Enabling gradle parallel execution can improve overall build performance, especially when libraries use C++ and because of that we should enable it by default in our template projects. This has already been the case in our infra for over 5 years (https://github.com/expo/turtle-v2/commit/b68c30c29b05029132d9ed5f2bcdd1ca6d62ba86) so there's no reason for no enabling this for users building locally 

Reference: [android-build-server-configurations](https://docs.expo.dev/build-reference/infrastructure/#android-build-server-configurations)


# How

Update bare-minimum template to set `org.gradle.parallel` to `true`

# Test Plan

 ```bash
tar -zcvf expo-template-bare-minimum.tar.gz expo-template-bare-minimum
npx expo prebuild  --clean --template /Users/gabriel/Workspace/expo/expo/templates/expo-template-bare-minimum.tar.gz
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
