### PR TITLE
[go] layout shift on app launch on android

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
@@ -22,6 +22,7 @@ import com.swmansion.gesturehandler.RNGestureHandlerPackage
 import com.swmansion.gesturehandler.react.RNGestureHandlerModule
 import com.swmansion.rnscreens.RNScreensPackage
 import com.th3rdwave.safeareacontext.SafeAreaContextPackage
+import com.th3rdwave.safeareacontext.SafeAreaContextModule
 import com.zoontek.rnedgetoedge.EdgeToEdgeModule
 import com.reactnativekeyboardcontroller.KeyboardControllerModule
 import com.reactnativekeyboardcontroller.KeyboardControllerPackage
@@ -128,6 +129,7 @@ class ExponentPackage : ReactPackage {
         nativeModules.add(RNViewShotModule(reactContext, scopedContext.cacheDir, scopedContext.externalCacheDir))
         nativeModules.add(ExponentTestNativeModule(reactContext))
         nativeModules.add(PedometerModule(reactContext))
+        nativeModules.add(SafeAreaContextModule(reactContext))
         nativeModules.add(ScreenOrientationModule(reactContext))
         nativeModules.add(RNGestureHandlerModule(reactContext))
         nativeModules.add(RNCWebViewModule(reactContext))


### PR DESCRIPTION
# Why
Expo go has an initial layout shift. 

https://github.com/user-attachments/assets/ef52d5e4-d135-4e0b-98ed-b2f848ef59bf


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Safe Area module was missing so React Navigation receives null [initial metrics](https://github.com/react-navigation/react-navigation/blob/69b2c148e7070ac40306f725420a6cec7b7aebc4/packages/elements/src/SafeAreaProviderCompat.tsx#L28) because [initialWindowMetrics](https://github.com/AppAndFlow/react-native-safe-area-context/blob/864a7e1bb296432658b40616ba727cb60775e133/src/InitialWindow.native.ts#L4) uses the module. Adding the module fixes it.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Build expo-go and test the initial mount, layout shift should disappear.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
