### PR TITLE
[docs] add animation to `Collapsible` component

### DIFF
--- a/docs/jest.config.js
+++ b/docs/jest.config.js
@@ -11,6 +11,7 @@ const jestConfig = {
     '^~/(.*)$': '<rootDir>/$1',
     // note(simek): force Jest to use non ESM bundle
     '^@radix-ui/react-select$': '<rootDir>/node_modules/@radix-ui/react-select/dist/index.js',
+    '^framer-motion$': '<rootDir>/node_modules/framer-motion/dist/cjs/index.js',
   },
   transform: {},
   extensionsToTreatAsEsm: ['.ts', '.tsx'],

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -1,6 +1,7 @@
 import { ThemeProvider } from '@expo/styleguide';
 import { MDXProvider } from '@mdx-js/react';
 import * as Sentry from '@sentry/react';
+import { MotionConfig } from 'framer-motion';
 import { AppProps } from 'next/app';
 import { Inter, JetBrains_Mono } from 'next/font/google';
 
@@ -78,19 +79,21 @@ export default function App({ Component, pageProps }: AppProps) {
           font-family: ${monospaceFont.style.fontFamily}, monospace;
         }
       `}</style>
-      <AnalyticsProvider>
-        <ThemeProvider>
-          <TutorialChapterCompletionProvider>
-            <CodeBlockSettingsProvider>
-              <MDXProvider components={rootMarkdownComponents}>
-                <Tooltip.Provider>
-                  <Component {...pageProps} />
-                </Tooltip.Provider>
-              </MDXProvider>
-            </CodeBlockSettingsProvider>
-          </TutorialChapterCompletionProvider>
-        </ThemeProvider>
-      </AnalyticsProvider>
+      <MotionConfig reducedMotion="user">
+        <AnalyticsProvider>
+          <ThemeProvider>
+            <TutorialChapterCompletionProvider>
+              <CodeBlockSettingsProvider>
+                <MDXProvider components={rootMarkdownComponents}>
+                  <Tooltip.Provider>
+                    <Component {...pageProps} />
+                  </Tooltip.Provider>
+                </MDXProvider>
+              </CodeBlockSettingsProvider>
+            </TutorialChapterCompletionProvider>
+          </ThemeProvider>
+        </AnalyticsProvider>
+      </MotionConfig>
     </>
   );
 }

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -40,6 +40,12 @@ code {
   outline: none;
 }
 
+/* Collapsible */
+
+details::details-content {
+  display: contents;
+}
+
 /* Selections */
 
 ::selection {

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -139,14 +139,19 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           <div />
         </summary>
         <div
-          class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
+          class="overflow-hidden"
+          style="height: 0px;"
         >
-          <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
-            data-text="true"
+          <div
+            class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
           >
-            Edit the 'Display Name' field in Xcode
-          </p>
+            <p
+              class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+              data-text="true"
+            >
+              Edit the 'Display Name' field in Xcode
+            </p>
+          </div>
         </div>
       </details>
     </div>
@@ -286,14 +291,19 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           <div />
         </summary>
         <div
-          class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
+          class="overflow-hidden"
+          style="height: 0px;"
         >
-          <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
-            data-text="true"
+          <div
+            class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
           >
-            Set this property using AppConstants.java.
-          </p>
+            <p
+              class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+              data-text="true"
+            >
+              Set this property using AppConstants.java.
+            </p>
+          </div>
         </div>
       </details>
       <details
@@ -362,14 +372,19 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           <div />
         </summary>
         <div
-          class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
+          class="overflow-hidden"
+          style="height: 0px;"
         >
-          <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
-            data-text="true"
+          <div
+            class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
           >
-            Set this property using just Xcode
-          </p>
+            <p
+              class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+              data-text="true"
+            >
+              Set this property using just Xcode
+            </p>
+          </div>
         </div>
       </details>
       <div
@@ -522,14 +537,19 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             <div />
           </summary>
           <div
-            class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
+            class="overflow-hidden"
+            style="height: 0px;"
           >
-            <p
-              class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
-              data-text="true"
+            <div
+              class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
             >
-              Set this property using Xcode.
-            </p>
+              <p
+                class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                data-text="true"
+              >
+                Set this property using Xcode.
+              </p>
+            </div>
           </div>
         </details>
         <div
@@ -854,14 +874,19 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           <div />
         </summary>
         <div
-          class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
+          class="overflow-hidden"
+          style="height: 0px;"
         >
-          <p
-            class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
-            data-text="true"
+          <div
+            class="px-5 py-4 last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0"
           >
-            This is set in AndroidManifest.xml directly.
-          </p>
+            <p
+              class="text-default font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+              data-text="true"
+            >
+              This is set in AndroidManifest.xml directly.
+            </p>
+          </div>
         </div>
       </details>
       <span

--- a/docs/ui/components/Collapsible/Collapsible.test.tsx
+++ b/docs/ui/components/Collapsible/Collapsible.test.tsx
@@ -8,9 +8,7 @@ import { HeadingsContext } from '~/common/withHeadingManager';
 import { Collapsible } from '.';
 
 const prepareHeadingManager = () => {
-  const headingManager = new HeadingManager(new GithubSlugger(), { headings: [] });
-
-  return headingManager;
+  return new HeadingManager(new GithubSlugger(), { headings: [] });
 };
 
 const WrapWithContext = ({ children }: PropsWithChildren) => {

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -1,5 +1,6 @@
 import { LinkBase, mergeClasses } from '@expo/styleguide';
 import { TriangleDownIcon } from '@expo/styleguide-icons/custom/TriangleDownIcon';
+import { motion } from 'framer-motion';
 import { useRouter } from 'next/compat/router';
 import {
   type ComponentType,
@@ -7,6 +8,7 @@ import {
   type ReactNode,
   useRef,
   useEffect,
+  useState,
 } from 'react';
 
 import withHeadingManager, { HeadingManagerProps } from '~/common/withHeadingManager';
@@ -35,6 +37,7 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
     headingManager,
     open = false,
   }: CollapsibleProps & HeadingManagerProps) => {
+    const [isOpen, setIsOpen] = useState(open);
     const router = useRouter();
     const detailsRef = useRef<HTMLDetailsElement>(null);
 
@@ -54,17 +57,25 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
       }
     }, []);
 
+    const animate = {
+      transition: { type: 'tween' },
+      height: isOpen ? 'auto' : 0,
+    };
+
     return (
       <details
         ref={detailsRef}
         id={heading.current.slug}
+        onToggle={event => {
+          setIsOpen(event.currentTarget.open);
+        }}
         className={mergeClasses(
           'mb-3 scroll-m-4 rounded-md border border-default bg-default p-0',
           '[&[open]]:shadow-xs',
           '[h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3',
           className
         )}
-        open={open}
+        open={isOpen}
         data-testid={testID}>
         <summary
           className={mergeClasses(
@@ -101,9 +112,12 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
           </LinkBase>
           <div />
         </summary>
-        <div className={mergeClasses('px-5 py-4', 'last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0')}>
-          {children}
-        </div>
+        <motion.div initial={false} animate={animate} className="overflow-hidden">
+          <div
+            className={mergeClasses('px-5 py-4', 'last:[&>*]:!mb-1 [&_p]:ml-0 [&_pre>pre]:mt-0')}>
+            {children}
+          </div>
+        </motion.div>
       </details>
     );
   }


### PR DESCRIPTION
# Why

Recently, I have find out how to overwrite the default HTML `details`/`summary` browser injection for content slot and hook up into native state, which enables fully user control animations.

# How

Add accessible animation to Collapsible component, add global `MotionConfig`, mock `framer-motion` for Jest context, update test snapshots.

# Test Plan

1. Run docs app locally, or visit the preview.
2. Make sure that Collapsible animation works.
3. Make sure that if hash to collapsible is present it is opened correctly.
4. Make sure that user set "Reduce motion" setting is respsected.

### Preview

https://github.com/user-attachments/assets/56b7080e-a8c3-4d07-8212-9f848cb7dc00

