### PR TITLE
[docs] specify jdk version in linux setup

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioEnvironmentInstructions.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioEnvironmentInstructions.mdx
@@ -68,7 +68,7 @@ Follow [instructions from the Watchman documentation](https://facebook.github.io
 
 Install [Java SE Development Kit (JDK)](https://openjdk.org/):
 
-You can download and install [OpenJDK](http://openjdk.java.net/) from [AdoptOpenJDK](https://adoptopenjdk.net/) or your system packager.
+You can download and install [OpenJDK@17](http://openjdk.java.net/) from [AdoptOpenJDK](https://adoptopenjdk.net/) or your system packager.
 
 </Step>
 


### PR DESCRIPTION
Specify that JDK 17 is required. 

# Why
Some package managers install 21 by default. The other instructions mention that version in the install instructions but the Linux ones do not.

# How
Small @ mention of the version you should be downloading.

# Test Plan

I followed these instructions using my package manager and was able to successfully run the bundled app in an android emulator device.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
