### PR TITLE
[docs] Minor fixes in multiple docs

### DIFF
--- a/docs/pages/config-plugins/development-and-debugging.mdx
+++ b/docs/pages/config-plugins/development-and-debugging.mdx
@@ -44,8 +44,8 @@ The `expo/config-plugins` and `expo/config` packages are re-exported from the `e
 
 {/* prettier-ignore */}
 ```js
-const { /* @hide ...*//* @end */ } = require('expo/config-plugins');
-const { /* @hide ...*//* @end */ } = require('expo/config');
+const { ... } = require('expo/config-plugins');
+const { ... } = require('expo/config');
 ```
 
 Importing through the `expo` package ensures that you are using the version of the `expo/config-plugins` and `expo/config` packages that are depended on by the `expo` package.

--- a/docs/pages/eas/workflows/examples/introduction.mdx
+++ b/docs/pages/eas/workflows/examples/introduction.mdx
@@ -1,7 +1,7 @@
 ---
-title: Workflows examples
+title: EAS Workflows examples
 sidebar_title: Introduction
-description: Common CI/CD workflows for developing, reviewing, and releasing your app.
+description: Common React Native CI/CD workflows for developing, reviewing, and releasing your app.
 hideTOC: true
 ---
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Code example in Config Plugins > Development and Debugging gets hidden because of using a comment.
- New EAS Workflows example introduction page misses keyword in page title and description.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR fixes both of the above issues.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
