### PR TITLE
fix: use new metro-cache exports

### DIFF
--- a/packages/@expo/metro-config/src/file-store.ts
+++ b/packages/@expo/metro-config/src/file-store.ts
@@ -1,4 +1,4 @@
-import UpstreamFileStore from 'metro-cache/src/stores/FileStore';
+import UpstreamFileStore from 'metro-cache/private/stores/FileStore';
 
 const debug = require('debug')('expo:metro:cache') as typeof console.log;
 


### PR DESCRIPTION
See https://github.com/facebook/metro/commit/ae6f42372ed361611b5672705f22081c2022cf28

This affects metro-cache v0.83.0+

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
