### PR TITLE
fix(expo-router): update test layout style for transparent modal component 

### DIFF
--- a/apps/router-e2e/__e2e__/web-modal/app/modal-transparent.tsx
+++ b/apps/router-e2e/__e2e__/web-modal/app/modal-transparent.tsx
@@ -2,7 +2,7 @@ import { Text, View } from 'react-native';
 
 export default function Page() {
   return (
-    <View style={{ height: '100%', padding: 60, backgroundColor: 'rgba(255, 0, 0, 0.3)' }}>
+    <View style={{ flex: 1, padding: 60, backgroundColor: 'rgba(255, 0, 0, 0.3)' }}>
       <Text style={{ fontSize: 24, fontWeight: 'bold', marginBottom: 16 }}>Transparent Modal</Text>
       <Text>
         This is a transparent modal to demonstrate default behaviour. You need to navigate or use


### PR DESCRIPTION
# Why

The transparent modal test page was broken after recent changes to modalBody.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Just tiny style update

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
