### PR TITLE
[sdk54][0.81.0.rc-0] Upgrade kotlin Dev launcher/menu, removed JSC support

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherReactHost.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherReactHost.kt
@@ -1,7 +1,6 @@
 package expo.modules.devlauncher.launcher
 
 import android.app.Application
-import com.facebook.react.JSEngineResolutionAlgorithm
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.JSBundleLoader
@@ -10,7 +9,6 @@ import com.facebook.react.defaults.DefaultComponentsRegistry
 import com.facebook.react.defaults.DefaultReactHostDelegate
 import com.facebook.react.defaults.DefaultTurboModuleManagerDelegate
 import com.facebook.react.fabric.ComponentFactory
-import com.facebook.react.runtime.JSCInstance
 import com.facebook.react.runtime.ReactHostImpl
 import com.facebook.react.runtime.hermes.HermesInstance
 import com.facebook.react.shell.MainReactPackage
@@ -34,12 +32,7 @@ object DevLauncherReactHost {
     val jsBundleAssetPath = "expo_dev_launcher_android.bundle"
     val jsBundleLoader =
       JSBundleLoader.createAssetLoader(application, "assets://$jsBundleAssetPath", true)
-    val jsResolutionAlgorithm = createJSEngineResolutionAlgorithm(application)
-    val jsRuntimeFactory = if (jsResolutionAlgorithm == JSEngineResolutionAlgorithm.JSC) {
-      JSCInstance()
-    } else {
-      HermesInstance()
-    }
+    val jsRuntimeFactory = HermesInstance()
     val jsMainModuleName = "packages/expo-dev-launcher/bundle/index"
     val defaultReactHostDelegate =
       DefaultReactHostDelegate(
@@ -92,13 +85,5 @@ object DevLauncherReactHost {
     ) +
       devMenuRelatedPackages +
       additionalPackages
-  }
-
-  private fun createJSEngineResolutionAlgorithm(application: Application): JSEngineResolutionAlgorithm {
-    SoLoader.init(application.applicationContext, /* native exopackage */ false)
-    if (SoLoader.getLibraryPath("libjsc.so") != null) {
-      return JSEngineResolutionAlgorithm.JSC
-    }
-    return JSEngineResolutionAlgorithm.HERMES
   }
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/react/DevLauncherReactNativeHostHandler.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/react/DevLauncherReactNativeHostHandler.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.devsupport.DevSupportManagerFactory
-import com.facebook.react.jscexecutor.JSCExecutorFactory
 import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.facebook.soloader.SoLoader
 import expo.modules.core.interfaces.ReactNativeHostHandler
@@ -34,9 +33,6 @@ class DevLauncherReactNativeHostHandler(context: Context) : ReactNativeHostHandl
       // Assuming V8 overrides the `getJavaScriptExecutorFactory` in the main ReactNativeHost,
       // return null here to use the default value.
       return null
-    }
-    if (SoLoader.getLibraryPath("libjsc.so") != null) {
-      return JSCExecutorFactory(applicationContext.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
     }
     return HermesExecutorFactory()
   }

--- a/packages/expo-dev-menu/android/src/main/java/com/facebook/react/devsupport/DevMenuSettingsBase.kt
+++ b/packages/expo-dev-menu/android/src/main/java/com/facebook/react/devsupport/DevMenuSettingsBase.kt
@@ -54,6 +54,8 @@ abstract class DevMenuSettingsBase(
       mPreferences.edit().putBoolean("remote_js_debug", remoteJSDebugEnabled).apply()
     }
 
+  // TODO(kudo,20250217) - Remove this when we drop react-native 0.78 support (this came up in 0.81.0)
+  @Suppress("NOTHING_TO_OVERRIDE")
   override var isStartSamplingProfilerOnInit: Boolean =
     mPreferences.getBoolean("start_sampling_profiler_on_init", false)
 

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuHostHelper.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/react/DevMenuHostHelper.kt
@@ -3,15 +3,10 @@ package expo.modules.devmenu.react
 import android.app.Application
 import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.react.bridge.JavaScriptExecutorFactory
-import com.facebook.react.jscexecutor.JSCExecutorFactory
-import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.facebook.soloader.SoLoader
 
 fun createNonDebuggableJavaScriptExecutorFactory(application: Application): JavaScriptExecutorFactory {
   SoLoader.init(application.applicationContext, /* native exopackage */ false)
-  if (SoLoader.getLibraryPath("libjsc.so") != null) {
-    return JSCExecutorFactory(application.packageName, AndroidInfoHelpers.getFriendlyDeviceName())
-  }
   return HermesExecutorFactory().also {
     try {
       HermesExecutorFactory::class.java

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -25,6 +25,7 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactRootView
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.core.PermissionListener
+import expo.modules.core.errors.InvalidArgumentException
 import expo.modules.core.interfaces.ReactActivityHandler.DelayLoadAppHandler
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.kotlin.Utils
@@ -172,7 +173,7 @@ class ReactActivityDelegateWrapper(
             launchOptions,
             isFabricEnabled
           ) {
-            override fun createRootView(): ReactRootView {
+            override fun createRootView(): ReactRootView? {
               return this@ReactActivityDelegateWrapper.createRootView() ?: super.createRootView()
             }
           }
@@ -438,7 +439,7 @@ class ReactActivityDelegateWrapper(
       mReactDelegate.isAccessible = true
       val reactDelegate = mReactDelegate[delegate] as ReactDelegate
 
-      reactDelegate.loadApp(appKey)
+      reactDelegate.loadApp(appKey ?: throw InvalidArgumentException("Expected string in appKey, got nullish value."))
       val reactRootView = reactDelegate.reactRootView
       (reactRootView?.parent as? ViewGroup)?.removeView(reactRootView)
       rootViewContainer.addView(reactRootView, ViewGroup.LayoutParams.MATCH_PARENT)

--- a/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactNativeHostWrapper.kt
@@ -2,7 +2,6 @@ package expo.modules
 
 import android.app.Application
 import android.content.Context
-import com.facebook.react.JSEngineResolutionAlgorithm
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackageTurboModuleManagerDelegate
@@ -29,10 +28,6 @@ class ReactNativeHostWrapper(
 
   override fun getUIManagerProvider(): UIManagerProvider? {
     return invokeDelegateMethod("getUIManagerProvider")
-  }
-
-  public override fun getJSEngineResolutionAlgorithm(): JSEngineResolutionAlgorithm? {
-    return invokeDelegateMethod("getJSEngineResolutionAlgorithm")
   }
 
   override fun getShouldRequireActivity(): Boolean {

--- a/packages/expo/android/src/rn78/main/expo/modules/ExpoReactHostFactory.kt
+++ b/packages/expo/android/src/rn78/main/expo/modules/ExpoReactHostFactory.kt
@@ -3,7 +3,6 @@
 package expo.modules
 
 import android.content.Context
-import com.facebook.react.JSEngineResolutionAlgorithm
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactInstanceEventListener
 import com.facebook.react.ReactNativeHost
@@ -16,7 +15,6 @@ import com.facebook.react.defaults.DefaultComponentsRegistry
 import com.facebook.react.defaults.DefaultTurboModuleManagerDelegate
 import com.facebook.react.fabric.ComponentFactory
 import com.facebook.react.runtime.BindingsInstaller
-import com.facebook.react.runtime.JSCInstance
 import com.facebook.react.runtime.JSRuntimeFactory
 import com.facebook.react.runtime.ReactHostDelegate
 import com.facebook.react.runtime.ReactHostImpl
@@ -58,11 +56,7 @@ object ExpoReactHostFactory {
       get() = reactNativeHostWrapper.jsMainModuleName
 
     override val jsRuntimeFactory: JSRuntimeFactory
-      get() = if (reactNativeHostWrapper.jsEngineResolutionAlgorithm == JSEngineResolutionAlgorithm.HERMES) {
-        HermesInstance()
-      } else {
-        JSCInstance()
-      }
+      get() = HermesInstance()
 
     override val reactPackages: List<ReactPackage>
       get() = reactNativeHostWrapper.packages


### PR DESCRIPTION
# Why

SDK54 - Upgrade to React Native 0.81.0.rc.0

# How

Removed support for JSC in Android code

# Test Plan

Build/run ExpoGo/BareEXpo

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
