### PR TITLE
[expo-cli] Fix e2e test for local run

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Added CSS-Modules Fast Refresh E2E Coverage ([#37845](https://github.com/expo/expo/pull/37845) by [@hirbod](https://github.com/hirbod))
 - Added tests for modal stacking ([#37856](https://github.com/expo/expo/pull/37856) by [@hirbod](https://github.com/hirbod))
 - simplify/optimize web-modal tests ([#38025](https://github.com/expo/expo/pull/38025) by [@hirbod](https://github.com/hirbod))
+- Fix e2e start-test for local runs ([#38066](https://github.com/expo/expo/pull/38066) by [@Ubax](https://github.com/Ubax))
 
 ### ⚠️ Notices
 

--- a/packages/@expo/cli/e2e/__tests__/start-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/start-test.ts
@@ -169,8 +169,10 @@ describe('start - dev clients', () => {
     },
   });
 
+  let projectRoot: string;
+
   beforeAll(async () => {
-    const projectRoot = await setupTestProjectWithOptionsAsync('start-dev-clients', 'with-blank');
+    projectRoot = await setupTestProjectWithOptionsAsync('start-dev-clients', 'with-blank');
     expo.options.cwd = projectRoot;
 
     // Add a `.env` file with `TEST_SCHEME`
@@ -191,6 +193,9 @@ describe('start - dev clients', () => {
   });
   afterAll(async () => {
     await expo.stopAsync();
+    // Remove app.config.js and .env files
+    await fs.promises.unlink(path.join(projectRoot, 'app.config.js'));
+    await fs.promises.unlink(path.join(projectRoot, '.env'));
   });
 
   it('runs `npx expo start` in dev client mode, using environment variable from .env', async () => {


### PR DESCRIPTION
# Why

When running this test locally, the `app.config.js` file remained in the temporary directory. On the second run of the same test, it threw an error. This was because `app.config.js` expected the environment variables to be present, while [`getConfig`](https://github.com/expo/expo/blob/ubax/cli/fix-local-e2e/packages/@expo/cli/e2e/__tests__/utils.ts#L203), used in the test, was run from jest and thus had different environment variables set.

# How

1. Removing `app.config.js` and `.env` from temporary directory after test

# Test Plan

1. Local run of e2e test
2. CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
