### PR TITLE
[modules-autolinking][iOS] Add check to disable user script sandboxing

### DIFF
--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/user_project_integrator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/user_project_integrator.rb
@@ -44,6 +44,7 @@ module Pod
 
             Expo::ProjectIntegrator::integrate_targets_in_project(project_targets, project)
             Expo::ProjectIntegrator::remove_nils_from_source_files(project)
+            Expo::ProjectIntegrator::disable_user_script_sandboxing(project)
             Expo::ProjectIntegrator::set_autolinking_configuration(project)
 
             # CocoaPods saves the projects to integrate at the next step,

--- a/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
@@ -286,5 +286,26 @@ module Expo
       SUPPORT_SCRIPT
     end
 
+    # From Xcode 15, new projects default to having the ENABLE_USER_SCRIPT_SANDBOXING build setting enabled
+    # preventing build scripts from running properly in brownfield apps.
+    def self.disable_user_script_sandboxing(project)
+      configs_to_change = []
+      project.native_targets.each do |native_target|
+        native_target.build_configurations.each do |build_configuration|
+          if build_configuration.build_settings['ENABLE_USER_SCRIPT_SANDBOXING'] == 'YES'
+            configs_to_change << build_configuration
+          end
+        end
+      end
+
+      if configs_to_change.any?
+        Pod::UI.warn 'User script sandboxing is enabled. Disabling it to allow react-native scripts to work.'
+        configs_to_change.each do |build_configuration|
+          build_configuration.build_settings['ENABLE_USER_SCRIPT_SANDBOXING'] = 'NO'
+        end
+        project.mark_dirty!
+      end
+    end
+
   end # module ProjectIntegrator
 end # module Expo


### PR DESCRIPTION
# Why

When integrating react-native into an existing iOS project, users face an issue with the `[Expo] Configure project` script and others, requiring them to manually disable user script sandboxing, which is not always clear from the error message. To mitigate this problem we can automatically detect if this setting is enabled and disable it for the project when installing pods.

Error example:  
<img width="1076" height="74" alt="image" src="https://github.com/user-attachments/assets/2aabad58-f830-46c8-bda8-7ec163229f88" />


# How

Add a check to disable user script sandboxing in iOS projects 

# Test Plan

Manually enabled `ENABLE_USER_SCRIPT_SANDBOXING` and run pod install 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
