### PR TITLE
[core][iOS] Return proper dynamic type for AnyEither

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [Android] Support object arrays in type converters. ([#37276](https://github.com/expo/expo/pull/37276) by [@jakex7](https://github.com/jakex7))
 - [iOS] Support cast from JavaScriptValue in DynamicArrayType. ([#37891](https://github.com/expo/expo/pull/37891) by [@jakex7](https://github.com/jakex7))
 - [Android] Add `testID` support to `ExpoComposeView`. ([#38005](https://github.com/expo/expo/pull/38005) by [@mateoguzmana](https://github.com/mateoguzmana))
+- [iOS] Return proper dynamic type for AnyEither.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [Android] Support object arrays in type converters. ([#37276](https://github.com/expo/expo/pull/37276) by [@jakex7](https://github.com/jakex7))
 - [iOS] Support cast from JavaScriptValue in DynamicArrayType. ([#37891](https://github.com/expo/expo/pull/37891) by [@jakex7](https://github.com/jakex7))
 - [Android] Add `testID` support to `ExpoComposeView`. ([#38005](https://github.com/expo/expo/pull/38005) by [@mateoguzmana](https://github.com/mateoguzmana))
-- [iOS] Return proper dynamic type for AnyEither.
+- [iOS] Return proper dynamic type for AnyEither. ([#38072](https://github.com/expo/expo/pull/38072) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/Arguments/Either.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/Either.swift
@@ -10,7 +10,7 @@ protocol AnyEither: AnyArgument {
    An array of dynamic equivalents for generic either types.
    */
   static func dynamicTypes() -> [AnyDynamicType]
-  
+
   /**
    A dynamic either type for the current either type.
    */

--- a/packages/expo-modules-core/ios/Core/Arguments/Either.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/Either.swift
@@ -10,6 +10,11 @@ protocol AnyEither: AnyArgument {
    An array of dynamic equivalents for generic either types.
    */
   static func dynamicTypes() -> [AnyDynamicType]
+  
+  /**
+   A dynamic either type for the current either type.
+   */
+  static func getDynamicType() -> any AnyDynamicType
 }
 
 /*

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
@@ -50,6 +50,9 @@ private func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
   if T.self == Void.self {
     return DynamicVoidType.shared
   }
+  if let AnyEitherType = T.self as? AnyEither.Type {
+    return AnyEitherType.getDynamicType()
+  }
   return DynamicRawType(innerType: T.self)
 }
 

--- a/packages/expo-modules-core/ios/Tests/DynamicEitherTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicEitherTypeSpec.swift
@@ -88,6 +88,37 @@ final class DynamicEitherTypeSpec: ExpoSpec {
       expect(either.is(String.self)) == false
       expect(try either.as(TestSharedObject.self).sharedObjectId) == nativeObject.sharedObjectId
     }
+    it("supports array of either") {
+      let eitherArray2 = try (~[Either<String, Int>].self).cast(["bg", 37], appContext: appContext) as! [Either<String, Int>]
+      expect(eitherArray2[0].is(String.self)) == true
+      expect(eitherArray2[0].get()) == "bg"
+      expect(eitherArray2[1].is(Int.self)) == true
+      expect(eitherArray2[1].is(String.self)) == false
+      expect(eitherArray2[1].get()) == 37
+      
+      let eitherArray3 = try (~[EitherOfThree<Int, String, Bool>].self).cast(["foo", 1, "bar", true, 3], appContext: appContext) as! [EitherOfThree<Int, String, Bool>]
+      expect(eitherArray3[0].is(String.self)) == true
+      expect(eitherArray3[0].get()) == "foo"
+      expect(eitherArray3[1].is(Int.self)) == true
+      expect(eitherArray3[1].get()) == 1
+      expect(eitherArray3[2].is(String.self)) == true
+      expect(eitherArray3[2].get()) == "bar"
+      expect(eitherArray3[3].is(Bool.self)) == true
+      expect(eitherArray3[3].get()) == true
+      expect(eitherArray3[4].is(Int.self)) == true
+      expect(eitherArray3[4].get()) == 3
+      
+      let eitherArray4 = try (~[EitherOfFour<Bool, CGFloat, CGColor, String>].self).cast(["foo", 123.4, false], appContext: appContext) as! [EitherOfFour<Bool, CGFloat, CGColor, String>]
+      expect(eitherArray4[0].is(String.self)) == true
+      expect(eitherArray4[0].get()) == "foo"
+      expect(eitherArray4[1].is(CGFloat.self)) == true
+      expect(eitherArray4[1].get()) == 123.4
+      expect(eitherArray4[1].is(CGColor.self)) == true
+      expect(eitherArray4[1].get()) == 123.4
+      expect(eitherArray4[2].is(Bool.self)) == true
+      expect(eitherArray4[2].get()) == false
+      expect(eitherArray4[2].is(CGFloat.self)) == false
+    }
   }
 }
 


### PR DESCRIPTION
# Why

To properly handle array of `Either` type, like: 
```swift
[Either<String, Int>]
```
or 
```swift
[EitherOfFour<Bool, CGFloat, CGColor, String>]
```

# How

Return proper dynamic type (`DynamicEitherType`) when type is `AnyEither`.

# Test Plan

I've added a test cases in `DynamicEitherTypeSpec`. 

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
