### PR TITLE
[android][updates] Fix procedures across reloads

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [CI] Removed Detox dependency and unused files in E2E code. ([#37751](https://github.com/expo/expo/pull/37751) by [@douglowder](https://github.com/douglowder))
 - Updates imports from `@expo/config`, `@expo/config-plugins` to `expo/config`, `expo/config-plugins`. ([#37860](https://github.com/expo/expo/pull/37860) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Migrate loaders and file downloader to coroutines. ([#37959](https://github.com/expo/expo/pull/37959) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fix procedure scope no surviving app reloads. ([#38073](https://github.com/expo/expo/pull/38073) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 📚 3rd party library updates
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
@@ -18,6 +18,7 @@ import expo.modules.updates.statemachine.UpdatesStateValue
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -182,7 +183,7 @@ class DisabledUpdatesController(
   }
 
   override fun shutdown() {
-    // no-op
+    controllerScope.cancel()
   }
 
   companion object {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -276,7 +276,6 @@ class EnabledUpdatesController(
   }
 
   override fun shutdown() {
-    stateMachine.shutdown()
     controllerScope.cancel()
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -59,7 +59,6 @@ class UpdatesModule : Module(), IUpdatesEventManagerObserver {
 
     OnDestroy {
       UpdatesController.removeUpdatesEventManagerObserver()
-      UpdatesController.instance.shutdown()
     }
 
     AsyncFunction("reload") Coroutine { ->

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -198,8 +198,4 @@ class UpdatesStateMachine(
       }
     }
   }
-
-  fun shutdown() {
-    serialExecutorQueue.cancel()
-  }
 }


### PR DESCRIPTION
# Why
Fixes an issue where after a reload, you cannot reload a second time. This is because the procedureScope was closed when the updates module is destroyed.

# How
We need the scope to exist for the lifetime of the app so I've removed the call.

# Test Plan
e2e app. Consecutive reloads work as expected.
