### PR TITLE
chore: add `eslint-config-expo` and `eslint-plugin-expo` to CLI E2E workflow paths

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -20,6 +20,7 @@ on:
       - packages/eslint-plugin-expo/**
       - packages/expo-router/**
       - yarn.lock
+      - '!**.md'
   pull_request:
     paths:
       - .github/workflows/cli.yml
@@ -38,6 +39,7 @@ on:
       - packages/eslint-plugin-expo/**
       - packages/expo-router/**
       - yarn.lock
+      - '!**.md'
   schedule:
     - cron: 0 14 * * *
 

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -16,6 +16,8 @@ on:
       - packages/@expo/prebuild-config/src/**
       - packages/@expo/server/src/**
       - packages/create-expo/**
+      - packages/eslint-config-expo/**
+      - packages/eslint-plugin-expo/**
       - packages/expo-router/**
       - yarn.lock
   pull_request:
@@ -32,6 +34,8 @@ on:
       - packages/@expo/prebuild-config/src/**
       - packages/@expo/server/src/**
       - packages/create-expo/**
+      - packages/eslint-config-expo/**
+      - packages/eslint-plugin-expo/**
       - packages/expo-router/**
       - yarn.lock
   schedule:


### PR DESCRIPTION
# Why

This avoids accidentally breaking the CLI E2E linting tests again.

# How

- Added `packages/eslint-config-expo` and `packages/eslint-plugin-expo` to the CLI E2E test paths in the workflow
- Added `!**.md` to ignore markdown file changes, like `CHANGELOG.md` files.

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
