### PR TITLE
[docs] upgrade `search-ui` package

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -30,7 +30,7 @@
     "@expo/styleguide": "^9.2.0",
     "@expo/styleguide-base": "^2.0.3",
     "@expo/styleguide-icons": "^2.2.2",
-    "@expo/styleguide-search-ui": "^3.1.2",
+    "@expo/styleguide-search-ui": "^3.1.3",
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/mdx": "^3.1.0",
     "@mdx-js/react": "^3.1.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -576,9 +576,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@expo/styleguide-search-ui@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "@expo/styleguide-search-ui@npm:3.1.2"
+"@expo/styleguide-search-ui@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "@expo/styleguide-search-ui@npm:3.1.3"
   dependencies:
     "@expo/styleguide": "npm:^9.2.0"
     "@expo/styleguide-icons": "npm:^2.2.2"
@@ -591,7 +591,7 @@ __metadata:
   peerDependencies:
     next: ">= 13"
     react: ">= 16"
-  checksum: 10c0/4e159f01018e51328788a536915b46d568639c72f0ec5503c11f86305f6d80222c6df9bd75b85629bac0b76562690637fe279c3e39d53c01490b168d2cc72114
+  checksum: 10c0/0895c2f0bd21c1387388c927c6414d9fe6f316cc92530542c1830dd1c722b63e88b77e0fa8264104e9907e67807556980ce6b07c92146b1381dbe86b63cf8b03
   languageName: node
   linkType: hard
 
@@ -5973,7 +5973,7 @@ __metadata:
     "@expo/styleguide": "npm:^9.2.0"
     "@expo/styleguide-base": "npm:^2.0.3"
     "@expo/styleguide-icons": "npm:^2.2.2"
-    "@expo/styleguide-search-ui": "npm:^3.1.2"
+    "@expo/styleguide-search-ui": "npm:^3.1.3"
     "@mdx-js/loader": "npm:^3.1.0"
     "@mdx-js/mdx": "npm:^3.1.0"
     "@mdx-js/react": "npm:^3.1.0"


### PR DESCRIPTION
# Why

We have spotted that `search-ui` steals the <kbd>Tab</kbd> event preventing users to focus element, even when search dialog was closed.

# How

Upgrade `search-ui` package to the latest version, which includes a fix for the bug.

# Test Plan

1. Run docs app locally, or visit PR preview.
2. Make sure that you can focus elements on the page by pressing <kbd>Tab</kbd>, when search dialog is closed.

# Preview

https://github.com/user-attachments/assets/2e884903-2dab-4565-90f1-347cee2ed512
