### PR TITLE
[expo-video][expo-media-library] Fix tvOS breakages

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
@@ -5,20 +5,68 @@ on:
     branches: [main, 'sdk-*']
     paths:
       - apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
-      - packages/expo-modules-core/ios/Core/Views/SwiftUI/**
-      - packages/expo-ui/**
       - packages/expo-updates/e2e/setup/create-eas-project-tv.ts
       - packages/expo-updates/e2e/setup/project.ts
       - templates/expo-template-bare-minimum/**
+      - packages/expo-application/ios/**
+      - packages/expo-device/ios/**
+      - packages/expo-eas-client/ios/**
+      - packages/expo-file-system/ios/**
+      - packages/expo-font/ios/**
+      - packages/expo-json-utils/ios/**
+      - packages/expo-keep-awake/ios/**
+      - packages/expo-structured-headers/ios/**
+      - packages/expo-updates/ios/**
+      - packages/expo-updates-interface/ios/**
+      - packages/expo-audio/ios/**
+      - packages/expo-av/ios/**
+      - packages/expo-blur/ios/**
+      - packages/expo-crypto/ios/**
+      - packages/expo-image/ios/**
+      - packages/expo-linear-gradient/ios/**
+      - packages/expo-linking/ios/**
+      - packages/expo-localization/ios/**
+      - packages/expo-media-library/ios/**
+      - packages/expo-modules-core/ios/**
+      - packages/expo-network/ios/**
+      - packages/expo-secure-store/ios/**
+      - packages/expo-symbols/ios/**
+      - packages/expo-system-ui/ios/**
+      - packages/expo-ui/ios/**
+      - packages/expo-video/ios/**
   pull_request:
     branches: [main]
     paths:
       - apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
-      - packages/expo-modules-core/ios/Core/Views/SwiftUI/**
-      - packages/expo-ui/**
       - packages/expo-updates/e2e/setup/create-eas-project-tv.ts
       - packages/expo-updates/e2e/setup/project.ts
       - templates/expo-template-bare-minimum/**
+      - packages/expo-application/ios/**
+      - packages/expo-device/ios/**
+      - packages/expo-eas-client/ios/**
+      - packages/expo-file-system/ios/**
+      - packages/expo-font/ios/**
+      - packages/expo-json-utils/ios/**
+      - packages/expo-keep-awake/ios/**
+      - packages/expo-structured-headers/ios/**
+      - packages/expo-updates/ios/**
+      - packages/expo-updates-interface/ios/**
+      - packages/expo-audio/ios/**
+      - packages/expo-av/ios/**
+      - packages/expo-blur/ios/**
+      - packages/expo-crypto/ios/**
+      - packages/expo-image/ios/**
+      - packages/expo-linear-gradient/ios/**
+      - packages/expo-linking/ios/**
+      - packages/expo-localization/ios/**
+      - packages/expo-media-library/ios/**
+      - packages/expo-modules-core/ios/**
+      - packages/expo-network/ios/**
+      - packages/expo-secure-store/ios/**
+      - packages/expo-symbols/ios/**
+      - packages/expo-system-ui/ios/**
+      - packages/expo-ui/ios/**
+      - packages/expo-video/ios/**
   schedule:
     - cron: '0 17 * * SUN' # 22:00 UTC every Sunday
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix tvOS compilation errors. ([#38085](https://github.com/expo/expo/pull/38085) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 ## 17.1.7 - 2025-06-04

--- a/packages/expo-media-library/ios/MediaLibraryRecords.swift
+++ b/packages/expo-media-library/ios/MediaLibraryRecords.swift
@@ -52,7 +52,7 @@ enum MediaSubtype: String, Enumerable {
       (.videoTimelapse, .timelapse),
       (.videoCinematic, .videoCinematic)
     ]
-    if #available(iOS 16.0, *) {
+    if #available(iOS 16.0, tvOS 16.0, *) {
       mapping.append((.spatialMedia, .spatialMedia))
     }
 
@@ -72,7 +72,7 @@ enum MediaSubtype: String, Enumerable {
     case .stream: .videoStreamed
     case .timelapse: .videoTimelapse
     case .spatialMedia:
-      if #available(iOS 16, *) {
+      if #available(iOS 16, tvOS 16, *) {
         .spatialMedia
       } else {
         []

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -384,7 +384,7 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@0.80.0-0rc5',
+        'react-native': 'npm:react-native-tvos@0.80.0-0',
         '@react-native-tvos/config-tv': '^0.1.3',
       },
       expo: {

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - [Android] Fix accessing player.loop causes app to crash. ([#37928](https://github.com/expo/expo/pull/37928) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Setting `player.currentTime` doesn't seek to the correct time on some videos. ([#37672](https://github.com/expo/expo/pull/37300) by [@petrkonecny2](https://github.com/petrkonecny2))
+- [iOS] Fix tvOS compilation errors. ([#38085](https://github.com/expo/expo/pull/38085) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/Enums/FullscreenOrientation.swift
+++ b/packages/expo-video/ios/Enums/FullscreenOrientation.swift
@@ -11,6 +11,7 @@ internal enum FullscreenOrientation: String, Enumerable {
   case portraitDown
   case `default`
 
+  #if !os(tvOS)
   func toUIInterfaceOrientationMask() -> UIInterfaceOrientationMask {
     switch self {
     case .landscape:
@@ -29,4 +30,5 @@ internal enum FullscreenOrientation: String, Enumerable {
       return .all
     }
   }
+  #endif
 }

--- a/packages/expo-video/ios/VideoAirPlayButtonView.swift
+++ b/packages/expo-video/ios/VideoAirPlayButtonView.swift
@@ -1,6 +1,6 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-import ContactsUI
+// import ContactsUI
 import SwiftUI
 import ExpoModulesCore
 import AVKit

--- a/packages/expo-video/ios/VideoModule.swift
+++ b/packages/expo-video/ios/VideoModule.swift
@@ -66,9 +66,9 @@ public final class VideoModule: Module {
       }
 
       Prop("fullscreenOptions") {(view, options: FullscreenOptions?) in
+        #if !os(tvOS)
         view.playerViewController.fullscreenOrientation = options?.orientation.toUIInterfaceOrientationMask() ?? .all
         view.playerViewController.autoExitOnRotate = options?.autoExitOnRotate ?? false
-        #if !os(tvOS)
         view.playerViewController.setValue(options?.enable ?? true, forKey: "allowsEnteringFullScreen")
         #endif
       }

--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -14,9 +14,8 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   #if os(tvOS)
   var wasPlaying: Bool = false
-  #endif
-  #if os(tvOS)
   let startPictureInPictureAutomatically = false
+  var isFullscreen: Bool = false
   #else
   var startPictureInPictureAutomatically = false {
     didSet {
@@ -78,8 +77,8 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
       self.wasPlaying = self.player?.isPlaying == true
       self.playerViewController.view.removeFromSuperview()
       self.reactViewController().present(self.playerViewController, animated: true)
-      onFullscreenEnter()
-      isFullscreen = true
+      self.onFullscreenEnter()
+      self.isFullscreen = true
       #endif
     }
     playerViewController.enterFullscreen(selectorUnsupportedFallback: tvOSFallback)
@@ -87,6 +86,7 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   func exitFullscreen() {
     playerViewController.exitFullscreen()
+    self.isFullscreen = false
   }
 
   func startPictureInPicture() throws {


### PR DESCRIPTION
# Why

tvOS compilation is broken due to recent changes in `expo-video` and `expo-media-library`.

# How

- Fix the code so that it compiles correctly for tvOS
- Add the `ios` folder from many Expo packages to the dependencies for the TV compile workflow

# Test Plan

CI should pass


