### PR TITLE
[document-picker] remove use of IOUtils for stream copying

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- remove use of `IOUtils` for stream copying ([#38096](https://github.com/expo/expo/pull/38096) by [@vonovak](https://github.com/vonovak))
+
 ## 13.1.6 - 2025-06-18
 
 ### 🐛 Bug fixes

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
+import android.os.FileUtils
 import expo.modules.core.utilities.FileUtilities
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.Exceptions
@@ -11,8 +13,8 @@ import expo.modules.kotlin.exception.toCodedException
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import org.apache.commons.io.FilenameUtils
-import org.apache.commons.io.IOUtils
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.FileOutputStream
 
 private const val OPEN_DOCUMENT_CODE = 4137
@@ -80,8 +82,13 @@ class DocumentPickerModule : Module() {
     )
     val outputFile = File(outputFilePath)
     context.contentResolver.openInputStream(documentUri).use { inputStream ->
+      inputStream ?: throw FileNotFoundException("Inputstream for $documentUri was null.")
       FileOutputStream(outputFile).use { outputStream ->
-        IOUtils.copy(inputStream, outputStream)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+          FileUtils.copy(inputStream, outputStream)
+        } else {
+          inputStream.copyTo(outputStream)
+        }
       }
     }
     return Uri.fromFile(outputFile)


### PR DESCRIPTION
# Why

just replacing Apache Commons IOUtils with other methods built into Android / Kotlin.

# How

- Replaced `IOUtils.copy()` with platform-specific file copying methods:
  - For Android Q (API 29) and above: Using `FileUtils.copy()` which uses some optimizations when copying from FileInputStream to FileOutputStream,
  - For older Android versions: Using Kotlin's `inputStream.copyTo(outputStream)`
- Added null check for input stream with appropriate error handling

# Test Plan

manually in bare expo

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)