### PR TITLE
[tvos][swift] Added missing tvos conditional

### DIFF
--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -86,7 +86,9 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
 
   func exitFullscreen() {
     playerViewController.exitFullscreen()
+    #if os(tvOS)
     self.isFullscreen = false
+    #endif
   }
 
   func startPictureInPicture() throws {


### PR DESCRIPTION
# Why

A missing `#if os(tvOS)` conditional was causing the build to break on iOS.

# How

This commit fixes this by adding the conditional:

```swift
func exitFullscreen() {
  playerViewController.exitFullscreen()
  #if os(tvOS)
  self.isFullscreen = false
  #endif
}
```

# Test Plan

CI Passes
# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
