### PR TITLE
[camera] Fix barcode options to correctly handle empty barcodeTypes

### DIFF
--- a/apps/native-component-list/src/screens/Camera/CameraScreenBarcode.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreenBarcode.tsx
@@ -7,7 +7,7 @@ export default function CameraScreenNextBarcode() {
   const [result, setResult] = useState<ScanningResult | null>(null);
   const [options, setOptions] = useState<ScanningOptions>({
     isGuidanceEnabled: false,
-    barcodeTypes: ['qr'],
+    barcodeTypes: [],
     isHighlightingEnabled: false,
     isPinchToZoomEnabled: false,
   });
@@ -62,6 +62,20 @@ export default function CameraScreenNextBarcode() {
               setOptions((opts) => ({
                 ...opts,
                 isPinchToZoomEnabled: !options.isPinchToZoomEnabled,
+              }))
+            }
+          />
+        </View>
+        <View style={styles.optionRow}>
+          <Text style={styles.optionsText}>Only scan QR codes</Text>
+          <Checkbox
+            value={options.barcodeTypes.includes('qr')}
+            onValueChange={() =>
+              setOptions((opts) => ({
+                ...opts,
+                barcodeTypes: opts.barcodeTypes.includes('qr')
+                  ? opts.barcodeTypes.filter((type) => type !== 'qr')
+                  : [...opts.barcodeTypes, 'qr'],
               }))
             }
           />

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixes returning `PictureRef` objects.([#37393](https://github.com/expo/expo/pull/37393) by [@alanjhughes](https://github.com/alanjhughes))
-- Fix barcode options to correctly handle empty barcodeTypes
+- Fix barcode options to correctly handle empty barcodeTypes ([#38100](https://github.com/expo/expo/pull/38100) by [@LeonDvlpmnt](https://github.com/LeonDvlpmnt))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### 🐛 Bug fixes
 
-[iOS] Fixes returning `PictureRef` objects.([#37393](https://github.com/expo/expo/pull/37393) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fixes returning `PictureRef` objects.([#37393](https://github.com/expo/expo/pull/37393) by [@alanjhughes](https://github.com/alanjhughes))
+- Fix barcode options to correctly handle empty barcodeTypes
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
@@ -125,12 +125,15 @@ class CameraViewModule : Module() {
     AsyncFunction("launchScanner") { settings: BarcodeSettings ->
       val reactContext = appContext.reactContext
         ?: throw Exceptions.ReactContextLost()
-      val options = GmsBarcodeScannerOptions.Builder()
-        .setBarcodeFormats(
-          settings.barcodeTypes.first().mapToBarcode(),
-          *settings.barcodeTypes.drop(1).map { it.mapToBarcode() }.toIntArray()
-        )
-        .build()
+
+      val options = GmsBarcodeScannerOptions.Builder().apply {
+        if (settings.barcodeTypes.isNotEmpty()) {
+          setBarcodeFormats(
+            settings.barcodeTypes.first().mapToBarcode(),
+            *settings.barcodeTypes.drop(1).map { it.mapToBarcode() }.toIntArray()
+          )
+        }
+      }.build()
 
       val scanner = GmsBarcodeScanning.getClient(reactContext, options)
       scanner.startScan()

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -379,7 +379,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
   @available(iOS 16.0, *)
   @MainActor
   private func launchScanner(with options: VisionScannerOptions?) {
-    let symbologies = options?.toSymbology() ?? [.qr]
+    let symbologies = options?.toSymbology() ?? []
     let controller = DataScannerViewController(
       recognizedDataTypes: [.barcode(symbologies: symbologies)],
       isPinchToZoomEnabled: options?.isPinchToZoomEnabled ?? true,


### PR DESCRIPTION
# Why

I've updated a project to SDK 53 and found a bug that would cause `launchScanner` to crash on Android if you supply an empty `barcodeTypes` array. If you supply an empty array to `launchScanner` on iOS it will scan all possible types of barcodes. 

# How

- Optionally call setBarcodeFormats on the `GmsBarcodeScannerOptions ` builder. If an empty array is supplied it will scan for all possible barcode types.
- Removed `[.qr]` default on iOS to align with Android. This default was only used when no array was supplied from javascript, however this is a required field in typescript/docs. The default behaviour should be scanning all barcode types

# Test Plan

Tested in the bare-expo app

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
