### PR TITLE
[sdk54][0.81.0.rc-1][android] updated some types after rc-1

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -399,6 +399,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - ExpoAppIntegrity (0.0.1):
+    - ExpoModulesCore
   - ExpoAppleAuthentication (7.2.4):
     - ExpoModulesCore
   - ExpoAsset (11.1.5):
@@ -3759,6 +3761,7 @@ DEPENDENCIES:
   - expo-dev-menu-interface (from `../../../packages/expo-dev-menu-interface/ios`)
   - expo-dev-menu/Tests (from `../../../packages/expo-dev-menu`)
   - expo-dev-menu/UITests (from `../../../packages/expo-dev-menu`)
+  - ExpoAppIntegrity (from `../../../packages/expo-app-integrity/ios`)
   - ExpoAppleAuthentication (from `../../../packages/expo-apple-authentication/ios`)
   - ExpoAsset (from `../../../packages/expo-asset/ios`)
   - ExpoAudio (from `../../../packages/expo-audio/ios`)
@@ -3980,6 +3983,9 @@ EXTERNAL SOURCES:
   expo-dev-menu-interface:
     inhibit_warnings: false
     :path: "../../../packages/expo-dev-menu-interface/ios"
+  ExpoAppIntegrity:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-app-integrity/ios"
   ExpoAppleAuthentication:
     inhibit_warnings: false
     :path: "../../../packages/expo-apple-authentication/ios"

--- a/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
+++ b/apps/expo-go/ios/Exponent.xcodeproj/project.pbxproj
@@ -1956,7 +1956,7 @@
 					"-Xlinker",
 					"-no_objc_category_merging",
 				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/yoga/Yoga.modulemap\" -D DEBUG -D EXPO_CONFIGURATION_DEBUG";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -D DEBUG -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = host.exp.Exponent;
 				PRODUCT_NAME = "Expo Go";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2026,7 +2026,7 @@
 					"-Xlinker",
 					"-no_objc_category_merging",
 				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -Xcc -fmodule-map-file=\"${PODS_ROOT}/Headers/Public/yoga/Yoga.modulemap\" -D RELEASE -D EXPO_CONFIGURATION_RELEASE";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS -D RELEASE -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = host.exp.Exponent;
 				PRODUCT_NAME = "Expo Go";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore host.exp.Exponent";

--- a/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
@@ -1,6 +1,12 @@
 #import "EXAppLoadingProgressWindowController.h"
 
-#import <React/React-Core-umbrella.h> // Keeps this import to fix the error from building React module: `error: definition of 'RCTBridge' must be imported from module 'React' before it is required`
+// Keeps this import to fix the error from building React module: `error: definition of 'RCTBridge' must be imported from module 'React' before it is required`
+#if __has_include(<React/React-Core-umbrella.h>)
+  #import <React/React-Core-umbrella.h>
+#else
+  #import <React_Core/React_Core-umbrella.h>
+#endif
+
 
 #import <ExpoModulesCore/EXDefines.h>
 

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/activitydelegates/DevLauncherReactActivityNOPDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/react/activitydelegates/DevLauncherReactActivityNOPDelegate.kt
@@ -16,6 +16,6 @@ open class DevLauncherReactActivityNOPDelegate(activity: ReactActivity) :
   override fun onNewIntent(intent: Intent?): Boolean = true
   override fun onBackPressed(): Boolean = true
   override fun onWindowFocusChanged(hasFocus: Boolean) {}
-  override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?, grantResults: IntArray?) {}
-  override fun onConfigurationChanged(newConfig: Configuration?) {}
+  override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {}
+  override fun onConfigurationChanged(newConfig: Configuration) {}
 }

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -293,7 +293,7 @@ class ReactActivityDelegateWrapper(
     }
   }
 
-  override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+  override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
     if (!loadAppReady.isCompleted) {
       return false
     }
@@ -304,7 +304,7 @@ class ReactActivityDelegateWrapper(
       .fold(false) { accu, current -> accu || current } || delegate.onKeyDown(keyCode, event)
   }
 
-  override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
+  override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
     if (!loadAppReady.isCompleted) {
       return false
     }
@@ -315,7 +315,7 @@ class ReactActivityDelegateWrapper(
       .fold(false) { accu, current -> accu || current } || delegate.onKeyUp(keyCode, event)
   }
 
-  override fun onKeyLongPress(keyCode: Int, event: KeyEvent?): Boolean {
+  override fun onKeyLongPress(keyCode: Int, event: KeyEvent): Boolean {
     if (!loadAppReady.isCompleted) {
       return false
     }
@@ -355,14 +355,14 @@ class ReactActivityDelegateWrapper(
     }
   }
 
-  override fun requestPermissions(permissions: Array<out String>?, requestCode: Int, listener: PermissionListener?) {
+  override fun requestPermissions(permissions: Array<out String>, requestCode: Int, listener: PermissionListener?) {
     launchLifecycleScopeWithLock {
       loadAppReady.await()
       delegate.requestPermissions(permissions, requestCode, listener)
     }
   }
 
-  override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?, grantResults: IntArray?) {
+  override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
     launchLifecycleScopeWithLock {
       loadAppReady.await()
       delegate.onRequestPermissionsResult(requestCode, permissions, grantResults)
@@ -389,7 +389,7 @@ class ReactActivityDelegateWrapper(
     return invokeDelegateMethod("composeLaunchOptions")
   }
 
-  override fun onConfigurationChanged(newConfig: Configuration?) {
+  override fun onConfigurationChanged(newConfig: Configuration) {
     launchLifecycleScopeWithLock {
       loadAppReady.await()
       delegate.onConfigurationChanged(newConfig)


### PR DESCRIPTION
# Why

SDK54 - Upgrade to React Native 0.81.0.rc.1

# How

Updated types after changes in rc-1 on Android

# Test Plan

Build/run ExpoGo/BareExpo on Android

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
