### PR TITLE
[image][iOS] Fix caching resized images from Photo Library

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [iOS] Speed up displaying local assets. ([#37795](https://github.com/expo/expo/pull/37795) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Fix animation resuming by casting image to GifDrawable. ([#37363](https://github.com/expo/expo/pull/37363) by [@Wenszel](https://github.com/Wenszel))
 - [Web] Fix `alt` as an alias for `accessibilityLabel` ([#37682](https://github.com/expo/expo/pull/37682) by [@huextrat](https://github.com/huextrat))
-- [iOS] Fix caching resized images from Photo Library.
+- [iOS] Fix caching resized images from Photo Library. ([#38105](https://github.com/expo/expo/pull/38105) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [iOS] Speed up displaying local assets. ([#37795](https://github.com/expo/expo/pull/37795) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Fix animation resuming by casting image to GifDrawable. ([#37363](https://github.com/expo/expo/pull/37363) by [@Wenszel](https://github.com/Wenszel))
 - [Web] Fix `alt` as an alias for `accessibilityLabel` ([#37682](https://github.com/expo/expo/pull/37682) by [@huextrat](https://github.com/huextrat))
+- [iOS] Fix caching resized images from Photo Library.
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageSource.swift
+++ b/packages/expo-image/ios/ImageSource.swift
@@ -37,8 +37,7 @@ struct ImageSource: Record {
     return isPhotoLibraryAssetUrl(uri)
   }
 
-  var isCachingAllowed: Bool {
-    // TODO: Don't cache other non-network requests (e.g. data URIs, local files)
+  var cacheOriginalImage: Bool {
     return !isPhotoLibraryAsset
   }
 }

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -182,18 +182,14 @@ func createSDWebImageContext(forSource source: ImageSource, cachePolicy: ImageCa
   // otherwise they would be saved in cache with scale = 1.0 which may result in
   // incorrectly rendered images for resize modes that don't scale (`center` and `repeat`).
   context[.imageScaleFactor] = source.scale
+  
+  let sdCacheType = cachePolicy.toSdCacheType().rawValue
+  context[.queryCacheType] = sdCacheType
+  context[.storeCacheType] = sdCacheType
 
-  // Set which cache can be used to query and store the downloaded image.
-  // We want to store only original images (without transformations).
-  context[.queryCacheType] = SDImageCacheType.none.rawValue
-  context[.storeCacheType] = SDImageCacheType.none.rawValue
-
-  if source.isCachingAllowed {
-    let sdCacheType = cachePolicy.toSdCacheType().rawValue
+  if source.cacheOriginalImage {
     context[.originalQueryCacheType] = sdCacheType
     context[.originalStoreCacheType] = sdCacheType
-    context[.queryCacheType] = sdCacheType
-    context[.storeCacheType] = sdCacheType
   } else {
     context[.originalQueryCacheType] = SDImageCacheType.none.rawValue
     context[.originalStoreCacheType] = SDImageCacheType.none.rawValue

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -182,7 +182,7 @@ func createSDWebImageContext(forSource source: ImageSource, cachePolicy: ImageCa
   // otherwise they would be saved in cache with scale = 1.0 which may result in
   // incorrectly rendered images for resize modes that don't scale (`center` and `repeat`).
   context[.imageScaleFactor] = source.scale
-  
+
   let sdCacheType = cachePolicy.toSdCacheType().rawValue
   context[.queryCacheType] = sdCacheType
   context[.storeCacheType] = sdCacheType

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -165,7 +165,7 @@ public final class ImageView: ExpoView {
 
     // It seems that `UIImageView` can't tint some vector graphics. If the `tintColor` prop is specified,
     // we tell the SVG coder to decode to a bitmap instead. This will become useless when we switch to SVGNative coder.
-    let shouldEarlyResize = imageTintColor != nil || enforceEarlyResizing
+    let shouldEarlyResize = imageTintColor != nil || enforceEarlyResizing || source.isPhotoLibraryAsset
     if shouldEarlyResize {
       context[.imagePreserveAspectRatio] = true
       context[.imageThumbnailPixelSize] = CGSize(


### PR DESCRIPTION
# Why

When loading image from PH with target size like 50x50 it's being cached as the original image, later, when we want to load the same image with bigger size, like 1000x1000 its being picked from cache ignoring that it's bigger size now.

# How

Images from PH are already loaded with `targetSize` so we dont want to store them as "original" image, instead we store them only as a processed image with size included. 

# Test Plan

https://github.com/user-attachments/assets/bc7684dc-1aa4-49de-addc-0d5d3e51c20c

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
