### PR TITLE
refactor(cli): regenerate Metro type definitions for `0.83.0`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Added tests for modal stacking ([#37856](https://github.com/expo/expo/pull/37856) by [@hirbod](https://github.com/hirbod))
 - simplify/optimize web-modal tests ([#38025](https://github.com/expo/expo/pull/38025) by [@hirbod](https://github.com/hirbod))
 - Fix e2e start-test for local runs ([#38066](https://github.com/expo/expo/pull/38066) by [@Ubax](https://github.com/Ubax))
+- Updated Metro types for `metro@0.83.0` ([#38106](https://github.com/expo/expo/pull/38106) by [@byCedric](https://github.com/byCedric)) 
 
 ### ⚠️ Notices
 

--- a/packages/@expo/cli/ts-declarations/metro-babel-transformer/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-babel-transformer/index.d.ts
@@ -7,7 +7,7 @@ declare module 'metro-babel-transformer' {
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-babel-transformer/src/index.js
 declare module 'metro-babel-transformer/private/index' {
   import type * as _babel_types from '@babel/types';
-  import type { BabelFileMetadata } from '@babel/core';
+  import type { BabelFileMetadata, TransformOptions } from '@babel/core';
   export type CustomTransformOptions = {
     [$$Key$$: string]: any;
   };
@@ -33,7 +33,7 @@ declare module 'metro-babel-transformer/private/index' {
   export type BabelTransformerArgs = Readonly<{
     filename: string;
     options: BabelTransformerOptions;
-    plugins?: any['plugins'];
+    plugins?: TransformOptions['plugins'];
     src: string;
   }>;
   export type BabelFileFunctionMapMetadata = Readonly<{
@@ -54,7 +54,16 @@ declare module 'metro-babel-transformer/private/index' {
     transform: ($$PARAM_0$$: BabelTransformerArgs) => Readonly<{
       ast: _babel_types.File;
       functionMap?: BabelFileFunctionMapMetadata;
-      metadata?: MetroBabelFileMetadata;
+      metadata?: MetroBabelFileMetadata & {
+        // NOTE(cedric): manual change, see: babel-preset-expo/src/{client-module-proxy-plugin.ts,server-actions-plugin.ts}
+        reactServerReference?: string;
+        // NOTE(cedric): manual change, see: babel-preset-expo/src/client-module-proxy-plugin.ts
+        reactClientReference?: string;
+        // NOTE(cedric): manual change, see: babel-preset-expo/src/use-dom-directive-plugin.ts
+        expoDomComponentReference?: string;
+        // NOTE(cedric): manual change, see: babel-preset-expo/src/detect-dynamic-exports.ts
+        hasCjsExports?: boolean;
+      };
     }>;
     getCacheKey?: () => string;
   }>;

--- a/packages/@expo/cli/ts-declarations/metro-babel-transformer/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-babel-transformer/index.d.ts
@@ -1,7 +1,7 @@
 // #region metro-babel-transformer
 declare module 'metro-babel-transformer' {
-  export * from 'metro-babel-transformer/src/index';
-  export { default } from 'metro-babel-transformer/src/index';
+  export * from 'metro-babel-transformer/private/index';
+  export { default } from 'metro-babel-transformer/private/index';
 }
 
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-babel-transformer/src/index.js

--- a/packages/@expo/cli/ts-declarations/metro-babel-transformer/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-babel-transformer/index.d.ts
@@ -4,16 +4,15 @@ declare module 'metro-babel-transformer' {
   export { default } from 'metro-babel-transformer/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-babel-transformer/src/index.js
-declare module 'metro-babel-transformer/src/index' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-babel-transformer/src/index.js
+declare module 'metro-babel-transformer/private/index' {
   import type * as _babel_types from '@babel/types';
-  import type { BabelFileMetadata, TransformOptions } from '@babel/core';
+  import type { BabelFileMetadata } from '@babel/core';
   export type CustomTransformOptions = {
     [$$Key$$: string]: any;
   };
   export type TransformProfile = 'default' | 'hermes-stable' | 'hermes-canary';
   type BabelTransformerOptions = Readonly<{
-    type?: 'script' | 'module' | 'asset';
     customTransformOptions?: CustomTransformOptions;
     dev: boolean;
     enableBabelRCLookup?: boolean;
@@ -34,7 +33,7 @@ declare module 'metro-babel-transformer/src/index' {
   export type BabelTransformerArgs = Readonly<{
     filename: string;
     options: BabelTransformerOptions;
-    plugins?: TransformOptions['plugins'];
+    plugins?: any['plugins'];
     src: string;
   }>;
   export type BabelFileFunctionMapMetadata = Readonly<{
@@ -51,23 +50,14 @@ declare module 'metro-babel-transformer/src/index' {
           unstable_importDeclarationLocs?: null | undefined | BabelFileImportLocsMetadata;
         };
   } & BabelFileMetadata;
-  export type BabelTransformer = {
-    transform: ($$PARAM_0$$: BabelTransformerArgs) => {
+  export type BabelTransformer = Readonly<{
+    transform: ($$PARAM_0$$: BabelTransformerArgs) => Readonly<{
       ast: _babel_types.File;
       functionMap?: BabelFileFunctionMapMetadata;
-      metadata?: MetroBabelFileMetadata & {
-        // NOTE(cedric): manual change, see: babel-preset-expo/src/{client-module-proxy-plugin.ts,server-actions-plugin.ts}
-        reactServerReference?: string;
-        // NOTE(cedric): manual change, see: babel-preset-expo/src/client-module-proxy-plugin.ts
-        reactClientReference?: string;
-        // NOTE(cedric): manual change, see: babel-preset-expo/src/use-dom-directive-plugin.ts
-        expoDomComponentReference?: string;
-        // NOTE(cedric): manual change, see: babel-preset-expo/src/detect-dynamic-exports.ts
-        hasCjsExports?: boolean;
-      };
-    };
+      metadata?: MetroBabelFileMetadata;
+    }>;
     getCacheKey?: () => string;
-  };
+  }>;
   const $$EXPORT_DEFAULT_DECLARATION$$: BabelTransformer;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }

--- a/packages/@expo/cli/ts-declarations/metro-cache-key/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-cache-key/index.d.ts
@@ -3,8 +3,7 @@ declare module 'metro-cache-key' {
   export { default } from 'metro-cache-key/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-cache-key/src/index.js
-declare module 'metro-cache-key/src/index' {
-  function getCacheKey(files: string[]): string;
-  export default getCacheKey;
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-cache-key/src/index.js
+declare module 'metro-cache-key/private/index' {
+  export function getCacheKey(files: string[]): string;
 }

--- a/packages/@expo/cli/ts-declarations/metro-cache-key/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-cache-key/index.d.ts
@@ -1,6 +1,6 @@
 // #region metro-cache-key
 declare module 'metro-cache-key' {
-  export { default } from 'metro-cache-key/src/index';
+  export { default } from 'metro-cache-key/private/index';
 }
 
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-cache-key/src/index.js

--- a/packages/@expo/cli/ts-declarations/metro-config/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-config/index.d.ts
@@ -1,12 +1,12 @@
 // #region metro-config
 declare module 'metro-config' {
-  export * from 'metro-config/src/index';
-  export { default } from 'metro-config/src/index';
+  export * from 'metro-config/private/index';
+  export { default } from 'metro-config/private/index';
 }
 
 // NOTE(cedric): this is a manual change, to avoid having to import `../configTypes.flow`
-declare module 'metro-config/src/configTypes' {
-  export * from 'metro-config/src/configTypes.flow';
+declare module 'metro-config/private/configTypes' {
+  export * from 'metro-config/private/configTypes.flow';
 }
 
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-config/src/configTypes.flow.js

--- a/packages/@expo/cli/ts-declarations/metro-config/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-config/index.d.ts
@@ -311,7 +311,7 @@ declare module 'metro-config/private/defaults/defaults' {
   export const moduleSystem: string;
   export const platforms: any;
   export const DEFAULT_METRO_MINIFIER_PATH: 'metro-minify-terser';
-  export { default as defaultCreateModuleIdFactory } from 'metro-config/metro/private/lib/createModuleIdFactory';
+  export { default as defaultCreateModuleIdFactory } from 'metro/private/lib/createModuleIdFactory';
   export const noopPerfLoggerFactory: () => RootPerfLogger;
 }
 

--- a/packages/@expo/cli/ts-declarations/metro-config/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-config/index.d.ts
@@ -9,9 +9,9 @@ declare module 'metro-config/src/configTypes' {
   export * from 'metro-config/src/configTypes.flow';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/configTypes.flow.js
-declare module 'metro-config/src/configTypes.flow' {
-  import type { IntermediateStackFrame } from 'metro/src/Server/symbolicate';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-config/src/configTypes.flow.js
+declare module 'metro-config/private/configTypes.flow' {
+  import type { IntermediateStackFrame } from 'metro/private/Server/symbolicate';
   import type { HandleFunction, Server } from 'connect';
   import type { CacheStore } from 'metro-cache';
   import type $$IMPORT_TYPEOF_1$$ from 'metro-cache';
@@ -19,15 +19,15 @@ declare module 'metro-config/src/configTypes.flow' {
   import type { CacheManagerFactory } from 'metro-file-map';
   import type { CustomResolver } from 'metro-resolver';
   import type { JsTransformerConfig } from 'metro-transform-worker';
-  import type { TransformResult } from 'metro/src/DeltaBundler';
+  import type { TransformResult } from 'metro/private/DeltaBundler';
   import type {
     DeltaResult,
     Module,
     ReadOnlyGraph,
     SerializerOptions,
-  } from 'metro/src/DeltaBundler/types.flow';
-  import type { Reporter } from 'metro/src/lib/reporting';
-  import type MetroServer from 'metro/src/Server';
+  } from 'metro/private/DeltaBundler/types.flow';
+  import type { Reporter } from 'metro/private/lib/reporting';
+  import type MetroServer from 'metro/private/Server';
   export type ExtraTransformOptions = Readonly<{
     preloadedModules?:
       | Readonly<{
@@ -46,7 +46,6 @@ declare module 'metro-config/src/configTypes.flow' {
         | boolean;
       nonInlinedRequires?: readonly string[];
       unstable_disableES6Transforms?: boolean;
-      unstable_inlinePlatform?: boolean;
       unstable_memoizeInlineRequires?: boolean;
       unstable_nonMemoizedInlineRequires?: readonly string[];
     }>;
@@ -166,7 +165,6 @@ declare module 'metro-config/src/configTypes.flow' {
     transformVariants: {
       readonly [name: string]: object;
     };
-    workerPath: string;
     publicPath: string;
     unstable_workerThreads: boolean;
   } & JsTransformerConfig;
@@ -303,9 +301,9 @@ declare module 'metro-config/src/configTypes.flow' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/defaults/defaults.js
-declare module 'metro-config/src/defaults/defaults' {
-  import type { RootPerfLogger } from 'metro-config/src/configTypes.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-config/src/defaults/defaults.js
+declare module 'metro-config/private/defaults/defaults' {
+  import type { RootPerfLogger } from 'metro-config/private/configTypes.flow';
   export const assetExts: any;
   export const assetResolutions: any;
   export const sourceExts: any;
@@ -313,43 +311,43 @@ declare module 'metro-config/src/defaults/defaults' {
   export const moduleSystem: string;
   export const platforms: any;
   export const DEFAULT_METRO_MINIFIER_PATH: 'metro-minify-terser';
-  export { default as defaultCreateModuleIdFactory } from 'metro/src/lib/createModuleIdFactory';
+  export { default as defaultCreateModuleIdFactory } from 'metro-config/metro/private/lib/createModuleIdFactory';
   export const noopPerfLoggerFactory: () => RootPerfLogger;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/defaults/index.js
-declare module 'metro-config/src/defaults/index' {
-  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/defaults/index.js
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-config/src/defaults/index.js
+declare module 'metro-config/private/defaults/index' {
+  // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-config/src/defaults/index.js
 
   // NOTE(cedric): This file can't be typed properly due to complex CJS structures
   // NOTE(cedric): This file has lots more exports, but neither of them should be used directly by Expo
 
-  import type { ConfigT } from 'metro-config/src/configTypes.flow';
+  import type { ConfigT } from 'metro-config/private/configTypes.flow';
   export default interface getDefaultConfig {
     (rootPath: string | null): Promise<ConfigT>;
     getDefaultValues: (rootPath: string | null) => ConfigT;
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/defaults/validConfig.js
-declare module 'metro-config/src/defaults/validConfig' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-config/src/defaults/validConfig.js
+declare module 'metro-config/private/defaults/validConfig' {
   const $$EXPORT_DEFAULT_DECLARATION$$: () => any;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/index.js
-declare module 'metro-config/src/index' {
-  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-config/src/index.js
+declare module 'metro-config/private/index' {
+  // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-config/src/index.js
 
   // NOTE(cedric): Metro uses this weird Flow syntax /*:: */ to override the exported types...
-  export type * from 'metro-config/src/configTypes.flow';
-  export { default as getDefaultConfig } from 'metro-config/src/defaults';
-  export { loadConfig, mergeConfig, resolveConfig } from 'metro-config/src/loadConfig';
+  export type * from 'metro-config/private/configTypes.flow';
+  export { default as getDefaultConfig } from 'metro-config/private/defaults';
+  export { loadConfig, mergeConfig, resolveConfig } from 'metro-config/private/loadConfig';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-config/src/loadConfig.js
-declare module 'metro-config/src/loadConfig' {
-  import type { ConfigT, InputConfigT, YargArguments } from 'metro-config/src/configTypes.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-config/src/loadConfig.js
+declare module 'metro-config/private/loadConfig' {
+  import type { ConfigT, InputConfigT, YargArguments } from 'metro-config/private/configTypes.flow';
   type CosmiConfigResult = {
     filepath: string;
     isEmpty: boolean;

--- a/packages/@expo/cli/ts-declarations/metro-core/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-core/index.d.ts
@@ -1,7 +1,7 @@
 // #region metro-core
 declare module 'metro-core' {
-  export * from 'metro-core/src/index';
-  export { default } from 'metro-core/src/index';
+  export * from 'metro-core/private/index';
+  export { default } from 'metro-core/private/index';
 }
 
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-core/src/canonicalize.js

--- a/packages/@expo/cli/ts-declarations/metro-file-map/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-file-map/index.d.ts
@@ -4,15 +4,15 @@ declare module 'metro-file-map' {
   export { default } from 'metro-file-map/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/cache/DiskCacheManager.js
-declare module 'metro-file-map/src/cache/DiskCacheManager' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/cache/DiskCacheManager.js
+declare module 'metro-file-map/private/cache/DiskCacheManager' {
   import type {
     BuildParameters,
     CacheData,
     CacheManager,
     CacheManagerFactoryOptions,
     CacheManagerWriteOptions,
-  } from 'metro-file-map/src/flow-types';
+  } from 'metro-file-map/private/flow-types';
   type AutoSaveOptions = Readonly<{
     debounceMs: number;
   }>;
@@ -35,8 +35,8 @@ declare module 'metro-file-map/src/cache/DiskCacheManager' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/constants.js
-declare module 'metro-file-map/src/constants' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/constants.js
+declare module 'metro-file-map/private/constants' {
   const constants: {
     DEPENDENCY_DELIM: '\0';
     ID: 0;
@@ -56,15 +56,15 @@ declare module 'metro-file-map/src/constants' {
   export default constants;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/crawlers/node/hasNativeFindSupport.js
-declare module 'metro-file-map/src/crawlers/node/hasNativeFindSupport' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/crawlers/node/hasNativeFindSupport.js
+declare module 'metro-file-map/private/crawlers/node/hasNativeFindSupport' {
   function hasNativeFindSupport(): Promise<boolean>;
   export default hasNativeFindSupport;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/crawlers/node/index.js
-declare module 'metro-file-map/src/crawlers/node/index' {
-  import type { CanonicalPath, CrawlerOptions, FileData } from 'metro-file-map/src/flow-types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/crawlers/node/index.js
+declare module 'metro-file-map/private/crawlers/node/index' {
+  import type { CanonicalPath, CrawlerOptions, FileData } from 'metro-file-map/private/flow-types';
   const $$EXPORT_DEFAULT_DECLARATION$$: (options: CrawlerOptions) => Promise<{
     removedFiles: Set<CanonicalPath>;
     changedFiles: FileData;
@@ -72,14 +72,14 @@ declare module 'metro-file-map/src/crawlers/node/index' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/crawlers/watchman/index.js
-declare module 'metro-file-map/src/crawlers/watchman/index' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/crawlers/watchman/index.js
+declare module 'metro-file-map/private/crawlers/watchman/index' {
   import type {
     CanonicalPath,
     CrawlerOptions,
     FileData,
     WatchmanClocks,
-  } from 'metro-file-map/src/flow-types';
+  } from 'metro-file-map/private/flow-types';
   const $$EXPORT_DEFAULT_DECLARATION$$: ($$PARAM_0$$: CrawlerOptions) => Promise<{
     changedFiles: FileData;
     removedFiles: Set<CanonicalPath>;
@@ -88,8 +88,8 @@ declare module 'metro-file-map/src/crawlers/watchman/index' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/crawlers/watchman/planQuery.js
-declare module 'metro-file-map/src/crawlers/watchman/planQuery' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/crawlers/watchman/planQuery.js
+declare module 'metro-file-map/private/crawlers/watchman/planQuery' {
   import type { WatchmanQuery, WatchmanQuerySince } from 'fb-watchman';
   export function planQuery(
     $$PARAM_0$$: Readonly<{
@@ -105,8 +105,8 @@ declare module 'metro-file-map/src/crawlers/watchman/planQuery' {
   };
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/flow-types.js
-declare module 'metro-file-map/src/flow-types' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/flow-types.js
+declare module 'metro-file-map/private/flow-types' {
   import type { PerfLogger, PerfLoggerFactory, RootPerfLogger } from 'metro-config';
   export type { PerfLoggerFactory, PerfLogger };
   export type BuildParameters = Readonly<{
@@ -198,6 +198,14 @@ declare module 'metro-file-map/src/flow-types' {
     roots: readonly string[];
     onStatus: (status: WatcherStatus) => void;
   };
+  export type DependencyExtractor = {
+    extract: (
+      content: string,
+      absoluteFilePath: string,
+      defaultExtractor?: DependencyExtractor['extract']
+    ) => Set<string>;
+    getCacheKey: () => string;
+  };
   export type WatcherStatus =
     | {
         type: 'watchman_slow_command';
@@ -241,7 +249,7 @@ declare module 'metro-file-map/src/flow-types' {
     files: FileSystemState;
     pluginState?: null | SerializableState;
   }>;
-  type V8Serializable = object;
+  type V8Serializable = {};
   export interface FileMapPlugin<SerializableState = V8Serializable> {
     readonly name: string;
     initialize(initOptions: FileMapPluginInitOptions<SerializableState>): Promise<void>;
@@ -413,7 +421,7 @@ declare module 'metro-file-map/src/flow-types' {
     request: Readonly<{
       computeSha1: boolean;
     }>
-  ) => Promise<null | undefined | Buffer>;
+  ) => null | undefined | Buffer;
   export type RawMockMap = Readonly<{
     duplicates: Map<string, Set<string>>;
     mocks: Map<string, Path>;
@@ -472,8 +480,8 @@ declare module 'metro-file-map/src/flow-types' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/index.js
-declare module 'metro-file-map/src/index' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/index.js
+declare module 'metro-file-map/private/index' {
   import type {
     BuildParameters,
     BuildResult,
@@ -497,11 +505,11 @@ declare module 'metro-file-map/src/index' {
     PerfLogger,
     PerfLoggerFactory,
     WatchmanClocks,
-  } from 'metro-file-map/src/flow-types';
-  import { FileProcessor } from 'metro-file-map/src/lib/FileProcessor';
-  import { RootPathUtils } from 'metro-file-map/src/lib/RootPathUtils';
-  import { Watcher } from 'metro-file-map/src/Watcher';
-  import EventEmitter from 'events';
+  } from 'metro-file-map/private/flow-types';
+  import { FileProcessor } from 'metro-file-map/private/lib/FileProcessor';
+  import { RootPathUtils } from 'metro-file-map/private/lib/RootPathUtils';
+  import { Watcher } from 'metro-file-map/private/Watcher';
+  import EventEmitter from 'node:events';
   export type {
     BuildParameters,
     BuildResult,
@@ -559,20 +567,21 @@ declare module 'metro-file-map/src/index' {
       watchmanDeferStates: readonly string[];
     } & BuildParameters
   >;
-  export { DiskCacheManager } from 'metro-file-map/src/cache/DiskCacheManager';
-  export { DuplicateHasteCandidatesError } from 'metro-file-map/src/plugins/haste/DuplicateHasteCandidatesError';
-  export { HasteConflictsError } from 'metro-file-map/src/plugins/haste/HasteConflictsError';
-  export { default as HastePlugin } from 'metro-file-map/src/plugins/HastePlugin';
-  export type { HasteMap } from 'metro-file-map/src/flow-types';
-  export type { HealthCheckResult } from 'metro-file-map/src/Watcher';
+  export { DiskCacheManager } from 'metro-file-map/private/cache/DiskCacheManager';
+  export { DuplicateHasteCandidatesError } from 'metro-file-map/private/plugins/haste/DuplicateHasteCandidatesError';
+  export { HasteConflictsError } from 'metro-file-map/private/plugins/haste/HasteConflictsError';
+  export { default as HastePlugin } from 'metro-file-map/private/plugins/HastePlugin';
+  export type { HasteMap } from 'metro-file-map/private/flow-types';
+  export type { HealthCheckResult } from 'metro-file-map/private/Watcher';
   export type {
     CacheManager,
     CacheManagerFactory,
     CacheManagerFactoryOptions,
     CacheManagerWriteOptions,
     ChangeEvent,
+    DependencyExtractor,
     WatcherStatus,
-  } from 'metro-file-map/src/flow-types';
+  } from 'metro-file-map/private/flow-types';
   /**
    * FileMap includes a JavaScript implementation of Facebook's haste module system.
    *
@@ -705,28 +714,28 @@ declare module 'metro-file-map/src/index' {
   export default FileMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/checkWatchmanCapabilities.js
-declare module 'metro-file-map/src/lib/checkWatchmanCapabilities' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/lib/checkWatchmanCapabilities.js
+declare module 'metro-file-map/private/lib/checkWatchmanCapabilities' {
   function checkWatchmanCapabilities(requiredCapabilities: readonly string[]): Promise<{
     version: string;
   }>;
   export default checkWatchmanCapabilities;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/dependencyExtractor.js
-declare module 'metro-file-map/src/lib/dependencyExtractor' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/lib/dependencyExtractor.js
+declare module 'metro-file-map/private/lib/dependencyExtractor' {
   export function extract(code: any): void;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/fast_path.js
-declare module 'metro-file-map/src/lib/fast_path' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/lib/fast_path.js
+declare module 'metro-file-map/private/lib/fast_path' {
   export function relative(rootDir: string, filename: string): string;
   export function resolve(rootDir: string, normalPath: string): string;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/FileProcessor.js
-declare module 'metro-file-map/src/lib/FileProcessor' {
-  import type { FileMetaData, PerfLogger } from 'metro-file-map/src/flow-types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/lib/FileProcessor.js
+declare module 'metro-file-map/private/lib/FileProcessor' {
+  import type { FileMetaData, PerfLogger } from 'metro-file-map/private/flow-types';
   type ProcessFileRequest = Readonly<{
     /**
      * Populate metadata[H.SHA1] with the SHA1 of the file's contents.
@@ -743,6 +752,9 @@ declare module 'metro-file-map/src/lib/FileProcessor' {
      */
     maybeReturnContent: boolean;
   }>;
+  interface MaybeCodedError extends Error {
+    code?: string;
+  }
   export class FileProcessor {
     constructor(
       opts: Readonly<{
@@ -761,9 +773,7 @@ declare module 'metro-file-map/src/lib/FileProcessor' {
     ): Promise<{
       errors: {
         absolutePath: string;
-        error: Error & {
-          code: string;
-        };
+        error: MaybeCodedError;
       }[];
     }>;
     processRegularFile(
@@ -773,27 +783,27 @@ declare module 'metro-file-map/src/lib/FileProcessor' {
     ):
       | null
       | undefined
-      | Promise<{
+      | {
           content?: null | Buffer;
-        }>;
+        };
     end(): Promise<void>;
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/normalizePathSeparatorsToPosix.js
-declare module 'metro-file-map/src/lib/normalizePathSeparatorsToPosix' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/lib/normalizePathSeparatorsToPosix.js
+declare module 'metro-file-map/private/lib/normalizePathSeparatorsToPosix' {
   let normalizePathSeparatorsToPosix: (string: string) => string;
   export default normalizePathSeparatorsToPosix;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/normalizePathSeparatorsToSystem.js
-declare module 'metro-file-map/src/lib/normalizePathSeparatorsToSystem' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/lib/normalizePathSeparatorsToSystem.js
+declare module 'metro-file-map/private/lib/normalizePathSeparatorsToSystem' {
   let normalizePathSeparatorsToSystem: (string: string) => string;
   export default normalizePathSeparatorsToSystem;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/RootPathUtils.js
-declare module 'metro-file-map/src/lib/RootPathUtils' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/lib/RootPathUtils.js
+declare module 'metro-file-map/private/lib/RootPathUtils' {
   export class RootPathUtils {
     constructor(rootDir: string);
     getBasenameOfNthAncestor(n: number): string;
@@ -813,9 +823,9 @@ declare module 'metro-file-map/src/lib/RootPathUtils' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/rootRelativeCacheKeys.js
-declare module 'metro-file-map/src/lib/rootRelativeCacheKeys' {
-  import type { BuildParameters } from 'metro-file-map/src/flow-types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/lib/rootRelativeCacheKeys.js
+declare module 'metro-file-map/private/lib/rootRelativeCacheKeys' {
+  import type { BuildParameters } from 'metro-file-map/private/flow-types';
   function rootRelativeCacheKeys(buildParameters: BuildParameters): {
     rootDirHash: string;
     relativeConfigHash: string;
@@ -823,16 +833,16 @@ declare module 'metro-file-map/src/lib/rootRelativeCacheKeys' {
   export default rootRelativeCacheKeys;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/sorting.js
-declare module 'metro-file-map/src/lib/sorting' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/lib/sorting.js
+declare module 'metro-file-map/private/lib/sorting' {
   export function compareStrings(a: null | string, b: null | string): number;
   export function chainComparators<T>(
     ...comparators: ((a: T, b: T) => number)[]
   ): (a: T, b: T) => number;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/lib/TreeFS.js
-declare module 'metro-file-map/src/lib/TreeFS' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/lib/TreeFS.js
+declare module 'metro-file-map/private/lib/TreeFS' {
   import type {
     FileData,
     FileMetaData,
@@ -841,7 +851,7 @@ declare module 'metro-file-map/src/lib/TreeFS' {
     MutableFileSystem,
     Path,
     ProcessFileFunction,
-  } from 'metro-file-map/src/flow-types';
+  } from 'metro-file-map/private/flow-types';
   type DirectoryNode = Map<string, MixedNode>;
   type FileNode = FileMetaData;
   type MixedNode = FileNode | DirectoryNode;
@@ -998,9 +1008,9 @@ declare module 'metro-file-map/src/lib/TreeFS' {
   export default TreeFS;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/plugins/haste/computeConflicts.js
-declare module 'metro-file-map/src/plugins/haste/computeConflicts' {
-  import type { HasteMapItem } from 'metro-file-map/src/flow-types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/plugins/haste/computeConflicts.js
+declare module 'metro-file-map/private/plugins/haste/computeConflicts' {
+  import type { HasteMapItem } from 'metro-file-map/private/flow-types';
   type Conflict = {
     id: string;
     platform?: string | null;
@@ -1016,9 +1026,9 @@ declare module 'metro-file-map/src/plugins/haste/computeConflicts' {
   ): Conflict[];
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/plugins/haste/DuplicateHasteCandidatesError.js
-declare module 'metro-file-map/src/plugins/haste/DuplicateHasteCandidatesError' {
-  import type { DuplicatesSet } from 'metro-file-map/src/flow-types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/plugins/haste/DuplicateHasteCandidatesError.js
+declare module 'metro-file-map/private/plugins/haste/DuplicateHasteCandidatesError' {
+  import type { DuplicatesSet } from 'metro-file-map/private/flow-types';
   export class DuplicateHasteCandidatesError extends Error {
     hasteName: string;
     platform: string | null;
@@ -1033,8 +1043,8 @@ declare module 'metro-file-map/src/plugins/haste/DuplicateHasteCandidatesError' 
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/plugins/haste/getPlatformExtension.js
-declare module 'metro-file-map/src/plugins/haste/getPlatformExtension' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/plugins/haste/getPlatformExtension.js
+declare module 'metro-file-map/private/plugins/haste/getPlatformExtension' {
   function getPlatformExtension(
     file: string,
     platforms: ReadonlySet<string>
@@ -1042,17 +1052,17 @@ declare module 'metro-file-map/src/plugins/haste/getPlatformExtension' {
   export default getPlatformExtension;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/plugins/haste/HasteConflictsError.js
-declare module 'metro-file-map/src/plugins/haste/HasteConflictsError' {
-  import type { HasteConflict } from 'metro-file-map/src/flow-types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/plugins/haste/HasteConflictsError.js
+declare module 'metro-file-map/private/plugins/haste/HasteConflictsError' {
+  import type { HasteConflict } from 'metro-file-map/private/flow-types';
   export class HasteConflictsError extends Error {
     constructor(conflicts: readonly HasteConflict[]);
     getDetailedMessage(pathsRelativeToRoot: null | undefined | string): string;
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/plugins/HastePlugin.js
-declare module 'metro-file-map/src/plugins/HastePlugin' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/plugins/HastePlugin.js
+declare module 'metro-file-map/private/plugins/HastePlugin' {
   import type {
     Console,
     DuplicatesSet,
@@ -1066,7 +1076,7 @@ declare module 'metro-file-map/src/plugins/HastePlugin' {
     HTypeValue,
     Path,
     PerfLogger,
-  } from 'metro-file-map/src/flow-types';
+  } from 'metro-file-map/private/flow-types';
   type HasteMapOptions = Readonly<{
     console?: null | undefined | Console;
     enableHastePackages: boolean;
@@ -1113,8 +1123,8 @@ declare module 'metro-file-map/src/plugins/HastePlugin' {
   export default HastePlugin;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/plugins/MockPlugin.js
-declare module 'metro-file-map/src/plugins/MockPlugin' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/plugins/MockPlugin.js
+declare module 'metro-file-map/private/plugins/MockPlugin' {
   import type {
     FileMapDelta,
     FileMapPlugin,
@@ -1122,17 +1132,19 @@ declare module 'metro-file-map/src/plugins/MockPlugin' {
     MockMap as IMockMap,
     Path,
     RawMockMap,
-  } from 'metro-file-map/src/flow-types';
+  } from 'metro-file-map/private/flow-types';
   export const CACHE_VERSION: 2;
   class MockPlugin implements FileMapPlugin<RawMockMap>, IMockMap {
     readonly name: any;
-    constructor($$PARAM_0$$: {
-      console: typeof console;
-      mocksPattern: RegExp;
-      rawMockMap?: RawMockMap;
-      rootDir: Path;
-      throwOnModuleCollision: boolean;
-    });
+    constructor(
+      $$PARAM_0$$: Readonly<{
+        console: typeof console;
+        mocksPattern: RegExp;
+        rawMockMap?: RawMockMap;
+        rootDir: Path;
+        throwOnModuleCollision: boolean;
+      }>
+    );
     initialize($$PARAM_0$$: FileMapPluginInitOptions<RawMockMap>): Promise<void>;
     getMockModule(name: string): null | undefined | Path;
     bulkUpdate(delta: FileMapDelta): Promise<void>;
@@ -1144,14 +1156,14 @@ declare module 'metro-file-map/src/plugins/MockPlugin' {
   export default MockPlugin;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/plugins/mocks/getMockName.js
-declare module 'metro-file-map/src/plugins/mocks/getMockName' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/plugins/mocks/getMockName.js
+declare module 'metro-file-map/private/plugins/mocks/getMockName' {
   const getMockName: (filePath: string) => string;
   export default getMockName;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/Watcher.js
-declare module 'metro-file-map/src/Watcher' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/Watcher.js
+declare module 'metro-file-map/private/Watcher' {
   import type {
     Console,
     CrawlerOptions,
@@ -1161,8 +1173,8 @@ declare module 'metro-file-map/src/Watcher' {
     WatcherBackend,
     WatcherBackendChangeEvent,
     WatchmanClocks,
-  } from 'metro-file-map/src/flow-types';
-  import EventEmitter from 'events';
+  } from 'metro-file-map/private/flow-types';
+  import EventEmitter from 'node:events';
   type CrawlResult = {
     changedFiles: FileData;
     clocks?: WatchmanClocks;
@@ -1221,9 +1233,12 @@ declare module 'metro-file-map/src/Watcher' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/watchers/AbstractWatcher.js
-declare module 'metro-file-map/src/watchers/AbstractWatcher' {
-  import type { WatcherBackend, WatcherBackendChangeEvent } from 'metro-file-map/src/flow-types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/watchers/AbstractWatcher.js
+declare module 'metro-file-map/private/watchers/AbstractWatcher' {
+  import type {
+    WatcherBackend,
+    WatcherBackendChangeEvent,
+  } from 'metro-file-map/private/flow-types';
   export type Listeners = Readonly<{
     onFileEvent: (event: WatcherBackendChangeEvent) => void;
     onError: (error: Error) => void;
@@ -1252,10 +1267,10 @@ declare module 'metro-file-map/src/watchers/AbstractWatcher' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/watchers/common.js
-declare module 'metro-file-map/src/watchers/common' {
-  import type { ChangeEventMetadata } from 'metro-file-map/src/flow-types';
-  import type { Stats } from 'fs';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/watchers/common.js
+declare module 'metro-file-map/private/watchers/common' {
+  import type { ChangeEventMetadata } from 'metro-file-map/private/flow-types';
+  import type { Stats } from 'node:fs';
   /**
    * Constants
    */
@@ -1293,15 +1308,15 @@ declare module 'metro-file-map/src/watchers/common' {
   export function typeFromStat(stat: Stats): null | undefined | ChangeEventMetadata['type'];
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/watchers/FallbackWatcher.js
-declare module 'metro-file-map/src/watchers/FallbackWatcher' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/watchers/FallbackWatcher.js
+declare module 'metro-file-map/private/watchers/FallbackWatcher' {
   const $$EXPORT_DEFAULT_DECLARATION$$: any;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/watchers/NativeWatcher.js
-declare module 'metro-file-map/src/watchers/NativeWatcher' {
-  import { AbstractWatcher } from 'metro-file-map/src/watchers/AbstractWatcher';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/watchers/NativeWatcher.js
+declare module 'metro-file-map/private/watchers/NativeWatcher' {
+  import { AbstractWatcher } from 'metro-file-map/private/watchers/AbstractWatcher';
   /**
    * NativeWatcher uses Node's native fs.watch API with recursive: true.
    *
@@ -1339,8 +1354,8 @@ declare module 'metro-file-map/src/watchers/NativeWatcher' {
   export default NativeWatcher;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/watchers/RecrawlWarning.js
-declare module 'metro-file-map/src/watchers/RecrawlWarning' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/watchers/RecrawlWarning.js
+declare module 'metro-file-map/private/watchers/RecrawlWarning' {
   class RecrawlWarning {
     static RECRAWL_WARNINGS: RecrawlWarning[];
     static REGEXP: RegExp;
@@ -1353,11 +1368,11 @@ declare module 'metro-file-map/src/watchers/RecrawlWarning' {
   export default RecrawlWarning;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/watchers/WatchmanWatcher.js
-declare module 'metro-file-map/src/watchers/WatchmanWatcher' {
-  import type { WatcherOptions } from 'metro-file-map/src/watchers/common';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/watchers/WatchmanWatcher.js
+declare module 'metro-file-map/private/watchers/WatchmanWatcher' {
+  import type { WatcherOptions } from 'metro-file-map/private/watchers/common';
   import type { Client, WatchmanFileChange, WatchmanSubscriptionEvent } from 'fb-watchman';
-  import { AbstractWatcher } from 'metro-file-map/src/watchers/AbstractWatcher';
+  import { AbstractWatcher } from 'metro-file-map/private/watchers/AbstractWatcher';
   /**
    * Watches `dir`.
    */
@@ -1386,13 +1401,13 @@ declare module 'metro-file-map/src/watchers/WatchmanWatcher' {
   export default WatchmanWatcher;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/worker.js
-declare module 'metro-file-map/src/worker' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/worker.js
+declare module 'metro-file-map/private/worker' {
   export function worker(data: any): void;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-file-map/src/workerExclusionList.js
-declare module 'metro-file-map/src/workerExclusionList' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/workerExclusionList.js
+declare module 'metro-file-map/private/workerExclusionList' {
   const extensions: any;
   export default extensions;
 }

--- a/packages/@expo/cli/ts-declarations/metro-file-map/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-file-map/index.d.ts
@@ -249,7 +249,7 @@ declare module 'metro-file-map/private/flow-types' {
     files: FileSystemState;
     pluginState?: null | SerializableState;
   }>;
-  type V8Serializable = {};
+  type V8Serializable = object;
   export interface FileMapPlugin<SerializableState = V8Serializable> {
     readonly name: string;
     initialize(initOptions: FileMapPluginInitOptions<SerializableState>): Promise<void>;

--- a/packages/@expo/cli/ts-declarations/metro-file-map/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-file-map/index.d.ts
@@ -1,7 +1,7 @@
 // #region metro-file-map
 declare module 'metro-file-map' {
-  export * from 'metro-file-map/src/index';
-  export { default } from 'metro-file-map/src/index';
+  export * from 'metro-file-map/private/index';
+  export { default } from 'metro-file-map/private/index';
 }
 
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-file-map/src/cache/DiskCacheManager.js

--- a/packages/@expo/cli/ts-declarations/metro-resolver/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-resolver/index.d.ts
@@ -3,10 +3,10 @@ declare module 'metro-resolver' {
   export * from 'metro-resolver/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/createDefaultContext.js
-declare module 'metro-resolver/src/createDefaultContext' {
-  import type { ResolutionContext } from 'metro-resolver/src/types';
-  import type { TransformResultDependency } from 'metro/src/DeltaBundler/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/createDefaultContext.js
+declare module 'metro-resolver/private/createDefaultContext' {
+  import type { ResolutionContext } from 'metro-resolver/private/types';
+  import type { TransformResultDependency } from 'metro/private/DeltaBundler/types.flow';
   type PartialContext = Readonly<
     {
       redirectModulePath?: ResolutionContext['redirectModulePath'];
@@ -24,8 +24,8 @@ declare module 'metro-resolver/src/createDefaultContext' {
   export default createDefaultContext;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/FailedToResolveNameError.js
-declare module 'metro-resolver/src/errors/FailedToResolveNameError' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/errors/FailedToResolveNameError.js
+declare module 'metro-resolver/private/errors/FailedToResolveNameError' {
   class FailedToResolveNameError extends Error {
     dirPaths: readonly string[];
     extraPaths: readonly string[];
@@ -34,9 +34,9 @@ declare module 'metro-resolver/src/errors/FailedToResolveNameError' {
   export default FailedToResolveNameError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/FailedToResolvePathError.js
-declare module 'metro-resolver/src/errors/FailedToResolvePathError' {
-  import type { FileAndDirCandidates } from 'metro-resolver/src/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/errors/FailedToResolvePathError.js
+declare module 'metro-resolver/private/errors/FailedToResolvePathError' {
+  import type { FileAndDirCandidates } from 'metro-resolver/private/types';
   class FailedToResolvePathError extends Error {
     candidates: FileAndDirCandidates;
     constructor(candidates: FileAndDirCandidates);
@@ -44,23 +44,23 @@ declare module 'metro-resolver/src/errors/FailedToResolvePathError' {
   export default FailedToResolvePathError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/FailedToResolveUnsupportedError.js
-declare module 'metro-resolver/src/errors/FailedToResolveUnsupportedError' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/errors/FailedToResolveUnsupportedError.js
+declare module 'metro-resolver/private/errors/FailedToResolveUnsupportedError' {
   class FailedToResolveUnsupportedError extends Error {
     constructor(message: string);
   }
   export default FailedToResolveUnsupportedError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/formatFileCandidates.js
-declare module 'metro-resolver/src/errors/formatFileCandidates' {
-  import type { FileCandidates } from 'metro-resolver/src/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/errors/formatFileCandidates.js
+declare module 'metro-resolver/private/errors/formatFileCandidates' {
+  import type { FileCandidates } from 'metro-resolver/private/types';
   function formatFileCandidates(candidates: FileCandidates): string;
   export default formatFileCandidates;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/InvalidPackageConfigurationError.js
-declare module 'metro-resolver/src/errors/InvalidPackageConfigurationError' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/errors/InvalidPackageConfigurationError.js
+declare module 'metro-resolver/private/errors/InvalidPackageConfigurationError' {
   /**
    * Raised when a package contains an invalid `package.json` configuration.
    */
@@ -77,9 +77,9 @@ declare module 'metro-resolver/src/errors/InvalidPackageConfigurationError' {
   export default InvalidPackageConfigurationError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/InvalidPackageError.js
-declare module 'metro-resolver/src/errors/InvalidPackageError' {
-  import type { FileCandidates } from 'metro-resolver/src/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/errors/InvalidPackageError.js
+declare module 'metro-resolver/private/errors/InvalidPackageError' {
+  import type { FileCandidates } from 'metro-resolver/private/types';
   class InvalidPackageError extends Error {
     fileCandidates: FileCandidates;
     indexCandidates: FileCandidates;
@@ -95,8 +95,8 @@ declare module 'metro-resolver/src/errors/InvalidPackageError' {
   export default InvalidPackageError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/PackageImportNotResolvedError.js
-declare module 'metro-resolver/src/errors/PackageImportNotResolvedError' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/errors/PackageImportNotResolvedError.js
+declare module 'metro-resolver/private/errors/PackageImportNotResolvedError' {
   /**
    * Raised when package imports do not define or permit a target subpath in the
    * package for the given import specifier.
@@ -114,8 +114,8 @@ declare module 'metro-resolver/src/errors/PackageImportNotResolvedError' {
   export default PackageImportNotResolvedError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/errors/PackagePathNotExportedError.js
-declare module 'metro-resolver/src/errors/PackagePathNotExportedError' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/errors/PackagePathNotExportedError.js
+declare module 'metro-resolver/private/errors/PackagePathNotExportedError' {
   /**
    * Raised when package exports do not define or permit a target subpath in the
    * package for the given module.
@@ -124,9 +124,9 @@ declare module 'metro-resolver/src/errors/PackagePathNotExportedError' {
   export default PackagePathNotExportedError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/index.js
-declare module 'metro-resolver/src/index' {
-  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/index.js
+declare module 'metro-resolver/private/index' {
+  // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/index.js
 
   export type {
     AssetFileResolution,
@@ -142,20 +142,24 @@ declare module 'metro-resolver/src/index' {
     Resolution,
     ResolveAsset,
     Result,
-  } from 'metro-resolver/src/types';
+  } from 'metro-resolver/private/types';
 
   // NOTE(cedric): the flow translation API can't resolve types when using inline requires in object properties
-  export { default as FailedToResolveNameError } from 'metro-resolver/src/errors/FailedToResolveNameError';
-  export { default as FailedToResolvePathError } from 'metro-resolver/src/errors/FailedToResolvePathError';
-  export { default as FailedToResolveUnsupportedError } from 'metro-resolver/src/errors/FailedToResolveUnsupportedError';
-  export { default as formatFileCandidates } from 'metro-resolver/src/errors/formatFileCandidates';
-  export { default as InvalidPackageError } from 'metro-resolver/src/errors/InvalidPackageError';
-  export { default as resolve } from 'metro-resolver/src/resolve';
+  export { default as FailedToResolveNameError } from 'metro-resolver/private/errors/FailedToResolveNameError';
+  export { default as FailedToResolvePathError } from 'metro-resolver/private/errors/FailedToResolvePathError';
+  export { default as FailedToResolveUnsupportedError } from 'metro-resolver/private/errors/FailedToResolveUnsupportedError';
+  export { default as formatFileCandidates } from 'metro-resolver/private/errors/formatFileCandidates';
+  export { default as InvalidPackageError } from 'metro-resolver/private/errors/InvalidPackageError';
+  export { default as resolve } from 'metro-resolver/private/resolve';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/PackageExportsResolve.js
-declare module 'metro-resolver/src/PackageExportsResolve' {
-  import type { ExportsField, FileResolution, ResolutionContext } from 'metro-resolver/src/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/PackageExportsResolve.js
+declare module 'metro-resolver/private/PackageExportsResolve' {
+  import type {
+    ExportsField,
+    FileResolution,
+    ResolutionContext,
+  } from 'metro-resolver/private/types';
   export function resolvePackageTargetFromExports(
     context: ResolutionContext,
     packagePath: string,
@@ -166,9 +170,13 @@ declare module 'metro-resolver/src/PackageExportsResolve' {
   ): FileResolution;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/PackageImportsResolve.js
-declare module 'metro-resolver/src/PackageImportsResolve' {
-  import type { ExportsLikeMap, FileResolution, ResolutionContext } from 'metro-resolver/src/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/PackageImportsResolve.js
+declare module 'metro-resolver/private/PackageImportsResolve' {
+  import type {
+    ExportsLikeMap,
+    FileResolution,
+    ResolutionContext,
+  } from 'metro-resolver/private/types';
   /**
    * Resolve a package subpath based on the entry points defined in the package's
    * "imports" field. If there is no match for the given subpath (which may be
@@ -189,9 +197,9 @@ declare module 'metro-resolver/src/PackageImportsResolve' {
   ): FileResolution;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/PackageResolve.js
-declare module 'metro-resolver/src/PackageResolve' {
-  import type { PackageInfo, ResolutionContext } from 'metro-resolver/src/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/PackageResolve.js
+declare module 'metro-resolver/private/PackageResolve' {
+  import type { PackageInfo, ResolutionContext } from 'metro-resolver/private/types';
   /**
    * Resolve the main entry point subpath for a package.
    *
@@ -223,9 +231,9 @@ declare module 'metro-resolver/src/PackageResolve' {
   ): string | false;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/resolve.js
-declare module 'metro-resolver/src/resolve' {
-  import type { Resolution, ResolutionContext } from 'metro-resolver/src/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/resolve.js
+declare module 'metro-resolver/private/resolve' {
+  import type { Resolution, ResolutionContext } from 'metro-resolver/private/types';
   function resolve(
     context: ResolutionContext,
     moduleName: string,
@@ -234,9 +242,9 @@ declare module 'metro-resolver/src/resolve' {
   export default resolve;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/resolveAsset.js
-declare module 'metro-resolver/src/resolveAsset' {
-  import type { AssetResolution, ResolutionContext } from 'metro-resolver/src/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/resolveAsset.js
+declare module 'metro-resolver/private/resolveAsset' {
+  import type { AssetResolution, ResolutionContext } from 'metro-resolver/private/types';
   /**
    * Resolve a file path as an asset. Returns the set of files found after
    * expanding asset resolutions (e.g. `icon@2x.png`). Users may override this
@@ -246,9 +254,9 @@ declare module 'metro-resolver/src/resolveAsset' {
   export default resolveAsset;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/types.js
-declare module 'metro-resolver/src/types' {
-  import type { TransformResultDependency } from 'metro/src/DeltaBundler/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/types.js
+declare module 'metro-resolver/private/types' {
+  import type { TransformResultDependency } from 'metro/private/DeltaBundler/types.flow';
   export type Result<TResolution, TCandidates> =
     | {
         readonly type: 'resolved';
@@ -455,8 +463,8 @@ declare module 'metro-resolver/src/types' {
   };
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/utils/isAssetFile.js
-declare module 'metro-resolver/src/utils/isAssetFile' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/utils/isAssetFile.js
+declare module 'metro-resolver/private/utils/isAssetFile' {
   /**
    * Determine if a file path should be considered an asset file based on the
    * given `assetExts`.
@@ -465,23 +473,23 @@ declare module 'metro-resolver/src/utils/isAssetFile' {
   export default isAssetFile;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/utils/isSubpathDefinedInExportsLike.js
-declare module 'metro-resolver/src/utils/isSubpathDefinedInExportsLike' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/utils/isSubpathDefinedInExportsLike.js
+declare module 'metro-resolver/private/utils/isSubpathDefinedInExportsLike' {
   /**
    * Identifies whether the given subpath is defined in the given "exports"-like
    * mapping. Does not reduce exports conditions (therefore does not identify
    * whether the subpath is mapped to a value).
    */
-  import type { NormalizedExportsLikeMap } from 'metro-resolver/src/types';
+  import type { NormalizedExportsLikeMap } from 'metro-resolver/private/types';
   export function isSubpathDefinedInExportsLike(
     exportsLikeMap: NormalizedExportsLikeMap,
     subpath: string
   ): boolean;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/utils/matchSubpathFromExportsLike.js
-declare module 'metro-resolver/src/utils/matchSubpathFromExportsLike' {
-  import type { NormalizedExportsLikeMap, ResolutionContext } from 'metro-resolver/src/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/utils/matchSubpathFromExportsLike.js
+declare module 'metro-resolver/private/utils/matchSubpathFromExportsLike' {
+  import type { NormalizedExportsLikeMap, ResolutionContext } from 'metro-resolver/private/types';
   /**
    * Get the mapped replacement for the given subpath.
    *
@@ -500,8 +508,8 @@ declare module 'metro-resolver/src/utils/matchSubpathFromExportsLike' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/utils/matchSubpathPattern.js
-declare module 'metro-resolver/src/utils/matchSubpathPattern' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/utils/matchSubpathPattern.js
+declare module 'metro-resolver/private/utils/matchSubpathPattern' {
   /**
    * If a subpath pattern expands to the passed subpath, return the subpath match
    * (value to substitute for '*'). Otherwise, return `null`.
@@ -511,13 +519,13 @@ declare module 'metro-resolver/src/utils/matchSubpathPattern' {
   export function matchSubpathPattern(subpathPattern: string, subpath: string): string | null;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/utils/reduceExportsLikeMap.js
-declare module 'metro-resolver/src/utils/reduceExportsLikeMap' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/utils/reduceExportsLikeMap.js
+declare module 'metro-resolver/private/utils/reduceExportsLikeMap' {
   /**
    * Reduce an "exports"-like mapping to a flat subpath mapping after resolving
    * conditional exports.
    */
-  import type { FlattenedExportMap, NormalizedExportsLikeMap } from 'metro-resolver/src/types';
+  import type { FlattenedExportMap, NormalizedExportsLikeMap } from 'metro-resolver/private/types';
   export function reduceExportsLikeMap(
     exportsLikeMap: NormalizedExportsLikeMap,
     conditionNames: ReadonlySet<string>,
@@ -525,8 +533,8 @@ declare module 'metro-resolver/src/utils/reduceExportsLikeMap' {
   ): FlattenedExportMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-resolver/src/utils/toPosixPath.js
-declare module 'metro-resolver/src/utils/toPosixPath' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/utils/toPosixPath.js
+declare module 'metro-resolver/private/utils/toPosixPath' {
   /**
    * Replace path separators in the passed string to coerce to a POSIX path. This
    * is a no-op on POSIX systems.

--- a/packages/@expo/cli/ts-declarations/metro-resolver/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-resolver/index.d.ts
@@ -1,6 +1,6 @@
 // #region metro-resolver
 declare module 'metro-resolver' {
-  export * from 'metro-resolver/src/index';
+  export * from 'metro-resolver/private/index';
 }
 
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-resolver/src/createDefaultContext.js

--- a/packages/@expo/cli/ts-declarations/metro-runtime/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-runtime/index.d.ts
@@ -1,8 +1,8 @@
 // #region metro-runtime
 // metro-runtime has no entrypoint
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/modules/asyncRequire.js
-declare module 'metro-runtime/src/modules/asyncRequire' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-runtime/src/modules/asyncRequire.js
+declare module 'metro-runtime/private/modules/asyncRequire' {
   type DependencyMapPaths =
     | null
     | undefined
@@ -17,15 +17,15 @@ declare module 'metro-runtime/src/modules/asyncRequire' {
   export default asyncRequire;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/modules/empty-module.js
-declare module 'metro-runtime/src/modules/empty-module' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-runtime/src/modules/empty-module.js
+declare module 'metro-runtime/private/modules/empty-module' {
   // This has no exports
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/modules/HMRClient.js
-declare module 'metro-runtime/src/modules/HMRClient' {
-  import type { HmrUpdate } from 'metro-runtime/src/modules/types.flow';
-  import EventEmitter from 'metro-runtime/src/modules/vendor/eventemitter3';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-runtime/src/modules/HMRClient.js
+declare module 'metro-runtime/private/modules/HMRClient' {
+  import type { HmrUpdate } from 'metro-runtime/private/modules/types.flow';
+  import EventEmitter from 'metro-runtime/private/modules/vendor/eventemitter3';
   type SocketState = 'opening' | 'open' | 'closed';
   class HMRClient extends EventEmitter {
     _isEnabled: boolean;
@@ -45,14 +45,14 @@ declare module 'metro-runtime/src/modules/HMRClient' {
   export default HMRClient;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/modules/null-module.js
-declare module 'metro-runtime/src/modules/null-module' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-runtime/src/modules/null-module.js
+declare module 'metro-runtime/private/modules/null-module' {
   const $$EXPORT_DEFAULT_DECLARATION$$: null;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/modules/types.flow.js
-declare module 'metro-runtime/src/modules/types.flow' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-runtime/src/modules/types.flow.js
+declare module 'metro-runtime/private/modules/types.flow' {
   export type ModuleMap = readonly [number, string][];
   export type Bundle = {
     readonly modules: ModuleMap;
@@ -144,9 +144,9 @@ declare module 'metro-runtime/src/modules/types.flow' {
     | HmrErrorMessage;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/modules/vendor/eventemitter3.js
-declare module 'metro-runtime/src/modules/vendor/eventemitter3' {
-  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/modules/vendor/eventemitter3.js
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-runtime/src/modules/vendor/eventemitter3.js
+declare module 'metro-runtime/private/modules/vendor/eventemitter3' {
+  // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-runtime/src/modules/vendor/eventemitter3.js
 
   /**
    * `object` should be in either of the following forms:
@@ -231,8 +231,8 @@ declare module 'metro-runtime/src/modules/vendor/eventemitter3' {
   export default EventEmitter;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-runtime/src/polyfills/require.js
-declare module 'metro-runtime/src/polyfills/require' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-runtime/src/polyfills/require.js
+declare module 'metro-runtime/private/polyfills/require' {
   type ArrayIndexable<T> = {
     readonly [indexer: number]: T;
   };

--- a/packages/@expo/cli/ts-declarations/metro-runtime/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-runtime/index.d.ts
@@ -1,5 +1,23 @@
 // #region metro-runtime
-// metro-runtime has no entrypoint
+declare module 'metro-runtime/modules/asyncRequire' {
+  export { default } from 'metro-runtime/private/modules/asyncRequire';
+}
+
+declare module 'metro-runtime/modules/empty-module' {
+  // This has no exports
+}
+
+declare module 'metro-runtime/modules/HMRClient' {
+  export { default } from 'metro-runtime/private/modules/HMRClient';
+}
+
+declare module 'metro-runtime/modules/null-module' {
+  export { default } from 'metro-runtime/private/modules/null-module';
+}
+
+declare module 'metro-runtime/polyfills/require' {
+  export * from 'metro-runtime/private/polyfills/require';
+}
 
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-runtime/src/modules/asyncRequire.js
 declare module 'metro-runtime/private/modules/asyncRequire' {

--- a/packages/@expo/cli/ts-declarations/metro-source-map/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-source-map/index.d.ts
@@ -1,6 +1,6 @@
 // #region metro-source-map
 declare module 'metro-source-map' {
-  export * from 'metro-source-map/src/source-map';
+  export * from 'metro-source-map/private/source-map';
 }
 
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/B64Builder.js

--- a/packages/@expo/cli/ts-declarations/metro-source-map/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-source-map/index.d.ts
@@ -3,8 +3,8 @@ declare module 'metro-source-map' {
   export * from 'metro-source-map/src/source-map';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/B64Builder.js
-declare module 'metro-source-map/src/B64Builder' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/B64Builder.js
+declare module 'metro-source-map/private/B64Builder' {
   /**
    * Efficient builder for base64 VLQ mappings strings.
    *
@@ -32,9 +32,13 @@ declare module 'metro-source-map/src/B64Builder' {
   export default B64Builder;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/BundleBuilder.js
-declare module 'metro-source-map/src/BundleBuilder' {
-  import type { IndexMap, IndexMapSection, MixedSourceMap } from 'metro-source-map/src/source-map';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/BundleBuilder.js
+declare module 'metro-source-map/private/BundleBuilder' {
+  import type {
+    IndexMap,
+    IndexMapSection,
+    MixedSourceMap,
+  } from 'metro-source-map/private/source-map';
   export class BundleBuilder {
     _file: string;
     _sections: IndexMapSection[];
@@ -52,22 +56,22 @@ declare module 'metro-source-map/src/BundleBuilder' {
   export function createIndexMap(file: string, sections: IndexMapSection[]): IndexMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/composeSourceMaps.js
-declare module 'metro-source-map/src/composeSourceMaps' {
-  import type { MixedSourceMap } from 'metro-source-map/src/source-map';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/composeSourceMaps.js
+declare module 'metro-source-map/private/composeSourceMaps' {
+  import type { MixedSourceMap } from 'metro-source-map/private/source-map';
   function composeSourceMaps(maps: readonly MixedSourceMap[]): MixedSourceMap;
   export default composeSourceMaps;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/AbstractConsumer.js
-declare module 'metro-source-map/src/Consumer/AbstractConsumer' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/Consumer/AbstractConsumer.js
+declare module 'metro-source-map/private/Consumer/AbstractConsumer' {
   import type {
     GeneratedPositionLookup,
     IConsumer,
     IterationOrder,
     Mapping,
     SourcePosition,
-  } from 'metro-source-map/src/Consumer/types.flow';
+  } from 'metro-source-map/private/Consumer/types.flow';
   class AbstractConsumer implements IConsumer {
     _sourceMap: {
       readonly file?: string;
@@ -82,13 +86,12 @@ declare module 'metro-source-map/src/Consumer/AbstractConsumer' {
   export default AbstractConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/constants.js
-declare module 'metro-source-map/src/Consumer/constants' {
-  import type { Number0, Number1 } from 'ob1';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/Consumer/constants.js
+declare module 'metro-source-map/private/Consumer/constants' {
   export type IterationOrder = unknown;
   export type LookupBias = unknown;
-  export const FIRST_COLUMN: Number0;
-  export const FIRST_LINE: Number1;
+  export const FIRST_COLUMN: number;
+  export const FIRST_LINE: number;
   export const GENERATED_ORDER: IterationOrder;
   export const ORIGINAL_ORDER: IterationOrder;
   export const GREATEST_LOWER_BOUND: LookupBias;
@@ -98,25 +101,25 @@ declare module 'metro-source-map/src/Consumer/constants' {
   export function lookupBiasToString(x: LookupBias): string;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/createConsumer.js
-declare module 'metro-source-map/src/Consumer/createConsumer' {
-  import type { MixedSourceMap } from 'metro-source-map/src/source-map';
-  import type { IConsumer } from 'metro-source-map/src/Consumer/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/Consumer/createConsumer.js
+declare module 'metro-source-map/private/Consumer/createConsumer' {
+  import type { MixedSourceMap } from 'metro-source-map/private/source-map';
+  import type { IConsumer } from 'metro-source-map/private/Consumer/types.flow';
   function createConsumer(sourceMap: MixedSourceMap): IConsumer;
   export default createConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/DelegatingConsumer.js
-declare module 'metro-source-map/src/Consumer/DelegatingConsumer' {
-  import type { MixedSourceMap } from 'metro-source-map/src/source-map';
-  import type { LookupBias } from 'metro-source-map/src/Consumer/constants';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/Consumer/DelegatingConsumer.js
+declare module 'metro-source-map/private/Consumer/DelegatingConsumer' {
+  import type { MixedSourceMap } from 'metro-source-map/private/source-map';
+  import type { LookupBias } from 'metro-source-map/private/Consumer/constants.js';
   import type {
     GeneratedPositionLookup,
     IConsumer,
     IterationOrder,
     Mapping,
     SourcePosition,
-  } from 'metro-source-map/src/Consumer/types.flow';
+  } from 'metro-source-map/private/Consumer/types.flow';
   /**
    * A source map consumer that supports both "basic" and "indexed" source maps.
    * Uses `MappingsConsumer` and `SectionsConsumer` under the hood (via
@@ -138,24 +141,21 @@ declare module 'metro-source-map/src/Consumer/DelegatingConsumer' {
   export default DelegatingConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/index.js
-declare module 'metro-source-map/src/Consumer/index' {
-  export { default as DelegatingConsumer } from 'metro-source-map/src/Consumer/DelegatingConsumer';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/Consumer/index.js
+declare module 'metro-source-map/private/Consumer/index' {
+  export { default as DelegatingConsumer } from 'metro-source-map/private/Consumer/DelegatingConsumer';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/MappingsConsumer.js
-declare module 'metro-source-map/src/Consumer/MappingsConsumer' {
-  import type { BasicSourceMap } from 'metro-source-map/src/source-map';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/Consumer/MappingsConsumer.js
+declare module 'metro-source-map/private/Consumer/MappingsConsumer' {
+  import type { BasicSourceMap } from 'metro-source-map/private/source-map';
   import type {
     GeneratedPositionLookup,
     IConsumer,
     Mapping,
     SourcePosition,
-  } from 'metro-source-map/src/Consumer/types.flow';
-  // import type { Number0 } from 'ob1';
-  // NOTE(cedric): ob1 is not typed
-  type Number0 = number;
-  import AbstractConsumer from 'metro-source-map/src/Consumer/AbstractConsumer';
+  } from 'metro-source-map/private/Consumer/types.flow';
+  import AbstractConsumer from 'metro-source-map/private/Consumer/AbstractConsumer';
   /**
    * A source map consumer that supports "basic" source maps (that have a
    * `mappings` field and no sections).
@@ -170,14 +170,14 @@ declare module 'metro-source-map/src/Consumer/MappingsConsumer' {
     _normalizeAndCacheSources(): readonly string[];
     _decodeAndCacheMappings(): readonly Mapping[];
     generatedMappings(): Iterable<Mapping>;
-    _indexOfSource(source: string): null | undefined | Number0;
+    _indexOfSource(source: string): null | undefined | number;
     sourceContentFor(source: string, nullOnMissing: true): null | undefined | string;
   }
   export default MappingsConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/normalizeSourcePath.js
-declare module 'metro-source-map/src/Consumer/normalizeSourcePath' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/Consumer/normalizeSourcePath.js
+declare module 'metro-source-map/private/Consumer/normalizeSourcePath' {
   function normalizeSourcePath(
     sourceInput: string,
     map: {
@@ -187,29 +187,25 @@ declare module 'metro-source-map/src/Consumer/normalizeSourcePath' {
   export default normalizeSourcePath;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/positionMath.js
-declare module 'metro-source-map/src/Consumer/positionMath' {
-  import type { GeneratedOffset } from 'metro-source-map/src/Consumer/types.flow';
-  // import type { Number0, Number1 } from 'ob1';
-  // NOTE(cedric): ob1 is not typed
-  type Number0 = number;
-  type Number1 = number;
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/Consumer/positionMath.js
+declare module 'metro-source-map/private/Consumer/positionMath' {
+  import type { GeneratedOffset } from 'metro-source-map/private/Consumer/types.flow';
   export function shiftPositionByOffset<
     T extends {
-      readonly line?: null | Number1;
-      readonly column?: null | Number0;
+      readonly line?: null | number;
+      readonly column?: null | number;
     },
   >(pos: T, offset: GeneratedOffset): T;
   export function subtractOffsetFromPosition<
     T extends {
-      readonly line?: null | Number1;
-      readonly column?: null | Number0;
+      readonly line?: null | number;
+      readonly column?: null | number;
     },
   >(pos: T, offset: GeneratedOffset): T;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/search.js
-declare module 'metro-source-map/src/Consumer/search' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/Consumer/search.js
+declare module 'metro-source-map/private/Consumer/search' {
   export function greatestLowerBound<T, U>(
     elements: readonly T[],
     target: U,
@@ -217,17 +213,17 @@ declare module 'metro-source-map/src/Consumer/search' {
   ): null | undefined | number;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/SectionsConsumer.js
-declare module 'metro-source-map/src/Consumer/SectionsConsumer' {
-  import type { IndexMap } from 'metro-source-map/src/source-map';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/Consumer/SectionsConsumer.js
+declare module 'metro-source-map/private/Consumer/SectionsConsumer' {
+  import type { IndexMap } from 'metro-source-map/private/source-map';
   import type {
     GeneratedOffset,
     GeneratedPositionLookup,
     IConsumer,
     Mapping,
     SourcePosition,
-  } from 'metro-source-map/src/Consumer/types.flow';
-  import AbstractConsumer from 'metro-source-map/src/Consumer/AbstractConsumer';
+  } from 'metro-source-map/private/Consumer/types.flow';
+  import AbstractConsumer from 'metro-source-map/private/Consumer/AbstractConsumer';
   /**
    * A source map consumer that supports "indexed" source maps (that have a
    * `sections` field and no top-level mappings).
@@ -245,41 +241,37 @@ declare module 'metro-source-map/src/Consumer/SectionsConsumer' {
   export default SectionsConsumer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Consumer/types.flow.js
-declare module 'metro-source-map/src/Consumer/types.flow' {
-  import type { IterationOrder, LookupBias } from 'metro-source-map/src/Consumer/constants';
-  // import type { Number0, Number1 } from 'ob1';
-  // NOTE(cedric): ob1 is not typed
-  type Number0 = number;
-  type Number1 = number;
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/Consumer/types.flow.js
+declare module 'metro-source-map/private/Consumer/types.flow' {
+  import type { IterationOrder, LookupBias } from 'metro-source-map/private/Consumer/constants';
   export type { IterationOrder, LookupBias };
   export type GeneratedOffset = {
-    readonly lines: Number0;
-    readonly columns: Number0;
+    readonly lines: number;
+    readonly columns: number;
   };
   export type SourcePosition = {
     source?: null | string;
-    line?: null | Number1;
-    column?: null | Number0;
+    line?: null | number;
+    column?: null | number;
     name?: null | string;
   };
   export type GeneratedPosition = {
-    readonly line: Number1;
-    readonly column: Number0;
+    readonly line: number;
+    readonly column: number;
   };
   export type GeneratedPositionLookup = {
-    readonly line?: null | Number1;
-    readonly column?: null | Number0;
+    readonly line?: null | number;
+    readonly column?: null | number;
     readonly bias?: LookupBias;
   };
-  export type Mapping = {
+  export type Mapping = Readonly<{
     source?: null | string;
-    generatedLine: Number1;
-    generatedColumn: Number0;
-    originalLine?: null | Number1;
-    originalColumn?: null | Number0;
+    generatedLine: number;
+    generatedColumn: number;
+    originalLine?: null | number;
+    originalColumn?: null | number;
     name?: null | string;
-  };
+  }>;
   export interface IConsumer {
     originalPositionFor(generatedPosition: GeneratedPositionLookup): SourcePosition;
     generatedMappings(): Iterable<Mapping>;
@@ -289,8 +281,8 @@ declare module 'metro-source-map/src/Consumer/types.flow' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/encode.js
-declare module 'metro-source-map/src/encode' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/encode.js
+declare module 'metro-source-map/private/encode' {
   /**
    * Encodes a number to base64 VLQ format and appends it to the passed-in buffer
    *
@@ -304,11 +296,11 @@ declare module 'metro-source-map/src/encode' {
   export default encode;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/generateFunctionMap.js
-declare module 'metro-source-map/src/generateFunctionMap' {
-  import type * as _babel_types from '@babel/types';
-  import type { FBSourceFunctionMap } from 'metro-source-map/src/source-map';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/generateFunctionMap.js
+declare module 'metro-source-map/private/generateFunctionMap' {
+  import type { FBSourceFunctionMap } from 'metro-source-map/private/source-map';
   import type { PluginObj } from '@babel/core';
+  import type { Node } from '@babel/types';
   type Position = {
     line: number;
     column: number;
@@ -321,24 +313,21 @@ declare module 'metro-source-map/src/generateFunctionMap' {
     filename?: null | undefined | string;
   };
   export function functionMapBabelPlugin(): PluginObj;
-  export function generateFunctionMap(
-    ast: _babel_types.Node,
-    context?: Context
-  ): FBSourceFunctionMap;
+  export function generateFunctionMap(ast: Node, context?: Context): FBSourceFunctionMap;
   export function generateFunctionMappingsArray(
-    ast: _babel_types.Node,
+    ast: Node,
     context?: Context
   ): readonly RangeMapping[];
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/Generator.js
-declare module 'metro-source-map/src/Generator' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/Generator.js
+declare module 'metro-source-map/private/Generator' {
   import type {
     BasicSourceMap,
     FBSourceFunctionMap,
     FBSourceMetadata,
-  } from 'metro-source-map/src/source-map';
-  import B64Builder from 'metro-source-map/src/B64Builder';
+  } from 'metro-source-map/private/source-map';
+  import B64Builder from 'metro-source-map/private/B64Builder';
   type FileFlags = Readonly<{
     addToIgnoreList?: boolean;
   }>;
@@ -415,10 +404,10 @@ declare module 'metro-source-map/src/Generator' {
   export default Generator;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-source-map/src/source-map.js
-declare module 'metro-source-map/src/source-map' {
-  import type { IConsumer } from 'metro-source-map/src/Consumer/types.flow';
-  import Generator from 'metro-source-map/src/Generator';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/source-map.js
+declare module 'metro-source-map/private/source-map' {
+  import type { IConsumer } from 'metro-source-map/private/Consumer/types.flow';
+  import Generator from 'metro-source-map/private/Generator';
   export type { IConsumer };
   type GeneratedCodeMapping = [number, number];
   type SourceMapping = [number, number, number, number];
@@ -475,11 +464,11 @@ declare module 'metro-source-map/src/source-map' {
     readonly x_google_ignoreList?: void;
   };
   export type MixedSourceMap = IndexMap | BasicSourceMap;
-  export { BundleBuilder } from 'metro-source-map/src/BundleBuilder';
-  export { default as composeSourceMaps } from 'metro-source-map/src/composeSourceMaps';
-  export { default as Consumer } from 'metro-source-map/src/Consumer';
-  export { createIndexMap } from 'metro-source-map/src/BundleBuilder';
-  export { generateFunctionMap } from 'metro-source-map/src/generateFunctionMap';
+  export { BundleBuilder } from 'metro-source-map/private/BundleBuilder';
+  export { default as composeSourceMaps } from 'metro-source-map/private/composeSourceMaps';
+  export { default as Consumer } from 'metro-source-map/private/Consumer';
+  export { createIndexMap } from 'metro-source-map/private/BundleBuilder';
+  export { generateFunctionMap } from 'metro-source-map/private/generateFunctionMap';
   export function fromRawMappings(
     modules: readonly {
       readonly map?: null | MetroSourceMapSegmentTuple[];
@@ -504,15 +493,8 @@ declare module 'metro-source-map/src/source-map' {
     }[],
     offsetLines?: number
   ): Promise<Generator>;
-  export { functionMapBabelPlugin } from 'metro-source-map/src/generateFunctionMap';
-  export { default as normalizeSourcePath } from 'metro-source-map/src/Consumer/normalizeSourcePath';
-  // NOTE(cedric): see https://github.com/facebook/metro/blob/a36e992ac74c5497e58b91d99c2bab21c7fa1451/flow-typed/npm/babel_v7.x.x.js#L23
-  export type BabelSourceMapSegment = {
-    name?: null | string;
-    source?: null | string;
-    generated: { line: number; column: number };
-    original?: { line: number; column: number };
-  } & Record<string, any>;
-  export function toBabelSegments(sourceMap: BasicSourceMap): BabelSourceMapSegment[];
-  export function toSegmentTuple(mapping: BabelSourceMapSegment): MetroSourceMapSegmentTuple;
+  export { functionMapBabelPlugin } from 'metro-source-map/private/generateFunctionMap';
+  export { default as normalizeSourcePath } from 'metro-source-map/private/Consumer/normalizeSourcePath';
+  export function toBabelSegments(sourceMap: BasicSourceMap): any[];
+  export function toSegmentTuple(mapping: any): MetroSourceMapSegmentTuple;
 }

--- a/packages/@expo/cli/ts-declarations/metro-source-map/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-source-map/index.d.ts
@@ -112,7 +112,7 @@ declare module 'metro-source-map/private/Consumer/createConsumer' {
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-source-map/src/Consumer/DelegatingConsumer.js
 declare module 'metro-source-map/private/Consumer/DelegatingConsumer' {
   import type { MixedSourceMap } from 'metro-source-map/private/source-map';
-  import type { LookupBias } from 'metro-source-map/private/Consumer/constants.js';
+  import type { LookupBias } from 'metro-source-map/private/Consumer/constants';
   import type {
     GeneratedPositionLookup,
     IConsumer,
@@ -495,6 +495,13 @@ declare module 'metro-source-map/private/source-map' {
   ): Promise<Generator>;
   export { functionMapBabelPlugin } from 'metro-source-map/private/generateFunctionMap';
   export { default as normalizeSourcePath } from 'metro-source-map/private/Consumer/normalizeSourcePath';
-  export function toBabelSegments(sourceMap: BasicSourceMap): any[];
-  export function toSegmentTuple(mapping: any): MetroSourceMapSegmentTuple;
+  // NOTE(cedric): see https://github.com/facebook/metro/blob/3eeba3d459592aa5128995c8224933f6a23a43f1/flow-typed/npm/babel_v7.x.x.js#L23
+  export type BabelSourceMapSegment = {
+    name?: null | string;
+    source?: null | string;
+    generated: { line: number; column: number };
+    original?: { line: number; column: number };
+  } & Record<string, any>;
+  export function toBabelSegments(sourceMap: BasicSourceMap): BabelSourceMapSegment[];
+  export function toSegmentTuple(mapping: BabelSourceMapSegment): MetroSourceMapSegmentTuple;
 }

--- a/packages/@expo/cli/ts-declarations/metro-transform-plugins/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-transform-plugins/index.d.ts
@@ -32,9 +32,8 @@ declare module 'metro-transform-plugins/private/constant-folding-plugin' {
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-plugins/src/import-export-plugin.js
 declare module 'metro-transform-plugins/private/import-export-plugin' {
   import type { PluginObj } from '@babel/core';
-  import type { Node, Statement, SourceLocation } from '@babel/types';
-  import type * as $$IMPORT_TYPEOF_1$$ from '@babel/types';
-  type Types = typeof $$IMPORT_TYPEOF_1$$;
+  import type * as _babel_types from '@babel/types';
+  type Types = typeof _babel_types;
   export type Options = Readonly<{
     importDefault: string;
     importAll: string;
@@ -46,22 +45,22 @@ declare module 'metro-transform-plugins/private/import-export-plugin' {
   type State = {
     exportAll: {
       file: string;
-      loc?: null | SourceLocation;
+      loc?: null | _babel_types.SourceLocation;
     }[];
     exportDefault: {
       local: string;
-      loc?: null | SourceLocation;
+      loc?: null | _babel_types.SourceLocation;
     }[];
     exportNamed: {
       local: string;
       remote: string;
-      loc?: null | SourceLocation;
+      loc?: null | _babel_types.SourceLocation;
     }[];
     imports: {
-      node: Statement;
+      node: _babel_types.Statement;
     }[];
-    importDefault: Node;
-    importAll: Node;
+    importDefault: _babel_types.Node;
+    importAll: _babel_types.Node;
     opts: Options;
   };
   function importExportPlugin($$PARAM_0$$: { types: Types }): PluginObj<State>;
@@ -112,9 +111,8 @@ declare module 'metro-transform-plugins/private/inline-plugin' {
 
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-plugins/src/inline-requires-plugin.js
 declare module 'metro-transform-plugins/private/inline-requires-plugin' {
-  import type { PluginObj } from '@babel/core';
-  import type * as $$IMPORT_TYPEOF_1$$ from '@babel/core';
-  type Babel = typeof $$IMPORT_TYPEOF_1$$;
+  import type * as _babel_core from '@babel/core';
+  type Babel = typeof _babel_core;
   export type PluginOptions = Readonly<{
     ignoredRequires?: readonly string[];
     inlineableCalls?: readonly string[];
@@ -127,7 +125,7 @@ declare module 'metro-transform-plugins/private/inline-requires-plugin' {
     inlineableCalls: Set<string>;
     membersAssigned: Map<string, Set<string>>;
   };
-  const $$EXPORT_DEFAULT_DECLARATION$$: ($$PARAM_0$$: Babel) => PluginObj<State>;
+  const $$EXPORT_DEFAULT_DECLARATION$$: ($$PARAM_0$$: Babel) => _babel_core.PluginObj<State>;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
@@ -144,12 +142,19 @@ declare module 'metro-transform-plugins/private/normalizePseudoGlobals' {
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-plugins/src/utils/createInlinePlatformChecks.js
 declare module 'metro-transform-plugins/private/utils/createInlinePlatformChecks' {
   import type { Scope } from '@babel/traverse';
-  import type { CallExpression, MemberExpression } from '@babel/types';
-  import type * as $$IMPORT_TYPEOF_1$$ from '@babel/types';
-  type Types = typeof $$IMPORT_TYPEOF_1$$;
+  import type * as _babel_types from '@babel/types';
+  type Types = typeof _babel_types;
   type PlatformChecks = {
-    isPlatformNode: (node: MemberExpression, scope: Scope, isWrappedModule: boolean) => boolean;
-    isPlatformSelectNode: (node: CallExpression, scope: Scope, isWrappedModule: boolean) => boolean;
+    isPlatformNode: (
+      node: _babel_types.MemberExpression,
+      scope: Scope,
+      isWrappedModule: boolean
+    ) => boolean;
+    isPlatformSelectNode: (
+      node: _babel_types.CallExpression,
+      scope: Scope,
+      isWrappedModule: boolean
+    ) => boolean;
   };
   function createInlinePlatformChecks(t: Types, requireName?: string): PlatformChecks;
   export default createInlinePlatformChecks;

--- a/packages/@expo/cli/ts-declarations/metro-transform-plugins/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-transform-plugins/index.d.ts
@@ -3,8 +3,8 @@ declare module 'metro-transform-plugins' {
   export * from 'metro-transform-plugins/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/addParamsToDefineCall.js
-declare module 'metro-transform-plugins/src/addParamsToDefineCall' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-plugins/src/addParamsToDefineCall.js
+declare module 'metro-transform-plugins/private/addParamsToDefineCall' {
   /**
    * Simple way of adding additional parameters to the end of the define calls.
    *
@@ -15,8 +15,8 @@ declare module 'metro-transform-plugins/src/addParamsToDefineCall' {
   export default addParamsToDefineCall;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/constant-folding-plugin.js
-declare module 'metro-transform-plugins/src/constant-folding-plugin' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-plugins/src/constant-folding-plugin.js
+declare module 'metro-transform-plugins/private/constant-folding-plugin' {
   import type { PluginObj } from '@babel/core';
   import type $$IMPORT_TYPEOF_1$$ from '@babel/traverse';
   type Traverse = typeof $$IMPORT_TYPEOF_1$$;
@@ -29,11 +29,12 @@ declare module 'metro-transform-plugins/src/constant-folding-plugin' {
   export default constantFoldingPlugin;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/import-export-plugin.js
-declare module 'metro-transform-plugins/src/import-export-plugin' {
-  import type * as _babel_types from '@babel/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-plugins/src/import-export-plugin.js
+declare module 'metro-transform-plugins/private/import-export-plugin' {
   import type { PluginObj } from '@babel/core';
-  type Types = typeof _babel_types;
+  import type { Node, Statement, SourceLocation } from '@babel/types';
+  import type * as $$IMPORT_TYPEOF_1$$ from '@babel/types';
+  type Types = typeof $$IMPORT_TYPEOF_1$$;
   export type Options = Readonly<{
     importDefault: string;
     importAll: string;
@@ -45,49 +46,48 @@ declare module 'metro-transform-plugins/src/import-export-plugin' {
   type State = {
     exportAll: {
       file: string;
-      loc?: null | _babel_types.SourceLocation;
+      loc?: null | SourceLocation;
     }[];
     exportDefault: {
       local: string;
-      loc?: null | _babel_types.SourceLocation;
+      loc?: null | SourceLocation;
     }[];
     exportNamed: {
       local: string;
       remote: string;
-      loc?: null | _babel_types.SourceLocation;
+      loc?: null | SourceLocation;
     }[];
     imports: {
-      node: _babel_types.Statement;
+      node: Statement;
     }[];
-    importDefault: _babel_types.Node;
-    importAll: _babel_types.Node;
+    importDefault: Node;
+    importAll: Node;
     opts: Options;
   };
   function importExportPlugin($$PARAM_0$$: { types: Types }): PluginObj<State>;
   export default importExportPlugin;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/index.js
-declare module 'metro-transform-plugins/src/index' {
-  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-plugins/src/index.js
+declare module 'metro-transform-plugins/private/index' {
+  // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-plugins/src/index.js
 
   // NOTE(cedric): this is quite a complicated CJS export, this can't be automatically typed
 
-  export type { Options as ImportExportPluginOptions } from 'metro-transform-plugins/src/import-export-plugin';
-  export type { Options as InlinePluginOptions } from 'metro-transform-plugins/src/inline-plugin';
-  export type { PluginOptions as InlineRequiresPluginOptions } from 'metro-transform-plugins/src/inline-requires-plugin';
-
-  export { default as addParamsToDefineCall } from 'metro-transform-plugins/src/addParamsToDefineCall';
-  export { default as constantFoldingPlugin } from 'metro-transform-plugins/src/constant-folding-plugin';
-  export { default as importExportPlugin } from 'metro-transform-plugins/src/import-export-plugin';
-  export { default as inlinePlugin } from 'metro-transform-plugins/src/inline-plugin';
-  export { default as inlineRequiresPlugin } from 'metro-transform-plugins/src/inline-requires-plugin';
-  export { default as normalizePseudoGlobals } from 'metro-transform-plugins/src/normalizePseudoGlobals';
+  export type { Options as ImportExportPluginOptions } from 'metro-transform-plugins/private/import-export-plugin';
+  export type { Options as InlinePluginOptions } from 'metro-transform-plugins/private/inline-plugin';
+  export type { PluginOptions as InlineRequiresPluginOptions } from 'metro-transform-plugins/private/inline-requires-plugin';
+  export { default as addParamsToDefineCall } from 'metro-transform-plugins/private/addParamsToDefineCall';
+  export { default as constantFoldingPlugin } from 'metro-transform-plugins/private/constant-folding-plugin';
+  export { default as importExportPlugin } from 'metro-transform-plugins/private/import-export-plugin';
+  export { default as inlinePlugin } from 'metro-transform-plugins/private/inline-plugin';
+  export { default as inlineRequiresPlugin } from 'metro-transform-plugins/private/inline-requires-plugin';
+  export { default as normalizePseudoGlobals } from 'metro-transform-plugins/private/normalizePseudoGlobals';
   export function getTransformPluginCacheKeyFiles(): string[];
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/inline-plugin.js
-declare module 'metro-transform-plugins/src/inline-plugin' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-plugins/src/inline-plugin.js
+declare module 'metro-transform-plugins/private/inline-plugin' {
   import type { PluginObj } from '@babel/core';
   import type * as $$IMPORT_TYPEOF_1$$ from '@babel/types';
   type Types = typeof $$IMPORT_TYPEOF_1$$;
@@ -110,10 +110,11 @@ declare module 'metro-transform-plugins/src/inline-plugin' {
   export default inlinePlugin;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/inline-requires-plugin.js
-declare module 'metro-transform-plugins/src/inline-requires-plugin' {
-  import type * as _babel_core from '@babel/core';
-  type Babel = typeof _babel_core;
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-plugins/src/inline-requires-plugin.js
+declare module 'metro-transform-plugins/private/inline-requires-plugin' {
+  import type { PluginObj } from '@babel/core';
+  import type * as $$IMPORT_TYPEOF_1$$ from '@babel/core';
+  type Babel = typeof $$IMPORT_TYPEOF_1$$;
   export type PluginOptions = Readonly<{
     ignoredRequires?: readonly string[];
     inlineableCalls?: readonly string[];
@@ -126,36 +127,29 @@ declare module 'metro-transform-plugins/src/inline-requires-plugin' {
     inlineableCalls: Set<string>;
     membersAssigned: Map<string, Set<string>>;
   };
-  const $$EXPORT_DEFAULT_DECLARATION$$: ($$PARAM_0$$: Babel) => _babel_core.PluginObj<State>;
+  const $$EXPORT_DEFAULT_DECLARATION$$: ($$PARAM_0$$: Babel) => PluginObj<State>;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/normalizePseudoGlobals.js
-declare module 'metro-transform-plugins/src/normalizePseudoGlobals' {
-  import type * as _babel_types from '@babel/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-plugins/src/normalizePseudoGlobals.js
+declare module 'metro-transform-plugins/private/normalizePseudoGlobals' {
+  import type { Node } from '@babel/types';
   export type Options = {
     reservedNames: readonly string[];
   };
-  function normalizePseudoglobals(ast: _babel_types.Node, options?: Options): readonly string[];
+  function normalizePseudoglobals(ast: Node, options?: Options): readonly string[];
   export default normalizePseudoglobals;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-plugins/src/utils/createInlinePlatformChecks.js
-declare module 'metro-transform-plugins/src/utils/createInlinePlatformChecks' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-plugins/src/utils/createInlinePlatformChecks.js
+declare module 'metro-transform-plugins/private/utils/createInlinePlatformChecks' {
   import type { Scope } from '@babel/traverse';
-  import type * as _babel_types from '@babel/types';
-  type Types = typeof _babel_types;
+  import type { CallExpression, MemberExpression } from '@babel/types';
+  import type * as $$IMPORT_TYPEOF_1$$ from '@babel/types';
+  type Types = typeof $$IMPORT_TYPEOF_1$$;
   type PlatformChecks = {
-    isPlatformNode: (
-      node: _babel_types.MemberExpression,
-      scope: Scope,
-      isWrappedModule: boolean
-    ) => boolean;
-    isPlatformSelectNode: (
-      node: _babel_types.CallExpression,
-      scope: Scope,
-      isWrappedModule: boolean
-    ) => boolean;
+    isPlatformNode: (node: MemberExpression, scope: Scope, isWrappedModule: boolean) => boolean;
+    isPlatformSelectNode: (node: CallExpression, scope: Scope, isWrappedModule: boolean) => boolean;
   };
   function createInlinePlatformChecks(t: Types, requireName?: string): PlatformChecks;
   export default createInlinePlatformChecks;

--- a/packages/@expo/cli/ts-declarations/metro-transform-plugins/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-transform-plugins/index.d.ts
@@ -1,6 +1,6 @@
 // #region metro-transform-plugins
 declare module 'metro-transform-plugins' {
-  export * from 'metro-transform-plugins/src/index';
+  export * from 'metro-transform-plugins/private/index';
 }
 
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-plugins/src/addParamsToDefineCall.js

--- a/packages/@expo/cli/ts-declarations/metro-transform-worker/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-transform-worker/index.d.ts
@@ -71,7 +71,42 @@ declare module 'metro-transform-worker/private/index' {
     unstable_staticHermesOptimizedRequire?: boolean;
     unstable_transformProfile: TransformProfile;
   }>;
-  type JSFileType = 'js/script' | 'js/module' | 'js/module/asset';
+  // NOTE(cedric): this is a manual change exporting these existing Flow types for reuse in Expo
+  // See: https://github.com/facebook/metro/blob/3eeba3d459592aa5128995c8224933f6a23a43f1/packages/metro-transform-worker/src/index.js#L136-L168
+  export type Path = string;
+  export type BaseFile = Readonly<{
+    code: string;
+    filename: Path;
+    inputFileSize: number;
+  }>;
+  export type AssetFile = Readonly<
+    {
+      type: 'asset';
+    } & BaseFile
+  >;
+  export type JSFileType = 'js/script' | 'js/module' | 'js/module/asset';
+  export type JSFile = Readonly<
+    {
+      ast?: null | undefined | _babel_types.File;
+      type: JSFileType;
+      functionMap?: FBSourceFunctionMap | null;
+      unstable_importDeclarationLocs?: ReadonlySet<string>;
+    } & BaseFile
+  >;
+  export type JSONFile = {
+    type: Type;
+  } & BaseFile;
+  export type TransformationContext = Readonly<{
+    config: JsTransformerConfig;
+    projectRoot: Path;
+    options: JsTransformOptions;
+  }>;
+  // See: https://github.com/facebook/metro/blob/3eeba3d459592aa5128995c8224933f6a23a43f1/packages/metro-transform-worker/src/index.js#L180-L183
+  export type TransformResponse = Readonly<{
+    dependencies: readonly TransformResultDependency[];
+    output: readonly JsOutput[];
+  }>;
+  // NOTE(cedric): this is a manual change exporting these existing Flow types for reuse in Expo
   export type JsOutput = Readonly<{
     data: Readonly<{
       code: string;
@@ -99,7 +134,7 @@ declare module 'metro-transform-worker/private/utils/assetTransformer' {
 
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-worker/src/utils/getMinifier.js
 declare module 'metro-transform-worker/private/utils/getMinifier' {
-  import type { Minifier } from 'metro-transform-worker/private/index.js';
+  import type { Minifier } from 'metro-transform-worker/private/index';
   function getMinifier(minifierPath: string): Minifier;
   export default getMinifier;
 }

--- a/packages/@expo/cli/ts-declarations/metro-transform-worker/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-transform-worker/index.d.ts
@@ -1,6 +1,6 @@
 // #region metro-transform-worker
 declare module 'metro-transform-worker' {
-  export * from 'metro-transform-worker/src/index';
+  export * from 'metro-transform-worker/private/index';
 }
 
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-worker/src/index.js

--- a/packages/@expo/cli/ts-declarations/metro-transform-worker/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro-transform-worker/index.d.ts
@@ -3,21 +3,17 @@ declare module 'metro-transform-worker' {
   export * from 'metro-transform-worker/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-worker/src/index.js
-declare module 'metro-transform-worker/src/index' {
-  // NOTE(cedric): this is a manual change exporting this existing Flow type for reuse in Expo
-  import type * as _babel_types from '@babel/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-worker/src/index.js
+declare module 'metro-transform-worker/private/index' {
   import type { CustomTransformOptions, TransformProfile } from 'metro-babel-transformer';
   import type {
     BasicSourceMap,
     FBSourceFunctionMap,
     MetroSourceMapSegmentTuple,
   } from 'metro-source-map';
-  import type { TransformResultDependency } from 'metro/src/DeltaBundler';
-  import type { AllowOptionalDependencies } from 'metro/src/DeltaBundler/types.flow';
-  import type { DynamicRequiresBehavior } from 'metro/src/ModuleGraph/worker/collectDependencies';
-  // NOTE(cedric): this is a manual change exporting this existing Flow type for reuse in Expo
-  export type MinifierConfig = Readonly<{
+  import type { AllowOptionalDependencies } from 'metro/private/DeltaBundler/types.flow';
+  import type { DynamicRequiresBehavior } from 'metro/private/ModuleGraph/worker/collectDependencies';
+  type MinifierConfig = Readonly<{
     [$$Key$$: string]: any;
   }>;
   export type MinifierOptions = {
@@ -72,38 +68,10 @@ declare module 'metro-transform-worker/src/index' {
     unstable_disableES6Transforms?: boolean;
     unstable_memoizeInlineRequires?: boolean;
     unstable_nonMemoizedInlineRequires?: readonly string[];
+    unstable_staticHermesOptimizedRequire?: boolean;
     unstable_transformProfile: TransformProfile;
   }>;
-  // NOTE(cedric): this is a manual change exporting these existing Flow types for reuse in Expo
-  export type Path = string;
-  export type BaseFile = Readonly<{
-    code: string;
-    filename: Path;
-    inputFileSize: number;
-  }>;
-  export type AssetFile = Readonly<
-    {
-      type: 'asset';
-    } & BaseFile
-  >;
-  export type JSFileType = 'js/script' | 'js/module' | 'js/module/asset';
-  export type JSFile = Readonly<
-    {
-      ast?: null | undefined | _babel_types.File;
-      type: JSFileType;
-      functionMap?: FBSourceFunctionMap | null;
-      unstable_importDeclarationLocs?: ReadonlySet<string>;
-    } & BaseFile
-  >;
-  export type JSONFile = {
-    type: Type;
-  } & BaseFile;
-  export type TransformationContext = Readonly<{
-    config: JsTransformerConfig;
-    projectRoot: Path;
-    options: JsTransformOptions;
-  }>;
-  // NOTE(cedric): this is a manual change exporting these existing Flow types for reuse in Expo
+  type JSFileType = 'js/script' | 'js/module' | 'js/module/asset';
   export type JsOutput = Readonly<{
     data: Readonly<{
       code: string;
@@ -113,16 +81,11 @@ declare module 'metro-transform-worker/src/index' {
     }>;
     type: JSFileType;
   }>;
-  // NOTE(cedric): this is a manual change exporting this existing Flow type for reuse in Expo
-  export type TransformResponse = Readonly<{
-    dependencies: readonly TransformResultDependency[];
-    output: readonly JsOutput[];
-  }>;
-  export { default as getCacheKey } from 'metro-cache-key';
+  export { getCacheKey } from 'metro-transform-worker/metro-cache-key';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-worker/src/utils/assetTransformer.js
-declare module 'metro-transform-worker/src/utils/assetTransformer' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-worker/src/utils/assetTransformer.js
+declare module 'metro-transform-worker/private/utils/assetTransformer' {
   import type { File } from '@babel/types';
   import type { BabelTransformerArgs } from 'metro-babel-transformer';
   export function transform(
@@ -134,9 +97,9 @@ declare module 'metro-transform-worker/src/utils/assetTransformer' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro-transform-worker/src/utils/getMinifier.js
-declare module 'metro-transform-worker/src/utils/getMinifier' {
-  import type { Minifier } from 'metro-transform-worker/src/index';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro-transform-worker/src/utils/getMinifier.js
+declare module 'metro-transform-worker/private/utils/getMinifier' {
+  import type { Minifier } from 'metro-transform-worker/private/index.js';
   function getMinifier(minifierPath: string): Minifier;
   export default getMinifier;
 }

--- a/packages/@expo/cli/ts-declarations/metro/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro/index.d.ts
@@ -1,7 +1,7 @@
 // #region metro
 declare module 'metro' {
-  export * from 'metro/src/index';
-  export { default } from 'metro/src/index';
+  export * from 'metro/private/index';
+  export { default } from 'metro/private/index';
 }
 
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/Assets.js
@@ -2908,8 +2908,8 @@ declare module 'metro/private/shared/output/writeFile' {
 }
 
 // NOTE(cedric): this is a manual change, to avoid having to import `../types.flow`
-declare module 'metro/src/shared/types' {
-  export * from 'metro/src/shared/types.flow';
+declare module 'metro/private/shared/types' {
+  export * from 'metro/private/shared/types.flow';
 }
 
 // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/types.flow.js

--- a/packages/@expo/cli/ts-declarations/metro/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/metro/index.d.ts
@@ -4,8 +4,8 @@ declare module 'metro' {
   export { default } from 'metro/src/index';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/Assets.js
-declare module 'metro/src/Assets' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/Assets.js
+declare module 'metro/private/Assets' {
   export type AssetInfo = {
     readonly files: string[];
     readonly hash: string;
@@ -70,14 +70,14 @@ declare module 'metro/src/Assets' {
   export function isAssetTypeAnImage(type: string): boolean;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/Bundler.js
-declare module 'metro/src/Bundler' {
-  import type { TransformResultWithSource } from 'metro/src/DeltaBundler';
-  import type { TransformOptions } from 'metro/src/DeltaBundler/Worker';
-  import type EventEmitter from 'events';
-  import type { ConfigT } from 'metro-config/src/configTypes.flow';
-  import Transformer from 'metro/src/DeltaBundler/Transformer';
-  import DependencyGraph from 'metro/src/node-haste/DependencyGraph';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/Bundler.js
+declare module 'metro/private/Bundler' {
+  import type { TransformResultWithSource } from 'metro/private/DeltaBundler';
+  import type { TransformOptions } from 'metro/private/DeltaBundler/Worker';
+  import type EventEmitter from 'node:events';
+  import type { ConfigT } from 'metro-config';
+  import Transformer from 'metro/private/DeltaBundler/Transformer';
+  import DependencyGraph from 'metro/private/node-haste/DependencyGraph';
   export type BundlerOptions = Readonly<{
     hasReducedPerformance?: boolean;
     watch?: boolean;
@@ -100,10 +100,10 @@ declare module 'metro/src/Bundler' {
   export default Bundler;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/Bundler/util.js
-declare module 'metro/src/Bundler/util' {
-  import type { AssetDataWithoutFiles } from 'metro/src/Assets';
-  import type { ModuleTransportLike } from 'metro/src/shared/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/Bundler/util.js
+declare module 'metro/private/Bundler/util' {
+  import type { AssetDataWithoutFiles } from 'metro/private/Assets';
+  import type { ModuleTransportLike } from 'metro/private/shared/types.flow';
   import type { File } from '@babel/types';
   type SubTree<T extends ModuleTransportLike> = (
     moduleTransport: T,
@@ -120,81 +120,17 @@ declare module 'metro/src/Bundler/util' {
   ): File;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/cli-utils.js
-declare module 'metro/src/cli-utils' {
-  export const watchFile: (filename: string, callback: () => any) => Promise<void>;
-  export const makeAsyncCommand: <T>(command: (argv: T) => Promise<void>) => (argv: T) => void;
-}
-
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/cli.js
-declare module 'metro/src/cli' {
-  // This has no exports
-}
-
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/cli/parseKeyValueParamArray.js
-declare module 'metro/src/cli/parseKeyValueParamArray' {
-  function coerceKeyValueArray(keyValueArray: readonly string[]): {
-    [key: string]: string;
-  };
-  export default coerceKeyValueArray;
-}
-
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/commands/build.js
-// NOTE(cedric): yargs is custom-typed in metro
-// declare module 'metro/src/commands/build' {
-//   import type { ModuleObject } from 'yargs';
-//   const $$EXPORT_DEFAULT_DECLARATION$$: () => Omit<
-//     ModuleObject,
-//     keyof {
-//       handler: Function;
-//     }
-//   > & {
-//     handler: Function;
-//   };
-//   export default $$EXPORT_DEFAULT_DECLARATION$$;
-// }
-
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/commands/dependencies.js
-// NOTE(cedric): yargs is custom-typed in metro
-// declare module 'metro/src/commands/dependencies' {
-//   import type { ModuleObject } from 'yargs';
-//   const $$EXPORT_DEFAULT_DECLARATION$$: () => Omit<
-//     ModuleObject,
-//     keyof {
-//       handler: Function;
-//     }
-//   > & {
-//     handler: Function;
-//   };
-//   export default $$EXPORT_DEFAULT_DECLARATION$$;
-// }
-
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/commands/serve.js
-// NOTE(cedric): yargs is custom-typed in metro
-// declare module 'metro/src/commands/serve' {
-//   import type { ModuleObject } from 'yargs';
-//   const $$EXPORT_DEFAULT_DECLARATION$$: () => Omit<
-//     ModuleObject,
-//     keyof {
-//       handler: Function;
-//     }
-//   > & {
-//     handler: Function;
-//   };
-//   export default $$EXPORT_DEFAULT_DECLARATION$$;
-// }
-
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler.js
-declare module 'metro/src/DeltaBundler' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler.js
+declare module 'metro/private/DeltaBundler' {
   import type {
     DeltaResult,
     Graph,
     MixedOutput,
     Options,
     ReadOnlyGraph,
-  } from 'metro/src/DeltaBundler/types.flow';
-  import type EventEmitter from 'events';
-  import DeltaCalculator from 'metro/src/DeltaBundler/DeltaCalculator';
+  } from 'metro/private/DeltaBundler/types.flow';
+  import type EventEmitter from 'node:events';
+  import DeltaCalculator from 'metro/private/DeltaBundler/DeltaCalculator';
   export type {
     DeltaResult,
     Graph,
@@ -206,7 +142,7 @@ declare module 'metro/src/DeltaBundler' {
     TransformResult,
     TransformResultDependency,
     TransformResultWithSource,
-  } from 'metro/src/DeltaBundler/types.flow';
+  } from 'metro/private/DeltaBundler/types.flow';
   /**
    * `DeltaBundler` uses the `DeltaTransformer` to build bundle deltas. This
    * module handles all the transformer instances so it can support multiple
@@ -236,19 +172,19 @@ declare module 'metro/src/DeltaBundler' {
   export default DeltaBundler;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/buildSubgraph.js
-declare module 'metro/src/DeltaBundler/buildSubgraph' {
-  import type { RequireContext } from 'metro/src/lib/contextModule';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/buildSubgraph.js
+declare module 'metro/private/DeltaBundler/buildSubgraph' {
+  import type { RequireContext } from 'metro/private/lib/contextModule';
   import type {
-    Dependency,
     ModuleData,
+    ResolvedDependency,
     ResolveFn,
     TransformFn,
-  } from 'metro/src/DeltaBundler/types.flow';
+  } from 'metro/private/DeltaBundler/types.flow';
   type Parameters<T> = Readonly<{
     resolve: ResolveFn;
     transform: TransformFn<T>;
-    shouldTraverse: ($$PARAM_0$$: Dependency) => boolean;
+    shouldTraverse: ($$PARAM_0$$: ResolvedDependency) => boolean;
   }>;
   export function buildSubgraph<T>(
     entryPaths: ReadonlySet<string>,
@@ -260,11 +196,11 @@ declare module 'metro/src/DeltaBundler/buildSubgraph' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/DeltaCalculator.js
-declare module 'metro/src/DeltaBundler/DeltaCalculator' {
-  import type { DeltaResult, Options } from 'metro/src/DeltaBundler/types.flow';
-  import { Graph } from 'metro/src/DeltaBundler/Graph';
-  import { EventEmitter } from 'events';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/DeltaCalculator.js
+declare module 'metro/private/DeltaBundler/DeltaCalculator' {
+  import type { DeltaResult, Options } from 'metro/private/DeltaBundler/types.flow';
+  import { Graph } from 'metro/private/DeltaBundler/Graph';
+  import { EventEmitter } from 'node:events';
   /**
    * This class is in charge of calculating the delta of changed modules that
    * happen between calls. To do so, it subscribes to file changes, so it can
@@ -299,9 +235,9 @@ declare module 'metro/src/DeltaBundler/DeltaCalculator' {
   export default DeltaCalculator;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/getTransformCacheKey.js
-declare module 'metro/src/DeltaBundler/getTransformCacheKey' {
-  import type { TransformerConfig } from 'metro/src/DeltaBundler/Worker';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/getTransformCacheKey.js
+declare module 'metro/private/DeltaBundler/getTransformCacheKey' {
+  import type { TransformerConfig } from 'metro/private/DeltaBundler/Worker';
   function getTransformCacheKey(opts: {
     readonly cacheVersion: string;
     readonly projectRoot: string;
@@ -310,8 +246,8 @@ declare module 'metro/src/DeltaBundler/getTransformCacheKey' {
   export default getTransformCacheKey;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Graph.js
-declare module 'metro/src/DeltaBundler/Graph' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Graph.js
+declare module 'metro/private/DeltaBundler/Graph' {
   /**
    * Portions of this code are based on the Synchronous Cycle Collection
    * algorithm described in:
@@ -332,7 +268,7 @@ declare module 'metro/src/DeltaBundler/Graph' {
    *    nodes and entries in the importBundleNodes set.
    */
 
-  import type { RequireContext } from 'metro/src/lib/contextModule';
+  import type { RequireContext } from 'metro/private/lib/contextModule';
   import type {
     Dependencies,
     Dependency,
@@ -341,14 +277,20 @@ declare module 'metro/src/DeltaBundler/Graph' {
     Module,
     ModuleData,
     Options,
+    ResolvedDependency,
     TransformInputOptions,
-  } from 'metro/src/DeltaBundler/types.flow';
-  import CountingSet from 'metro/src/lib/CountingSet';
+  } from 'metro/private/DeltaBundler/types.flow';
+  import CountingSet from 'metro/private/lib/CountingSet';
   export type Result<T> = {
     added: Map<string, Module<T>>;
     modified: Map<string, Module<T>>;
     deleted: Set<string>;
   };
+  /**
+   * Internal data structure that the traversal logic uses to know which of the
+   * files have been modified. This allows to return the added modules before the
+   * modified ones (which is useful for things like Hot Module Reloading).
+   **/
   /**
    * Internal data structure that the traversal logic uses to know which of the
    * files have been modified. This allows to return the added modules before the
@@ -418,8 +360,8 @@ declare module 'metro/src/DeltaBundler/Graph' {
         shallow: boolean;
       }
     ): void;
-    _incrementImportBundleReference(dependency: Dependency, parentModule: Module<T>): void;
-    _decrementImportBundleReference(dependency: Dependency, parentModule: Module<T>): void;
+    _incrementImportBundleReference(dependency: ResolvedDependency, parentModule: Module<T>): void;
+    _decrementImportBundleReference(dependency: ResolvedDependency, parentModule: Module<T>): void;
     _markModuleInUse(module: Module<T>): void;
     _children(module: Module<T>, options: InternalOptions<T>): Iterator<Module<T>>;
     _moduleSnapshot(module: Module<T>): ModuleData<T>;
@@ -434,17 +376,21 @@ declare module 'metro/src/DeltaBundler/Graph' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/mergeDeltas.js
-declare module 'metro/src/DeltaBundler/mergeDeltas' {
-  import type { DeltaBundle } from 'metro-runtime/src/modules/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/mergeDeltas.js
+declare module 'metro/private/DeltaBundler/mergeDeltas' {
+  import type { DeltaBundle } from 'metro-runtime/modules/types.flow';
   function mergeDeltas(delta1: DeltaBundle, delta2: DeltaBundle): DeltaBundle;
   export default mergeDeltas;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/baseJSBundle.js
-declare module 'metro/src/DeltaBundler/Serializers/baseJSBundle' {
-  import type { Module, ReadOnlyGraph, SerializerOptions } from 'metro/src/DeltaBundler/types.flow';
-  import type { Bundle } from 'metro-runtime/src/modules/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Serializers/baseJSBundle.js
+declare module 'metro/private/DeltaBundler/Serializers/baseJSBundle' {
+  import type {
+    Module,
+    ReadOnlyGraph,
+    SerializerOptions,
+  } from 'metro/private/DeltaBundler/types.flow';
+  import type { Bundle } from 'metro-runtime/modules/types.flow';
   function baseJSBundle(
     entryPoint: string,
     preModules: readonly Module[],
@@ -454,9 +400,9 @@ declare module 'metro/src/DeltaBundler/Serializers/baseJSBundle' {
   export default baseJSBundle;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/getAllFiles.js
-declare module 'metro/src/DeltaBundler/Serializers/getAllFiles' {
-  import type { Module, ReadOnlyGraph } from 'metro/src/DeltaBundler/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Serializers/getAllFiles.js
+declare module 'metro/private/DeltaBundler/Serializers/getAllFiles' {
+  import type { Module, ReadOnlyGraph } from 'metro/private/DeltaBundler/types.flow';
   type Options = {
     platform?: null | string;
     readonly processModuleFilter: (module: Module) => boolean;
@@ -469,10 +415,10 @@ declare module 'metro/src/DeltaBundler/Serializers/getAllFiles' {
   export default getAllFiles;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/getAssets.js
-declare module 'metro/src/DeltaBundler/Serializers/getAssets' {
-  import type { AssetData } from 'metro/src/Assets';
-  import type { Module, ReadOnlyDependencies } from 'metro/src/DeltaBundler/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Serializers/getAssets.js
+declare module 'metro/private/DeltaBundler/Serializers/getAssets' {
+  import type { AssetData } from 'metro/private/Assets';
+  import type { Module, ReadOnlyDependencies } from 'metro/private/DeltaBundler/types.flow';
   type Options = {
     readonly processModuleFilter: (module: Module) => boolean;
     assetPlugins: readonly string[];
@@ -487,9 +433,9 @@ declare module 'metro/src/DeltaBundler/Serializers/getAssets' {
   export default getAssets;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/getExplodedSourceMap.js
-declare module 'metro/src/DeltaBundler/Serializers/getExplodedSourceMap' {
-  import type { Module } from 'metro/src/DeltaBundler/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Serializers/getExplodedSourceMap.js
+declare module 'metro/private/DeltaBundler/Serializers/getExplodedSourceMap' {
+  import type { Module } from 'metro/private/DeltaBundler/types.flow';
   import type { FBSourceFunctionMap, MetroSourceMapSegmentTuple } from 'metro-source-map';
   export type ExplodedSourceMap = readonly {
     readonly map: MetroSourceMapSegmentTuple[];
@@ -505,12 +451,16 @@ declare module 'metro/src/DeltaBundler/Serializers/getExplodedSourceMap' {
   ): ExplodedSourceMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/getRamBundleInfo.js
-declare module 'metro/src/DeltaBundler/Serializers/getRamBundleInfo' {
-  import type { ModuleTransportLike } from 'metro/src/shared/types.flow';
-  import type { Module, ReadOnlyGraph, SerializerOptions } from 'metro/src/DeltaBundler/types.flow';
-  import type { SourceMapGeneratorOptions } from 'metro/src/DeltaBundler/Serializers/sourceMapGenerator';
-  import type { GetTransformOptions } from 'metro-config/src/configTypes.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Serializers/getRamBundleInfo.js
+declare module 'metro/private/DeltaBundler/Serializers/getRamBundleInfo' {
+  import type { ModuleTransportLike } from 'metro/private/shared/types.flow';
+  import type {
+    Module,
+    ReadOnlyGraph,
+    SerializerOptions,
+  } from 'metro/private/DeltaBundler/types.flow';
+  import type { SourceMapGeneratorOptions } from 'metro/private/DeltaBundler/Serializers/sourceMapGenerator';
+  import type { GetTransformOptions } from 'metro-config';
   type Options = Readonly<
     {
       getTransformOptions?: null | GetTransformOptions;
@@ -533,15 +483,15 @@ declare module 'metro/src/DeltaBundler/Serializers/getRamBundleInfo' {
   export default getRamBundleInfo;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/helpers/getInlineSourceMappingURL.js
-declare module 'metro/src/DeltaBundler/Serializers/helpers/getInlineSourceMappingURL' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Serializers/helpers/getInlineSourceMappingURL.js
+declare module 'metro/private/DeltaBundler/Serializers/helpers/getInlineSourceMappingURL' {
   function getInlineSourceMappingURL(sourceMap: string): string;
   export default getInlineSourceMappingURL;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/helpers/getSourceMapInfo.js
-declare module 'metro/src/DeltaBundler/Serializers/helpers/getSourceMapInfo' {
-  import type { Module } from 'metro/src/DeltaBundler/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Serializers/helpers/getSourceMapInfo.js
+declare module 'metro/private/DeltaBundler/Serializers/helpers/getSourceMapInfo' {
+  import type { Module } from 'metro/private/DeltaBundler/types.flow';
   import type { FBSourceFunctionMap, MetroSourceMapSegmentTuple } from 'metro-source-map';
   function getSourceMapInfo(
     module: Module,
@@ -562,22 +512,16 @@ declare module 'metro/src/DeltaBundler/Serializers/helpers/getSourceMapInfo' {
   export default getSourceMapInfo;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/helpers/getTransitiveDependencies.js
-declare module 'metro/src/DeltaBundler/Serializers/helpers/getTransitiveDependencies' {
-  import type { ReadOnlyGraph } from 'metro/src/DeltaBundler/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Serializers/helpers/getTransitiveDependencies.js
+declare module 'metro/private/DeltaBundler/Serializers/helpers/getTransitiveDependencies' {
+  import type { ReadOnlyGraph } from 'metro/private/DeltaBundler/types.flow';
   function getTransitiveDependencies<T>(path: string, graph: ReadOnlyGraph<T>): Set<string>;
   export default getTransitiveDependencies;
 }
 
-// NOTE(cedric): this is a workaround for a jest-resolve bug to import this file with explicit extension
-// See: https://github.com/lukeed/resolve.exports/issues/40
-declare module 'metro/src/DeltaBundler/Serializers/helpers/js.js' {
-  export * from 'metro/src/DeltaBundler/Serializers/helpers/js';
-}
-
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/helpers/js.js
-declare module 'metro/src/DeltaBundler/Serializers/helpers/js' {
-  import type { MixedOutput, Module } from 'metro/src/DeltaBundler/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Serializers/helpers/js.js
+declare module 'metro/private/DeltaBundler/Serializers/helpers/js' {
+  import type { MixedOutput, Module } from 'metro/private/DeltaBundler/types.flow';
   import type { JsOutput } from 'metro-transform-worker';
   export type Options = Readonly<{
     createModuleId: ($$PARAM_0$$: string) => number | string;
@@ -598,9 +542,9 @@ declare module 'metro/src/DeltaBundler/Serializers/helpers/js' {
   export function wrapModule(module: Module, options: Options): string;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/helpers/processModules.js
-declare module 'metro/src/DeltaBundler/Serializers/helpers/processModules' {
-  import type { Module } from 'metro/src/DeltaBundler/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Serializers/helpers/processModules.js
+declare module 'metro/private/DeltaBundler/Serializers/helpers/processModules' {
+  import type { Module } from 'metro/private/DeltaBundler/types.flow';
   function processModules(
     modules: readonly Module[],
     $$PARAM_1$$: Readonly<{
@@ -616,11 +560,11 @@ declare module 'metro/src/DeltaBundler/Serializers/helpers/processModules' {
   export default processModules;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/hmrJSBundle.js
-declare module 'metro/src/DeltaBundler/Serializers/hmrJSBundle' {
-  import type { EntryPointURL } from 'metro/src/HmrServer';
-  import type { DeltaResult, ReadOnlyGraph } from 'metro/src/DeltaBundler/types.flow';
-  import type { HmrModule } from 'metro-runtime/src/modules/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Serializers/hmrJSBundle.js
+declare module 'metro/private/DeltaBundler/Serializers/hmrJSBundle' {
+  import type { EntryPointURL } from 'metro/private/HmrServer';
+  import type { DeltaResult, ReadOnlyGraph } from 'metro/private/DeltaBundler/types.flow';
+  import type { HmrModule } from 'metro-runtime/modules/types.flow';
   type Options = Readonly<{
     clientUrl: EntryPointURL;
     createModuleId: ($$PARAM_0$$: string) => number;
@@ -640,9 +584,9 @@ declare module 'metro/src/DeltaBundler/Serializers/hmrJSBundle' {
   export default hmrJSBundle;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/sourceMapGenerator.js
-declare module 'metro/src/DeltaBundler/Serializers/sourceMapGenerator' {
-  import type { Module } from 'metro/src/DeltaBundler/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Serializers/sourceMapGenerator.js
+declare module 'metro/private/DeltaBundler/Serializers/sourceMapGenerator' {
+  import type { Module } from 'metro/private/DeltaBundler/types.flow';
   import { fromRawMappings, fromRawMappingsNonBlocking } from 'metro-source-map';
   export type SourceMapGeneratorOptions = Readonly<{
     excludeSource: boolean;
@@ -660,10 +604,10 @@ declare module 'metro/src/DeltaBundler/Serializers/sourceMapGenerator' {
   ): ReturnType<typeof fromRawMappingsNonBlocking>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/sourceMapObject.js
-declare module 'metro/src/DeltaBundler/Serializers/sourceMapObject' {
-  import type { Module } from 'metro/src/DeltaBundler/types.flow';
-  import type { SourceMapGeneratorOptions } from 'metro/src/DeltaBundler/Serializers/sourceMapGenerator';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Serializers/sourceMapObject.js
+declare module 'metro/private/DeltaBundler/Serializers/sourceMapObject' {
+  import type { Module } from 'metro/private/DeltaBundler/types.flow';
+  import type { SourceMapGeneratorOptions } from 'metro/private/DeltaBundler/Serializers/sourceMapGenerator';
   import type { MixedSourceMap } from 'metro-source-map';
   export function sourceMapObject(
     modules: readonly Module[],
@@ -675,10 +619,10 @@ declare module 'metro/src/DeltaBundler/Serializers/sourceMapObject' {
   ): Promise<MixedSourceMap>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Serializers/sourceMapString.js
-declare module 'metro/src/DeltaBundler/Serializers/sourceMapString' {
-  import type { Module } from 'metro/src/DeltaBundler/types.flow';
-  import type { SourceMapGeneratorOptions } from 'metro/src/DeltaBundler/Serializers/sourceMapGenerator';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Serializers/sourceMapString.js
+declare module 'metro/private/DeltaBundler/Serializers/sourceMapString' {
+  import type { Module } from 'metro/private/DeltaBundler/types.flow';
+  import type { SourceMapGeneratorOptions } from 'metro/private/DeltaBundler/Serializers/sourceMapGenerator';
   export function sourceMapString(
     modules: readonly Module[],
     options: SourceMapGeneratorOptions
@@ -689,17 +633,19 @@ declare module 'metro/src/DeltaBundler/Serializers/sourceMapString' {
   ): Promise<string>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Transformer.js
-declare module 'metro/src/DeltaBundler/Transformer' {
-  import type { TransformResult, TransformResultWithSource } from 'metro/src/DeltaBundler';
-  import type { TransformOptions } from 'metro/src/DeltaBundler/Worker';
-  import type { ConfigT } from 'metro-config/src/configTypes.flow';
-  import WorkerFarm from 'metro/src/DeltaBundler/WorkerFarm';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Transformer.js
+declare module 'metro/private/DeltaBundler/Transformer' {
+  import type { TransformResult, TransformResultWithSource } from 'metro/private/DeltaBundler';
+  import type { TransformOptions } from 'metro/private/DeltaBundler/Worker';
+  import type { ConfigT } from 'metro-config';
+  import WorkerFarm from 'metro/private/DeltaBundler/WorkerFarm';
   import { Cache } from 'metro-cache';
-  type GetOrComputeSha1Fn = ($$PARAM_0$$: string) => Promise<{
-    content?: Buffer;
-    sha1: string;
-  }>;
+  type GetOrComputeSha1Fn = ($$PARAM_0$$: string) => Promise<
+    Readonly<{
+      content?: Buffer;
+      sha1: string;
+    }>
+  >;
   class Transformer {
     _config: ConfigT;
     _cache: Cache<TransformResult>;
@@ -722,26 +668,19 @@ declare module 'metro/src/DeltaBundler/Transformer' {
   export default Transformer;
 }
 
-// NOTE(cedric): this is a manual change, to avoid having to import `../types.flow`
-declare module 'metro/src/DeltaBundler/types' {
-  export * from 'metro/src/DeltaBundler/types.flow';
-}
-
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/types.flow.js
-declare module 'metro/src/DeltaBundler/types.flow' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/types.flow.js
+declare module 'metro/private/DeltaBundler/types.flow' {
   import type * as _babel_types from '@babel/types';
-  import type { RequireContext } from 'metro/src/lib/contextModule';
-  import type { RequireContextParams } from 'metro/src/ModuleGraph/worker/collectDependencies';
-  import type { Graph } from 'metro/src/DeltaBundler/Graph';
+  import type { RequireContext } from 'metro/private/lib/contextModule';
+  import type { RequireContextParams } from 'metro/private/ModuleGraph/worker/collectDependencies';
+  import type { Graph } from 'metro/private/DeltaBundler/Graph';
   import type { JsTransformOptions } from 'metro-transform-worker';
-  import CountingSet from 'metro/src/lib/CountingSet';
+  import CountingSet from 'metro/private/lib/CountingSet';
   export type MixedOutput = {
     readonly data: any;
     readonly type: string;
   };
-  // NOTE(cedric): this is a manual change for worker support through `require.unstable_resolveWorker()`
   export type AsyncDependencyType = 'async' | 'maybeSync' | 'prefetch' | 'weak' | 'worker';
-  // export type AsyncDependencyType = 'async' | 'maybeSync' | 'prefetch' | 'weak';
   export type TransformResultDependency = Readonly<{
     /**
      * The literal name provided to a require or import call. For example 'foo' in
@@ -774,10 +713,15 @@ declare module 'metro/src/DeltaBundler/types.flow' {
       contextParams?: RequireContextParams;
     }>;
   }>;
-  export type Dependency = Readonly<{
+  export type ResolvedDependency = Readonly<{
     absolutePath: string;
     data: TransformResultDependency;
   }>;
+  export type Dependency =
+    | ResolvedDependency
+    | Readonly<{
+        data: TransformResultDependency;
+      }>;
   export type Module<T = MixedOutput> = Readonly<{
     dependencies: Map<string, Dependency>;
     inverseDependencies: CountingSet<string>;
@@ -795,16 +739,7 @@ declare module 'metro/src/DeltaBundler/types.flow' {
   }>;
   export type Dependencies<T = MixedOutput> = Map<string, Module<T>>;
   export type ReadOnlyDependencies<T = MixedOutput> = ReadonlyMap<string, Module<T>>;
-  export type TransformInputOptions = Pick<
-    JsTransformOptions,
-    Exclude<
-      keyof JsTransformOptions,
-      keyof {
-        inlinePlatform: boolean;
-        inlineRequires: boolean;
-      }
-    >
-  >;
+  export type TransformInputOptions = Omit<JsTransformOptions, 'inlinePlatform' | 'inlineRequires'>;
   export type GraphInputOptions = Readonly<{
     entryPoints: ReadonlySet<string>;
     transformOptions: TransformInputOptions;
@@ -877,21 +812,21 @@ declare module 'metro/src/DeltaBundler/types.flow' {
   }>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Worker.js
-declare module 'metro/src/DeltaBundler/Worker' {
-  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Worker.js
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Worker.js
+declare module 'metro/private/DeltaBundler/Worker' {
+  // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Worker.js
 
   // NOTE(cedric): Metro uses this weird Flow syntax /*:: */ to override the exported types...
-  export * from 'metro/src/DeltaBundler/Worker.flow';
-  export { default } from 'metro/src/DeltaBundler/Worker.flow';
+  export * from 'metro/private/DeltaBundler/Worker.flow';
+  export { default } from 'metro/private/DeltaBundler/Worker.flow';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/Worker.flow.js
-declare module 'metro/src/DeltaBundler/Worker.flow' {
-  import type { TransformResult } from 'metro/src/DeltaBundler/types.flow';
-  import type { LogEntry } from 'metro-core/src/Logger';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/Worker.flow.js
+declare module 'metro/private/DeltaBundler/Worker.flow' {
+  import type { TransformResult } from 'metro/private/DeltaBundler/types.flow';
+  import type { LogEntry } from 'metro-core/private/Logger';
   import type { JsTransformerConfig, JsTransformOptions } from 'metro-transform-worker';
-  export type { JsTransformOptions as TransformOptions } from 'metro-transform-worker';
+  export type { JsTransformOptions as TransformOptions } from 'metro/metro-transform-worker';
   export type Worker = {
     readonly transform: typeof transform;
   };
@@ -916,12 +851,16 @@ declare module 'metro/src/DeltaBundler/Worker.flow' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/DeltaBundler/WorkerFarm.js
-declare module 'metro/src/DeltaBundler/WorkerFarm' {
-  import type { TransformResult } from 'metro/src/DeltaBundler';
-  import type { TransformerConfig, TransformOptions, Worker } from 'metro/src/DeltaBundler/Worker';
-  import type { ConfigT } from 'metro-config/src/configTypes.flow';
-  import type { Readable } from 'stream';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/DeltaBundler/WorkerFarm.js
+declare module 'metro/private/DeltaBundler/WorkerFarm' {
+  import type { TransformResult } from 'metro/private/DeltaBundler';
+  import type {
+    TransformerConfig,
+    TransformOptions,
+    Worker,
+  } from 'metro/private/DeltaBundler/Worker';
+  import type { ConfigT } from 'metro-config';
+  import type { Readable } from 'node:stream';
   type WorkerInterface = {
     getStdout(): Readable;
     getStderr(): Readable;
@@ -958,14 +897,14 @@ declare module 'metro/src/DeltaBundler/WorkerFarm' {
   export default WorkerFarm;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/HmrServer.js
-declare module 'metro/src/HmrServer' {
-  import type { GraphOptions } from 'metro/src/shared/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/HmrServer.js
+declare module 'metro/private/HmrServer' {
+  import type { GraphOptions } from 'metro/private/shared/types.flow';
   import type { ConfigT, RootPerfLogger } from 'metro-config';
-  import type { HmrErrorMessage, HmrUpdateMessage } from 'metro-runtime/src/modules/types.flow';
-  import type { UrlWithParsedQuery } from 'url';
-  import type IncrementalBundler from 'metro/src/IncrementalBundler';
-  import type { RevisionId } from 'metro/src/IncrementalBundler';
+  import type { HmrErrorMessage, HmrUpdateMessage } from 'metro-runtime/modules/types.flow';
+  import type { UrlWithParsedQuery } from 'node:url';
+  import type IncrementalBundler from 'metro/private/IncrementalBundler';
+  import type { RevisionId } from 'metro/private/IncrementalBundler';
   export type EntryPointURL = UrlWithParsedQuery;
   export type Client = {
     optedIntoHMR: boolean;
@@ -988,7 +927,7 @@ declare module 'metro/src/HmrServer' {
    * getting connected, disconnected or having errors (through the
    * `onClientConnect`, `onClientDisconnect` and `onClientError` methods).
    */
-  class HmrServer<TClient extends Client = Client> {
+  class HmrServer<TClient extends Client> {
     _config: ConfigT;
     _bundler: IncrementalBundler;
     _createModuleId: (path: string) => number;
@@ -1039,19 +978,19 @@ declare module 'metro/src/HmrServer' {
   export default HmrServer;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/IncrementalBundler.js
-declare module 'metro/src/IncrementalBundler' {
-  import type { DeltaResult, Graph, Module } from 'metro/src/DeltaBundler';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/IncrementalBundler.js
+declare module 'metro/private/IncrementalBundler' {
+  import type { DeltaResult, Graph, Module } from 'metro/private/DeltaBundler';
   import type {
     Options as DeltaBundlerOptions,
     ReadOnlyDependencies,
     TransformInputOptions,
-  } from 'metro/src/DeltaBundler/types.flow';
-  import type { GraphId } from 'metro/src/lib/getGraphId';
-  import type { ResolverInputOptions } from 'metro/src/shared/types.flow';
-  import type { ConfigT } from 'metro-config/src/configTypes.flow';
-  import Bundler from 'metro/src/Bundler';
-  import DeltaBundler from 'metro/src/DeltaBundler';
+  } from 'metro/private/DeltaBundler/types.flow';
+  import type { GraphId } from 'metro/private/lib/getGraphId';
+  import type { ResolverInputOptions } from 'metro/private/shared/types.flow';
+  import type { ConfigT } from 'metro-config';
+  import Bundler from 'metro/private/Bundler';
+  import DeltaBundler from 'metro/private/DeltaBundler';
   export type RevisionId = string;
   export type OutputGraph = Graph;
   type OtherOptions = Readonly<{
@@ -1127,9 +1066,9 @@ declare module 'metro/src/IncrementalBundler' {
   export default IncrementalBundler;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/IncrementalBundler/GraphNotFoundError.js
-declare module 'metro/src/IncrementalBundler/GraphNotFoundError' {
-  import type { GraphId } from 'metro/src/lib/getGraphId';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/IncrementalBundler/GraphNotFoundError.js
+declare module 'metro/private/IncrementalBundler/GraphNotFoundError' {
+  import type { GraphId } from 'metro/private/lib/getGraphId';
   class GraphNotFoundError extends Error {
     graphId: GraphId;
     constructor(graphId: GraphId);
@@ -1137,8 +1076,8 @@ declare module 'metro/src/IncrementalBundler/GraphNotFoundError' {
   export default GraphNotFoundError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/IncrementalBundler/ResourceNotFoundError.js
-declare module 'metro/src/IncrementalBundler/ResourceNotFoundError' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/IncrementalBundler/ResourceNotFoundError.js
+declare module 'metro/private/IncrementalBundler/ResourceNotFoundError' {
   class ResourceNotFoundError extends Error {
     resourcePath: string;
     constructor(resourcePath: string);
@@ -1146,9 +1085,9 @@ declare module 'metro/src/IncrementalBundler/ResourceNotFoundError' {
   export default ResourceNotFoundError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/IncrementalBundler/RevisionNotFoundError.js
-declare module 'metro/src/IncrementalBundler/RevisionNotFoundError' {
-  import type { RevisionId } from 'metro/src/IncrementalBundler';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/IncrementalBundler/RevisionNotFoundError.js
+declare module 'metro/private/IncrementalBundler/RevisionNotFoundError' {
+  import type { RevisionId } from 'metro/private/IncrementalBundler';
   class RevisionNotFoundError extends Error {
     revisionId: RevisionId;
     constructor(revisionId: RevisionId);
@@ -1156,16 +1095,16 @@ declare module 'metro/src/IncrementalBundler/RevisionNotFoundError' {
   export default RevisionNotFoundError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/index.js
-declare module 'metro/src/index' {
-  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/index.js
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/index.js
+declare module 'metro/private/index' {
+  // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/index.js
 
   // NOTE(cedric): Metro uses this weird Flow syntax /*:: */ to override the exported types...
-  export * from 'metro/src/index.flow';
+  export * from 'metro/private/index.flow';
 
   // NOTE(cedric): these are exported in Metro's own custom `index.d.ts`
-  export * from 'metro/src/Assets'; // lmao, the typo
-  export * from 'metro/src/DeltaBundler/types.flow';
+  export * from 'metro/private/Assets'; // lmao, the typo
+  export * from 'metro/private/DeltaBundler/types.flow';
   // NOTE(cedric): only exporting select types due to type conflicts
   export {
     Dependency,
@@ -1179,34 +1118,29 @@ declare module 'metro/src/index' {
     DependencyTransformer,
     DynamicRequiresBehavior,
     ImportQualifier,
-  } from 'metro/src/ModuleGraph/worker/collectDependencies';
-  export * from 'metro/src/Server';
-  export * from 'metro/src/lib/reporting';
-
-  // NOTE(cedric): add this since we had this already, might be nice to deprecate
-  export { default as Server } from 'metro/src/Server';
+  } from 'metro/private/ModuleGraph/worker/collectDependencies';
+  export * from 'metro/private/Server';
+  export * from 'metro/private/lib/reporting';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/index.flow.js
-declare module 'metro/src/index.flow' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/index.flow.js
+declare module 'metro/private/index.flow' {
   import type * as _ws from 'ws';
-  import type { ReadOnlyGraph } from 'metro/src/DeltaBundler';
-  import type { ServerOptions } from 'metro/src/Server';
-  import type { OutputOptions, RequestOptions } from 'metro/src/shared/types.flow';
+  import type { AssetData } from 'metro/private/Assets';
+  import type { ReadOnlyGraph } from 'metro/private/DeltaBundler';
+  import type { ServerOptions } from 'metro/private/Server';
+  import type { BuildOptions } from 'metro/private/shared/types.flow';
+  import type { OutputOptions, RequestOptions } from 'metro/private/shared/types.flow.js';
   import type { HandleFunction } from 'connect';
-  import type { Server as HttpServer } from 'http';
-  import type { Server as HttpsServer } from 'https';
-  import type {
-    ConfigT,
-    InputConfigT,
-    MetroConfig,
-    Middleware,
-  } from 'metro-config/src/configTypes.flow';
+  import type { Server as HttpServer } from 'node:http';
+  import type { Server as HttpsServer } from 'node:https';
+  import type { TransformProfile } from 'metro-babel-transformer';
+  import type { ConfigT, InputConfigT, MetroConfig, Middleware } from 'metro-config';
   import type { CustomResolverOptions } from 'metro-resolver';
   import type { CustomTransformOptions } from 'metro-transform-worker';
   import type $$IMPORT_TYPEOF_1$$ from 'yargs';
   type Yargs = typeof $$IMPORT_TYPEOF_1$$;
-  import MetroServer from 'metro/src/Server';
+  import MetroServer from 'metro/private/Server';
   type MetroMiddleWare = {
     attachHmrServer: (httpServer: HttpServer | HttpsServer) => void;
     end: () => Promise<void>;
@@ -1237,6 +1171,9 @@ declare module 'metro/src/index.flow' {
       [path: string]: _ws.WebSocketServer;
     }>;
   }>;
+  export type RunServerResult = {
+    httpServer?: HttpServer | HttpsServer;
+  };
   type BuildGraphOptions = {
     entries: readonly string[];
     customTransformOptions?: CustomTransformOptions;
@@ -1248,8 +1185,11 @@ declare module 'metro/src/index.flow' {
   };
   export type RunBuildOptions = {
     entry: string;
+    assets?: boolean;
     dev?: boolean;
     out?: string;
+    bundleOut?: string;
+    sourceMapOut?: string;
     onBegin?: () => void;
     onComplete?: () => void;
     onProgress?: (transformedFileCount: number, totalFileCount: number) => void;
@@ -1257,10 +1197,12 @@ declare module 'metro/src/index.flow' {
     output?: Readonly<{
       build: (
         $$PARAM_0$$: MetroServer,
-        $$PARAM_1$$: RequestOptions
+        $$PARAM_1$$: RequestOptions,
+        $$PARAM_2$$: void | BuildOptions
       ) => Promise<{
         code: string;
         map: string;
+        assets?: readonly AssetData[];
       }>;
       save: (
         $$PARAM_0$$: {
@@ -1276,21 +1218,31 @@ declare module 'metro/src/index.flow' {
     sourceMapUrl?: string;
     customResolverOptions?: CustomResolverOptions;
     customTransformOptions?: CustomTransformOptions;
+    unstable_transformProfile?: TransformProfile;
   };
-  type BuildCommandOptions = object | null;
-  type ServeCommandOptions = object | null;
+  export type RunBuildResult = {
+    code: string;
+    map: string;
+    assets?: readonly AssetData[];
+  };
+  type BuildCommandOptions = {} | null;
+  type ServeCommandOptions = {} | null;
+  export type { AssetData } from 'metro/private/Assets';
+  export type { Reporter, ReportableEvent } from 'metro/private/lib/reporting';
+  export type { TerminalReportableEvent } from 'metro/private/lib/TerminalReporter';
   export type { MetroConfig };
   type AttachMetroCLIOptions = {
     build?: BuildCommandOptions;
     serve?: ServeCommandOptions;
     dependencies?: any;
   };
-  export { Terminal } from 'metro-core';
-  export { default as TerminalReporter } from 'metro/src/lib/TerminalReporter';
+  export { Terminal } from 'metro/metro-core';
+  export { default as JsonReporter } from 'metro/private/lib/JsonReporter';
+  export { default as TerminalReporter } from 'metro/private/lib/TerminalReporter';
   export function runMetro(config: InputConfigT, options?: RunMetroOptions): void;
-  export { loadConfig } from 'metro-config';
-  export { mergeConfig } from 'metro-config';
-  export { resolveConfig } from 'metro-config';
+  export { loadConfig } from 'metro/metro-config';
+  export { mergeConfig } from 'metro/metro-config';
+  export { resolveConfig } from 'metro/metro-config';
   export let createConnectMiddleware: (
     config: ConfigT,
     options?: RunMetroOptions
@@ -1298,14 +1250,8 @@ declare module 'metro/src/index.flow' {
   export const runServer: (
     config: ConfigT,
     $$PARAM_1$$: RunServerOptions
-  ) => Promise<HttpServer | HttpsServer>;
-  export const runBuild: (
-    config: ConfigT,
-    $$PARAM_1$$: RunBuildOptions
-  ) => Promise<{
-    code: string;
-    map: string;
-  }>;
+  ) => Promise<RunServerResult>;
+  export const runBuild: (config: ConfigT, $$PARAM_1$$: RunBuildOptions) => Promise<RunBuildResult>;
   export const buildGraph: (
     config: InputConfigT,
     $$PARAM_1$$: BuildGraphOptions
@@ -1313,8 +1259,8 @@ declare module 'metro/src/index.flow' {
   export const attachMetroCli: (yargs: Yargs, options?: AttachMetroCLIOptions) => Yargs;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/BatchProcessor.js
-declare module 'metro/src/lib/BatchProcessor' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/BatchProcessor.js
+declare module 'metro/private/lib/BatchProcessor' {
   type ProcessBatch<TItem, TResult> = (batch: TItem[]) => Promise<TResult[]>;
   type BatchProcessorOptions = {
     maximumDelayMs: number;
@@ -1351,9 +1297,9 @@ declare module 'metro/src/lib/BatchProcessor' {
   export default BatchProcessor;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/bundleToString.js
-declare module 'metro/src/lib/bundleToString' {
-  import type { Bundle, BundleMetadata } from 'metro-runtime/src/modules/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/bundleToString.js
+declare module 'metro/private/lib/bundleToString' {
+  import type { Bundle, BundleMetadata } from 'metro-runtime/modules/types.flow';
   /**
    * Serializes a bundle into a plain JS bundle.
    */
@@ -1364,12 +1310,12 @@ declare module 'metro/src/lib/bundleToString' {
   export default bundleToString;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/contextModule.js
-declare module 'metro/src/lib/contextModule' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/contextModule.js
+declare module 'metro/private/lib/contextModule' {
   import type {
     ContextMode,
     RequireContextParams,
-  } from 'metro/src/ModuleGraph/worker/collectDependencies';
+  } from 'metro/private/ModuleGraph/worker/collectDependencies';
   export type RequireContext = Readonly<{
     recursive: boolean;
     filter: RegExp;
@@ -1387,9 +1333,9 @@ declare module 'metro/src/lib/contextModule' {
   export function fileMatchesContext(testPath: string, context: RequireContext): boolean;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/contextModuleTemplates.js
-declare module 'metro/src/lib/contextModuleTemplates' {
-  import type { ContextMode } from 'metro/src/ModuleGraph/worker/collectDependencies';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/contextModuleTemplates.js
+declare module 'metro/private/lib/contextModuleTemplates' {
+  import type { ContextMode } from 'metro/private/ModuleGraph/worker/collectDependencies';
   /**
    * Generate a context module as a virtual file string.
    *
@@ -1406,9 +1352,9 @@ declare module 'metro/src/lib/contextModuleTemplates' {
   ): string;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/CountingSet.js
-declare module 'metro/src/lib/CountingSet' {
-  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/CountingSet.js
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/CountingSet.js
+declare module 'metro/private/lib/CountingSet' {
+  // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/CountingSet.js
 
   export interface ReadOnlyCountingSet<T> extends Iterable<T> {
     get size(): number;
@@ -1455,20 +1401,20 @@ declare module 'metro/src/lib/CountingSet' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/countLines.js
-declare module 'metro/src/lib/countLines' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/countLines.js
+declare module 'metro/private/lib/countLines' {
   const countLines: (string: string) => number;
   export default countLines;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/createModuleIdFactory.js
-declare module 'metro/src/lib/createModuleIdFactory' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/createModuleIdFactory.js
+declare module 'metro/private/lib/createModuleIdFactory' {
   function createModuleIdFactory(): (path: string) => number;
   export default createModuleIdFactory;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/createWebsocketServer.js
-declare module 'metro/src/lib/createWebsocketServer' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/createWebsocketServer.js
+declare module 'metro/private/lib/createWebsocketServer' {
   import ws from 'ws';
   type WebsocketServiceInterface<T> = {
     readonly onClientConnect: (
@@ -1502,17 +1448,17 @@ declare module 'metro/src/lib/createWebsocketServer' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/debounceAsyncQueue.js
-declare module 'metro/src/lib/debounceAsyncQueue' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/debounceAsyncQueue.js
+declare module 'metro/private/lib/debounceAsyncQueue' {
   function debounceAsyncQueue<T>(fn: () => Promise<T>, delay: number): () => Promise<T>;
   export default debounceAsyncQueue;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/formatBundlingError.js
-declare module 'metro/src/lib/formatBundlingError' {
-  import type { FormattedError } from 'metro-runtime/src/modules/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/formatBundlingError.js
+declare module 'metro/private/lib/formatBundlingError' {
+  import type { FormattedError } from 'metro-runtime/modules/types.flow';
   export type CustomError = Error & {
-    type?: string;
+    readonly type?: string;
     filename?: string;
     lineNumber?: number;
     errors?: {
@@ -1525,9 +1471,9 @@ declare module 'metro/src/lib/formatBundlingError' {
   export default formatBundlingError;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/getAppendScripts.js
-declare module 'metro/src/lib/getAppendScripts' {
-  import type { Module } from 'metro/src/DeltaBundler';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/getAppendScripts.js
+declare module 'metro/private/lib/getAppendScripts' {
+  import type { Module } from 'metro/private/DeltaBundler';
   type Options<T extends number | string> = Readonly<{
     asyncRequireModulePath: string;
     createModuleId: ($$PARAM_0$$: string) => T;
@@ -1548,10 +1494,10 @@ declare module 'metro/src/lib/getAppendScripts' {
   export default getAppendScripts;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/getGraphId.js
-declare module 'metro/src/lib/getGraphId' {
-  import type { TransformInputOptions } from 'metro/src/DeltaBundler/types.flow';
-  import type { ResolverInputOptions } from 'metro/src/shared/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/getGraphId.js
+declare module 'metro/private/lib/getGraphId' {
+  import type { TransformInputOptions } from 'metro/private/DeltaBundler/types.flow';
+  import type { ResolverInputOptions } from 'metro/private/shared/types.flow';
   export type GraphId = string;
   function getGraphId(
     entryFile: string,
@@ -1566,14 +1512,14 @@ declare module 'metro/src/lib/getGraphId' {
   export default getGraphId;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/getMaxWorkers.js
-declare module 'metro/src/lib/getMaxWorkers' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/getMaxWorkers.js
+declare module 'metro/private/lib/getMaxWorkers' {
   const $$EXPORT_DEFAULT_DECLARATION$$: (workers: null | undefined | number) => number;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/getPreludeCode.js
-declare module 'metro/src/lib/getPreludeCode' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/getPreludeCode.js
+declare module 'metro/private/lib/getPreludeCode' {
   function getPreludeCode($$PARAM_0$$: {
     readonly extraVars?: {
       [$$Key$$: string]: any;
@@ -1585,25 +1531,17 @@ declare module 'metro/src/lib/getPreludeCode' {
   export default getPreludeCode;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/getPrependedScripts.js
-declare module 'metro/src/lib/getPrependedScripts' {
-  import type Bundler from 'metro/src/Bundler';
-  import type { TransformInputOptions } from 'metro/src/DeltaBundler/types.flow';
-  import type { ResolverInputOptions } from 'metro/src/shared/types.flow';
-  import type { ConfigT } from 'metro-config/src/configTypes.flow';
-  import type DeltaBundler from 'metro/src/DeltaBundler';
-  import type { Module } from 'metro/src/DeltaBundler';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/getPrependedScripts.js
+declare module 'metro/private/lib/getPrependedScripts' {
+  import type Bundler from 'metro/private/Bundler';
+  import type { TransformInputOptions } from 'metro/private/DeltaBundler/types.flow';
+  import type { ResolverInputOptions } from 'metro/private/shared/types.flow';
+  import type { ConfigT } from 'metro-config/private/configTypes.flow';
+  import type DeltaBundler from 'metro/private/DeltaBundler';
+  import type { Module } from 'metro/private/DeltaBundler';
   function getPrependedScripts(
     config: ConfigT,
-    options: Pick<
-      TransformInputOptions,
-      Exclude<
-        keyof TransformInputOptions,
-        keyof {
-          type: TransformInputOptions['type'];
-        }
-      >
-    >,
+    options: Omit<TransformInputOptions, 'type'>,
     resolverOptions: ResolverInputOptions,
     bundler: Bundler,
     deltaBundler: DeltaBundler
@@ -1611,9 +1549,15 @@ declare module 'metro/src/lib/getPrependedScripts' {
   export default getPrependedScripts;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/JsonReporter.js
-declare module 'metro/src/lib/JsonReporter' {
-  import type { Writable } from 'stream';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/isResolvedDependency.js
+declare module 'metro/private/lib/isResolvedDependency' {
+  import type { Dependency } from 'metro/private/DeltaBundler/types.flow';
+  export function isResolvedDependency(dep: Dependency): any;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/JsonReporter.js
+declare module 'metro/private/lib/JsonReporter' {
+  import type { Writable } from 'node:stream';
   export type SerializedError = {
     message: string;
     stack: string;
@@ -1637,8 +1581,8 @@ declare module 'metro/src/lib/JsonReporter' {
   export default JsonReporter;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/logToConsole.js
-declare module 'metro/src/lib/logToConsole' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/logToConsole.js
+declare module 'metro/private/lib/logToConsole' {
   import type { Terminal } from 'metro-core';
   const $$EXPORT_DEFAULT_DECLARATION$$: (
     terminal: Terminal,
@@ -1649,9 +1593,9 @@ declare module 'metro/src/lib/logToConsole' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/parseCustomResolverOptions.js
-declare module 'metro/src/lib/parseCustomResolverOptions' {
-  import type { CustomResolverOptions } from 'metro-resolver/src/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/parseCustomResolverOptions.js
+declare module 'metro/private/lib/parseCustomResolverOptions' {
+  import type { CustomResolverOptions } from 'metro-resolver/private/types';
   const $$EXPORT_DEFAULT_DECLARATION$$: (urlObj: {
     readonly query?: {
       [$$Key$$: string]: string;
@@ -1660,8 +1604,8 @@ declare module 'metro/src/lib/parseCustomResolverOptions' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/parseCustomTransformOptions.js
-declare module 'metro/src/lib/parseCustomTransformOptions' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/parseCustomTransformOptions.js
+declare module 'metro/private/lib/parseCustomTransformOptions' {
   import type { CustomTransformOptions } from 'metro-transform-worker';
   const $$EXPORT_DEFAULT_DECLARATION$$: (urlObj: {
     readonly query?: {
@@ -1671,18 +1615,40 @@ declare module 'metro/src/lib/parseCustomTransformOptions' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/parseOptionsFromUrl.js
-declare module 'metro/src/lib/parseOptionsFromUrl' {
-  import type { BundleOptions } from 'metro/src/shared/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/parseJsonBody.js
+declare module 'metro/private/lib/parseJsonBody' {
+  import type { IncomingMessage } from 'node:http';
+  /**
+   * Attempt to parse a request body as JSON.
+   */
+  function parseJsonBody(
+    req: IncomingMessage,
+    options?: {
+      strict?: boolean;
+    }
+  ): Promise<any>;
+  export default parseJsonBody;
+}
+
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/parseOptionsFromUrl.js
+declare module 'metro/private/lib/parseOptionsFromUrl' {
+  import type { BundleOptions } from 'metro/private/shared/types.flow';
   const $$EXPORT_DEFAULT_DECLARATION$$: (
     normalizedRequestUrl: string,
     platforms: Set<string>
-  ) => BundleOptions;
+  ) => Omit<
+    BundleOptions,
+    keyof {
+      bundleType: string;
+    }
+  > & {
+    bundleType: string;
+  };
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/RamBundleParser.js
-declare module 'metro/src/lib/RamBundleParser' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/RamBundleParser.js
+declare module 'metro/private/lib/RamBundleParser' {
   /**
    * Implementation of a RAM bundle parser in JS.
    *
@@ -1705,15 +1671,15 @@ declare module 'metro/src/lib/RamBundleParser' {
   export default RamBundleParser;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/relativizeSourceMap.js
-declare module 'metro/src/lib/relativizeSourceMap' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/relativizeSourceMap.js
+declare module 'metro/private/lib/relativizeSourceMap' {
   import type { MixedSourceMap } from 'metro-source-map';
   function relativizeSourceMapInline(sourceMap: MixedSourceMap, sourcesRoot: string): void;
   export default relativizeSourceMapInline;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/reporting.js
-declare module 'metro/src/lib/reporting' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/reporting.js
+declare module 'metro/private/lib/reporting' {
   import type { Terminal } from 'metro-core';
   import type { HealthCheckResult, WatcherStatus } from 'metro-file-map';
   import type { CustomResolverOptions } from 'metro-resolver';
@@ -1873,30 +1839,30 @@ declare module 'metro/src/lib/reporting' {
    * calling this, add a new type of ReportableEvent instead, and implement a
    * proper handler in the reporter(s).
    */
-  export function logWarning(terminal: Terminal, format: string, ...args: any[]): void;
 
   /**
    * Similar to `logWarning`, but for messages that require the user to act.
    */
-  export function logError(terminal: Terminal, format: string, ...args: any[]): void;
 
   /**
    * Similar to `logWarning`, but for informational messages.
    */
-  export function logInfo(terminal: Terminal, format: string, ...args: any[]): void;
 
   /**
    * A reporter that does nothing. Errors and warnings will be swallowed, that
    * is generally not what you want.
    */
+  export function logWarning(terminal: Terminal, format: string, ...args: any[]): void;
+  export function logError(terminal: Terminal, format: string, ...args: any[]): void;
+  export function logInfo(terminal: Terminal, format: string, ...args: any[]): void;
   export const nullReporter: {
     update(): void;
   };
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/splitBundleOptions.js
-declare module 'metro/src/lib/splitBundleOptions' {
-  import type { BundleOptions, SplitBundleOptions } from 'metro/src/shared/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/splitBundleOptions.js
+declare module 'metro/private/lib/splitBundleOptions' {
+  import type { BundleOptions, SplitBundleOptions } from 'metro/private/shared/types.flow';
   /**
    * Splits a BundleOptions object into smaller, more manageable parts.
    */
@@ -1904,9 +1870,9 @@ declare module 'metro/src/lib/splitBundleOptions' {
   export default splitBundleOptions;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/TerminalReporter.js
-declare module 'metro/src/lib/TerminalReporter' {
-  import type { BundleDetails, ReportableEvent } from 'metro/src/lib/reporting';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/TerminalReporter.js
+declare module 'metro/private/lib/TerminalReporter' {
+  import type { BundleDetails, ReportableEvent } from 'metro/private/lib/reporting';
   import type { Terminal } from 'metro-core';
   import type { HealthCheckResult, WatcherStatus } from 'metro-file-map';
   type BundleProgress = {
@@ -1937,14 +1903,7 @@ declare module 'metro/src/lib/TerminalReporter' {
         type: 'unstable_server_menu_cleared';
       };
   type BuildPhase = 'in_progress' | 'done' | 'failed';
-  // NOTE(cedric): manually corrected, its an internal Flow type
-  type ErrnoError = {
-    errno: number;
-    code: string;
-    path: string;
-    syscall: string;
-  };
-  type SnippetError = ErrnoError & {
+  type SnippetError = any & {
     filename?: string;
     snippet?: string;
   };
@@ -1986,18 +1945,18 @@ declare module 'metro/src/lib/TerminalReporter' {
   export default TerminalReporter;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/lib/transformHelpers.js
-declare module 'metro/src/lib/transformHelpers' {
-  import type Bundler from 'metro/src/Bundler';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/lib/transformHelpers.js
+declare module 'metro/private/lib/transformHelpers' {
+  import type Bundler from 'metro/private/Bundler';
   import type {
     BundlerResolution,
     TransformInputOptions,
     TransformResultDependency,
-  } from 'metro/src/DeltaBundler/types.flow';
-  import type { ResolverInputOptions } from 'metro/src/shared/types.flow';
-  import type { ConfigT } from 'metro-config/src/configTypes.flow';
-  import type DeltaBundler from 'metro/src/DeltaBundler';
-  import type { TransformFn } from 'metro/src/DeltaBundler';
+  } from 'metro/private/DeltaBundler/types.flow';
+  import type { ResolverInputOptions } from 'metro/private/shared/types.flow';
+  import type { ConfigT } from 'metro-config';
+  import type DeltaBundler from 'metro/private/DeltaBundler';
+  import type { TransformFn } from 'metro/private/DeltaBundler';
   export function getTransformFn(
     entryFiles: readonly string[],
     bundler: Bundler,
@@ -2013,20 +1972,20 @@ declare module 'metro/src/lib/transformHelpers' {
   ): Promise<(from: string, dependency: TransformResultDependency) => BundlerResolution>;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/ModuleGraph/worker/collectDependencies.js
-declare module 'metro/src/ModuleGraph/worker/collectDependencies' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/ModuleGraph/worker/collectDependencies.js
+declare module 'metro/private/ModuleGraph/worker/collectDependencies' {
   import type { NodePath } from '@babel/traverse';
   import type {
     CallExpression,
-    File,
     Identifier,
     StringLiteral,
     SourceLocation,
+    File,
   } from '@babel/types';
   import type {
     AllowOptionalDependencies,
     AsyncDependencyType,
-  } from 'metro/src/DeltaBundler/types.flow';
+  } from 'metro/private/private/DeltaBundler/types.flow';
   export type Dependency = Readonly<{
     data: DependencyData;
     name: string;
@@ -2115,8 +2074,8 @@ declare module 'metro/src/ModuleGraph/worker/collectDependencies' {
   export default collectDependencies;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/ModuleGraph/worker/generateImportNames.js
-declare module 'metro/src/ModuleGraph/worker/generateImportNames' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/ModuleGraph/worker/generateImportNames.js
+declare module 'metro/private/ModuleGraph/worker/generateImportNames' {
   import type * as _babel_types from '@babel/types';
   /**
    * Select unused names for "metroImportDefault" and "metroImportAll", by
@@ -2129,47 +2088,59 @@ declare module 'metro/src/ModuleGraph/worker/generateImportNames' {
   export default generateImportNames;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/ModuleGraph/worker/importLocationsPlugin.js
-declare module 'metro/src/ModuleGraph/worker/importLocationsPlugin' {
-  import type * as _babel_types from '@babel/types';
-  import type { PluginObj } from '@babel/core';
-  type Types = typeof _babel_types;
-  export function importLocationsPlugin($$PARAM_0$$: { types: Types }): PluginObj;
-  export function locToKey(loc: _babel_types.SourceLocation): string;
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/ModuleGraph/worker/importLocationsPlugin.js
+declare module 'metro/private/ModuleGraph/worker/importLocationsPlugin' {
+  import type { File, PluginObj } from '@babel/core';
+  import type * as $$IMPORT_TYPEOF_1$$ from '@babel/types';
+  type Types = typeof $$IMPORT_TYPEOF_1$$;
+  type ImportDeclarationLocs = Set<string>;
+  type State = {
+    importDeclarationLocs: ImportDeclarationLocs;
+    file: File;
+  };
+  export function importLocationsPlugin($$PARAM_0$$: { types: Types }): PluginObj<State>;
+  export function locToKey(loc: Types.SourceLocation): string;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/ModuleGraph/worker/JsFileWrapping.js
-declare module 'metro/src/ModuleGraph/worker/JsFileWrapping' {
-  import type * as _babel_types from '@babel/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/ModuleGraph/worker/JsFileWrapping.js
+declare module 'metro/private/ModuleGraph/worker/JsFileWrapping' {
+  import type { File } from '@babel/types';
   export const WRAP_NAME: '$$_REQUIRE';
-  export function wrapJson(source: string, globalPrefix: string): string;
+  export function wrapJson(
+    source: string,
+    globalPrefix: string,
+    unstable_useStaticHermesModuleFactory?: boolean
+  ): string;
   export function jsonToCommonJS(source: string): string;
   export function wrapModule(
-    fileAst: _babel_types.File,
+    fileAst: File,
     importDefaultName: string,
     importAllName: string,
     dependencyMapName: string,
     globalPrefix: string,
-    skipRequireRename: boolean
+    skipRequireRename: boolean,
+    $$PARAM_6$$: Readonly<{
+      unstable_useStaticHermesModuleFactory?: boolean;
+    }>
   ): {
-    ast: _babel_types.File;
+    ast: File;
     requireName: string;
   };
-  export function wrapPolyfill(fileAst: _babel_types.File): _babel_types.File;
+  export function wrapPolyfill(fileAst: File): File;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/DependencyGraph.js
-declare module 'metro/src/node-haste/DependencyGraph' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/node-haste/DependencyGraph.js
+declare module 'metro/private/node-haste/DependencyGraph' {
   import type {
     BundlerResolution,
     TransformResultDependency,
-  } from 'metro/src/DeltaBundler/types.flow';
-  import type { ResolverInputOptions } from 'metro/src/shared/types.flow';
-  import type Package from 'metro/src/node-haste/Package';
-  import type { ConfigT } from 'metro-config/src/configTypes.flow';
-  import { ModuleResolver } from 'metro/src/node-haste/DependencyGraph/ModuleResolution';
-  import ModuleCache from 'metro/src/node-haste/ModuleCache';
-  import { EventEmitter } from 'events';
+  } from 'metro/private/DeltaBundler/types.flow';
+  import type { ResolverInputOptions } from 'metro/private/shared/types.flow';
+  import type Package from 'metro/private/node-haste/Package';
+  import type { ConfigT } from 'metro-config';
+  import { ModuleResolver } from 'metro/private/node-haste/DependencyGraph/ModuleResolution';
+  import ModuleCache from 'metro/private/node-haste/ModuleCache';
+  import { EventEmitter } from 'node:events';
   import type MetroFileMap from 'metro-file-map';
   import type {
     ChangeEvent,
@@ -2247,9 +2218,9 @@ declare module 'metro/src/node-haste/DependencyGraph' {
   export default DependencyGraph;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/DependencyGraph/createFileMap.js
-declare module 'metro/src/node-haste/DependencyGraph/createFileMap' {
-  import type { ConfigT } from 'metro-config/src/configTypes.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/node-haste/DependencyGraph/createFileMap.js
+declare module 'metro/private/node-haste/DependencyGraph/createFileMap' {
+  import type { ConfigT } from 'metro-config';
   import MetroFileMap from 'metro-file-map';
   function createFileMap(
     config: ConfigT,
@@ -2263,14 +2234,14 @@ declare module 'metro/src/node-haste/DependencyGraph/createFileMap' {
   export default createFileMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
-declare module 'metro/src/node-haste/DependencyGraph/ModuleResolution' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+declare module 'metro/private/node-haste/DependencyGraph/ModuleResolution' {
   import type {
     BundlerResolution,
     TransformResultDependency,
-  } from 'metro/src/DeltaBundler/types.flow';
-  import type { Reporter } from 'metro/src/lib/reporting';
-  import type { ResolverInputOptions } from 'metro/src/shared/types.flow';
+  } from 'metro/private/DeltaBundler/types.flow';
+  import type { Reporter } from 'metro/private/lib/reporting';
+  import type { ResolverInputOptions } from 'metro/private/shared/types.flow';
   import type {
     CustomResolver,
     DoesFileExist,
@@ -2279,7 +2250,7 @@ declare module 'metro/src/node-haste/DependencyGraph/ModuleResolution' {
     Resolution,
     ResolveAsset,
   } from 'metro-resolver';
-  import type { PackageJson } from 'metro-resolver/src/types';
+  import type { PackageJson } from 'metro-resolver/private/types';
   export type DirExistsFn = (filePath: string) => boolean;
   export type Packageish = {
     path: string;
@@ -2353,6 +2324,7 @@ declare module 'metro/src/node-haste/DependencyGraph/ModuleResolution' {
     originModulePath: string;
     targetModuleName: string;
     cause: null | undefined | Error;
+    readonly type: 'UnableToResolveError';
     constructor(
       originModulePath: string,
       targetModuleName: string,
@@ -2368,8 +2340,8 @@ declare module 'metro/src/node-haste/DependencyGraph/ModuleResolution' {
   }
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/lib/AssetPaths.js
-declare module 'metro/src/node-haste/lib/AssetPaths' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/node-haste/lib/AssetPaths.js
+declare module 'metro/private/node-haste/lib/AssetPaths' {
   export type AssetPath = {
     assetName: string;
     name: string;
@@ -2388,8 +2360,8 @@ declare module 'metro/src/node-haste/lib/AssetPaths' {
   ): null | undefined | AssetPath;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/lib/parsePlatformFilePath.js
-declare module 'metro/src/node-haste/lib/parsePlatformFilePath' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/node-haste/lib/parsePlatformFilePath.js
+declare module 'metro/private/node-haste/lib/parsePlatformFilePath' {
   type PlatformFilePathParts = {
     dirPath: string;
     baseName: string;
@@ -2407,10 +2379,10 @@ declare module 'metro/src/node-haste/lib/parsePlatformFilePath' {
   export default parsePlatformFilePath;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/Module.js
-declare module 'metro/src/node-haste/Module' {
-  import type ModuleCache from 'metro/src/node-haste/ModuleCache';
-  import type Package from 'metro/src/node-haste/Package';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/node-haste/Module.js
+declare module 'metro/private/node-haste/Module' {
+  import type ModuleCache from 'metro/private/node-haste/ModuleCache';
+  import type Package from 'metro/private/node-haste/Package';
   class Module {
     path: string;
     _moduleCache: ModuleCache;
@@ -2422,10 +2394,10 @@ declare module 'metro/src/node-haste/Module' {
   export default Module;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/ModuleCache.js
-declare module 'metro/src/node-haste/ModuleCache' {
-  import Module from 'metro/src/node-haste/Module';
-  import Package from 'metro/src/node-haste/Package';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/node-haste/ModuleCache.js
+declare module 'metro/private/node-haste/ModuleCache' {
+  import Module from 'metro/private/node-haste/Module';
+  import Package from 'metro/private/node-haste/Package';
   type GetClosestPackageFn = (absoluteFilePath: string) =>
     | null
     | undefined
@@ -2475,9 +2447,9 @@ declare module 'metro/src/node-haste/ModuleCache' {
   export default ModuleCache;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/node-haste/Package.js
-declare module 'metro/src/node-haste/Package' {
-  import type { PackageJson } from 'metro-resolver/src/types';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/node-haste/Package.js
+declare module 'metro/private/node-haste/Package' {
+  import type { PackageJson } from 'metro-resolver/private/types';
   class Package {
     path: string;
     _root: string;
@@ -2489,34 +2461,36 @@ declare module 'metro/src/node-haste/Package' {
   export default Package;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/Server.js
-declare module 'metro/src/Server' {
-  import type { AssetData } from 'metro/src/Assets';
-  import type { ExplodedSourceMap } from 'metro/src/DeltaBundler/Serializers/getExplodedSourceMap';
-  import type { RamBundleInfo } from 'metro/src/DeltaBundler/Serializers/getRamBundleInfo';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/Server.js
+declare module 'metro/private/Server' {
+  import type { AssetData } from 'metro/private/Assets';
+  import type { ExplodedSourceMap } from 'metro/private/DeltaBundler/Serializers/getExplodedSourceMap';
+  import type { RamBundleInfo } from 'metro/private/DeltaBundler/Serializers/getRamBundleInfo';
   import type {
     Module,
+    ReadOnlyDependencies,
     ReadOnlyGraph,
     TransformInputOptions,
-  } from 'metro/src/DeltaBundler/types.flow';
-  import type { RevisionId } from 'metro/src/IncrementalBundler';
-  import type { GraphId } from 'metro/src/lib/getGraphId';
-  import type { Reporter } from 'metro/src/lib/reporting';
+  } from 'metro/private/DeltaBundler/types.flow';
+  import type { RevisionId } from 'metro/private/IncrementalBundler';
+  import type { GraphId } from 'metro/private/lib/getGraphId';
+  import type { Reporter } from 'metro/private/lib/reporting';
   import type {
+    BuildOptions,
     BundleOptions,
     GraphOptions,
     ResolverInputOptions,
     SplitBundleOptions,
-  } from 'metro/src/shared/types.flow';
+  } from 'metro/private/shared/types.flow';
   import type { IncomingMessage } from 'connect';
-  import type { ServerResponse } from 'http';
-  import type { ConfigT, RootPerfLogger } from 'metro-config/src/configTypes.flow';
-  import type { ActionLogEntryData, ActionStartLogEntry, LogEntry } from 'metro-core/src/Logger';
-  import type { CustomResolverOptions } from 'metro-resolver/src/types';
+  import type { ServerResponse } from 'node:http';
+  import type { ConfigT, RootPerfLogger } from 'metro-config';
+  import type { ActionLogEntryData, ActionStartLogEntry } from 'metro-core/private/Logger';
+  import type { CustomResolverOptions } from 'metro-resolver/private/types';
   import type { CustomTransformOptions } from 'metro-transform-worker';
-  import { SourcePathsMode } from 'metro/src/shared/types.flow';
-  import IncrementalBundler from 'metro/src/IncrementalBundler';
-  import MultipartResponse from 'metro/src/Server/MultipartResponse';
+  import { SourcePathsMode } from 'metro/private/shared/types.flow';
+  import IncrementalBundler from 'metro/private/IncrementalBundler';
+  import MultipartResponse from 'metro/private/Server/MultipartResponse';
   import { Logger } from 'metro-core';
   export type SegmentLoadData = {
     [$$Key$$: number]: [number[], null | undefined | number];
@@ -2568,12 +2542,30 @@ declare module 'metro/src/Server' {
     end(): void;
     getBundler(): IncrementalBundler;
     getCreateModuleId(): (path: string) => number;
-    build(options: BundleOptions): Promise<{
+    _serializeGraph(
+      $$PARAM_0$$: Readonly<{
+        splitOptions: SplitBundleOptions;
+        prepend: readonly Module[];
+        graph: ReadOnlyGraph;
+      }>
+    ): Promise<{
       code: string;
       map: string;
     }>;
+    build(
+      bundleOptions: BundleOptions,
+      $$PARAM_1$$: BuildOptions
+    ): Promise<{
+      code: string;
+      map: string;
+      assets?: readonly AssetData[];
+    }>;
     getRamBundleInfo(options: BundleOptions): Promise<RamBundleInfo>;
     getAssets(options: BundleOptions): Promise<readonly AssetData[]>;
+    _getAssetsFromDependencies(
+      dependencies: ReadOnlyDependencies,
+      platform: null | undefined | string
+    ): Promise<readonly AssetData[]>;
     getOrderedDependencyPaths(options: {
       readonly dev: boolean;
       readonly entryFile: string;
@@ -2605,10 +2597,9 @@ declare module 'metro/src/Server' {
       res: ServerResponse
     ): Promise<void>;
     _createRequestProcessor<T>($$PARAM_0$$: {
+      readonly bundleType?: 'assets' | 'bundle' | 'map';
       readonly createStartEntry: (context: ProcessStartContext) => ActionLogEntryData;
-      readonly createEndEntry: (
-        context: ProcessEndContext<T>
-      ) => Pick<ActionStartLogEntry, Exclude<keyof ActionStartLogEntry, keyof LogEntry>>;
+      readonly createEndEntry: (context: ProcessEndContext<T>) => Partial<ActionStartLogEntry>;
       readonly build: (context: ProcessStartContext) => Promise<T>;
       readonly delete?: (context: ProcessDeleteContext) => Promise<void>;
       readonly finish: (context: ProcessEndContext<T>) => void;
@@ -2691,9 +2682,9 @@ declare module 'metro/src/Server' {
   export default Server;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/Server/MultipartResponse.js
-declare module 'metro/src/Server/MultipartResponse' {
-  import type { IncomingMessage, ServerResponse } from 'http';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/Server/MultipartResponse.js
+declare module 'metro/private/Server/MultipartResponse' {
+  import type { IncomingMessage, ServerResponse } from 'node:http';
   type Data = string | Buffer | Uint8Array;
   type Headers = {
     [$$Key$$: string]: string | number;
@@ -2716,10 +2707,10 @@ declare module 'metro/src/Server/MultipartResponse' {
   export default MultipartResponse;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/Server/symbolicate.js
-declare module 'metro/src/Server/symbolicate' {
-  import type { ExplodedSourceMap } from 'metro/src/DeltaBundler/Serializers/getExplodedSourceMap';
-  import type { ConfigT } from 'metro-config/src/configTypes.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/Server/symbolicate.js
+declare module 'metro/private/Server/symbolicate' {
+  import type { ExplodedSourceMap } from 'metro/private/DeltaBundler/Serializers/getExplodedSourceMap';
+  import type { ConfigT } from 'metro-config';
   export type StackFrameInput = {
     readonly file?: null | string;
     readonly lineNumber?: null | number;
@@ -2739,19 +2730,27 @@ declare module 'metro/src/Server/symbolicate' {
   export default symbolicate;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/bundle.js
-declare module 'metro/src/shared/output/bundle' {
-  // See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/bundle.js
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/output/bundle.js
+declare module 'metro/private/shared/output/bundle' {
+  // See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/output/bundle.js
 
   // NOTE(cedric): Metro uses this weird Flow syntax /*:: */ to override the exported types...
-  export * from 'metro/src/shared/output/bundle.flow';
+  export * from 'metro/private/shared/output/bundle.flow';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/bundle.flow.js
-declare module 'metro/src/shared/output/bundle.flow' {
-  import type { OutputOptions, RequestOptions } from 'metro/src/shared/types.flow';
-  import Server from 'metro/src/Server';
-  export function build(packagerClient: Server, requestOptions: RequestOptions): void;
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/output/bundle.flow.js
+declare module 'metro/private/shared/output/bundle.flow' {
+  import type {
+    BuildOptions,
+    OutputOptions,
+    RequestOptions,
+  } from 'metro/private/shared/types.flow';
+  import Server from 'metro/private/Server';
+  export function build(
+    packagerClient: Server,
+    requestOptions: RequestOptions,
+    buildOptions?: BuildOptions
+  ): void;
   export function save(
     bundle: {
       code: string;
@@ -2763,8 +2762,8 @@ declare module 'metro/src/shared/output/bundle.flow' {
   export const formatName: 'bundle';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/meta.js
-declare module 'metro/src/shared/output/meta' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/output/meta.js
+declare module 'metro/private/shared/output/meta' {
   const $$EXPORT_DEFAULT_DECLARATION$$: (
     code: Buffer | string,
     encoding: 'ascii' | 'utf16le' | 'utf8'
@@ -2772,11 +2771,11 @@ declare module 'metro/src/shared/output/meta' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/RamBundle.js
-declare module 'metro/src/shared/output/RamBundle' {
-  import type { RamBundleInfo } from 'metro/src/DeltaBundler/Serializers/getRamBundleInfo';
-  import type { OutputOptions, RequestOptions } from 'metro/src/shared/types.flow';
-  import Server from 'metro/src/Server';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/output/RamBundle.js
+declare module 'metro/private/shared/output/RamBundle' {
+  import type { RamBundleInfo } from 'metro/private/DeltaBundler/Serializers/getRamBundleInfo';
+  import type { OutputOptions, RequestOptions } from 'metro/private/shared/types.flow';
+  import Server from 'metro/private/Server';
   export function build(packagerClient: Server, requestOptions: RequestOptions): void;
   export function save(
     bundle: RamBundleInfo,
@@ -2786,10 +2785,10 @@ declare module 'metro/src/shared/output/RamBundle' {
   export const formatName: 'bundle';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/RamBundle/as-assets.js
-declare module 'metro/src/shared/output/RamBundle/as-assets' {
-  import type { RamBundleInfo } from 'metro/src/DeltaBundler/Serializers/getRamBundleInfo';
-  import type { OutputOptions } from 'metro/src/shared/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/output/RamBundle/as-assets.js
+declare module 'metro/private/shared/output/RamBundle/as-assets' {
+  import type { RamBundleInfo } from 'metro/private/DeltaBundler/Serializers/getRamBundleInfo';
+  import type { OutputOptions } from 'metro/private/shared/types.flow';
   /**
    * Saves all JS modules of an app as single files
    * The startup code (prelude, polyfills etc.) are written to the file
@@ -2805,14 +2804,14 @@ declare module 'metro/src/shared/output/RamBundle/as-assets' {
   export default saveAsAssets;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/RamBundle/as-indexed-file.js
-declare module 'metro/src/shared/output/RamBundle/as-indexed-file' {
-  import type { RamBundleInfo } from 'metro/src/DeltaBundler/Serializers/getRamBundleInfo';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/output/RamBundle/as-indexed-file.js
+declare module 'metro/private/shared/output/RamBundle/as-indexed-file' {
+  import type { RamBundleInfo } from 'metro/private/DeltaBundler/Serializers/getRamBundleInfo';
   import type {
     ModuleGroups,
     ModuleTransportLike,
     OutputOptions,
-  } from 'metro/src/shared/types.flow';
+  } from 'metro/private/shared/types.flow';
   export function save(
     bundle: RamBundleInfo,
     options: OutputOptions,
@@ -2830,9 +2829,9 @@ declare module 'metro/src/shared/output/RamBundle/as-indexed-file' {
   ): void;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/RamBundle/buildSourcemapWithMetadata.js
-declare module 'metro/src/shared/output/RamBundle/buildSourcemapWithMetadata' {
-  import type { ModuleGroups, ModuleTransportLike } from 'metro/src/shared/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/output/RamBundle/buildSourcemapWithMetadata.js
+declare module 'metro/private/shared/output/RamBundle/buildSourcemapWithMetadata' {
+  import type { ModuleGroups, ModuleTransportLike } from 'metro/private/shared/types.flow';
   import type { IndexMap } from 'metro-source-map';
   type Params = {
     fixWrapperOffset: boolean;
@@ -2844,15 +2843,15 @@ declare module 'metro/src/shared/output/RamBundle/buildSourcemapWithMetadata' {
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/RamBundle/magic-number.js
-declare module 'metro/src/shared/output/RamBundle/magic-number' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/output/RamBundle/magic-number.js
+declare module 'metro/private/shared/output/RamBundle/magic-number' {
   const $$EXPORT_DEFAULT_DECLARATION$$: 0xfb0bd1e5;
   export default $$EXPORT_DEFAULT_DECLARATION$$;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/RamBundle/util.js
-declare module 'metro/src/shared/output/RamBundle/util' {
-  import type { ModuleGroups, ModuleTransportLike } from 'metro/src/shared/types.flow';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/output/RamBundle/util.js
+declare module 'metro/private/shared/output/RamBundle/util' {
+  import type { ModuleGroups, ModuleTransportLike } from 'metro/private/shared/types.flow';
   import type { BasicSourceMap, IndexMap } from 'metro-source-map';
   type CombineOptions = {
     fixWrapperOffset: boolean;
@@ -2868,7 +2867,7 @@ declare module 'metro/src/shared/output/RamBundle/util' {
     moduleGroups?: null | undefined | ModuleGroups,
     options?: null | undefined | CombineOptions
   ): IndexMap;
-  export { default as countLines } from 'metro/src/lib/countLines';
+  export { default as countLines } from 'metro/private/lib/countLines';
   export const joinModules: (
     modules: readonly {
       readonly code: string;
@@ -2877,8 +2876,8 @@ declare module 'metro/src/shared/output/RamBundle/util' {
   export function lineToLineSourceMap(source: string, filename?: string): BasicSourceMap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/RamBundle/write-sourcemap.js
-declare module 'metro/src/shared/output/RamBundle/write-sourcemap' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/output/RamBundle/write-sourcemap.js
+declare module 'metro/private/shared/output/RamBundle/write-sourcemap' {
   function writeSourcemap(
     fileName: string,
     contents: string,
@@ -2887,34 +2886,28 @@ declare module 'metro/src/shared/output/RamBundle/write-sourcemap' {
   export default writeSourcemap;
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/unbundle.js
-declare module 'metro/src/shared/output/unbundle' {
-  export { default } from 'metro/src/shared/output/RamBundle';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/output/unbundle.js
+declare module 'metro/private/shared/output/unbundle' {
+  export { default } from 'metro/private/shared/output/RamBundle';
 }
 
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/output/writeFile.js
-declare module 'metro/src/shared/output/writeFile' {
-  import fs from 'fs';
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/output/writeFile.js
+declare module 'metro/private/shared/output/writeFile' {
+  import fs from 'node:fs';
   const writeFile: typeof fs.promises.writeFile;
   export default writeFile;
 }
 
-// NOTE(cedric): this is a manual change, to avoid having to import `../types.flow`
-declare module 'metro/src/shared/types' {
-  export * from 'metro/src/shared/types.flow';
-}
-
-// See: https://github.com/facebook/metro/blob/v0.82.0/packages/metro/src/shared/types.flow.js
-declare module 'metro/src/shared/types.flow' {
+// See: https://github.com/facebook/metro/blob/v0.83.0/packages/metro/src/shared/types.flow.js
+declare module 'metro/private/shared/types.flow' {
   import type {
     Options as DeltaBundlerOptions,
     TransformInputOptions,
-  } from 'metro/src/DeltaBundler/types.flow';
+  } from 'metro/private/DeltaBundler/types.flow';
   import type { TransformProfile } from 'metro-babel-transformer';
   import type { CustomResolverOptions } from 'metro-resolver';
   import type { MetroSourceMapSegmentTuple, MixedSourceMap } from 'metro-source-map';
   import type { CustomTransformOptions, MinifierOptions } from 'metro-transform-worker';
-  type BundleType = 'bundle' | 'delta' | 'meta' | 'map' | 'ram' | 'cli' | 'hmr' | 'todo' | 'graph';
   type MetroSourceMapOrMappings = MixedSourceMap | MetroSourceMapSegmentTuple[];
   export enum SourcePathsMode {
     Absolute = 'absolute',
@@ -2927,7 +2920,6 @@ declare module 'metro/src/shared/types.flow' {
     export function getName(value: SourcePathsMode): string;
   }
   export type BundleOptions = {
-    bundleType: BundleType;
     readonly customResolverOptions: CustomResolverOptions;
     customTransformOptions: CustomTransformOptions;
     dev: boolean;
@@ -2948,6 +2940,9 @@ declare module 'metro/src/shared/types.flow' {
     readonly unstable_transformProfile: TransformProfile;
     readonly sourcePaths: SourcePathsMode;
   };
+  export type BuildOptions = Readonly<{
+    withAssets?: boolean;
+  }>;
   export type ResolverInputOptions = Readonly<{
     customResolverOptions?: CustomResolverOptions;
     dev: boolean;
@@ -2965,14 +2960,14 @@ declare module 'metro/src/shared/types.flow' {
     readonly lazy: boolean;
     readonly shallow: boolean;
   };
-  export type SplitBundleOptions = {
-    readonly entryFile: string;
-    readonly resolverOptions: ResolverInputOptions;
-    readonly transformOptions: TransformInputOptions;
-    readonly serializerOptions: SerializerOptions;
-    readonly graphOptions: GraphOptions;
-    readonly onProgress: DeltaBundlerOptions['onProgress'];
-  };
+  export type SplitBundleOptions = Readonly<{
+    entryFile: string;
+    resolverOptions: ResolverInputOptions;
+    transformOptions: TransformInputOptions;
+    serializerOptions: SerializerOptions;
+    graphOptions: GraphOptions;
+    onProgress: DeltaBundlerOptions['onProgress'];
+  }>;
   export type ModuleGroups = {
     groups: Map<number, Set<number>>;
     modulesById: Map<number, ModuleTransportLike>;
@@ -3017,6 +3012,7 @@ declare module 'metro/src/shared/types.flow' {
     onProgress?: (transformedFileCount: number, totalFileCount: number) => void;
     readonly customResolverOptions?: CustomResolverOptions;
     readonly customTransformOptions?: CustomTransformOptions;
+    readonly unstable_transformProfile?: TransformProfile;
   };
   export type { MinifierOptions };
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
