### PR TITLE
Update plugins docs: use more reliable `tsx`

### DIFF
--- a/docs/pages/config-plugins/plugins.mdx
+++ b/docs/pages/config-plugins/plugins.mdx
@@ -135,19 +135,20 @@ export default withPlugin;
 
 We recommend writing config plugins in TypeScript, since this will provide intellisense for the configuration objects. However, your app config is ultimately evaluated by Node.js, which does not recognize TypeScript code by default. Therefore, you will need to add a parser for the TypeScript files from the the **plugins** directory to **app.config.ts** file.
 
-Install `ts-node` library by running the following command:
+Install `tsx` library by running the following command:
 
-<Terminal cmd={['$ npm install --save-dev ts-node']} />
+<Terminal cmd={['$ npm install --save-dev tsx']} />
 
 Then, change the static app config (**app.json**) to the [dynamic app config (**app.config.ts**)](/workflow/configuration/#dynamic-configuration) file. You can do this by renaming the **app.json** file to **app.config.ts** and changing the content of the file as shown below. Ensure to add the following import statement at the top of your **app.config.ts** file:
 
 ```ts app.config.ts
-import 'ts-node/register';
+import "tsx";
+import { ConfigContext, ExpoConfig } from "expo/config";
 
-module.exports = () => {
+export default ({ config }: ConfigContext): ExpoConfig => ({
   /* @hide ... rest of your app config */
   /* @end */
-};
+});
 ```
 
 </Step>
@@ -159,19 +160,19 @@ module.exports = () => {
 Now, you can call the config plugin from your dynamic app config. To do this, you need to add the path to the **withPlugin.ts** file to the plugins array in your app config:
 
 ```ts app.config.ts
-import "ts-node/register";
+import "tsx";
 /* @info */
-import { ExpoConfig } from "expo/config";
+import { ExpoConfig, ConfigContext } from "expo/config";
 /* @end */
 
-module.exports = /* @info */({ config }: { config: ExpoConfig })/* @end */ => {
+export default ({ config }: ConfigContext): ExpoConfig => ({
   /* @hide ... rest of your app config */ /* @end */
   /* @info */
   plugins: [
-      ["./plugins/withPlugin.ts"],
+      ["./plugins/withPlugin"],
     ],
   /* @end */
-};
+});
 ```
 
 To see the custom config applied in native projects, run the following command:


### PR DESCRIPTION
# Why

TSX is better, faster, and more stable.
It has more up-to-date features support.
Is able to better resolve the node modules and files.
It more consistently follows and respects the tsconfig.

# How

I tried tsx, works like a charm.

# Test Plan

- follow the docs
- your blessing

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
