### PR TITLE
[docs] fix return symbol misalignment issue in reference documentation

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -2611,7 +2611,7 @@ sign-out operation.
     </div>
     <br />
     <div
-      class=""
+      class="px-4 [table_&]:!mb-0 [table_&]:px-0"
     >
       <div
         class="flex flex-row items-start gap-2 mb-2.5 [table_&]:last:mb-0"

--- a/docs/components/plugins/api/components/APICommentTextBlock.tsx
+++ b/docs/components/plugins/api/components/APICommentTextBlock.tsx
@@ -43,7 +43,7 @@ export const APICommentTextBlock = ({
   emptyCommentFallback,
 }: Props) => {
   const content = comment?.summary ? getCommentContent(comment.summary) : undefined;
-  const hasContent = Boolean(content?.length);
+  const hasContent = Boolean(content?.length) || Boolean(afterContent);
 
   const paramTags = hasContent ? getParamTags(content) : undefined;
   const parsedContent = (


### PR DESCRIPTION
# Why

|  | |
|--|--|
| Before | <img width="1234" height="264" alt="docs expo dev_versions_latest_sdk_router_" src="https://github.com/user-attachments/assets/b20cf903-d247-49a3-8264-22800647aa28" /> |
| After | <img width="1234" height="264" alt="localhost_3002_versions_latest_sdk_router_" src="https://github.com/user-attachments/assets/f1359be8-d099-45ff-9577-217a5c997682" /> |

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
