### PR TITLE
[docs] add changelog links to SDK packages

### DIFF
--- a/docs/ui/components/PageHeader/PageTitleButtons.tsx
+++ b/docs/ui/components/PageHeader/PageTitleButtons.tsx
@@ -1,4 +1,4 @@
-import { Button, mergeClasses } from '@expo/styleguide';
+import { Button } from '@expo/styleguide';
 import { BuildIcon } from '@expo/styleguide-icons/custom/BuildIcon';
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { Edit05Icon } from '@expo/styleguide-icons/outline/Edit05Icon';
@@ -7,7 +7,8 @@ import { useRouter } from 'next/compat/router';
 
 import { githubUrl } from '~/ui/components/Footer/utils';
 import { FOOTNOTE, MONOSPACE } from '~/ui/components/Text';
-import * as Tooltip from '~/ui/components/Tooltip';
+
+import { SdkPackageButton } from './SdkPackageButton';
 
 type Props = {
   packageName?: string;
@@ -72,30 +73,8 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
               },
             ]
           : []),
-      ].map(({ label, icon, tooltip, href }) => (
-        <Tooltip.Root key={label} delayDuration={500}>
-          <Tooltip.Trigger asChild>
-            <Button
-              theme="quaternary"
-              className="min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]"
-              openInNewTab
-              href={href}>
-              <div
-                className={mergeClasses(
-                  'flex flex-col items-center',
-                  'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
-                )}>
-                {icon}
-                <FOOTNOTE crawlable={false} theme="secondary">
-                  {label}
-                </FOOTNOTE>
-              </div>
-            </Button>
-          </Tooltip.Trigger>
-          <Tooltip.Content className="max-w-[300px]">
-            <FOOTNOTE>{tooltip}</FOOTNOTE>
-          </Tooltip.Content>
-        </Tooltip.Root>
+      ].map(props => (
+        <SdkPackageButton key={props.label} {...props} />
       ))}
     </>
   );

--- a/docs/ui/components/PageHeader/PageTitleButtons.tsx
+++ b/docs/ui/components/PageHeader/PageTitleButtons.tsx
@@ -2,6 +2,7 @@ import { Button, mergeClasses } from '@expo/styleguide';
 import { BuildIcon } from '@expo/styleguide-icons/custom/BuildIcon';
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { Edit05Icon } from '@expo/styleguide-icons/outline/Edit05Icon';
+import { Tag03Icon } from '@expo/styleguide-icons/outline/Tag03Icon';
 import { useRouter } from 'next/compat/router';
 
 import { githubUrl } from '~/ui/components/Footer/utils';
@@ -32,58 +33,70 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
           </div>
         </Button>
       )}
-      {sourceCodeUrl && (
-        <Tooltip.Root delayDuration={500}>
+      {[
+        ...(sourceCodeUrl
+          ? [
+              {
+                icon: <GithubIcon className="mt-0.5 text-icon-secondary" />,
+                label: 'GitHub',
+                tooltip: (
+                  <>
+                    View source code of <MONOSPACE>{packageName}</MONOSPACE> on GitHub
+                  </>
+                ),
+                href: sourceCodeUrl,
+              },
+            ]
+          : []),
+        ...(sourceCodeUrl?.startsWith('https://github.com/expo/expo')
+          ? [
+              {
+                icon: <Tag03Icon className="mt-0.5 text-icon-secondary" />,
+                label: 'Changelog',
+                tooltip: (
+                  <>
+                    View the changelog of <MONOSPACE>{packageName}</MONOSPACE> on GitHub
+                  </>
+                ),
+                href: `${sourceCodeUrl}/CHANGELOG.md`,
+              },
+            ]
+          : []),
+        ...(packageName
+          ? [
+              {
+                icon: <BuildIcon className="mt-0.5 text-icon-secondary" />,
+                label: 'npm',
+                tooltip: 'View package in npm registry',
+                href: `https://www.npmjs.com/package/${packageName}`,
+              },
+            ]
+          : []),
+      ].map(({ label, icon, tooltip, href }) => (
+        <Tooltip.Root key={label} delayDuration={500}>
           <Tooltip.Trigger asChild>
             <Button
               theme="quaternary"
               className="min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]"
               openInNewTab
-              href={sourceCodeUrl}>
+              href={href}>
               <div
                 className={mergeClasses(
                   'flex flex-col items-center',
                   'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
                 )}>
-                <GithubIcon className="mt-0.5 text-icon-secondary" />
+                {icon}
                 <FOOTNOTE crawlable={false} theme="secondary">
-                  GitHub
+                  {label}
                 </FOOTNOTE>
               </div>
             </Button>
           </Tooltip.Trigger>
           <Tooltip.Content className="max-w-[300px]">
-            <FOOTNOTE>
-              View source code of <MONOSPACE>{packageName}</MONOSPACE> on GitHub
-            </FOOTNOTE>
+            <FOOTNOTE>{tooltip}</FOOTNOTE>
           </Tooltip.Content>
         </Tooltip.Root>
-      )}
-      {packageName && (
-        <Tooltip.Root delayDuration={500}>
-          <Tooltip.Trigger asChild>
-            <Button
-              theme="quaternary"
-              openInNewTab
-              className="min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]"
-              href={`https://www.npmjs.com/package/${packageName}`}>
-              <div
-                className={mergeClasses(
-                  'flex flex-col items-center',
-                  'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
-                )}>
-                <BuildIcon className="mt-0.5 text-icon-secondary" />
-                <FOOTNOTE crawlable={false} theme="secondary">
-                  npm
-                </FOOTNOTE>
-              </div>
-            </Button>
-          </Tooltip.Trigger>
-          <Tooltip.Content>
-            <FOOTNOTE>View package in npm registry</FOOTNOTE>
-          </Tooltip.Content>
-        </Tooltip.Root>
-      )}
+      ))}
     </>
   );
 }

--- a/docs/ui/components/PageHeader/SdkPackageButton.tsx
+++ b/docs/ui/components/PageHeader/SdkPackageButton.tsx
@@ -1,0 +1,40 @@
+import { Button, mergeClasses } from '@expo/styleguide';
+import React from 'react';
+
+import { FOOTNOTE } from '~/ui/components/Text';
+import * as Tooltip from '~/ui/components/Tooltip';
+
+export type SdkPackageButtonProps = {
+  label: string;
+  icon: React.ReactNode;
+  tooltip: React.ReactNode;
+  href: string;
+};
+
+export const SdkPackageButton = ({ label, icon, tooltip, href }: SdkPackageButtonProps) => {
+  return (
+    <Tooltip.Root key={label} delayDuration={500}>
+      <Tooltip.Trigger asChild>
+        <Button
+          theme="quaternary"
+          className="min-h-[48px] min-w-[60px] justify-center px-2 max-xl-gutters:min-h-[unset]"
+          openInNewTab
+          href={href}>
+          <div
+            className={mergeClasses(
+              'flex flex-col items-center',
+              'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
+            )}>
+            {icon}
+            <FOOTNOTE crawlable={false} theme="secondary">
+              {label}
+            </FOOTNOTE>
+          </div>
+        </Button>
+      </Tooltip.Trigger>
+      <Tooltip.Content className="max-w-[300px]">
+        <FOOTNOTE>{tooltip}</FOOTNOTE>
+      </Tooltip.Content>
+    </Tooltip.Root>
+  );
+};


### PR DESCRIPTION
# Why

Add a changelog button to the page header for Expo packages, allowing users to easily access the changelog from the documentation. Seemed like a useful thing to do. Example /versions/latest/sdk/asset/:

![Screenshot 2025-07-17 at 14.28.18.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/jedBphTC4kiypS6zFnpk/950559fd-921b-42d3-92cf-5d4c368d5474.png)

# How

- Added a new changelog button for packages hosted on GitHub in the Expo repository


# Test Plan

- Confirmed the button links to the correct CHANGELOG.md file
- Ensured the button doesn't appear for packages not hosted in the Expo repository

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)