### PR TITLE
[android][secure-store] Reset isAuthenticating when error is thrown

### DIFF
--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- [secure-store] Reset android isAuthenticating prompt flag when error is thrown ([#38132](https://github.com/expo/expo/pull/38132) by [@SYoder1](https://github.com/SYoder1))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/AuthenticationHelper.kt
+++ b/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/AuthenticationHelper.kt
@@ -40,19 +40,19 @@ class AuthenticationHelper(
 
     isAuthenticating = true
 
-    assertBiometricsSupport()
-    val fragmentActivity = getCurrentActivity() as? FragmentActivity
-      ?: throw AuthenticationException("Cannot display biometric prompt when the app is not in the foreground")
+    try {
+      assertBiometricsSupport()
+      val fragmentActivity = getCurrentActivity() as? FragmentActivity
+        ?: throw AuthenticationException("Cannot display biometric prompt when the app is not in the foreground")
 
-    val authenticationPrompt = AuthenticationPrompt(fragmentActivity, context, title)
+      val authenticationPrompt = AuthenticationPrompt(fragmentActivity, context, title)
 
-    return withContext(Dispatchers.Main.immediate) {
-      try {
+      return withContext(Dispatchers.Main.immediate) {
         return@withContext authenticationPrompt.authenticate(cipher)
           ?: throw AuthenticationException("Couldn't get the authentication result")
-      } finally {
-        isAuthenticating = false
       }
+    } finally {
+      isAuthenticating = false
     }
   }
 


### PR DESCRIPTION
# Why
I have not been able to reproduce this, but I have seen logs with our users where an error is thrown for one reason or another, such as:
`Call to function 'ExpoSecureStore.getValueWithKeyAsync' has been rejected. → Caused by: Could not Authenticate the user: Could not authenticate the user`

Then until the app is killed, any biometrics actions (get or set) will then throw a new error
`Call to function 'ExpoSecureStore.getValueWithKeyAsync' has been rejected. → Caused by: Could not Authenticate the user: Authentication is already in progress`.

# How
Looking at the code, it seems that if `openAuthenticationPrompt` throws an error either from `assertBiometricsSupport()` or `getCurrentActivity()`, the `isAuthenticating` flag is never reset back to false, and "disables" biometrics until the app is killed.

# Test Plan
I haven't been able to reproduce this for my self.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
