### PR TITLE
fix(expo-video): avoid Swift type ambiguity with asset.load in Xcode 26

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Avoid type ambiguity in Swift async asset.load() for Xcode 26 ([#38137](https://github.com/expo/expo/pull/38137) by [@CavalcanteLeo](https://github.com/CavalcanteLeo))
 - [Android] Fix duration property resetting to 0 on video repeat. ([#37984](https://github.com/expo/expo/pull/37984) by [@Wenszel](https://github.com/Wenszel))
 - [Android] Fix accessing player.loop causes app to crash. ([#37928](https://github.com/expo/expo/pull/37928) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Setting `player.currentTime` doesn't seek to the correct time on some videos. ([#37672](https://github.com/expo/expo/pull/37300) by [@petrkonecny2](https://github.com/petrkonecny2))

--- a/packages/expo-video/ios/VideoPlayerItem.swift
+++ b/packages/expo-video/ios/VideoPlayerItem.swift
@@ -39,11 +39,7 @@ class VideoPlayerItem: AVPlayerItem {
     self.urlAsset = asset
     // We can ignore any exceptions thrown during the load. The asset will be assigned to the `VideoPlayer` anyways
     // and cause it to go into .error state trigerring the `onStatusChange` event.
-    do {
-      _ = try await asset.load(.duration, .preferredTransform, .isPlayable)
-    } catch {
-        // Catch block is intentionally left empty
-    }
+    let _: Void? = try? await asset.loadValuesAsynchronously(forKeys: ["duration", "preferredTransform", "isPlayable"])
 
     super.init(asset: urlAsset, automaticallyLoadedAssetKeys: nil)
     self.createTracksLoadingTask()


### PR DESCRIPTION
Fixes Swift compiler error in Xcode 26 caused by ambiguous use of `AVAsset.load(...)` with async/await.

# Why

In Xcode 26 beta, the following line fails to compile due to stricter Swift type inference rules:

```swift
try? await asset.load(.duration, .preferredTransform, .isPlayable)
```

The compiler throws:
```
type of expression is ambiguous without a type annotation
```

This breaks `expo-video` builds on the latest Xcode versions (including 26.0 beta 3).

# How

Replaced the shorthand async API with the explicit version:

```swift
try? await asset.loadValuesAsynchronously(forKeys: ["duration", "preferredTransform", "isPlayable"])
```

This avoids ambiguity and is safe, stable, and supported on all Swift and Xcode versions.

# Test Plan

- Reproduced the original build error on Xcode Version 26.0 beta 3 (17A5276g) using `expo run:ios`
- Applied the patch and re-ran `npx expo run:ios` using a local dev client
- Verified that the app builds successfully and video playback works as expected
- Also confirmed build still works with Xcode 16 for compatibility

Here’s the full Swift error that this PR resolves:

```
error: type of expression is ambiguous without a type annotation
let _: Void? = try? await asset.load(.duration, .preferredTransform, .isPlayable)
```
