### PR TITLE
[templates] Remove signing resource bundles workaround

### DIFF
--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -50,16 +50,5 @@ target 'HelloWorld' do
       :mac_catalyst_enabled => false,
       :ccache_enabled => podfile_properties['apple.ccacheEnabled'] == 'true',
     )
-
-    # This is necessary for Xcode 14, because it signs resource bundles by default
-    # when building for devices.
-    installer.target_installation_results.pod_target_installation_results
-      .each do |pod_name, target_installation_result|
-      target_installation_result.resource_bundle_targets.each do |resource_bundle_target|
-        resource_bundle_target.build_configurations.each do |config|
-          config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
# Why

This was introduced into our template three years ago (https://github.com/expo/expo/pull/19111), and has been fixed in Cocoapods 1.2 a few years ago as well. React Native's core template doesn't use this anymore and they added this internally to `react_native_post_install` (https://github.com/facebook/react-native/pull/34826)

I wonder if we can now safely remove this from `expo-template-bare-minimum/ios/Podfile`

# How

Remove the signing resource bundles workaround

# Test Plan


 ```bash
tar -zcvf expo-template-bare-minimum.tar.gz expo-template-bare-minimum
npx expo prebuild  --clean --template /Users/gabriel/Workspace/expo/expo/templates/expo-template-bare-minimum.tar.gz
``` 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
