### PR TITLE
Update authentication.mdx

### DIFF
--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -306,11 +306,10 @@ export default function Index() {
 
 <Step label="7">
 
-Create the `(app)` layout: 
+Create the **app/(app)/_layout.tsx**:
 
-```tsx app/(app)/_layout.tsx|collapseHeight=480
+```tsx app/(app)/_layout.tsx
 import { Stack } from 'expo-router';
-
 
 export default function AppLayout() {
   // Renders the navigation stack for all authenticated app routes

--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -304,6 +304,22 @@ export default function Index() {
 
 </Step>
 
+<Step label="7">
+
+Create the `(app)` layout: 
+
+```tsx app/(app)/_layout.tsx|collapseHeight=480
+import { Stack } from 'expo-router';
+
+
+export default function AppLayout() {
+  // Renders the navigation stack for all authenticated app routes
+  return <Stack />;
+}
+```
+
+</Step>
+
 You now have an app that will present the splash screen until the initial authentication state has loaded and will redirects to the sign-in screen if the user is not authenticated. If a user visits a deep link to any routes with the authentication check, they'll be redirected to the sign-in screen.
 
 ## Modals and per-route authentication

--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -306,7 +306,7 @@ export default function Index() {
 
 <Step label="7">
 
-Create the **app/(app)/_layout.tsx**:
+Create the **app/(app)/\_layout.tsx**:
 
 ```tsx app/(app)/_layout.tsx
 import { Stack } from 'expo-router';


### PR DESCRIPTION
**What’s changed:**
- Added a new “Create the `(app)` layout” step to the Authentication guide.
- Instructs users to create `app/(app)/_layout.tsx` with: ```tsx import { Stack } from 'expo-router';

  export default function AppLayout() { return <Stack />; }

# Why
(https://github.com/expo/expo/issues/37305)

