### PR TITLE
[docs] tweaks for reference pages buttons

### DIFF
--- a/docs/ui/components/PageHeader/PageHeader.test.tsx
+++ b/docs/ui/components/PageHeader/PageHeader.test.tsx
@@ -30,7 +30,7 @@ describe(PageHeader, () => {
         testRequire={require}
       />
     );
-    const linkElement = screen.getAllByRole('link', { hidden: false })[0];
+    const linkElement = screen.getAllByRole('link', { hidden: false, name: 'GitHub' })[0];
     expect(linkElement.getAttribute('href')).toEqual(
       'https://github.com/expo/expo/tree/main/packages/expo-av'
     );
@@ -38,7 +38,40 @@ describe(PageHeader, () => {
     fireEvent.focus(linkElement);
     const tooltip = await screen.findByRole('tooltip', {}, { timeout: 1000 });
     expect(tooltip).toBeInTheDocument();
-    expect(tooltip).toHaveTextContent('View source code of expo-av on GitHub');
+    expect(tooltip).toHaveTextContent('View source code on GitHub');
+  });
+
+  test('displays GitHub changelog link', async () => {
+    renderWithHeadings(
+      <PageHeader
+        title="test-title"
+        packageName="expo-audio"
+        sourceCodeUrl="https://github.com/expo/expo/tree/main/packages/expo-audio"
+        testRequire={require}
+      />
+    );
+    const linkElement = screen.getAllByRole('link', { hidden: false, name: 'Changelog' })[0];
+    expect(linkElement.getAttribute('href')).toEqual(
+      'https://github.com/expo/expo/tree/main/packages/expo-audio/CHANGELOG.md'
+    );
+
+    fireEvent.focus(linkElement);
+    const tooltip = await screen.findByRole('tooltip', {}, { timeout: 1000 });
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent('View package changelog on GitHub');
+  });
+
+  test('do not display GitHub changelog link for vendored packages', async () => {
+    renderWithHeadings(
+      <PageHeader
+        title="test-title"
+        packageName="react-native-reanimated"
+        sourceCodeUrl="https://github.com/software-mansion/react-native-reanimated"
+        testRequire={require}
+      />
+    );
+    const linkElement = screen.queryAllByRole('link', { hidden: false, name: 'Changelog' })[0];
+    expect(linkElement).toBe(undefined);
   });
 
   test('displays bundled version when packageName provided', () => {

--- a/docs/ui/components/PageHeader/PageTitleButtons.tsx
+++ b/docs/ui/components/PageHeader/PageTitleButtons.tsx
@@ -6,7 +6,7 @@ import { Tag03Icon } from '@expo/styleguide-icons/outline/Tag03Icon';
 import { useRouter } from 'next/compat/router';
 
 import { githubUrl } from '~/ui/components/Footer/utils';
-import { FOOTNOTE, MONOSPACE } from '~/ui/components/Text';
+import { FOOTNOTE } from '~/ui/components/Text';
 
 import { SdkPackageButton } from './SdkPackageButton';
 
@@ -34,48 +34,30 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
           </div>
         </Button>
       )}
-      {[
-        ...(sourceCodeUrl
-          ? [
-              {
-                icon: <GithubIcon className="mt-0.5 text-icon-secondary" />,
-                label: 'GitHub',
-                tooltip: (
-                  <>
-                    View source code of <MONOSPACE>{packageName}</MONOSPACE> on GitHub
-                  </>
-                ),
-                href: sourceCodeUrl,
-              },
-            ]
-          : []),
-        ...(sourceCodeUrl?.startsWith('https://github.com/expo/expo')
-          ? [
-              {
-                icon: <Tag03Icon className="mt-0.5 text-icon-secondary" />,
-                label: 'Changelog',
-                tooltip: (
-                  <>
-                    View the changelog of <MONOSPACE>{packageName}</MONOSPACE> on GitHub
-                  </>
-                ),
-                href: `${sourceCodeUrl}/CHANGELOG.md`,
-              },
-            ]
-          : []),
-        ...(packageName
-          ? [
-              {
-                icon: <BuildIcon className="mt-0.5 text-icon-secondary" />,
-                label: 'npm',
-                tooltip: 'View package in npm registry',
-                href: `https://www.npmjs.com/package/${packageName}`,
-              },
-            ]
-          : []),
-      ].map(props => (
-        <SdkPackageButton key={props.label} {...props} />
-      ))}
+      {sourceCodeUrl && (
+        <SdkPackageButton
+          label="GitHub"
+          Icon={GithubIcon}
+          href={sourceCodeUrl}
+          tooltip="View source code of package on GitHub"
+        />
+      )}
+      {sourceCodeUrl?.startsWith('https://github.com/expo/expo') && (
+        <SdkPackageButton
+          label="Changelog"
+          Icon={Tag03Icon}
+          href={`${sourceCodeUrl}/CHANGELOG.md`}
+          tooltip="View package changelog on GitHub"
+        />
+      )}
+      {packageName && (
+        <SdkPackageButton
+          label="npm"
+          Icon={BuildIcon}
+          href={`https://www.npmjs.com/package/${packageName}`}
+          tooltip="View package in npm registry"
+        />
+      )}
     </>
   );
 }

--- a/docs/ui/components/PageHeader/PageTitleButtons.tsx
+++ b/docs/ui/components/PageHeader/PageTitleButtons.tsx
@@ -39,7 +39,7 @@ export function PageTitleButtons({ packageName, sourceCodeUrl }: Props) {
           label="GitHub"
           Icon={GithubIcon}
           href={sourceCodeUrl}
-          tooltip="View source code of package on GitHub"
+          tooltip="View source code on GitHub"
         />
       )}
       {sourceCodeUrl?.startsWith('https://github.com/expo/expo') && (

--- a/docs/ui/components/PageHeader/SdkPackageButton.tsx
+++ b/docs/ui/components/PageHeader/SdkPackageButton.tsx
@@ -1,17 +1,17 @@
 import { Button, mergeClasses } from '@expo/styleguide';
-import React from 'react';
+import { ComponentType, HTMLAttributes, ReactNode } from 'react';
 
 import { FOOTNOTE } from '~/ui/components/Text';
 import * as Tooltip from '~/ui/components/Tooltip';
 
 export type SdkPackageButtonProps = {
   label: string;
-  icon: React.ReactNode;
-  tooltip: React.ReactNode;
+  Icon: ComponentType<HTMLAttributes<SVGSVGElement>>;
+  tooltip: ReactNode;
   href: string;
 };
 
-export const SdkPackageButton = ({ label, icon, tooltip, href }: SdkPackageButtonProps) => {
+export const SdkPackageButton = ({ label, Icon, tooltip, href }: SdkPackageButtonProps) => {
   return (
     <Tooltip.Root key={label} delayDuration={500}>
       <Tooltip.Trigger asChild>
@@ -25,14 +25,14 @@ export const SdkPackageButton = ({ label, icon, tooltip, href }: SdkPackageButto
               'flex flex-col items-center',
               'max-xl-gutters:flex-row max-xl-gutters:gap-1.5'
             )}>
-            {icon}
+            <Icon className="mt-0.5 text-icon-secondary" />
             <FOOTNOTE crawlable={false} theme="secondary">
               {label}
             </FOOTNOTE>
           </div>
         </Button>
       </Tooltip.Trigger>
-      <Tooltip.Content className="max-w-[300px]">
+      <Tooltip.Content sideOffset={8} className="max-w-[300px]">
         <FOOTNOTE>{tooltip}</FOOTNOTE>
       </Tooltip.Content>
     </Tooltip.Root>


### PR DESCRIPTION
# Why

Make tooltips more concise, avoid styling repetitions.

# How

Convert buttons array to components for readability, drop package name from tooltips, small refactor to `SdkPackageButton` to avoid icon style repetition, adjust tooltip position.

# Test Plan

1. Run docs app locally, or visit PR preview.
2. Navigate to one of the reference pages, 
3. Make sure that header buttons still function properly, and tooltips are shown.

### Preview

<img width="744" height="450" alt="Screenshot 2025-07-18 at 12 07 05" src="https://github.com/user-attachments/assets/5be939d0-cbd0-4e32-9aa3-93119948ccff" />

