### PR TITLE
[expo-go] fix ExpoUpdatesAppLoader.kt build errors

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -4,6 +4,7 @@ package host.exp.exponent
 import android.content.Context
 import android.util.Log
 import expo.modules.core.utilities.EmulatorUtilities
+import expo.modules.easclient.EASClientID
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.UpdatesUtils
 import expo.modules.updates.db.DatabaseHolder
@@ -36,7 +37,6 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.File
-import java.util.*
 import javax.inject.Inject
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -164,7 +164,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
       return
     }
     val logger = UpdatesLogger(context.filesDir)
-    val fileDownloader = FileDownloader(context, configuration, logger)
+    val fileDownloader = FileDownloader(context.filesDir, EASClientID(context).uuid.toString(), configuration, logger)
     loaderScope.launch {
       startLoaderTask(configuration, fileDownloader, directory, selectionPolicy, context, logger)
     }
@@ -298,7 +298,8 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
             Log.e(TAG, "Failed to emit event to JS", e)
           }
         }
-      }
+      },
+      CoroutineScope(Dispatchers.IO)
     ).start()
   }
 


### PR DESCRIPTION
# Why

fix expo go compilation on android

related: https://github.com/expo/expo/pull/37959

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

expo go builds

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
