### PR TITLE
refactor(babel-preset-expo): Re-remove `@babel/core` dependency in `babel-preset-expo` by using host types/template

### DIFF
--- a/packages/babel-preset-expo/build/babel-plugin-transform-export-namespace-from.d.ts
+++ b/packages/babel-preset-expo/build/babel-plugin-transform-export-namespace-from.d.ts
@@ -5,6 +5,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { PluginObj } from '@babel/core';
-declare const _default: () => PluginObj;
+import type { ConfigAPI, PluginObj } from '@babel/core';
+declare const _default: ({ types: t }: ConfigAPI & typeof import("@babel/core")) => PluginObj;
 export default _default;

--- a/packages/babel-preset-expo/build/babel-plugin-transform-export-namespace-from.js
+++ b/packages/babel-preset-expo/build/babel-plugin-transform-export-namespace-from.js
@@ -7,10 +7,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-const core_1 = require("@babel/core");
 // Original: https://github.com/babel/babel/blob/e5c8dc7330cb2f66c37637677609df90b31ff0de/packages/babel-plugin-transform-export-namespace-from/src/index.ts
 // NOTE: Original plugin asserts that Babel version 7 or newer is used. This was removed for simplicity.
-exports.default = () => ({
+exports.default = ({ types: t }) => ({
     name: 'transform-export-namespace-from',
     manipulateOptions: process.env.BABEL_8_BREAKING
         ? undefined
@@ -19,21 +18,21 @@ exports.default = () => ({
         ExportNamedDeclaration(path) {
             const { node, scope } = path;
             const { specifiers } = node;
-            const index = core_1.types.isExportDefaultSpecifier(specifiers[0]) ? 1 : 0;
-            if (!core_1.types.isExportNamespaceSpecifier(specifiers[index]))
+            const index = t.isExportDefaultSpecifier(specifiers[0]) ? 1 : 0;
+            if (!t.isExportNamespaceSpecifier(specifiers[index]))
                 return;
             const nodes = [];
             if (index === 1) {
-                nodes.push(core_1.types.exportNamedDeclaration(null, [specifiers.shift()], node.source));
+                nodes.push(t.exportNamedDeclaration(null, [specifiers.shift()], node.source));
             }
             const specifier = specifiers.shift();
             const { exported } = specifier;
             const uid = scope.generateUidIdentifier(
             // @ts-expect-error Identifier ?? StringLiteral
             exported.name ?? exported.value);
-            nodes.push(withLocation(core_1.types.importDeclaration([core_1.types.importNamespaceSpecifier(uid)], 
+            nodes.push(withLocation(t.importDeclaration([t.importNamespaceSpecifier(uid)], 
             // @ts-expect-error
-            core_1.types.cloneNode(node.source)), node.loc), withLocation(core_1.types.exportNamedDeclaration(null, [core_1.types.exportSpecifier(core_1.types.cloneNode(uid), exported)]), node.loc));
+            t.cloneNode(node.source)), node.loc), withLocation(t.exportNamedDeclaration(null, [t.exportSpecifier(t.cloneNode(uid), exported)]), node.loc));
             if (node.specifiers.length >= 1) {
                 nodes.push(node);
             }

--- a/packages/babel-preset-expo/build/client-module-proxy-plugin.d.ts
+++ b/packages/babel-preset-expo/build/client-module-proxy-plugin.d.ts
@@ -1,5 +1,5 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import { ConfigAPI } from '@babel/core';
-export declare function reactClientReferencesPlugin(api: ConfigAPI): babel.PluginObj;
+import type { ConfigAPI, PluginObj } from '@babel/core';
+export declare function reactClientReferencesPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj;

--- a/packages/babel-preset-expo/build/client-module-proxy-plugin.js
+++ b/packages/babel-preset-expo/build/client-module-proxy-plugin.js
@@ -4,14 +4,11 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.reactClientReferencesPlugin = reactClientReferencesPlugin;
-/**
- * Copyright © 2024 650 Industries.
- */
-const core_1 = require("@babel/core");
 const node_path_1 = require("node:path");
 const node_url_1 = __importDefault(require("node:url"));
 const common_1 = require("./common");
 function reactClientReferencesPlugin(api) {
+    const { template, types } = api;
     const isReactServer = api.caller(common_1.getIsReactServer);
     const possibleProjectRoot = api.caller(common_1.getPossibleProjectRoot);
     return {
@@ -81,7 +78,7 @@ function reactClientReferencesPlugin(api) {
                             }
                             else {
                                 exportPath.node.specifiers.forEach((specifier) => {
-                                    if (core_1.types.isIdentifier(specifier.exported)) {
+                                    if (types.isIdentifier(specifier.exported)) {
                                         const exportName = specifier.exported.name;
                                         exportNames.add(exportName);
                                         callback(exportName, exportPath);
@@ -115,7 +112,7 @@ function reactClientReferencesPlugin(api) {
                     // Assert that assignment to `module.exports` or `exports` is not allowed.
                     path.traverse({
                         AssignmentExpression(path) {
-                            if (core_1.types.isMemberExpression(path.node.left) &&
+                            if (types.isMemberExpression(path.node.left) &&
                                 'name' in path.node.left.object &&
                                 (path.node.left.object.name === 'module' ||
                                     path.node.left.object.name === 'exports')) {
@@ -124,7 +121,7 @@ function reactClientReferencesPlugin(api) {
                         },
                         // Also check Object.assign
                         CallExpression(path) {
-                            if (core_1.types.isMemberExpression(path.node.callee) &&
+                            if (types.isMemberExpression(path.node.callee) &&
                                 'name' in path.node.callee.property &&
                                 'name' in path.node.callee.object &&
                                 path.node.callee.property.name === 'assign' &&
@@ -159,7 +156,7 @@ function reactClientReferencesPlugin(api) {
                     // Clear the body
                     path.node.body = [];
                     path.node.directives = [];
-                    path.pushContainer('body', core_1.template.ast(proxyModule.join('\n')));
+                    path.pushContainer('body', template.ast(proxyModule.join('\n')));
                     assertExpoMetadata(state.file.metadata);
                     // Store the proxy export names for testing purposes.
                     state.file.metadata.proxyExports = [...proxyExports];
@@ -210,7 +207,7 @@ function reactClientReferencesPlugin(api) {
                     // Clear the body
                     path.node.body = [];
                     path.node.directives = [];
-                    path.pushContainer('body', core_1.template.ast(proxyModule.join('\n')));
+                    path.pushContainer('body', template.ast(proxyModule.join('\n')));
                     assertExpoMetadata(state.file.metadata);
                     // Store the proxy export names for testing purposes.
                     state.file.metadata.proxyExports = [...proxyExports];

--- a/packages/babel-preset-expo/build/common.d.ts
+++ b/packages/babel-preset-expo/build/common.d.ts
@@ -1,4 +1,4 @@
-import { type NodePath, types as t } from '@babel/core';
+import type { NodePath, types as t } from '@babel/core';
 export declare function hasModule(name: string): boolean;
 /** Determine which bundler is being used. */
 export declare function getBundler(caller?: any): "metro" | "webpack" | null;

--- a/packages/babel-preset-expo/build/define-plugin.d.ts
+++ b/packages/babel-preset-expo/build/define-plugin.d.ts
@@ -5,8 +5,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { types as t } from '@babel/core';
-declare const plugin: (_: {
-    types: typeof t;
-}) => babel.PluginObj;
-export default plugin;
+import type { ConfigAPI, PluginObj } from '@babel/core';
+declare function definePlugin({ types: t }: ConfigAPI & typeof import('@babel/core')): PluginObj;
+export default definePlugin;

--- a/packages/babel-preset-expo/build/detect-dynamic-exports.d.ts
+++ b/packages/babel-preset-expo/build/detect-dynamic-exports.d.ts
@@ -1,7 +1,5 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import { ConfigAPI, types } from '@babel/core';
-export declare function detectDynamicExports(api: ConfigAPI & {
-    types: typeof types;
-}): babel.PluginObj;
+import type { PluginObj, ConfigAPI } from '@babel/core';
+export declare function detectDynamicExports(api: ConfigAPI & typeof import('@babel/core')): PluginObj;

--- a/packages/babel-preset-expo/build/environment-restricted-imports.d.ts
+++ b/packages/babel-preset-expo/build/environment-restricted-imports.d.ts
@@ -1,8 +1,6 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import { ConfigAPI, types } from '@babel/core';
+import type { ConfigAPI, PluginObj } from '@babel/core';
 /** Prevent importing certain known imports in given environments. This is for sanity to ensure a module never accidentally gets imported unexpectedly. */
-export declare function environmentRestrictedImportsPlugin(api: ConfigAPI & {
-    types: typeof types;
-}): babel.PluginObj;
+export declare function environmentRestrictedImportsPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj;

--- a/packages/babel-preset-expo/build/expo-inline-manifest-plugin.d.ts
+++ b/packages/babel-preset-expo/build/expo-inline-manifest-plugin.d.ts
@@ -1,9 +1,2 @@
-import { ConfigAPI } from '@babel/core';
-export declare function expoInlineManifestPlugin(api: ConfigAPI & {
-    types: any;
-}): {
-    name: string;
-    visitor: {
-        MemberExpression(path: any, state: any): void;
-    };
-};
+import type { ConfigAPI, PluginObj } from '@babel/core';
+export declare function expoInlineManifestPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj;

--- a/packages/babel-preset-expo/build/expo-router-plugin.d.ts
+++ b/packages/babel-preset-expo/build/expo-router-plugin.d.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import { ConfigAPI, types } from '@babel/core';
+import type { ConfigAPI, PluginObj } from '@babel/core';
 /**
  * Inlines environment variables to configure the process:
  *
@@ -10,11 +10,4 @@ import { ConfigAPI, types } from '@babel/core';
  * EXPO_ROUTER_APP_ROOT
  * EXPO_ROUTER_IMPORT_MODE
  */
-export declare function expoRouterBabelPlugin(api: ConfigAPI & {
-    types: typeof types;
-}): {
-    name: string;
-    visitor: {
-        MemberExpression(path: any, state: any): void;
-    };
-};
+export declare function expoRouterBabelPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj;

--- a/packages/babel-preset-expo/build/expo-router-plugin.js
+++ b/packages/babel-preset-expo/build/expo-router-plugin.js
@@ -4,10 +4,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.expoRouterBabelPlugin = expoRouterBabelPlugin;
-/**
- * Copyright © 2024 650 Industries.
- */
-const core_1 = require("@babel/core");
 const node_path_1 = __importDefault(require("node:path"));
 const resolve_from_1 = __importDefault(require("resolve-from"));
 const common_1 = require("./common");
@@ -33,7 +29,7 @@ function expoRouterBabelPlugin(api) {
     const asyncRoutes = api.caller(common_1.getAsyncRoutes);
     const routerAbsoluteRoot = api.caller(common_1.getExpoRouterAbsoluteAppRoot);
     function isFirstInAssign(path) {
-        return core_1.types.isAssignmentExpression(path.parent) && path.parent.left === path.node;
+        return t.isAssignmentExpression(path.parent) && path.parent.left === path.node;
     }
     return {
         name: 'expo-router',

--- a/packages/babel-preset-expo/build/import-meta-transform-plugin.d.ts
+++ b/packages/babel-preset-expo/build/import-meta-transform-plugin.d.ts
@@ -1,4 +1,2 @@
-import { ConfigAPI, types } from '@babel/core';
-export declare function expoImportMetaTransformPluginFactory(pluginEnabled: boolean): (api: ConfigAPI & {
-    types: typeof types;
-}) => babel.PluginObj;
+import type { ConfigAPI, PluginObj } from '@babel/core';
+export declare function expoImportMetaTransformPluginFactory(pluginEnabled: boolean): (api: ConfigAPI & typeof import("@babel/core")) => PluginObj;

--- a/packages/babel-preset-expo/build/index.d.ts
+++ b/packages/babel-preset-expo/build/index.d.ts
@@ -1,4 +1,4 @@
-import { ConfigAPI, TransformOptions } from '@babel/core';
+import type { ConfigAPI, TransformOptions } from '@babel/core';
 type BabelPresetExpoPlatformOptions = {
     /** Disable or configure the `@babel/plugin-proposal-decorators` plugin. */
     decorators?: false | {

--- a/packages/babel-preset-expo/build/inline-env-vars.d.ts
+++ b/packages/babel-preset-expo/build/inline-env-vars.d.ts
@@ -1,4 +1,2 @@
-import { ConfigAPI, PluginObj, types as t } from '@babel/core';
-export declare function expoInlineEnvVars(api: ConfigAPI & {
-    types: typeof t;
-}): PluginObj;
+import type { ConfigAPI, PluginObj } from '@babel/core';
+export declare function expoInlineEnvVars(api: ConfigAPI & typeof import('@babel/core')): PluginObj;

--- a/packages/babel-preset-expo/build/inline-env-vars.js
+++ b/packages/babel-preset-expo/build/inline-env-vars.js
@@ -1,20 +1,20 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.expoInlineEnvVars = expoInlineEnvVars;
-const core_1 = require("@babel/core");
 const common_1 = require("./common");
 const debug = require('debug')('expo:babel:env-vars');
 function expoInlineEnvVars(api) {
+    const { types: t } = api;
     const isProduction = api.caller(common_1.getIsProd);
     function isFirstInAssign(path) {
-        return core_1.types.isAssignmentExpression(path.parent) && path.parent.left === path.node;
+        return t.isAssignmentExpression(path.parent) && path.parent.left === path.node;
     }
     let addEnvImport;
     const publicEnvVars = new Set();
     return {
         name: 'expo-inline-or-reference-env-vars',
         pre(file) {
-            const addNamedImportOnce = (0, common_1.createAddNamedImportOnce)(core_1.types);
+            const addNamedImportOnce = (0, common_1.createAddNamedImportOnce)(t);
             addEnvImport = () => {
                 return addNamedImportOnce(file.path, 'env', 'expo/virtual/env');
             };
@@ -24,17 +24,17 @@ function expoInlineEnvVars(api) {
                 const filename = state.filename;
                 if (path.get('object').matchesPattern('process.env')) {
                     const key = path.toComputedKey();
-                    if (core_1.types.isStringLiteral(key) &&
+                    if (t.isStringLiteral(key) &&
                         !isFirstInAssign(path) &&
                         key.value.startsWith('EXPO_PUBLIC_')) {
                         const envVar = key.value;
                         debug(`${isProduction ? 'Inlining' : 'Referencing'} environment variable in %s: %s`, filename, envVar);
                         publicEnvVars.add(envVar);
                         if (isProduction) {
-                            path.replaceWith(core_1.types.valueToNode(process.env[envVar]));
+                            path.replaceWith(t.valueToNode(process.env[envVar]));
                         }
                         else {
-                            path.replaceWith(core_1.types.memberExpression(addEnvImport(), core_1.types.identifier(envVar)));
+                            path.replaceWith(t.memberExpression(addEnvImport(), t.identifier(envVar)));
                         }
                     }
                 }

--- a/packages/babel-preset-expo/build/minify-platform-select-plugin.d.ts
+++ b/packages/babel-preset-expo/build/minify-platform-select-plugin.d.ts
@@ -5,7 +5,5 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { ConfigAPI, types } from '@babel/core';
-export default function minifyPlatformSelectPlugin({ types: t, }: ConfigAPI & {
-    types: typeof types;
-}): babel.PluginObj;
+import type { ConfigAPI, PluginObj } from '@babel/core';
+export default function minifyPlatformSelectPlugin({ types: t, }: ConfigAPI & typeof import('@babel/core')): PluginObj;

--- a/packages/babel-preset-expo/build/restricted-react-api-plugin.d.ts
+++ b/packages/babel-preset-expo/build/restricted-react-api-plugin.d.ts
@@ -1,7 +1,5 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import { ConfigAPI, types } from '@babel/core';
-export declare function environmentRestrictedReactAPIsPlugin(api: ConfigAPI & {
-    types: typeof types;
-}): babel.PluginObj;
+import type { ConfigAPI, PluginObj } from '@babel/core';
+export declare function environmentRestrictedReactAPIsPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj;

--- a/packages/babel-preset-expo/build/server-actions-plugin.d.ts
+++ b/packages/babel-preset-expo/build/server-actions-plugin.d.ts
@@ -7,5 +7,5 @@
  *
  * https://github.com/lubieowoce/tangle/blob/5229666fb317d0da9363363fc46dc542ba51e4f7/packages/babel-rsc/src/babel-rsc-actions.ts#L1C1-L909C25
  */
-import { ConfigAPI, type PluginObj, type PluginPass } from '@babel/core';
-export declare function reactServerActionsPlugin(api: ConfigAPI): PluginObj<PluginPass>;
+import type { ConfigAPI, PluginObj, PluginPass } from '@babel/core';
+export declare function reactServerActionsPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj<PluginPass>;

--- a/packages/babel-preset-expo/build/use-dom-directive-plugin.d.ts
+++ b/packages/babel-preset-expo/build/use-dom-directive-plugin.d.ts
@@ -1,7 +1,5 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import { ConfigAPI, types } from '@babel/core';
-export declare function expoUseDomDirectivePlugin(api: ConfigAPI & {
-    types: typeof types;
-}): babel.PluginObj;
+import type { ConfigAPI, PluginObj } from '@babel/core';
+export declare function expoUseDomDirectivePlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj;

--- a/packages/babel-preset-expo/build/use-dom-directive-plugin.js
+++ b/packages/babel-preset-expo/build/use-dom-directive-plugin.js
@@ -4,16 +4,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.expoUseDomDirectivePlugin = expoUseDomDirectivePlugin;
-/**
- * Copyright © 2024 650 Industries.
- */
-const core_1 = require("@babel/core");
 const node_crypto_1 = __importDefault(require("node:crypto"));
 const node_path_1 = require("node:path");
 const node_url_1 = __importDefault(require("node:url"));
 const common_1 = require("./common");
 function expoUseDomDirectivePlugin(api) {
-    const { types: t } = api;
+    const { template, types: t } = api;
     const isProduction = api.caller(common_1.getIsProd);
     const platform = api.caller((caller) => caller?.platform);
     const projectRoot = api.caller(common_1.getPossibleProjectRoot);
@@ -107,7 +103,7 @@ function expoUseDomDirectivePlugin(api) {
           export default _Expo_DOMProxyComponent;
         `;
                 // Convert template to AST and push to body
-                const ast = core_1.template.ast(proxyModuleTemplate);
+                const ast = template.ast(proxyModuleTemplate);
                 const results = path.pushContainer('body', ast);
                 // Find and register the component declaration
                 results.forEach((nodePath) => {

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -41,7 +41,6 @@
     "extends": "universe/node"
   },
   "dependencies": {
-    "@babel/core": "^7.20.0",
     "@babel/helper-module-imports": "^7.25.9",
     "@babel/plugin-proposal-decorators": "^7.12.9",
     "@babel/plugin-syntax-export-default-from": "^7.24.7",

--- a/packages/babel-preset-expo/src/babel-plugin-transform-export-namespace-from.ts
+++ b/packages/babel-preset-expo/src/babel-plugin-transform-export-namespace-from.ts
@@ -6,12 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { PluginObj, types as t } from '@babel/core';
+import type { ConfigAPI, PluginObj, types as t } from '@babel/core';
 
 // Original: https://github.com/babel/babel/blob/e5c8dc7330cb2f66c37637677609df90b31ff0de/packages/babel-plugin-transform-export-namespace-from/src/index.ts
 
 // NOTE: Original plugin asserts that Babel version 7 or newer is used. This was removed for simplicity.
-export default (): PluginObj => ({
+export default ({ types: t }: ConfigAPI & typeof import('@babel/core')): PluginObj => ({
   name: 'transform-export-namespace-from',
   manipulateOptions: process.env.BABEL_8_BREAKING
     ? undefined

--- a/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
+++ b/packages/babel-preset-expo/src/client-module-proxy-plugin.ts
@@ -1,13 +1,16 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import { ConfigAPI, template, types } from '@babel/core';
+import type { ConfigAPI, PluginObj } from '@babel/core';
 import { relative as getRelativePath } from 'node:path';
 import url from 'node:url';
 
 import { getPossibleProjectRoot, getIsReactServer, toPosixPath } from './common';
 
-export function reactClientReferencesPlugin(api: ConfigAPI): babel.PluginObj {
+export function reactClientReferencesPlugin(
+  api: ConfigAPI & typeof import('@babel/core')
+): PluginObj {
+  const { template, types } = api;
   const isReactServer = api.caller(getIsReactServer);
   const possibleProjectRoot = api.caller(getPossibleProjectRoot);
 

--- a/packages/babel-preset-expo/src/common.ts
+++ b/packages/babel-preset-expo/src/common.ts
@@ -1,4 +1,4 @@
-import { type NodePath, types as t } from '@babel/core';
+import type { NodePath, types as t } from '@babel/core';
 // @ts-expect-error: missing types
 import { addNamed as addNamedImport } from '@babel/helper-module-imports';
 import { type ExpoBabelCaller } from '@expo/metro-config/build/babel-transformer';

--- a/packages/babel-preset-expo/src/common.ts
+++ b/packages/babel-preset-expo/src/common.ts
@@ -1,7 +1,7 @@
 import type { NodePath, types as t } from '@babel/core';
 // @ts-expect-error: missing types
 import { addNamed as addNamedImport } from '@babel/helper-module-imports';
-import { type ExpoBabelCaller } from '@expo/metro-config/build/babel-transformer';
+import type { ExpoBabelCaller } from '@expo/metro-config/build/babel-transformer';
 import path from 'node:path';
 
 export function hasModule(name: string): boolean {

--- a/packages/babel-preset-expo/src/detect-dynamic-exports.ts
+++ b/packages/babel-preset-expo/src/detect-dynamic-exports.ts
@@ -1,13 +1,13 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import { ConfigAPI, types } from '@babel/core';
+import type { PluginObj, ConfigAPI, types as t } from '@babel/core';
 
 const debug = require('debug')('expo:babel:exports');
 
 // A babel pass to detect the usage of `module.exports` or `exports` in a module for use in
 // export all expansion passes during tree shaking.
-export function detectDynamicExports(api: ConfigAPI & { types: typeof types }): babel.PluginObj {
+export function detectDynamicExports(api: ConfigAPI & typeof import('@babel/core')): PluginObj {
   const { types: t } = api;
 
   return {

--- a/packages/babel-preset-expo/src/environment-restricted-imports.ts
+++ b/packages/babel-preset-expo/src/environment-restricted-imports.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import { ConfigAPI, NodePath, types } from '@babel/core';
+import type { ConfigAPI, PluginObj, NodePath } from '@babel/core';
 
 import { getIsReactServer } from './common';
 
@@ -10,8 +10,8 @@ const FORBIDDEN_REACT_SERVER_IMPORTS = ['client-only'];
 
 /** Prevent importing certain known imports in given environments. This is for sanity to ensure a module never accidentally gets imported unexpectedly. */
 export function environmentRestrictedImportsPlugin(
-  api: ConfigAPI & { types: typeof types }
-): babel.PluginObj {
+  api: ConfigAPI & typeof import('@babel/core')
+): PluginObj {
   const { types: t } = api;
 
   const isReactServer = api.caller(getIsReactServer);

--- a/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
+++ b/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
@@ -1,4 +1,4 @@
-import { ConfigAPI } from '@babel/core';
+import type { ConfigAPI, PluginObj } from '@babel/core';
 import { ExpoConfig, getConfig, getNameFromConfig, ProjectConfig } from 'expo/config';
 
 import { getIsReactServer, getPlatform, getPossibleProjectRoot } from './common';
@@ -121,7 +121,7 @@ function getConfigMemo(projectRoot: string) {
 }
 
 // Convert `process.env.APP_MANIFEST` to a modified web-specific variation of the app.json public manifest.
-export function expoInlineManifestPlugin(api: ConfigAPI & { types: any }) {
+export function expoInlineManifestPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj {
   const { types: t } = api;
 
   const isReactServer = api.caller(getIsReactServer);

--- a/packages/babel-preset-expo/src/expo-router-plugin.ts
+++ b/packages/babel-preset-expo/src/expo-router-plugin.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import { ConfigAPI, NodePath, types } from '@babel/core';
+import type { ConfigAPI, PluginObj, NodePath, types as t } from '@babel/core';
 import nodePath from 'node:path';
 import resolveFrom from 'resolve-from';
 
@@ -27,14 +27,14 @@ function getExpoRouterAppRoot(projectRoot: string, appFolder: string) {
  * EXPO_ROUTER_APP_ROOT
  * EXPO_ROUTER_IMPORT_MODE
  */
-export function expoRouterBabelPlugin(api: ConfigAPI & { types: typeof types }) {
+export function expoRouterBabelPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj {
   const { types: t } = api;
   const possibleProjectRoot = api.caller(getPossibleProjectRoot);
   const asyncRoutes = api.caller(getAsyncRoutes);
   const routerAbsoluteRoot = api.caller(getExpoRouterAbsoluteAppRoot);
 
-  function isFirstInAssign(path: NodePath<types.MemberExpression>) {
-    return types.isAssignmentExpression(path.parent) && path.parent.left === path.node;
+  function isFirstInAssign(path: NodePath<t.MemberExpression>) {
+    return t.isAssignmentExpression(path.parent) && path.parent.left === path.node;
   }
 
   return {

--- a/packages/babel-preset-expo/src/import-meta-transform-plugin.ts
+++ b/packages/babel-preset-expo/src/import-meta-transform-plugin.ts
@@ -1,11 +1,11 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-import { ConfigAPI, types } from '@babel/core';
+import type { ConfigAPI, PluginObj } from '@babel/core';
 
 import { getPlatform } from './common';
 
 export function expoImportMetaTransformPluginFactory(pluginEnabled: boolean) {
-  return (api: ConfigAPI & { types: typeof types }): babel.PluginObj => {
+  return (api: ConfigAPI & typeof import('@babel/core')): PluginObj => {
     const { types: t } = api;
     const platform = api.caller(getPlatform);
 

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -1,4 +1,4 @@
-import { ConfigAPI, PluginItem, TransformOptions } from '@babel/core';
+import type { ConfigAPI, PluginItem, TransformOptions } from '@babel/core';
 
 import { reactClientReferencesPlugin } from './client-module-proxy-plugin';
 import {

--- a/packages/babel-preset-expo/src/inline-env-vars.ts
+++ b/packages/babel-preset-expo/src/inline-env-vars.ts
@@ -1,10 +1,11 @@
-import { ConfigAPI, NodePath, PluginObj, types as t } from '@babel/core';
+import type { ConfigAPI, NodePath, PluginObj, types as t } from '@babel/core';
 
 import { createAddNamedImportOnce, getIsProd } from './common';
 
 const debug = require('debug')('expo:babel:env-vars');
 
-export function expoInlineEnvVars(api: ConfigAPI & { types: typeof t }): PluginObj {
+export function expoInlineEnvVars(api: ConfigAPI & typeof import('@babel/core')): PluginObj {
+  const { types: t } = api;
   const isProduction = api.caller(getIsProd);
 
   function isFirstInAssign(path: NodePath<t.MemberExpression>) {

--- a/packages/babel-preset-expo/src/minify-platform-select-plugin.ts
+++ b/packages/babel-preset-expo/src/minify-platform-select-plugin.ts
@@ -6,18 +6,63 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ConfigAPI, NodePath, types } from '@babel/core';
+import type { ConfigAPI, PluginObj, NodePath, types as t } from '@babel/core';
 
 export default function minifyPlatformSelectPlugin({
   types: t,
-}: ConfigAPI & { types: typeof types }): babel.PluginObj {
+}: ConfigAPI & typeof import('@babel/core')): PluginObj {
+  function isPlatformSelect(path: NodePath<t.CallExpression>): boolean {
+    return (
+      t.isMemberExpression(path.node.callee) &&
+      t.isIdentifier(path.node.callee.object) &&
+      t.isIdentifier(path.node.callee.property) &&
+      path.node.callee.object.name === 'Platform' &&
+      path.node.callee.property.name === 'select' &&
+      t.isObjectExpression(path.node.arguments[0])
+    );
+  }
+
+  function findProperty(objectExpression: t.ObjectExpression, key: string, fallback: () => any) {
+    let value = null;
+    for (const p of objectExpression.properties) {
+      if (!t.isObjectProperty(p) && !t.isObjectMethod(p)) {
+        continue;
+      }
+      if (
+        (t.isIdentifier(p.key) && p.key.name === key) ||
+        (t.isStringLiteral(p.key) && p.key.value === key)
+      ) {
+        if (t.isObjectProperty(p)) {
+          value = p.value;
+          break;
+        } else if (t.isObjectMethod(p)) {
+          value = t.toExpression(p);
+          break;
+        }
+      }
+    }
+    return value ?? fallback();
+  }
+
+  function hasStaticProperties(objectExpression: t.ObjectExpression) {
+    return objectExpression.properties.every((p) => {
+      if (('computed' in p && p.computed) || t.isSpreadElement(p)) {
+        return false;
+      }
+      if (t.isObjectMethod(p) && p.kind !== 'method') {
+        return false;
+      }
+      return t.isIdentifier(p.key) || t.isStringLiteral(p.key);
+    });
+  }
+
   return {
     visitor: {
       CallExpression(path, state) {
         const node = path.node;
         const arg = node.arguments[0];
         const opts = state.opts as { platform: string };
-        if (isPlatformSelect(path) && types.isObjectExpression(arg)) {
+        if (isPlatformSelect(path) && t.isObjectExpression(arg)) {
           if (hasStaticProperties(arg)) {
             let fallback: any;
             if (opts.platform === 'web') {
@@ -34,49 +79,4 @@ export default function minifyPlatformSelectPlugin({
       },
     },
   };
-}
-
-function isPlatformSelect(path: NodePath<types.CallExpression>): boolean {
-  return (
-    types.isMemberExpression(path.node.callee) &&
-    types.isIdentifier(path.node.callee.object) &&
-    types.isIdentifier(path.node.callee.property) &&
-    path.node.callee.object.name === 'Platform' &&
-    path.node.callee.property.name === 'select' &&
-    types.isObjectExpression(path.node.arguments[0])
-  );
-}
-
-function findProperty(objectExpression: types.ObjectExpression, key: string, fallback: () => any) {
-  let value = null;
-  for (const p of objectExpression.properties) {
-    if (!types.isObjectProperty(p) && !types.isObjectMethod(p)) {
-      continue;
-    }
-    if (
-      (types.isIdentifier(p.key) && p.key.name === key) ||
-      (types.isStringLiteral(p.key) && p.key.value === key)
-    ) {
-      if (types.isObjectProperty(p)) {
-        value = p.value;
-        break;
-      } else if (types.isObjectMethod(p)) {
-        value = types.toExpression(p);
-        break;
-      }
-    }
-  }
-  return value ?? fallback();
-}
-
-function hasStaticProperties(objectExpression: types.ObjectExpression) {
-  return objectExpression.properties.every((p) => {
-    if (('computed' in p && p.computed) || types.isSpreadElement(p)) {
-      return false;
-    }
-    if (types.isObjectMethod(p) && p.kind !== 'method') {
-      return false;
-    }
-    return types.isIdentifier(p.key) || types.isStringLiteral(p.key);
-  });
 }

--- a/packages/babel-preset-expo/src/restricted-react-api-plugin.ts
+++ b/packages/babel-preset-expo/src/restricted-react-api-plugin.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import { ConfigAPI, types } from '@babel/core';
+import type { ConfigAPI, PluginObj } from '@babel/core';
 
 const INVALID_SERVER_REACT_DOM_APIS = [
   'findDOMNode',
@@ -41,8 +41,8 @@ const FORBIDDEN_IMPORTS: Record<string, string[]> = {
 };
 
 export function environmentRestrictedReactAPIsPlugin(
-  api: ConfigAPI & { types: typeof types }
-): babel.PluginObj {
+  api: ConfigAPI & typeof import('@babel/core')
+): PluginObj {
   const { types: t } = api;
 
   return {

--- a/packages/babel-preset-expo/src/use-dom-directive-plugin.ts
+++ b/packages/babel-preset-expo/src/use-dom-directive-plugin.ts
@@ -1,7 +1,7 @@
 /**
  * Copyright © 2024 650 Industries.
  */
-import { ConfigAPI, template, types } from '@babel/core';
+import type { ConfigAPI, PluginObj } from '@babel/core';
 import crypto from 'node:crypto';
 import { basename } from 'node:path';
 import url from 'node:url';
@@ -9,9 +9,9 @@ import url from 'node:url';
 import { getIsProd, getPossibleProjectRoot } from './common';
 
 export function expoUseDomDirectivePlugin(
-  api: ConfigAPI & { types: typeof types }
-): babel.PluginObj {
-  const { types: t } = api;
+  api: ConfigAPI & typeof import('@babel/core')
+): PluginObj {
+  const { template, types: t } = api;
 
   const isProduction = api.caller(getIsProd);
   const platform = api.caller((caller) => (caller as any)?.platform);


### PR DESCRIPTION
This is based on #38171 which switches as many imports as possible to `@babel/core`. Furthermore, that meant that the only realised dependency for Babel packages (apart from sub-plugins/presets/helpers) was `@babel/core` in `babel-preset-expo`. The PR then added `@babel/core` as a dependency to `babel-preset-expo`.

This PR refactors the accidentally used imports from `@babel/core` further to remove them and intead use the host `@babel/core` values (i.e. what the plugin receives as an argument)
This has slipped through in a few places, and the types were a little misaligned.