### PR TITLE
chore(tools): Add package+import ratcheting to allow dangerous dependencies

### DIFF
--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -88,7 +88,11 @@ export async function checkDependenciesAsync(pkg: Package, type: PackageCheckTyp
   }
 
   const getValidExternalImportKind = createExternalImportValidator(pkg);
-  let invalidImports: { file: SourceFile; importRef: SourceFileImportRef; kind: DependencyKind.Dev | undefined }[] = [];
+  let invalidImports: {
+    file: SourceFile;
+    importRef: SourceFileImportRef;
+    kind: DependencyKind.Dev | undefined;
+  }[] = [];
 
   for (const source of sources) {
     source.importRefs.forEach((importRef) => {
@@ -216,15 +220,15 @@ function collectTypescriptImports(node: ts.Node | ts.SourceFile, imports: Source
   if (ts.isImportDeclaration(node)) {
     let isTypeOnly = false;
     if (node.importClause?.namedBindings) {
-      isTypeOnly = node.importClause.isTypeOnly || 
-        (ts.isNamedImports(node.importClause.namedBindings) &&  node.importClause.namedBindings.elements.every((binding) => binding.isTypeOnly));
+      isTypeOnly =
+        node.importClause.isTypeOnly ||
+        (ts.isNamedImports(node.importClause.namedBindings) &&
+          node.importClause.namedBindings.elements.every((binding) => binding.isTypeOnly));
     } else {
       isTypeOnly = !!node.importClause?.isTypeOnly;
     }
     // Collect `import` statements
-    imports.push(
-      createTypescriptImportRef(node.moduleSpecifier.getText(), isTypeOnly)
-    );
+    imports.push(createTypescriptImportRef(node.moduleSpecifier.getText(), isTypeOnly));
   } else if (
     ts.isCallExpression(node) &&
     node.expression.getText() === 'require' &&

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -78,7 +78,9 @@ const IGNORED_IMPORTS: Record<string, IgnoreKind | void> = {
  * @param type What part of the package needs to be checked
  */
 export async function checkDependenciesAsync(pkg: Package, type: PackageCheckType = 'package') {
-  if (IGNORED_PACKAGES.includes(pkg.packageName)) {
+  if (isNCCBuilt(pkg)) {
+    return;
+  } else if (IGNORED_PACKAGES.includes(pkg.packageName)) {
     return;
   }
 
@@ -152,6 +154,11 @@ export async function checkDependenciesAsync(pkg: Package, type: PackageCheckTyp
       throw new Error(`${pkg.packageName} has invalid dependency chains.`);
     }
   }
+}
+
+function isNCCBuilt(pkg: Package): boolean {
+  const { build: buildScript } = pkg.packageJson.scripts;
+  return !!pkg.packageJson.bin && buildScript.includes('ncc');
 }
 
 /**

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -32,7 +32,6 @@ const IGNORED_PACKAGES = [
   '@expo/image-utils', // package: sharp, sharp-cli
   '@expo/metro-config', // package: @babel/*, babel-preset-expo, hermes-parser, metro, metro-*
   '@expo/metro-runtime', // package: anser, expo, expo-constants, metro-runtime, pretty-format, react, react-dom, react-native-web, react-refresh, stacktrace-parser
-  'babel-preset-expo', // package: @babel/*, debug, expo, react-native-reanimated, resolve-from
   'expo-asset', // package: @react-native/assets-registry, expo-updates (types only)
   'expo-av', // package: expo-asset
   'expo-font', // package: expo-asset
@@ -48,6 +47,13 @@ const IGNORED_PACKAGES = [
 ];
 
 const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind>> = {
+  'babel-preset-expo': {
+    '@babel/core': 'types-only',
+    '@expo/metro-config/build/babel-transformer': 'types-only',
+    'react-native-worklets/plugin': 'ignore', // Checked via hasModule before requiring
+    'react-native-reanimated/plugin': 'ignore', // Checked via hasModule before requiring
+    'expo/config': 'ignore', // WARN: May need a reverse peer dependency
+  },
 };
 
 /**

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -105,7 +105,9 @@ export async function checkDependenciesAsync(pkg: Package, type: PackageCheckTyp
   if (config) {
     // Filter out ignored imports per package
     invalidImports = invalidImports.filter(({ importRef, kind }) => {
-      switch (config[importRef.importValue]) {
+      const importKind =
+        config[importRef.importValue] || config[getPackageName(importRef.importValue)];
+      switch (importKind) {
         case 'types-only':
           return !importRef.isTypeOnly;
         case 'ignore':
@@ -177,6 +179,17 @@ async function getSourceFilesAsync(pkg: Package, type: PackageCheckType): Promis
         ? { path: filePath, type: 'test' }
         : { path: filePath, type: 'source' }
     );
+}
+
+function getPackageName(name: string): string {
+  let idx: number;
+  if (name[0] === '@') {
+    idx = name.indexOf('/');
+    if (idx < 0) return name;
+    return name.slice(0, name.indexOf('/', idx + 1));
+  } else {
+    return name.slice(0, name.indexOf('/'));
+  }
 }
 
 /** Get the path of source files based on the package, and the type of check currently running */

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -55,6 +55,13 @@ const IGNORED_PACKAGES = [
 ];
 
 const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | void> = {
+  'expo-dev-menu': {
+    'react-native': 'ignore', // WARN: May need a peer dependency for react-native
+  },
+  'expo-modules-test-core': {
+    typescript: 'ignore-dev', // TODO: Should probably be a peer dep
+  },
+
   'babel-preset-expo': {
     '@babel/core': 'ignore-dev', // TODO: Switch to types-only (#38177)
     '@babel/traverse': 'types-only', // TODO: Remove (#38171)

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -191,9 +191,16 @@ function getSourceFileImports(sourceFile: SourceFile): SourceFileImportRef[] {
 /** Iterate the parsed TypeScript AST and collect all imports or require statements */
 function collectTypescriptImports(node: ts.Node | ts.SourceFile, imports: SourceFileImportRef[]) {
   if (ts.isImportDeclaration(node)) {
+    let isTypeOnly = false;
+    if (node.importClause?.namedBindings) {
+      isTypeOnly = node.importClause.isTypeOnly || 
+        (ts.isNamedImports(node.importClause.namedBindings) &&  node.importClause.namedBindings.elements.every((binding) => binding.isTypeOnly));
+    } else {
+      isTypeOnly = !!node.importClause?.isTypeOnly;
+    }
     // Collect `import` statements
     imports.push(
-      createTypescriptImportRef(node.moduleSpecifier.getText(), node.importClause?.isTypeOnly)
+      createTypescriptImportRef(node.moduleSpecifier.getText(), isTypeOnly)
     );
   } else if (
     ts.isCallExpression(node) &&

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -33,8 +33,6 @@ type SourceFileImportRef = {
   isTypeOnly?: boolean;
 };
 
-// We are incrementally rolling this out, the imports in this list are expected to be invalid
-const IGNORED_IMPORTS = ['expo-modules-core', 'typescript'];
 // We are incrementally rolling this out, the sdk packages in this list are expected to be invalid
 const IGNORED_PACKAGES = [
   '@expo/cli', // package: @react-native-community/cli-server-api, expo-modules-autolinking, expo-router, express, metro-*, webpack, webpack-dev-server
@@ -157,10 +155,7 @@ function createExternalImportValidator(pkg: Package) {
     DependencyKind.Dev,
     DependencyKind.Peer,
   ]);
-
-  IGNORED_IMPORTS.forEach((dependency) => dependencyMap.set(dependency, null));
   dependencies.forEach((dependency) => dependencyMap.set(dependency.name, dependency));
-
   return (ref: SourceFileImportRef) =>
     ref.type !== 'external' ||
     pkg.packageName === ref.packageName ||


### PR DESCRIPTION
# Why

The idea here is that with the current allow list, even as we fix up dependency chains, we won't be able to mark unsafe chains as allowed. For example, this PR shows that `babel-preset-expo` can be included in `checkDependencies` again and that remaining dependencies should be ignored/accepted selectively.

# How

> [!WARNING]
> This will flag new errors for `devDependencies`. It's not safe for us to allow any imports from `devDependencies` by default, so it's now also considered unsafe. Let's wait to see whether CI flags new packages.

There will be three "levels" of ignoring invalid dependencies:
- `type-only` (allows type-only imports of any non-specified dependency; often this is OK)
- `ignore` (allows `devDependencies`; dangerous)
- `ignore-dev` (allows any import; very dangerous)

Basically, `type-only` is an unavoidable configuration. For example, as can be seen in the changes in this PR, `babel-preset-expo` needs type-only imports of `@babel/core`. While it shouldn't import `@babel/core` by value, the type imports will still need to be there.

The `ignore` configuration will be used for things like `expo/*` sub-imports, until we add peer dependencies for reverse-dependency imports. It remains to be seen if we want to do that for SDK 54, but I reckon we should for Yarn Berry.

The `ignore-dev` configuration just ignores all imports. This is needed for user-imports, e.g. `react-native-worklets/plugin`, if we're unwilling to add optional peer dependencies (which we should maybe consider)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
