### PR TITLE
chore(tools): Ratchet up dependencies checks (`@expo/image-utils`, expo-asset, expo-image, expo-video, expo-audio)

### DIFF
--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -37,21 +37,16 @@ type SourceFileImportRef = {
 const IGNORED_PACKAGES = [
   '@expo/cli', // package: @react-native-community/cli-server-api, expo-modules-autolinking, expo-router, express, metro-*, webpack, webpack-dev-server
   '@expo/html-elements', // package: react, react-native, react-native-web
-  '@expo/image-utils', // package: sharp, sharp-cli
   '@expo/metro-config', // package: @babel/*, babel-preset-expo, hermes-parser, metro, metro-*
   '@expo/metro-runtime', // package: anser, expo, expo-constants, metro-runtime, pretty-format, react, react-dom, react-native-web, react-refresh, stacktrace-parser
-  'expo-asset', // package: @react-native/assets-registry, expo-updates (types only)
   'expo-av', // package: expo-asset
   'expo-font', // package: expo-asset
   'expo-gl', // package: react-dom, react-native-reanimated
-  'expo-image', // package: @react-native/assets-registry
   'expo-modules-core', // package: react, react-native
   'expo-router', // package: @react-navigation/core, @react-navigation/routers, debug, escape-string-regexp, expect, expo-font, fast-deep-equal, nanoid, react, react-dom, react-native, react-native-web
   'expo-sqlite', // package: expo-asset
   'expo-store-review', // package: expo-constants
   'expo-updates', // cli: @expo/plist, debug, getenv - utils: @expo/cli, @expo/metro-config, metro
-  'expo-video', // package: @react-native/assets-registry
-  'expo-audio', // package: @react-native/assets-registry
 ];
 
 const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | void> = {

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -62,6 +62,21 @@ const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | v
     typescript: 'ignore-dev', // TODO: Should probably be a peer dep
   },
 
+  'expo-asset': {
+    '@expo/config-plugins/build/utils/warnings.js': 'ignore-dev', // TODO: Remove
+  },
+
+  'expo-updates': {
+    debug: 'ignore-dev', // TODO: Add dependency
+    getenv: 'ignore-dev', // TODO: Add dependency
+    '@expo/plist': 'ignore-dev', // TODO: Add dependency
+  },
+
+  '@expo/image-utils': {
+    sharp: 'ignore-dev', // TODO: Mark as optional peer dep, if that's the intention
+    'sharp-cli': 'ignore-dev',
+  },
+
   'babel-preset-expo': {
     '@babel/core': 'types-only',
     '@expo/metro-config/build/babel-transformer': 'types-only',

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -61,12 +61,6 @@ const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | v
     '@expo/config-plugins/build/utils/warnings.js': 'ignore-dev', // TODO: Remove
   },
 
-  'expo-updates': {
-    debug: 'ignore-dev', // TODO: Add dependency
-    getenv: 'ignore-dev', // TODO: Add dependency
-    '@expo/plist': 'ignore-dev', // TODO: Add dependency
-  },
-
   '@expo/image-utils': {
     sharp: 'ignore-dev', // TODO: Mark as optional peer dep, if that's the intention
     'sharp-cli': 'ignore-dev',

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -74,6 +74,10 @@ const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | v
 // NOTE: These are globally ignored dependencies, and this list shouldn't ever get longer
 const IGNORED_IMPORTS: Record<string, IgnoreKind | void> = {
   'expo-modules-core': 'ignore-dev',
+
+  // This is force-resolved in the CLI and therefore, for Expo modules, is generally safe
+  // See: https://github.com/expo/expo/blob/d63143c/packages/%40expo/cli/src/start/server/metro/withMetroMultiPlatform.ts#L603-L622
+  '@react-native/assets-registry/registry': 'ignore-dev',
 };
 
 /**
@@ -123,7 +127,7 @@ export async function checkDependenciesAsync(pkg: Package, type: PackageCheckTyp
       ignoreKind = config?.[packageName];
       if (!ignoreKind) {
         // if we still don't find an exception, we see if it's a global exception
-        ignoreKind = IGNORED_IMPORTS[packageName];
+        ignoreKind = IGNORED_IMPORTS[importRef.importValue] ?? IGNORED_IMPORTS[packageName];
       }
     }
     switch (ignoreKind) {


### PR DESCRIPTION
- Mark `@react-native/assets-registry/registry` as generally safe
  - NOTE: This only applies to dependencies bundled by `@expo/cli`, but that's typically how this import will be used anyway, since it's non-functional outside of RN builds
- Ratchet `@expo/image-utils` explicitly (missing optional peer)