### PR TITLE
[Expo Maps Docs] Fix: Expo dashboard UI says "Project Settings", not "Credentials"

### DIFF
--- a/docs/pages/versions/unversioned/sdk/maps.mdx
+++ b/docs/pages/versions/unversioned/sdk/maps.mdx
@@ -66,7 +66,7 @@ Expo Maps provides access to the platform native map APIs on Android and iOS.
 <Tab label="For development builds">
 
 - If you have already created a [development build](/develop/development-builds/introduction/), your project will be signed using a debug keystore.
-- After the build is complete, go to your [project's dashboard](https://expo.dev/accounts/[username]/projects/[project-name]), then, under **Configure** > click **Credentials**.
+- After the build is complete, go to your [project's dashboard](https://expo.dev/accounts/[username]/projects/[project-name]), then, under **Project settings** > click **Credentials**.
 - Under **Application Identifiers**, click your project's package name and under **Android Keystore** copy the value of **SHA-1 Certificate Fingerprint**.
 
 </Tab>

--- a/docs/pages/versions/v53.0.0/sdk/maps.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/maps.mdx
@@ -66,7 +66,7 @@ Expo Maps provides access to the platform native map APIs on Android and iOS.
 <Tab label="For development builds">
 
 - If you have already created a [development build](/develop/development-builds/introduction/), your project will be signed using a debug keystore.
-- After the build is complete, go to your [project's dashboard](https://expo.dev/accounts/[username]/projects/[project-name]), then, under **Configure** > click **Credentials**.
+- After the build is complete, go to your [project's dashboard](https://expo.dev/accounts/[username]/projects/[project-name]), then, under **Project settings** > click **Credentials**.
 - Under **Application Identifiers**, click your project's package name and under **Android Keystore** copy the value of **SHA-1 Certificate Fingerprint**.
 
 </Tab>


### PR DESCRIPTION
# Why

This is a docs change: I was going through initial setup of expo maps yesterday and came across this step in the setup instructions in the docs - the Expo Dashboard doesn't say "Configure -> Credentials" as far as I can see (screenshot below)

<img width="1241" height="898" alt="Pasted_Image_7_20_25__8_33 AM" src="https://github.com/user-attachments/assets/b1bd5ae7-0560-467a-b203-7b96b615434c" />



# How

<!--
How did you build this feature or fix this bug and why?
-->

This is what I had to do to get expo maps working on a dev build on my device.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
