### PR TITLE
[media-library][android] Rewrite getAssetsAsync to Coroutines

### DIFF
--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/Exceptions.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/Exceptions.kt
@@ -31,3 +31,9 @@ class ContentEntryException :
 
 class AssetFileException(message: String) :
   CodedException(message)
+
+class UnableToLoadPermissionException(message: String) :
+  CodedException(message)
+
+class UnableToLoadException(message: String) :
+  CodedException(message)

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -49,7 +49,6 @@ import expo.modules.medialibrary.assets.GetAssetInfo
 import expo.modules.medialibrary.assets.GetAssets
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -221,9 +221,8 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("getAssetsAsync") Coroutine { assetOptions: AssetsOptions ->
-      throwUnlessPermissionsGrantedCoroutines(isWrite = false) {
-        GetAssets(context, assetOptions).execute()
-      }
+      throwUnlessPermissionsGrantedCoroutines(isWrite = false)
+      GetAssets(context, assetOptions).execute()
     }
 
     AsyncFunction("migrateAlbumIfNeededAsync") { albumId: String, promise: Promise ->
@@ -439,7 +438,7 @@ class MediaLibraryModule : Module() {
     block()
   }
 
-  private suspend inline fun <T> throwUnlessPermissionsGrantedCoroutines(isWrite: Boolean = true, crossinline block: suspend () -> T): T {
+  private fun throwUnlessPermissionsGrantedCoroutines(isWrite: Boolean = true) {
     val missingPermissionsCondition =
       if (isWrite) isMissingWritePermission else isMissingPermissions
     if (missingPermissionsCondition) {
@@ -447,7 +446,6 @@ class MediaLibraryModule : Module() {
         if (isWrite) ERROR_NO_WRITE_PERMISSION_MESSAGE else ERROR_NO_PERMISSIONS_MESSAGE
       throw PermissionsException(missingPermissionsMessage)
     }
-    return block()
   }
 
   private fun interface Action {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -223,10 +223,7 @@ class MediaLibraryModule : Module() {
 
     AsyncFunction("getAssetsAsync") Coroutine { assetOptions: AssetsOptions ->
       throwUnlessPermissionsGrantedCoroutines(isWrite = false) {
-        moduleCoroutineScope.async {
-          GetAssets(context, assetOptions)
-            .execute()
-        }.await()
+        GetAssets(context, assetOptions).execute()
       }
     }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -12,10 +12,13 @@ import android.text.TextUtils
 import android.util.Log
 import android.webkit.MimeTypeMap
 import expo.modules.kotlin.Promise
+import kotlinx.coroutines.isActive
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CancellationException
 
 object MediaLibraryUtils {
   class AssetFile(pathname: String, val assetId: String, val mimeType: String) : File(pathname)
@@ -258,4 +261,8 @@ object MediaLibraryUtils {
    */
   fun hasManifestPermission(context: Context, permission: String): Boolean =
     getManifestPermissions(context).contains(permission)
+
+  fun CoroutineContext.ensureActiveOrThrow(message: String = "Coroutine context is inactive") {
+    if (!this.isActive) throw CancellationException(message)
+  }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -12,13 +12,10 @@ import android.text.TextUtils
 import android.util.Log
 import android.webkit.MimeTypeMap
 import expo.modules.kotlin.Promise
-import kotlinx.coroutines.isActive
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
-import kotlin.coroutines.CoroutineContext
-import kotlinx.coroutines.CancellationException
 
 object MediaLibraryUtils {
   class AssetFile(pathname: String, val assetId: String, val mimeType: String) : File(pathname)
@@ -261,8 +258,4 @@ object MediaLibraryUtils {
    */
   fun hasManifestPermission(context: Context, permission: String): Boolean =
     getManifestPermissions(context).contains(permission)
-
-  fun CoroutineContext.ensureActiveOrThrow(message: String = "Coroutine context is inactive") {
-    if (!this.isActive) throw CancellationException(message)
-  }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/GetAssets.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/GetAssets.kt
@@ -6,9 +6,9 @@ import expo.modules.medialibrary.ASSET_PROJECTION
 import expo.modules.medialibrary.AssetQueryException
 import expo.modules.medialibrary.AssetsOptions
 import expo.modules.medialibrary.EXTERNAL_CONTENT_URI
-import expo.modules.medialibrary.MediaLibraryUtils.ensureActiveOrThrow
 import expo.modules.medialibrary.PermissionsException
 import expo.modules.medialibrary.UnableToLoadException
+import kotlinx.coroutines.ensureActive
 import java.io.IOException
 import kotlin.coroutines.coroutineContext
 
@@ -27,7 +27,7 @@ internal class GetAssets(
         null,
         order
       ).use { assetsCursor ->
-        coroutineContext.ensureActiveOrThrow()
+        coroutineContext.ensureActive()
         if (assetsCursor == null) {
           throw AssetQueryException()
         }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/GetAssets.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/GetAssets.kt
@@ -48,17 +48,12 @@ internal class GetAssets(
         }
       }
     } catch (e: Exception) {
-      when (e) {
-        is SecurityException -> throw UnableToLoadException("Could not get asset: need read_external_storage permission")
-        is IOException -> throw UnableToLoadException("Could not read file $e")
-        is IllegalArgumentException -> throw UnableToLoadException(
-          e.message
-            ?: "Invalid MediaType $e"
-        )
-        is UnsupportedOperationException -> {
-          throw PermissionsException(e.message ?: "Permission denied $e")
-        }
-        else -> throw e
+      throw when (e) {
+        is SecurityException -> UnableToLoadException("Could not get asset: need read_external_storage permission")
+        is IOException -> UnableToLoadException("Could not read file $e")
+        is IllegalArgumentException -> UnableToLoadException(e.message ?: "Invalid MediaType $e")
+        is UnsupportedOperationException -> PermissionsException(e.message ?: "Permission denied $e")
+        else -> e
       }
     }
   }

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetsTest.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetsTest.kt
@@ -2,17 +2,12 @@ package expo.modules.medialibrary.assets
 
 import expo.modules.medialibrary.AssetQueryException
 import expo.modules.medialibrary.AssetsOptions
-import expo.modules.medialibrary.ERROR_UNABLE_TO_LOAD
-import expo.modules.medialibrary.ERROR_UNABLE_TO_LOAD_PERMISSION
 import expo.modules.medialibrary.MockContext
 import expo.modules.medialibrary.MockData
 import expo.modules.medialibrary.UnableToLoadException
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockContentResolverForResult
 import expo.modules.medialibrary.throwableContentResolver
-import expo.modules.test.core.legacy.PromiseMock
-import expo.modules.test.core.legacy.assertRejectedWithCode
-import expo.modules.test.core.legacy.promiseResolved
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetsTest.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetsTest.kt
@@ -13,10 +13,9 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockkStatic
 import io.mockk.runs
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -57,7 +56,7 @@ internal class GetAssetsTest {
   }
 
   @Test
-  fun `getAssets should resolve with correct response`() = runBlocking {
+  fun `getAssets should resolve with correct response`() = runTest {
     // arrange
     val context = mockContext with mockContentResolverForResult(
       arrayOf(
@@ -74,41 +73,41 @@ internal class GetAssetsTest {
   }
 
   @Test
-  fun `GetAssets should reject on null cursor`() {
+  fun `GetAssets should reject on null cursor`() = runTest {
     // arrange
     val context = mockContext with mockContentResolver(null)
 
     // act && assert
-    assertThrows(AssetQueryException::class.java) {
-      runBlocking {
-        GetAssets(context, defaultAssets).execute()
-      }
+    try {
+      GetAssets(context, defaultAssets).execute()
+    } catch (e: Exception) {
+      assert(e is AssetQueryException)
     }
   }
 
   @Test
-  fun `GetAssets should reject on SecurityException`() {
+  fun `GetAssets should reject on SecurityException`() = runTest {
     // arrange
     val context = mockContext with throwableContentResolver(SecurityException())
 
     // act && assert
-    assertThrows(UnableToLoadException::class.java) {
-      runBlocking {
-        GetAssets(context, defaultAssets).execute()
-      }
+    try {
+      GetAssets(context, defaultAssets).execute()
+    } catch (e: Exception) {
+      assert(e is UnableToLoadException)
     }
   }
 
   @Test
-  fun `GetAssets should reject on IOException`() {
+  fun `GetAssets should reject on IOException`() = runTest {
     // arrange
     val context = mockContext with throwableContentResolver(IOException())
 
     // act && assert
-    assertThrows(UnableToLoadException::class.java) {
-      runBlocking {
-        GetAssets(context, defaultAssets).execute()
-      }
+    try {
+      GetAssets(context, defaultAssets).execute()
+    } catch (e: Exception) {
+      assert(e is UnableToLoadException)
     }
   }
 }


### PR DESCRIPTION
# Why

This is the first PR in a series transforming the MediaLibrary API to use Coroutines.

# How

- Added `throwUnlessPermissionsGrantedCoroutines` — a temporary function to ensure compatibility until all AsyncFunctions are rewritten to coroutines.
- Removed `withModuleScope` because catching errors is redundant without promise rejection. Moreover, marking AsyncFunction as a coroutine creates a scope with a SupervisedJob.
- Added check in `GetAssets.execute()` after querying assets to verify if coroutineContext is still active.

# Test Plan
Tested on Bare Expo.
<img width="300" height="750" alt="Screenshot_20250721_111152" src="https://github.com/user-attachments/assets/70cb5e1f-f082-4220-b43d-18e32d952281" />
