### PR TITLE
[launcher][Android] Imporve loading running packagers

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/HomeViewModel.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/HomeViewModel.kt
@@ -18,6 +18,7 @@ import expo.modules.devlauncher.services.UserState
 import expo.modules.devlauncher.services.inject
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 
 sealed interface HomeAction {
@@ -60,15 +61,14 @@ class HomeViewModel() : ViewModel() {
     get() = _state.value
 
   init {
-    viewModelScope.launch {
-      packagerService.refetchedPackager()
-    }
-
-    packagerService.runningPackagers.onEach { newPackagers ->
-      _state.value = _state.value.copy(
-        runningPackagers = newPackagers
-      )
-    }.launchIn(viewModelScope)
+    packagerService
+      .runningPackagers
+      .onEach { newPackagers ->
+        _state.value = _state.value.copy(
+          runningPackagers = newPackagers
+        )
+      }
+      .launchIn(viewModelScope)
 
     sessionService.user.onEach { newUser ->
       when (newUser) {
@@ -100,7 +100,7 @@ class HomeViewModel() : ViewModel() {
           }
         }
 
-      HomeAction.RefetchRunningApps -> viewModelScope.launch { packagerService.refetchedPackager() }
+      HomeAction.RefetchRunningApps -> packagerService.refetchedPackager()
 
       HomeAction.ResetRecentlyOpenedApps -> viewModelScope.launch {
         devLauncherController.clearRecentlyOpenedApps()


### PR DESCRIPTION
# Why

Improves loading running packagers

# How

- Added 5 5-second cache to not refetch packagers when changing screens
- Made sure that fetching takes 2 seconds, to reduce network traffic   

# Test Plan

- bare-expo ✅ 