### PR TITLE
[screen-capture] [iOS] Replace-deprecated-keyWindow-usage

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### 💡 Others
 
+- [iOS] Replaced deprecated keyWindow usage. ([#38207](https://github.com/expo/expo/pull/38207) by [@hryhoriiK97](https://github.com/hryhoriiK97))
+
 ## 7.1.5 - 2025-07-01
 
 ### 💡 Others

--- a/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
+++ b/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
@@ -10,6 +10,11 @@ public final class ScreenCaptureModule: Module {
   private var originalParent: CALayer?
   private var blurEffectView: AnimatedBlurEffectView?
   private var blurIntensity: CGFloat = 0.5
+  private var keyWindow: UIWindow? {
+    return UIApplication.shared.connectedScenes
+      .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+      .last { $0.isKeyWindow }
+  }
 
   public func definition() -> ModuleDefinition {
     Name("ExpoScreenCapture")
@@ -41,7 +46,7 @@ public final class ScreenCaptureModule: Module {
 
       NotificationCenter.default.addObserver(
         self,
-        selector: #selector(self.preventScreenRecording),
+        selector: #selector(preventScreenRecording),
         name: UIScreen.capturedDidChangeNotification,
         object: nil
       )
@@ -91,10 +96,12 @@ public final class ScreenCaptureModule: Module {
 
   @objc
   func preventScreenRecording() {
+    guard let keyWindow = keyWindow,
+      let visibleView = keyWindow.subviews.first else { return }
     let isCaptured = UIScreen.main.isCaptured
 
     if isCaptured {
-      UIApplication.shared.keyWindow?.subviews.first?.addSubview(blockView)
+      keyWindow.subviews.first?.addSubview(blockView)
     } else {
       blockView.removeFromSuperview()
     }
@@ -108,7 +115,7 @@ public final class ScreenCaptureModule: Module {
   }
 
   private func preventScreenshots() {
-    guard let keyWindow = UIApplication.shared.keyWindow,
+    guard let keyWindow = keyWindow,
       let visibleView = keyWindow.subviews.first else { return }
 
     let textField = UITextField()
@@ -192,7 +199,7 @@ public final class ScreenCaptureModule: Module {
   }
 
   private func showPrivacyOverlay() {
-    if let keyWindow = UIApplication.shared.keyWindow,
+    if let keyWindow = keyWindow,
       let rootView = keyWindow.subviews.first {
       let blurEffectView = AnimatedBlurEffectView(style: .light, intensity: self.blurIntensity)
       blurEffectView.frame = rootView.bounds

--- a/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
+++ b/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
@@ -46,7 +46,7 @@ public final class ScreenCaptureModule: Module {
 
       NotificationCenter.default.addObserver(
         self,
-        selector: #selector(preventScreenRecording),
+        selector: #selector(self.preventScreenRecording),
         name: UIScreen.capturedDidChangeNotification,
         object: nil
       )
@@ -101,7 +101,7 @@ public final class ScreenCaptureModule: Module {
     let isCaptured = UIScreen.main.isCaptured
 
     if isCaptured {
-      keyWindow.subviews.first?.addSubview(blockView)
+      visibleView.addSubview(blockView)
     } else {
       blockView.removeFromSuperview()
     }


### PR DESCRIPTION
# Why
Thread with the context: https://github.com/expo/expo/pull/38192#discussion_r2218864134

# How
I've used the same approach to declaring keyWindow as shown in the ScreenOrientationRegistry:
https://github.com/expo/expo/blob/main/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift#L25

# Test Plan
It would be great to test the screen capture functionality in the bare-expo app. Everything should work as expected.

https://github.com/user-attachments/assets/c82650d2-f757-427a-8d32-1c9fbecc6a64

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
