### PR TITLE
[constants][iOS] forward PROJECT_ROOT env var to app config script

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- [iOS] forward PROJECT_ROOT env var to app config script ([#38208](https://github.com/expo/expo/pull/38208) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 17.1.7 - 2025-07-03
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-constants/ios/EXConstants.podspec
+++ b/packages/expo-constants/ios/EXConstants.podspec
@@ -34,9 +34,10 @@ Pod::Spec.new do |s|
     s.source_files = "**/*.{h,m,swift}"
   end
 
+  env_vars = ENV['PROJECT_ROOT'] ? "PROJECT_ROOT=#{ENV['PROJECT_ROOT']} " : ""
   script_phase = {
     :name => 'Generate app.config for prebuilt Constants.manifest',
-    :script => 'bash -l -c "$PODS_TARGET_SRCROOT/../scripts/get-app-config-ios.sh"',
+    :script => "bash -l -c \"#{env_vars}$PODS_TARGET_SRCROOT/../scripts/get-app-config-ios.sh\"",
     :execution_position => :before_compile
   }
   # :always_out_of_date is only available in CocoaPods 1.13.0 and later


### PR DESCRIPTION
# Why

The `get-app-config-ios` script allows users to set a custom location for the root of their project, especially useful for brownfield apps that don't follow the typical /ios folder structure, but right now, you can't set it through CocoaPods because Pods env vars are not injected into build scripts.

https://github.com/expo/expo/blob/9c0cb80ee362fe1468e205ba9e7af59917e48227/packages/expo-constants/scripts/get-app-config-ios.sh#L19-L21

To fix this, we need to forward the `PROJECT_ROOT` env var to app config script

# How

Forward the `PROJECT_ROOT` environment variable to `app-config-ios` script

# Test Plan

Set a custom `PROJECT_ROOT` path inside a Podfile, install pods and build a project 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
