### PR TITLE
[autolinking][iOS] Add :projectRoot option to use_expo_modules

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add `--source-dir` option ([#38218](https://github.com/expo/expo/pull/38218) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Add `:projectRoot` option to `use_expo_modules!` ([#38210](https://github.com/expo/expo/pull/38210) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -209,7 +209,14 @@ module Expo
     end
 
     private def resolve_command_args
-      node_command_args('resolve').concat(['--json'])
+      resolve_command_args = ['--json']
+
+      project_root = @options.fetch(:projectRoot, nil)
+      if project_root
+        resolve_command_args.concat(['--project-root', project_root])
+      end
+
+      node_command_args('resolve').concat(resolve_command_args)
     end
 
     public def generate_modules_provider_command_args(target_path)


### PR DESCRIPTION
# Why

`use_expo_modules!` does not work as expected when an iOS project is not using the standard `/ios` folder structure. This happens because the `initialize()` function of `AutolinkingManager` calls `expo-modules-autolinking` `resolve` command without providing the custom `--project-root` flag, which will lead to one of two errors:

- `Error: Couldn't find "package.json" up from path "/Users/gabriel/xzy"`

or

- Mistakenly reading the root `package.json` in the monorepo and not detecting `extraDependencies`, `coreFeatures`, and `modules` correctly. 


When calling the CLI manually and providing `--project-root` (`npx expo-modules-autolinking resolve --json --project-root ./exp1`) this works as expected 


# How

Add `:projectRoot` option to `use_expo_modules!` allowing users to configure custom project root folder from a `Podfile`

> Another approach that we could use is reading this value from `ENV['PROJECT_ROOT']`

# Test Plan

```
target 'BrownApp' do
  use_expo_modules!({projectRoot: project_dir})
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
