### PR TITLE
[CI] Fix Android dev client E2E

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
@@ -91,6 +91,7 @@ jobs:
         run: |
           sudo apt-get --quiet update --yes
           sudo apt-get --quiet install openjdk-17-jdk openjdk-17-jre libc6 libdbus-1-3 libfontconfig1 libgcc1 libpulse0 libtinfo5 libx11-6 libxcb1 libxdamage1 libnss3 libxcomposite1 libxcursor1 libxi6 libxext6 libxfixes3 zlib1g libgl1 pulseaudio socat --yes
+          set-env JAVA_HOME $JAVA_HOME
       - uses: eas/install_maestro
       - uses: eas/checkout
       - uses: eas/use_npm_token
@@ -107,36 +108,24 @@ jobs:
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
-        env:
-          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
         run: |
           yarn generate-test-update-bundles android test-update-1
       - uses: eas/start_android_emulator
         with:
-          device_name: pixel_4
+          device_name: pixel_9
+          system_image_package: system-images;android-34;default;x86_64
       - name: Build E2E test app (debug)
         id: builddebug
         working_directory: ../../../updates-e2e
-        env:
-          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
         run: |
           yarn maestro:android:debug:build
-      ###### This test works on Android in local testing, but not in Linux workers
-      # - name: Run Maestro test (debug) (load update through dev client)
-      #   id: testdebug1
-      #   env:
-      #     JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
-      #   working_directory: ../../../updates-e2e
-      #   run: |
-      #     # start packager
-      #     yarn start:dev-client
-      #     ./maestro/maestro-test-executor.sh ./maestro/tests/devClient_runUpdate.yml android debug
-      - name: Run Maestro test (debug) (verify state)
-        id: testdebug2
-        env:
-          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
+      - name: Start packager
+        id: startpackager
         working_directory: ../../../updates-e2e
         run: |
-          # start packager
           yarn start:dev-client
-          ./maestro/maestro-test-executor.sh ./maestro/tests/devClient_verifyState.yml android debug
+      - name: Run Maestro test (debug) (load update through dev client)
+        id: testdebug1
+        working_directory: ../../../updates-e2e
+        run: |
+          ./maestro/maestro-test-executor.sh ./maestro/tests/devClient_runUpdate.yml android debug


### PR DESCRIPTION
# Why

Adjust dev client updates E2E test on Android to just test that we can load an update.

# Test Plan

CI should pass