### PR TITLE
fix(expo-linear-gradient): replace deprecated

### DIFF
--- a/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
+++ b/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
@@ -59,22 +59,18 @@ final class LinearGradientLayer: CALayer {
       return result || color.cgColor.alpha < 1.0
     }
 
-    UIGraphicsBeginImageContextWithOptions(bounds.size, !hasAlpha, 0.0)
-
-    guard let contextRef = UIGraphicsGetCurrentContext() else {
-      return
-    }
-
-    draw(in: contextRef)
-
-    guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
-      return
+    let format = UIGraphicsImageRendererFormat()
+    format.opaque = !hasAlpha
+    format.scale = 0.0 // Use main screen scale
+    
+    let renderer = UIGraphicsImageRenderer(size: bounds.size, format: format)
+    
+    let image = renderer.image { context in
+      draw(in: context.cgContext)
     }
 
     self.contents = image.cgImage
     self.contentsScale = image.scale
-
-    UIGraphicsEndImageContext()
   }
 
   override func draw(in ctx: CGContext) {


### PR DESCRIPTION
Fix for the following crash: 

# expo-linear-gradient Crash Report: UIGraphicsBeginImageContext Memory Allocation Failure

## Issue Summary
The `expo-linear-gradient` library crashes on iOS devices when rendering gradients with large dimensions, specifically failing with `UIGraphicsBeginImageContext() failed to allocate CGBitampContext` error.

## Environment
- **Device**: iPad Pro (12.9-inch) (7th generation)
- **iOS Version**: 18.5
- **expo-linear-gradient Version**: 14.1.5
- **React Native**: Via Expo
- **Screen Resolution**: 1376x1032 pixels
- **Device Scale**: 2.0x

## Error Details
```
NSInternalInconsistencyException: UIGraphicsBeginImageContext() failed to allocate CGBitampContext: size={1169.5, 1559.5}, scale=2.000000, bitmapInfo=0x2002. Use UIGraphicsImageRenderer to avoid this assert.
```

## Stack Trace
```
Exception Stack Trace:
- LinearGradientLayer.display (lineargradientlayer.swift)
- objc_exception_throw
- UIApplicationMain
- main (appdelegate.swift)
```

## Root Cause
The issue is in `LinearGradientLayer.swift` at line 62:
```swift
UIGraphicsBeginImageContextWithOptions(bounds.size, !hasAlpha, 0.0)
```

The deprecated `UIGraphicsBeginImageContextWithOptions` API has memory allocation limitations and fails when:
- Gradient bounds are large (1169.5 x 1559.5 in this case)
- Combined with device scale factor (2.0x)
- Results in attempting to allocate a bitmap context larger than system limits

## Reproduction Steps
1. Create a React Native app using Expo with `expo-linear-gradient`
2. Render a `LinearGradient` component with large dimensions (e.g., full screen on iPad Pro)
3. Use the component in a card or container that spans significant screen real estate
4. Navigate to the screen containing the gradient on a high-resolution device
5. The crash occurs during the gradient rendering process

## Expected Behavior
Gradients should render successfully regardless of size, or gracefully degrade/fallback when memory limits are reached.

## Actual Behavior
Application crashes with `NSInternalInconsistencyException` when gradient dimensions exceed memory allocation limits.

## Affected Use Cases
- Full-screen gradients on tablets
- Large card components with gradient backgrounds
- Dynamic layouts where gradient size isn't predetermined
- High-resolution device displays (Retina, iPad Pro)

## Proposed Solution
Replace the deprecated `UIGraphicsBeginImageContextWithOptions` with `UIGraphicsImageRenderer` in `LinearGradientLayer.swift`:

```swift
// Current problematic code (line 52-78):
override func display() {
    super.display()

    if colors.isEmpty || bounds.size.width.isZero || bounds.size.height.isZero {
      return
    }
    let hasAlpha = colors.reduce(false) { result, color in
      return result || color.cgColor.alpha < 1.0
    }

    UIGraphicsBeginImageContextWithOptions(bounds.size, !hasAlpha, 0.0)

    guard let contextRef = UIGraphicsGetCurrentContext() else {
      return
    }

    draw(in: contextRef)

    guard let image = UIGraphicsGetImageFromCurrentImageContext() else {
      return
    }

    self.contents = image.cgImage
    self.contentsScale = image.scale

    UIGraphicsEndImageContext()
}

// Proposed fix:
override func display() {
    super.display()

    if colors.isEmpty || bounds.size.width.isZero || bounds.size.height.isZero {
      return
    }
    let hasAlpha = colors.reduce(false) { result, color in
      return result || color.cgColor.alpha < 1.0
    }

    let format = UIGraphicsImageRendererFormat()
    format.opaque = !hasAlpha
    format.scale = 0.0 // Use main screen scale
    
    let renderer = UIGraphicsImageRenderer(size: bounds.size, format: format)
    
    let image = renderer.image { context in
      draw(in: context.cgContext)
    }

    self.contents = image.cgImage
    self.contentsScale = image.scale
}
```

## Benefits of UIGraphicsImageRenderer
- **Better memory management**: Automatically handles memory allocation more efficiently
- **Improved performance**: Optimized for modern iOS versions
- **Wider compatibility**: Better support for large image contexts
- **Future-proof**: Recommended by Apple as replacement for deprecated APIs

## Workarounds (Temporary)
1. **Limit gradient dimensions**: Avoid gradients larger than ~1000x1000 pixels
2. **Use CSS gradients**: For simple gradients, consider using React Native's built-in gradient support
3. **Conditional rendering**: Check device dimensions before rendering large gradients
4. **Patch the library**: Apply the proposed fix locally until official update

## Additional Context
- This issue primarily affects larger iOS devices (iPad Pro, iPhone Plus/Max models)
- The error message specifically suggests using `UIGraphicsImageRenderer`
- The issue has been present across multiple versions of expo-linear-gradient
- Similar issues have been reported in other React Native gradient libraries

## Related Issues
- iOS memory allocation limits for bitmap contexts
- Deprecated UIGraphicsBeginImageContext API warnings
- High-DPI device compatibility issues

---

**Device Info:**
- Model: iPad Pro (12.9-inch) (7th generation) 
- Memory: 15.1 GiB total, 13.7 GiB usable
- Architecture: arm64
- Build: 22F76