### PR TITLE
[font] throw when loading empty font file

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- [android] throw when loading empty font file ([#38229](https://github.com/expo/expo/pull/38229) by [@vonovak](https://github.com/vonovak))
+
 ## 11.1.7 - 2025-07-03
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-font/android/src/main/java/expo/modules/font/FontLoaderModule.kt
+++ b/packages/expo-font/android/src/main/java/expo/modules/font/FontLoaderModule.kt
@@ -44,6 +44,12 @@ open class FontLoaderModule : Module() {
         val file = Uri.parse(localUri).path?.let { File(it) }
           ?: throw FileNotFoundException(localUri)
 
+        if (file.length() == 0L) {
+          throw CodedException(
+            "Font file for $fontFamilyName is empty. Make sure the local file path is correctly populated."
+          )
+        }
+
         Typeface.createFromFile(file)
       }
 


### PR DESCRIPTION
# Why

This PR adds a check to prevent loading empty font files on Android. This normally wouldn't happen but if it did, Android TypeFace throws `ArrayIndexOutOfBoundsException` which is pretty useless for debugging.

# How

Added a simple check in the `FontLoaderModule.kt` file that verifies if the font file has a non-zero length before attempting to create a Typeface from it. If the file is empty (length is 0), it throws a `CodedException` with a error message that's better than `ArrayIndexOutOfBoundsException`.

# Test Plan

- bare expo

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)