### PR TITLE
[fetch] refactor reference equality

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Simplify expo-modules-core usage. ([#37588](https://github.com/expo/expo/pull/37588) by [@EvanBacon](https://github.com/EvanBacon))
 - Reexport `@expo/config/paths` paths as `expo/config/paths`. ([#37860](https://github.com/expo/expo/pull/37860) by [@aleqsio](https://github.com/aleqsio))
+- [fetch] refactor reference equality ([#38231](https://github.com/expo/expo/pull/38231) by [@vonovak](https://github.com/vonovak))
 
 ### ⚠️ Notices
 

--- a/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/NativeResponse.kt
@@ -100,7 +100,7 @@ internal class NativeResponse(appContext: AppContext, private val coroutineScope
 
   override fun onFailure(call: Call, e: IOException) {
     // Canceled request should be handled by emitRequestCanceled
-    if (e.message === "Canceled") {
+    if (e.message == "Canceled") {
       return
     }
 


### PR DESCRIPTION
# Why

Changed a suspicious comparison in the `NativeResponse` class where string comparison was using the identity operator (`===`) instead of the equality operator (`==`) when checking for a "Canceled" message in the `onFailure` method.

Suggesting this change after the same kind of change fixed a bug here https://github.com/expo/expo/pull/38227/files#diff-6b0bfb15514c6b82838a22b104375e1d3aced131d9c552d5af01c04862902028

# How

Changed the string comparison

# Test Plan

I did not test this

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)