### PR TITLE
[bare-expo][Android] Remove `releaseWithDevMenu` variant

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -128,10 +128,6 @@ android {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
-        releaseWithDevMenu {
-            initWith release
-            matchingFallbacks = ['release', 'debug']
-        }
     }
     packagingOptions {
         jniLibs {


### PR DESCRIPTION
# Why

Removes `releaseWithDevMenu` variant

# Test Plan

- bare-expo ✅ 