### PR TITLE
[docs] Add bi-directional links to Router reference and Router introduction pages

### DIFF
--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -5,7 +5,7 @@ description: How to implement authentication and protect routes with Expo Router
 hasVideoLink: true
 ---
 
-> This guide requires SDK 53. For the previous version of this guide see [Authentication (redirects)](/router/advanced/authentication-rewrites/)
+> **info** **Note:**This guide requires SDK 53. For the previous version of this guide see [Authentication (redirects)](/router/advanced/authentication-rewrites/).
 
 import { Lock01Icon } from '@expo/styleguide-icons/outline/Lock01Icon';
 import { LockUnlocked01Icon } from '@expo/styleguide-icons/outline/LockUnlocked01Icon';

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -6,6 +6,7 @@ sidebar_title: Introduction
 searchRank: 15
 ---
 
+import { DocsLogo } from '@expo/styleguide';
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { Rocket02Icon } from '@expo/styleguide-icons/outline/Rocket02Icon';
@@ -16,6 +17,13 @@ import { Collapsible } from '~/ui/components/Collapsible';
 Expo Router is a file-based router for React Native and web applications. It allows you to manage navigation between screens in your app, allowing users to move seamlessly between different parts of your app's UI, using the same components on multiple platforms (Android, iOS, and web).
 
 It brings the best file-system routing concepts from the web to a universal application &mdash; allowing your routing to work across every platform. When a file is added to the **app** directory, the file automatically becomes a route in your navigation.
+
+<BoxLink
+  title="Expo Router reference"
+  Icon={DocsLogo}
+  description="For information on API components, hooks, methods, and more, see the Expo Router reference."
+  href="/versions/latest/sdk/router/"
+/>
 
 ## Features
 
@@ -92,6 +100,12 @@ Basic static rendering (SSG) is supported in Expo Router. Server-side rendering 
   Icon={BookOpen02Icon}
   description="Detailed instructions on how to get started and add Expo Router to your existing app."
   href="/router/installation/#manual-installation"
+/>
+<BoxLink
+  title="Router 101"
+  Icon={BookOpen02Icon}
+  description="For information core concepts, notation patterns, navigation layouts, and common navigation patterns, start with Router 101 section."
+  href="/router/basics/core-concepts/"
 />
 <BoxLink
   title="Example app"

--- a/docs/pages/versions/unversioned/sdk/router-ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/router-ui.mdx
@@ -6,7 +6,10 @@ packageName: 'expo-router'
 platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import APISection from '~/components/plugins/APISection';
+import { BoxLink } from '~/ui/components/BoxLink';
 import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
 `expo-router/ui` is a submodule of `expo-router` library and exports components and hooks to build custom tab layouts, rather than using the default [React Navigation](https://reactnavigation.org/) navigators provided by `expo-router`.
@@ -15,7 +18,14 @@ import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
 ## Installation
 
-To use `expo-router/ui` in your project, you need to install `expo-router` in your project. Follow the instructions from the [Install Expo Router](/router/installation/) guide.
+To use `expo-router/ui` in your project, you need to install `expo-router` in your project. Follow the instructions from the Expo Router's installation guide:
+
+<BoxLink
+  title="Install Expo Router"
+  description="Learn how to install Expo Router in your project."
+  href="/router/installation/"
+  Icon={BookOpen02Icon}
+/>
 
 ## Configuration in app config
 
@@ -35,7 +45,9 @@ If you are using the [default](/more/create-expo/#--template) template to create
 
 ## Usage
 
-Find more information about using `expo-router/ui` in [Expo Router UI](/router/advanced/custom-tabs/) guide.
+For information about using `expo-router/ui` in Custom tab layouts guide:
+
+<BoxLink title="Custom tab layouts" Icon={BookOpen02Icon} href="/router/advanced/custom-tabs/" />
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/router.mdx
+++ b/docs/pages/versions/unversioned/sdk/router.mdx
@@ -7,14 +7,31 @@ platforms: ['android', 'ios', 'tvos', 'web']
 searchRank: 6
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import APISection from '~/components/plugins/APISection';
+import { BoxLink } from '~/ui/components/BoxLink';
 import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
 `expo-router` is a routing library for React Native and web apps. It enables navigation management using a file-based routing system and provides native navigation components and is built on top of [React Navigation](https://reactnavigation.org/).
 
+<BoxLink
+  title="Expo Router guides"
+  description="Learn about Expo Router basics, navigation patterns, core concepts, and more."
+  href="/router/introduction/"
+  Icon={BookOpen02Icon}
+/>
+
 ## Installation
 
-To use Expo Router in your project, you need to install. Follow the instructions from the [Install Expo Router](/router/installation/) guide.
+To use Expo Router in your project, you need to install. Follow the instructions from the Expo Router's installation guide:
+
+<BoxLink
+  title="Install Expo Router"
+  description="Learn how to install Expo Router in your project."
+  href="/router/installation/"
+  Icon={BookOpen02Icon}
+/>
 
 ## Configuration in app config
 
@@ -34,7 +51,9 @@ If you are using the [default](/more/create-expo/#--template) template to create
 
 ## Usage
 
-Find more information and guides about using `expo-router` in [Expo Router](/router/introduction/) section.
+For information core concepts, notation patterns, navigation layouts, and common navigation patterns, start with Router 101 section:
+
+<BoxLink title="Router 101" Icon={BookOpen02Icon} href="/router/basics/core-concepts/" />
 
 ## API
 

--- a/docs/pages/versions/v52.0.0/sdk/router-ui.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/router-ui.mdx
@@ -7,7 +7,10 @@ platforms: ['android', 'ios', 'tvos', 'web']
 isNew: true
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import APISection from '~/components/plugins/APISection';
+import { BoxLink } from '~/ui/components/BoxLink';
 import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
 `expo-router/ui` is a submodule of `expo-router` library and exports components and hooks to build custom tab layouts, rather than using the default [React Navigation](https://reactnavigation.org/) navigators provided by `expo-router`.
@@ -16,7 +19,14 @@ import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
 ## Installation
 
-To use `expo-router/ui` in your project, you need to install `expo-router` in your project. Follow the instructions from the [Install Expo Router](/router/installation/) guide.
+To use `expo-router/ui` in your project, you need to install `expo-router` in your project. Follow the instructions from the Expo Router's installation guide:
+
+<BoxLink
+  title="Install Expo Router"
+  description="Learn how to install Expo Router in your project."
+  href="/router/installation/"
+  Icon={BookOpen02Icon}
+/>
 
 ## Configuration in app config
 
@@ -36,7 +46,9 @@ If you are using the [default](/more/create-expo/#--template) template to create
 
 ## Usage
 
-Find more information about using `expo-router/ui` in [Expo Router UI](/router/advanced/custom-tabs/) guide.
+For information about using `expo-router/ui` in Custom tab layouts guide:
+
+<BoxLink title="Custom tab layouts" Icon={BookOpen02Icon} href="/router/advanced/custom-tabs/" />
 
 ## API
 

--- a/docs/pages/versions/v52.0.0/sdk/router.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/router.mdx
@@ -7,10 +7,20 @@ platforms: ['android', 'ios', 'tvos', 'web']
 isNew: true
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import APISection from '~/components/plugins/APISection';
+import { BoxLink } from '~/ui/components/BoxLink';
 import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
 `expo-router` is a routing library for React Native and web apps. It enables navigation management using a file-based routing system and provides native navigation components and is built on top of [React Navigation](https://reactnavigation.org/).
+
+<BoxLink
+  title="Expo Router guides"
+  description="Learn about Router basics, navigation patterns, and core concepts."
+  href="/router/introduction/"
+  Icon={BookOpen02Icon}
+/>
 
 ## Installation
 

--- a/docs/pages/versions/v53.0.0/sdk/router-ui.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/router-ui.mdx
@@ -6,7 +6,10 @@ packageName: 'expo-router'
 platforms: ['android', 'ios', 'tvos', 'web']
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import APISection from '~/components/plugins/APISection';
+import { BoxLink } from '~/ui/components/BoxLink';
 import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
 `expo-router/ui` is a submodule of `expo-router` library and exports components and hooks to build custom tab layouts, rather than using the default [React Navigation](https://reactnavigation.org/) navigators provided by `expo-router`.
@@ -15,7 +18,14 @@ import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
 ## Installation
 
-To use `expo-router/ui` in your project, you need to install `expo-router` in your project. Follow the instructions from the [Install Expo Router](/router/installation/) guide.
+To use `expo-router/ui` in your project, you need to install `expo-router` in your project. Follow the instructions from the Expo Router's installation guide:
+
+<BoxLink
+  title="Install Expo Router"
+  description="Learn how to install Expo Router in your project."
+  href="/router/installation/"
+  Icon={BookOpen02Icon}
+/>
 
 ## Configuration in app config
 
@@ -35,7 +45,9 @@ If you are using the [default](/more/create-expo/#--template) template to create
 
 ## Usage
 
-Find more information about using `expo-router/ui` in [Expo Router UI](/router/advanced/custom-tabs/) guide.
+For information about using `expo-router/ui` in Custom tab layouts guide:
+
+<BoxLink title="Custom tab layouts" Icon={BookOpen02Icon} href="/router/advanced/custom-tabs/" />
 
 ## API
 

--- a/docs/pages/versions/v53.0.0/sdk/router.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/router.mdx
@@ -7,14 +7,31 @@ platforms: ['android', 'ios', 'tvos', 'web']
 searchRank: 6
 ---
 
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
 import APISection from '~/components/plugins/APISection';
+import { BoxLink } from '~/ui/components/BoxLink';
 import { ConfigPluginExample } from '~/ui/components/ConfigSection';
 
 `expo-router` is a routing library for React Native and web apps. It enables navigation management using a file-based routing system and provides native navigation components and is built on top of [React Navigation](https://reactnavigation.org/).
 
+<BoxLink
+  title="Expo Router guides"
+  description="Learn about Expo Router basics, navigation patterns, core concepts, and more."
+  href="/router/introduction/"
+  Icon={BookOpen02Icon}
+/>
+
 ## Installation
 
-To use Expo Router in your project, you need to install. Follow the instructions from the [Install Expo Router](/router/installation/) guide.
+To use Expo Router in your project, you need to install. Follow the instructions from the Expo Router's installation guide:
+
+<BoxLink
+  title="Install Expo Router"
+  description="Learn how to install Expo Router in your project."
+  href="/router/installation/"
+  Icon={BookOpen02Icon}
+/>
 
 ## Configuration in app config
 
@@ -34,7 +51,9 @@ If you are using the [default](/more/create-expo/#--template) template to create
 
 ## Usage
 
-Find more information and guides about using `expo-router` in [Expo Router](/router/introduction/) section.
+For information core concepts, notation patterns, navigation layouts, and common navigation patterns, start with Router 101 section:
+
+<BoxLink title="Router 101" Icon={BookOpen02Icon} href="/router/basics/core-concepts/" />
 
 ## API
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15607

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add bi-directional links to Router reference and Router introduction pages.
- In Router and Router UI references, convert all inline links to BoxLinks.
- In Router > Introduction, add link to Router 101 > Core concepts (as a starting point) to the basics section.
- Fix typo and improve callout in Authentication in Expo Router guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

**Router and Router UI changes**

<img width="2228" height="1660" alt="CleanShot 2025-07-22 at 17 44 31@2x" src="https://github.com/user-attachments/assets/63ed6067-16fe-4f6c-832a-2fb0416fbc9c" />

<img width="3356" height="1930" alt="CleanShot 2025-07-22 at 17 44 47@2x" src="https://github.com/user-attachments/assets/75cfcaec-b2a5-4be1-9735-3ebb03dfa6bc" />

<img width="2128" height="348" alt="CleanShot 2025-07-22 at 17 44 37@2x" src="https://github.com/user-attachments/assets/32e7c3b2-5e79-4e39-8c66-9053f8a8e27d" />

**Router > Introduction** changes
<img width="2404" height="762" alt="CleanShot 2025-07-22 at 17 35 54@2x" src="https://github.com/user-attachments/assets/27df016c-3a7c-43d6-927e-cd3e035dddd5" />
<img width="2324" height="840" alt="CleanShot 2025-07-22 at 17 45 14@2x" src="https://github.com/user-attachments/assets/e655806c-252b-4950-8d6a-7f1520bf3d5c" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
