### PR TITLE
[module-scripts] add typescript project references support

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added TypeScript Project References support. ([#38241](https://github.com/expo/expo/pull/38241) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-module-scripts/bin/expo-module-tsc
+++ b/packages/expo-module-scripts/bin/expo-module-tsc
@@ -4,4 +4,4 @@ set -eo pipefail
 
 script_dir="$(dirname "$0")"
 
-"$script_dir/npx" tsc "$@"
+"$script_dir/npx" tsc -b "$@"

--- a/packages/expo-module-scripts/bin/expo-module-tsc
+++ b/packages/expo-module-scripts/bin/expo-module-tsc
@@ -4,4 +4,8 @@ set -eo pipefail
 
 script_dir="$(dirname "$0")"
 
-"$script_dir/npx" tsc -b "$@"
+if [[ "$#" -eq 0 ]]; then
+  "$script_dir/npx" tsc -b
+else
+  "$script_dir/npx" tsc "$@"
+fi


### PR DESCRIPTION
# Why

introduce typescript [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) support

# How

run `tsc -b`

# Test Plan

tested on upstack pr

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
