### PR TITLE
[paper-tester][iOS] Enable static frameworks

### DIFF
--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -1,0 +1,49 @@
+name: Test iOS Static Frameworks
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 0 * * SUN' # 0:00 AM UTC time every Sunday
+  pull_request:
+    paths:
+      - .github/workflows/ios-static-frameworks.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: macos-15
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-workspace: 'true'
+          yarn-tools: 'true'
+      - name: 🧶 Yarn install
+        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: 🍏 Build iOS Project
+        working-directory: ./apps/paper-tester
+        run: |
+          pod install --project-directory=ios
+          xcodebuild -workspace ios/papertester.xcworkspace -scheme papertester -configuration Release -sdk iphonesimulator -derivedDataPath "ios/build" | xcpretty
+      - name: 🔔 Notify on Slack
+        uses: 8398a7/action-slack@v3
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_ios }}
+        with:
+          channel: '#expo-ios'
+          status: ${{ job.status }}
+          fields: job,message,ref,eventName,author,took
+          author_name: Static Frameworks iOS Test (paper-tester)

--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -32,10 +32,11 @@ jobs:
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🍏 Build iOS Project
-        working-directory: ./apps/paper-tester
+        working-directory: ./apps/bare-expo
         run: |
+          jq '.["ios.useFrameworks"] = "static"' ios/Podfile.properties.json > temp.json && mv temp.json ios/Podfile.properties.json
           pod install --project-directory=ios
-          xcodebuild -workspace ios/papertester.xcworkspace -scheme papertester -configuration Release -sdk iphonesimulator -derivedDataPath "ios/build" | xcpretty
+          xcodebuild -workspace ios/BareExpo.xcworkspace -scheme BareExpo -configuration Release -sdk iphonesimulator -derivedDataPath "ios/build" | xcpretty
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -22,6 +22,12 @@ jobs:
           submodules: true
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: 💎 Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.2
+      - name: 💎 Install Ruby gems
+        run: gem install cocoapods xcpretty
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches


### PR DESCRIPTION
# Why

Every now and then our packages break when using static frameworks on iOS, and usually, we only notice it's broken after we release new versions of our packages and a user reports the problem. To improve this and make static frameworks support more stable, we should have one of our test apps using static frameworks.

# How

Enable static frameworks on paper-tester 

# Test Plan 

Added a new workflow file scheduled to run every Sunday midnight, building PaperTester on iOS with static frameworks enabled. If the build fails, it will send a notification to the #expo-ios Slack channel.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
