### PR TITLE
[dev-launcher][android] Add FAB option in the settings screen

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Reimplement UI in SwiftUI. ([#37413](https://github.com/expo/expo/pull/37413) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Add floating action button option in the settings menu. ([#38247](https://github.com/expo/expo/pull/38247) by [@behenate](https://github.com/behenate))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/SettingsViewModel.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/SettingsViewModel.kt
@@ -13,7 +13,9 @@ data class SettingsState(
   val isShakeEnable: Boolean = true,
   val isThreeFingerLongPressEnable: Boolean = true,
   val isKeyCommandEnabled: Boolean = true,
-  val applicationInfo: ApplicationInfo? = null
+  val applicationInfo: ApplicationInfo? = null,
+  // TODO @behenate - make true the default for VR
+  val showFabAtLaunch: Boolean = false
 )
 
 sealed interface SettingsAction {
@@ -21,6 +23,7 @@ sealed interface SettingsAction {
   data class ToggleShakeEnable(val newValue: Boolean) : SettingsAction
   data class ToggleThreeFingerLongPressEnable(val newValue: Boolean) : SettingsAction
   data class ToggleKeyCommandEnable(val newValue: Boolean) : SettingsAction
+  data class ToggleShowFabAtLaunch(val newValue: Boolean) : SettingsAction
 }
 
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {
@@ -33,7 +36,8 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
       isShakeEnable = menuPreferences.motionGestureEnabled,
       isThreeFingerLongPressEnable = menuPreferences.touchGestureEnabled,
       isKeyCommandEnabled = menuPreferences.keyCommandsEnabled,
-      applicationInfo = appService.applicationInfo
+      applicationInfo = appService.applicationInfo,
+      showFabAtLaunch = menuPreferences.showFab
     )
   )
 
@@ -45,7 +49,8 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
       showMenuAtLaunch = menuPreferences.showsAtLaunch,
       isShakeEnable = menuPreferences.motionGestureEnabled,
       isThreeFingerLongPressEnable = menuPreferences.touchGestureEnabled,
-      isKeyCommandEnabled = menuPreferences.keyCommandsEnabled
+      isKeyCommandEnabled = menuPreferences.keyCommandsEnabled,
+      showFabAtLaunch = menuPreferences.showFab
     )
   }
 
@@ -74,6 +79,10 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
       is SettingsAction.ToggleKeyCommandEnable -> {
         menuPreferences.keyCommandsEnabled = action.newValue
+      }
+
+      is SettingsAction.ToggleShowFabAtLaunch -> {
+        menuPreferences.showFab = action.newValue
       }
     }
   }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/SettingsScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/SettingsScreen.kt
@@ -43,7 +43,7 @@ fun SettingsScreen(
 
     RoundedSurface {
       MenuSwitch(
-        "Show menu as launch",
+        "Show menu at launch",
         icon = painterResource(R.drawable.show_menu_at_launch_icon),
         toggled = state.showMenuAtLaunch,
         onToggled = { onAction(SettingsAction.ToggleShowMenuAtLaunch(it)) }
@@ -92,6 +92,20 @@ fun SettingsScreen(
             onAction(SettingsAction.ToggleThreeFingerLongPressEnable(!state.isThreeFingerLongPressEnable))
           },
           rightIcon = if (state.isThreeFingerLongPressEnable) {
+            painterResource(R.drawable.check_icon)
+          } else {
+            null
+          }
+        )
+        Divider()
+        MenuButton(
+          "Floating Action Button",
+          // TODO: @behenate Find a proper icon for this option
+          leftIcon = painterResource(R.drawable.show_menu_at_launch_icon),
+          onClick = {
+            onAction(SettingsAction.ToggleShowFabAtLaunch(!state.showFabAtLaunch))
+          },
+          rightIcon = if (state.showFabAtLaunch) {
             painterResource(R.drawable.check_icon)
           } else {
             null


### PR DESCRIPTION
# Why

We want it to be possible to configure the visibility of the FAB outside of the application.

# How

Added an option to show or hide the FAB. It changes the same value that the dev-menu uses to show/hide FAB, so it's synchronised with the dev-menu option

# Test Plan

Tested in Bare Expo on Android

<img width="256" alt="Screenshot_20250722-181848" src="https://github.com/user-attachments/assets/b4cfb779-52e6-4c8b-800f-811120143589" />
