### PR TITLE
[docs] Re-order Submit and Hosting sections in sidebar

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -468,6 +468,12 @@ export const eas = [
       { expanded: false }
     ),
   ]),
+  makeSection('EAS Submit', [
+    makePage('submit/introduction.mdx'),
+    makePage('submit/android.mdx'),
+    makePage('submit/ios.mdx'),
+    makePage('submit/eas-json.mdx'),
+  ]),
   makeSection('EAS Hosting', [
     makePage('eas/hosting/introduction.mdx'),
     makePage('eas/hosting/get-started.mdx'),
@@ -481,12 +487,6 @@ export const eas = [
       makePage('eas/hosting/reference/responses-and-headers.mdx'),
       makePage('eas/hosting/reference/worker-runtime.mdx'),
     ]),
-  ]),
-  makeSection('EAS Submit', [
-    makePage('submit/introduction.mdx'),
-    makePage('submit/android.mdx'),
-    makePage('submit/ios.mdx'),
-    makePage('submit/eas-json.mdx'),
   ]),
   makeSection('EAS Update', [
     makePage('eas-update/introduction.mdx'),

--- a/docs/pages/eas/index.mdx
+++ b/docs/pages/eas/index.mdx
@@ -34,17 +34,17 @@ Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links
 />
 
 <BoxLink
-  title="EAS Hosting (in preview)"
-  description="Deploy Expo Router and React Native web apps and API routes."
-  href="/eas/hosting/introduction"
-  Icon={Cloud01Icon}
-/>
-
-<BoxLink
   title="EAS Submit"
   description="Upload your app to the Google Play Store or Apple App Store from the cloud with one CLI command."
   href="/submit/introduction"
   Icon={EasSubmitIcon}
+/>
+
+<BoxLink
+  title="EAS Hosting (in preview)"
+  description="Deploy Expo Router and React Native web apps and API routes."
+  href="/eas/hosting/introduction"
+  Icon={Cloud01Icon}
 />
 
 <BoxLink


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16673

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update navigation.js to reverse Submit and Hosting sections order. Also update order of BoxLink on EAS Overview page to reflect the same.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

**Sidebar**:

<img width="270" height="850" alt="CleanShot 2025-07-22 at 22 16 20" src="https://github.com/user-attachments/assets/aedb4981-554e-470c-ac68-c5be4cc03bf3" />

**EAS overview:**

<img width="1227" height="837" alt="CleanShot 2025-07-22 at 22 18 36" src="https://github.com/user-attachments/assets/0f4e44c6-c613-46b3-817d-cf101ef4459f" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
