### PR TITLE
Support `--output-dir` being a directory outside of the project root.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- Support `--output-dir` being a directory outside of the project root.
 - Update error message for ngrok ([#22469](https://github.com/expo/expo/pull/22469) by [@russorat](https://github.com/russorat))
 - Support SSR imports of internal node builtins such as `_http_agent`. ([#37494](https://github.com/expo/expo/pull/37494) by [@EvanBacon](https://github.com/EvanBacon))
 - Allow anonymous sessions even when `projectId` is set ([#36874](https://github.com/expo/expo/pull/36874) by [@kadikraman](https://github.com/kadikraman))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 🐛 Bug fixes
 
-- Support `--output-dir` being a directory outside of the project root.
+- Support `--output-dir` being a directory outside of the project root. ([#38260](https://github.com/expo/expo/pull/38260) by [@EvanBacon](https://github.com/EvanBacon))
 - Update error message for ngrok ([#22469](https://github.com/expo/expo/pull/22469) by [@russorat](https://github.com/russorat))
 - Support SSR imports of internal node builtins such as `_http_agent`. ([#37494](https://github.com/expo/expo/pull/37494) by [@EvanBacon](https://github.com/EvanBacon))
 - Allow anonymous sessions even when `projectId` is set ([#36874](https://github.com/expo/expo/pull/36874) by [@kadikraman](https://github.com/kadikraman))

--- a/packages/@expo/cli/src/export/exportAsync.ts
+++ b/packages/@expo/cli/src/export/exportAsync.ts
@@ -10,16 +10,19 @@ import { ensureDirectoryAsync, removeAsync } from '../utils/dir';
 import { CommandError } from '../utils/errors';
 import { ensureProcessExitsAfterDelay } from '../utils/exit';
 
+function isChildDirectory(dir: string, subDir: string): boolean {
+  const relativePath = path.relative(dir, subDir);
+  return !!relativePath && !relativePath.startsWith('..');
+}
+
 export async function exportAsync(projectRoot: string, options: Options) {
   // Ensure the output directory is created
   const outputPath = path.resolve(projectRoot, options.outputDir);
 
   if (outputPath === projectRoot) {
     throw new CommandError('--output-dir cannot be the same as the project directory.');
-  } else if (path.relative(projectRoot, outputPath).startsWith('..')) {
-    throw new CommandError(
-      '--output-dir must be a subdirectory of the project directory. Generating outside of the project directory is not supported.'
-    );
+  } else if (isChildDirectory(outputPath, projectRoot)) {
+    throw new CommandError('--output-dir cannot be the parent of the project directory.');
   }
 
   // Delete the output directory if it exists

--- a/packages/@expo/cli/src/export/exportAsync.ts
+++ b/packages/@expo/cli/src/export/exportAsync.ts
@@ -10,21 +10,15 @@ import { ensureDirectoryAsync, removeAsync } from '../utils/dir';
 import { CommandError } from '../utils/errors';
 import { ensureProcessExitsAfterDelay } from '../utils/exit';
 
-function isChildDirectory(dir: string, subDir: string): boolean {
-  const relativePath = path.relative(dir, subDir);
-  return !!relativePath && !relativePath.startsWith('..');
-}
-
 export async function exportAsync(projectRoot: string, options: Options) {
   // Ensure the output directory is created
   const outputPath = path.resolve(projectRoot, options.outputDir);
 
   if (outputPath === projectRoot) {
     throw new CommandError('--output-dir cannot be the same as the project directory.');
-  } else if (isChildDirectory(outputPath, projectRoot)) {
-    throw new CommandError('--output-dir cannot be the parent of the project directory.');
+  } else if (projectRoot.startsWith(outputPath)) {
+    throw new CommandError(`--output-dir cannot be a parent directory of the project directory.`);
   }
-
   // Delete the output directory if it exists
   await removeAsync(outputPath);
   // Create the output directory


### PR DESCRIPTION
# Why

- fix https://github.com/expo/expo/issues/37357
- Support the output-dir being outside of the project root and add protection against clearing the parent dir.