### PR TITLE
[docs] Fix some bad docs on `environment` and `env` in workflows

### DIFF
--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -266,20 +266,7 @@ Calculates a fingerprint of your project.
 jobs:
   fingerprint:
     type: fingerprint
-    params:
-      environment: production | preview | development # optional, defaults to production
-      env: # optional
-        APP_VARIANT: staging # just an example
 ```
-
-#### Parameters
-
-You can pass the following parameters into the `params` list:
-
-| Parameter   | Type   | Description                                                                                                   |
-| ----------- | ------ | ------------------------------------------------------------------------------------------------------------- |
-| environment | string | Optional. The environment to use. Can be `production`, `preview`, or `development`. Defaults to `production`. |
-| env         | object | Optional. Environment variables to use during fingerprint calculation.                                        |
 
 #### Outputs
 
@@ -305,8 +292,7 @@ jobs:
   fingerprint:
     name: Calculate Fingerprint
     type: fingerprint
-    params:
-      environment: production
+    environment: production
 ```
 
 </Collapsible>
@@ -322,11 +308,10 @@ jobs:
   fingerprint:
     name: Calculate Fingerprint
     type: fingerprint
-    params:
-      environment: production
-      env:
-        APP_VARIANT: staging
-        API_URL: https://api.staging.example.com
+    environment: production
+    env:
+      APP_VARIANT: staging
+      API_URL: https://api.staging.example.com
 ```
 
 </Collapsible>

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -226,7 +226,7 @@ Sets the [EAS environment variable](/eas/environment-variables/) environment for
 - `preview`
 - `development`
 
-The `environment` key is available on all jobs except for the pre-packaged `build`, `submit`, and `get-build` jobs.
+The `environment` key is available on all jobs.
 
 ```yaml
 jobs:
@@ -546,10 +546,6 @@ jobs:
     # @info #
     type: fingerprint
     # @end #
-    params:
-      environment: production | preview | development # optional, defaults to production
-      env: # optional
-        APP_VARIANT: staging # just an example
 ```
 
 This job outputs the following properties:

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -236,6 +236,20 @@ jobs:
     # @end #
 ```
 
+### `jobs.<job_id>.env`
+
+Sets environment variables for the job. The property is available on all jobs running a VM (all jobs except for the pre-packaged `require-approval`, `doc`, `get-build` and `slack` jobs).
+
+```yaml
+jobs:
+  my_job:
+    # @info #
+    env:
+      APP_VARIANT: staging
+      RETRY_COUNT: 3
+    # @end #
+```
+
 ### `jobs.<job_id>.defaults.run.working_directory`
 
 Sets the directory to run commands in for all steps in the job.

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -247,6 +247,7 @@ jobs:
     env:
       APP_VARIANT: staging
       RETRY_COUNT: 3
+      PREV_JOB_OUTPUT: ${{ needs.previous_job.outputs.some_output }}
     # @end #
 ```
 


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C06EFBQK3B7/p1752783091395859

# How

Removed `env` and `environment` from under `type: fingerprint` job's params.

Added docs for `env` property available on most jobs.
