### PR TITLE
[docs] Add docs for workflow run inputs

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -9,6 +9,7 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
+import { Terminal } from '~/ui/components/Snippet';
 
 A workflow is a configurable automated process made up of one or more jobs. You must create a YAML file to define your workflow configuration.
 
@@ -203,43 +204,40 @@ on:
     # @end #
 ```
 
-#### Input Properties
+| Property      | Type       | Required                 | Description                                                                 |
+| ------------- | ---------- | ------------------------ | --------------------------------------------------------------------------- |
+| `type`        | `string`   | Yes                      | The input type (`string`, `boolean`, `number`, `choice`, or `environment`). |
+| `description` | `string`   | No                       | Description for the input.                                                  |
+| `required`    | `boolean`  | No                       | Whether the input is required. Defaults to `false`.                         |
+| `default`     | varies     | No                       | Default value for the input. Must match the input type.                     |
+| `options`     | `string[]` | Yes (for `type: choice`) | Available options for choice inputs.                                        |
 
-Each input can have the following properties:
-
-| Property      | Type     | Required                 | Description                                                                |
-| ------------- | -------- | ------------------------ | -------------------------------------------------------------------------- |
-| `type`        | string   | Yes                      | The input type (`string`, `boolean`, `number`, `choice` or `environment`). |
-| `description` | string   | No                       | Description for the input.                                                 |
-| `required`    | boolean  | No                       | Whether the input is required. Defaults to `false`.                        |
-| `default`     | varies   | No                       | Default value for the input. Must match the input type.                    |
-| `options`     | string[] | Yes (for `type: choice`) | Available options for choice inputs.                                       |
-
-#### Providing Inputs
+#### Providing inputs
 
 When running a workflow with inputs, you can provide them in several ways:
 
-**1. Command line flags:**
+1. Command line flags:
 
-```bash
-eas workflow:run .eas/workflows/deploy.yml -F environment=production -F debug=true -F version=1.2.3
-```
+   <Terminal
+     cmd={[
+       '$ eas workflow:run .eas/workflows/deploy.yml -F environment=production -F debug=true -F version=1.2.3',
+     ]}
+   />
 
-**2. JSON via stdin:**
+2. JSON via stdin:
 
-```bash
-echo '{"environment": "production", "debug": true, "version": "1.2.3"}' | eas workflow:run .eas/workflows/deploy.yml
-```
+   <Terminal
+     cmd={[
+       `$ echo '{"environment": "production", "debug": true, "version": "1.2.3"}' | eas workflow:run .eas/workflows/deploy.yml`,
+     ]}
+   />
 
-**3. Interactive prompts:**
-If required inputs are missing and you're not using `--non-interactive`, the CLI will prompt you for them:
+3. Interactive prompts:
+   If required inputs are missing and you're not using `--non-interactive`, the CLI will prompt you for them:
 
-```bash
-eas workflow:run .eas/workflows/deploy.yml
-# CLI will prompt for missing required inputs
-```
+   <Terminal cmd={['$ eas workflow:run .eas/workflows/deploy.yml']} />
 
-#### Using Inputs in Workflows
+#### Usage
 
 Input values are available in your workflow jobs through the `${{ inputs.<input_name> }}` syntax:
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -180,6 +180,90 @@ on:
     - cron: '0 0 * * *' # Runs at midnight GMT every day
 ```
 
+### `on.workflow_dispatch.inputs`
+
+Defines inputs that can be provided when manually triggering a workflow using the `eas workflow:run` command. This allows you to create parameterized workflows that can accept different values each time they run.
+
+```yaml
+on:
+  workflow_dispatch:
+    # @info #
+    inputs:
+      name:
+        type: string
+        required: false
+        description: 'Name of the person to greet'
+        default: 'World'
+      choice_example:
+        type: choice
+        options:
+          - to be
+          - not to be
+        required: true
+    # @end #
+```
+
+#### Input Properties
+
+Each input can have the following properties:
+
+| Property      | Type     | Required                 | Description                                                                |
+| ------------- | -------- | ------------------------ | -------------------------------------------------------------------------- |
+| `type`        | string   | Yes                      | The input type (`string`, `boolean`, `number`, `choice` or `environment`). |
+| `description` | string   | No                       | Description for the input.                                                 |
+| `required`    | boolean  | No                       | Whether the input is required. Defaults to `false`.                        |
+| `default`     | varies   | No                       | Default value for the input. Must match the input type.                    |
+| `options`     | string[] | Yes (for `type: choice`) | Available options for choice inputs.                                       |
+
+#### Providing Inputs
+
+When running a workflow with inputs, you can provide them in several ways:
+
+**1. Command line flags:**
+
+```bash
+eas workflow:run .eas/workflows/deploy.yml -F environment=production -F debug=true -F version=1.2.3
+```
+
+**2. JSON via stdin:**
+
+```bash
+echo '{"environment": "production", "debug": true, "version": "1.2.3"}' | eas workflow:run .eas/workflows/deploy.yml
+```
+
+**3. Interactive prompts:**
+If required inputs are missing and you're not using `--non-interactive`, the CLI will prompt you for them:
+
+```bash
+eas workflow:run .eas/workflows/deploy.yml
+# CLI will prompt for missing required inputs
+```
+
+#### Using Inputs in Workflows
+
+Input values are available in your workflow jobs through the `${{ inputs.<input_name> }}` syntax:
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        type: string
+        required: true
+        description: 'Name of the person to greet'
+
+jobs:
+  deploy:
+    steps:
+      - name: Deploy to environment
+        run: |
+          echo "Hello, ${{ inputs.name }}!"
+
+          # Note: you can use `||` to provide a default value
+          #       for non-eas-workflow:run-run workflows.
+          echo "Hello, ${{ inputs.name || 'World' }}!"
+```
+
 ## `jobs`
 
 A workflow run is made up of one or more jobs.


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C06EFBQK3B7/p1753203324304679

# How

I asked Cursor to generate it based on code, then adjusted.

# Test Plan

<img width="559" height="1178" alt="Zrzut ekranu 2025-08-6 o 22 23 17" src="https://github.com/user-attachments/assets/57ce4281-5d07-4cf2-a5f0-21e802d15bd5" />
