### PR TITLE
[expo-modules-core][iOS] Fix view functions for SwiftUI views.

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix view functions for SwiftUI views.
+- [iOS] Fix view functions for SwiftUI views. ([#38275](https://github.com/expo/expo/pull/38275) by [@aleqsio](https://github.com/aleqsio))
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
 - [android] Fix android build without coreFeatures compose ([#38153](https://github.com/expo/expo/pull/38153) by [@Ubax](https://github.com/Ubax))
 - [iOS] Fix `ExpoRequestInterceptorProtocol` to properly notify client about HTTP redirects. ([#38078](https://github.com/expo/expo/pull/38078) by [@kudo](https://github.com/kudo))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix view functions for SwiftUI views.
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
 - [android] Fix android build without coreFeatures compose ([#38153](https://github.com/expo/expo/pull/38153) by [@Ubax](https://github.com/Ubax))
 - [iOS] Fix `ExpoRequestInterceptorProtocol` to properly notify client about HTTP redirects. ([#38078](https://github.com/expo/expo/pull/38078) by [@kudo](https://github.com/kudo))

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSwiftUIViewType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSwiftUIViewType.swift
@@ -34,6 +34,9 @@ internal struct DynamicSwiftUIViewType<ViewType: ExpoSwiftUIView>: AnyDynamicTyp
     guard Thread.isMainThread else {
       throw NonMainThreadException()
     }
+    if let view = appContext.findView(withTag: viewTag, ofType: ExpoSwiftUI.SwiftUIVirtualView<ViewType.Props, ViewType>.self) {
+      return view.contentView
+    }
     guard let view = appContext.findView(withTag: viewTag, ofType: AnyExpoSwiftUIHostingView.self) else {
       throw Exceptions.SwiftUIViewNotFound((tag: viewTag, type: innerType.self))
     }


### PR DESCRIPTION
# Why

This PR fixes an issue with AsyncFunctions for SwiftUI views on iOS. 
Currently the function is not being called

# How

Added a check to first look for views of type `ExpoSwiftUI.SwiftUIVirtualView` (which seems to be the actual type after introducing host) before falling back to the existing `AnyExpoSwiftUIHostingView` check.

# Test Plan

1. Create a SwiftUI view with view functions
2. Call the view functions from JavaScript
3. Verify that the functions are properly executed on the view

# Checklist

- [x] I added a changelog.md entry and rebuilt the package sources according to this short guide
- [ ] This diff will work correctly for npx expo prebuild & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the Documentation Writing Style Guide