### PR TITLE
[core][iOS] Fix null string conversion

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,7 +19,7 @@
 - [android] Fix android build without coreFeatures compose ([#38153](https://github.com/expo/expo/pull/38153) by [@Ubax](https://github.com/Ubax))
 - [iOS] Fix `ExpoRequestInterceptorProtocol` to properly notify client about HTTP redirects. ([#38078](https://github.com/expo/expo/pull/38078) by [@kudo](https://github.com/kudo))
 - [Android] Conditionally register `RuntimeHolder` bindings. ([#38345](https://github.com/expo/expo/pull/38345) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix null string conversion.
+- [iOS] Fix null string conversion. ([#38284](https://github.com/expo/expo/pull/38284) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [android] Fix android build without coreFeatures compose ([#38153](https://github.com/expo/expo/pull/38153) by [@Ubax](https://github.com/Ubax))
 - [iOS] Fix `ExpoRequestInterceptorProtocol` to properly notify client about HTTP redirects. ([#38078](https://github.com/expo/expo/pull/38078) by [@kudo](https://github.com/kudo))
 - [Android] Conditionally register `RuntimeHolder` bindings. ([#38345](https://github.com/expo/expo/pull/38345) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix null string conversion.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -27,6 +27,7 @@ jsi::Value convertNSNumberToJSINumber(jsi::Runtime &runtime, NSNumber *value)
 
 jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *value)
 {
+#if !TARGET_OS_OSX
   const uint8_t *utf8 = (const uint8_t *)[value UTF8String];
   const size_t length = [value length];
   if (expo::isAllASCIIAndNotNull(utf8, utf8 + length)) {
@@ -34,6 +35,9 @@ jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *value)
   }
   // Using cStringUsingEncoding should be fine as long as we provide the length.
   return jsi::String::createFromUtf16(runtime, (const char16_t *)[value cStringUsingEncoding:NSUTF16StringEncoding], length);
+#else
+  return jsi::String::createFromUtf8(runtime, [value UTF8String]);
+#endif
 }
 
 jsi::Object convertNSDictionaryToJSIObject(jsi::Runtime &runtime, NSDictionary *value)

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -8,6 +8,7 @@
 #import <ExpoModulesCore/EXJavaScriptValue.h>
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>
 #import <ExpoModulesCore/EXJavaScriptSharedObjectBinding.h>
+#import <ExpoModulesCore/EXStringUtils.h>
 
 namespace expo {
 
@@ -26,7 +27,12 @@ jsi::Value convertNSNumberToJSINumber(jsi::Runtime &runtime, NSNumber *value)
 
 jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *value)
 {
-  return jsi::String::createFromUtf8(runtime, [value UTF8String] ?: "");
+  const uint8_t *utf8 = (const uint8_t *)[value UTF8String];
+  const size_t length = [value length];
+  if (expo::isAllASCIIAndNotNull(utf8, utf8 + length)) {
+    return jsi::String::createFromAscii(runtime, (const char *)utf8, length);
+  }
+  return jsi::String::createFromUtf16(runtime, (const char16_t *)[value cStringUsingEncoding:NSUTF16StringEncoding], length);
 }
 
 jsi::Object convertNSDictionaryToJSIObject(jsi::Runtime &runtime, NSDictionary *value)

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -36,7 +36,7 @@ jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *value)
   // Using cStringUsingEncoding should be fine as long as we provide the length.
   return jsi::String::createFromUtf16(runtime, (const char16_t *)[value cStringUsingEncoding:NSUTF16StringEncoding], length);
 #else
-  // TODO: @jakex7: Remove after update to react-native-macos@0.79.0
+  // TODO(@jakex7): Remove after update to react-native-macos@0.79.0
   return jsi::String::createFromUtf8(runtime, [value UTF8String]);
 #endif
 }

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -32,6 +32,7 @@ jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *value)
   if (expo::isAllASCIIAndNotNull(utf8, utf8 + length)) {
     return jsi::String::createFromAscii(runtime, (const char *)utf8, length);
   }
+  // Using cStringUsingEncoding should be fine as long as we provide the length.
   return jsi::String::createFromUtf16(runtime, (const char16_t *)[value cStringUsingEncoding:NSUTF16StringEncoding], length);
 }
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -36,6 +36,7 @@ jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *value)
   // Using cStringUsingEncoding should be fine as long as we provide the length.
   return jsi::String::createFromUtf16(runtime, (const char16_t *)[value cStringUsingEncoding:NSUTF16StringEncoding], length);
 #else
+  // TODO: @jakex7: Remove after update to react-native-macos@0.79.0
   return jsi::String::createFromUtf8(runtime, [value UTF8String]);
 #endif
 }

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
@@ -188,7 +188,7 @@
 {
   jsi::Runtime *jsiRuntime = [runtime get];
   return [[EXJavaScriptValue alloc] initWithRuntime:runtime
-                                              value:jsi::String::createFromUtf8(*jsiRuntime, [value UTF8String])];
+                                              value:expo::convertNSStringToJSIString(*jsiRuntime, value)];
 }
 
 + (nonnull EXJavaScriptValue *)from:(nullable id)value runtime:(nonnull EXJavaScriptRuntime *)runtime

--- a/packages/expo-modules-core/ios/JSI/EXStringUtils.cpp
+++ b/packages/expo-modules-core/ios/JSI/EXStringUtils.cpp
@@ -1,0 +1,22 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#import <cstdint>
+#import <ExpoModulesCore/EXStringUtils.h>
+
+namespace expo {
+
+bool isASCIIAndNotNull(const uint8_t c) {
+  constexpr uint32_t asciiMask = 0x7f;
+  return ((c & static_cast<uint8_t>(~asciiMask)) == 0 && c != 0);
+}
+
+bool isAllASCIIAndNotNull(const uint8_t * _Nonnull begin, const uint8_t * _Nonnull end) {
+  while (begin < end) {
+    if (!isASCIIAndNotNull(*begin))
+      return false;
+    ++begin;
+  }
+  return true;
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/ios/JSI/EXStringUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXStringUtils.h
@@ -1,0 +1,23 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#ifdef __cplusplus
+
+namespace expo {
+
+bool isASCIIAndNotNull(const uint8_t c) {
+  constexpr uint32_t asciiMask = 0x7f;
+  return ((c & static_cast<uint8_t>(~asciiMask)) == 0 && c != 0);
+}
+
+inline bool isAllASCIIAndNotNull(const uint8_t * _Nonnull begin, const uint8_t * _Nonnull end) {
+  while (begin < end) {
+    if (!isASCIIAndNotNull(*begin))
+      return false;
+    ++begin;
+  }
+  return true;
+}
+
+} // namespace expo
+
+#endif

--- a/packages/expo-modules-core/ios/JSI/EXStringUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXStringUtils.h
@@ -1,22 +1,12 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
+#pragma once
 #ifdef __cplusplus
 
 namespace expo {
 
-bool isASCIIAndNotNull(const uint8_t c) {
-  constexpr uint32_t asciiMask = 0x7f;
-  return ((c & static_cast<uint8_t>(~asciiMask)) == 0 && c != 0);
-}
-
-inline bool isAllASCIIAndNotNull(const uint8_t * _Nonnull begin, const uint8_t * _Nonnull end) {
-  while (begin < end) {
-    if (!isASCIIAndNotNull(*begin))
-      return false;
-    ++begin;
-  }
-  return true;
-}
+bool isASCIIAndNotNull(const uint8_t c);
+bool isAllASCIIAndNotNull(const uint8_t * _Nonnull begin, const uint8_t * _Nonnull end);
 
 } // namespace expo
 


### PR DESCRIPTION
# Why

Converting NSString to JavaScriptValue strips everything after null even if it's still a valid javascript string.
This issue also exists in react-native: facebook/react-native/issues/24129

# How

https://github.com/facebook/hermes/blob/8b384559583d98879a7987141d2c430419b8340d/lib/VM/StringPrimitive.cpp#L93

This implementation is essentially the same as what hermes does under the hood. When creating a `jsi::String` from a utf8 string, hermes checks if the string `isAllASCII`. If so, it uses `createFromAscii`. However, null character passes this check, so any content after the null character is stripped.

To avoid this behavior, we can treat the string as utf16 and create the `jsi::String` using `createFromUtf16`, which skips the ASCII check and preserves the entire string, including content after the null character.

* Using `cStringUsingEncoding` should be fine as long as we provide the `length`.
* `jsi::String::createFromUtf16` was introduced in `react-native@0.79` but macos is still on `0.78` so it uses a previous implementation until it's updated.

# Test Plan

CI should not fail on my changes.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
