### PR TITLE
Fix DOM component metadata overwriting bug causing 404s after EAS upd…

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix DOM component metadata overwriting causing WebView 404s after EAS updates. ([#37269](https://github.com/expo/expo/issues/37269) by [@danoc](https://github.com/danoc))
+- Fix DOM component metadata overwriting causing WebView 404s after EAS updates. ([#38290](https://github.com/expo/expo/pull/38290) by [@danoc](https://github.com/danoc))
 - Support `--output-dir` being a directory outside of the project root. ([#38260](https://github.com/expo/expo/pull/38260) by [@EvanBacon](https://github.com/EvanBacon))
 - Update error message for ngrok ([#22469](https://github.com/expo/expo/pull/22469) by [@russorat](https://github.com/russorat))
 - Support SSR imports of internal node builtins such as `_http_agent`. ([#37494](https://github.com/expo/expo/pull/37494) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix DOM component metadata overwriting causing WebView 404s after EAS updates. ([#37269](https://github.com/expo/expo/issues/37269) by [@danoc](https://github.com/danoc))
 - Support `--output-dir` being a directory outside of the project root. ([#38260](https://github.com/expo/expo/pull/38260) by [@EvanBacon](https://github.com/EvanBacon))
 - Update error message for ngrok ([#22469](https://github.com/expo/expo/pull/22469) by [@russorat](https://github.com/russorat))
 - Support SSR imports of internal node builtins such as `_http_agent`. ([#37494](https://github.com/expo/expo/pull/37494) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -250,6 +250,7 @@ export async function exportAppAsync(
                 htmlOutputName,
               });
               domComponentAssetsMetadata[platform] = [
+                ...(domComponentAssetsMetadata[platform] || []),
                 ...(await addDomBundleToMetadataAsync(platformDomComponentsBundle)),
                 ...transformDomEntryForMd5Filename({
                   files,


### PR DESCRIPTION
# Why

When exporting apps with multiple DOM components (WebViews), only one WebView works correctly after an EAS update while others return 404 errors. This is because the metadata accumulation loop overwrites the `domComponentAssetsMetadata` array for each component instead of accumulating entries, causing only the last processed DOM component to have its metadata preserved in the final metadata.json file.

This regression was introduced in commit 489252a58219cb48d52beef528add184b6143ae2 which refactored DOM component asset handling but inadvertently changed the metadata accumulation from `push()` to direct assignment.

Fixes #37269

# How

Changed the array assignment in the DOM component processing loop to spread the existing metadata before adding new entries:

```diff
domComponentAssetsMetadata[platform] = [
+   ...(domComponentAssetsMetadata[platform] || []),
    ...(await addDomBundleToMetadataAsync(platformDomComponentsBundle)),
    ...transformDomEntryForMd5Filename({
      files,
      htmlOutputName,
    }),
];
```

This ensures all DOM components have their metadata properly preserved instead of being overwritten.

# Test Plan

**Manual Testing:**
1. Create an Expo app with multiple DOM components (WebViews)
2. Build the app with EAS: `eas build --platform ios`
3. Install the build on a device
4. Verify all WebViews load correctly
5. Publish an update
6. Force close and reopen the app to load the update
7. Verify all WebViews still load correctly (previously only one would work)

I tested this fix in a production app with multiple DOM components and confirmed that all components now load correctly after EAS updates, whereas previously only the last one would work. I tested it using `yarn patch` within my project.

**Automated Testing:**
Added comprehensive regression tests in `src/export/__tests__/exportDomComponents-test.ts`:

I also verified that the regression test would have failed without the patch.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
