### PR TITLE
[expo-go] Do not show message on emulator/simulator

### DIFF
--- a/apps/expo-go/src/screens/HomeScreen/UpgradeWarning/utils.ts
+++ b/apps/expo-go/src/screens/HomeScreen/UpgradeWarning/utils.ts
@@ -24,12 +24,16 @@ type VersionsApiResponseType = {
   sdkVersions: Record<string, SdkVersionFromApiType>;
 };
 
-// Show the message if current SDK !== latest SDK AND the latest SDK is yet to be released
+/**
+ * Show the message if:
+ * - On a real device AND
+ * - The latest SDK is in beta AND
+ * - The app is running the latest published SDK (this avoids showing on Android when the user has installed an older version)
+ */
 export async function shouldShowUpgradeWarningAsync(): Promise<{
   shouldShow: boolean;
   betaSdkVersion?: string;
 }> {
-  // No need to show the message on simulator / emulator
   if (!Device.isDevice) {
     return {
       shouldShow: false,

--- a/apps/expo-go/src/screens/HomeScreen/UpgradeWarning/utils.ts
+++ b/apps/expo-go/src/screens/HomeScreen/UpgradeWarning/utils.ts
@@ -49,11 +49,12 @@ export async function shouldShowUpgradeWarningAsync(): Promise<{
       .filter((version) => !!version.sdk) as SdkVersionTypeWithSdkType[];
 
     const lastVersion = publishedVersions[publishedVersions.length - 1];
-    const currentIsOutdated = Environment.supportedSdksString !== lastVersion.sdk;
+    const penultimateVersion = publishedVersions[publishedVersions.length - 2];
+    const currentIsLatestPublished = Environment.supportedSdksString === penultimateVersion.sdk;
     const latestIsBeta = !lastVersion.releaseNoteUrl;
 
     return {
-      shouldShow: Boolean(currentIsOutdated && latestIsBeta),
+      shouldShow: Boolean(currentIsLatestPublished && latestIsBeta),
       betaSdkVersion: lastVersion.sdk,
     };
   } catch {}

--- a/apps/expo-go/src/screens/HomeScreen/UpgradeWarning/utils.ts
+++ b/apps/expo-go/src/screens/HomeScreen/UpgradeWarning/utils.ts
@@ -1,3 +1,4 @@
+import * as Device from 'expo-device';
 import Environment from 'src/utils/Environment';
 
 const SDK_VERSION_REGEXP = new RegExp(/\b(\d*)\.0\.0/);
@@ -28,6 +29,13 @@ export async function shouldShowUpgradeWarningAsync(): Promise<{
   shouldShow: boolean;
   betaSdkVersion?: string;
 }> {
+  // No need to show the message on simulator / emulator
+  if (!Device.isDevice) {
+    return {
+      shouldShow: false,
+    };
+  }
+
   const result = await fetch('https://api.expo.dev/v2/versions');
 
   try {


### PR DESCRIPTION
# Why

Follow-up to https://github.com/expo/expo/pull/38197 to address [this feedback](https://github.com/expo/expo/pull/38197#issuecomment-3104674536)

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Update the logic to only show the message on real device.

Also updated the logic to only show the message if you're installed version is the latest published version. This ensures that Android users who have downloaded an older version of Expo Go and installed via apk will not see the message.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Verified locally

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
