### PR TITLE
[media-library][android] Remove promises

### DIFF
--- a/apps/test-suite/tests/MediaLibrary.js
+++ b/apps/test-suite/tests/MediaLibrary.js
@@ -144,13 +144,12 @@ export async function test(t) {
       let album;
 
       async function initializeDefaultAssetsAsync() {
-        testAssets = await getAssets(files);
         album = await MediaLibrary.getAlbumAsync(ALBUM_NAME);
-        if (album == null) {
-          album = await createAlbum(testAssets, ALBUM_NAME);
-        } else {
-          await MediaLibrary.addAssetsToAlbumAsync(testAssets, album, shouldCopyAssets);
+        if (album != null) {
+          await MediaLibrary.deleteAlbumsAsync(album, true);
         }
+        testAssets = await getAssets(files);
+        album = await createAlbum(testAssets, ALBUM_NAME);
       }
 
       async function cleanupAsync() {

--- a/packages/expo-media-library/android/build.gradle
+++ b/packages/expo-media-library/android/build.gradle
@@ -17,6 +17,7 @@ android {
 dependencies {
   implementation "androidx.annotation:annotation:1.2.0"
   api "androidx.exifinterface:exifinterface:1.3.3"
+  implementation 'androidx.activity:activity-ktx:1.10.1'
 
   if (project.findProject(':expo-modules-test-core')) {
     testImplementation project(':expo-modules-test-core')

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/Exceptions.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/Exceptions.kt
@@ -37,3 +37,9 @@ class UnableToLoadPermissionException(message: String) :
 
 class UnableToLoadException(message: String) :
   CodedException(message)
+
+class UnableToDeleteException(message: String) :
+  CodedException(message)
+
+class UnableToSaveException(message: String) :
+  CodedException(message)

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/Exceptions.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/Exceptions.kt
@@ -32,14 +32,14 @@ class ContentEntryException :
 class AssetFileException(message: String) :
   CodedException(message)
 
-class UnableToLoadPermissionException(message: String) :
-  CodedException(message)
+class UnableToLoadPermissionException(message: String, cause: Throwable? = null) :
+  CodedException(message, cause)
 
-class UnableToLoadException(message: String) :
-  CodedException(message)
+class UnableToLoadException(message: String, cause: Throwable? = null) :
+  CodedException(message, cause)
 
-class UnableToDeleteException(message: String) :
-  CodedException(message)
+class UnableToDeleteException(message: String, cause: Throwable? = null) :
+  CodedException(message, cause)
 
-class UnableToSaveException(message: String) :
-  CodedException(message)
+class UnableToSaveException(message: String, cause: Throwable? = null) :
+  CodedException(message, cause)

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -286,10 +286,10 @@ class MediaLibraryModule : Module() {
     }
 
     RegisterActivityContracts {
-      val deleteContract = DeleteContract(this@MediaLibraryModule)
-      val writeContract = WriteContract(this@MediaLibraryModule)
-      deleteLauncher = registerForActivityResult(deleteContract)
-      writeLauncher = registerForActivityResult(writeContract)
+      deleteLauncher =
+        registerForActivityResult(DeleteContract(this@MediaLibraryModule))
+      writeLauncher =
+        registerForActivityResult(WriteContract(this@MediaLibraryModule))
     }
   }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -430,10 +430,10 @@ class MediaLibraryModule : Module() {
 
       if (pathsWithoutPermissions.isNotEmpty()) {
         val granted = if (useDeletePermission) {
-            deleteLauncher.launch(DeleteContractInput(uris = pathsWithoutPermissions))
-          } else {
-            writeLauncher.launch(WriteContractInput(uris = pathsWithoutPermissions))
-          }
+          deleteLauncher.launch(DeleteContractInput(uris = pathsWithoutPermissions))
+        } else {
+          writeLauncher.launch(WriteContractInput(uris = pathsWithoutPermissions))
+        }
         if (!granted) {
           return action.runWithPermissions(false)
         }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -11,7 +11,6 @@ import android.provider.MediaStore
 import android.text.TextUtils
 import android.util.Log
 import android.webkit.MimeTypeMap
-import expo.modules.kotlin.Promise
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -75,7 +74,7 @@ object MediaLibraryUtils {
     }
   }
 
-  fun deleteAssets(context: Context, selection: String?, selectionArgs: Array<out String?>?, promise: Promise) {
+  fun deleteAssets(context: Context, selection: String?, selectionArgs: Array<out String?>?) {
     val projection = arrayOf(MediaStore.MediaColumns._ID, MediaStore.MediaColumns.DATA)
     try {
       context.contentResolver.query(
@@ -112,18 +111,12 @@ object MediaLibraryUtils {
               }
             }
           }
-          promise.resolve(true)
         }
       }
     } catch (e: SecurityException) {
-      promise.reject(
-        ERROR_UNABLE_TO_SAVE_PERMISSION,
-        "Could not delete asset: need WRITE_EXTERNAL_STORAGE permission.",
-        e
-      )
+      throw UnableToDeleteException("Could not delete asset: need WRITE_EXTERNAL_STORAGE permission. $e")
     } catch (e: Exception) {
-      e.printStackTrace()
-      promise.reject(ERROR_UNABLE_TO_DELETE, "Could not delete file.", e)
+      throw UnableToDeleteException("Could not delete file. $e")
     }
   }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -114,9 +114,9 @@ object MediaLibraryUtils {
         }
       }
     } catch (e: SecurityException) {
-      throw UnableToDeleteException("Could not delete asset: need WRITE_EXTERNAL_STORAGE permission. $e")
+      throw UnableToDeleteException("Could not delete asset: need WRITE_EXTERNAL_STORAGE permission.", e)
     } catch (e: Exception) {
-      throw UnableToDeleteException("Could not delete file. $e")
+      throw UnableToDeleteException("Could not delete file: ${e.message}", e)
     }
   }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -12,10 +12,13 @@ import android.text.TextUtils
 import android.util.Log
 import android.webkit.MimeTypeMap
 import expo.modules.kotlin.Promise
+import kotlinx.coroutines.isActive
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CancellationException
 
 object MediaLibraryUtils {
   class AssetFile(pathname: String, val assetId: String, val mimeType: String) : File(pathname)
@@ -258,4 +261,8 @@ object MediaLibraryUtils {
    */
   fun hasManifestPermission(context: Context, permission: String): Boolean =
     getManifestPermissions(context).contains(permission)
+
+  fun CoroutineContext.ensureActiveOrThrow(message: String = "Coroutine context is inactive") {
+    if (!this.isActive) throw CancellationException(message)
+  }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -12,13 +12,10 @@ import android.text.TextUtils
 import android.util.Log
 import android.webkit.MimeTypeMap
 import expo.modules.kotlin.Promise
-import kotlinx.coroutines.isActive
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
-import kotlin.coroutines.CoroutineContext
-import kotlinx.coroutines.CancellationException
 
 object MediaLibraryUtils {
   class AssetFile(pathname: String, val assetId: String, val mimeType: String) : File(pathname)
@@ -261,8 +258,4 @@ object MediaLibraryUtils {
    */
   fun hasManifestPermission(context: Context, permission: String): Boolean =
     getManifestPermissions(context).contains(permission)
-
-  fun CoroutineContext.ensureActiveOrThrow(message: String = "Coroutine context is inactive") {
-    if (!this.isActive) throw CancellationException(message)
-  }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/AlbumUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/AlbumUtils.kt
@@ -50,9 +50,9 @@ fun queryAlbum(
       return result
     }
   } catch (e: SecurityException) {
-    throw UnableToLoadException("Could not get albums: need READ_EXTERNAL_STORAGE permission $e")
+    throw UnableToLoadException("Could not get albums: need READ_EXTERNAL_STORAGE permission ${e.message}", e)
   } catch (e: IllegalArgumentException) {
-    throw UnableToLoadException("Could not get album $e")
+    throw UnableToLoadException("Could not get album: ${e.message}", e)
   }
 }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/CreateAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/CreateAlbum.kt
@@ -49,9 +49,9 @@ internal class CreateAlbum(
 
       return result.await()
     } catch (e: SecurityException) {
-      throw UnableToLoadException("Could not create album: need WRITE_EXTERNAL_STORAGE permission $e")
+      throw UnableToLoadException("Could not create album: need WRITE_EXTERNAL_STORAGE permission: ${e.message}", e)
     } catch (e: IOException) {
-      throw UnableToLoadException("Could not read file or parse EXIF tags $e")
+      throw UnableToLoadException("Could not read file or parse EXIF tags: ${e.message}", e)
     }
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/CreateAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/CreateAlbum.kt
@@ -26,7 +26,6 @@ internal class CreateAlbum(
       val albumCreator = files[0]
       val album = createAlbumFile(albumCreator.mimeType, albumName)
       val newFile = mStrategy.apply(albumCreator, album, context)
-
       val result = CompletableDeferred<Bundle?>()
 
       MediaScannerConnection.scanFile(

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/CreateAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/CreateAlbum.kt
@@ -3,13 +3,13 @@ package expo.modules.medialibrary.albums
 import android.content.Context
 import android.media.MediaScannerConnection
 import android.net.Uri
+import android.os.Bundle
 import android.provider.MediaStore
-import expo.modules.kotlin.Promise
 import expo.modules.medialibrary.AlbumException
-import expo.modules.medialibrary.ERROR_UNABLE_TO_LOAD
-import expo.modules.medialibrary.ERROR_UNABLE_TO_LOAD_PERMISSION
 import expo.modules.medialibrary.MediaLibraryUtils
+import expo.modules.medialibrary.UnableToLoadException
 import expo.modules.medialibrary.assets.CreateAssetWithAlbumFile
+import kotlinx.coroutines.CompletableDeferred
 import java.io.File
 import java.io.IOException
 
@@ -17,72 +17,63 @@ internal class CreateAlbum(
   private val context: Context,
   private val albumName: String,
   private val assetId: String,
-  copyAsset: Boolean,
-  private val promise: Promise
+  copyAsset: Boolean
 ) {
   private val mStrategy = if (copyAsset) AssetFileStrategy.copyStrategy else AssetFileStrategy.moveStrategy
-
-  fun execute() {
+  suspend fun execute(): Bundle? {
     try {
       val files = MediaLibraryUtils.getAssetsById(context, assetId)
       val albumCreator = files[0]
       val album = createAlbumFile(albumCreator.mimeType, albumName)
       val newFile = mStrategy.apply(albumCreator, album, context)
+
+      val result = CompletableDeferred<Bundle?>()
+
       MediaScannerConnection.scanFile(
         context,
         arrayOf(newFile.path),
         null
       ) { path: String, uri: Uri? ->
         if (uri == null) {
-          throw AlbumException("Could not add image to album.")
+          result.completeExceptionally(
+            AlbumException("Could not add image to album.")
+          )
+          return@scanFile
         }
+
         val selection = "${MediaStore.Images.Media.DATA}=?"
         val args = arrayOf(path)
-        queryAlbum(context, selection, args, promise)
+        val bundle = queryAlbum(context, selection, args)
+        result.complete(bundle)
       }
+
+      return result.await()
     } catch (e: SecurityException) {
-      promise.reject(
-        ERROR_UNABLE_TO_LOAD_PERMISSION,
-        "Could not create album: need WRITE_EXTERNAL_STORAGE permission.",
-        e
-      )
+      throw UnableToLoadException("Could not create album: need WRITE_EXTERNAL_STORAGE permission $e")
     } catch (e: IOException) {
-      promise.reject(ERROR_UNABLE_TO_LOAD, "Could not read file or parse EXIF tags", e)
+      throw UnableToLoadException("Could not read file or parse EXIF tags $e")
     }
   }
 }
 
 // Creates the album file and uses existing CreateAssetWithAlbumFile to create the asset inside the album.
-internal class CreateAlbumWithInitialFileUri(val context: Context, val albumName: String, val assetUri: Uri, val promise: Promise) {
-  fun execute() {
+internal class CreateAlbumWithInitialFileUri(val context: Context, val albumName: String, val assetUri: Uri) {
+  suspend fun execute(): Bundle? {
     val mimeType: String = MediaLibraryUtils.getMimeType(context.contentResolver, assetUri) ?: run {
-      promise.reject(AlbumException("Failed to create album: could not determine MIME type of the asset with uri: `$assetUri`."))
-      return
+      throw AlbumException("Failed to create album: could not determine MIME type of the asset with uri: `$assetUri`.")
     }
     val assetUriPath = assetUri.path ?: run {
-      promise.reject(AlbumException("Failed to create album: could not determine path of the asset with uri: `$assetUri`."))
-      return
+      throw AlbumException("Failed to create album: could not determine path of the asset with uri: `$assetUri`.")
     }
 
     val albumFile: File = createAlbumFile(mimeType, albumName)
     val mediaFile: File = File(assetUriPath)
 
     if (!mediaFile.exists()) {
-      promise.reject(AlbumException("Failed to create album: the local media file with uri: `$assetUri` does not exist."))
-      return
+      throw AlbumException("Failed to create album: the local media file with uri: `$assetUri` does not exist.")
     }
 
-    val createAssetPromise = object : Promise {
-      override fun resolve(value: Any?) {
-        // Resolve our promise with the newly created album
-        GetAlbum(context, albumName, promise).execute()
-      }
-
-      override fun reject(code: String, message: String?, cause: Throwable?) {
-        promise.reject(code, "Failed to create the album: $message", cause)
-      }
-    }
-
-    CreateAssetWithAlbumFile(context, assetUri.toString(), createAssetPromise, false, albumFile).execute()
+    CreateAssetWithAlbumFile(context, assetUri.toString(), false, albumFile).execute()
+    return GetAlbum(context, albumName).execute()
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/DeleteAlbums.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/DeleteAlbums.kt
@@ -16,8 +16,7 @@ internal class DeleteAlbums(
     val selectionVideos = "${MediaStore.Video.Media.BUCKET_ID} IN (${queryPlaceholdersFor(mAlbumIds)})"
     val selectionArgs = mAlbumIds
 
-    MediaLibraryUtils.deleteAssets(context, selectionImages, selectionArgs)
-    MediaLibraryUtils.deleteAssets(context, selectionVideos, selectionArgs)
-    return true
+    return MediaLibraryUtils.deleteAssets(context, selectionImages, selectionArgs) &&
+      MediaLibraryUtils.deleteAssets(context, selectionVideos, selectionArgs)
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/DeleteAlbums.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/DeleteAlbums.kt
@@ -2,34 +2,22 @@ package expo.modules.medialibrary.albums
 
 import android.content.Context
 import android.provider.MediaStore
-import expo.modules.kotlin.Promise
 import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.MediaLibraryUtils.queryPlaceholdersFor
 
 internal class DeleteAlbums(
   private val context: Context,
-  albumIds: List<String>,
-  private val promise: Promise
+  albumIds: List<String>
 ) {
   private val mAlbumIds = albumIds.toTypedArray()
 
-  fun execute() {
+  fun execute(): Boolean {
     val selectionImages = "${MediaStore.Images.Media.BUCKET_ID} IN (${queryPlaceholdersFor(mAlbumIds)})"
     val selectionVideos = "${MediaStore.Video.Media.BUCKET_ID} IN (${queryPlaceholdersFor(mAlbumIds)})"
     val selectionArgs = mAlbumIds
 
-    // We need to run delete for images and videos separately, but resolve the promise only once
-    val promiseOverride = object : Promise {
-      override fun resolve(value: Any?) {
-        MediaLibraryUtils.deleteAssets(context, selectionVideos, selectionArgs, promise)
-      }
-
-      override fun reject(code: String, message: String?, cause: Throwable?) {
-        promise.reject(code, message, cause)
-      }
-    }
-
-    // Delete Images
-    MediaLibraryUtils.deleteAssets(context, selectionImages, selectionArgs, promiseOverride)
+    MediaLibraryUtils.deleteAssets(context, selectionImages, selectionArgs)
+    MediaLibraryUtils.deleteAssets(context, selectionVideos, selectionArgs)
+    return true
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/GetAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/GetAlbum.kt
@@ -1,20 +1,19 @@
 package expo.modules.medialibrary.albums
 
 import android.content.Context
+import android.os.Bundle
 import android.provider.MediaStore.Files.FileColumns
 import android.provider.MediaStore.MediaColumns
-import expo.modules.kotlin.Promise
 
 internal class GetAlbum(
   private val context: Context,
-  private val albumName: String,
-  private val promise: Promise
+  private val albumName: String
 ) {
-  fun execute() {
+  fun execute(): Bundle? {
     val selection = "${FileColumns.MEDIA_TYPE} != ${FileColumns.MEDIA_TYPE_NONE}" +
       " AND ${MediaColumns.BUCKET_DISPLAY_NAME}=?"
     val selectionArgs = arrayOf(albumName)
 
-    queryAlbum(context, selection, selectionArgs, promise)
+    return queryAlbum(context, selection, selectionArgs)
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/GetAlbums.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/GetAlbums.kt
@@ -5,17 +5,14 @@ import android.database.Cursor.FIELD_TYPE_NULL
 import android.os.Bundle
 import android.provider.MediaStore
 import android.provider.MediaStore.Images.Media
-import expo.modules.kotlin.Promise
 import expo.modules.medialibrary.AlbumException
-import expo.modules.medialibrary.ERROR_UNABLE_TO_LOAD
-import expo.modules.medialibrary.ERROR_UNABLE_TO_LOAD_PERMISSION
 import expo.modules.medialibrary.EXTERNAL_CONTENT_URI
+import expo.modules.medialibrary.UnableToLoadException
 
 internal open class GetAlbums(
-  private val context: Context,
-  private val promise: Promise
+  private val context: Context
 ) {
-  fun execute() {
+  fun execute(): List<Bundle> {
     val projection = arrayOf(Media.BUCKET_ID, Media.BUCKET_DISPLAY_NAME)
     val selection = "${MediaStore.Files.FileColumns.MEDIA_TYPE} != ${MediaStore.Files.FileColumns.MEDIA_TYPE_NONE}"
 
@@ -53,17 +50,12 @@ internal open class GetAlbums(
 
             album.count++
           }
-
-          promise.resolve(albums.values.map { it.toBundle() })
+          return albums.values.map { it.toBundle() }
         }
     } catch (e: SecurityException) {
-      promise.reject(
-        ERROR_UNABLE_TO_LOAD_PERMISSION,
-        "Could not get albums: need READ_EXTERNAL_STORAGE permission.",
-        e
-      )
+      throw UnableToLoadException("Could not get albums: need READ_EXTERNAL_STORAGE permission $e")
     } catch (e: RuntimeException) {
-      promise.reject(ERROR_UNABLE_TO_LOAD, "Could not get albums.", e)
+      throw UnableToLoadException("Could not get albums $e")
     }
   }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/GetAlbums.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/GetAlbums.kt
@@ -53,9 +53,9 @@ internal open class GetAlbums(
           return albums.values.map { it.toBundle() }
         }
     } catch (e: SecurityException) {
-      throw UnableToLoadException("Could not get albums: need READ_EXTERNAL_STORAGE permission $e")
+      throw UnableToLoadException("Could not get albums: need READ_EXTERNAL_STORAGE permission ${e.message}", e)
     } catch (e: RuntimeException) {
-      throw UnableToLoadException("Could not get albums $e")
+      throw UnableToLoadException("Could not get albums ${e.message}", e)
     }
   }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/RemoveAssetsFromAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/RemoveAssetsFromAlbum.kt
@@ -2,19 +2,17 @@ package expo.modules.medialibrary.albums
 
 import android.content.Context
 import android.provider.MediaStore.Images.Media
-import expo.modules.kotlin.Promise
 import expo.modules.medialibrary.MediaLibraryUtils
 
 internal class RemoveAssetsFromAlbum(
   private val context: Context,
   private val assetIds: Array<String>,
-  private val albumId: String,
-  private val promise: Promise
+  private val albumId: String
 ) {
   fun execute() {
     val bucketSelection = "${Media.BUCKET_ID}=? AND ${Media._ID} IN (${assetIds.joinToString(",")} )"
     val bucketId = arrayOf(albumId)
 
-    MediaLibraryUtils.deleteAssets(context, bucketSelection, bucketId, promise)
+    MediaLibraryUtils.deleteAssets(context, bucketSelection, bucketId)
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/migration/CheckIfAlbumShouldBeMigrated.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/migration/CheckIfAlbumShouldBeMigrated.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Build
 import android.provider.MediaStore
 import androidx.annotation.RequiresApi
-import expo.modules.kotlin.Promise
 import expo.modules.medialibrary.AlbumNotFound
 import expo.modules.medialibrary.EXTERNAL_CONTENT_URI
 import java.io.File
@@ -12,15 +11,14 @@ import java.io.File
 @RequiresApi(Build.VERSION_CODES.R)
 class CheckIfAlbumShouldBeMigrated(
   private val context: Context,
-  private val albumId: String,
-  private val promise: Promise
+  private val albumId: String
 ) {
-  fun execute() {
+  fun execute(): Boolean {
     val albumDir = getAlbumDirectory(context, albumId)
     if (albumDir == null) {
       throw AlbumNotFound()
     } else {
-      promise.resolve(!albumDir.canWrite())
+      return !albumDir.canWrite()
     }
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/migration/MigrateAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/migration/MigrateAlbum.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.os.Build
 import android.provider.MediaStore
 import androidx.annotation.RequiresApi
-import expo.modules.kotlin.Promise
 import expo.modules.medialibrary.AlbumException
 import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.MediaLibraryUtils.AssetFile
@@ -16,8 +15,7 @@ import java.io.File
 internal class MigrateAlbum(
   private val context: Context,
   private val assetFiles: List<AssetFile>,
-  private val albumDirName: String,
-  private val promise: Promise
+  private val albumDirName: String
 ) {
   fun execute() {
     // Previously, users were able to save different assets type in the same directory.
@@ -47,6 +45,5 @@ internal class MigrateAlbum(
           null
         )
     }
-    promise.resolve(null)
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -62,9 +62,9 @@ fun queryAssetInfo(
     }
   } catch (e: Exception) {
     throw when (e) {
-      is SecurityException -> UnableToLoadException("Could not get asset: need READ_EXTERNAL_STORAGE permission. $e")
-      is IOException -> UnableToLoadException("Could not read file $e")
-      is UnsupportedOperationException -> UnableToLoadException(e.message ?: "Invalid MediaType $e")
+      is SecurityException -> UnableToLoadException("Could not get asset: need READ_EXTERNAL_STORAGE permission", e)
+      is IOException -> UnableToLoadException("Could not read file ${e.message}", e)
+      is UnsupportedOperationException -> UnableToLoadException(e.message ?: "Invalid MediaType", e)
       else -> e
     }
   }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -12,15 +12,12 @@ import android.provider.MediaStore
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.exifinterface.media.ExifInterface
-import expo.modules.kotlin.Promise
 import expo.modules.medialibrary.ASSET_PROJECTION
 import expo.modules.medialibrary.AssetQueryException
-import expo.modules.medialibrary.ERROR_IO_EXCEPTION
-import expo.modules.medialibrary.ERROR_NO_PERMISSIONS
-import expo.modules.medialibrary.ERROR_UNABLE_TO_LOAD_PERMISSION
 import expo.modules.medialibrary.EXTERNAL_CONTENT_URI
 import expo.modules.medialibrary.EXIF_TAGS
 import expo.modules.medialibrary.MediaType
+import expo.modules.medialibrary.UnableToLoadException
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.lang.NumberFormatException
@@ -36,9 +33,8 @@ fun queryAssetInfo(
   context: Context,
   selection: String?,
   selectionArgs: Array<String>?,
-  resolveWithFullInfo: Boolean,
-  promise: Promise
-) {
+  resolveWithFullInfo: Boolean
+): ArrayList<Bundle>? {
   val contentResolver = context.contentResolver
   try {
     contentResolver.query(
@@ -58,23 +54,19 @@ fun queryAssetInfo(
           // actually we want to return just the first item, but array.getMap returns ReadableMap
           // which is not compatible with promise.resolve and there is no simple solution to convert
           // ReadableMap to WritableMap so it's easier to return an array and pick the first item on JS side
-          promise.resolve(array)
+          return array
         } else {
-          promise.resolve(null)
+          return null
         }
       }
     }
-  } catch (e: SecurityException) {
-    promise.reject(
-      ERROR_UNABLE_TO_LOAD_PERMISSION,
-      "Could not get asset: need READ_EXTERNAL_STORAGE permission.",
-      e
-    )
-  } catch (e: IOException) {
-    promise.reject(ERROR_IO_EXCEPTION, "Could not read file", e)
-  } catch (e: UnsupportedOperationException) {
-    e.printStackTrace()
-    promise.reject(ERROR_NO_PERMISSIONS, e.message, e)
+  } catch (e: Exception) {
+    throw when (e) {
+      is SecurityException -> UnableToLoadException("Could not get asset: need READ_EXTERNAL_STORAGE permission. $e")
+      is IOException -> UnableToLoadException("Could not read file $e")
+      is UnsupportedOperationException -> UnableToLoadException(e.message ?: "Invalid MediaType $e")
+      else -> e
+    }
   }
 }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/CreateAsset.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/CreateAsset.kt
@@ -167,9 +167,9 @@ class CreateAssetWithAlbumFile(
     } catch (e: IOException) {
       throw IOException("Unable to copy file into external storage.", e)
     } catch (e: SecurityException) {
-      throw UnableToLoadPermissionException("Could not get asset: need READ_EXTERNAL_STORAGE permission $e")
+      throw UnableToLoadPermissionException("Could not get asset: need READ_EXTERNAL_STORAGE permission", e)
     } catch (e: Exception) {
-      throw UnableToSaveException("Could not create asset $e")
+      throw UnableToSaveException("Could not create asset: ${e.message}", e)
     }
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/DeleteAssets.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/DeleteAssets.kt
@@ -2,18 +2,17 @@ package expo.modules.medialibrary.assets
 
 import android.content.Context
 import android.provider.MediaStore
-import expo.modules.kotlin.Promise
 import expo.modules.medialibrary.MediaLibraryUtils
 
 internal class DeleteAssets(
   private val context: Context,
-  private val assetIds: Array<String>,
-  private val promise: Promise
+  private val assetIds: Array<String>
 ) {
-  fun execute() {
+  fun execute(): Boolean {
     val selection = "${MediaStore.Images.Media._ID} IN (${assetIds.joinToString(separator = ",")} )"
     val selectionArgs: Array<String>? = null
 
-    MediaLibraryUtils.deleteAssets(context, selection, selectionArgs, promise)
+    MediaLibraryUtils.deleteAssets(context, selection, selectionArgs)
+    return true
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/DeleteAssets.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/DeleteAssets.kt
@@ -12,7 +12,6 @@ internal class DeleteAssets(
     val selection = "${MediaStore.Images.Media._ID} IN (${assetIds.joinToString(separator = ",")} )"
     val selectionArgs: Array<String>? = null
 
-    MediaLibraryUtils.deleteAssets(context, selection, selectionArgs)
-    return true
+    return MediaLibraryUtils.deleteAssets(context, selection, selectionArgs)
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/GetAssetInfo.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/GetAssetInfo.kt
@@ -1,18 +1,17 @@
 package expo.modules.medialibrary.assets
 
 import android.content.Context
+import android.os.Bundle
 import android.provider.MediaStore
-import expo.modules.kotlin.Promise
 
 internal class GetAssetInfo(
   private val context: Context,
-  private val assetId: String,
-  private val promise: Promise
+  private val assetId: String
 ) {
-  fun execute() {
+  fun execute(): ArrayList<Bundle>? {
     val selection = "${MediaStore.Images.Media._ID}=?"
     val selectionArgs = arrayOf(assetId)
 
-    queryAssetInfo(context, selection, selectionArgs, true, promise)
+    return queryAssetInfo(context, selection, selectionArgs, true)
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/GetAssets.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/GetAssets.kt
@@ -49,10 +49,10 @@ internal class GetAssets(
       }
     } catch (e: Exception) {
       throw when (e) {
-        is SecurityException -> UnableToLoadException("Could not get asset: need read_external_storage permission")
-        is IOException -> UnableToLoadException("Could not read file $e")
-        is IllegalArgumentException -> UnableToLoadException(e.message ?: "Invalid MediaType $e")
-        is UnsupportedOperationException -> PermissionsException(e.message ?: "Permission denied $e")
+        is SecurityException -> UnableToLoadException("Could not get asset: need read_external_storage permission", e)
+        is IOException -> UnableToLoadException("Could not read file: ${e.message}", e)
+        is IllegalArgumentException -> UnableToLoadException(e.message ?: "Invalid MediaType ${e.message}", e)
+        is UnsupportedOperationException -> PermissionsException(e.message ?: "Permission denied: ${e.message}")
         else -> e
       }
     }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/contracts/DeleteContract.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/contracts/DeleteContract.kt
@@ -13,15 +13,15 @@ import androidx.activity.result.contract.ActivityResultContracts.StartIntentSend
 import androidx.annotation.RequiresApi
 import expo.modules.kotlin.activityresult.AppContextActivityResultContract
 import expo.modules.kotlin.providers.AppContextProvider
+import expo.modules.kotlin.exception.Exceptions
 import java.io.Serializable
 
 class DeleteContract(
   private val appContextProvider: AppContextProvider
 ) : AppContextActivityResultContract<DeleteContractInput, Boolean> {
-  private val contentResolver: ContentResolver
-    get() = requireNotNull(appContextProvider.appContext.reactContext) {
-      "React Application Context is null"
-    }.contentResolver
+  private val contentResolver: ContentResolver get() =
+    appContextProvider.appContext.reactContext?.contentResolver
+      ?: throw Exceptions.ReactContextLost()
 
   @RequiresApi(Build.VERSION_CODES.R)
   override fun createIntent(context: Context, input: DeleteContractInput): Intent {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/contracts/DeleteContract.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/contracts/DeleteContract.kt
@@ -8,6 +8,8 @@ import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
 import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult.Companion.ACTION_INTENT_SENDER_REQUEST
+import androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult.Companion.EXTRA_INTENT_SENDER_REQUEST
 import androidx.annotation.RequiresApi
 import expo.modules.kotlin.activityresult.AppContextActivityResultContract
 import expo.modules.kotlin.providers.AppContextProvider
@@ -16,13 +18,6 @@ import java.io.Serializable
 class DeleteContract(
   private val appContextProvider: AppContextProvider
 ) : AppContextActivityResultContract<DeleteContractInput, Boolean> {
-  companion object {
-    const val ACTION_INTENT_SENDER_REQUEST =
-      "androidx.activity.result.contract.action.INTENT_SENDER_REQUEST"
-    const val EXTRA_INTENT_SENDER_REQUEST =
-      "androidx.activity.result.contract.extra.INTENT_SENDER_REQUEST"
-  }
-
   private val contentResolver: ContentResolver
     get() = requireNotNull(appContextProvider.appContext.reactContext) {
       "React Application Context is null"

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/contracts/DeleteContract.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/contracts/DeleteContract.kt
@@ -1,0 +1,43 @@
+package expo.modules.medialibrary.contracts
+
+import android.app.Activity
+import android.content.ContentResolver
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import androidx.activity.result.IntentSenderRequest
+import androidx.annotation.RequiresApi
+import expo.modules.kotlin.activityresult.AppContextActivityResultContract
+import expo.modules.kotlin.providers.AppContextProvider
+import java.io.Serializable
+
+class DeleteContract(
+  private val appContextProvider: AppContextProvider
+) : AppContextActivityResultContract<DeleteContractInput, Boolean> {
+  companion object {
+    const val ACTION_INTENT_SENDER_REQUEST =
+      "androidx.activity.result.contract.action.INTENT_SENDER_REQUEST"
+    const val EXTRA_INTENT_SENDER_REQUEST =
+      "androidx.activity.result.contract.extra.INTENT_SENDER_REQUEST"
+  }
+
+  private val contentResolver: ContentResolver
+    get() = requireNotNull(appContextProvider.appContext.reactContext) {
+      "React Application Context is null"
+    }.contentResolver
+
+  @RequiresApi(Build.VERSION_CODES.R)
+  override fun createIntent(context: Context, input: DeleteContractInput): Intent {
+    val request = MediaStore.createDeleteRequest(contentResolver, input.uris)
+    val intentSenderRequest = IntentSenderRequest.Builder(request.intentSender).build()
+    return Intent(ACTION_INTENT_SENDER_REQUEST).putExtra(EXTRA_INTENT_SENDER_REQUEST, intentSenderRequest)
+  }
+
+  override fun parseResult(input: DeleteContractInput, resultCode: Int, intent: Intent?): Boolean {
+    return resultCode == Activity.RESULT_OK
+  }
+}
+
+data class DeleteContractInput(val uris: List<Uri>) : Serializable

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/contracts/WriteContract.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/contracts/WriteContract.kt
@@ -1,0 +1,43 @@
+package expo.modules.medialibrary.contracts
+
+import android.app.Activity
+import android.content.ContentResolver
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import androidx.activity.result.IntentSenderRequest
+import androidx.annotation.RequiresApi
+import expo.modules.kotlin.activityresult.AppContextActivityResultContract
+import expo.modules.kotlin.providers.AppContextProvider
+import java.io.Serializable
+
+class WriteContract(
+  private val appContextProvider: AppContextProvider
+) : AppContextActivityResultContract<WriteContractInput, Boolean> {
+  companion object {
+    const val ACTION_INTENT_SENDER_REQUEST =
+      "androidx.activity.result.contract.action.INTENT_SENDER_REQUEST"
+    const val EXTRA_INTENT_SENDER_REQUEST =
+      "androidx.activity.result.contract.extra.INTENT_SENDER_REQUEST"
+  }
+
+  private val contentResolver: ContentResolver
+    get() = requireNotNull(appContextProvider.appContext.reactContext) {
+      "React Application Context is null"
+    }.contentResolver
+
+  @RequiresApi(Build.VERSION_CODES.R)
+  override fun createIntent(context: Context, input: WriteContractInput): Intent {
+    val request = MediaStore.createWriteRequest(contentResolver, input.uris)
+    val intentSenderRequest = IntentSenderRequest.Builder(request.intentSender).build()
+    return Intent(ACTION_INTENT_SENDER_REQUEST).putExtra(EXTRA_INTENT_SENDER_REQUEST, intentSenderRequest)
+  }
+
+  override fun parseResult(input: WriteContractInput, resultCode: Int, intent: Intent?): Boolean {
+    return resultCode == Activity.RESULT_OK
+  }
+}
+
+data class WriteContractInput(val uris: List<Uri>) : Serializable

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/contracts/WriteContract.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/contracts/WriteContract.kt
@@ -8,6 +8,8 @@ import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
 import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult.Companion.ACTION_INTENT_SENDER_REQUEST
+import androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult.Companion.EXTRA_INTENT_SENDER_REQUEST
 import androidx.annotation.RequiresApi
 import expo.modules.kotlin.activityresult.AppContextActivityResultContract
 import expo.modules.kotlin.providers.AppContextProvider
@@ -16,13 +18,6 @@ import java.io.Serializable
 class WriteContract(
   private val appContextProvider: AppContextProvider
 ) : AppContextActivityResultContract<WriteContractInput, Boolean> {
-  companion object {
-    const val ACTION_INTENT_SENDER_REQUEST =
-      "androidx.activity.result.contract.action.INTENT_SENDER_REQUEST"
-    const val EXTRA_INTENT_SENDER_REQUEST =
-      "androidx.activity.result.contract.extra.INTENT_SENDER_REQUEST"
-  }
-
   private val contentResolver: ContentResolver
     get() = requireNotNull(appContextProvider.appContext.reactContext) {
       "React Application Context is null"

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/contracts/WriteContract.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/contracts/WriteContract.kt
@@ -12,16 +12,16 @@ import androidx.activity.result.contract.ActivityResultContracts.StartIntentSend
 import androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult.Companion.EXTRA_INTENT_SENDER_REQUEST
 import androidx.annotation.RequiresApi
 import expo.modules.kotlin.activityresult.AppContextActivityResultContract
+import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.providers.AppContextProvider
 import java.io.Serializable
 
 class WriteContract(
   private val appContextProvider: AppContextProvider
 ) : AppContextActivityResultContract<WriteContractInput, Boolean> {
-  private val contentResolver: ContentResolver
-    get() = requireNotNull(appContextProvider.appContext.reactContext) {
-      "React Application Context is null"
-    }.contentResolver
+  private val contentResolver: ContentResolver get() =
+    appContextProvider.appContext.reactContext?.contentResolver
+      ?: throw Exceptions.ReactContextLost()
 
   @RequiresApi(Build.VERSION_CODES.R)
   override fun createIntent(context: Context, input: WriteContractInput): Intent {

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumInfoTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumInfoTests.kt
@@ -1,25 +1,22 @@
 package expo.modules.medialibrary.albums
 
+import android.os.Bundle
 import android.provider.MediaStore
 import expo.modules.medialibrary.AlbumException
-import expo.modules.medialibrary.ERROR_UNABLE_TO_LOAD
-import expo.modules.medialibrary.ERROR_UNABLE_TO_LOAD_PERMISSION
 import expo.modules.medialibrary.MockContext
 import expo.modules.medialibrary.MockData
+import expo.modules.medialibrary.UnableToLoadException
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockCursor
 import expo.modules.medialibrary.throwableContentResolver
-import expo.modules.test.core.legacy.PromiseMock
-import expo.modules.test.core.legacy.assertRejectedWithCode
-import expo.modules.test.core.legacy.promiseResolved
 import io.mockk.every
-import io.mockk.just
+import io.mockk.mockk
 import io.mockk.mockkStatic
-import io.mockk.runs
 import io.mockk.slot
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,12 +25,10 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 internal class GetAlbumInfoTests {
 
-  private lateinit var promise: PromiseMock
   private lateinit var mockContext: MockContext
 
   @Before
   fun setUp() {
-    promise = PromiseMock()
     mockContext = MockContext()
   }
 
@@ -49,16 +44,15 @@ internal class GetAlbumInfoTests {
       queryAlbum(
         context,
         capture(selectionSlot),
-        capture(selectionArgsSlot),
-        promise
+        capture(selectionArgsSlot)
       )
-    } just runs
+    } returns mockk<Bundle>(relaxed = true)
 
     val expectedSelection = "${MediaStore.Images.Media.BUCKET_DISPLAY_NAME}=?"
     val albumName = "testAlbumName"
 
     // act
-    GetAlbum(context, albumName, promise).execute()
+    GetAlbum(context, albumName).execute()
 
     // assert
     assertTrue(selectionSlot.captured.contains(expectedSelection, ignoreCase = true))
@@ -84,14 +78,14 @@ internal class GetAlbumInfoTests {
     val context = mockContext with mockContentResolver(cursor)
 
     // act
-    queryAlbum(context, selection, selectionArgs, promise)
+    val result = queryAlbum(context, selection, selectionArgs)
 
     // assert
-    promiseResolved(promise) {
+    result?.let {
       assertEquals(bucketDisplayName, it.getString("title"))
       assertEquals(2, it.getInt("assetCount"))
       assertEquals(MockData.MOCK_ALBUM_ID, it.getString("id"))
-    }
+    } ?: fail()
   }
 
   @Test
@@ -99,10 +93,9 @@ internal class GetAlbumInfoTests {
     // arrange
     val context = mockContext with mockContentResolver(null)
 
-    // act
-    // assert
+    // act && assert
     assertThrows(AlbumException::class.java) {
-      queryAlbum(context, "", emptyArray(), promise)
+      queryAlbum(context, "", emptyArray())
     }
   }
 
@@ -111,11 +104,13 @@ internal class GetAlbumInfoTests {
     // arrange
     val context = mockContext with throwableContentResolver(SecurityException())
 
-    // act
-    queryAlbum(context, "", emptyArray(), promise)
-
-    // assert
-    assertRejectedWithCode(promise, ERROR_UNABLE_TO_LOAD_PERMISSION)
+    // act && assert
+    try {
+      queryAlbum(context, "", emptyArray())
+      fail()
+    } catch (e: Exception) {
+      assert(e is UnableToLoadException)
+    }
   }
 
   @Test
@@ -123,10 +118,12 @@ internal class GetAlbumInfoTests {
     // arrange
     val context = mockContext with throwableContentResolver(IllegalArgumentException())
 
-    // act
-    queryAlbum(context, "", emptyArray(), promise)
-
-    // assert
-    assertRejectedWithCode(promise, ERROR_UNABLE_TO_LOAD)
+    // act && assert
+    try {
+      queryAlbum(context, "", emptyArray())
+      fail()
+    } catch (e: Exception) {
+      assert(e is UnableToLoadException)
+    }
   }
 }

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumTests.kt
@@ -117,7 +117,7 @@ internal class GetAlbumTests {
 
     // act && assert
     try {
-      GetAlbums(context).execute()
+      queryAlbum(context, "", emptyArray())
       fail()
     } catch (e: Exception) {
       assert(e is UnableToLoadException)

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
@@ -3,20 +3,18 @@ package expo.modules.medialibrary.assets
 import android.os.Bundle
 import android.provider.MediaStore
 import expo.modules.medialibrary.AssetQueryException
-import expo.modules.medialibrary.ERROR_IO_EXCEPTION
-import expo.modules.medialibrary.ERROR_UNABLE_TO_LOAD_PERMISSION
 import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.MockContext
 import expo.modules.medialibrary.MockData
+import expo.modules.medialibrary.UnableToLoadException
+import expo.modules.medialibrary.albums.queryAlbum
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockContentResolverForResult
 import expo.modules.medialibrary.throwableContentResolver
-import expo.modules.test.core.legacy.PromiseMock
-import expo.modules.test.core.legacy.assertRejectedWithCode
-import expo.modules.test.core.legacy.promiseResolvedWithType
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
@@ -24,6 +22,7 @@ import junit.framework.ComparisonFailure
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -45,12 +44,10 @@ private fun assertListsEqual(first: List<*>?, second: List<*>?, message: String 
 @RunWith(RobolectricTestRunner::class)
 internal class GetAssetInfoTests {
 
-  private lateinit var promise: PromiseMock
   private lateinit var mockContext: MockContext
 
   @Before
   fun setUp() {
-    promise = PromiseMock()
     mockContext = MockContext()
   }
 
@@ -72,16 +69,15 @@ internal class GetAssetInfoTests {
         context,
         capture(selectionSlot),
         capture(selectionArgsSlot),
-        true,
-        promise
+        true
       )
-    } just runs
+    } returns mockk<ArrayList<Bundle>>(relaxed = true)
 
     val expectedSelection = "${MediaStore.Images.Media._ID}=?"
     val assetId = "testAssetId"
 
     // act
-    GetAssetInfo(context, assetId, promise).execute()
+    GetAssetInfo(context, assetId).execute()
 
     // assert
     assertEquals(expectedSelection, selectionSlot.captured)
@@ -107,12 +103,12 @@ internal class GetAssetInfoTests {
     val selectionArgs = arrayOf(MockData.mockImage.id.toString())
 
     // act
-    queryAssetInfo(context, selection, selectionArgs, false, promise)
+    val result = queryAssetInfo(context, selection, selectionArgs, false)
 
     // assert
-    promiseResolvedWithType<ArrayList<Bundle>>(promise) {
-      assertListsEqual(emptyList<Bundle>(), it)
-    }
+    result?.let {
+      assertListsEqual(emptyList<Bundle>(), result)
+    } ?: fail()
   }
 
   @Test
@@ -120,10 +116,9 @@ internal class GetAssetInfoTests {
     // arrange
     val context = mockContext with mockContentResolver(null)
 
-    // act
-    // assert
+    // act && assert
     assertThrows(AssetQueryException::class.java) {
-      queryAssetInfo(context, "", emptyArray(), false, promise)
+      queryAssetInfo(context, "", emptyArray(), false)
     }
   }
 
@@ -132,10 +127,13 @@ internal class GetAssetInfoTests {
     // arrange
     val context = mockContext with throwableContentResolver(SecurityException())
 
-    // act
-    queryAssetInfo(context, "", emptyArray(), false, promise)
-    // assert
-    assertRejectedWithCode(promise, ERROR_UNABLE_TO_LOAD_PERMISSION)
+    // act && assert
+    try {
+      queryAlbum(context, "", emptyArray())
+      fail()
+    } catch (e: Exception) {
+      assert(e is UnableToLoadException)
+    }
   }
 
   @Test
@@ -143,10 +141,12 @@ internal class GetAssetInfoTests {
     // arrange
     val context = mockContext with throwableContentResolver(IOException())
 
-    // act
-    queryAssetInfo(context, "", emptyArray(), false, promise)
-
-    // assert
-    assertRejectedWithCode(promise, ERROR_IO_EXCEPTION)
+    // act && assert
+    try {
+      queryAlbum(context, "", emptyArray())
+      fail()
+    } catch (e: Exception) {
+      assert(e is IOException)
+    }
   }
 }

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
@@ -7,7 +7,6 @@ import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.MockContext
 import expo.modules.medialibrary.MockData
 import expo.modules.medialibrary.UnableToLoadException
-import expo.modules.medialibrary.albums.queryAlbum
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockContentResolverForResult
 import expo.modules.medialibrary.throwableContentResolver
@@ -129,7 +128,7 @@ internal class GetAssetInfoTests {
 
     // act && assert
     try {
-      queryAlbum(context, "", emptyArray())
+      queryAssetInfo(context, "", emptyArray(), false)
       fail()
     } catch (e: Exception) {
       assert(e is UnableToLoadException)
@@ -143,10 +142,10 @@ internal class GetAssetInfoTests {
 
     // act && assert
     try {
-      queryAlbum(context, "", emptyArray())
+      queryAssetInfo(context, "", emptyArray(), false)
       fail()
     } catch (e: Exception) {
-      assert(e is IOException)
+      assert(e is UnableToLoadException)
     }
   }
 }

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetsTest.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetsTest.kt
@@ -16,6 +16,7 @@ import io.mockk.runs
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -80,6 +81,7 @@ internal class GetAssetsTest {
     // act && assert
     try {
       GetAssets(context, defaultAssets).execute()
+      fail()
     } catch (e: Exception) {
       assert(e is AssetQueryException)
     }
@@ -93,6 +95,7 @@ internal class GetAssetsTest {
     // act && assert
     try {
       GetAssets(context, defaultAssets).execute()
+      fail()
     } catch (e: Exception) {
       assert(e is UnableToLoadException)
     }
@@ -106,6 +109,7 @@ internal class GetAssetsTest {
     // act && assert
     try {
       GetAssets(context, defaultAssets).execute()
+      fail()
     } catch (e: Exception) {
       assert(e is UnableToLoadException)
     }


### PR DESCRIPTION
# Why

Depends on [#38226](https://github.com/expo/expo/pull/38226), which aims to rewrite the `MediaLibrary` module to be coroutine-based.

# How
- **Refactored `runActionWithPermissions` to return a value instead of just triggering an intent.**  
  In order to remove `Promise` usage from functions relying on `runActionWithPermissions`, it was necessary to make `runActionWithPermissions` return a value, instead of just running an intent.
  **Was:**
save action -> run intent -> handle result and execute saved action in OnActivityResult
**Is:**
register launcher using RegisterActivityContract -> launch it as a suspendable function within runActionWithPermissions
- **Replaced all `promise.reject` usages with `CodedException`**
- **Rewrote native tests**, as the constructors no longer take a `Promise`.
- **Refactored `initializeDefaultAssetsAsync`** in the TS tests to make the logic more verbose.
- **Removed `moduleCoroutineScope`**, and replaced its usage with the `Coroutine` annotation in the `AsyncFunction` declarations.


# Test Plan
Tested on BareExpo ✅

<img width="300" height="700" alt="Screenshot_20250725_083158" src="https://github.com/user-attachments/assets/b842f052-d439-4238-80b2-f0aa7d3b1168" />

