### PR TITLE
[docs] Update setNotificationChannel in push-notification-setup.mdx to include an await

### DIFF
--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -107,7 +107,7 @@ function handleRegistrationError(errorMessage: string) {
 
 async function registerForPushNotificationsAsync() {
   if (Platform.OS === 'android') {
-    Notifications.setNotificationChannelAsync('default', {
+    await Notifications.setNotificationChannelAsync('default', {
       name: 'default',
       importance: Notifications.AndroidImportance.MAX,
       vibrationPattern: [0, 250, 250, 250],


### PR DESCRIPTION
The code example for the android channel setup path doesn't await the channel setup. This is required in order to ensure the channel is setup, otherwise the notifications will not get successfully processed. This change is will be in parity with a similar example in the reference section of the docs. 

# Why
The example in the doc was incorrect. This corrects it. 

In addition, I found this doc was very similar to the one published [here](https://docs.expo.dev/versions/latest/sdk/notifications/#usage). So, this matches the guide version of it, to the reference version. 

# How
Not applicable.

# Test Plan
Not applicable. This change establishes parity with the reference guide for the same notification capability. 

# Checklist
Not applicable.
