### PR TITLE
feat: enable React Compiler by default in template

### DIFF
--- a/templates/expo-template-default/app.json
+++ b/templates/expo-template-default/app.json
@@ -36,7 +36,8 @@
       ]
     ],
     "experiments": {
-      "typedRoutes": true
+      "typedRoutes": true,
+      "reactCompiler": true
     }
   }
 }


### PR DESCRIPTION
# Why

- React Compiler is a fantastic new feature in React that automatically improves performance for all React components in the user's project. It has had a few blockers that prevented us from enabling it sooner but those should all be resolved in SDK 54. CC @poteto
- In SDK 54 we use React 19.1 with the release candidate build of React Compiler. https://github.com/expo/expo/pull/38309
- We also pulled in `experimentalImportSupport` and fixed the numerous quirks with it to allow for require cycles. https://github.com/expo/expo/pull/38051

# How

We'll toggle on the flag and install the babel plugin so all new projects from `npx create-expo` (with the default template) will have react compiler enabled. Users can disable it by changing or deleting the `experiments.reactCompiler` flag in the `app.json`.
