### PR TITLE
[templates][iOS] Remove explicit setting deterministic uuids to false

### DIFF
--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -8,8 +8,7 @@ ENV['RCT_NEW_ARCH_ENABLED'] = '0' if podfile_properties['newArchEnabled'] == 'fa
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
 
 platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
-install! 'cocoapods',
-  :deterministic_uuids => false
+
 source 'https://cdn.cocoapods.org/'
 if ENV['CI']
   inhibit_all_warnings!

--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -8,8 +8,7 @@ install! 'cocoapods',
          :generate_multiple_pod_projects => true,
          :incremental_installation => true
 platform :ios, '15.1'
-install! 'cocoapods',
-  :deterministic_uuids => false
+
 inhibit_all_warnings!
 
 # Disable expo-updates auto create updates resources in podspec script_phase

--- a/apps/native-tests/ios/Podfile
+++ b/apps/native-tests/ios/Podfile
@@ -7,8 +7,6 @@ podfile_properties = JSON.parse(File.read('./Podfile.properties.json')) rescue {
 prepare_react_native_project!
 
 platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
-install! 'cocoapods',
-  :deterministic_uuids => false
 
 target 'NativeTests' do
   pod 'expo-dev-menu-interface', path: '../../../packages/expo-dev-menu-interface/ios'

--- a/apps/paper-tester/ios/Podfile
+++ b/apps/paper-tester/ios/Podfile
@@ -8,8 +8,6 @@ ENV['RCT_NEW_ARCH_ENABLED'] = '0' if podfile_properties['newArchEnabled'] == 'fa
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
 
 platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
-install! 'cocoapods',
-  :deterministic_uuids => false
 
 prepare_react_native_project!
 

--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -9,8 +9,6 @@ ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWO
 ENV['RCT_USE_RN_DEP'] = '1' if podfile_properties['ios.buildFromSource'] == 'false'
 
 platform :ios, podfile_properties['ios.deploymentTarget'] || '15.1'
-install! 'cocoapods',
-  :deterministic_uuids => false
 
 prepare_react_native_project!
 


### PR DESCRIPTION
# Why

`:deterministic_uuids => false` was first introduced to our templates when we upgraded react-native to 0.68, but since then react native has incorporated this into their `prepare_react_native_project` function, and we no longer need to set this explicitly anymore (https://github.com/facebook/react-native/commit/34fafb2b881751cdd998d7d5ef486d536607c9ce)

# How

Remove `:deterministic_uuids => false` from templates and apps

# Test Plan

Run `pod install` and build apps locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
