### PR TITLE
[docs] Add sidebar main, section, group data attributes

### DIFF
--- a/docs/ui/components/Sidebar/SidebarCollapsible.tsx
+++ b/docs/ui/components/Sidebar/SidebarCollapsible.tsx
@@ -66,8 +66,9 @@ export function SidebarCollapsible({ info, children }: Props) {
     window.sidebarState[info.name] = !isOpen;
   };
 
-  const customDataAttributes = containsActiveChild && {
-    'data-collapsible-active': true,
+  const customDataAttributes = {
+    ...(containsActiveChild && { 'data-collapsible-active': true }),
+    ...(info.type === 'group' && { 'data-group-name': info.name }),
   };
 
   return (

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -65,7 +65,9 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
       <div className="mb-5">
         {!shouldSkipTitle(route, parentRoute) && title && (
           <div className="flex flex-row items-center justify-between py-0">
-            <SidebarTitle Icon={Icon}>{title}</SidebarTitle>
+            <SidebarTitle Icon={Icon} sectionName={title}>
+              {title}
+            </SidebarTitle>
             <div className="flex flex-row items-center pb-1">
               <CircularProgressBar progress={progressPercentage} />{' '}
               <p className="ml-2 text-xs text-tertiary">{`${completedChaptersCount} of ${totalChapters}`}</p>
@@ -135,7 +137,9 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
       <div className="mb-5">
         {!shouldSkipTitle(route, parentRoute) && title && (
           <div className="flex flex-row items-center justify-between py-0">
-            <SidebarTitle Icon={Icon}>{title}</SidebarTitle>
+            <SidebarTitle Icon={Icon} sectionName={title}>
+              {title}
+            </SidebarTitle>
             <div className="flex flex-row items-center pb-1">
               <CircularProgressBar progress={progressPercentageForGetStarted} />{' '}
               <p className="ml-2 text-xs text-tertiary">{`${completedGetStartedChaptersCount} of ${totalGetStartedChapters}`}</p>
@@ -181,7 +185,9 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
   return (
     <div className="mb-5">
       {!shouldSkipTitle(route, parentRoute) && title && (
-        <SidebarTitle Icon={Icon}>{title}</SidebarTitle>
+        <SidebarTitle Icon={Icon} sectionName={title}>
+          {title}
+        </SidebarTitle>
       )}
       {(route.children ?? []).map(child =>
         child.type === 'page' ? (

--- a/docs/ui/components/Sidebar/SidebarHead.tsx
+++ b/docs/ui/components/Sidebar/SidebarHead.tsx
@@ -52,6 +52,7 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
             Icon={Home02DuotoneIcon}
             isActive={sidebarActiveGroup === 'home'}
             allowCompactDisplay
+            mainSection="Home"
           />
           <SidebarSingleEntry
             href="/guides/overview/"
@@ -59,6 +60,7 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
             Icon={BookOpen02DuotoneIcon}
             isActive={sidebarActiveGroup === 'general'}
             allowCompactDisplay
+            mainSection="Guides"
           />
           <SidebarSingleEntry
             href="/eas/"
@@ -66,6 +68,7 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
             Icon={PlanEnterpriseIcon}
             isActive={sidebarActiveGroup === 'eas'}
             allowCompactDisplay
+            mainSection="EAS"
           />
           <SidebarSingleEntry
             href="/versions/latest/"
@@ -73,6 +76,7 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
             Icon={DocsLogo}
             isActive={sidebarActiveGroup === 'reference'}
             allowCompactDisplay
+            mainSection="Reference"
           />
           <SidebarSingleEntry
             href="/tutorial/overview/"
@@ -80,6 +84,7 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
             Icon={GraduationHat02DuotoneIcon}
             isActive={sidebarActiveGroup === 'learn'}
             allowCompactDisplay
+            mainSection="Learn"
           />
           {isPreviewVisible && (
             <SidebarSingleEntry

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -13,6 +13,7 @@ type SidebarSingleEntryProps = {
   secondary?: boolean;
   shouldLeakReferrer?: boolean;
   allowCompactDisplay?: boolean;
+  mainSection?: string;
 };
 
 export const SidebarSingleEntry = ({
@@ -24,6 +25,7 @@ export const SidebarSingleEntry = ({
   secondary = false,
   shouldLeakReferrer = false,
   allowCompactDisplay = false,
+  mainSection,
 }: SidebarSingleEntryProps) => {
   return (
     <Tooltip.Root delayDuration={500} disableHoverableContent>
@@ -39,7 +41,8 @@ export const SidebarSingleEntry = ({
             isActive &&
               '!bg-palette-blue3 font-medium text-link hocus:!bg-palette-blue4 hocus:text-link'
           )}
-          {...(shouldLeakReferrer && { target: '_blank', referrerPolicy: 'origin' })}>
+          {...(shouldLeakReferrer && { target: '_blank', referrerPolicy: 'origin' })}
+          {...(isActive && mainSection && { 'data-main-section': mainSection })}>
           <Icon
             className={mergeClasses(
               'shrink-0',

--- a/docs/ui/components/Sidebar/SidebarTitle.tsx
+++ b/docs/ui/components/Sidebar/SidebarTitle.tsx
@@ -4,10 +4,13 @@ import { LABEL } from '../Text';
 
 type SidebarTitleProps = {
   Icon?: ComponentType<HTMLAttributes<SVGSVGElement>>;
+  sectionName?: string;
 } & PropsWithChildren;
 
-export const SidebarTitle = ({ children, Icon }: SidebarTitleProps) => (
-  <div className="relative -mr-4 ml-3 flex items-center gap-2 pb-1">
+export const SidebarTitle = ({ children, Icon, sectionName }: SidebarTitleProps) => (
+  <div
+    className="relative -mr-4 ml-3 flex items-center gap-2 pb-1"
+    {...(sectionName && { 'data-section-name': sectionName })}>
     {Icon && <Icon className="icon-sm" />}
     <LABEL weight="medium" crawlable={false}>
       {children}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We need to pass sidebar main section, sub-section, and collapsible group values to Alogila crawler. This will help us retrieve these data attributes values easily in the crawler.

- The `data-main-section` identifies which major section of docs is currently active. For example, Home, Guides, EAS, Reference, or Learn.
- The `data-section-name` identifies which sidebar section is active when viewing a page. For example, Development process, EAS Build, Expo SDK, etc.
- The `data-group-name` identifies which sidebar collapsible section is active when a page is being viewed under a sub-section to the sidebar section. For example, Linking, Write native code, Compile locally, etc.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Key changes include adding new data attributes for better tracking, updating component props to support these attributes, and ensuring consistent usage across related components.
- `SidebarSingleEntry` components include the `mainSection` prop for each entry (e.g., "Home," "Guides," "EAS"), ensuring consistent tracking across the sidebar.
- Updated all instances of `SidebarTitle` to pass the `title` as the `sectionName` prop for consistency and to utilize the new data attribute
- Added a new `sectionName` prop and applied a `data-section-name` attribute when provided, enabling section-specific identification for collapsible groups.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Visit preview and then visit a page.
- Open developer console in browser and ensure `data-main-section`, `data-section-name`, and `data-group-name` attributes are applied.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
