### PR TITLE
[docs] Clarify "Workflows" under the Hosting section, note that GitHub integration is optional, general capitalization and grammar

### DIFF
--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trigger builds from CI
-description: Learn how to trigger builds on EAS for your app from a CI environment such as GitHub Action and more.
+description: Learn how to trigger builds on EAS for your app from a CI environment such as GitHub Actions and more.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -27,7 +27,7 @@ If you haven't done this yet, see the [Create your first build](/build/setup/) g
 
 ## Using EAS Workflows
 
-[EAS Workflows](/eas/workflows/get-started) is a service from Expo that allows you to run builds, and many other types of jobs, on EAS. You can use EAS Workflows to automate your development and release processes, like creating development builds or automatically building and submitting to the app stores.
+[EAS Workflows](/eas/workflows/get-started) is a CI/CD service from Expo that allows you to run builds, and many other types of jobs, on EAS. You can use EAS Workflows to automate your development and release processes, like creating development builds or automatically building and submitting to the app stores.
 
 To create a build with EAS Workflows, start by adding the following code in **.eas/workflows/build.yml**:
 

--- a/docs/pages/eas/hosting/api-routes.mdx
+++ b/docs/pages/eas/hosting/api-routes.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_title: Monitoring API routes
+sidebar_title: Monitor API routes
 title: API Routes
 description: Learn how to inspect requests from API routes on the EAS Hosting dashboard.
 ---

--- a/docs/pages/eas/hosting/introduction.mdx
+++ b/docs/pages/eas/hosting/introduction.mdx
@@ -55,7 +55,7 @@ Hosting offers the fastest path from `npx create-expo-app` to a fully deployed w
 
 <BoxLink
   title="Deploy with EAS Workflows"
-  description="Automate deployments with EAS workflows."
+  description="Automate deployments with EAS Workflows."
   href="/eas/hosting/workflows"
   Icon={Cloud01Icon}
 />

--- a/docs/pages/eas/hosting/workflows.mdx
+++ b/docs/pages/eas/hosting/workflows.mdx
@@ -1,16 +1,15 @@
 ---
-sidebar_title: Workflows
-title: Deploy with Workflows
-description: Learn how to automate React Native CI/CD for web deployments with EAS Hosting and Workflows.
+title: Web deployments with EAS Workflows
+description: Learn how to automate website and server deployments with EAS Hosting and Workflows.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
 
-EAS Workflows is a great way to automate the React Native CI/CD pipeline for web deployment of your project to EAS Hosting with pull request (PR) previews and production deployments.
+EAS Workflows is a great way to automate the React Native CI/CD pipeline for deploying your project's website and API routes to EAS Hosting with pull request (PR) previews and production deployments.
 
-## Setup workflows
+## Set up workflows
 
-To use [EAS workflows](/eas/workflows/get-started/) to automatically deploy your project, follow the instructions in [Get started with EAS workflows](/eas/workflows/get-started/) and add the [GitHub integration](/eas/workflows/get-started/#configure-your-project) for your project.
+To use [EAS Workflows](/eas/workflows/get-started/) to automatically deploy your project, follow the instructions in [Get started with EAS Workflows](/eas/workflows/get-started/). You can also add the [GitHub integration](/eas/workflows/get-started/#configure-your-project) to connect a GitHub repository to your workflows.
 
 ## Create a deployment workflow
 

--- a/docs/pages/eas/index.mdx
+++ b/docs/pages/eas/index.mdx
@@ -21,7 +21,7 @@ Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links
 
 <BoxLink
   title="EAS Workflows"
-  description="Automate your development release workflows."
+  description="Automate your development and release workflows with CI/CD jobs."
   href="/eas/workflows/get-started/"
   Icon={Dataflow03Icon}
 />
@@ -49,7 +49,7 @@ Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links
 
 <BoxLink
   title="EAS Update"
-  description="Address small bugs and push quick fixes directly to end-users."
+  description="Address small bugs and push quick fixes directly to end users."
   href="/eas-update/introduction"
   Icon={LayersTwo02Icon}
 />

--- a/docs/pages/eas/workflows/automating-eas-cli.mdx
+++ b/docs/pages/eas/workflows/automating-eas-cli.mdx
@@ -14,7 +14,7 @@ Below you'll find how to set up your project to use EAS Workflows, followed by c
 
 ## Configure your project
 
-EAS Workflows require a GitHub repository that's linked to your EAS project to run. You can link a GitHub repo to your EAS project with the following steps:
+EAS Workflows optionally supports a GitHub repository that's linked to your EAS project to run. This guide assumes a GitHub repository is linked, and shows how to trigger workflows when pushing to specific branches on GitHub. You can link a GitHub repo to your EAS project with the following steps:
 
 - Navigate to your project's [GitHub settings](https://expo.dev/accounts/%5Baccount%5D/projects/%5BprojectName%5D/github).
 - Follow the UI to install the GitHub app.

--- a/docs/pages/guides/publishing-websites.mdx
+++ b/docs/pages/guides/publishing-websites.mdx
@@ -419,8 +419,8 @@ Now that the web app is published to the `gh-pages` branch, configure GitHub Pag
 
 <Step label="7">
 
-Once the web app is published and the GitHub Pages configuration is set, a GitHub action will deploy your website. You can monitor its progress by navigating to your repository's **Actions** tab. Upon completion, your web app will be available at the URL `http://username-on-github.github.io/repo-name`.
+Once the web app is published and the GitHub Pages configuration is set, a GitHub Action will deploy your website. You can monitor its progress by navigating to your repository's **Actions** tab. Upon completion, your web app will be available at the URL `http://username-on-github.github.io/repo-name`.
 
-For subsequent deployments and updates, run the `deploy` command and the GitHub action will start automatically to update your web app.
+For subsequent deployments and updates, run the `deploy` command and the GitHub Action will start automatically to update your web app.
 
 </Step>

--- a/docs/pages/review/overview.mdx
+++ b/docs/pages/review/overview.mdx
@@ -82,7 +82,7 @@ You can use [development builds](/develop/development-builds/introduction/) to l
 
 </Collapsible>
 
-<Collapsible summary="You can configure GitHub actions to automatically publish updates on PRs and commits.">
+<Collapsible summary="You can configure GitHub Actions to automatically publish updates on PRs and commits.">
 
 <ContentSpotlight controls file="review/eas-update-03.mp4" />
 

--- a/docs/pages/tutorial/eas/next-steps.mdx
+++ b/docs/pages/tutorial/eas/next-steps.mdx
@@ -23,7 +23,7 @@ But this is just the beginning. Here are some next steps to continue your journe
 
 <BoxLink
   title="EAS Workflows"
-  description="See EAS Workflows documentation to learn more about automating your development release workflows."
+  description="See EAS Workflows documentation to learn more about automating your development and release workflows."
   href="/eas/workflows/get-started/"
   Icon={Dataflow03Icon}
 />


### PR DESCRIPTION
Why/How
===
I found "Workflows" in the Hosting section to be ambiguous. This PR changes it to "Deploy with EAS Workflows" and clarifies in the page title that it's about web deployments. For grammatical consistency I changed "Monitoring API routes" to "Monitor API routes" which matches the tense we use in other sections.

Also, GitHub integration is now optional for Workflows. I changed the wording of that requirement in automating-eas-cli.mdx.

Also fixed up various errors throughout the docs.
