### PR TITLE
[ios][expo-image] Remove trailing comma that was causing build errors

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Android] Fix animation resuming by casting image to GifDrawable. ([#37363](https://github.com/expo/expo/pull/37363) by [@Wenszel](https://github.com/Wenszel))
 - [Web] Fix `alt` as an alias for `accessibilityLabel` ([#37682](https://github.com/expo/expo/pull/37682) by [@huextrat](https://github.com/huextrat))
 - [iOS] Fix caching resized images from Photo Library. ([#38105](https://github.com/expo/expo/pull/38105) by [@jakex7](https://github.com/jakex7))
+- [iOS] Fix `generatePlaceholder` method syntax error by removing unwanted trailing comma. ([#38318](https://github.com/expo/expo/pull/38318) by [@bortolilucas](https://github.com/bortolilucas))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -233,7 +233,7 @@ public final class ImageModule: Module {
 
   func generatePlaceholder(
     source: Either<Image, URL>,
-    generator: @escaping (UIImage) -> Void,
+    generator: @escaping (UIImage) -> Void
   ) {
     if let image: Image = source.get() {
       generator(image.ref)


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While using the version canary `2.5.0-canary-20250722-599a28f`, I was having build errors. I noticed there's an unwanted trailing comma causing syntax errors. This PR aims to fix the error.

<img width="1203" height="356" alt="Screenshot 2025-07-24 at 22 46 08" src="https://github.com/user-attachments/assets/078be141-38b2-43cb-abfb-b09fce36f065" />

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove the trailing comma from the method `generatePlaceholder` in `ImageModule.swift`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Open the project in Xcode and fix the syntax
<img width="925" height="328" alt="Screenshot 2025-07-24 at 23 03 58" src="https://github.com/user-attachments/assets/c1f94d01-49c6-4736-908f-75c208f64b61" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
