### PR TITLE
pin node 22.14 in tv compile workflow

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install applesimutils
         id: ios_simulator
         env:
-          HOMEBREW_NO_AUTO_UPDATE: '1'
+          HOMEBREW_NO_AUTO_UPDATE: "1"
         run: |
           /opt/homebrew/bin/brew tap wix/brew
           /opt/homebrew/bin/brew install applesimutils
@@ -95,7 +95,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: '4747'
+          UPDATES_PORT: "4747"
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project-tv.ts
           ls -la ../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
@@ -69,6 +69,11 @@ on:
   schedule:
     - cron: '0 17 * * SUN' # 22:00 UTC every Sunday
 
+defaults:
+  tools:
+    node: 22.14.0
+    yarn: 1.22.22
+
 jobs:
   ios:
     runs_on: macos-large
@@ -77,7 +82,7 @@ jobs:
       - name: Install applesimutils
         id: ios_simulator
         env:
-          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_AUTO_UPDATE: '1'
         run: |
           /opt/homebrew/bin/brew tap wix/brew
           /opt/homebrew/bin/brew install applesimutils
@@ -90,7 +95,7 @@ jobs:
         working_directory: ../..
         env:
           UPDATES_HOST: localhost
-          UPDATES_PORT: "4747"
+          UPDATES_PORT: '4747'
         run: |
           yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project-tv.ts
           ls -la ../updates-e2e


### PR DESCRIPTION
TV-Compile step is failing in a few PRs.

https://expo.dev/accounts/expo-ci/projects/expo-workflow-testing/workflows/01983fce-0c67-7e14-af60-3d516adba984#job-01983fce-13eb-7054-8c16-ec38872237c1

metro 0.83 requires node 22+. ~~[PR](https://github.com/expo/expo/pull/38166) by @kitten~~. [PR](https://github.com/expo/expo/pull/37600) by @douglowder  added it to other workflow files.

