### PR TITLE
[expo-router] Extract screen search logic to swift

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 - Create href preview component ([#37335](https://github.com/expo/expo/pull/37335) by [@Ubax](https://github.com/Ubax))
 - Add formsheet warning ([#37982](https://github.com/expo/expo/pull/37982) by [@Ubax](https://github.com/Ubax))
+- Extract screen search logic to swift ([#38320](https://github.com/expo/expo/pull/38320) by [@Ubax](https://github.com/Ubax))
 
 
 ## 5.1.4 - 2025-07-18

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeNavigation.h
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeNavigation.h
@@ -2,23 +2,34 @@
 
 #import <RNScreens/RNSScreenStack.h>
 
-@interface LinkPreviewNativeNavigation: NSObject
+@interface LinkPreviewNativeNavigationObjC : NSObject
 
 /*
-* Updates the preloaded view with the given screenId and UIResponder.
-* This function will go through the responder's view hierarchy to find the screen view with the given screenId and activity state 0.
-*/
-- (void)updatePreloadedView:(NSString *)screenId withUiResponder:(UIResponder *)responder;
+ * Pushes the previously preloaded view.
+ * This function will set the activity state of the preloaded screen view to 2
+ */
++ (void)pushPreloadedView:(UIView *)view ontoStackView:(UIView *)rawStackView;
 
 /*
-* Pushes the previously preloaded view.
-* This function will set the activity state of the preloaded screen view to 2
-*/
-- (void)pushPreloadedView;
+ * Helper function to check if the view is a RNSScreenStackView. Can be used in
+ * Swift
+ */
++ (BOOL)isRNSScreenStackView:(UIView *)view;
+/*
+ * Helper function to get all screen IDs from a RNSScreenStackView.
+ */
++ (nonnull NSArray<NSString *> *)getStackViewScreenIds:(UIView *)view;
+/*
+ * Helper function to get all screen views from a RNSScreenStackView.
+ */
++ (nonnull NSArray<UIView *> *)getScreenViews:(UIView *)view;
+/*
+ * Helper function to get the screen ID of a RNSScreenView.
+ */
++ (nonnull NSString *)getScreenId:(UIView *)view;
 
 @end
 
 @protocol LinkPreviewModalDismissible <RNSDismissibleModalProtocol>
 @required
 @end
-

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeNavigation.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeNavigation.swift
@@ -1,0 +1,55 @@
+import UIKit
+
+internal class LinkPreviewNativeNavigation {
+  private var preloadedView: UIView?
+  private var preloadedStackView: UIView?
+
+  init() {}
+
+  func pushPreloadedView() {
+    guard let preloadedView,
+      let preloadedStackView
+    else {
+      return
+    }
+    LinkPreviewNativeNavigationObjC.pushPreloadedView(
+      preloadedView, ontoStackView: preloadedStackView)
+  }
+
+  func updatePreloadedView(screenId: String, responder: UIView) {
+    if screenId.isEmpty {
+      print("LinkPreviewNativeNavigation: No screenId provided, skipping preloading.")
+      return
+    }
+
+    let stackView = findStackViewWithScreenId(screenId: screenId, responder: responder)
+    if let stackView = stackView {
+      let screenViews = LinkPreviewNativeNavigationObjC.getScreenViews(stackView)
+      if let screenView = screenViews.first(where: {
+        LinkPreviewNativeNavigationObjC.getScreenId($0) == screenId
+      }) {
+        preloadedView = screenView
+        preloadedStackView = stackView
+        print("LinkPreviewNativeNavigation: Preloaded view for screenId \(screenId).")
+      }
+    } else {
+      print("LinkPreviewNativeNavigation: No stack view found for screenId \(screenId).")
+    }
+  }
+
+  private func findStackViewWithScreenId(screenId: String, responder: UIView) -> UIView? {
+    var currentResponder: UIResponder? = responder
+
+    while let nextResponder = currentResponder?.next {
+      if let view = nextResponder as? UIView,
+        LinkPreviewNativeNavigationObjC.isRNSScreenStackView(view) {
+        let screenIds = LinkPreviewNativeNavigationObjC.getStackViewScreenIds(view)
+        if screenIds.contains(screenId) {
+          return view
+        }
+      }
+      currentResponder = nextResponder
+    }
+    return nil
+  }
+}

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
@@ -32,7 +32,7 @@ class NativeLinkPreviewView: ExpoView, UIContextMenuInteractionDelegate, LinkPre
 
   func setNextScreenId(_ screenId: String) {
     self.nextScreenId = screenId
-    linkPreviewNativeNavigation.updatePreloadedView(screenId, with: self)
+    linkPreviewNativeNavigation.updatePreloadedView(screenId: screenId, responder: self)
   }
 
   // MARK: - Children


### PR DESCRIPTION
# Why

Objective-C lacks a lot of modern language syntax. The integration of link preview with native tabs will be much easier while most of the logic is written in swift rather then objective C. This is the base PR, then extended in the native tabs integration.

# How

Keep only thin integration layer in objective-c and move all the logic to Swift

# Test Plan

Manual testing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
