### PR TITLE
[android][camera] Correctly handle errors with new barcode scanner

### DIFF
--- a/apps/native-component-list/src/screens/Camera/CameraScreenBarcode.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreenBarcode.tsx
@@ -25,7 +25,11 @@ export default function CameraScreenNextBarcode() {
 
   async function launchScanner() {
     if (CameraView.isModernBarcodeScannerAvailable) {
-      await CameraView.launchScanner(options);
+      try {
+        await CameraView.launchScanner(options);
+      } catch (error) {
+        console.error('Error launching scanner:', error);
+      }
     }
   }
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [iOS] Fixes returning `PictureRef` objects.([#37393](https://github.com/expo/expo/pull/37393) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix barcode options to correctly handle empty barcodeTypes ([#38100](https://github.com/expo/expo/pull/38100) by [@LeonDvlpmnt](https://github.com/LeonDvlpmnt))
 - [Android] Add dismissScanner to module to prevent undefined error. ([#38129](https://github.com/expo/expo/pull/38129) by [@LeonDvlpmnt](https://github.com/LeonDvlpmnt))
-- [Android] Correctly handle errors when using `launchScanner`.
+- [Android] Correctly handle errors when using `launchScanner`. ([#38322](https://github.com/expo/expo/pull/38322) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [iOS] Fixes returning `PictureRef` objects.([#37393](https://github.com/expo/expo/pull/37393) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix barcode options to correctly handle empty barcodeTypes ([#38100](https://github.com/expo/expo/pull/38100) by [@LeonDvlpmnt](https://github.com/LeonDvlpmnt))
 - [Android] Add dismissScanner to module to prevent undefined error. ([#38129](https://github.com/expo/expo/pull/38129) by [@LeonDvlpmnt](https://github.com/LeonDvlpmnt))
+- [Android] Correctly handle errors when using `launchScanner`.
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraExceptions.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraExceptions.kt
@@ -10,8 +10,8 @@ class CameraExceptions {
   class ImageRetrievalException(url: String) :
     CodedException("Could not get the image from given url: '$url'")
 
-  class UnsupportedAspectRatioException(aspectRatio: String) :
-    CodedException("Unsupported aspect ratio: '$aspectRatio'")
+  class BarcodeScanningCancelledException() :
+    CodedException("Barcode scanning was cancelled")
 
   class BarcodeScanningFailedException :
     CodedException("Barcode scanning failed")


### PR DESCRIPTION
# Why
Closes #38306

# How
We should be using a promise to handle errors in the `startScan` callbacks otherwise they will be unhandled.

# Test Plan
Bare-expo. Errors are handled correctly

