### PR TITLE
[media-library][android] Refactor `MediaLibraryModule`

### DIFF
--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -28,20 +28,20 @@ import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
-import expo.modules.medialibrary.albums.AddAssetsToAlbum
-import expo.modules.medialibrary.albums.CreateAlbum
-import expo.modules.medialibrary.albums.CreateAlbumWithInitialFileUri
-import expo.modules.medialibrary.albums.DeleteAlbums
-import expo.modules.medialibrary.albums.GetAlbum
-import expo.modules.medialibrary.albums.GetAlbums
-import expo.modules.medialibrary.albums.RemoveAssetsFromAlbum
+import expo.modules.medialibrary.albums.addAssetsToAlbum
+import expo.modules.medialibrary.albums.createAlbum
+import expo.modules.medialibrary.albums.createAlbumWithInitialFileUri
+import expo.modules.medialibrary.albums.deleteAlbums
+import expo.modules.medialibrary.albums.getAlbum
+import expo.modules.medialibrary.albums.getAlbums
 import expo.modules.medialibrary.albums.getAssetsInAlbums
-import expo.modules.medialibrary.albums.migration.CheckIfAlbumShouldBeMigrated
-import expo.modules.medialibrary.albums.migration.MigrateAlbum
-import expo.modules.medialibrary.assets.CreateAssetWithAlbumId
-import expo.modules.medialibrary.assets.DeleteAssets
-import expo.modules.medialibrary.assets.GetAssetInfo
-import expo.modules.medialibrary.assets.GetAssets
+import expo.modules.medialibrary.albums.migration.checkIfAlbumShouldBeMigrated
+import expo.modules.medialibrary.albums.migration.migrateAlbum
+import expo.modules.medialibrary.albums.removeAssetsFromAlbum
+import expo.modules.medialibrary.assets.createAssetWithAlbumId
+import expo.modules.medialibrary.assets.deleteAssets
+import expo.modules.medialibrary.assets.getAssetInfo
+import expo.modules.medialibrary.assets.getAssets
 import expo.modules.medialibrary.contracts.DeleteContract
 import expo.modules.medialibrary.contracts.DeleteContractInput
 import expo.modules.medialibrary.contracts.WriteContract
@@ -101,45 +101,45 @@ class MediaLibraryModule : Module() {
 
     AsyncFunction("saveToLibraryAsync") Coroutine { localUri: String ->
       requireSystemPermissions()
-      CreateAssetWithAlbumId(context, localUri, false).execute()
+      createAssetWithAlbumId(context, localUri, false)
     }
 
     AsyncFunction("createAssetAsync") Coroutine { localUri: String, albumId: String? ->
       requireSystemPermissions()
-      CreateAssetWithAlbumId(context, localUri, true, albumId).execute()
+      createAssetWithAlbumId(context, localUri, true, albumId)
     }
 
     AsyncFunction("addAssetsToAlbumAsync") Coroutine { assetsId: List<String>, albumId: String, copyToAlbum: Boolean ->
       requireSystemPermissions()
       requestMediaLibraryActionPermission(if (copyToAlbum) emptyList() else assetsId)
-      AddAssetsToAlbum(context, assetsId.toTypedArray(), albumId, copyToAlbum).execute()
+      addAssetsToAlbum(context, assetsId.toTypedArray(), albumId, copyToAlbum)
     }
 
     AsyncFunction("removeAssetsFromAlbumAsync") Coroutine { assetsId: List<String>, albumId: String ->
       requireSystemPermissions()
       requestMediaLibraryActionPermission(assetsId)
-      RemoveAssetsFromAlbum(context, assetsId.toTypedArray(), albumId).execute()
+      removeAssetsFromAlbum(context, assetsId.toTypedArray(), albumId)
     }
 
     AsyncFunction("deleteAssetsAsync") Coroutine { assetsId: List<String> ->
       requireSystemPermissions()
       requestMediaLibraryActionPermission(assetsId, needsDeletePermission = true)
-      DeleteAssets(context, assetsId.toTypedArray()).execute()
+      deleteAssets(context, assetsId.toTypedArray())
     }
 
     AsyncFunction("getAssetInfoAsync") Coroutine { assetId: String, _: Map<String, Any?>?/* unused on android atm */ ->
       requireSystemPermissions(false)
-      GetAssetInfo(context, assetId).execute()
+      getAssetInfo(context, assetId)
     }
 
     AsyncFunction("getAlbumsAsync") Coroutine { _: Map<String, Any?>?/* unused on android atm */ ->
       requireSystemPermissions(false)
-      GetAlbums(context).execute()
+      getAlbums(context)
     }
 
     AsyncFunction("getAlbumAsync") Coroutine { albumName: String ->
       requireSystemPermissions(false)
-      GetAlbum(context, albumName).execute()
+      getAlbum(context, albumName)
     }
 
     AsyncFunction("createAlbumAsync") Coroutine { albumName: String, assetId: String?, copyAsset: Boolean, initialAssetUri: Uri? ->
@@ -154,9 +154,9 @@ class MediaLibraryModule : Module() {
       requestMediaLibraryActionPermission(assetIdList)
 
       if (assetId != null) {
-        CreateAlbum(context, albumName, assetId, copyAsset).execute()
+        createAlbum(context, albumName, assetId, copyAsset)
       } else if (initialAssetUri != null) {
-        CreateAlbumWithInitialFileUri(context, albumName, initialAssetUri).execute()
+        createAlbumWithInitialFileUri(context, albumName, initialAssetUri)
       } else {
         null
       }
@@ -166,12 +166,12 @@ class MediaLibraryModule : Module() {
       requireSystemPermissions()
       val assetIds = getAssetsInAlbums(context, *albumIds.toTypedArray())
       requestMediaLibraryActionPermission(assetIds)
-      DeleteAlbums(context, albumIds).execute()
+      deleteAlbums(context, albumIds)
     }
 
     AsyncFunction("getAssetsAsync") Coroutine { assetOptions: AssetsOptions ->
       requireSystemPermissions(false)
-      GetAssets(context, assetOptions).execute()
+      getAssets(context, assetOptions)
     }
 
     AsyncFunction("migrateAlbumIfNeededAsync") Coroutine { albumId: String ->
@@ -210,13 +210,13 @@ class MediaLibraryModule : Module() {
 
       val needsToCheckPermissions = assets.map { it.assetId }
       requestMediaLibraryActionPermission(needsToCheckPermissions)
-      MigrateAlbum(context, assets, albumDir.name).execute()
+      migrateAlbum(context, assets, albumDir.name)
     }
 
     AsyncFunction("albumNeedsMigrationAsync") Coroutine { albumId: String ->
       requireSystemPermissions(false)
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        CheckIfAlbumShouldBeMigrated(context, albumId).execute()
+        checkIfAlbumShouldBeMigrated(context, albumId)
       }
       false
     }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -109,22 +109,22 @@ class MediaLibraryModule : Module() {
       return@Coroutine createAssetWithAlbumId(context, localUri, true, albumId)
     }
 
-    AsyncFunction("addAssetsToAlbumAsync") Coroutine { assetsId: List<String>, albumId: String, copyToAlbum: Boolean ->
+    AsyncFunction("addAssetsToAlbumAsync") Coroutine { assetsId: Array<String>, albumId: String, copyToAlbum: Boolean ->
       requireSystemPermissions()
-      requestMediaLibraryActionPermission(if (copyToAlbum) emptyList() else assetsId)
-      return@Coroutine addAssetsToAlbum(context, assetsId.toTypedArray(), albumId, copyToAlbum)
+      requestMediaLibraryActionPermission(if (copyToAlbum) emptyArray() else assetsId)
+      return@Coroutine addAssetsToAlbum(context, assetsId, albumId, copyToAlbum)
     }
 
-    AsyncFunction("removeAssetsFromAlbumAsync") Coroutine { assetsId: List<String>, albumId: String ->
+    AsyncFunction("removeAssetsFromAlbumAsync") Coroutine { assetsId: Array<String>, albumId: String ->
       requireSystemPermissions()
       requestMediaLibraryActionPermission(assetsId)
-      return@Coroutine removeAssetsFromAlbum(context, assetsId.toTypedArray(), albumId)
+      return@Coroutine removeAssetsFromAlbum(context, assetsId, albumId)
     }
 
-    AsyncFunction("deleteAssetsAsync") Coroutine { assetsId: List<String> ->
+    AsyncFunction("deleteAssetsAsync") Coroutine { assetsId: Array<String> ->
       requireSystemPermissions()
       requestMediaLibraryActionPermission(assetsId, needsDeletePermission = true)
-      return@Coroutine deleteAssets(context, assetsId.toTypedArray())
+      return@Coroutine deleteAssets(context, assetsId)
     }
 
     AsyncFunction("getAssetInfoAsync") Coroutine { assetId: String, _: Map<String, Any?>?/* unused on android atm */ ->
@@ -145,13 +145,13 @@ class MediaLibraryModule : Module() {
     AsyncFunction("createAlbumAsync") Coroutine { albumName: String, assetId: String?, copyAsset: Boolean, initialAssetUri: Uri? ->
       requireSystemPermissions()
 
-      val assetIdList = if (!copyAsset && assetId != null) {
-        listOf(assetId)
+      val assetIdArray = if (!copyAsset && assetId != null) {
+        arrayOf(assetId)
       } else {
-        emptyList()
+        emptyArray()
       }
 
-      requestMediaLibraryActionPermission(assetIdList)
+      requestMediaLibraryActionPermission(assetIdArray)
 
       return@Coroutine if (assetId != null) {
         createAlbum(context, albumName, assetId, copyAsset)
@@ -162,9 +162,9 @@ class MediaLibraryModule : Module() {
       }
     }
 
-    AsyncFunction("deleteAlbumsAsync") Coroutine { albumIds: List<String> ->
+    AsyncFunction("deleteAlbumsAsync") Coroutine { albumIds: Array<String> ->
       requireSystemPermissions()
-      val assetIds = getAssetsInAlbums(context, *albumIds.toTypedArray())
+      val assetIds = getAssetsInAlbums(context, *albumIds).toTypedArray()
       requestMediaLibraryActionPermission(assetIds)
       return@Coroutine deleteAlbums(context, albumIds)
     }
@@ -208,8 +208,8 @@ class MediaLibraryModule : Module() {
         return@Coroutine
       }
 
-      val needsToCheckPermissions = assets.map { it.assetId }
-      requestMediaLibraryActionPermission(needsToCheckPermissions)
+      val idsOfAssets = assets.map { it.assetId }.toTypedArray()
+      requestMediaLibraryActionPermission(idsOfAssets)
       return@Coroutine migrateAlbum(context, assets, albumDir.name)
     }
 
@@ -391,7 +391,7 @@ class MediaLibraryModule : Module() {
   }
 
   private suspend fun requestMediaLibraryActionPermission(
-    assetIds: List<String>,
+    assetIds: Array<String>,
     needsDeletePermission: Boolean = false
   ) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -101,45 +101,45 @@ class MediaLibraryModule : Module() {
 
     AsyncFunction("saveToLibraryAsync") Coroutine { localUri: String ->
       requireSystemPermissions()
-      createAssetWithAlbumId(context, localUri, false)
+      return@Coroutine createAssetWithAlbumId(context, localUri, false)
     }
 
     AsyncFunction("createAssetAsync") Coroutine { localUri: String, albumId: String? ->
       requireSystemPermissions()
-      createAssetWithAlbumId(context, localUri, true, albumId)
+      return@Coroutine createAssetWithAlbumId(context, localUri, true, albumId)
     }
 
     AsyncFunction("addAssetsToAlbumAsync") Coroutine { assetsId: List<String>, albumId: String, copyToAlbum: Boolean ->
       requireSystemPermissions()
       requestMediaLibraryActionPermission(if (copyToAlbum) emptyList() else assetsId)
-      addAssetsToAlbum(context, assetsId.toTypedArray(), albumId, copyToAlbum)
+      return@Coroutine addAssetsToAlbum(context, assetsId.toTypedArray(), albumId, copyToAlbum)
     }
 
     AsyncFunction("removeAssetsFromAlbumAsync") Coroutine { assetsId: List<String>, albumId: String ->
       requireSystemPermissions()
       requestMediaLibraryActionPermission(assetsId)
-      removeAssetsFromAlbum(context, assetsId.toTypedArray(), albumId)
+      return@Coroutine removeAssetsFromAlbum(context, assetsId.toTypedArray(), albumId)
     }
 
     AsyncFunction("deleteAssetsAsync") Coroutine { assetsId: List<String> ->
       requireSystemPermissions()
       requestMediaLibraryActionPermission(assetsId, needsDeletePermission = true)
-      deleteAssets(context, assetsId.toTypedArray())
+      return@Coroutine deleteAssets(context, assetsId.toTypedArray())
     }
 
     AsyncFunction("getAssetInfoAsync") Coroutine { assetId: String, _: Map<String, Any?>?/* unused on android atm */ ->
       requireSystemPermissions(false)
-      getAssetInfo(context, assetId)
+      return@Coroutine getAssetInfo(context, assetId)
     }
 
     AsyncFunction("getAlbumsAsync") Coroutine { _: Map<String, Any?>?/* unused on android atm */ ->
       requireSystemPermissions(false)
-      getAlbums(context)
+      return@Coroutine getAlbums(context)
     }
 
     AsyncFunction("getAlbumAsync") Coroutine { albumName: String ->
       requireSystemPermissions(false)
-      getAlbum(context, albumName)
+      return@Coroutine getAlbum(context, albumName)
     }
 
     AsyncFunction("createAlbumAsync") Coroutine { albumName: String, assetId: String?, copyAsset: Boolean, initialAssetUri: Uri? ->
@@ -153,12 +153,12 @@ class MediaLibraryModule : Module() {
 
       requestMediaLibraryActionPermission(assetIdList)
 
-      if (assetId != null) {
+      return@Coroutine if (assetId != null) {
         createAlbum(context, albumName, assetId, copyAsset)
       } else if (initialAssetUri != null) {
         createAlbumWithInitialFileUri(context, albumName, initialAssetUri)
       } else {
-        null
+        throw AlbumException("Could not create the album")
       }
     }
 
@@ -166,12 +166,12 @@ class MediaLibraryModule : Module() {
       requireSystemPermissions()
       val assetIds = getAssetsInAlbums(context, *albumIds.toTypedArray())
       requestMediaLibraryActionPermission(assetIds)
-      deleteAlbums(context, albumIds)
+      return@Coroutine deleteAlbums(context, albumIds)
     }
 
     AsyncFunction("getAssetsAsync") Coroutine { assetOptions: AssetsOptions ->
       requireSystemPermissions(false)
-      getAssets(context, assetOptions)
+      return@Coroutine getAssets(context, assetOptions)
     }
 
     AsyncFunction("migrateAlbumIfNeededAsync") Coroutine { albumId: String ->
@@ -210,15 +210,16 @@ class MediaLibraryModule : Module() {
 
       val needsToCheckPermissions = assets.map { it.assetId }
       requestMediaLibraryActionPermission(needsToCheckPermissions)
-      migrateAlbum(context, assets, albumDir.name)
+      return@Coroutine migrateAlbum(context, assets, albumDir.name)
     }
 
     AsyncFunction("albumNeedsMigrationAsync") Coroutine { albumId: String ->
       requireSystemPermissions(false)
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      return@Coroutine if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         checkIfAlbumShouldBeMigrated(context, albumId)
+      } else {
+        false
       }
-      false
     }
 
     OnStartObserving {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -181,9 +181,9 @@ object MediaLibraryUtils {
   fun getMimeType(contentResolver: ContentResolver, uri: Uri): String? =
     contentResolver.getType(uri) ?: getMimeTypeFromFileUrl(uri.toString())
 
-  fun getAssetsUris(context: Context, assetsId: List<String?>?): List<Uri> {
+  fun getAssetsUris(context: Context, assetsId: Array<String>): List<Uri> {
     val result = mutableListOf<Uri>()
-    val selection = MediaStore.MediaColumns._ID + " IN (" + TextUtils.join(",", assetsId!!) + " )"
+    val selection = MediaStore.MediaColumns._ID + " IN (" + TextUtils.join(",", assetsId) + " )"
     val selectionArgs: Array<String>? = null
     val projection = arrayOf(MediaStore.MediaColumns._ID, MediaStore.MediaColumns.MIME_TYPE)
     context.contentResolver.query(

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/AddAssetsToAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/AddAssetsToAlbum.kt
@@ -5,46 +5,39 @@ import android.media.MediaScannerConnection
 import android.os.Build
 import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.PermissionsException
-import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CompletableDeferred
 
-internal class AddAssetsToAlbum(
-  private val context: Context,
-  private val assetIds: Array<String>,
-  private val albumId: String,
-  copyToAlbum: Boolean
-) {
-  private val strategy = if (copyToAlbum) AssetFileStrategy.copyStrategy else AssetFileStrategy.moveStrategy
-
-  // Media store table can be corrupted. Extra check won't harm anyone.
-  private val album: File
-    get() {
-      return getAlbumFile(context, albumId)
-    }
-
-  suspend fun execute(): Boolean {
-    val assets = MediaLibraryUtils.getAssetsById(context, *assetIds)
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !album.canWrite()) {
-      throw PermissionsException(
-        "The application doesn't have permission to write to the album's directory. For more information, check out https://expo.fyi/android-r."
-      )
-    }
-
-    val paths = assets.map { asset ->
-      val newAsset = strategy.apply(asset, album, context)
-      newAsset.path
-    }
-
-    val atomicInteger = AtomicInteger(paths.size)
-
-    val result = CompletableDeferred<Boolean>()
-    MediaScannerConnection.scanFile(context, paths.toTypedArray(), null) { _, _ ->
-      if (atomicInteger.decrementAndGet() == 0) {
-        result.complete(true)
-      }
-    }
-    return result.await()
+suspend fun addAssetsToAlbum(context: Context, assetIds: Array<String>, albumId: String, copyToAlbum: Boolean): Boolean {
+  val strategy = if (copyToAlbum) {
+    AssetFileStrategy.copyStrategy
+  } else {
+    AssetFileStrategy.moveStrategy
   }
+
+  val album = getAlbumFile(context, albumId)
+
+  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && !album.canWrite()) {
+    throw PermissionsException(
+      "The application doesn't have permission to write to the album's directory. For more information, check out https://expo.fyi/android-r."
+    )
+  }
+
+  val assets = MediaLibraryUtils.getAssetsById(context, *assetIds)
+
+  val paths = assets.map { asset ->
+    val newAsset = strategy.apply(asset, album, context)
+    newAsset.path
+  }
+
+  val result = CompletableDeferred<Boolean>()
+  val atomicInteger = AtomicInteger(paths.size)
+
+  MediaScannerConnection.scanFile(context, paths.toTypedArray(), null) { _, _ ->
+    if (atomicInteger.decrementAndGet() == 0) {
+      result.complete(true)
+    }
+  }
+
+  return result.await()
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/CreateAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/CreateAlbum.kt
@@ -13,66 +13,58 @@ import kotlinx.coroutines.CompletableDeferred
 import java.io.File
 import java.io.IOException
 
-internal class CreateAlbum(
-  private val context: Context,
-  private val albumName: String,
-  private val assetId: String,
-  copyAsset: Boolean
-) {
-  private val mStrategy = if (copyAsset) AssetFileStrategy.copyStrategy else AssetFileStrategy.moveStrategy
-  suspend fun execute(): Bundle? {
-    try {
-      val files = MediaLibraryUtils.getAssetsById(context, assetId)
-      val albumCreator = files[0]
-      val album = createAlbumFile(albumCreator.mimeType, albumName)
-      val newFile = mStrategy.apply(albumCreator, album, context)
-      val result = CompletableDeferred<Bundle?>()
+suspend fun createAlbum(context: Context, albumName: String, assetId: String, copyAsset: Boolean): Bundle? {
+  try {
+    val mStrategy = if (copyAsset) AssetFileStrategy.copyStrategy else AssetFileStrategy.moveStrategy
+    val files = MediaLibraryUtils.getAssetsById(context, assetId)
+    val albumCreator = files[0]
+    val album = createAlbumFile(albumCreator.mimeType, albumName)
+    val newFile = mStrategy.apply(albumCreator, album, context)
 
-      MediaScannerConnection.scanFile(
-        context,
-        arrayOf(newFile.path),
-        null
-      ) { path: String, uri: Uri? ->
-        if (uri == null) {
-          result.completeExceptionally(
-            AlbumException("Could not add image to album.")
-          )
-          return@scanFile
-        }
+    val result = CompletableDeferred<Bundle?>()
 
-        val selection = "${MediaStore.Images.Media.DATA}=?"
-        val args = arrayOf(path)
-        val bundle = queryAlbum(context, selection, args)
-        result.complete(bundle)
+    MediaScannerConnection.scanFile(
+      context,
+      arrayOf(newFile.path),
+      null
+    ) { path: String, uri: Uri? ->
+      if (uri == null) {
+        result.completeExceptionally(
+          AlbumException("Could not add image to album.")
+        )
+        return@scanFile
       }
 
-      return result.await()
-    } catch (e: SecurityException) {
-      throw UnableToLoadException("Could not create album: need WRITE_EXTERNAL_STORAGE permission: ${e.message}", e)
-    } catch (e: IOException) {
-      throw UnableToLoadException("Could not read file or parse EXIF tags: ${e.message}", e)
+      val selection = "${MediaStore.Images.Media.DATA}=?"
+      val args = arrayOf(path)
+      val bundle = queryAlbum(context, selection, args)
+      result.complete(bundle)
     }
+
+    return result.await()
+  } catch (e: SecurityException) {
+    throw UnableToLoadException("Could not create album: need WRITE_EXTERNAL_STORAGE permission: ${e.message}", e)
+  } catch (e: IOException) {
+    throw UnableToLoadException("Could not read file or parse EXIF tags: ${e.message}", e)
   }
 }
 
 // Creates the album file and uses existing CreateAssetWithAlbumFile to create the asset inside the album.
-internal class CreateAlbumWithInitialFileUri(val context: Context, val albumName: String, val assetUri: Uri) {
-  suspend fun execute(): Bundle? {
-    val mimeType: String = MediaLibraryUtils.getMimeType(context.contentResolver, assetUri) ?: run {
-      throw AlbumException("Failed to create album: could not determine MIME type of the asset with uri: `$assetUri`.")
-    }
-    val assetUriPath = assetUri.path ?: run {
-      throw AlbumException("Failed to create album: could not determine path of the asset with uri: `$assetUri`.")
-    }
-
-    val albumFile: File = createAlbumFile(mimeType, albumName)
-    val mediaFile: File = File(assetUriPath)
-
-    if (!mediaFile.exists()) {
-      throw AlbumException("Failed to create album: the local media file with uri: `$assetUri` does not exist.")
-    }
-
-    CreateAssetWithAlbumFile(context, assetUri.toString(), false, albumFile).execute()
-    return GetAlbum(context, albumName).execute()
+suspend fun createAlbumWithInitialFileUri(context: Context, albumName: String, assetUri: Uri): Bundle? {
+  val mimeType: String = MediaLibraryUtils.getMimeType(context.contentResolver, assetUri) ?: run {
+    throw AlbumException("Failed to create album: could not determine MIME type of the asset with uri: `$assetUri`.")
   }
+  val assetUriPath = assetUri.path ?: run {
+    throw AlbumException("Failed to create album: could not determine path of the asset with uri: `$assetUri`.")
+  }
+
+  val albumFile: File = createAlbumFile(mimeType, albumName)
+  val mediaFile: File = File(assetUriPath)
+
+  if (!mediaFile.exists()) {
+    throw AlbumException("Failed to create album: the local media file with uri: `$assetUri` does not exist.")
+  }
+
+  CreateAssetWithAlbumFile(context, assetUri.toString(), false, albumFile).execute()
+  return getAlbum(context, albumName)
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/DeleteAlbums.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/DeleteAlbums.kt
@@ -5,11 +5,10 @@ import android.provider.MediaStore
 import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.MediaLibraryUtils.queryPlaceholdersFor
 
-fun deleteAlbums(context: Context, albumIds: List<String>): Boolean {
-  val mAlbumIds = albumIds.toTypedArray()
-  val selectionImages = "${MediaStore.Images.Media.BUCKET_ID} IN (${queryPlaceholdersFor(mAlbumIds)})"
-  val selectionVideos = "${MediaStore.Video.Media.BUCKET_ID} IN (${queryPlaceholdersFor(mAlbumIds)})"
+fun deleteAlbums(context: Context, albumIds: Array<String>): Boolean {
+  val selectionImages = "${MediaStore.Images.Media.BUCKET_ID} IN (${queryPlaceholdersFor(albumIds)})"
+  val selectionVideos = "${MediaStore.Video.Media.BUCKET_ID} IN (${queryPlaceholdersFor(albumIds)})"
 
-  return MediaLibraryUtils.deleteAssets(context, selectionImages, mAlbumIds) &&
-    MediaLibraryUtils.deleteAssets(context, selectionVideos, mAlbumIds)
+  return MediaLibraryUtils.deleteAssets(context, selectionImages, albumIds) &&
+    MediaLibraryUtils.deleteAssets(context, selectionVideos, albumIds)
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/DeleteAlbums.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/DeleteAlbums.kt
@@ -5,18 +5,11 @@ import android.provider.MediaStore
 import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.MediaLibraryUtils.queryPlaceholdersFor
 
-internal class DeleteAlbums(
-  private val context: Context,
-  albumIds: List<String>
-) {
-  private val mAlbumIds = albumIds.toTypedArray()
+fun deleteAlbums(context: Context, albumIds: List<String>): Boolean {
+  val mAlbumIds = albumIds.toTypedArray()
+  val selectionImages = "${MediaStore.Images.Media.BUCKET_ID} IN (${queryPlaceholdersFor(mAlbumIds)})"
+  val selectionVideos = "${MediaStore.Video.Media.BUCKET_ID} IN (${queryPlaceholdersFor(mAlbumIds)})"
 
-  fun execute(): Boolean {
-    val selectionImages = "${MediaStore.Images.Media.BUCKET_ID} IN (${queryPlaceholdersFor(mAlbumIds)})"
-    val selectionVideos = "${MediaStore.Video.Media.BUCKET_ID} IN (${queryPlaceholdersFor(mAlbumIds)})"
-    val selectionArgs = mAlbumIds
-
-    return MediaLibraryUtils.deleteAssets(context, selectionImages, selectionArgs) &&
-      MediaLibraryUtils.deleteAssets(context, selectionVideos, selectionArgs)
-  }
+  return MediaLibraryUtils.deleteAssets(context, selectionImages, mAlbumIds) &&
+    MediaLibraryUtils.deleteAssets(context, selectionVideos, mAlbumIds)
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/GetAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/GetAlbum.kt
@@ -5,15 +5,10 @@ import android.os.Bundle
 import android.provider.MediaStore.Files.FileColumns
 import android.provider.MediaStore.MediaColumns
 
-internal class GetAlbum(
-  private val context: Context,
-  private val albumName: String
-) {
-  fun execute(): Bundle? {
-    val selection = "${FileColumns.MEDIA_TYPE} != ${FileColumns.MEDIA_TYPE_NONE}" +
-      " AND ${MediaColumns.BUCKET_DISPLAY_NAME}=?"
-    val selectionArgs = arrayOf(albumName)
+fun getAlbum(context: Context, albumName: String): Bundle? {
+  val selection = "${FileColumns.MEDIA_TYPE} != ${FileColumns.MEDIA_TYPE_NONE}" +
+    " AND ${MediaColumns.BUCKET_DISPLAY_NAME}=?"
+  val selectionArgs = arrayOf(albumName)
 
-    return queryAlbum(context, selection, selectionArgs)
-  }
+  return queryAlbum(context, selection, selectionArgs)
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/RemoveAssetsFromAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/RemoveAssetsFromAlbum.kt
@@ -4,15 +4,8 @@ import android.content.Context
 import android.provider.MediaStore.Images.Media
 import expo.modules.medialibrary.MediaLibraryUtils
 
-internal class RemoveAssetsFromAlbum(
-  private val context: Context,
-  private val assetIds: Array<String>,
-  private val albumId: String
-) {
-  fun execute() {
-    val bucketSelection = "${Media.BUCKET_ID}=? AND ${Media._ID} IN (${assetIds.joinToString(",")} )"
-    val bucketId = arrayOf(albumId)
-
-    MediaLibraryUtils.deleteAssets(context, bucketSelection, bucketId)
-  }
+fun removeAssetsFromAlbum(context: Context, assetIds: Array<String>, albumId: String) {
+  val bucketSelection = "${Media.BUCKET_ID}=? AND ${Media._ID} IN (${assetIds.joinToString(",")} )"
+  val bucketId = arrayOf(albumId)
+  MediaLibraryUtils.deleteAssets(context, bucketSelection, bucketId)
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/migration/CheckIfAlbumShouldBeMigrated.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/migration/CheckIfAlbumShouldBeMigrated.kt
@@ -9,17 +9,12 @@ import expo.modules.medialibrary.EXTERNAL_CONTENT_URI
 import java.io.File
 
 @RequiresApi(Build.VERSION_CODES.R)
-class CheckIfAlbumShouldBeMigrated(
-  private val context: Context,
-  private val albumId: String
-) {
-  fun execute(): Boolean {
-    val albumDir = getAlbumDirectory(context, albumId)
-    if (albumDir == null) {
-      throw AlbumNotFound()
-    } else {
-      return !albumDir.canWrite()
-    }
+fun checkIfAlbumShouldBeMigrated(context: Context, albumId: String): Boolean {
+  val albumDir = getAlbumDirectory(context, albumId)
+  if (albumDir == null) {
+    throw AlbumNotFound()
+  } else {
+    return !albumDir.canWrite()
   }
 }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/migration/MigrateAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/migration/MigrateAlbum.kt
@@ -12,38 +12,32 @@ import expo.modules.medialibrary.MediaLibraryUtils.AssetFile
 import java.io.File
 
 @RequiresApi(Build.VERSION_CODES.R)
-internal class MigrateAlbum(
-  private val context: Context,
-  private val assetFiles: List<AssetFile>,
-  private val albumDirName: String
-) {
-  fun execute() {
-    // Previously, users were able to save different assets type in the same directory.
-    // But now, it's not always possible.
-    // If album contains movies or pictures, we can move it to Environment.DIRECTORY_PICTURES.
-    // Otherwise, we reject.
-    val assetsRelativePaths = assetFiles
-      .map { MediaLibraryUtils.getRelativePathForAssetType(it.mimeType, false) }
-      .toSet()
-    if (assetsRelativePaths.size > 1) {
-      throw AlbumException("The album contains incompatible file types.")
-    }
+fun migrateAlbum(context: Context, assetFiles: List<AssetFile>, albumDirName: String) {
+  // Previously, users were able to save different assets type in the same directory.
+  // But now, it's not always possible.
+  // If album contains movies or pictures, we can move it to Environment.DIRECTORY_PICTURES.
+  // Otherwise, we reject.
+  val assetsRelativePaths = assetFiles
+    .map { MediaLibraryUtils.getRelativePathForAssetType(it.mimeType, false) }
+    .toSet()
+  if (assetsRelativePaths.size > 1) {
+    throw AlbumException("The album contains incompatible file types.")
+  }
 
-    val relativePath = assetsRelativePaths.iterator().next() + File.separator + albumDirName
-    val values = ContentValues().apply {
-      put(MediaStore.MediaColumns.RELATIVE_PATH, relativePath)
-    }
-    assetFiles.forEach { assetFile ->
-      context
-        .contentResolver
-        .update(
-          ContentUris.withAppendedId(
-            MediaLibraryUtils.mimeTypeToExternalUri(assetFile.mimeType),
-            assetFile.assetId.toLong()
-          ),
-          values,
-          null
-        )
-    }
+  val relativePath = assetsRelativePaths.iterator().next() + File.separator + albumDirName
+  val values = ContentValues().apply {
+    put(MediaStore.MediaColumns.RELATIVE_PATH, relativePath)
+  }
+  assetFiles.forEach { assetFile ->
+    context
+      .contentResolver
+      .update(
+        ContentUris.withAppendedId(
+          MediaLibraryUtils.mimeTypeToExternalUri(assetFile.mimeType),
+          assetFile.assetId.toLong()
+        ),
+        values,
+        null
+      )
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/CreateAsset.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/CreateAsset.kt
@@ -174,18 +174,12 @@ class CreateAssetWithAlbumFile(
   }
 }
 
-class CreateAssetWithAlbumId @JvmOverloads constructor(
-  private val context: Context,
-  private val uri: String,
-  private val resolveWithAdditionalData: Boolean = true,
-  private val albumId: String? = null
-) {
-  private val album: File?
-    get() {
-      return albumId?.let { getAlbumFileOrNull(context, albumId) }
-    }
-
-  suspend fun execute(): ArrayList<Bundle>? {
-    return CreateAssetWithAlbumFile(context, uri, resolveWithAdditionalData, album).execute()
-  }
+suspend fun createAssetWithAlbumId(
+  context: Context,
+  uri: String,
+  resolveWithAdditionalData: Boolean = true,
+  albumId: String? = null
+): ArrayList<Bundle>? {
+  val album = albumId?.let { getAlbumFileOrNull(context, albumId) }
+  return CreateAssetWithAlbumFile(context, uri, resolveWithAdditionalData, album).execute()
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/DeleteAssets.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/DeleteAssets.kt
@@ -4,14 +4,9 @@ import android.content.Context
 import android.provider.MediaStore
 import expo.modules.medialibrary.MediaLibraryUtils
 
-internal class DeleteAssets(
-  private val context: Context,
-  private val assetIds: Array<String>
-) {
-  fun execute(): Boolean {
-    val selection = "${MediaStore.Images.Media._ID} IN (${assetIds.joinToString(separator = ",")} )"
-    val selectionArgs: Array<String>? = null
+fun deleteAssets(context: Context, assetIds: Array<String>): Boolean {
+  val selection = "${MediaStore.Images.Media._ID} IN (${assetIds.joinToString(separator = ",")} )"
+  val selectionArgs: Array<String>? = null
 
-    return MediaLibraryUtils.deleteAssets(context, selection, selectionArgs)
-  }
+  return MediaLibraryUtils.deleteAssets(context, selection, selectionArgs)
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/GetAssetInfo.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/GetAssetInfo.kt
@@ -4,14 +4,8 @@ import android.content.Context
 import android.os.Bundle
 import android.provider.MediaStore
 
-internal class GetAssetInfo(
-  private val context: Context,
-  private val assetId: String
-) {
-  fun execute(): ArrayList<Bundle>? {
-    val selection = "${MediaStore.Images.Media._ID}=?"
-    val selectionArgs = arrayOf(assetId)
-
-    return queryAssetInfo(context, selection, selectionArgs, true)
-  }
+fun getAssetInfo(context: Context, assetId: String): ArrayList<Bundle>? {
+  val selection = "${MediaStore.Images.Media._ID}=?"
+  val selectionArgs = arrayOf(assetId)
+  return queryAssetInfo(context, selection, selectionArgs, true)
 }

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumInfoTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumInfoTests.kt
@@ -52,7 +52,7 @@ internal class GetAlbumInfoTests {
     val albumName = "testAlbumName"
 
     // act
-    GetAlbum(context, albumName).execute()
+    getAlbum(context, albumName)
 
     // assert
     assertTrue(selectionSlot.captured.contains(expectedSelection, ignoreCase = true))

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumTests.kt
@@ -58,7 +58,7 @@ internal class GetAlbumTests {
     val albumName = "TestAlbum"
 
     // act
-    GetAlbum(context, albumName).execute()
+    getAlbum(context, albumName)
 
     // assert
     assertEquals(expectedSelection, selectionSlot.captured)

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumsTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumsTests.kt
@@ -42,7 +42,7 @@ class GetAlbumsTests {
     val context = mockContext with mockContentResolver(cursor)
 
     // act
-    val result = GetAlbums(context).execute()
+    val result = getAlbums(context)
 
     // assert
     assertEquals(1, result.size)
@@ -68,7 +68,7 @@ class GetAlbumsTests {
     val context = mockContext with mockContentResolver(cursor)
 
     // act
-    val result = GetAlbums(context).execute()
+    val result = getAlbums(context)
 
     // assert
     assertEquals(0, result.size)
@@ -81,7 +81,7 @@ class GetAlbumsTests {
 
     // act && assert
     assertThrows(AlbumException::class.java) {
-      GetAlbums(context).execute()
+      getAlbums(context)
     }
   }
 
@@ -92,7 +92,7 @@ class GetAlbumsTests {
 
     // act && assert
     try {
-      GetAlbums(context).execute()
+      getAlbums(context)
       fail()
     } catch (e: Exception) {
       assert(e is UnableToLoadException)
@@ -106,7 +106,7 @@ class GetAlbumsTests {
 
     // act && assert
     try {
-      GetAlbums(context).execute()
+      getAlbums(context)
       fail()
     } catch (e: Exception) {
       assert(e is UnableToLoadException)

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
@@ -76,7 +76,7 @@ internal class GetAssetInfoTests {
     val assetId = "testAssetId"
 
     // act
-    GetAssetInfo(context, assetId).execute()
+    getAssetInfo(context, assetId)
 
     // assert
     assertEquals(expectedSelection, selectionSlot.captured)

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetsTest.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetsTest.kt
@@ -67,7 +67,7 @@ internal class GetAssetsTest {
     )
 
     // act
-    val response = GetAssets(context, defaultAssets).execute()
+    val response = getAssets(context, defaultAssets)
 
     // assert
     assertEquals(2, response.getInt("totalCount"))
@@ -80,7 +80,7 @@ internal class GetAssetsTest {
 
     // act && assert
     try {
-      GetAssets(context, defaultAssets).execute()
+      getAssets(context, defaultAssets)
       fail()
     } catch (e: Exception) {
       assert(e is AssetQueryException)
@@ -94,7 +94,7 @@ internal class GetAssetsTest {
 
     // act && assert
     try {
-      GetAssets(context, defaultAssets).execute()
+      getAssets(context, defaultAssets)
       fail()
     } catch (e: Exception) {
       assert(e is UnableToLoadException)
@@ -108,7 +108,7 @@ internal class GetAssetsTest {
 
     // act && assert
     try {
-      GetAssets(context, defaultAssets).execute()
+      getAssets(context, defaultAssets)
       fail()
     } catch (e: Exception) {
       assert(e is UnableToLoadException)


### PR DESCRIPTION
# Why
Depends on: [#38301](https://github.com/expo/expo/pull/38301)
This PR aims to simplify module functions by removing callbacks and making it more linear 
# How
- Removed the `Action` interface and replaced its behavior with the `requestMediaLibraryActionPermission` suspend function.
- Changed classes with only an `execute` method into functions
# Test Plan
Tested on BareExpo ✅
