### PR TITLE
[docs] Add env to workflow syntax

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -236,6 +236,20 @@ jobs:
     # @end #
 ```
 
+### `jobs.<job_id>.env`
+
+Sets individual environment variables for the job. This is often useful for exposing outputs from a previous job as environment variables for use in the current job:
+
+```yaml
+jobs:
+  my_job:
+    # @info #
+    env:
+      PREV_JOB_OUTPUT: ${{ needs.previous_job.outputs.some_output }}
+      OTHER_ENV_VAR: test
+    # @end #
+```
+
 ### `jobs.<job_id>.defaults.run.working_directory`
 
 Sets the directory to run commands in for all steps in the job.


### PR DESCRIPTION
# Why

Workflow jobs also have an `env` property that can be used to set individual environment variables, beyond using one of the standard environments.

# How

Added it

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
