### PR TITLE
[file-system][next][android] Add full support for SAF Uris.

### DIFF
--- a/apps/test-suite/tests/FileSystemNext.ts
+++ b/apps/test-suite/tests/FileSystemNext.ts
@@ -54,6 +54,9 @@ export async function test({ describe, expect, it, ...t }) {
       //     throw new Error();
       //   }
       //   const safDirectory = new Directory(saf.directoryUri);
+      //   safDirectory.list().forEach((sd) => {
+      //     sd.delete();
+      //   });
       //   expect(safDirectory.list().length).toBe(0);
 
       //   safDirectory.createFile('newFile', 'text/plain');
@@ -63,7 +66,20 @@ export async function test({ describe, expect, it, ...t }) {
       //     sd.delete();
       //   });
       //   expect(safDirectory.list().length).toBe(0);
+
+      //   const file = safDirectory.createFile('newFile', 'text/plain');
+      //   file.write('test');
+      //   expect(file.textSync()).toBe('test');
+      //   expect(file.bytesSync()).toEqual(new Uint8Array([116, 101, 115, 116]));
+      //   expect(file.base64Sync()).toBe('dGVzdA==');
+      //   const file2 = safDirectory.createFile('newFile2', 'text/plain');
+
+      //   file2.write(new Uint8Array([116, 101, 115, 116]));
+      //   expect(file2.textSync()).toBe('test');
+      //   expect(file2.size).toBe(4);
+      //   expect(safDirectory.size).toBe(8);
       // });
+
       it('Creates a lazy file reference', () => {
         const file = new File('file:///path/to/file');
         expect(file.uri).toBe('file:///path/to/file');

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add info method, modificationTime and creationTime properties to file-system/next. ([#37505](https://github.com/expo/expo/pull/37505) by [@Wenszel](https://github.com/Wenszel))
 - Add support for custom headers in downloadFileAsync ([#36108](https://github.com/expo/expo/pull/36108) by [@leonhh](https://github.com/leonhh))
 - [next] Add limited support for SAF Uris. ([#38075](https://github.com/expo/expo/pull/38075) by [@aleqsio](https://github.com/aleqsio))
+- [next] Add full support for SAF Uris. ([#38075](https://github.com/expo/expo/pull/38075) by [@aleqsio](https://github.com/aleqsio))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemPath.kt
@@ -142,7 +142,7 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
 
   val modificationTime: Long? get() {
     validateType()
-    return file.lastModified
+    return file.lastModified()
   }
 
   val creationTime: Long? get() {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/FileSystemPath.kt
@@ -9,12 +9,8 @@ import expo.modules.filesystem.next.unifiedfile.UnifiedFileInterface
 import expo.modules.interfaces.filesystem.Permission
 import expo.modules.kotlin.sharedobjects.SharedObject
 import java.io.File
-import java.nio.file.attribute.BasicFileAttributes
 import java.util.EnumSet
-import kotlin.io.path.Path
 import kotlin.io.path.moveTo
-import kotlin.io.path.readAttributes
-import kotlin.time.Duration.Companion.milliseconds
 
 val Uri.isContentUri get(): Boolean {
   return scheme == "content"
@@ -144,18 +140,12 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
     }
   }
 
-  val modificationTime: Long get() {
+  val modificationTime: Long? get() {
     validateType()
-    return javaFile.lastModified()
+    return file.lastModified
   }
 
   val creationTime: Long? get() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      validateType()
-      val attributes = Path(javaFile.path).readAttributes<BasicFileAttributes>()
-      return attributes.creationTime().toMillis().milliseconds.inWholeMilliseconds
-    } else {
-      return null
-    }
+    return file.creationTime
   }
 }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/unifiedfile/JavaFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/unifiedfile/JavaFile.kt
@@ -1,19 +1,21 @@
 package expo.modules.filesystem.next.unifiedfile
 
 import android.net.Uri
+import android.os.Build
+import android.webkit.MimeTypeMap
 import androidx.core.net.toUri
 import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.io.OutputStream
 import java.net.URI
+import java.nio.file.attribute.BasicFileAttributes
+import kotlin.io.path.Path
+import kotlin.io.path.readAttributes
+import kotlin.time.Duration.Companion.milliseconds
 
 class JavaFile(override val uri: Uri) : UnifiedFileInterface, File(URI.create(uri.toString())) {
-  override fun isDirectory(): Boolean {
-    return super<File>.isDirectory()
-  }
-
-  override fun isFile(): Boolean {
-    return super<File>.isFile()
-  }
-
   override val parentFile: UnifiedFileInterface?
     get() = super<File>.parentFile?.toUri()?.let { JavaFile(it) }
 
@@ -31,4 +33,33 @@ class JavaFile(override val uri: Uri) : UnifiedFileInterface, File(URI.create(ur
 
   override fun listFilesAsUnified(): List<UnifiedFileInterface> =
     super<File>.listFiles()?.map { JavaFile(it.toUri()) } ?: emptyList()
+
+  override val type: String? get() {
+    return MimeTypeMap.getFileExtensionFromUrl(path)
+      ?.run { MimeTypeMap.getSingleton().getMimeTypeFromExtension(lowercase()) }
+  }
+
+  override val fileName: String?
+    get() = super<File>.name
+
+  override val creationTime: Long? get() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      val attributes = Path(path).readAttributes<BasicFileAttributes>()
+      return attributes.creationTime().toMillis().milliseconds.inWholeMilliseconds
+    } else {
+      return null
+    }
+  }
+
+  override fun outputStream(): OutputStream {
+    return FileOutputStream(this)
+  }
+
+  override fun inputStream(): InputStream {
+    return FileInputStream(this)
+  }
+
+  override fun walkTopDown(): Sequence<JavaFile> {
+    return walk(direction = FileWalkDirection.TOP_DOWN).map { JavaFile(it.toUri()) }
+  }
 }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/unifiedfile/SAFDocumentFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/unifiedfile/SAFDocumentFile.kt
@@ -3,19 +3,20 @@ package expo.modules.filesystem.next.unifiedfile
 import android.content.Context
 import android.net.Uri
 import androidx.documentfile.provider.DocumentFile
+import java.io.InputStream
+import java.io.OutputStream
 
 class SAFDocumentFile(private val context: Context, override val uri: Uri) : UnifiedFileInterface {
   private val treeDocumentFile: DocumentFile? = DocumentFile.fromTreeUri(context, uri)
-  private val singleDocumentFile: DocumentFile? = DocumentFile.fromSingleUri(context, uri)
 
-  override fun exists(): Boolean = singleDocumentFile?.exists() == true
+  override fun exists(): Boolean = treeDocumentFile?.exists() == true
 
   override fun isDirectory(): Boolean {
-    return singleDocumentFile?.isDirectory == true
+    return treeDocumentFile?.isDirectory == true
   }
 
   override fun isFile(): Boolean {
-    return singleDocumentFile?.isFile == true
+    return treeDocumentFile?.isFile == true
   }
 
   override val parentFile: UnifiedFileInterface?
@@ -31,8 +32,48 @@ class SAFDocumentFile(private val context: Context, override val uri: Uri) : Uni
     return documentFile?.uri?.let { SAFDocumentFile(context, it) }
   }
 
-  override fun delete(): Boolean = singleDocumentFile?.delete() ?: false
+  override fun delete(): Boolean = treeDocumentFile?.delete() == true
 
   override fun listFilesAsUnified(): List<UnifiedFileInterface> =
     treeDocumentFile?.listFiles()?.map { SAFDocumentFile(context, it.uri) } ?: emptyList()
+
+  override val type: String?
+    get() = treeDocumentFile?.type
+
+  override fun lastModified(): Long? {
+    return treeDocumentFile?.lastModified()
+  }
+
+  override val fileName: String?
+    get() = treeDocumentFile?.name
+
+  override val creationTime: Long? get() {
+    // It seems there's no way to get this
+    return null
+  }
+
+  override fun outputStream(): OutputStream {
+    return context.contentResolver.openOutputStream(uri)
+      ?: throw IllegalStateException("Unable to open output stream for URI: $uri")
+  }
+
+  override fun inputStream(): InputStream {
+    return context.contentResolver.openInputStream(uri)
+      ?: throw IllegalStateException("Unable to open output stream for URI: $uri")
+  }
+
+  override fun length(): Long {
+    return treeDocumentFile?.length() ?: 0
+  }
+
+  override fun walkTopDown(): Sequence<SAFDocumentFile> {
+    return sequence {
+      yield(this@SAFDocumentFile)
+      if (isDirectory()) {
+        treeDocumentFile?.listFiles()?.forEach { child ->
+          yieldAll(SAFDocumentFile(context, child.uri).walkTopDown())
+        }
+      }
+    }
+  }
 }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/unifiedfile/UnifiedFileInterface.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/next/unifiedfile/UnifiedFileInterface.kt
@@ -12,4 +12,12 @@ interface UnifiedFileInterface {
   fun delete(): Boolean
   fun listFilesAsUnified(): List<UnifiedFileInterface>
   val uri: Uri
+  val type: String?
+  fun lastModified(): Long?
+  val creationTime: Long?
+  val fileName: String?
+  fun outputStream(): java.io.OutputStream
+  fun inputStream(): java.io.InputStream
+  fun length(): Long
+  fun walkTopDown(): Sequence<UnifiedFileInterface>
 }


### PR DESCRIPTION
# Why

This PR adds full support for Storage Access Framework (SAF) URIs in the `expo-file-system` package.

# How

- Added implementation for reading and writing files with SAF URIs
- Implemented file operations like `text()`, `bytes()`, `base64()`, and `write()` for SAF URIs
- Added support for getting file metadata (size, modification time) from SAF URIs
- Implemented directory traversal and file listing for SAF URIs
- Updated the `UnifiedFileInterface` to include additional methods needed for SAF support

# Test Plan

Unit Tests pass (not on CI due to the picker requiring user input, but still)

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)