### PR TITLE
[docs] Add note about silent mode affecting `expo-speech` on iOS devices

### DIFF
--- a/docs/pages/versions/unversioned/sdk/speech.mdx
+++ b/docs/pages/versions/unversioned/sdk/speech.mdx
@@ -17,6 +17,10 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
+<br />
+
+> **info** On iOS physical devices, `expo-speech` won't produce sound if the device is in silent mode. Make sure silent mode is turned off.
+
 ## Usage
 
 <SnackInline label='Speech' dependencies={['expo-speech']}>

--- a/docs/pages/versions/unversioned/sdk/speech.mdx
+++ b/docs/pages/versions/unversioned/sdk/speech.mdx
@@ -13,13 +13,11 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-speech` provides an API that allows you to utilize Text-to-speech functionality in your app.
 
+> **info** On iOS physical devices, `expo-speech` won't produce sound if the device is in silent mode. Make sure silent mode is turned off.
+
 ## Installation
 
 <APIInstallSection />
-
-<br />
-
-> **info** On iOS physical devices, `expo-speech` won't produce sound if the device is in silent mode. Make sure silent mode is turned off.
 
 ## Usage
 

--- a/docs/pages/versions/v51.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/speech.mdx
@@ -17,6 +17,10 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
+<br />
+
+> **info** On iOS physical devices, `expo-speech` won't produce sound if the device is in silent mode. Make sure silent mode is turned off.
+
 ## Usage
 
 <SnackInline label='Speech' dependencies={['expo-speech']}>

--- a/docs/pages/versions/v51.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/speech.mdx
@@ -13,13 +13,11 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-speech` provides an API that allows you to utilize Text-to-speech functionality in your app.
 
+> **info** On iOS physical devices, `expo-speech` won't produce sound if the device is in silent mode. Make sure silent mode is turned off.
+
 ## Installation
 
 <APIInstallSection />
-
-<br />
-
-> **info** On iOS physical devices, `expo-speech` won't produce sound if the device is in silent mode. Make sure silent mode is turned off.
 
 ## Usage
 

--- a/docs/pages/versions/v52.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/speech.mdx
@@ -17,6 +17,10 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
+<br />
+
+> **info** On iOS physical devices, `expo-speech` won't produce sound if the device is in silent mode. Make sure silent mode is turned off.
+
 ## Usage
 
 <SnackInline label='Speech' dependencies={['expo-speech']}>

--- a/docs/pages/versions/v52.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/speech.mdx
@@ -13,13 +13,11 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-speech` provides an API that allows you to utilize Text-to-speech functionality in your app.
 
+> **info** On iOS physical devices, `expo-speech` won't produce sound if the device is in silent mode. Make sure silent mode is turned off.
+
 ## Installation
 
 <APIInstallSection />
-
-<br />
-
-> **info** On iOS physical devices, `expo-speech` won't produce sound if the device is in silent mode. Make sure silent mode is turned off.
 
 ## Usage
 

--- a/docs/pages/versions/v53.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/speech.mdx
@@ -17,6 +17,10 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
+<br />
+
+> **info** On iOS physical devices, `expo-speech` won't produce sound if the device is in silent mode. Make sure silent mode is turned off.
+
 ## Usage
 
 <SnackInline label='Speech' dependencies={['expo-speech']}>

--- a/docs/pages/versions/v53.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/speech.mdx
@@ -13,13 +13,11 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-speech` provides an API that allows you to utilize Text-to-speech functionality in your app.
 
+> **info** On iOS physical devices, `expo-speech` won't produce sound if the device is in silent mode. Make sure silent mode is turned off.
+
 ## Installation
 
 <APIInstallSection />
-
-<br />
-
-> **info** On iOS physical devices, `expo-speech` won't produce sound if the device is in silent mode. Make sure silent mode is turned off.
 
 ## Usage
 


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-16688/tell-developers-to-have-silent-mode-off-on-ios-when-testing-speech

# How

Used an **info**

# Test Plan

Ran locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
