### PR TITLE
[android][secure-store] Update logging for error while using authentication prompt

### DIFF
--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [android] Reset `isAuthenticating` prompt flag when error is thrown ([#38132](https://github.com/expo/expo/pull/38132) by [@SYoder1](https://github.com/SYoder1))
 
-- use more specific error messages in authentication prompt errors ([#38340](https://github.com/expo/expo/pull/38340) by [@SYoder1](https://github.com/SYoder1))
+- [android] use more specific error messages in authentication prompt errors ([#38340](https://github.com/expo/expo/pull/38340) by [@SYoder1](https://github.com/SYoder1))
 
 ### 💡 Others
 

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ## Unpublished
 
-- [secure-store] Reset android isAuthenticating prompt flag when error is thrown ([#38132](https://github.com/expo/expo/pull/38132) by [@SYoder1](https://github.com/SYoder1))
-
-- [secure-store] use more specific error messages in authentication prompt errors ([#38340](https://github.com/expo/expo/pull/38340) by [@SYoder1](https://github.com/SYoder1))
-
 ### 🛠 Breaking changes
 
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+- [secure-store] Reset android isAuthenticating prompt flag when error is thrown ([#38132](https://github.com/expo/expo/pull/38132) by [@SYoder1](https://github.com/SYoder1))
+
+- [secure-store] use more specific error messages in authentication prompt errors ([#38340](https://github.com/expo/expo/pull/38340) by [@SYoder1](https://github.com/SYoder1))
 
 ### 💡 Others
 

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - [secure-store] Reset android isAuthenticating prompt flag when error is thrown ([#38132](https://github.com/expo/expo/pull/38132) by [@SYoder1](https://github.com/SYoder1))
 
+- [secure-store] Update logging for error while using authentication prompt ([#38340](https://github.com/expo/expo/pull/38340) by [@SYoder1](https://github.com/SYoder1))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - [secure-store] Reset android isAuthenticating prompt flag when error is thrown ([#38132](https://github.com/expo/expo/pull/38132) by [@SYoder1](https://github.com/SYoder1))
 
-- [secure-store] Update logging for error while using authentication prompt ([#38340](https://github.com/expo/expo/pull/38340) by [@SYoder1](https://github.com/SYoder1))
+- [secure-store] use more specific error messages in authentication prompt errors ([#38340](https://github.com/expo/expo/pull/38340) by [@SYoder1](https://github.com/SYoder1))
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -8,9 +8,9 @@
 
 ### 🐛 Bug fixes
 
-- [secure-store] Reset android isAuthenticating prompt flag when error is thrown ([#38132](https://github.com/expo/expo/pull/38132) by [@SYoder1](https://github.com/SYoder1))
+- [android] Reset `isAuthenticating` prompt flag when error is thrown ([#38132](https://github.com/expo/expo/pull/38132) by [@SYoder1](https://github.com/SYoder1))
 
-- [secure-store] use more specific error messages in authentication prompt errors ([#38340](https://github.com/expo/expo/pull/38340) by [@SYoder1](https://github.com/SYoder1))
+- use more specific error messages in authentication prompt errors ([#38340](https://github.com/expo/expo/pull/38340) by [@SYoder1](https://github.com/SYoder1))
 
 ### 💡 Others
 

--- a/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/AuthenticationPrompt.kt
+++ b/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/AuthenticationPrompt.kt
@@ -28,7 +28,7 @@ class AuthenticationPrompt(private val currentActivity: FragmentActivity, contex
             super.onAuthenticationError(errorCode, errString)
 
             val errorType = convertErrorCode(errorCode)
-            val·message·=·"$errorType.·$errString"
+            val message = "$errorType. $errString"
             continuation.resumeWithException(AuthenticationException(message))
           }
 

--- a/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/AuthenticationPrompt.kt
+++ b/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/AuthenticationPrompt.kt
@@ -28,7 +28,7 @@ class AuthenticationPrompt(private val currentActivity: FragmentActivity, contex
             super.onAuthenticationError(errorCode, errString)
 
             val errorType = convertErrorCode(errorCode)
-            val message = "$errorType. ${errString.toString()}"
+            val·message·=·"$errorType.·$errString"
             continuation.resumeWithException(AuthenticationException(message))
           }
 

--- a/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/AuthenticationPrompt.kt
+++ b/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/AuthenticationPrompt.kt
@@ -27,11 +27,9 @@ class AuthenticationPrompt(private val currentActivity: FragmentActivity, contex
           override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
             super.onAuthenticationError(errorCode, errString)
 
-            if (errorCode == BiometricPrompt.ERROR_USER_CANCELED || errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON) {
-              continuation.resumeWithException(AuthenticationException("User canceled the authentication"))
-            } else {
-              continuation.resumeWithException(AuthenticationException("Could not authenticate the user"))
-            }
+            val errorType = convertErrorCode(errorCode)
+            val message = "$errorType. ${errString.toString()}"
+            continuation.resumeWithException(AuthenticationException(message))
           }
 
           override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
@@ -41,4 +39,22 @@ class AuthenticationPrompt(private val currentActivity: FragmentActivity, contex
         }
       ).authenticate(promptInfo, BiometricPrompt.CryptoObject(cipher))
     }
+
+  private fun convertErrorCode(code: Int): String {
+    return when (code) {
+      BiometricPrompt.ERROR_USER_CANCELED -> "User canceled the authentication"
+      BiometricPrompt.ERROR_NEGATIVE_BUTTON -> "User canceled the authentication"
+      BiometricPrompt.ERROR_HW_NOT_PRESENT -> "Hardware not present"
+      BiometricPrompt.ERROR_HW_UNAVAILABLE -> "Hardware unavailable"
+      BiometricPrompt.ERROR_NO_BIOMETRICS -> "No biometrics enrolled"
+      BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL -> "No device credential"
+      BiometricPrompt.ERROR_LOCKOUT -> "Lockout"
+      BiometricPrompt.ERROR_LOCKOUT_PERMANENT -> "Lockout permanent"
+      BiometricPrompt.ERROR_NO_SPACE -> "No space"
+      BiometricPrompt.ERROR_TIMEOUT -> "Timeout"
+      BiometricPrompt.ERROR_UNABLE_TO_PROCESS -> "Unable to process"
+      BiometricPrompt.ERROR_VENDOR -> "Vendor error"
+      else -> "Unknown error (code: $code)"
+    }
+  }
 }


### PR DESCRIPTION
# Why
If there is an error during the biometrics authentication prompt, all errors were being grouped into one generic error. This PR adds more verbose logging

Such as:
```
Call to function 'ExpoSecureStore.setValueWithKeyAsync' has been rejected.
→ Caused by: Could not Authenticate the user: Hardware unavailable. Fingerprint hardware not available
```

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Logging only

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
