### PR TITLE
[android][core] Conditionally register `RuntimeHolder` bindings

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
 - [android] Fix android build without coreFeatures compose ([#38153](https://github.com/expo/expo/pull/38153) by [@Ubax](https://github.com/Ubax))
 - [iOS] Fix `ExpoRequestInterceptorProtocol` to properly notify client about HTTP redirects. ([#38078](https://github.com/expo/expo/pull/38078) by [@kudo](https://github.com/kudo))
+- [Android] Conditionally register `RuntimeHolder` bindings. ([#38345](https://github.com/expo/expo/pull/38345) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
@@ -29,7 +29,9 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
 
     expo::FrontendConverterProvider::instance()->createConverters();
 
+#if UNIT_TEST
     expo::RuntimeHolder::registerNatives();
+#endif
     expo::JSIContext::registerNatives();
     expo::JavaScriptModuleObject::registerNatives();
     expo::JavaScriptValue::registerNatives();

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/tests/RuntimeHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/tests/RuntimeHolder.kt
@@ -14,7 +14,6 @@ import java.util.concurrent.atomic.AtomicBoolean
  * It can't be moved to test package, because it uses the cpp code.
  * We don't want to generate another cpp library just to export those functions.
  */
-@DoNotStrip
 internal class RuntimeHolder : AutoCloseable {
   // Has to be called "mHybridData" - fbjni uses it via reflection
   @DoNotStrip


### PR DESCRIPTION
# Why
Tries to address https://exponent-internal.slack.com/archives/C1QNF5L3C/p1753144612495529

# How
From my understanding, `RuntimeHolder` should only be used in tests. #30572 prevented it from causing issues with R8 but it should be excluded from release build entirely. We have a `UNIT_TEST` macro we can use to only register the JNI bindings when we are in a test environment. We can remove `@DoNotStrip` to allow R8 to remove the class in production

# Test Plan
Tests are passing. Built bare expo in release with R8 enabled and it works fine. Let's see how CI goes. 

