### PR TITLE
[router] bump vaul to latest version for React 19 compatibility

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -37,7 +37,7 @@
 
 - Create href preview component ([#37335](https://github.com/expo/expo/pull/37335) by [@Ubax](https://github.com/Ubax))
 - Add formsheet warning ([#37982](https://github.com/expo/expo/pull/37982) by [@Ubax](https://github.com/Ubax))
-
+- Bump vaul to latest version for React 19 compatibility
 
 ## 5.1.4 - 2025-07-18
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -37,7 +37,7 @@
 
 - Create href preview component ([#37335](https://github.com/expo/expo/pull/37335) by [@Ubax](https://github.com/Ubax))
 - Add formsheet warning ([#37982](https://github.com/expo/expo/pull/37982) by [@Ubax](https://github.com/Ubax))
-- Bump vaul to latest version for React 19 compatibility
+- Bump vaul to latest version for React 19 compatibility ([#38346](https://github.com/expo/expo/pull/38346) by [@LeonDvlpmnt](https://github.com/LeonDvlpmnt))
 
 ## 5.1.4 - 2025-07-18
 

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -120,6 +120,6 @@
     "server-only": "^0.0.1",
     "sf-symbols-typescript": "^2.1.0",
     "shallowequal": "^1.1.0",
-    "vaul": "^0.9.0"
+    "vaul": "^1.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16188,10 +16188,10 @@ vary@^1.1.2, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-vaul@^0.9.0:
-  version "0.9.9"
-  resolved "https://registry.yarnpkg.com/vaul/-/vaul-0.9.9.tgz#ff075c3cba6193d4859bb6f1b09efcce049cf812"
-  integrity sha512-7afKg48srluhZwIkaU+lgGtFCUsYBSGOl8vcc8N/M3YQlZFlynHD15AE+pwrYdc826o7nrIND4lL9Y6b9WWZZQ==
+vaul@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vaul/-/vaul-1.1.2.tgz#c959f8b9dc2ed4f7d99366caee433fbef91f5ba9"
+  integrity sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==
   dependencies:
     "@radix-ui/react-dialog" "^1.1.1"
 


### PR DESCRIPTION
# Why

expo-router uses vaul ^0.9.0 which doesn't have a peer dependency on React 19. This causes issues with the default template because multiple react versions will be installed. Not sure why this isn't an issue with the router-e2e tester app though (cc @hirbod).

# How

bumped vaul from ^0.9.0 to ^1.1.0

# Test Plan

`cd apps/router-e2e && yarn start:web-modal`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
