### PR TITLE
[sdk54] update react-native-pager-view to 6.8.1

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2465,7 +2465,7 @@ PODS:
     - Yoga
   - react-native-netinfo (11.4.1):
     - React-Core
-  - react-native-pager-view (6.7.1):
+  - react-native-pager-view (6.8.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -4376,7 +4376,7 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: 4f1ef719ba6c7ebbd2d75346ffa2916f9b4771c9
   react-native-keyboard-controller: ca6a84ab8464c1fdf67e610bc9fa3eaa03a81a0f
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
-  react-native-pager-view: 03553493db7fd49946d709ab6d65c7ef0cc929be
+  react-native-pager-view: adf5c4ae45a4ce743b0ff2855bda83ffce13b4c4
   react-native-safe-area-context: 47c1782a327ca2affa9bec5a2f95534cbabb620a
   react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
   react-native-slider: dd3636cb9b888b4d8aaf7ac0bb5e0d2921c5eec6
@@ -4431,6 +4431,6 @@ SPEC CHECKSUMS:
   Yoga: daa1e4de4b971b977b23bc842aaa3e135324f1f3
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: a4b563d9d9c73e29b619314cb8136ce02bea61e0
+PODFILE CHECKSUM: f5d503a683b23e49517a81aa6eeffbc2b323828a
 
 COCOAPODS: 1.16.2

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -67,7 +67,7 @@
     "react-native-edge-to-edge": "~1.6.1",
     "react-native-gesture-handler": "~2.26.0",
     "react-native-keyboard-controller": "^1.17.5",
-    "react-native-pager-view": "6.7.1",
+    "react-native-pager-view": "6.8.1",
     "react-native-reanimated": "3.18.0",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "4.11.1-nightly-20250611-8b82e081e",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2244,7 +2244,7 @@ PODS:
     - React-Core
   - react-native-netinfo (11.4.1):
     - React-Core
-  - react-native-pager-view (6.7.1):
+  - react-native-pager-view (6.8.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -4174,7 +4174,7 @@ SPEC CHECKSUMS:
   ExpoWebBrowser: 41dc1db6ed9185a3b80a9f917ba3c62dafd22eec
   EXStructuredHeaders: 1c799cb91e8057e0671610635e5b2109fa295114
   EXTaskManager: 0128b9f39a088b0c762d8d1c42017e6d44200b29
-  EXUpdates: 5cbd41ca43ec772070b5997ce1f51f2e99055731
+  EXUpdates: a8427b57ecd860a4391ee838c73903e76055f3f7
   EXUpdatesInterface: d6c802a2d1d11867523d03a95397957f9ba3d1c7
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 09f03e4b6f42f955734b64a118f86509cc719427
@@ -4193,7 +4193,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: a3ec960e841e867d0c120fb8722d1bad078789e9
+  hermes-engine: 95be12d50073e1867a87b55118fc1e23c92b3be2
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4242,7 +4242,7 @@ SPEC CHECKSUMS:
   react-native-keyboard-controller: ca6a84ab8464c1fdf67e610bc9fa3eaa03a81a0f
   react-native-maps: ee1e65647460c3d41e778071be5eda10e3da6225
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
-  react-native-pager-view: 03553493db7fd49946d709ab6d65c7ef0cc929be
+  react-native-pager-view: adf5c4ae45a4ce743b0ff2855bda83ffce13b4c4
   react-native-safe-area-context: 47c1782a327ca2affa9bec5a2f95534cbabb620a
   react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
   react-native-skia: 02ffb448bb7c1d181d9b6860274c2ac142331b11
@@ -4307,6 +4307,6 @@ SPEC CHECKSUMS:
   Yoga: daa1e4de4b971b977b23bc842aaa3e135324f1f3
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: ee6901ca120b93e4938c943d3743febeb70fce16
+PODFILE CHECKSUM: 7116bc722000b18e5791b7675731af4a46e3ad5e
 
 COCOAPODS: 1.16.2

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -76,7 +76,7 @@
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-keyboard-controller": "^1.17.5",
     "react-native-maps": "1.20.1",
-    "react-native-pager-view": "6.7.1",
+    "react-native-pager-view": "6.8.1",
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "3.18.0",
     "react-native-safe-area-context": "5.4.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -140,7 +140,7 @@
     "react-native-gesture-handler": "~2.26.0",
     "react-native-keyboard-controller": "^1.17.5",
     "react-native-maps": "1.20.1",
-    "react-native-pager-view": "6.7.1",
+    "react-native-pager-view": "6.8.1",
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "3.18.0",
     "react-native-safe-area-context": "5.4.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -98,7 +98,7 @@
   "react-native-get-random-values": "~1.11.0",
   "react-native-keyboard-controller": "1.17.5",
   "react-native-maps": "1.20.1",
-  "react-native-pager-view": "6.7.1",
+  "react-native-pager-view": "6.8.1",
   "react-native-reanimated": "~3.18.0",
   "react-native-screens": "~4.11.1",
   "react-native-safe-area-context": "5.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13527,10 +13527,10 @@ react-native-maps@1.20.1:
   dependencies:
     "@types/geojson" "^7946.0.13"
 
-react-native-pager-view@6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.7.1.tgz#60d52dedbcc92ee7037a13287ebeed5f74e49df7"
-  integrity sha512-cBSr6xw4g5N7Kd3VGWcf+kmaH7iBWb0DXAf2bVo3bXkzBcBbTOmYSvc0LVLHhUPW8nEq5WjT9LCIYAzgF++EXw==
+react-native-pager-view@6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.8.1.tgz#fa0ec09ea7c44190c7c013d75dd09fdc17b96100"
+  integrity sha512-XIyVEMhwq7sZqM7GobOJZXxFCfdFgVNq/CFB2rZIRNRSVPJqE1k1fsc8xfQKfdzsp6Rpt6I7VOIvhmP7/YHdVg==
 
 react-native-paper@^5.12.5:
   version "5.12.5"


### PR DESCRIPTION
# Why

Update react-native-pager-view to 6.8.1 for SDK54

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
Bumped version to 6.8.1 at the appropriate places.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Tested the Pager view example in ExpoAPIs app.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
