### PR TITLE
[expo/cli]: Fix change exit code to 1 for abort and silent errors

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Remove flipper hack support ([#37532](https://github.com/expo/expo/pull/37532) by [@EvanBacon](https://github.com/EvanBacon))
 - Use template tarball from expo package. ([#37334](https://github.com/expo/expo/pull/37334) by [@jakex7](https://github.com/jakex7))
-- CLI returns non-zero return code on Abort and Silent Errors ([#](https://github.com/expo/expo/pull/) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+- CLI returns non-zero return code on Abort and Silent Errors ([#38365](https://github.com/expo/expo/pull/38365) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 
 ### 🎉 New features
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove flipper hack support ([#37532](https://github.com/expo/expo/pull/37532) by [@EvanBacon](https://github.com/EvanBacon))
 - Use template tarball from expo package. ([#37334](https://github.com/expo/expo/pull/37334) by [@jakex7](https://github.com/jakex7))
+- CLI returns non-zero return code on Abort and Silent Errors ([#](https://github.com/expo/expo/pull/) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 
 ### 🎉 New features
 

--- a/packages/@expo/cli/e2e/__tests__/__snapshots__/prebuild-test.ts.snap
+++ b/packages/@expo/cli/e2e/__tests__/__snapshots__/prebuild-test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`runs \`npx expo prebuild --template <github-url>\` 1`] = `
+exports[`prebuild from github runs \`npx expo prebuild --template <github-url>\` 1`] = `
 [
   "App.js",
   "android/.gitignore",

--- a/packages/@expo/cli/e2e/__tests__/__snapshots__/prebuild-test.ts.snap
+++ b/packages/@expo/cli/e2e/__tests__/__snapshots__/prebuild-test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`prebuild from github runs \`npx expo prebuild --template <github-url>\` 1`] = `
+exports[`runs \`npx expo prebuild --template <github-url>\` 1`] = `
 [
   "App.js",
   "android/.gitignore",

--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -8,6 +8,7 @@ import {
   getLoadedModulesAsync,
   setupTestProjectWithOptionsAsync,
   findProjectFiles,
+  stripWhitespace,
 } from './utils';
 import { executeBunAsync, executeExpoAsync } from '../utils/expo';
 
@@ -267,8 +268,29 @@ describe('expo-router integration', () => {
       '@react-navigation/native': '6.1.18',
     });
 
-    // Run `--fix` project dependencies with expo@52 and expo-router from source
-    await executeExpoAsync(projectRoot, ['install', '--fix']);
+    let error: unknown = undefined;
+    try {
+      // Run `--fix` project dependencies with expo@52 and expo-router from source
+      await executeExpoAsync(projectRoot, ['install', '--fix']);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeDefined();
+    expect((error as Error).message).toContain(
+      'Cannot automatically write to dynamic config at: app.config.js'
+    );
+    expect(stripWhitespace((error as Error).message)).toContain(
+      stripWhitespace(`
+        Add the following to your Expo config
+
+        {
+          "plugins": [
+            "expo-router"
+          ]
+        }
+      `)
+    );
 
     // Ensure `@react-navigation/native` was updated
     expect(pkg.read().dependencies).toMatchObject({

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -17,6 +17,9 @@ import { createPackageTarball } from '../utils/package';
 const originalForceColor = process.env.FORCE_COLOR;
 const originalCI = process.env.CI;
 
+// to avoid flaky fail when testing prebuild form github template
+jest.retryTimes(3, { logErrorsBeforeRetry: true });
+
 beforeAll(async () => {
   await fs.mkdir(projectRoot, { recursive: true });
   process.env.FORCE_COLOR = '0';
@@ -227,7 +230,6 @@ itNotWindows('runs `npx expo prebuild --template <invalid-url>`', async () => {
     'with-blank',
     { reuseExisting: false }
   );
-  const pkg = new JsonFile(path.resolve(projectRoot, 'package.json'));
 
   const expoPackage = require(path.join(projectRoot, 'package.json')).dependencies.expo;
   const expoSdkVersion = semver.minVersion(expoPackage)?.major;
@@ -237,57 +239,64 @@ itNotWindows('runs `npx expo prebuild --template <invalid-url>`', async () => {
 
   const templateUrl = `https://github.com/expo/expo/tree/sdk-${expoSdkVersion}/templates/this-template-does-not-exist`;
 
-  let failed = false;
+  let error: unknown = undefined;
   try {
     await executeExpoAsync(projectRoot, ['prebuild', '--no-install', '--template', templateUrl], {
       // To avoid error log output in tests
       verbose: false,
     });
   } catch (e) {
-    failed = true;
+    error = e;
   }
 
-  expect(failed).toBeTruthy();
+  expect(error).toBeDefined();
+  expect(error).toMatchObject({
+    message: expect.stringContaining(`Could not locate the repository for "${templateUrl}".`),
+  });
+  expect(error).toMatchObject({
+    message: expect.stringContaining(`Failed to create the native directories`),
+  });
+  expect(findProjectFiles(projectRoot)).toEqual(
+    expect.not.arrayContaining([
+      expect.stringMatching(/^ios\//),
+      expect.stringMatching(/^android\//),
+    ])
+  );
 });
 
-describe('prebuild from github', () => {
-  // scope retry only for the github url test
-  jest.retryTimes(3, { logErrorsBeforeRetry: true });
+itNotWindows('runs `npx expo prebuild --template <github-url>`', async () => {
+  const projectRoot = await setupTestProjectWithOptionsAsync(
+    'github-template-prebuild',
+    'with-blank',
+    { reuseExisting: false }
+  );
+  const pkg = new JsonFile(path.resolve(projectRoot, 'package.json'));
 
-  itNotWindows('runs `npx expo prebuild --template <github-url>`', async () => {
-    const projectRoot = await setupTestProjectWithOptionsAsync(
-      'github-template-prebuild',
-      'with-blank',
-      { reuseExisting: false }
-    );
-    const pkg = new JsonFile(path.resolve(projectRoot, 'package.json'));
+  const expoPackage = require(path.join(projectRoot, 'package.json')).dependencies.expo;
+  const expoSdkVersion = semver.minVersion(expoPackage)?.major;
+  if (!expoSdkVersion) {
+    throw new Error('Could not determine Expo SDK major version from template');
+  }
 
-    const expoPackage = require(path.join(projectRoot, 'package.json')).dependencies.expo;
-    const expoSdkVersion = semver.minVersion(expoPackage)?.major;
-    if (!expoSdkVersion) {
-      throw new Error('Could not determine Expo SDK major version from template');
-    }
+  const templateUrl = `https://github.com/expo/expo/tree/sdk-${expoSdkVersion}/templates/expo-template-bare-minimum`;
 
-    const templateUrl = `https://github.com/expo/expo/tree/sdk-${expoSdkVersion}/templates/expo-template-bare-minimum`;
+  await executeExpoAsync(projectRoot, ['prebuild', '--no-install', '--template', templateUrl]);
 
-    await executeExpoAsync(projectRoot, ['prebuild', '--no-install', '--template', templateUrl]);
-
-    // Added new packages
-    expect(pkg.read().dependencies).toMatchObject({
-      expo: expect.any(String),
-      react: expect.any(String),
-      'react-native': expect.any(String),
-    });
-
-    // Updated scripts
-    expect(pkg.read().scripts).toMatchObject({
-      android: 'expo run:android',
-      ios: 'expo run:ios',
-    });
-
-    // If this changes then everything else probably changed as well.
-    expect(findProjectFiles(projectRoot)).toMatchSnapshot();
+  // Added new packages
+  expect(pkg.read().dependencies).toMatchObject({
+    expo: expect.any(String),
+    react: expect.any(String),
+    'react-native': expect.any(String),
   });
+
+  // Updated scripts
+  expect(pkg.read().scripts).toMatchObject({
+    android: 'expo run:android',
+    ios: 'expo run:ios',
+  });
+
+  // If this changes then everything else probably changed as well.
+  expect(findProjectFiles(projectRoot)).toMatchSnapshot();
 });
 
 // Regression test for https://github.com/expo/expo/issues/36289

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -221,7 +221,7 @@ itNotWindows('runs `npx expo prebuild --template expo-template-bare-minimum@50.0
 });
 
 // This tests contains assertions related to ios files, making it incompatible with Windows
-itNotWindows('runs `npx expo prebuild --template <github-url>`', async () => {
+itNotWindows('runs `npx expo prebuild --template <invalid-url>`', async () => {
   const projectRoot = await setupTestProjectWithOptionsAsync(
     'github-template-prebuild',
     'with-blank',
@@ -235,25 +235,59 @@ itNotWindows('runs `npx expo prebuild --template <github-url>`', async () => {
     throw new Error('Could not determine Expo SDK major version from template');
   }
 
-  const templateUrl = `https://github.com/expo/expo/tree/sdk-${expoSdkVersion}/templates/expo-template-bare-minimum`;
+  const templateUrl = `https://github.com/expo/expo/tree/sdk-${expoSdkVersion}/templates/this-template-does-not-exist`;
 
-  await executeExpoAsync(projectRoot, ['prebuild', '--no-install', '--template', templateUrl]);
+  let failed = false;
+  try {
+    await executeExpoAsync(projectRoot, ['prebuild', '--no-install', '--template', templateUrl], {
+      // To avoid error log output in tests
+      verbose: false,
+    });
+  } catch (e) {
+    failed = true;
+  }
 
-  // Added new packages
-  expect(pkg.read().dependencies).toMatchObject({
-    expo: expect.any(String),
-    react: expect.any(String),
-    'react-native': expect.any(String),
+  expect(failed).toBeTruthy();
+});
+
+describe('prebuild from github', () => {
+  // scope retry only for the github url test
+  jest.retryTimes(3, { logErrorsBeforeRetry: true });
+
+  itNotWindows('runs `npx expo prebuild --template <github-url>`', async () => {
+    const projectRoot = await setupTestProjectWithOptionsAsync(
+      'github-template-prebuild',
+      'with-blank',
+      { reuseExisting: false }
+    );
+    const pkg = new JsonFile(path.resolve(projectRoot, 'package.json'));
+
+    const expoPackage = require(path.join(projectRoot, 'package.json')).dependencies.expo;
+    const expoSdkVersion = semver.minVersion(expoPackage)?.major;
+    if (!expoSdkVersion) {
+      throw new Error('Could not determine Expo SDK major version from template');
+    }
+
+    const templateUrl = `https://github.com/expo/expo/tree/sdk-${expoSdkVersion}/templates/expo-template-bare-minimum`;
+
+    await executeExpoAsync(projectRoot, ['prebuild', '--no-install', '--template', templateUrl]);
+
+    // Added new packages
+    expect(pkg.read().dependencies).toMatchObject({
+      expo: expect.any(String),
+      react: expect.any(String),
+      'react-native': expect.any(String),
+    });
+
+    // Updated scripts
+    expect(pkg.read().scripts).toMatchObject({
+      android: 'expo run:android',
+      ios: 'expo run:ios',
+    });
+
+    // If this changes then everything else probably changed as well.
+    expect(findProjectFiles(projectRoot)).toMatchSnapshot();
   });
-
-  // Updated scripts
-  expect(pkg.read().scripts).toMatchObject({
-    android: 'expo run:android',
-    ios: 'expo run:ios',
-  });
-
-  // If this changes then everything else probably changed as well.
-  expect(findProjectFiles(projectRoot)).toMatchSnapshot();
 });
 
 // Regression test for https://github.com/expo/expo/issues/36289

--- a/packages/@expo/cli/e2e/__tests__/utils.ts
+++ b/packages/@expo/cli/e2e/__tests__/utils.ts
@@ -300,3 +300,7 @@ export function findProjectFiles(projectRoot: string) {
     .filter(Boolean)
     .sort() as string[];
 }
+
+export function stripWhitespace(str: string): string {
+  return str.replace(/\s+/g, '').trim();
+}

--- a/packages/@expo/cli/src/utils/errors.ts
+++ b/packages/@expo/cli/src/utils/errors.ts
@@ -57,7 +57,7 @@ export function logCmdError(error: any): never {
   }
   if (error instanceof AbortCommandError || error instanceof SilentError) {
     // Do nothing, this is used for prompts or other cases that were custom logged.
-    process.exit(0);
+    process.exit(1);
   } else if (
     error instanceof CommandError ||
     error instanceof AssertionError ||


### PR DESCRIPTION
This PR changes the `expo/cli` return code for `Silent` and `AbortCommand` errors from `0` to `1`. This ensures the error can be detected in CI and/or in our own tests.

This PR ands retry to the GitHub url template test and adds one more test checking the error code and message with invalid url.

Fixes [ENG-16690](https://linear.app/expo/issue/ENG-16690/fix-flaky-test-npx-expo-prebuild-template-github-url)