### PR TITLE
[sdk-54] Update `react-native-screens` to 4.13.1

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3500,7 +3500,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNScreens (4.11.1-nightly-20250611-8b82e081e):
+  - RNScreens (4.13.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3528,10 +3528,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.11.1-nightly-20250611-8b82e081e)
+    - RNScreens/common (= 4.13.1)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.11.1-nightly-20250611-8b82e081e):
+  - RNScreens/common (4.13.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -4420,7 +4420,7 @@ SPEC CHECKSUMS:
   RNFlashList: 995a7cad345dcb6f203db0f50bcf4b83cc04f3c9
   RNGestureHandler: 9d04ec6e1379b595222c2467f5e8d1c44157fcc9
   RNReanimated: 9afbfc6ca21aea3291cc058334b53b6069a2808b
-  RNScreens: 9ad148de25aabec3bd8aa81d1709ad70f7fec7cc
+  RNScreens: 75074e642b69b086813a943bdf63da7085fb2166
   RNSVG: c73af7848d94ca3e8136a5191d055e3c1d6fedab
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
@@ -4431,6 +4431,6 @@ SPEC CHECKSUMS:
   Yoga: daa1e4de4b971b977b23bc842aaa3e135324f1f3
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: a4b563d9d9c73e29b619314cb8136ce02bea61e0
+PODFILE CHECKSUM: f5d503a683b23e49517a81aa6eeffbc2b323828a
 
 COCOAPODS: 1.16.2

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -70,7 +70,7 @@
     "react-native-pager-view": "6.7.1",
     "react-native-reanimated": "3.18.0",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "4.11.1-nightly-20250611-8b82e081e",
+    "react-native-screens": "4.13.1",
     "react-native-svg": "15.12.0",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.13.5",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3310,7 +3310,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNScreens (4.11.1-nightly-20250611-8b82e081e):
+  - RNScreens (4.13.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3338,10 +3338,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.11.1-nightly-20250611-8b82e081e)
+    - RNScreens/common (= 4.13.1)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.11.1-nightly-20250611-8b82e081e):
+  - RNScreens/common (4.13.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -4174,7 +4174,7 @@ SPEC CHECKSUMS:
   ExpoWebBrowser: 41dc1db6ed9185a3b80a9f917ba3c62dafd22eec
   EXStructuredHeaders: 1c799cb91e8057e0671610635e5b2109fa295114
   EXTaskManager: 0128b9f39a088b0c762d8d1c42017e6d44200b29
-  EXUpdates: 5cbd41ca43ec772070b5997ce1f51f2e99055731
+  EXUpdates: a8427b57ecd860a4391ee838c73903e76055f3f7
   EXUpdatesInterface: d6c802a2d1d11867523d03a95397957f9ba3d1c7
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 09f03e4b6f42f955734b64a118f86509cc719427
@@ -4287,7 +4287,7 @@ SPEC CHECKSUMS:
   RNFlashList: 995a7cad345dcb6f203db0f50bcf4b83cc04f3c9
   RNGestureHandler: 9d04ec6e1379b595222c2467f5e8d1c44157fcc9
   RNReanimated: 9afbfc6ca21aea3291cc058334b53b6069a2808b
-  RNScreens: 9ad148de25aabec3bd8aa81d1709ad70f7fec7cc
+  RNScreens: 75074e642b69b086813a943bdf63da7085fb2166
   RNSVG: c73af7848d94ca3e8136a5191d055e3c1d6fedab
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
@@ -4307,6 +4307,6 @@ SPEC CHECKSUMS:
   Yoga: daa1e4de4b971b977b23bc842aaa3e135324f1f3
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: ee6901ca120b93e4938c943d3743febeb70fce16
+PODFILE CHECKSUM: 7116bc722000b18e5791b7675731af4a46e3ad5e
 
 COCOAPODS: 1.16.2

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -80,7 +80,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "3.18.0",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "4.11.1-nightly-20250611-8b82e081e",
+    "react-native-screens": "4.13.1",
     "react-native-svg": "15.12.0",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.13.5",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -144,7 +144,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "3.18.0",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "4.11.1-nightly-20250611-8b82e081e",
+    "react-native-screens": "4.13.1",
     "react-native-svg": "15.12.0",
     "react-native-view-shot": "4.0.3",
     "react-native-web": "~0.20.0",

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -32,7 +32,7 @@
     "react": "19.1.0",
     "react-native": "0.80.1",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "4.11.1-nightly-20250611-8b82e081e"
+    "react-native-screens": "4.13.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -42,7 +42,7 @@
     "react": "19.1.0",
     "react-native": "0.80.1",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "4.11.1-nightly-20250611-8b82e081e",
+    "react-native-screens": "4.13.1",
     "react-native-webview": "13.13.5"
   },
   "devDependencies": {

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -17,7 +17,7 @@
     "react": "19.1.0",
     "react-native": "0.80.1",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "4.11.1-nightly-20250611-8b82e081e"
+    "react-native-screens": "4.13.1"
   },
   "devDependencies": {
     "babel-preset-expo": "~13.1.11"

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -100,7 +100,7 @@
   "react-native-maps": "1.20.1",
   "react-native-pager-view": "6.7.1",
   "react-native-reanimated": "~3.18.0",
-  "react-native-screens": "~4.11.1",
+  "react-native-screens": "~4.13.1",
   "react-native-safe-area-context": "5.4.0",
   "react-native-svg": "15.12.0",
   "react-native-view-shot": "4.0.3",

--- a/patches/react-native-screens+4.13.1.patch
+++ b/patches/react-native-screens+4.13.1.patch
@@ -18,10 +18,10 @@ index f3a2363..fa520de 100644
      : UINavigationController <RNSViewControllerDelegate, RNSBottomTabsSpecialEffectsSupporting>
  
 diff --git a/node_modules/react-native-screens/ios/RNSScreenStack.mm b/node_modules/react-native-screens/ios/RNSScreenStack.mm
-index 56481ac..0567296 100644
+index 56481ac..4b65bba 100644
 --- a/node_modules/react-native-screens/ios/RNSScreenStack.mm
 +++ b/node_modules/react-native-screens/ios/RNSScreenStack.mm
-@@ -571,59 +571,65 @@ RNS_IGNORE_SUPER_CALL_END
+@@ -571,59 +571,67 @@ RNS_IGNORE_SUPER_CALL_END
  
    UIViewController *firstModalToBeDismissed = changeRootController.presentedViewController;
  

--- a/patches/react-native-screens+4.13.1.patch
+++ b/patches/react-native-screens+4.13.1.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/react-native-screens/ios/RNSScreenStack.h b/node_modules/react-native-screens/ios/RNSScreenStack.h
-index 71dc7f3..0425e63 100644
+index f3a2363..fa520de 100644
 --- a/node_modules/react-native-screens/ios/RNSScreenStack.h
 +++ b/node_modules/react-native-screens/ios/RNSScreenStack.h
-@@ -9,6 +9,14 @@
+@@ -10,6 +10,14 @@
  
  NS_ASSUME_NONNULL_BEGIN
  
@@ -14,14 +14,14 @@ index 71dc7f3..0425e63 100644
 +
 +@end
 +
- @interface RNSNavigationController : UINavigationController <RNSViewControllerDelegate>
+ @interface RNSNavigationController
+     : UINavigationController <RNSViewControllerDelegate, RNSBottomTabsSpecialEffectsSupporting>
  
- @end
 diff --git a/node_modules/react-native-screens/ios/RNSScreenStack.mm b/node_modules/react-native-screens/ios/RNSScreenStack.mm
-index b3970af..43bc304 100644
+index 56481ac..0567296 100644
 --- a/node_modules/react-native-screens/ios/RNSScreenStack.mm
 +++ b/node_modules/react-native-screens/ios/RNSScreenStack.mm
-@@ -534,58 +534,66 @@ - (void)setModalViewControllers:(NSArray<UIViewController *> *)controllers
+@@ -571,59 +571,65 @@ RNS_IGNORE_SUPER_CALL_END
  
    UIViewController *firstModalToBeDismissed = changeRootController.presentedViewController;
  
@@ -77,9 +77,9 @@ index b3970af..43bc304 100644
 +          // If the modal is owned we let it control whether the dismissal is animated or not. For foreign controllers
 +          // we just assume animation.
 +          const BOOL firstModalToBeDismissedPrefersAnimation = firstModalToBeDismissedIsOwned
-+              ? static_cast<RNSScreen *>(firstModalToBeDismissed).screenView.stackAnimation !=
-+                  RNSScreenStackAnimationNone
-+              : YES;
++          ? static_cast<RNSScreen *>(firstModalToBeDismissed).screenView.stackAnimation !=
++          RNSScreenStackAnimationNone
++          : YES;
 +          [changeRootController dismissViewControllerAnimated:firstModalToBeDismissedPrefersAnimation
 +                                                   completion:finish];
 +        } else {
@@ -88,16 +88,16 @@ index b3970af..43bc304 100644
 +          // immediately present another owned one. Dismissal of the foreign one will be triggered by foreign
 +          // controller.
 +          [[firstModalToBeDismissed transitionCoordinator]
-+              animateAlongsideTransition:nil
-+                              completion:^(id<UIViewControllerTransitionCoordinatorContext> _) {
-+                                finish();
-+                              }];
++           animateAlongsideTransition:nil
++           completion:^(id<UIViewControllerTransitionCoordinatorContext> _) {
++            finish();
++          }];
 +        }
 +        return;
        }
 -      return;
      }
--  }
+   }
  
 -  // changeRootController does not have presentedViewController but it does not mean that no modals are in presentation;
 -  // modals could be presented by another stack (nested / outer), third-party view controller or they could be using
@@ -116,6 +116,7 @@ index b3970af..43bc304 100644
 -    if ([_presentedModals containsObject:topMostVc] && ![controllers containsObject:topMostVc]) {
 -      [changeRootController dismissViewControllerAnimated:YES completion:finish];
 -      return;
+-    }
 +    // changeRootController does not have presentedViewController but it does not mean that no modals are in
 +    // presentation; modals could be presented by another stack (nested / outer), third-party view controller or they
 +    // could be using UIModalPresentationCurrentContext / UIModalPresentationOverCurrentContext presentation styles; in
@@ -124,16 +125,16 @@ index b3970af..43bc304 100644
 +    // top-level controller manually:
 +    UIViewController *reactRootVc = [self findReactRootViewController];
 +    UIViewController *topMostVc = [RNSScreenStackView findTopMostPresentedViewControllerFromViewController:reactRootVc];
-+
++    
 +    if (topMostVc != reactRootVc) {
 +      changeRootController = topMostVc;
-+
++      
 +      // Here we handle just the simplest case where the top level VC was dismissed. In any more complex
 +      // scenario we will still have problems, see: https://github.com/software-mansion/react-native-screens/issues/1813
 +      if ([_presentedModals containsObject:topMostVc] && ![controllers containsObject:topMostVc]) {
 +        [changeRootController dismissViewControllerAnimated:YES completion:finish];
 +        return;
 +      }
-     }
    }
  
+   // We didn't detect any controllers for dismissal, thus we start presenting new VCs

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -35,7 +35,7 @@
     "react-native-gesture-handler": "~2.26.0",
     "react-native-reanimated": "~3.18.0",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "~4.11.1",
+    "react-native-screens": "~4.13.1",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5"
   },

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -30,7 +30,7 @@
     "react-native": "0.80.1",
     "react-native-reanimated": "~3.18.0",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "~4.11.1",
+    "react-native-screens": "~4.13.1",
     "react-native-web": "~0.20.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13500,10 +13500,15 @@ react-native-iphone-x-helper@^1.0.3:
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
   integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
 
-react-native-is-edge-to-edge@1.1.7, react-native-is-edge-to-edge@^1.1.6, react-native-is-edge-to-edge@^1.1.7:
+react-native-is-edge-to-edge@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz#28947688f9fafd584e73a4f935ea9603bd9b1939"
   integrity sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==
+
+react-native-is-edge-to-edge@^1.1.6, react-native-is-edge-to-edge@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz#64e10851abd9d176cbf2b40562f751622bde3358"
+  integrity sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==
 
 react-native-keyboard-aware-scroll-view@^0.9.5:
   version "0.9.5"
@@ -13564,13 +13569,13 @@ react-native-safe-area-context@5.4.0:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz#04b51940408c114f75628a12a93569d30c525454"
   integrity sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==
 
-react-native-screens@4.11.1-nightly-20250611-8b82e081e:
-  version "4.11.1-nightly-20250611-8b82e081e"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.11.1-nightly-20250611-8b82e081e.tgz#fa41372cc3a31b217513758597b6a9f6a95cd43c"
-  integrity sha512-6hF155fY5z3uuBHG6qYNpu0XuqAKn5omNATzVCAwMPlpiIJ2j+iHOWbYVyqBT8bDnVvcczZT/eloGvt6A2OtEQ==
+react-native-screens@4.13.1:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.13.1.tgz#bf19f09b76dee90b5f7bd8aab3c951a565dd111d"
+  integrity sha512-EESsMAtyzYcL3gpAI2NKKiIo+Ew0fnX4P4b3Zy/+MTc6SJIo3foJbZwdIWd/SUBswOf7IYCvWBppg+D8tbwnsw==
   dependencies:
     react-freeze "^1.0.0"
-    react-native-is-edge-to-edge "^1.1.7"
+    react-native-is-edge-to-edge "^1.2.1"
     warn-once "^0.1.0"
 
 react-native-scrollable-mixin@^1.0.0:


### PR DESCRIPTION
# Why
Closes ENG-16719
Update `react-native-screens` to `4.13.1`

# Test Plan
- Bare Expo ✅
- Expo go ✅
