### PR TITLE
[sdk-54] upgraded `@shopfiy/react-native-skia` -> 2.1.1

### DIFF
--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2365,7 +2365,7 @@ PODS:
     - Yoga
   - react-native-segmented-control (2.5.7):
     - React-Core
-  - react-native-skia (2.0.0-next.4):
+  - react-native-skia (2.1.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -4246,7 +4246,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: adf5c4ae45a4ce743b0ff2855bda83ffce13b4c4
   react-native-safe-area-context: 47c1782a327ca2affa9bec5a2f95534cbabb620a
   react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
-  react-native-skia: 02ffb448bb7c1d181d9b6860274c2ac142331b11
+  react-native-skia: b093318344053a530690ff9e3d2e01f312f885f6
   react-native-slider: 83d77040942794b3994a8c3e116258463326cee5
   react-native-view-shot: a18275ac858eb4866365148517774182319c7aee
   react-native-webview: a53cadbdc946b2d14055284ee9f5f81c1d4817a3

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -39,7 +39,7 @@
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/stack": "^7.2.10",
     "@shopify/flash-list": "1.8.3",
-    "@shopify/react-native-skia": "v2.0.0-next.4",
+    "@shopify/react-native-skia": "2.1.1",
     "@stripe/stripe-react-native": "0.50.1",
     "date-fns": "^2.28.0",
     "dedent": "^0.7.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -50,7 +50,7 @@
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/stack": "^7.2.10",
     "@shopify/flash-list": "1.8.3",
-    "@shopify/react-native-skia": "v2.0.0-next.4",
+    "@shopify/react-native-skia": "2.1.1",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.9",
     "expo": "~53.0.9",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -108,7 +108,7 @@
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~5.1.3",
   "unimodules-image-loader-interface": "~6.1.0",
-  "@shopify/react-native-skia": "v2.0.0-next.4",
+  "@shopify/react-native-skia": "2.1.1",
   "@shopify/flash-list": "1.8.3",
   "@sentry/react-native": "~6.14.0",
   "react-native-bootsplash": "^6.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3405,10 +3405,10 @@
     recyclerlistview "4.2.3"
     tslib "2.8.1"
 
-"@shopify/react-native-skia@v2.0.0-next.4":
-  version "2.0.0-next.4"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-2.0.0-next.4.tgz#eb3e142d9e5cccbc248c3bb232cecd82224758c4"
-  integrity sha512-NzvdgryRz6tkKMHgCChCKa3wXfN9TZhlV0/LrfIU/wKLC1uKgGXkoZgNz7Is0wwdhtao1JJJJ81fqHCGHgzk9g==
+"@shopify/react-native-skia@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-2.1.1.tgz#87af15ad1d5d0f032667bff423bfffa195f27144"
+  integrity sha512-ZLlehE47YqOw3MmBWX6VgJY6vB39vrJpoN35RQaYK+LvhQqH5GB1qhR+LBCjOSgYgHvdapJ89gC+LrpngnfbYQ==
   dependencies:
     canvaskit-wasm "0.40.0"
     react-reconciler "0.31.0"


### PR DESCRIPTION
# Why

- Updated @shopfiy/react-native-skia to version 2.1.1
- Updated podfile.lock in Expo-go

# How

Closes ENG-16711

# Test Plan

Run in ExpoGo

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
