### PR TITLE
[android][go] Add FAB for old dev-menu

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -52,6 +52,7 @@ import host.exp.exponent.kernel.Kernel.KernelStartedRunningEvent
 import host.exp.exponent.kernel.KernelConstants
 import host.exp.exponent.kernel.KernelConstants.ExperienceOptions
 import host.exp.exponent.kernel.KernelProvider
+import host.exp.exponent.kernel.fab.ExperienceFabView
 import host.exp.exponent.notifications.ExponentNotification
 import host.exp.exponent.notifications.ExponentNotificationManager
 import host.exp.exponent.notifications.NotificationConstants
@@ -106,6 +107,9 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
 
   @Inject
   lateinit var devMenuManager: DevMenuManager
+  private val floatingActionButton: ExperienceFabView by lazy {
+    ExperienceFabView(this)
+  }
 
   private val devBundleDownloadProgressListener: DevBundleDownloadProgressListener =
     object : DevBundleDownloadProgressListener {
@@ -330,6 +334,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
   override fun onDoneLoading() {
     reactSurface?.view?.let {
       setReactRootView(it)
+      addReactViewToContentContainer(floatingActionButton)
     }
   }
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/fab/ComposeMovableFloatingActionButton.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/fab/ComposeMovableFloatingActionButton.kt
@@ -1,0 +1,223 @@
+package expo.modules.devmenu.fab
+
+import android.annotation.SuppressLint
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector2D
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.drag
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import com.facebook.react.devsupport.DevInternalSettings
+import expo.modules.devmenu.fab.ExpoVelocityTracker.PointF
+import host.exp.exponent.experience.ExperienceActivity
+import host.exp.expoview.R
+import java.lang.ref.WeakReference
+
+private val FabSize = 56.dp
+private val Margin = 16.dp
+private const val ClickDragTolerance = 40f
+
+private typealias AnimatableOffset = Animatable<Offset, AnimationVector2D>
+
+/**
+ * A floating action button that can be dragged across the screen and springs to the
+ * nearest horizontal edge when released. A tap triggers the onClick action.
+ */
+@SuppressLint("UnusedBoxWithConstraintsScope")
+@Composable
+fun ComposeMovableFloatingActionButton(
+  context: ExperienceActivity,
+  modifier: Modifier = Modifier,
+  fabSize: Dp = FabSize,
+  margin: Dp = Margin,
+) {
+  var visible by remember { mutableStateOf(false) }
+
+  remember {
+    val listener = object : DevInternalSettings.Listener {
+      lateinit var parent: WeakReference<DevInternalSettings>
+      override fun onInternalSettingsChanged() {
+        visible = parent.get()?.isFloatingActionButtonEnabled == true
+      }
+    }
+
+    DevInternalSettings(context, listener).also {
+      visible = it.isFloatingActionButtonEnabled
+      listener.parent = WeakReference(it)
+    }
+  }
+
+  BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+    val totalFabSize = fabSize + margin * 2
+    val totalFabSizePx = with(LocalDensity.current) { totalFabSize.toPx() }
+    val bounds = Offset(
+      x = constraints.maxWidth - totalFabSizePx,
+      y = constraints.maxHeight - totalFabSizePx
+    )
+
+    val previousBounds = rememberPrevious(bounds)
+
+    // Use our velocity tracker. I couldn't get satisfying results with androidx.compose.ui.input.pointer.util.VelocityTracker
+    val velocityTracker = ExpoVelocityTracker()
+
+    /*
+     * Reasoning for the default FAB position: I assume that we want the users to have to change the FAB position as seldom as possible.
+     * Most of the time apps users (developers testing the app) will read app content that is displayed at around 1/3 of the height of the screen
+     * therefore we probably don't want to have the FAB there because it will be in the way. We also can't it have at the very bottom, because it will often
+     * collide with the bottom tabs. For the very top of the screen - we will collide with screen headers. 75% of the height of the screen seems like a
+     * reasonable default spot. We keep it on the right to make it easier to press for right-handed people.
+     */
+    val defaultOffset = bounds.copy(y = bounds.y * 0.75f)
+    val animatedOffset = remember {
+      Animatable(defaultOffset, Offset.VectorConverter)
+    }
+
+    LaunchedEffect(bounds.x, bounds.y) {
+      previousBounds?.let {
+        val oldX = animatedOffset.value.x
+        val oldY = animatedOffset.value.y
+        val newX = (oldX / previousBounds.x) * bounds.x
+        val newY = (oldY / previousBounds.y) * bounds.y
+        val newTarget = calculateTargetPosition(
+          currentPosition = Offset(newX, newY),
+          velocity = PointF(0f, 0f),
+          bounds = bounds,
+          totalFabSizePx = totalFabSizePx
+        )
+
+        animatedOffset.snapTo(newTarget)
+      }
+    }
+
+    AnimatedVisibility(
+      visible = visible,
+      enter = fadeIn(),
+      exit = fadeOut()
+    ) {
+      Box(
+        modifier = Modifier
+          .offset { animatedOffset.value.toIntOffset() }
+          .size(totalFabSize)
+          .padding(margin)
+          .shadow(8.dp, CircleShape)
+          .clip(CircleShape)
+          .clickable {}
+          .background(Color.White)
+          .pointerInput(bounds.x, bounds.y) {
+            coroutineScope {
+              while (true) {
+                awaitPointerEventScope {
+                  // React to the first touch down event
+                  val pointerId = awaitFirstDown().id
+
+                  launch {
+                    animatedOffset.stop()
+                  }
+
+                  // React to drag
+                  var dragDistance = 0f
+                  var dragOffset = animatedOffset.value
+
+                  drag(pointerId) { change ->
+                    dragOffset = (dragOffset + change.positionChange())
+                      .coerceIn(maxX = bounds.x, maxY = bounds.y)
+                    dragDistance += change.positionChange().getDistance()
+                    velocityTracker.registerPosition(dragOffset.x, dragOffset.y)
+                    change.consume()
+
+                    // Only start moving after sufficient drag
+                    if (dragDistance > ClickDragTolerance) {
+                      launch {
+                        animatedOffset.animateTo(dragOffset)
+                      }
+                    }
+                  }
+
+                  // React to touch release
+                  if (dragDistance < ClickDragTolerance) {
+                    context.toggleDevMenu()
+                    velocityTracker.clear()
+                  } else {
+                    handleRelease(
+                      animatedOffset,
+                      velocityTracker,
+                      totalFabSizePx,
+                      bounds
+                    )
+                  }
+                }
+              }
+            }
+          },
+        contentAlignment = Alignment.Center
+      ) {
+        Image(
+          // TODO: @behenate Get a proper icon for the dev menu.
+          painter = painterResource(id = R.drawable.big_logo_dark),
+          contentDescription = "Pull up the dev menu"
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Handles the release of the FAB, calculating momentum and animating it to the nearest edge.
+ */
+private fun CoroutineScope.handleRelease(
+  animatedOffset: AnimatableOffset,
+  velocityTracker: ExpoVelocityTracker,
+  totalFabSizePx: Float,
+  bounds: Offset
+) {
+  val velocity = velocityTracker.calculateVelocity()
+  val newOffset = calculateTargetPosition(animatedOffset.value, velocity, bounds, totalFabSizePx)
+
+  velocityTracker.clear()
+  launch {
+    animatedOffset.animateTo(
+      targetValue = newOffset,
+      animationSpec = spring(
+        dampingRatio = Spring.DampingRatioLowBouncy, // Spring.DampingRatioLowBouncy > 0.65f > Spring.DampingRatioMediumBouncy
+        stiffness = Spring.StiffnessLow
+      ),
+      initialVelocity = Offset(velocity.x, velocity.y)
+    )
+  }
+}

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/fab/ExperienceFabView.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/fab/ExperienceFabView.kt
@@ -1,0 +1,22 @@
+package host.exp.exponent.kernel.fab
+
+import android.annotation.SuppressLint
+import android.widget.LinearLayout
+import androidx.compose.ui.platform.ComposeView
+import expo.modules.devmenu.fab.ComposeMovableFloatingActionButton
+import host.exp.exponent.experience.ExperienceActivity
+
+@SuppressLint("ViewConstructor")
+class ExperienceFabView(
+  context: ExperienceActivity,
+): LinearLayout(context) {
+  init {
+    addView(
+      ComposeView(context).apply {
+        setContent {
+          ComposeMovableFloatingActionButton(context)
+        }
+      }
+    )
+  }
+}

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/fab/ExpoVelocityTracker.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/fab/ExpoVelocityTracker.kt
@@ -1,0 +1,65 @@
+package expo.modules.devmenu.fab
+
+import java.util.LinkedList
+
+/**
+ * Velocity tracker to calculate the rate of change of a 2D position
+ * over a specific time window.
+ *
+ * @param timeFrameMillis Timeframe duration of the points for velocity calculation.
+ * Positions older than this will be discarded.
+ */
+internal class ExpoVelocityTracker(private val timeFrameMillis: Long = 100L) {
+  data class PointF(val x: Float, val y: Float)
+  private data class PositionSnapshot(val point: PointF, val timestamp: Long)
+
+  private val positions = LinkedList<PositionSnapshot>()
+
+  fun registerPosition(x: Float, y: Float) {
+    val snapshot = PositionSnapshot(PointF(x, y), System.currentTimeMillis())
+    positions.add(snapshot)
+    pruneOldPositions()
+  }
+
+  /**
+   * Calculates the average velocity in pixels per second between the oldest and newest
+   * data points within the defined `timeFrameMillis`.
+   */
+  fun calculateVelocity(): PointF {
+    pruneOldPositions()
+
+    if (positions.size < 2) {
+      return PointF(0f, 0f)
+    }
+
+    val first = positions.first()
+    val last = positions.last()
+
+    val deltaTimeSeconds = (last.timestamp - first.timestamp) / 1000.0f
+
+    if (deltaTimeSeconds == 0f) {
+      return PointF(0f, 0f)
+    }
+
+    val deltaX = last.point.x - first.point.x
+    val deltaY = last.point.y - first.point.y
+
+    val velocityX = deltaX / deltaTimeSeconds
+    val velocityY = deltaY / deltaTimeSeconds
+
+    return PointF(velocityX, velocityY)
+  }
+
+  private fun pruneOldPositions() {
+    val currentTime = System.currentTimeMillis()
+    val cutoffTime = currentTime - timeFrameMillis
+
+    while (positions.isNotEmpty() && positions.first().timestamp < cutoffTime) {
+      positions.pollFirst()
+    }
+  }
+
+  fun clear() {
+    positions.clear()
+  }
+}

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/fab/FabUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/fab/FabUtils.kt
@@ -1,0 +1,60 @@
+package expo.modules.devmenu.fab
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntOffset
+import expo.modules.devmenu.fab.ExpoVelocityTracker.PointF
+import kotlin.math.roundToInt
+
+/**
+ * Finds an appropriate resting position for the fab based on it's position velocity and size.
+ */
+internal fun calculateTargetPosition(
+  currentPosition: Offset,
+  velocity: PointF,
+  bounds: Offset,
+  totalFabSizePx: Float
+): Offset {
+  // Simulate the bubble keeping the movement momentum
+  // I've found that these values feel good (assume that the bubble keeps the momentum for ~100ms)
+  val momentumOffsetX = velocity.x / 10f
+  val momentumOffsetY = velocity.y / 10f
+  val offsetXWithMomentumEstimate = currentPosition.x + totalFabSizePx / 2 + momentumOffsetX
+  val targetX = if (offsetXWithMomentumEstimate < bounds.x / 2) {
+    0f
+  } else {
+    bounds.x
+  }
+  val targetY = currentPosition.y + momentumOffsetY
+  val newOffset = Offset(targetX, targetY)
+    .coerceIn(maxX = bounds.x, maxY = bounds.y)
+  return newOffset
+}
+
+internal fun Offset.toIntOffset(): IntOffset {
+  return IntOffset(
+    this.x.roundToInt(),
+    this.y.roundToInt()
+  )
+}
+
+internal fun Offset.coerceIn(minX: Float = 0f, maxX: Float, minY: Float = 0f, maxY: Float): Offset {
+  return this.copy(
+    x = this.x.coerceIn(minX, maxX),
+    y = this.y.coerceIn(minY, maxY)
+  )
+}
+
+@Composable
+internal fun <T> rememberPrevious(current: T): T? {
+  val previousRef = remember { mutableStateOf<T?>(null) }
+
+  LaunchedEffect(current) {
+    previousRef.value = current
+  }
+
+  return previousRef.value
+}

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
@@ -1,9 +1,11 @@
 package versioned.host.exp.exponent.modules.internal
-
+import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
 import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -11,6 +13,8 @@ import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.devsupport.DevInternalSettings
 import com.facebook.react.devsupport.HMRClient
 import com.facebook.react.devsupport.interfaces.DevSupportManager
+import com.reactnativekeyboardcontroller.extensions.removeSelf
+import expo.modules.devmenu.fab.ComposeMovableFloatingActionButton
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.experience.ExperienceActivity
@@ -22,6 +26,7 @@ import host.exp.expoview.Exponent
 import host.exp.expoview.R
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.lang.ref.WeakReference
 import java.util.UUID
 import javax.inject.Inject
 
@@ -78,6 +83,7 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
     val debuggerMap = Bundle()
     val hmrMap = Bundle()
     val perfMap = Bundle()
+    val fabMap = Bundle()
 
     if (devSettings != null && devSupportManager.devSupportEnabled) {
       inspectorMap.putString("label", getString(if (devSettings.isElementInspectorEnabled) R.string.devmenu_hide_element_inspector else R.string.devmenu_show_element_inspector))
@@ -93,6 +99,17 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
       debuggerMap.putBoolean("isEnabled", devSupportManager.devSupportEnabled)
       items.putBundle("dev-remote-debug", debuggerMap)
     }
+
+    if (devSettings != null && devSupportManager.devSupportEnabled) {
+      val label = if (devSettings.isFloatingActionButtonEnabled) {
+        getString(R.string.devmenu_hide_fab)
+      } else {
+        getString(R.string.devmenu_show_fab)
+      }
+      fabMap.putString("label", label)
+      fabMap.putBoolean("isEnabled", true)
+    }
+    items.putBundle("dev-fab", fabMap)
 
     if (devSettings != null && devSupportManager.devSupportEnabled && devSettings is DevInternalSettings) {
       hmrMap.putString("label", getString(if (devSettings.isHotModuleReplacementEnabled) R.string.devmenu_disable_fast_refresh else R.string.devmenu_enable_fast_refresh))
@@ -146,6 +163,9 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
             requestOverlaysPermission()
           }
           devSupportManager.setFpsDebugEnabled(!devSettings.isFpsDebugEnabled)
+        }
+        "dev-fab" -> {
+          devSupportManager.setFloatingActionButtonEnabled(!devSettings.isFloatingActionButtonEnabled)
         }
       }
     }

--- a/apps/expo-go/android/expoview/src/main/res/values/strings.xml
+++ b/apps/expo-go/android/expoview/src/main/res/values/strings.xml
@@ -45,6 +45,8 @@
   <string name="devmenu_open_js_debugger">Open JS Debugger</string>
   <string name="devmenu_disable_fast_refresh">Disable Fast Refresh</string>
   <string name="devmenu_enable_fast_refresh">Enable Fast Refresh</string>
+  <string name="devmenu_show_fab">Show Dev Menu button</string>
+  <string name="devmenu_hide_fab">Hide Dev Menu button</string>
   <string name="devmenu_fast_refresh_unavailable">Fast Refresh Unavailable</string>
   <string name="devmenu_fast_refresh_unavailable_details">Use the Reload button above to reload when in production mode. Switch back to development mode to use Fast Refresh.</string>
   <string name="devmenu_hide_performance_monitor">Hide Performance Monitor</string>

--- a/apps/expo-go/src/menu/DevMenuView.tsx
+++ b/apps/expo-go/src/menu/DevMenuView.tsx
@@ -46,6 +46,7 @@ const MENU_ITEMS_ICON_MAPPINGS: {
   'dev-remote-debug': <ThemedMaterialIcon name="remote-desktop" />,
   'dev-perf-monitor': <ThemedMaterialIcon name="speedometer" />,
   'dev-inspector': <ThemedMaterialIcon name="border-style" />,
+  'dev-fab': <ThemedMaterialIcon name="chart-bubble" />,
 };
 
 export function DevMenuView({ uuid, task }: Props) {


### PR DESCRIPTION
# Why

I've added FAB support to the new dev-menu, but we won't use it in the SDK 54 version of expo go. Therefore I've added it to the current expo-go dev-menu.

This PR depends on the changes introduced in there:
https://github.com/expo/react-native/pull/41
Once above is merged we should change the commit hash for the react-native-labs submodule in this PR.

# How

Copied the FAB implementation to expo-go, updated it slightly to work with the setup in Expo Go. The FAB is added above the app content, but below the dev menu, so it stays in the background once the dev menu is pulled up.
I have also added a button to show/hide the button into the dev-menu.

# Test Plan

Tested in Expo Go running NCL on an Android 16 device.
