### PR TITLE
[docs] Remove non-existing import from API routes example

### DIFF
--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -180,8 +180,6 @@ export function GET() {
 You can respond to server errors by using the `Response` object.
 
 ```ts app/blog/[post].ts
-import { Request, Response } from 'expo-router/server';
-
 export async function GET(request: Request, { post }: Record<string, string>) {
   if (!post) {
     return new Response('No post found', {


### PR DESCRIPTION
## Why
The Request and Response exports do not exist anymore. This is the last place in the codebase I've noticed them being used. 

https://github.com/expo/expo/blob/60b028cb6220b412a5af6cc3b474501ea32179d8/packages/%40expo/server/build/environment.d.ts#L30-L42