### PR TITLE
[media-library][android] Add context and ensureActivity to suspend functions

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### 💡 Others
 
+- [Android] Migrate to coroutines. ([#38193](https://github.com/expo/expo/pull/38193) by [@Wenszel](http://github.com/wenszel))
+
 ## 17.1.7 - 2025-06-04
 
 ### 🐛 Bug fixes

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -80,7 +80,11 @@ object MediaLibraryUtils {
     }
   }
 
-  fun deleteAssets(context: Context, selection: String?, selectionArgs: Array<out String?>?): Boolean {
+  suspend fun deleteAssets(
+    context: Context,
+    selection: String?,
+    selectionArgs: Array<out String?>?
+  ): Boolean = withContext(Dispatchers.IO) {
     val projection = arrayOf(MediaStore.MediaColumns._ID, MediaStore.MediaColumns.DATA)
     try {
       context.contentResolver.query(
@@ -92,33 +96,37 @@ object MediaLibraryUtils {
       ).use { filesToDelete ->
         if (filesToDelete == null) {
           throw AssetFileException("Could not delete assets. Cursor is null.")
-        }
-        while (filesToDelete.moveToNext()) {
-          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            val columnId = filesToDelete.getColumnIndex(MediaStore.MediaColumns._ID)
-            val id = filesToDelete.getLong(columnId)
-            val assetUri = ContentUris.withAppendedId(EXTERNAL_CONTENT_URI, id)
-            val rowsDeleted = context.contentResolver.delete(assetUri, null)
-            if (rowsDeleted == 0) {
-              throw AssetFileException("Could not delete file.")
-            }
-          } else {
-            val dataColumnIndex = filesToDelete.getColumnIndex(MediaStore.MediaColumns.DATA)
-            val filePath = filesToDelete.getString(dataColumnIndex)
-            val file = File(filePath)
-            if (file.delete()) {
-              context.contentResolver.delete(
-                EXTERNAL_CONTENT_URI,
-                "${MediaStore.MediaColumns.DATA}=?",
-                arrayOf(filePath)
-              )
+        } else {
+          while (filesToDelete.moveToNext()) {
+            // Interrupting file deletion when scope is closed is desired, as
+            // user might want to stop this process in the meantime
+            coroutineContext.ensureActive()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+              val columnId = filesToDelete.getColumnIndex(MediaStore.MediaColumns._ID)
+              val id = filesToDelete.getLong(columnId)
+              val assetUri = ContentUris.withAppendedId(EXTERNAL_CONTENT_URI, id)
+              val rowsDeleted = context.contentResolver.delete(assetUri, null)
+              if (rowsDeleted == 0) {
+                throw AssetFileException("Could not delete file.")
+              }
             } else {
-              throw AssetFileException("Could not delete file.")
+              val dataColumnIndex = filesToDelete.getColumnIndex(MediaStore.MediaColumns.DATA)
+              val filePath = filesToDelete.getString(dataColumnIndex)
+              val file = File(filePath)
+              if (file.delete()) {
+                context.contentResolver.delete(
+                  EXTERNAL_CONTENT_URI,
+                  "${MediaStore.MediaColumns.DATA}=?",
+                  arrayOf(filePath)
+                )
+              } else {
+                throw AssetFileException("Could not delete file.")
+              }
             }
           }
         }
-        return true
       }
+      return@withContext true
     } catch (e: SecurityException) {
       throw UnableToDeleteException("Could not delete asset: need WRITE_EXTERNAL_STORAGE permission.", e)
     } catch (e: Exception) {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -266,15 +266,10 @@ object MediaLibraryUtils {
   fun hasManifestPermission(context: Context, permission: String): Boolean =
     getManifestPermissions(context).contains(permission)
 
-  suspend fun scanFile(
-    context: Context,
-    paths: Array<String>,
-    mimeTypes: Array<String>?
-  ) = withContext(Dispatchers.IO) {
+  suspend fun scanFile(context: Context, paths: Array<String>, mimeTypes: Array<String>?) =
     suspendCoroutine { complete ->
       MediaScannerConnection.scanFile(context, paths, mimeTypes) { path: String, uri: Uri? ->
         complete.resume(Pair(path, uri))
       }
     }
-  }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryUtils.kt
@@ -269,7 +269,7 @@ object MediaLibraryUtils {
   suspend fun scanFile(
     context: Context,
     paths: Array<String>,
-    mimeTypes: Array<String>?,
+    mimeTypes: Array<String>?
   ) = withContext(Dispatchers.IO) {
     suspendCoroutine { complete ->
       MediaScannerConnection.scanFile(context, paths, mimeTypes) { path: String, uri: Uri? ->

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/AddAssetsToAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/AddAssetsToAlbum.kt
@@ -16,7 +16,7 @@ suspend fun addAssetsToAlbum(
   assetIds: Array<String>,
   albumId: String,
   copyToAlbum: Boolean
-): Boolean = withContext(Dispatchers.IO){
+): Boolean = withContext(Dispatchers.IO) {
   val strategy = if (copyToAlbum) {
     AssetFileStrategy.copyStrategy
   } else {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/CreateAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/CreateAlbum.kt
@@ -20,7 +20,7 @@ suspend fun createAlbum(
   albumName: String,
   assetId: String,
   copyAsset: Boolean
-): Bundle? = withContext(Dispatchers.IO){
+): Bundle? = withContext(Dispatchers.IO) {
   try {
     val mStrategy = if (copyAsset) AssetFileStrategy.copyStrategy else AssetFileStrategy.moveStrategy
     val files = MediaLibraryUtils.getAssetsById(context, assetId)

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/DeleteAlbums.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/DeleteAlbums.kt
@@ -5,7 +5,7 @@ import android.provider.MediaStore
 import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.MediaLibraryUtils.queryPlaceholdersFor
 
-fun deleteAlbums(context: Context, albumIds: Array<String>): Boolean {
+suspend fun deleteAlbums(context: Context, albumIds: Array<String>): Boolean {
   val selectionImages = "${MediaStore.Images.Media.BUCKET_ID} IN (${queryPlaceholdersFor(albumIds)})"
   val selectionVideos = "${MediaStore.Video.Media.BUCKET_ID} IN (${queryPlaceholdersFor(albumIds)})"
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/GetAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/GetAlbum.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import android.provider.MediaStore.Files.FileColumns
 import android.provider.MediaStore.MediaColumns
 
-fun getAlbum(context: Context, albumName: String): Bundle? {
+suspend fun getAlbum(context: Context, albumName: String): Bundle? {
   val selection = "${FileColumns.MEDIA_TYPE} != ${FileColumns.MEDIA_TYPE_NONE}" +
     " AND ${MediaColumns.BUCKET_DISPLAY_NAME}=?"
   val selectionArgs = arrayOf(albumName)

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/RemoveAssetsFromAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/RemoveAssetsFromAlbum.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.provider.MediaStore.Images.Media
 import expo.modules.medialibrary.MediaLibraryUtils
 
-fun removeAssetsFromAlbum(context: Context, assetIds: Array<String>, albumId: String) {
+suspend fun removeAssetsFromAlbum(context: Context, assetIds: Array<String>, albumId: String) {
   val bucketSelection = "${Media.BUCKET_ID}=? AND ${Media._ID} IN (${assetIds.joinToString(",")} )"
   val bucketId = arrayOf(albumId)
   MediaLibraryUtils.deleteAssets(context, bucketSelection, bucketId)

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/migration/CheckIfAlbumShouldBeMigrated.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/migration/CheckIfAlbumShouldBeMigrated.kt
@@ -6,10 +6,13 @@ import android.provider.MediaStore
 import androidx.annotation.RequiresApi
 import expo.modules.medialibrary.AlbumNotFound
 import expo.modules.medialibrary.EXTERNAL_CONTENT_URI
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
 import java.io.File
 
 @RequiresApi(Build.VERSION_CODES.R)
-fun checkIfAlbumShouldBeMigrated(context: Context, albumId: String): Boolean {
+suspend fun checkIfAlbumShouldBeMigrated(context: Context, albumId: String): Boolean {
   val albumDir = getAlbumDirectory(context, albumId)
   if (albumDir == null) {
     throw AlbumNotFound()
@@ -22,7 +25,10 @@ fun checkIfAlbumShouldBeMigrated(context: Context, albumId: String): Boolean {
  * Returns directory for given Album ID (`BUCKET_ID` column) or `null` if album not found.
  */
 @RequiresApi(Build.VERSION_CODES.R)
-private fun getAlbumDirectory(context: Context, albumId: String): File? {
+private suspend fun getAlbumDirectory(
+  context: Context,
+  albumId: String
+): File? = withContext(Dispatchers.IO) {
   val selection =
     "${MediaStore.Files.FileColumns.MEDIA_TYPE} != ${MediaStore.Files.FileColumns.MEDIA_TYPE_NONE}" +
       " AND ${MediaStore.MediaColumns.BUCKET_ID}=?"
@@ -35,13 +41,14 @@ private fun getAlbumDirectory(context: Context, albumId: String): File? {
     selectionArgs,
     null
   ).use { albumCursor ->
+    coroutineContext.ensureActive()
     if (albumCursor != null && albumCursor.moveToNext()) {
       val dataColumnIndex = albumCursor.getColumnIndex(MediaStore.Images.Media.DATA)
       val fileInAlbum = File(albumCursor.getString(dataColumnIndex))
       if (fileInAlbum.isFile) {
-        return File(fileInAlbum.parent ?: return null)
+        return@withContext File(fileInAlbum.parent ?: return@withContext null)
       }
     }
   }
-  return null
+  return@withContext null
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/migration/MigrateAlbum.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/albums/migration/MigrateAlbum.kt
@@ -9,10 +9,16 @@ import androidx.annotation.RequiresApi
 import expo.modules.medialibrary.AlbumException
 import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.MediaLibraryUtils.AssetFile
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 
 @RequiresApi(Build.VERSION_CODES.R)
-fun migrateAlbum(context: Context, assetFiles: List<AssetFile>, albumDirName: String) {
+suspend fun migrateAlbum(
+  context: Context,
+  assetFiles: List<AssetFile>,
+  albumDirName: String
+) = withContext(Dispatchers.IO) {
   // Previously, users were able to save different assets type in the same directory.
   // But now, it's not always possible.
   // If album contains movies or pictures, we can move it to Environment.DIRECTORY_PICTURES.

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/CreateAsset.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/CreateAsset.kt
@@ -3,7 +3,6 @@ package expo.modules.medialibrary.assets
 import android.content.ContentUris
 import android.content.ContentValues
 import android.content.Context
-import android.media.MediaScannerConnection
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -18,7 +17,6 @@ import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.UnableToLoadPermissionException
 import expo.modules.medialibrary.UnableToSaveException
 import expo.modules.medialibrary.albums.getAlbumFileOrNull
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/DeleteAssets.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/DeleteAssets.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.provider.MediaStore
 import expo.modules.medialibrary.MediaLibraryUtils
 
-fun deleteAssets(context: Context, assetIds: Array<String>): Boolean {
+suspend fun deleteAssets(context: Context, assetIds: Array<String>): Boolean {
   val selection = "${MediaStore.Images.Media._ID} IN (${assetIds.joinToString(separator = ",")} )"
   val selectionArgs: Array<String>? = null
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/GetAssetInfo.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/GetAssetInfo.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.os.Bundle
 import android.provider.MediaStore
 
-fun getAssetInfo(context: Context, assetId: String): ArrayList<Bundle>? {
+suspend fun getAssetInfo(context: Context, assetId: String): ArrayList<Bundle>? {
   val selection = "${MediaStore.Images.Media._ID}=?"
   val selectionArgs = arrayOf(assetId)
   return queryAssetInfo(context, selection, selectionArgs, true)

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumInfoTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumInfoTests.kt
@@ -10,13 +10,11 @@ import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockCursor
 import expo.modules.medialibrary.throwableContentResolver
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumInfoTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumInfoTests.kt
@@ -9,10 +9,12 @@ import expo.modules.medialibrary.UnableToLoadException
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockCursor
 import expo.modules.medialibrary.throwableContentResolver
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
@@ -33,14 +35,14 @@ internal class GetAlbumInfoTests {
   }
 
   @Test
-  fun `GetAlbum should call queryAlbum`() {
+  fun `getAlbum should call queryAlbum`() = runTest {
     // arrange
     val context = mockContext.get()
     val selectionSlot = slot<String>()
     val selectionArgsSlot = slot<Array<String>>()
 
     mockkStatic(::queryAlbum)
-    every {
+    coEvery {
       queryAlbum(
         context,
         capture(selectionSlot),
@@ -61,7 +63,7 @@ internal class GetAlbumInfoTests {
   }
 
   @Test
-  fun `queryAlbum returns correct values`() {
+  fun `queryAlbum returns correct values`() = runTest {
     // arrange
     val bucketDisplayName = "Some Album Name"
     val selection = MediaStore.Images.Media.BUCKET_DISPLAY_NAME + "=?"
@@ -89,18 +91,21 @@ internal class GetAlbumInfoTests {
   }
 
   @Test
-  fun `queryAlbum should reject on null cursor`() {
+  fun `queryAlbum should reject on null cursor`() = runTest {
     // arrange
     val context = mockContext with mockContentResolver(null)
 
     // act && assert
-    assertThrows(AlbumException::class.java) {
+    try {
       queryAlbum(context, "", emptyArray())
+      fail()
+    } catch (e: Exception) {
+      assert(e is AlbumException)
     }
   }
 
   @Test
-  fun `queryAlbum should reject on SecurityException`() {
+  fun `queryAlbum should reject on SecurityException`() = runTest {
     // arrange
     val context = mockContext with throwableContentResolver(SecurityException())
 
@@ -114,7 +119,7 @@ internal class GetAlbumInfoTests {
   }
 
   @Test
-  fun `queryAlbum should reject on IllegalArgumentException`() {
+  fun `queryAlbum should reject on IllegalArgumentException`() = runTest {
     // arrange
     val context = mockContext with throwableContentResolver(IllegalArgumentException())
 

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumTests.kt
@@ -10,10 +10,12 @@ import expo.modules.medialibrary.MockData
 import expo.modules.medialibrary.UnableToLoadException
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.throwableContentResolver
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
@@ -39,14 +41,14 @@ internal class GetAlbumTests {
   }
 
   @Test
-  fun `GetAlbum should call queryAlbum`() {
+  fun `getAlbum should call queryAlbum`() = runTest {
     // arrange
     val context = mockContext.get()
     val selectionSlot = slot<String>()
     val selectionArgsSlot = slot<Array<String>>()
 
     mockkStatic(::queryAlbum)
-    every {
+    coEvery {
       queryAlbum(
         context,
         capture(selectionSlot),
@@ -67,7 +69,7 @@ internal class GetAlbumTests {
   }
 
   @Test
-  fun `queryAlbum should resolve album by name`() {
+  fun `queryAlbum should resolve album by name`() = runTest {
     // arrange
     val context = mockContext with mockContentResolverForAlbum(
       arrayOf(
@@ -87,7 +89,7 @@ internal class GetAlbumTests {
   }
 
   @Test
-  fun `queryAlbum should resolve null if album is not found`() {
+  fun `queryAlbum should resolve null if album is not found`() = runTest {
     // arrange
     val context = mockContext with mockContentResolverForAlbum(emptyArray())
     val selectionArgs = arrayOf(MockData.mockAlbum.name)
@@ -100,18 +102,21 @@ internal class GetAlbumTests {
   }
 
   @Test
-  fun `queryAlbum should reject on null cursor`() {
+  fun `queryAlbum should reject on null cursor`() = runTest {
     // arrange
     val context = mockContext with mockContentResolver(null)
 
     // act && assert
-    assertThrows(AlbumException::class.java) {
+    try {
       queryAlbum(context, "", emptyArray())
+      fail()
+    } catch (e: Exception) {
+      assert(e is AlbumException)
     }
   }
 
   @Test
-  fun `queryAlbum should reject on SecurityException`() {
+  fun `queryAlbum should reject on SecurityException`() = runTest {
     // arrange
     val context = mockContext with throwableContentResolver(SecurityException())
 
@@ -125,7 +130,7 @@ internal class GetAlbumTests {
   }
 
   @Test
-  fun `queryAlbum should reject on IllegalArgumentException`() {
+  fun `queryAlbum should reject on IllegalArgumentException`() = runTest {
     // arrange
     val context = mockContext with throwableContentResolver(IllegalArgumentException())
 

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumTests.kt
@@ -11,14 +11,12 @@ import expo.modules.medialibrary.UnableToLoadException
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.throwableContentResolver
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertThrows
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumsTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumsTests.kt
@@ -8,6 +8,7 @@ import expo.modules.medialibrary.UnableToLoadException
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockCursor
 import expo.modules.medialibrary.throwableContentResolver
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Assert.fail
@@ -27,7 +28,7 @@ class GetAlbumsTests {
   }
 
   @Test
-  fun `GetAlbums should resolve with correct response`() {
+  fun `getAlbums should resolve with correct response`() = runTest {
     // arrange
     val bucketDisplayName = "Some Album Name"
 
@@ -53,7 +54,7 @@ class GetAlbumsTests {
   }
 
   @Test
-  fun `GetAlbums should not list albums with null name`() {
+  fun `getAlbums should not list albums with null name`() = runTest {
     // arrange
     val bucketId = 123456
     val bucketDisplayName = null
@@ -75,18 +76,21 @@ class GetAlbumsTests {
   }
 
   @Test
-  fun `GetAlbums should reject on null cursor`() {
+  fun `getAlbums should reject on null cursor`() = runTest {
     // arrange
     val context = mockContext with mockContentResolver(null)
 
     // act && assert
-    assertThrows(AlbumException::class.java) {
+    try {
       getAlbums(context)
+      fail()
+    } catch (e: Exception) {
+      assert(e is AlbumException)
     }
   }
 
   @Test
-  fun `GetAlbums should reject on SecurityException`() {
+  fun `getAlbums should reject on SecurityException`() = runTest {
     // arrange
     val context = mockContext with throwableContentResolver(SecurityException())
 
@@ -100,7 +104,7 @@ class GetAlbumsTests {
   }
 
   @Test
-  fun `GetAlbums should reject on IllegalArgumentException`() {
+  fun `getAlbums should reject on IllegalArgumentException`() = runTest {
     // arrange
     val context = mockContext with throwableContentResolver(IllegalArgumentException())
 

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumsTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/albums/GetAlbumsTests.kt
@@ -10,7 +10,6 @@ import expo.modules.medialibrary.mockCursor
 import expo.modules.medialibrary.throwableContentResolver
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
@@ -11,6 +11,7 @@ import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockContentResolverForResult
 import expo.modules.medialibrary.throwableContentResolver
 import io.mockk.clearAllMocks
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -18,6 +19,7 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
 import junit.framework.ComparisonFailure
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
@@ -56,14 +58,14 @@ internal class GetAssetInfoTests {
   }
 
   @Test
-  fun `GetAssetInfo should call queryAssetInfo`() {
+  fun `getAssetInfo should call queryAssetInfo`() = runTest {
     // arrange
     val context = mockContext.get()
     val selectionSlot = slot<String>()
     val selectionArgsSlot = slot<Array<String>>()
 
     mockkStatic(::queryAssetInfo)
-    every {
+    coEvery {
       queryAssetInfo(
         context,
         capture(selectionSlot),
@@ -85,7 +87,7 @@ internal class GetAssetInfoTests {
   }
 
   @Test
-  fun `queryAssetInfo should resolve asset`() {
+  fun `queryAssetInfo should resolve asset`() = runTest {
     // arrange
     val context = mockContext with mockContentResolverForResult(
       arrayOf(
@@ -111,18 +113,21 @@ internal class GetAssetInfoTests {
   }
 
   @Test
-  fun `queryAssetInfo should reject on null cursor`() {
+  fun `queryAssetInfo should reject on null cursor`() = runTest {
     // arrange
     val context = mockContext with mockContentResolver(null)
 
     // act && assert
-    assertThrows(AssetQueryException::class.java) {
+    try {
       queryAssetInfo(context, "", emptyArray(), false)
+      fail()
+    } catch (e: Exception) {
+      assert(e is AssetQueryException)
     }
   }
 
   @Test
-  fun `queryAssetInfo should reject on SecurityException`() {
+  fun `queryAssetInfo should reject on SecurityException`() = runTest {
     // arrange
     val context = mockContext with throwableContentResolver(SecurityException())
 
@@ -136,7 +141,7 @@ internal class GetAssetInfoTests {
   }
 
   @Test
-  fun `queryAssetInfo should reject on IOException`() {
+  fun `queryAssetInfo should reject on IOException`() = runTest {
     // arrange
     val context = mockContext with throwableContentResolver(IOException())
 

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
@@ -22,7 +22,6 @@ import junit.framework.ComparisonFailure
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test


### PR DESCRIPTION
# Why

Depends on: [#38324](https://github.com/expo/expo/pull/38324)

# How

- Added `withContext(Dispatchers.IO)` to appropriate functions
- Added `ensureActive` before and/or after heavy operations
- Added `scanFile` to utils - a suspendable wrapper around `MediaScannerConnection.scanFile`

# Test Plan
Tested on BareExpo ✅
