### PR TITLE
[metro][expo-updates] updated imports in expo-updates

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed imports after upgrading to Metro 0.83
+
 ### 💡 Others
 
 - [Android] Cleanup state machine resources when the module is destroyed. ([#37193](https://github.com/expo/expo/pull/37193) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed imports after upgrading to Metro 0.83
+- Fixed imports after upgrading to Metro 0.83 ([#38375](https://github.com/expo/expo/pull/38375) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -51,6 +51,7 @@
     "resolve-from": "^5.0.0"
   },
   "devDependencies": {
+    "@expo/metro": "~0.1.0",
     "@types/jest": "^29.2.1",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.14.0",

--- a/packages/expo-updates/utils/src/createManifestForBuildAsync.ts
+++ b/packages/expo-updates/utils/src/createManifestForBuildAsync.ts
@@ -3,13 +3,13 @@ import {
   exportEmbedAssetsAsync,
 } from '@expo/cli/build/src/export/embed/exportEmbedAsync';
 import { drawableFileTypes } from '@expo/cli/build/src/export/metroAssetLocalPath';
+import Server from '@expo/metro/metro/Server';
+import type { BundleOptions } from '@expo/metro/metro/shared/types.flow';
 import { HashedAssetData } from '@expo/metro-config/build/transform-worker/getAssets';
 import crypto from 'crypto';
 import { convertEntryPointToRelative, resolveRelativeEntryPoint } from 'expo/config/paths';
 import { EmbeddedManifest } from 'expo-manifests';
 import fs from 'fs';
-import Server from 'metro/src/Server';
-import type { BundleOptions } from 'metro/src/shared/types';
 import path from 'path';
 
 import { filterPlatformAssetScales } from './filterPlatformAssetScales';


### PR DESCRIPTION
# Why

After upgrading to Metro 0.83 we changed how/what we can import from Metro. This causes expo-updates build to fail on CI due to some direct imports from Metro.

# How

This commit fixes this by using the (hopefully) correct imports.

# Test Plan

Make sure CI passes

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
