### PR TITLE
Added shouldShowAlert to notifications example

### DIFF
--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -74,6 +74,7 @@ Notifications.setNotificationHandler({
     shouldSetBadge: true,
     shouldShowBanner: true,
     shouldShowList: true,
+		shouldShowAlert: true,
   }),
 });
 /* @end */


### PR DESCRIPTION
# Why

Without this field you get this TS error:
```
Type 'Promise<{ shouldPlaySound: true; shouldSetBadge: true; shouldShowBanner: boolean; shouldShowList: boolean; }>' is not assignable to type 'Promise<NotificationBehavior>'.
  Property 'shouldShowAlert' is missing in type '{ shouldPlaySound: true; shouldSetBadge: true; shouldShowBanner: boolean; shouldShowList: boolean; }' but required in type 'NotificationBehavior'.ts(2322)
```

# How

I added the field.
```
	handleNotification: async () => ({
		shouldPlaySound: true,
		shouldSetBadge: true,
		shouldShowBanner: true,
		shouldShowList: true,
		shouldShowAlert: true, // here
	}),
```

# Test Plan

No additional tests needed.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
