### PR TITLE
[iOS][screen-capture] Fix issue with header flickering on screenshot prevention on ios

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix permissions on Android 13.
+- [iOS] Fix issue with header flickering on screenshot prevention. ([#38384](https://github.com/expo/expo/pull/38384) by [@hryhoriiK97](https://github.com/hryhoriiK97))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
+++ b/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
@@ -125,7 +125,7 @@ public final class ScreenCaptureModule: Module {
     textField.backgroundColor = UIColor.clear
     textField.frame = UIScreen.main.bounds
 
-    self.originalParent = keyWindow.layer.superlayer
+    originalParent = keyWindow.layer.superlayer
 
     keyWindow.layer.superlayer?.addSublayer(textField.layer)
 
@@ -140,15 +140,15 @@ public final class ScreenCaptureModule: Module {
   private func allowScreenshots() {
     guard let textField = protectionTextField,
       let window = keyWindow,
-      let originalParent = originalParent else {
+      let originalParentLayer = originalParent else {
       return
     }
 
     window.layer.removeFromSuperlayer()
-    originalParent.addSublayer(window.layer)
+    originalParentLayer.addSublayer(window.layer)
     textField.layer.removeFromSuperlayer()
-    self.protectionTextField = nil
-    self.originalParent = nil
+    protectionTextField = nil
+    originalParent = nil
   }
 
   private func enableAppSwitcherProtection() {

--- a/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
+++ b/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
@@ -115,45 +115,42 @@ public final class ScreenCaptureModule: Module {
   }
 
   private func preventScreenshots() {
-    guard let keyWindow = keyWindow,
-      let visibleView = keyWindow.subviews.first else { return }
+    guard let keyWindow = keyWindow else {
+      return
+    }
 
     let textField = UITextField()
     textField.isSecureTextEntry = true
     textField.isUserInteractionEnabled = false
-    textField.backgroundColor = UIColor.black
+    textField.backgroundColor = UIColor.clear
+    textField.frame = UIScreen.main.bounds
 
-    originalParent = visibleView.layer.superlayer
+    self.originalParent = keyWindow.layer.superlayer
 
-    if let viewSuperlayer = visibleView.layer.superlayer {
-      viewSuperlayer.addSublayer(textField.layer)
+    keyWindow.makeKeyAndVisible()
+    keyWindow.layer.superlayer?.addSublayer(textField.layer)
 
-      if let firstTextFieldSublayer = textField.layer.sublayers?.first {
-        visibleView.layer.removeFromSuperlayer()
-        visibleView.layer.position = CGPoint(x: visibleView.bounds.width / 2, y: visibleView.bounds.height / 2)
-        firstTextFieldSublayer.addSublayer(visibleView.layer)
-      }
+    if let firstTextFieldSublayer = textField.layer.sublayers?.first {
+      keyWindow.layer.removeFromSuperlayer()
+      firstTextFieldSublayer.addSublayer(keyWindow.layer)
     }
 
     protectionTextField = textField
   }
 
   private func allowScreenshots() {
-    guard let textField = protectionTextField else {
+    guard let textField = protectionTextField,
+      let window = keyWindow,
+      let originalParent = originalParent else {
       return
     }
 
-    if let protectedLayer = textField.layer.sublayers?.first?.sublayers?.first {
-      protectedLayer.removeFromSuperlayer()
-      if let parent = originalParent {
-        parent.addSublayer(protectedLayer)
-      }
-    }
-
+    window.layer.removeFromSuperlayer()
+    originalParent.addSublayer(window.layer)
     textField.layer.removeFromSuperlayer()
-
-    protectionTextField = nil
-    originalParent = nil
+    window.makeKeyAndVisible()
+    self.protectionTextField = nil
+    self.originalParent = nil
   }
 
   private func enableAppSwitcherProtection() {

--- a/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
+++ b/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
@@ -127,7 +127,6 @@ public final class ScreenCaptureModule: Module {
 
     self.originalParent = keyWindow.layer.superlayer
 
-    keyWindow.makeKeyAndVisible()
     keyWindow.layer.superlayer?.addSublayer(textField.layer)
 
     if let firstTextFieldSublayer = textField.layer.sublayers?.first {
@@ -148,7 +147,6 @@ public final class ScreenCaptureModule: Module {
     window.layer.removeFromSuperlayer()
     originalParent.addSublayer(window.layer)
     textField.layer.removeFromSuperlayer()
-    window.makeKeyAndVisible()
     self.protectionTextField = nil
     self.originalParent = nil
   }


### PR DESCRIPTION
# Why
Fixed a layout issue applications using @react-navigation/native-stack where navigation headers would move to the top of the screen when preventScreenCapture() was called, making the screen appear taller. Also resolved black screen issues when calling allowScreenCapture(). 

https://github.com/user-attachments/assets/086c821c-59b1-4f5e-9f2f-ee3910d3966d

# How
The solution involved targeting keyWindow.layer directly instead of manipulating subviews that interfere with React Navigation's native stack layout calculations, adding proper originalParent storage for layer restoration, and simplifying the restoration logic in allowScreenshots() to ensure the window layer is correctly restored to its original position. This maintains screenshot prevention functionality while keeping native stack navigation layouts stable throughout prevent/allow cycles.

# Test Plan
To test this change, you will need to use the native stack instead of the JavaScript stack for navigation in ExpoApiStackNavigator.tsx:

import { createNativeStackNavigator } from '@react-navigation/native-stack';
const Stack = createNativeStackNavigator();

Then follow these steps:
1.  Prevent screenshots
2. Trigger a screenshot
3. Allow screenshots again

The header should remain in the same position on the screen without any flickering.

https://github.com/user-attachments/assets/e9ef0a18-17f5-4e80-ad95-1168ea09eab1

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
