### PR TITLE
[go] Add Brewfile + instructions to Expo Go readme

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,7 @@
+# Install dependencies with: brew bundle
+
+# Expo Go uses react-native-lab, which sets RCT_BUILD_HERMES_FROM_SOURCE, and building Hermes
+# requires cmake and ninja.
+# https://github.com/facebook/hermes/blob/eda3c083a57e9aa3b5b04df12ef8588b2961c02e/doc/BuildingAndRunning.md
+brew "cmake"
+brew "ninja"

--- a/apps/expo-go/README.md
+++ b/apps/expo-go/README.md
@@ -29,8 +29,9 @@ If you need to make native code changes to your Expo project, such as adding cus
 
 > Note: We support building Expo Go only on macOS.
 
-- Install [direnv](http://direnv.net/).
+- Install [direnv](http://direnv.net/) and [Homebrew](https://brew.sh/).
 - Clone this repo; we recommend cloning it to a directory whose full path does not include any spaces (you should clone all the submodules with `git clone --recurse-submodules`).
+- Run `brew bundle` in the root directory.
 - Run `yarn` in the root directory.
 - Run `yarn setup:native` in the root directory.
 - Run `yarn build` in the `packages/expo` directory.
@@ -42,7 +43,7 @@ If you need to make native code changes to your Expo project, such as adding cus
 
 You can build the React Native Android dep using `./gradlew :packages:react-native:ReactAndroid:buildCMakeDebug` in `react-native-lab/react-native` directory. This is optional because React Native will be built anyway when you build Expo Go, but can help to narrow down a potential issue surface area.
 
-2. Run `yarn start` in `apps/expo-go` directory to start Metro 
+2. Run `yarn start` in `apps/expo-go` directory to start Metro
 
 Metro needs to run prior running the build. Verify it runs on port 80. This is because `et android-generate-dynamic-macros` / `et ios-generate-dynamic-macros` is run during the build and needs Metro on port 80 to be running.
 


### PR DESCRIPTION
Why
===
Expo Go builds Hermes from source, which requires cmake and ninja (and git, but that's obviously installed in order to clone this repo - so we don't want to touch that).

Other projects under `apps` do not link to react-native-lab the same way Expo Go does so I updated only the Expo Go instructions.

How
===
Updated the Expo Go readme to tell people to install tools using Homebrew with `brew bundle`. This uses the dependencies specified in a Brewfile introduced by this commit, which documents why we're adding cmake and ninja in a way that is aligned with the Hermes build instructions.

Test Plan
===
Ran `brew bundle` in the root directory. I didn't try building Expo Go but Hirbod mentioned that installing cmake 4.0.3 (latest in the brew tap) got Expo Go building for him successfully.
