### PR TITLE
[dev-client] Partial support for Apple TV

### DIFF
--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Partial support for Apple TV. ([#38388](https://github.com/expo/expo/pull/38388) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-client/ios/expo-dev-client.podspec
+++ b/packages/expo-dev-client/ios/expo-dev-client.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1'
   }
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [iOS] Reimplement UI in SwiftUI. ([#37413](https://github.com/expo/expo/pull/37413) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Add floating action button option in the settings menu. ([#38247](https://github.com/expo/expo/pull/38247) by [@behenate](https://github.com/behenate))
+- [iOS] Partial support for Apple TV. ([#38388](https://github.com/expo/expo/pull/38388) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/expo-dev-launcher.podspec
+++ b/packages/expo-dev-launcher/expo-dev-launcher.podspec
@@ -20,7 +20,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1'
   }
   s.swift_version  = '5.2'
   s.source         = { :git => 'https://github.com/github_account/expo-development-client.git', :tag => "#{s.version}" }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -719,8 +719,10 @@
 }
 
 -(void)copyToClipboard:(NSString *)content {
+#if !TARGET_OS_TV
   UIPasteboard *clipboard = [UIPasteboard generalPasteboard];
   clipboard.string = (content ?: @"");
+#endif
 }
 
 - (void)setDevMenuAppBridge

--- a/packages/expo-dev-launcher/ios/EXDevLauncherInstallationIDHelper.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherInstallationIDHelper.swift
@@ -1,5 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+// swiftlint:disable force_unwrapping
+// swiftlint:disable legacy_objc_type
+// swiftlint:disable identifier_name
 import Foundation
 
 let DEV_LAUNCHER_INSTALLATION_ID_FILENAME = "expo-dev-launcher-installation-id.txt"
@@ -68,3 +71,6 @@ public class EXDevLauncherInstallationIDHelper: NSObject {
     return applicationSupportURL.appendingPathComponent(DEV_LAUNCHER_INSTALLATION_ID_FILENAME)
   }
 }
+// swiftlint:enable force_unwrapping
+// swiftlint:enable identifier_name
+// swiftlint:enable legacy_objc_type

--- a/packages/expo-dev-launcher/ios/EXDevLauncherPendingDeepLinkRegistry.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherPendingDeepLinkRegistry.swift
@@ -1,5 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+// swiftlint:disable force_unwrapping
 import Foundation
 
 @objc
@@ -30,3 +31,4 @@ public class EXDevLauncherPendingDeepLinkRegistry: NSObject {
     return result
   }
 }
+// swiftlint:enable force_unwrapping

--- a/packages/expo-dev-launcher/ios/EXDevLauncherRecentlyOpenedAppsRegistry.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherRecentlyOpenedAppsRegistry.swift
@@ -74,6 +74,7 @@ public class EXDevLauncherRecentlyOpenedAppsRegistry: NSObject {
     var apps: [[String: Any]] = []
 
     appRegistry = registry.filter { (_: String, appEntry: [String: Any]) in
+      // swiftlint:disable:next force_cast
       if getCurrentTimestamp() - (appEntry["timestamp"] as! Int64) > TIME_TO_REMOVE {
         return false
       }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherUtils.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherUtils.swift
@@ -50,10 +50,10 @@ class EXDevLauncherUtils {
   /**
    Invokes the original implementation before swizzling for the given selector
    */
-  static func invokeOriginalClassMethod(selector: Selector, forClass: AnyClass, A0: Any) throws -> Any? {
+  static func invokeOriginalClassMethod(selector: Selector, forClass: AnyClass, a0: Any) throws -> Any? {
     typealias ClassMethod = @convention(c) (AnyObject, Selector, Any) -> Any
     let imp = try getOriginalClassMethodImp(selector: selector, forClass: forClass)
-    return unsafeBitCast(imp, to: ClassMethod.self)(self, selector, A0)
+    return unsafeBitCast(imp, to: ClassMethod.self)(self, selector, a0)
   }
 
   private static func getOriginalClassMethodImp(selector: Selector, forClass: AnyClass) throws -> IMP {

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherErrorManager.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherErrorManager.swift
@@ -31,5 +31,4 @@ public class EXDevLauncherErrorManager: NSObject {
       }
     }
   }
-
 }

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
@@ -4,6 +4,7 @@ import UIKit
 
 @objc
 public class EXDevLauncherManifestHelper: NSObject {
+  #if !os(tvOS)
   private static func defaultOrientationForOrientationMask(_ orientationMask: UIInterfaceOrientationMask) -> UIInterfaceOrientation {
     if orientationMask.contains(.all) {
       return UIInterfaceOrientation.unknown
@@ -35,6 +36,7 @@ public class EXDevLauncherManifestHelper: NSObject {
 
     return defaultOrientationForOrientationMask(orientationMask)
   }
+#endif
 
   @objc
   public static func hexStringToColor(_ hexString: String?) -> UIColor? {

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestHelper.swift
@@ -53,21 +53,23 @@ public class EXDevLauncherManifestHelper: NSObject {
     var rgbValue: UInt64 = 0
     Scanner(string: hexString).scanHexInt64(&rgbValue)
 
-    return UIColor(red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
-                   green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
-                   blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
-                   alpha: 1.0)
+    return UIColor(
+      red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
+      green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
+      blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
+      alpha: 1.0
+    )
   }
 
   @objc
   public static func exportManifestUserInterfaceStyle(_ userInterfaceStyle: String?) -> UIUserInterfaceStyle {
     switch userInterfaceStyle {
-      case "light":
-        return .light
-      case "dark":
-        return .dark
-      default:
-        return .unspecified
+    case "light":
+      return .light
+    case "dark":
+      return .dark
+    default:
+      return .unspecified
     }
   }
 }

--- a/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherBundleURLProviderInterceptor.swift
+++ b/packages/expo-dev-launcher/ios/ReactNative/EXDevLauncherBundleURLProviderInterceptor.swift
@@ -1,5 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+// swiftlint:disable type_name
 @objc
 public class EXDevLauncherBundleURLProviderInterceptor: NSObject {
   @objc
@@ -28,3 +29,4 @@ extension RCTBundleURLProvider {
     return nil
   }
 }
+// swiftlint:enable type_name

--- a/packages/expo-dev-launcher/ios/SwiftUI/AccountSheet.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/AccountSheet.swift
@@ -25,7 +25,9 @@ struct AccountSheet: View {
         Spacer()
       }
     }
+    #if !os(tvOS)
     .background(Color(.systemGroupedBackground))
+    #endif
   }
 
   private var accountScreenHeader: some View {
@@ -63,7 +65,9 @@ struct AccountSheet: View {
             }
           }
         }
+        #if !os(tvOS)
         .background(Color(.systemBackground))
+        #endif
         .clipShape(RoundedRectangle(cornerRadius: 12))
       }
 
@@ -102,7 +106,9 @@ struct AccountSheet: View {
       }
     }
     .padding(16)
+    #if !os(tvOS)
     .background(Color(.systemBackground))
+    #endif
     .cornerRadius(12)
   }
 
@@ -139,7 +145,9 @@ struct AccountSheet: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)
     }
+    #if !os(tvOS)
     .background(Color(.systemGray5))
+    #endif
     .cornerRadius(8)
     .disabled(viewModel.isAuthenticating)
   }
@@ -169,7 +177,9 @@ struct AccountSheet: View {
       }
       .padding(.horizontal, 16)
       .padding(.vertical, 12)
+      #if !os(tvOS)
       .background(Color(.systemBackground))
+      #endif
     }
     .buttonStyle(PlainButtonStyle())
   }
@@ -199,7 +209,9 @@ struct AccountSheet: View {
           .aspectRatio(contentMode: .fill)
       } placeholder: {
         Circle()
+        #if !os(tvOS)
           .fill(Color(.systemGray5))
+        #endif
           .overlay(
             Image(systemName: "person")
               .font(.system(size: 18))

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -37,7 +37,9 @@ class DevLauncherViewModel: ObservableObject {
   @Published var user: User?
   @Published var selectedAccountId: String?
 
+  #if !os(tvOS)
   private let presentationContext = DevLauncherAuthPresentationContext()
+  #endif
 
   var selectedAccount: UserAccount? {
     guard let userData = user,
@@ -323,6 +325,9 @@ class DevLauncherViewModel: ObservableObject {
   }
 
   private func performAuthentication(isSignUp: Bool) async throws -> Bool {
+    #if os(tvOS)
+    throw Exception(name: "NotImplementedError", description: "Not implemented on tvOS")
+    #else
     return try await withCheckedThrowingContinuation { continuation in
       let websiteOrigin = APIClient.shared.websiteOrigin
       let authType = isSignUp ? "signup" : "login"
@@ -360,6 +365,7 @@ class DevLauncherViewModel: ObservableObject {
       session.prefersEphemeralWebBrowserSession = true
       session.start()
     }
+    #endif
   }
 
   private func getURLScheme() -> String {
@@ -373,9 +379,11 @@ class DevLauncherViewModel: ObservableObject {
   }
 }
 
+#if !os(tvOS)
 private class DevLauncherAuthPresentationContext: NSObject, ASWebAuthenticationPresentationContextProviding {
   func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
     let window = UIApplication.shared.windows.first { $0.isKeyWindow }
     return window ?? ASPresentationAnchor()
   }
 }
+#endif

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
@@ -93,7 +93,9 @@ struct RecentlyOpenedAppRow: View {
           .foregroundColor(.secondary)
       }
       .padding()
+      #if !os(tvOS)
       .background(Color(.systemBackground))
+      #endif
     }
     .buttonStyle(PlainButtonStyle())
   }

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServerInfoModal.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServerInfoModal.swift
@@ -7,13 +7,15 @@ struct DevServerInfoModal: View {
 
   var body: some View {
     Group {
-      if showingInfoDialog {
-        Color.black.opacity(0.4)
-          .ignoresSafeArea(.all)
-          .onTapGesture {
-            showingInfoDialog = false
-          }
-        content
+      if #available(iOS 15.0, tvOS 16.0, *) {
+        if showingInfoDialog {
+          Color.black.opacity(0.4)
+            .ignoresSafeArea(.all)
+            .onTapGesture {
+              showingInfoDialog = false
+            }
+          content
+        }
       }
     }
     .animation(.easeInOut(duration: 0.3), value: showingInfoDialog)
@@ -26,7 +28,9 @@ struct DevServerInfoModal: View {
       info
     }
     .padding(20)
+    #if !os(tvOS)
     .background(Color(.systemBackground))
+    #endif
     .clipShape(RoundedRectangle(cornerRadius: 16))
     .shadow(color: .black.opacity(0.1), radius: 10, x: 0, y: 5)
     .padding(.horizontal, 40)
@@ -48,6 +52,14 @@ struct DevServerInfoModal: View {
     }
   }
 
+  #if os(tvOS)
+  let systemGray6 = Color(.systemGray)
+  let systemGray4 = Color(.systemGray)
+  #else
+  let systemGray6 = Color(.systemGray6)
+  let systemGray4 = Color(.systemGray4)
+  #endif
+
   private var info: some View {
     VStack(alignment: .leading, spacing: 12) {
       Text("Start a local development server with:")
@@ -58,11 +70,11 @@ struct DevServerInfoModal: View {
         .font(.system(.callout, design: .monospaced))
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(Color(.systemGray6))
+        .background(systemGray6)
         .clipShape(RoundedRectangle(cornerRadius: 6))
         .overlay(
           RoundedRectangle(cornerRadius: 6)
-            .stroke(Color(.systemGray4), lineWidth: 1)
+            .stroke(systemGray4, lineWidth: 1)
         )
 
       Text("Then, select the local server when it appears here.")

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -46,7 +46,9 @@ struct DevServersView: View {
 
         enterUrl
       }
+      #if !os(tvOS)
       .background(Color(.systemBackground))
+      #endif
       .clipShape(RoundedRectangle(cornerRadius: 8))
     }
     .onAppear {
@@ -81,10 +83,12 @@ struct DevServersView: View {
           .disableAutocorrection(true)
           .padding(.horizontal, 16)
           .padding(.vertical, 12)
+        #if !os(tvOS)
           .overlay(
             RoundedRectangle(cornerRadius: 5)
               .stroke(Color(.systemGray4), lineWidth: 1)
           )
+        #endif
           .clipShape(RoundedRectangle(cornerRadius: 5))
 
         connectButton

--- a/packages/expo-dev-launcher/ios/SwiftUI/ErrorView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/ErrorView.swift
@@ -8,6 +8,16 @@ struct ErrorView: View {
   let onReload: () -> Void
   let onGoHome: () -> Void
 
+#if os(tvOS)
+  let systemGray6 = Color(.systemGray)
+  let systemGray4 = Color(.systemGray)
+  let systemBackground = Color(.white)
+#else
+  let systemGray6 = Color(.systemGray6)
+  let systemGray4 = Color(.systemGray4)
+  let systemBackground = Color(.systemBackground)
+#endif
+
   var body: some View {
     VStack(spacing: 0) {
       ScrollView {
@@ -31,7 +41,7 @@ struct ErrorView: View {
       }
       actions
     }
-    .background(Color(.systemBackground))
+    .background(systemBackground)
     .navigationBarHidden(true)
   }
 
@@ -45,7 +55,7 @@ struct ErrorView: View {
         .font(.system(.body, design: .monospaced))
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color(.systemGray6))
+        .background(systemGray6)
         .cornerRadius(8)
 
       if let stack = error.stack, !stack.isEmpty {
@@ -61,7 +71,7 @@ struct ErrorView: View {
             }
           }
           .padding()
-          .background(Color(.systemGray6))
+          .background(systemGray6)
           .cornerRadius(8)
         }
       }
@@ -92,7 +102,7 @@ struct ErrorView: View {
     }
     .padding(.horizontal, 20)
     .padding(.vertical, 20)
-    .background(Color(.systemBackground))
+    .background(systemBackground)
   }
 }
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/ExtensionsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/ExtensionsTabView.swift
@@ -1,0 +1,70 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+func getDevLauncherBundle() -> Bundle? {
+  if let bundleURL = Bundle.main.url(forResource: "EXDevLauncher", withExtension: "bundle") {
+    if let bundle = Bundle(url: bundleURL) {
+      return bundle
+    }
+  }
+
+  // fallback to the main bundle
+  return .main
+}
+
+struct ExtensionsTabView: View {
+  var body: some View {
+    VStack(spacing: 0) {
+      DevLauncherNavigationHeader()
+      List {
+        Section {
+          VStack(spacing: 16) {
+            Image("extensions", bundle: getDevLauncherBundle())
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(width: 44, height: 44)
+
+            description
+            learnMore
+          }
+        }
+        .cornerRadius(5)
+      }
+    }
+    #if !os(tvOS)
+    .background(Color(.systemGroupedBackground))
+    #endif
+  }
+
+  private var description: some View {
+    VStack {
+      Text("Extensions allow you to customize your development build with additional capabilities.")
+        .font(.system(size: 12))
+        .multilineTextAlignment(.center)
+        .foregroundStyle(.gray)
+
+      if let destination = URL(string: "https://docs.expo.dev/development/extensions/") {
+        Link("Learn more", destination: destination)
+          .font(.system(size: 12))
+      }
+    }
+  }
+
+  private var learnMore: some View {
+    VStack {
+      Text("If you would like to extend the display on this screen, let us know about your use case")
+        .multilineTextAlignment(.center)
+        .foregroundStyle(.gray)
+
+      if let destination = URL(string: "https://expo.canny.io/feature-requests") {
+        Link("Let us know about your use case", destination: destination)
+      }
+    }
+    .font(.system(size: 12))
+  }
+}
+
+#Preview {
+  ExtensionsTabView()
+}

--- a/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
@@ -43,7 +43,9 @@ struct HomeTabView: View {
         .padding()
       }
     }
+    #if !os(tvOS)
     .background(Color(.systemGroupedBackground))
+    #endif
     .overlay(
       DevServerInfoModal(showingInfoDialog: $showingInfoDialog)
     )

--- a/packages/expo-dev-launcher/ios/SwiftUI/Navigation/Navigation.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/Navigation/Navigation.swift
@@ -65,7 +65,9 @@ struct DevLauncherNavigationHeader: View {
     }
     .padding(.horizontal)
     .padding(.vertical, 8)
+    #if !os(tvOS)
     .background(Color(.systemBackground))
+    #endif
   }
 
   @ViewBuilder
@@ -94,7 +96,9 @@ struct DevLauncherNavigationHeader: View {
           .aspectRatio(contentMode: .fill)
       } placeholder: {
         Circle()
+        #if !os(tvOS)
           .fill(Color(.systemGray5))
+        #endif
           .overlay(
             Image(systemName: "person")
               .font(.system(size: 16))

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -50,7 +50,9 @@ struct SettingsTabView: View {
         }
       }
     }
+    #if !os(tvOS)
     .background(Color(.systemGroupedBackground))
+    #endif
     .navigationBarHidden(true)
   }
 
@@ -90,6 +92,9 @@ struct SettingsTabView: View {
   }
 
   private var copyToClipboardButton: some View {
+    #if os(tvOS)
+    Button("Clipboard not available on tvOS") {}
+    #else
     Button(showCopiedMessage ? "Copied to clipboard!" : "Tap to Copy All") {
       let buildInfoJSON = createBuildInfoJSON()
       let clipboard = UIPasteboard.general
@@ -101,6 +106,7 @@ struct SettingsTabView: View {
         showCopiedMessage = false
       }
     }
+    #endif
   }
 
   private var isAdminUser: Bool {
@@ -134,7 +140,9 @@ struct SettingsTabView: View {
       VStack(alignment: .leading, spacing: 8) {
         Text(createEASConfigJSON())
           .font(.system(.caption, design: .monospaced))
+        #if !os(tvOS)
           .textSelection(.enabled)
+        #endif
           .padding(.vertical, 4)
       }
     }

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -8,6 +8,11 @@ struct SettingsTabView: View {
   @State private var defaultPageSize: Int = 10
   @State private var showCacheClearedMessage = false
 
+  private let selectedGesturesInfoMessage = """
+  Selected gestures will toggle the developer menu while inside a preview.
+  The menu allows you to reload or return to home and exposes developer tools.
+  """
+
   private func createBuildInfoJSON() -> String {
     let buildInfoDict: [String: Any] = [
       "runtimeVersion": viewModel.buildInfo["runtimeVersion"] as? String ?? "",
@@ -34,7 +39,7 @@ struct SettingsTabView: View {
         gestures
 
         Section {
-          Text("Selected gestures will toggle the developer menu while inside a preview. The menu allows you to reload or return to home and exposes developer tools.")
+          Text(selectedGesturesInfoMessage)
             .font(.system(size: 13))
             .foregroundStyle(.secondary)
         }

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdateRow.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdateRow.swift
@@ -32,7 +32,9 @@ struct UpdateRow: View {
       Text("Open")
     }
     .buttonStyle(.bordered)
+    #if !os(tvOS)
     .controlSize(.small)
+    #endif
     .disabled(!isCompatible)
   }
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
@@ -40,7 +40,9 @@ struct UpdatesListView: View {
         }
       }
     }
+    #if !os(tvOS)
     .background(Color(.systemGroupedBackground))
+    #endif
     .onChange(of: filterByCompatibility) { _ in
       applyFilters()
     }

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+// swiftlint:disable closure_body_length
 
 struct UpdatesListView: View {
   @EnvironmentObject var viewModel: DevLauncherViewModel
@@ -196,3 +197,4 @@ struct UpdatesListView: View {
 #Preview {
   UpdatesListView()
 }
+// swiftlint:enable closure_body_length

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesTabView.swift
@@ -2,17 +2,6 @@
 
 import SwiftUI
 
-func getDevLauncherBundle() -> Bundle? {
-  if let bundleURL = Bundle.main.url(forResource: "EXDevLauncher", withExtension: "bundle") {
-    if let bundle = Bundle(url: bundleURL) {
-      return bundle
-    }
-  }
-
-  // fallback to the main bundle
-  return .main
-}
-
 struct UpdatesTabView: View {
   @EnvironmentObject var viewModel: DevLauncherViewModel
 
@@ -28,7 +17,9 @@ struct UpdatesTabView: View {
         UpdatesListView()
       }
     }
+    #if !os(tvOS)
     .background(Color(.systemGroupedBackground))
+    #endif
   }
 }
 

--- a/packages/expo-dev-menu-interface/ios/expo-dev-menu-interface.podspec
+++ b/packages/expo-dev-menu-interface/ios/expo-dev-menu-interface.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1'
   }
   s.swift_version  = '5.2'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [iOS] Migrate dev menu UI to SwiftUI ([#37414](https://github.com/expo/expo/pull/37414) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Add floating action button that pulls up the dev menu. ([#38246](https://github.com/expo/expo/pull/38246) by [@behenate](https://github.com/behenate))
+- [iOS] Partial support for Apple TV. ([#38388](https://github.com/expo/expo/pull/38388) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-menu/expo-dev-menu.podspec
+++ b/packages/expo-dev-menu/expo-dev-menu.podspec
@@ -25,7 +25,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1'
   }
   s.swift_version  = '5.2'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-dev-menu/ios/DevMenuGestureRecognizer.swift
+++ b/packages/expo-dev-menu/ios/DevMenuGestureRecognizer.swift
@@ -10,9 +10,11 @@ class DevMenuGestureRecognizerDelegate {
   func handleLongPress(_ gestureReconizer: UILongPressGestureRecognizer) {
     if gestureReconizer.state == UIGestureRecognizer.State.began {
       if DevMenuManager.shared.toggleMenu() {
+        #if !os(tvOS)
         let feedback = UIImpactFeedbackGenerator(style: .light)
         feedback.prepare()
         feedback.impactOccurred()
+        #endif
       }
       cancelGesture(gestureReconizer)
     }
@@ -33,7 +35,9 @@ class DevMenuGestureRecognizer: UILongPressGestureRecognizer {
   init() {
     super.init(target: DevMenuGestureRecognizer.gestureDelegate, action: #selector(DevMenuGestureRecognizer.gestureDelegate.handleLongPress(_:)))
 
+    #if !os(tvOS)
     numberOfTouchesRequired = 3
+    #endif
     minimumPressDuration = 0.5
     allowableMovement = 30
   }

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -95,7 +95,9 @@ open class DevMenuManager: NSObject {
 
   @objc
   public func autoLaunch(_ shouldRemoveObserver: Bool = true) {
+    // swiftlint:disable notification_center_detachment
     NotificationCenter.default.removeObserver(self)
+    // swiftlint:enable notification_center_detachment
 
     DispatchQueue.main.async {
       self.openMenu()
@@ -107,9 +109,11 @@ open class DevMenuManager: NSObject {
     NotificationCenter.default.removeObserver(self)
     // swiftlint:enable notification_center_detachment
 
+    // swiftlint:disable legacy_objc_type
     if canLaunchDevMenuOnStart && currentBridge != nil && (DevMenuPreferences.showsAtLaunch || shouldShowOnboarding()) {
       NotificationCenter.default.addObserver(self, selector: #selector(DevMenuManager.autoLaunch), name: NSNotification.Name.RCTContentDidAppear, object: nil)
     }
+    // swiftlint:enable legacy_objc_type
   }
 
   private func disableRNDevMenuHoykeys(for bridge: RCTBridge) {

--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -66,8 +66,8 @@ class DevMenuPackagerConnectionHandler {
   @objc
   func sendDevCommandNotificationHandler(_ params: [String: Any]) {
     guard let manager = manager,
-          let command = params["name"] as? String,
-          let bridge = manager.currentBridge
+      let command = params["name"] as? String,
+      let bridge = manager.currentBridge
     else {
       return
     }

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -31,9 +31,11 @@ class DevMenuViewController: UIViewController {
     NotificationCenter.default.post(name: DevMenuViewController.ContentDidAppearNotification, object: nil)
   }
 
+  #if !os(tvOS)
   override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
     return UIInterfaceOrientationMask.all
   }
+  #endif
 
   override var overrideUserInterfaceStyle: UIUserInterfaceStyle {
     get {

--- a/packages/expo-dev-menu/ios/DevMenuViewController.swift
+++ b/packages/expo-dev-menu/ios/DevMenuViewController.swift
@@ -17,6 +17,7 @@ class DevMenuViewController: UIViewController {
     extendedLayoutIncludesOpaqueBars = true
   }
 
+  @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }

--- a/packages/expo-dev-menu/ios/DevMenuWindow.swift
+++ b/packages/expo-dev-menu/ios/DevMenuWindow.swift
@@ -3,7 +3,16 @@
 import UIKit
 import React
 
-class DevMenuWindow: UIWindow, UISheetPresentationControllerDelegate {
+#if os(tvOS)
+protocol PresentationControllerDelegate: AnyObject {
+
+}
+#else
+protocol PresentationControllerDelegate: UISheetPresentationControllerDelegate {
+
+}
+#endif
+class DevMenuWindow: UIWindow, PresentationControllerDelegate {
   private let manager: DevMenuManager
   private let devMenuViewController: DevMenuViewController
   private var isPresenting = false
@@ -17,7 +26,11 @@ class DevMenuWindow: UIWindow, UISheetPresentationControllerDelegate {
 
     self.rootViewController = UIViewController()
     self.backgroundColor = UIColor(white: 0, alpha: 0.4)
+    #if os(tvOS)
+    self.windowLevel = .normal
+    #else
     self.windowLevel = .statusBar
+    #endif
     self.isHidden = true
   }
 
@@ -39,8 +52,14 @@ class DevMenuWindow: UIWindow, UISheetPresentationControllerDelegate {
     }
 
     isPresenting = true
+    #if os(tvOS)
+    devMenuViewController.modalPresentationStyle = .automatic
+    #else
     devMenuViewController.modalPresentationStyle = .pageSheet
+    #endif
 
+    #if os(tvOS)
+    #else
     if #available(iOS 15.0, *) {
       if let sheet = devMenuViewController.sheetPresentationController {
         if #available(iOS 16.0, *) {
@@ -59,6 +78,7 @@ class DevMenuWindow: UIWindow, UISheetPresentationControllerDelegate {
         sheet.delegate = self
       }
     }
+    #endif
 
     self.rootViewController?.present(devMenuViewController, animated: true) {
       self.isPresenting = false

--- a/packages/expo-dev-menu/ios/DevMenuWindow.swift
+++ b/packages/expo-dev-menu/ios/DevMenuWindow.swift
@@ -5,11 +5,9 @@ import React
 
 #if os(tvOS)
 protocol PresentationControllerDelegate: AnyObject {
-
 }
 #else
 protocol PresentationControllerDelegate: UISheetPresentationControllerDelegate {
-
 }
 #endif
 class DevMenuWindow: UIWindow, PresentationControllerDelegate {

--- a/packages/expo-dev-menu/ios/EXDevMenuDevSettings.swift
+++ b/packages/expo-dev-menu/ios/EXDevMenuDevSettings.swift
@@ -19,7 +19,7 @@ class EXDevMenuDevSettings: NSObject {
     let manager = DevMenuManager.shared
 
     if let bridge = manager.currentBridge,
-        let bridgeSettings = bridge.module(forName: "DevSettings") as? RCTDevSettings {
+      let bridgeSettings = bridge.module(forName: "DevSettings") as? RCTDevSettings {
       let perfMonitor = bridge.module(forName: "PerfMonitor")
       let isPerfMonitorAvailable = perfMonitor != nil
 

--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuTouchInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuTouchInterceptor.swift
@@ -47,7 +47,8 @@ extension UIWindow {
       self.addGestureRecognizer(recognizer)
     }
 
-    // `EXDevMenu_gestureRecognizers` implementation has been swizzled with `gestureRecognizers` - it might be confusing that we call it recursively, but we don't.
+    // `EXDevMenu_gestureRecognizers` implementation has been swizzled with `gestureRecognizers`
+    // It might be confusing that we call it recursively, but we don't.
     return self.EXDevMenu_gestureRecognizers
   }
 }

--- a/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
@@ -1,7 +1,9 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
+#if !os(tvOS)
 import SafariServices
+#endif
 import React
 
 public class DevMenuInternalModule: Module {
@@ -68,8 +70,12 @@ public class DevMenuInternalModule: Module {
     }
 
     AsyncFunction("copyToClipboardAsync") { (content: String) in
+      #if os(tvOS)
+      throw Exception(name: "ERR_DEVMENU_ACTION_FAILED", description: "copy to clipboard is not available in tvOS")
+      #else
       let clipboard = UIPasteboard.general
       clipboard.string = content as String
+      #endif
     }
   }
 }

--- a/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
@@ -20,7 +20,7 @@ public class DevMenuPreferences: Module {
     }
   }
 
-  /**
+  /*
    Initializes dev menu preferences by registering user defaults
    and applying some preferences to static classes like interceptors.
    */
@@ -33,7 +33,7 @@ public class DevMenuPreferences: Module {
       isOnboardingFinishedKey: false
     ])
 
-    /**
+    /*
      We don't want to uninstall `DevMenuMotionInterceptor`, because otherwise, the app on shake gesture will bring up the dev-menu from the RN.
      So we added `isEnabled` to disable it, but not uninstall.
      */

--- a/packages/expo-dev-menu/ios/SwiftUI/CustomItems.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/CustomItems.swift
@@ -27,7 +27,9 @@ struct CustomItems: View {
             }
             .padding()
           }
+          #if !os(tvOS)
           .background(Color(.systemBackground))
+          #endif
 
           if index < callbacks.count - 1 {
             Divider()

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuActions.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuActions.swift
@@ -23,7 +23,9 @@ struct DevMenuActions: View {
         )
       }
     }
+    #if !os(tvOS)
     .background(Color(.systemBackground))
+    #endif
     .cornerRadius(12)
     .padding(.horizontal)
     .padding(.vertical, 8)

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuAppInfo.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuAppInfo.swift
@@ -29,9 +29,13 @@ struct DevMenuAppInfo: View {
         .padding()
       }
       .disabled(viewModel.clipboardMessage != nil)
+      #if !os(tvOS)
       .background(Color(.systemBackground))
+      #endif
     }
+    #if !os(tvOS)
     .background(Color(.systemBackground))
+    #endif
     .cornerRadius(12)
     .padding(.horizontal)
     .padding(.vertical, 8)

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
@@ -41,7 +41,9 @@ struct DevMenuDeveloperTools: View {
         disabled: !(viewModel.devSettings?.isHotLoadingAvailable ?? true)
       )
     }
+    #if !os(tvOS)
     .background(Color(.systemBackground))
+    #endif
     .cornerRadius(12)
     .padding(.horizontal)
     .padding(.vertical, 8)

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuRNDevMenu.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuRNDevMenu.swift
@@ -13,7 +13,9 @@ struct DevMenuRNDevMenu: View {
       }
       .padding()
     }
+    #if !os(tvOS)
     .background(Color(.systemBackground))
+    #endif
     .cornerRadius(12)
     .padding(.horizontal)
     .padding(.vertical, 8)

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuRootView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuRootView.swift
@@ -17,12 +17,16 @@ struct DevMenuRootView: View {
           DevMenuMainView()
             .environmentObject(viewModel)
 
+          #if !os(tvOS)
           if !viewModel.isOnboardingFinished {
             DevMenuOnboardingView(onFinish: viewModel.finishOnboarding)
           }
+          #endif
         }
       }
+      #if !os(tvOS)
       .background(Color(.systemGroupedBackground))
+      #endif
     }
   }
 }

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
@@ -107,15 +107,18 @@ class DevMenuViewModel: ObservableObject {
   }
 
   func copyToClipboard(_ content: String) {
+    #if !os(tvOS)
     UIPasteboard.general.string = content
     hostUrlCopiedMessage = "Copied!"
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
       self.hostUrlCopiedMessage = nil
     }
+    #endif
   }
 
   func copyAppInfo() {
+    #if !os(tvOS)
     guard let appInfo = appInfo else {
       return
     }
@@ -142,6 +145,7 @@ class DevMenuViewModel: ObservableObject {
     DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
       self.clipboardMessage = nil
     }
+    #endif
   }
 
   func fireCallback(_ name: String) {

--- a/packages/expo-dev-menu/ios/SwiftUI/HeaderView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/HeaderView.swift
@@ -36,7 +36,9 @@ struct HeaderView: View {
     }
     .padding(.horizontal)
     .padding(.vertical, 12)
+    #if !os(tvOS)
     .background(Color(.systemBackground))
+    #endif
   }
 
   private var versionInfo: some View {

--- a/packages/expo-dev-menu/ios/SwiftUI/HostUrl.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/HostUrl.swift
@@ -29,12 +29,16 @@ struct HostUrl: View {
           Image(systemName: "doc.on.clipboard")
             .foregroundColor(.secondary)
         }
+        #if !os(tvOS)
         .background(Color(.systemBackground))
+        #endif
         .cornerRadius(8)
       }
       .buttonStyle(.plain)
     }
     .padding()
+    #if !os(tvOS)
     .background(Color(.systemBackground))
+    #endif
   }
 }

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Add `placeholder` TextInput prop. ([#36590](https://github.com/expo/expo/pull/36590) by [@ramonfabrega](https://github.com/ramonfabrega))
+- [iOS] Fix tvOS compilation. ([#38388](https://github.com/expo/expo/pull/38388) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-ui/ios/ContentUnavailableView.swift
+++ b/packages/expo-ui/ios/ContentUnavailableView.swift
@@ -17,7 +17,7 @@ struct ContentUnavailableView: ExpoSwiftUI.View {
   @ObservedObject var props: ContentUnavailableViewProps
 
   var body: some View {
-    if #available(iOS 17.0, *) {
+    if #available(iOS 17.0, tvOS 17.0, *) {
       SwiftUI.ContentUnavailableView(props.title, systemImage: props.systemImage, description: Text(props.description))
         .modifier(CommonViewModifiers(props: props))
     }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add experimental support for macOS. ([#37629](https://github.com/expo/expo/pull/37629) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Add support for a customisable reloading view when `reloadAsync` is called. ([#38074](https://github.com/expo/expo/pull/38074) by [@alanjhughes](https://github.com/alanjhughes)), ([#38362](https://github.com/expo/expo/pull/38362) by [@alanjhughes](https://github.com/alanjhughes)) and ([#38409](https://github.com/expo/expo/pull/38409) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Add `downloadProgress` state to the `useUpdates` hook to support listening to overall asset download progress. ([#38307](https://github.com/expo/expo/pull/38307)) by [@nishan](https://github.com/intergalacticspacehighway)
+- [iOS] dev-client support for Apple TV. ([#38388](https://github.com/expo/expo/pull/38388) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/e2e/setup/create-dev-client-eas-project.ts
+++ b/packages/expo-updates/e2e/setup/create-dev-client-eas-project.ts
@@ -15,8 +15,8 @@ const runtimeVersion = '1.0.0';
 /**
  *
  * This generates a project at the location TEST_PROJECT_ROOT,
- * that is configured to build a test app and run both suites
- * of updates E2E tests with Maestro.
+ * that is configured to build a test app and run dev client
+ * updates E2E tests with Maestro.
  *
  * See `packages/expo-updates/e2e/README.md` for instructions on how
  * to run these tests locally.

--- a/packages/expo-updates/e2e/setup/create-eas-project-tv.ts
+++ b/packages/expo-updates/e2e/setup/create-eas-project-tv.ts
@@ -2,7 +2,12 @@
 
 import path from 'path';
 
-import { initAsync, setupE2EAppAsync, repoRoot } from './project';
+import {
+  initAsync,
+  repoRoot,
+  setupUpdatesDevClientE2EAppAsync,
+  transformAppJsonForE2EWithDevClient,
+} from './project';
 
 const workingDir = path.resolve(repoRoot, '..');
 const runtimeVersion = '1.0.0';
@@ -10,7 +15,11 @@ const runtimeVersion = '1.0.0';
 /**
  *
  * This generates a project at the location TEST_PROJECT_ROOT,
- * that is configured to build a test app to verify compilation on tvOS.
+ * that is configured to verify compilation of Expo packages on tvOS,
+ * and manually exercise the dev client and dev launcher on tvOS.
+ *
+ * See `packages/expo-updates/e2e/README.md` for instructions on how
+ * to run these tests locally.
  *
  */
 
@@ -21,7 +30,17 @@ const runtimeVersion = '1.0.0';
   const projectRoot = process.env.TEST_PROJECT_ROOT || path.join(workingDir, 'updates-e2e');
   const localCliBin = path.join(repoRoot, 'packages/@expo/cli/build/bin/cli');
 
-  await initAsync(projectRoot, { repoRoot, runtimeVersion, localCliBin, isTV: true });
+  await initAsync(projectRoot, {
+    repoRoot,
+    runtimeVersion,
+    localCliBin,
+    configureE2E: true,
+    shouldGenerateTestUpdateBundles: true,
+    shouldConfigureCodeSigning: true,
+    includeDevClient: true,
+    isTV: true,
+    transformAppJson: transformAppJsonForE2EWithDevClient,
+  });
 
-  await setupE2EAppAsync(projectRoot, { localCliBin, repoRoot, isTV: true });
+  await setupUpdatesDevClientE2EAppAsync(projectRoot, { localCliBin, repoRoot, isTV: true });
 })();

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -55,7 +55,7 @@ function getExpoDependencyChunks({
       'expo-updates-interface',
     ],
     ...(includeSplashScreen ? [['expo-splash-screen']] : []),
-    ...(includeDevClient
+    ...(includeDevClient || includeTV
       ? [['expo-dev-menu-interface'], ['expo-dev-menu'], ['expo-dev-launcher'], ['expo-dev-client']]
       : []),
     ...(includeTV
@@ -307,6 +307,7 @@ async function preparePackageJson(
   // Additional scripts and dependencies for Maestro testing
   const extraScripts = configureE2E
     ? {
+        start: 'expo start --private-key-path ./keys/private-key.pem',
         'maestro:android:debug:build': 'cd android; ./gradlew :app:assembleDebug; cd ..',
         'maestro:android:debug:install':
           'adb install android/app/build/outputs/apk/debug/app-debug.apk',
@@ -1082,12 +1083,12 @@ export async function setupUpdatesBrickingMeasuresDisabledE2EAppAsync(
 
 export async function setupUpdatesDevClientE2EAppAsync(
   projectRoot: string,
-  { localCliBin, repoRoot }: { localCliBin: string; repoRoot: string }
+  { localCliBin, repoRoot, isTV }: { localCliBin: string; repoRoot: string; isTV?: boolean }
 ) {
   await copyCommonFixturesToProject(
     projectRoot,
     ['tsconfig.json', '.env', 'eas.json', 'maestro', 'includedAssets', 'scripts'],
-    { appJsFileName: 'App.tsx', repoRoot, isTV: false }
+    { appJsFileName: 'App.tsx', repoRoot, isTV: isTV ?? false }
   );
 
   // install extra fonts package

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -385,7 +385,7 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@0.80.0-0',
+        'react-native': 'npm:react-native-tvos@0.80.1-0',
         '@react-native-tvos/config-tv': '^0.1.3',
       },
       expo: {

--- a/packages/expo-updates/ios/EXUpdates/ReloadScreen/ReloadScreenConfiguration.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReloadScreen/ReloadScreenConfiguration.swift
@@ -67,7 +67,7 @@ enum ImageResizeMode: String, Enumerable {
   case center
   case stretch
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
   var contentMode: UIView.ContentMode {
     switch self {
     case .contain:


### PR DESCRIPTION
# Why

Customers have requested that the Expo dev client should work on Apple TV. This leverages the new SwiftUI implementation to make this partially work.

Supported:

- Basic operations (reload, select a server, type in a server URL)
- Load from packager
- Load from a local update server (will test with EAS update server as well)
- Keyboard commands (e.g. dev menu appears when 'd' key is pressed)

Not supported:

- Touchscreen gestures
- Logging into EAS (requires web views that do not exist on tvOS)


# How

- Add tvOS support to module configs and podspecs
- Fix all compilation issues (including new issues recently introduced in expo-updates and expo-ui)

# Test Plan

- CI should pass

