### PR TITLE
[expo][iOS] Add basic support for Swift 6

### DIFF
--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -11,7 +11,7 @@ import ReactAppDependencyProvider
  Keep functions and markers in sync with https://developer.apple.com/documentation/uikit/uiapplicationdelegate
  */
 @objc(EXExpoAppDelegate)
-open class ExpoAppDelegate: NSObject, ReactNativeFactoryProvider, UIApplicationDelegate {
+open class ExpoAppDelegate: NSObject, @preconcurrency ReactNativeFactoryProvider, UIApplicationDelegate {
   @objc public var factory: RCTReactNativeFactory?
   private let defaultModuleName = "main"
   private let defaultInitialProps = [AnyHashable: Any]()

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -2,7 +2,7 @@
 
 import React_RCTAppDelegate
 
-public class ExpoReactNativeFactory: RCTReactNativeFactory {
+@MainActor public class ExpoReactNativeFactory: RCTReactNativeFactory {
   private let reactDelegate = ExpoReactDelegate(handlers: ExpoAppDelegateSubscriberRepository.reactDelegateHandlers)
 
   @objc func createRCTRootViewFactory() -> RCTRootViewFactory {

--- a/packages/expo/ios/Fetch/ExpoFetchCustomExtension.swift
+++ b/packages/expo/ios/Fetch/ExpoFetchCustomExtension.swift
@@ -5,7 +5,7 @@
  */
 @objc(EXFetchCustomExtension)
 public class ExpoFetchCustomExtension: NSObject {
-  @objc
+  @MainActor @objc
   public static func setCustomURLSessionConfigurationProvider(_ provider: NSURLSessionConfigurationProvider?) {
     urlSessionConfigurationProvider = provider
   }

--- a/packages/expo/ios/Fetch/ExpoFetchModule.swift
+++ b/packages/expo/ios/Fetch/ExpoFetchModule.swift
@@ -1,11 +1,11 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-import ExpoModulesCore
+@preconcurrency import ExpoModulesCore
 
 private let fetchRequestQueue = DispatchQueue(label: "expo.modules.fetch.RequestQueue")
-internal var urlSessionConfigurationProvider: NSURLSessionConfigurationProvider?
+@MainActor internal var urlSessionConfigurationProvider: NSURLSessionConfigurationProvider?
 
-public final class ExpoFetchModule: Module {
+@MainActor public final class ExpoFetchModule: @preconcurrency Module {
   private lazy var urlSession = createURLSession()
   private let urlSessionDelegate: URLSessionSessionDelegateProxy
 
@@ -99,7 +99,7 @@ public final class ExpoFetchModule: Module {
     }
   }
 
-  private func createURLSession() -> URLSession {
+  @MainActor private func createURLSession() -> URLSession {
     let config: URLSessionConfiguration
     if let urlSessionConfigurationProvider, let concreteConfig = urlSessionConfigurationProvider() {
       config = concreteConfig

--- a/packages/expo/ios/Fetch/ExpoFetchModule.swift
+++ b/packages/expo/ios/Fetch/ExpoFetchModule.swift
@@ -99,7 +99,7 @@ private let fetchRequestQueue = DispatchQueue(label: "expo.modules.fetch.Request
     }
   }
 
-  @MainActor private func createURLSession() -> URLSession {
+  private func createURLSession() -> URLSession {
     let config: URLSessionConfiguration
     if let urlSessionConfigurationProvider, let concreteConfig = urlSessionConfigurationProvider() {
       config = concreteConfig

--- a/packages/expo/ios/Fetch/ExpoURLSessionTask.swift
+++ b/packages/expo/ios/Fetch/ExpoURLSessionTask.swift
@@ -5,7 +5,7 @@ import ExpoModulesCore
 /**
  An URLSessionDataTask wrapper.
  */
-internal final class ExpoURLSessionTask: NSObject, URLSessionTaskDelegate, URLSessionDataDelegate {
+internal final class ExpoURLSessionTask: NSObject, URLSessionTaskDelegate, URLSessionDataDelegate, @unchecked Sendable {
   private let delegate: ExpoURLSessionTaskDelegate
   private var task: URLSessionDataTask?
 
@@ -88,7 +88,7 @@ internal final class ExpoURLSessionTask: NSObject, URLSessionTaskDelegate, URLSe
   }
 }
 
-internal protocol ExpoURLSessionTaskDelegate: AnyObject {
+internal protocol ExpoURLSessionTaskDelegate: AnyObject, Sendable {
   func urlSessionDidStart(_ session: ExpoURLSessionTask)
   func urlSession(_ session: ExpoURLSessionTask, didReceive response: URLResponse)
   func urlSession(_ session: ExpoURLSessionTask, didReceive data: Data)

--- a/packages/expo/ios/Fetch/NativeRequest.swift
+++ b/packages/expo/ios/Fetch/NativeRequest.swift
@@ -5,7 +5,7 @@ import ExpoModulesCore
 /**
  A SharedObject for request.
  */
-internal final class NativeRequest: SharedObject {
+internal final class NativeRequest: SharedObject, @unchecked Sendable {
   internal let response: NativeResponse
   internal let task: ExpoURLSessionTask
 

--- a/packages/expo/ios/Fetch/NativeResponse.swift
+++ b/packages/expo/ios/Fetch/NativeResponse.swift
@@ -20,7 +20,7 @@ internal final class NativeResponse: SharedObject, ExpoURLSessionTaskDelegate, @
       }
     }
   }
-  private typealias StateChangeListener = @Sendable (ResponseState) -> Bool
+  private typealias StateChangeListener = (ResponseState) -> Bool
   private var stateChangeOnceListeners: [StateChangeListener] = []
 
   private(set) var responseInit: NativeResponseInit?

--- a/packages/expo/ios/Fetch/NativeResponse.swift
+++ b/packages/expo/ios/Fetch/NativeResponse.swift
@@ -5,7 +5,7 @@ import ExpoModulesCore
 /**
  A SharedObject for response.
  */
-internal final class NativeResponse: SharedObject, ExpoURLSessionTaskDelegate {
+internal final class NativeResponse: SharedObject, ExpoURLSessionTaskDelegate, @unchecked Sendable {
   internal let sink: ResponseSink
 
   private let dispatchQueue: DispatchQueue
@@ -20,7 +20,7 @@ internal final class NativeResponse: SharedObject, ExpoURLSessionTaskDelegate {
       }
     }
   }
-  private typealias StateChangeListener = (ResponseState) -> Bool
+  private typealias StateChangeListener = @Sendable (ResponseState) -> Bool
   private var stateChangeOnceListeners: [StateChangeListener] = []
 
   private(set) var responseInit: NativeResponseInit?
@@ -72,7 +72,7 @@ internal final class NativeResponse: SharedObject, ExpoURLSessionTaskDelegate {
   /**
    Waits for given states and when it meets the requirement, executes the callback.
    */
-  func waitFor(states: [ResponseState], callback: @escaping (ResponseState) -> Void) {
+  func waitFor(states: [ResponseState], callback: @escaping @Sendable (ResponseState) -> Void) {
     if states.contains(state) {
       callback(state)
       return


### PR DESCRIPTION
# Why

While trying to integrate Expo with https://github.com/Dimillian/IceCubesApp to test brownfiled with a SwiftUI app I notice that apps using Swift 6 fail to build due to concurrency checks 

# How

Applied the necessary adjustments to compile using Swift 6, including adding `@MainActor` and `@preconcurrency` tags and extending from Sendable

# Test Plan

Tested this with PaperTester (by manually bumping the project Swift version to 6.0) and 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
