### PR TITLE
fix: e2e custom init e2e test

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -143,7 +143,7 @@ public protocol AppControllerInterface {
   @objc func start()
 }
 
-protocol InternalAppControllerInterface: AppControllerInterface {
+public protocol InternalAppControllerInterface: AppControllerInterface {
   var updatesDirectory: URL? { get }
 
   var reloadScreenManager: Reloadable? { get }

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -201,7 +201,7 @@ public class AppController: NSObject {
     return _sharedInstance != nil
   }
   private static var _sharedInstance: InternalAppControllerInterface?
-  static var sharedInstance: InternalAppControllerInterface {
+  public static var sharedInstance: InternalAppControllerInterface {
     assert(_sharedInstance != nil, "AppController.sharedInstace was called before the module was initialized")
     return _sharedInstance!
   }

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -47,7 +47,7 @@ enum DevLauncherAppControllerError: Int, Error, LocalizedError {
 @objcMembers
 public final class DevLauncherAppController: NSObject, InternalAppControllerInterface, UpdatesExternalInterface {
   public let eventManager: UpdatesEventManager = NoOpUpdatesEventManager()
-  var reloadScreenManager: Reloadable? = ReloadScreenManager()
+  public var reloadScreenManager: Reloadable? = ReloadScreenManager()
 
   private let logger = UpdatesLogger()
 

--- a/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
@@ -10,7 +10,7 @@ import ExpoModulesCore
  * - Configuration errors (missing required configuration)
  */
 public class DisabledAppController: InternalAppControllerInterface {
-  var reloadScreenManager: Reloadable?
+  public var reloadScreenManager: Reloadable?
 
   public let isActiveController = false
   private var isStarted: Bool = false

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -8,7 +8,7 @@ import ExpoModulesCore
  */
 public class EnabledAppController: InternalAppControllerInterface, StartupProcedureDelegate {
   public weak var delegate: AppControllerDelegate?
-  var reloadScreenManager: Reloadable? = ReloadScreenManager()
+  public var reloadScreenManager: Reloadable? = ReloadScreenManager()
 
   internal let config: UpdatesConfig
   private let database: UpdatesDatabase

--- a/packages/expo-updates/ios/EXUpdates/ReloadScreen/ReloadScreenConfiguration.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReloadScreen/ReloadScreenConfiguration.swift
@@ -7,7 +7,9 @@ private let defaultSpinnerColor = UIColor.systemBlue
 private let defaultSpinnerSize = SpinnerSize.medium
 private let defaultImageResizeMode = ImageResizeMode.contain
 
-internal struct ReloadScreenOptions: Record {
+public struct ReloadScreenOptions: Record {
+  public init() {}
+
   @Field var backgroundColor: UIColor = .white
   @Field var image: ReloadScreenImageSource?
   @Field var imageResizeMode: ImageResizeMode = .contain

--- a/packages/expo-updates/ios/EXUpdates/ReloadScreen/ReloadScreenManager.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReloadScreen/ReloadScreenManager.swift
@@ -11,11 +11,11 @@ public class ReloadScreenManager: Reloadable {
     NotificationCenter.default.addObserver(self, selector: #selector(hide), name: Notification.Name("RCTContentDidAppearNotification"), object: nil)
   }
 
-  func setConfiguration(_ options: ReloadScreenOptions?) {
+  public func setConfiguration(_ options: ReloadScreenOptions?) {
     currentConfiguration = ReloadScreenConfiguration(options: options)
   }
 
-  func show() {
+  public func show() {
     if isShowing {
       return
     }
@@ -29,7 +29,7 @@ public class ReloadScreenManager: Reloadable {
   }
 
   @objc
-  func hide() {
+  public func hide() {
     if !isShowing {
       return
     }

--- a/packages/expo-updates/ios/EXUpdates/ReloadScreen/Reloadable.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReloadScreen/Reloadable.swift
@@ -1,4 +1,4 @@
-protocol Reloadable {
+public protocol Reloadable {
   func setConfiguration(_ options: ReloadScreenOptions?)
   func show()
   func hide()


### PR DESCRIPTION
# Why
Keep `InternalAppControllerInterface` public to support expo updates in [custom native projects.](https://docs.expo.dev/eas-update/integration-in-existing-native-apps/)

Currently e2e updates (custom init) test iOS build is [failing](https://expo.dev/accounts/expo-ci/projects/expo-workflow-testing/workflows/0198548a-aebd-78b6-9905-fa3fb77d519f). The protocol was made internal [here](https://github.com/expo/expo/pull/38362), so changing it back to public.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Make the interface back to public. 

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Make sure e2e updates custom init test passes
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
