### PR TITLE
[docs] [expo-updates] using Expo CLI is required for expo-updates as of SDK 53

### DIFF
--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -17,7 +17,7 @@ You may be reading the wrong guide. To use `expo-updates` in a project that uses
 
 ## Prerequisites
 
-**The `expo` package must be installed and configured.** If you created your project with `npx @react-native-community/cli@latest init` and do not have any other Expo libraries installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding. Make sure you also [Configure Expo CLI](/bare/installing-expo-modules/#configure-expo-cli-for-bundling-on-android-and-ios) as of SDK 53 the expo-updates requires Expo CLI to work.
+**The `expo` package must be installed and configured.** If you created your project with `npx @react-native-community/cli@latest init` and do not have any other Expo libraries installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding. Make sure you also [Configure Expo CLI](/bare/installing-expo-modules/#configure-expo-cli-for-bundling-on-android-and-ios) for the `expo-updates` library to work.
 
 ## Installation
 

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -17,7 +17,7 @@ You may be reading the wrong guide. To use `expo-updates` in a project that uses
 
 ## Prerequisites
 
-**The `expo` package must be installed and configured.** If you created your project with `npx @react-native-community/cli@latest init` and do not have any other Expo libraries installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding. Make sure you also [Configure Expo CLI](/bare/installing-expo-modules/#configure-expo-cli-for-bundling-on-android-and-ios) for the `expo-updates` library to work.
+**The `expo` package must be installed and configured.** If you created your project with `npx @react-native-community/cli@latest init` and do not have any other Expo libraries installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding. Starting from SDK 53, make sure you also [Configure Expo CLI](/bare/installing-expo-modules/#configure-expo-cli-for-bundling-on-android-and-ios) for the `expo-updates` library to work.
 
 ## Installation
 

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -17,7 +17,7 @@ You may be reading the wrong guide. To use `expo-updates` in a project that uses
 
 ## Prerequisites
 
-**The `expo` package must be installed and configured.** If you created your project with `npx @react-native-community/cli@latest init` and do not have any other Expo libraries installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding.
+**The `expo` package must be installed and configured.** If you created your project with `npx @react-native-community/cli@latest init` and do not have any other Expo libraries installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding. Make sure you also [Configure Expo CLI](/bare/installing-expo-modules/#configure-expo-cli-for-bundling-on-android-and-ios) as of SDK 53 the expo-updates requires Expo CLI to work.
 
 ## Installation
 


### PR DESCRIPTION
Expo CLI warning added

# Why

As of SDK 53 in order to use expo-updates Expo CLI configuration is required. We encountered [this issue](https://github.com/expo/expo/issues/38108) because we weren't using the cli in SDK 52 and opt-out of it in 53.

# How

This commit was made only to warn people to avoid a rabbit hole.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
