### PR TITLE
Fix <H1> <H2> etc "role" on web

### DIFF
--- a/packages/html-elements/src/elements/Headings.tsx
+++ b/packages/html-elements/src/elements/Headings.tsx
@@ -10,7 +10,7 @@ function createHeadingComponent(level: HeadingLevel): ComponentType<TextProps> {
   const nativeProps: any = Platform.select({
     web: {
       'aria-level': level,
-      role: 'header',
+      role: 'heading',
     },
     default: {
       accessibilityRole: 'header',


### PR DESCRIPTION
As per https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/heading_role it's `heading` not `header`

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The current `header` value is incorrect for web.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
