### PR TITLE
[android][audio] Add `recordForDuration` support on android

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [Android] Add support for `recordForDuration`.
+- [Android] Add support for `recordForDuration`. ([#38405](https://github.com/expo/expo/pull/38405) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [Android] Add support for `recordForDuration`.
+
 ### 🐛 Bug fixes
 
 - [iOS] Fix connected bluetooth devices not playing back recordings. ([#37580](https://github.com/expo/expo/pull/37580) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -472,6 +472,13 @@ class AudioModule : Module() {
         }
       }
 
+      Function("recordForDuration") { recorder: AudioRecorder, seconds: Double ->
+        checkRecordingPermission()
+        if (recorder.isPrepared) {
+          recorder.recordForDuration(seconds)
+        }
+      }
+
       Function("pause") { recorder: AudioRecorder ->
         checkRecordingPermission()
         recorder.pauseRecording()


### PR DESCRIPTION
# Why
Closes #38402
`recordForDuration` is not currently supported on android. This PR adds it.

# Test Plan
Bare-expo

