### PR TITLE
[docs] Enhance Android local dev instructions to account for flakiness when running in Android Studio

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioEnvironmentInstructions.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioEnvironmentInstructions.mdx
@@ -1,6 +1,7 @@
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
+import { Collapsible } from '~/ui/components/Collapsible';
 
 ## Install Watchman and JDK
 
@@ -35,6 +36,28 @@ After you install the JDK, add the `JAVA_HOME` environment variable in **~/.bash
 ```bash
 export JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home
 ```
+
+<Collapsible summary="Troubleshooting: Android Studio not recognizing JDK">
+
+If Android Studio doesn't recognize your homebrew installed JDK, you can create a Gradle configuration file to explicitly set the Java path:
+
+1.  Create a Gradle properties file in your home directory:
+
+    <Terminal cmd={['$ touch ~/.gradle/gradle.properties']} />
+
+2.  Add the following line to the **gradle.properties** file, replacing the path with your actual Java installation path:
+
+    ```bash gradle.properties
+    java.home=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home
+    ```
+
+3.  If you have an existing `.gradle` folder in your project directory, delete it and reopen your project in Android Studio:
+
+    <Terminal cmd={['$ rm -rf .gradle']} />
+
+This should resolve issues with Android Studio not detecting your JDK installation.
+
+</Collapsible>
 
 </Step>
 
@@ -75,3 +98,4 @@ You can download and install [OpenJDK@17](http://openjdk.java.net/) from [AdoptO
 </Tab>
 
 </Tabs>
+```

--- a/docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioEnvironmentInstructions.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioEnvironmentInstructions.mdx
@@ -1,7 +1,6 @@
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
-import { Collapsible } from '~/ui/components/Collapsible';
 
 ## Install Watchman and JDK
 
@@ -36,28 +35,6 @@ After you install the JDK, add the `JAVA_HOME` environment variable in **~/.bash
 ```bash
 export JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home
 ```
-
-<Collapsible summary="Troubleshooting: Android Studio not recognizing JDK">
-
-If Android Studio doesn't recognize your homebrew installed JDK, you can create a Gradle configuration file to explicitly set the Java path:
-
-1.  Create a Gradle properties file in your home directory:
-
-    <Terminal cmd={['$ touch ~/.gradle/gradle.properties']} />
-
-2.  Add the following line to the **gradle.properties** file, replacing the path with your actual Java installation path:
-
-    ```bash gradle.properties
-    java.home=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home
-    ```
-
-3.  If you have an existing `.gradle` folder in your project directory, delete it and reopen your project in Android Studio:
-
-    <Terminal cmd={['$ rm -rf .gradle']} />
-
-This should resolve issues with Android Studio not detecting your JDK installation.
-
-</Collapsible>
 
 </Step>
 
@@ -98,4 +75,3 @@ You can download and install [OpenJDK@17](http://openjdk.java.net/) from [AdoptO
 </Tab>
 
 </Tabs>
-```

--- a/docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioInstructions.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioInstructions.mdx
@@ -88,6 +88,28 @@ Reload the path environment variables in your current shell:
 
 Finally, make sure that you can run `adb` from your terminal.
 
+<Collapsible summary="Troubleshooting: Android Studio not recognizing JDK">
+
+If Android Studio doesn't recognize your homebrew installed JDK, you can create a Gradle configuration file to explicitly set the Java path:
+
+1.  Create a Gradle properties file in your home directory:
+
+    <Terminal cmd={['$ touch ~/.gradle/gradle.properties']} />
+
+2.  Add the following line to the **gradle.properties** file, replacing the path with your actual Java installation path:
+
+    ```bash gradle.properties
+    java.home=/Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home
+    ```
+
+3.  If you have an existing `.gradle` folder in your project directory, delete it and reopen your project in Android Studio:
+
+    <Terminal cmd={['$ rm -rf .gradle']} />
+
+This should resolve issues with Android Studio not detecting your JDK installation.
+
+</Collapsible>
+
 </Step>
 
 </Tab>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16399

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add troubleshooting steps for Android Studio not recognizing JDK in `_androidStudioInstructions.mdx` scene. This updates both Get started > Set up your environment and Android Studio Emulator guides. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="1476" height="1047" alt="CleanShot 2025-07-29 at 18 16 35" src="https://github.com/user-attachments/assets/c6e62b61-c216-4ebb-96eb-6309fc7e0f6f" />

<img width="1120" height="723" alt="CleanShot 2025-07-29 at 18 16 15" src="https://github.com/user-attachments/assets/3fee3e03-a716-49ab-a34d-a82aa8409fce" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
