### PR TITLE
[docs] Fix file URL in custom tabs

### DIFF
--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -291,7 +291,7 @@ You can provide a custom renderer to `TabSlot` to customize how it renders a scr
   files={[
     ['directory/_layout.tsx', 'The local pathname is /directory'],
     ['directory/page.tsx', 'The pathname is /directory/page'],
-    ['directory/profile.tsx', 'The pathname is /directory/page'],
+    ['directory/profile.tsx', 'The pathname is /directory/profile'],
   ]}
 />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The link in the file tree is incorrect.

# How

<!--
How did you build this feature or fix this bug and why?
-->
-

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
-

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
