### PR TITLE
[changelogs] update 'no user-facing changes' description

### DIFF
--- a/tools/src/Changelogs.ts
+++ b/tools/src/Changelogs.ts
@@ -87,7 +87,7 @@ export enum ChangeType {
 export const UNPUBLISHED_VERSION_NAME = 'Unpublished';
 
 export const VERSION_EMPTY_PARAGRAPH_TEXT =
-  '_This version does not introduce any user-facing changes._\n';
+  '_This version does not introduce any user-facing changes. This typically means that some dependency was updated or there was a minor internal change._\n';
 
 /**
  * Depth of headings that mean the version containing following changes.


### PR DESCRIPTION
# Why

Update the message for empty changelog entries to clarify that they typically indicate package dependency updates or internal changes.

# How

Modified the `VERSION_EMPTY_PARAGRAPH_TEXT` constant in `tools/src/Changelogs.ts`.

# Test Plan


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)