### PR TITLE
[go] fix build error on ios

### DIFF
--- a/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionedNetworkInterceptor.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionedNetworkInterceptor.swift
@@ -8,7 +8,7 @@ import React
 internal final class EXVersionedNetworkInterceptor: NSObject, ExpoRequestCdpInterceptorDelegate {
   private let metroConnection: RCTReconnectingWebSocket
 
-  @objc
+  @MainActor @objc
   init(bundleUrl: URL) {
     assert(Thread.isMainThread)
     self.metroConnection = RCTReconnectingWebSocket(


### PR DESCRIPTION
# Why

fix expo-go build error like https://github.com/expo/expo/actions/runs/16614301386

```
- call to main actor-isolated static method 'setCustomURLSessionConfigurationProvider' in a synchronous nonisolated context
```

# How

caused from #38390 and add `@MainActor` to the callsite as well

# Test Plan

ios expo-go build passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
