### PR TITLE
[expo-doctor] Add a peer dependency check

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### 🛠 Breaking changes
 
 ### 🎉 New features
+- Add a check for required peer dependencies ([#38445](https://github.com/expo/expo/pull/38445) by [@kadikraman](https://github.com/kadikraman))
+
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-doctor/src/checks/PeerDependencyChecks.ts
+++ b/packages/expo-doctor/src/checks/PeerDependencyChecks.ts
@@ -1,0 +1,108 @@
+import fs from 'fs';
+import path from 'path';
+
+import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+
+interface PackageJson {
+  name: string;
+  version: string;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+}
+
+export class PeerDependencyChecks implements DoctorCheck {
+  description = 'Check that required peer dependencies are installed';
+
+  sdkVersionRange = '*';
+
+  async runAsync({ pkg, projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    const issues: string[] = [];
+    const advice: string[] = [];
+
+    // Get all dependencies (including devDependencies)
+    const allDependencies = {
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+    };
+
+    if (!allDependencies || Object.keys(allDependencies).length === 0) {
+      return {
+        isSuccessful: true,
+        issues: [],
+        advice: [],
+      };
+    }
+
+    // Check each dependency for missing peer dependencies
+    for (const [packageName, packageVersion] of Object.entries(allDependencies)) {
+      const peerDependencyIssues = await this.checkPackagePeerDependencies(
+        packageName,
+        String(packageVersion),
+        projectRoot,
+        allDependencies
+      );
+      issues.push(...peerDependencyIssues);
+    }
+
+    if (issues.length > 0) {
+      advice.push(
+        'Install missing required peer dependencies using your package manager (npm install, yarn add, or pnpm add). Note: This check only verifies installation, not version compatibility.'
+      );
+    }
+
+    return {
+      isSuccessful: issues.length === 0,
+      issues,
+      advice,
+    };
+  }
+
+  private async checkPackagePeerDependencies(
+    packageName: string,
+    packageVersion: string,
+    projectRoot: string,
+    installedDependencies: Record<string, string>
+  ): Promise<string[]> {
+    const issues: string[] = [];
+
+    try {
+      // Read the package.json of the dependency
+      const packageJsonPath = path.join(projectRoot, 'node_modules', packageName, 'package.json');
+
+      if (!fs.existsSync(packageJsonPath)) {
+        // Package might not be installed or might be a workspace package
+        return issues;
+      }
+
+      const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+      const packageJson: PackageJson = JSON.parse(packageJsonContent);
+
+      if (!packageJson.peerDependencies) {
+        return issues;
+      }
+
+      // Check each peer dependency
+      for (const [peerDepName, peerDepVersion] of Object.entries(packageJson.peerDependencies)) {
+        const isOptional = packageJson.peerDependenciesMeta?.[peerDepName]?.optional;
+
+        // Skip optional peer dependencies
+        if (isOptional) {
+          continue;
+        }
+
+        // Check if the required peer dependency is installed
+        if (!installedDependencies[peerDepName]) {
+          issues.push(
+            `Required peer dependency "${peerDepName}@${peerDepVersion}" for "${packageName}" is not installed.`
+          );
+        }
+        // Note: We only check if the peer dependency is installed, not version compatibility
+      }
+    } catch (error) {
+      // If we can't read the package.json, skip this package
+      console.warn(`Warning: Could not read package.json for ${packageName}:`, error);
+    }
+
+    return issues;
+  }
+}

--- a/packages/expo-doctor/src/checks/PeerDependencyChecks.ts
+++ b/packages/expo-doctor/src/checks/PeerDependencyChecks.ts
@@ -85,7 +85,7 @@ export class PeerDependencyChecks implements DoctorCheck {
         `Install missing required peer ${isPlural ? 'dependencies' : 'dependency'} with "npx expo install ${Object.keys(groupedByMissingPeerDependency).join(' ')}"`
       );
       advice.push(
-        `Your app may crash outside of Expo Go without ${isPlural ? 'these dependencies' : 'this dependency'}.`
+        `Your app may crash outside of Expo Go without ${isPlural ? 'these dependencies' : 'this dependency'}. Native module peer dependencies must be installed directly.`
       );
     }
 

--- a/packages/expo-doctor/src/checks/__tests__/PeerDependencyChecks.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/PeerDependencyChecks.test.ts
@@ -97,7 +97,7 @@ describe('PeerDependencyChecks', () => {
       'Install missing required peer dependency with "npx expo install react-native-safe-area-context"'
     );
     expect(result.advice[1]).toContain(
-      'Your app may crash outside of Expo Go without this dependency.'
+      'Your app may crash outside of Expo Go without this dependency. Native module peer dependencies must be installed directly.'
     );
   });
 
@@ -142,7 +142,7 @@ describe('PeerDependencyChecks', () => {
       'Install missing required peer dependencies with "npx expo install react-native-safe-area-context react-native-screens"'
     );
     expect(result.advice[1]).toContain(
-      'Your app may crash outside of Expo Go without these dependencies.'
+      'Your app may crash outside of Expo Go without these dependencies. Native module peer dependencies must be installed directly.'
     );
   });
 
@@ -191,7 +191,7 @@ describe('PeerDependencyChecks', () => {
       'Install missing required peer dependency with "npx expo install react-native-safe-area-context"'
     );
     expect(result.advice[1]).toContain(
-      'Your app may crash outside of Expo Go without this dependency.'
+      'Your app may crash outside of Expo Go without this dependency. Native module peer dependencies must be installed directly.'
     );
   });
 

--- a/packages/expo-doctor/src/checks/__tests__/PeerDependencyChecks.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/PeerDependencyChecks.test.ts
@@ -1,0 +1,193 @@
+import { vol } from 'memfs';
+
+import { PeerDependencyChecks } from '../PeerDependencyChecks';
+
+jest.mock('fs');
+
+const projectRoot = '/tmp/project';
+
+// required by runAsync
+const additionalProjectProps = {
+  exp: {
+    name: 'name',
+    slug: 'slug',
+  },
+  projectRoot,
+  hasUnusedStaticConfig: false,
+  staticConfigPath: null,
+  dynamicConfigPath: null,
+};
+
+describe('PeerDependencyChecks', () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it('returns successful result when no dependencies exist', async () => {
+    const check = new PeerDependencyChecks();
+    const result = await check.runAsync({
+      pkg: { name: 'test-project', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('returns successful result when dependencies have no peer dependencies', async () => {
+    // Mock a package.json for a dependency without peer dependencies
+    vol.fromJSON({
+      [`${projectRoot}/node_modules/some-package/package.json`]: JSON.stringify({
+        name: 'some-package',
+        version: '1.0.0',
+      }),
+    });
+
+    const check = new PeerDependencyChecks();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          'some-package': '^1.0.0',
+        },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('detects missing required peer dependencies', async () => {
+    // Mock a package.json for a dependency with peer dependencies
+    vol.fromJSON({
+      [`${projectRoot}/node_modules/react-hook-form/package.json`]: JSON.stringify({
+        name: 'react-hook-form',
+        version: '7.0.0',
+        peerDependencies: {
+          react: '>=16.8.0',
+          'react-dom': '>=16.8.0',
+        },
+      }),
+    });
+
+    const check = new PeerDependencyChecks();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          'react-hook-form': '^7.0.0',
+        },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.issues).toHaveLength(2);
+    expect(result.issues[0]).toContain('Required peer dependency "react');
+    expect(result.issues[1]).toContain('Required peer dependency "react-dom');
+  });
+
+  it('ignores optional peer dependencies', async () => {
+    // Mock a package.json for a dependency with optional peer dependencies
+    vol.fromJSON({
+      [`${projectRoot}/node_modules/some-ui-lib/package.json`]: JSON.stringify({
+        name: 'some-ui-lib',
+        version: '1.0.0',
+        peerDependencies: {
+          'styled-components': '^5.0.0',
+        },
+        peerDependenciesMeta: {
+          'styled-components': {
+            optional: true,
+          },
+        },
+      }),
+    });
+
+    const check = new PeerDependencyChecks();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          'some-ui-lib': '^1.0.0',
+        },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('does not check version compatibility for installed peer dependencies', async () => {
+    // Mock a package.json for a dependency with peer dependencies
+    vol.fromJSON({
+      [`${projectRoot}/node_modules/react-hook-form/package.json`]: JSON.stringify({
+        name: 'react-hook-form',
+        version: '7.0.0',
+        peerDependencies: {
+          react: '^18.0.0',
+        },
+      }),
+    });
+
+    const check = new PeerDependencyChecks();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          'react-hook-form': '^7.0.0',
+          react: '^17.0.0', // Version that doesn't satisfy ^18.0.0, but should not be flagged
+        },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('handles missing package.json gracefully', async () => {
+    const check = new PeerDependencyChecks();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          'non-existent-package': '^1.0.0',
+        },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('provides helpful advice when issues are found', async () => {
+    // Mock a package.json for a dependency with peer dependencies
+    vol.fromJSON({
+      [`${projectRoot}/node_modules/react-hook-form/package.json`]: JSON.stringify({
+        name: 'react-hook-form',
+        version: '7.0.0',
+        peerDependencies: {
+          react: '>=16.8.0',
+        },
+      }),
+    });
+
+    const check = new PeerDependencyChecks();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          'react-hook-form': '^7.0.0',
+        },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.advice).toHaveLength(1);
+    expect(result.advice[0]).toContain('Install missing required peer dependencies');
+  });
+}); 

--- a/packages/expo-doctor/src/utils/checkResolver.ts
+++ b/packages/expo-doctor/src/utils/checkResolver.ts
@@ -18,6 +18,7 @@ import { MetroConfigCheck } from '../checks/MetroConfigCheck';
 import { NativeToolingVersionCheck } from '../checks/NativeToolingVersionCheck';
 import { PackageJsonCheck } from '../checks/PackageJsonCheck';
 import { PackageManagerVersionCheck } from '../checks/PackageManagerVersionCheck';
+import { PeerDependencyChecks } from '../checks/PeerDependencyChecks';
 import { ProjectSetupCheck } from '../checks/ProjectSetupCheck';
 import { ReactNativeDirectoryCheck } from '../checks/ReactNativeDirectoryCheck';
 import { StoreCompatibilityCheck } from '../checks/StoreCompatibilityCheck';
@@ -45,6 +46,7 @@ export function resolveChecksInScope(exp: ExpoConfig, pkg: PackageJSONConfig): D
     new IllegalPackageCheck(),
     new GlobalPackageInstalledLocallyCheck(),
     new DirectPackageInstallCheck(),
+    new PeerDependencyChecks(),
 
     // Version Checks
     new SupportPackageVersionCheck(),


### PR DESCRIPTION
# Why

Users are often running into an issue where their app works in Expo Go, but when they build a dev build or an App Store build, the app crashes or gets stuck on the splash screen.

I have found that this is often caused by missing required peer dependencies. The app works in Expo Go because it includes a lot of native packages even if the user hasn't installed them. But when a dev build (or an App Store build) is created, only dependencies in the `package.json` are included.

To try it yourself:

```sh
bun create expo-app my-app
cd my-app
bun remove react-native-safe-area-context
npx expo run:ios
```

As `react-native-safe-area-context` is required by `@react-navigation/bottom-tabs`, `@react-navigation/elements`, `expo-router`, without it the app will hang on the Splash screen.

In the "real world" the way this easily happens is when users install a library, but miss the instruction for the peer dependency. There is no immediate feedback to the user if they're using Expo Go and the library is pre-installed.

Some examples from the community:
1. installing `@react-navigation/stack`, but missing [this instruction](https://reactnavigation.org/docs/stack-navigator/#installation) to install `react-native-gesture-handler` (crashes)
2. installing `react-native-qrcode-svg`, but missing [this instruction](https://github.com/Expensify/react-native-qrcode-svg#installation) for `react-native-svg` (red box of sadness)

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Add another doctor check that will check **required** peer dependencies of all the packages in your `package.json` and error for missing ones.

I have intentionally ignored the required version (since that is handled by `npx expo install`) and optional peer deps.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Build `expo-doctor` with `yarn`.

```sh
bun create expo-app my-app
cd my-app
bun remove react-native-safe-area-context
# run the expo doctor check from expo-doctor/build/index.js
```

<img width="1082" height="357" alt="Screenshot 2025-07-30 at 17 52 48" src="https://github.com/user-attachments/assets/e756b04e-87c7-4266-8aee-0ea0ae42695c" />

Also added unit tests.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
