### PR TITLE
[test-suite] Fix devtools imports in test-suite

### DIFF
--- a/apps/test-suite/tests/DevToolsPluginClient.ts
+++ b/apps/test-suite/tests/DevToolsPluginClient.ts
@@ -2,11 +2,11 @@ import {
   DevToolsPluginClient,
   getDevToolsPluginClientAsync,
   type DevToolsPluginClientOptions,
-} from 'expo/devtools';
-import { createDevToolsPluginClient } from 'expo/src/devtools/DevToolsPluginClientFactory';
-import { WebSocketBackingStore } from 'expo/src/devtools/WebSocketBackingStore';
-import { type ConnectionInfo } from 'expo/src/devtools/devtools.types';
-import { getConnectionInfo } from 'expo/src/devtools/getConnectionInfo';
+} from '@expo/devtools';
+import { createDevToolsPluginClient } from '@expo/devtools/src/DevToolsPluginClientFactory';
+import { WebSocketBackingStore } from '@expo/devtools/src/WebSocketBackingStore';
+import { type ConnectionInfo } from '@expo/devtools/src/devtools.types';
+import { getConnectionInfo } from '@expo/devtools/src/getConnectionInfo';
 
 export const name = 'DevToolsPluginClient';
 


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/38438 Moves the devtools to `@expo` we need to update the imports in `test-suite`. Currently bare-expo and test-suite don't work for me on main.

# How

Updated the imports in `DevToolsPluginClient.ts` to import from `@expo`

# Test Plan

Tested in `test-suite` and Expo Go on Android
✅ `DevToolsPluginClient` tests pass 
