### PR TITLE
[docs] Update API routes Bun example, remove `./websocket` and `dotenv`

### DIFF
--- a/docs/pages/router/reference/api-routes.mdx
+++ b/docs/pages/router/reference/api-routes.mdx
@@ -380,10 +380,6 @@ Write a server entry file that serves the static files and delegates requests to
 
 ```ts server.ts
 import { createRequestHandler } from '@expo/server/adapter/bun';
-import dotenv from 'dotenv';
-
-import { websocket } from './websocket';
-dotenv.config();
 
 const CLIENT_BUILD_DIR = `${process.cwd()}/dist/client`;
 const SERVER_BUILD_DIR = `${process.cwd()}/dist/server`;


### PR DESCRIPTION
This PR fixes the example to be copy-pastable and work out of the box. 

The following breaks the example: `./websocket` is a local file which is not needed for the minimal example and the guide doesn't instruct users to create it.

The following is extra: `dotenv` is useful to load envs from `.env` files, but it's an extra and the other guides on the page do not add it. (Maybe we should add it to all of the guides.)
