### PR TITLE
[docs] improve code blocks on mobile

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -102,20 +102,22 @@ export function Code({ className, children, title }: CodeProps) {
         <CopyAction text={cleanCopyValue(value)} />
         <SettingsAction />
       </SnippetHeader>
-      <SnippetContent>
+      <SnippetContent className="p-0">
         <pre
           ref={contentRef}
           style={{
             maxHeight: collapseBound,
           }}
-          className={mergeClasses('relative w-fit whitespace-pre', commonClasses)}
+          className={mergeClasses('relative whitespace-pre', commonClasses)}
           {...attributes}>
-          <code
-            className="text-2xs text-default"
-            dangerouslySetInnerHTML={{ __html: highlightedHtml.replace(/^@@@.+@@@/g, '') }}
-          />
+          <div className="w-fit p-4">
+            <code
+              className="text-2xs text-default"
+              dangerouslySetInnerHTML={{ __html: highlightedHtml.replace(/^@@@.+@@@/g, '') }}
+            />
+          </div>
+          {showExpand && <SnippetExpandOverlay onClick={expandCodeBlock} />}
         </pre>
-        {showExpand && <SnippetExpandOverlay onClick={expandCodeBlock} />}
       </SnippetContent>
     </Snippet>
   ) : (

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -93,7 +93,7 @@ export function Code({ className, children, title }: CodeProps) {
 
   const commonClasses = mergeClasses(
     wordWrap && '!break-words !whitespace-pre-wrap',
-    showExpand && !isExpanded && `!overflow-hidden`
+    showExpand && !isExpanded && `!overflow-y-hidden [&::-webkit-scrollbar-track]:!bg-default`
   );
 
   return codeBlockTitle ? (
@@ -102,20 +102,20 @@ export function Code({ className, children, title }: CodeProps) {
         <CopyAction text={cleanCopyValue(value)} />
         <SettingsAction />
       </SnippetHeader>
-      <SnippetContent className="p-0">
+      <SnippetContent>
         <pre
           ref={contentRef}
           style={{
             maxHeight: collapseBound,
           }}
-          className={mergeClasses('relative whitespace-pre p-4', commonClasses)}
+          className={mergeClasses('relative w-fit whitespace-pre', commonClasses)}
           {...attributes}>
           <code
             className="text-2xs text-default"
             dangerouslySetInnerHTML={{ __html: highlightedHtml.replace(/^@@@.+@@@/g, '') }}
           />
-          {showExpand && <SnippetExpandOverlay onClick={expandCodeBlock} />}
         </pre>
+        {showExpand && <SnippetExpandOverlay onClick={expandCodeBlock} />}
       </SnippetContent>
     </Snippet>
   ) : (
@@ -125,16 +125,18 @@ export function Code({ className, children, title }: CodeProps) {
         maxHeight: collapseBound,
       }}
       className={mergeClasses(
-        'relative my-4 overflow-x-auto whitespace-pre rounded-md border border-secondary bg-subtle p-4',
+        'relative my-4 overflow-x-auto whitespace-pre rounded-md border border-secondary bg-subtle',
         preferredTheme === Themes.DARK && 'dark-theme',
         commonClasses,
         '[p+&]:mt-0'
       )}
       {...attributes}>
-      <code
-        className="text-2xs text-default"
-        dangerouslySetInnerHTML={{ __html: highlightedHtml }}
-      />
+      <div className="w-fit p-4">
+        <code
+          className="text-2xs text-default"
+          dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+        />
+      </div>
       {showExpand && <SnippetExpandOverlay onClick={expandCodeBlock} />}
     </pre>
   );

--- a/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
+++ b/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
@@ -109,53 +109,57 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
         </span>
       </p>
       <pre
-        class="relative my-4 overflow-x-auto whitespace-pre rounded-md border border-secondary bg-subtle p-4 [p+&]:mt-0"
+        class="relative my-4 overflow-x-auto whitespace-pre rounded-md border border-secondary bg-subtle [p+&]:mt-0"
         data-text="true"
       >
-        <code
-          class="text-2xs text-default"
+        <div
+          class="w-fit p-4"
         >
-          <span
-            class="token keyword"
+          <code
+            class="text-2xs text-default"
           >
-            await
-          </span>
-           Application
-          <span
-            class="token punctuation"
-          >
-            .
-          </span>
-          <span
-            class="token function"
-          >
-            getInstallReferrerAsync
-          </span>
-          <span
-            class="token punctuation"
-          >
-            (
-          </span>
-          <span
-            class="token punctuation"
-          >
-            )
-          </span>
-          <span
-            class="token punctuation"
-          >
-            ;
-          </span>
-          
+            <span
+              class="token keyword"
+            >
+              await
+            </span>
+             Application
+            <span
+              class="token punctuation"
+            >
+              .
+            </span>
+            <span
+              class="token function"
+            >
+              getInstallReferrerAsync
+            </span>
+            <span
+              class="token punctuation"
+            >
+              (
+            </span>
+            <span
+              class="token punctuation"
+            >
+              )
+            </span>
+            <span
+              class="token punctuation"
+            >
+              ;
+            </span>
+            
 
-          <span
-            class="token comment"
-          >
-            // "utm_source=google-play&utm_medium=organic"
-          </span>
-          
+            <span
+              class="token comment"
+            >
+              // "utm_source=google-play&utm_medium=organic"
+            </span>
+            
 
-        </code>
+          </code>
+        </div>
       </pre>
     </div>
   </div>

--- a/docs/ui/components/Snippet/SnippetAction.tsx
+++ b/docs/ui/components/Snippet/SnippetAction.tsx
@@ -25,7 +25,7 @@ export const SnippetAction = ({
         alwaysDark &&
           'dark-theme border-transparent bg-transparent hocus:border-palette-gray9 hocus:bg-palette-gray5 hocus:shadow-xs',
         !alwaysDark &&
-          'h-10 rounded-none border-0 border-l border-l-default px-4 leading-10 hocus:bg-subtle hocus:shadow-none',
+          'h-10 rounded-none border-0 border-l border-l-default leading-10 hocus:bg-subtle hocus:shadow-none',
         className
       )}
       {...rest}>

--- a/docs/ui/components/Snippet/SnippetExpandOverlay.tsx
+++ b/docs/ui/components/Snippet/SnippetExpandOverlay.tsx
@@ -6,8 +6,8 @@ type Props = {
 
 export function SnippetExpandOverlay({ onClick }: Props) {
   return (
-    <div className="absolute bottom-0 left-0 flex w-full bg-gradient-to-b from-transparent to-default p-6">
-      <Button theme="secondary" onClick={onClick} className="mx-auto">
+    <div className="sticky bottom-0 left-0 flex w-full bg-gradient-to-b from-transparent to-default p-6">
+      <Button theme="secondary" onClick={onClick} className="asset-sm-shadow mx-auto">
         Show more
       </Button>
     </div>

--- a/docs/ui/components/Snippet/actions/CopyAction.tsx
+++ b/docs/ui/components/Snippet/actions/CopyAction.tsx
@@ -20,12 +20,13 @@ export const CopyAction = ({ text, ...rest }: CopyActionProps) => {
 
   return (
     <SnippetAction
-      leftSlot={<ClipboardIcon className="icon-sm text-icon-secondary max-sm-gutters:-mr-1" />}
+      leftSlot={<ClipboardIcon className="icon-sm text-icon-secondary" />}
       onClick={onCopyClick}
       disabled={copyDone}
+      className="max-sm-gutters:gap-0 [&_p]:max-sm-gutters:hidden"
       aria-label="Copy content"
       {...rest}>
-      <span className="max-sm-gutters:hidden">{copyDone ? 'Copied!' : 'Copy'}</span>
+      {copyDone ? 'Copied!' : 'Copy'}
     </SnippetAction>
   );
 };

--- a/docs/ui/components/Snippet/blocks/SnackInline.tsx
+++ b/docs/ui/components/Snippet/blocks/SnackInline.tsx
@@ -100,9 +100,8 @@ export const SnackInline = ({
           <CopyAction text={cleanCopyValue(value)} />
           <SnippetAction
             disabled={!isReady}
-            rightSlot={
-              <ArrowUpRightIcon className="icon-sm text-icon-secondary max-sm-gutters:-ml-1.5" />
-            }
+            rightSlot={<ArrowUpRightIcon className="icon-sm text-icon-secondary" />}
+            className="max-sm-gutters:gap-0 [&_p]:max-sm-gutters:hidden"
             type="submit">
             <span className="max-sm-gutters:hidden">
               <span className="max-md-gutters:hidden">Open in </span>Snack

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -78,7 +78,7 @@ function cmdMapper(line: string, index: number) {
 
   if (line.startsWith('$')) {
     return (
-      <div key={key}>
+      <div key={key} className="w-fit">
         <CODE className="select-none whitespace-pre !border-none !bg-transparent !text-secondary">
           -&nbsp;
         </CODE>


### PR DESCRIPTION
# Why

Fixes ENG-16811

# How

Summary of changes:
* allow scrolling code block horizontally even when collapsed
* fix missing padding on the right side of scrollable code blocks
* improve the action buttons rendering on mobile viewport

# Test Plan

1. Run docs app locally.
2. Test out different types of code blocks: bare blocks, snippets with header and terminal.
3. Switch to mobile viewports, re-tests code blocks listed above.

# Preview

https://github.com/user-attachments/assets/5120bdb0-d997-4007-8737-fb8af00d6547

