### PR TITLE
[ios][0.81.0] Use RN Precompiled binaries in tests

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -70,6 +70,9 @@ jobs:
       - name: 🥥 Install CocoaPods in `apps/native-tests/ios`
         if: steps.expo-caches.outputs.bare-expo-pods-hit != 'true'
         run: pod install
+        env:
+          RCT_USE_PREBUILT_RNCORE: 1
+          RCT_USE_RN_DEP: 1
         working-directory: apps/native-tests/ios
       - name: 🧪 Run native iOS unit tests
         timeout-minutes: 60

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -68,6 +68,9 @@ jobs:
       - name: 🥥 Install pods in apps/bare-expo/ios
         if: steps.expo-caches.outputs.ios-pods-hit != 'true'
         run: pod install
+        env:
+          RCT_USE_PREBUILT_RNCORE: 1
+          RCT_USE_RN_DEP: 1
         working-directory: apps/bare-expo/ios
       - name: 🏗️ Build iOS project
         run: ./scripts/start-ios-e2e-test.js --build


### PR DESCRIPTION
# Why

Use precompiled binaries when running tests

# How

Added to the build / pod install step in ios-unit-tests and test-suite

# Test Plan

Run tests, measure speed of iOS builds

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
