### PR TITLE
[docs] Clarify that accounts with SSO still need a single non-SSO account

### DIFF
--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -27,6 +27,8 @@ We implement the [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-
 
 ## Setting up SSO on an organization
 
+> Organization accounts must maintain at least one non-SSO user with the Owner role. This user is needed for the initial SSO setup and to ensure uninterrupted access to your organization if your SSO configuration changes or if you discontinue the use of SSO.
+
 <Step label="1">
 
 Log in as the Organization account owner. In your account's EAS dashboard, go to **Settings** > **Organization settings** > **Create SSO configuration for account**.


### PR DESCRIPTION
# Why

It's a question that's been asked more than once or twice, let's clarify it

# How

Added a callout regarding this

# Test Plan

checked the doc

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
