### PR TITLE
Bump react-native-worklets to 0.4.1

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3685,7 +3685,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNWorklets (0.4.0):
+  - RNWorklets (0.4.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3711,10 +3711,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets (= 0.4.0)
+    - RNWorklets/worklets (= 0.4.1)
     - SocketRocket
     - Yoga
-  - RNWorklets/worklets (0.4.0):
+  - RNWorklets/worklets (0.4.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3740,10 +3740,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets/apple (= 0.4.0)
+    - RNWorklets/worklets/apple (= 0.4.1)
     - SocketRocket
     - Yoga
-  - RNWorklets/worklets/apple (0.4.0):
+  - RNWorklets/worklets/apple (0.4.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -4578,7 +4578,7 @@ SPEC CHECKSUMS:
   RNReanimated: bc92d92315bde5372395f9f9b96e44bde14ea612
   RNScreens: c0f1e602f1c663c721a8faf7a10f48b9823e45f5
   RNSVG: 8d87cff016edf1b6ca409ed39804101836d75e90
-  RNWorklets: cdcb3e4f5e9aea5b946974d0f95e40d01d651033
+  RNWorklets: f0b4bfd581c55f18a8bea9beae9cef26650c8cda
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -69,7 +69,7 @@
     "react-native-gesture-handler": "~2.26.0",
     "react-native-keyboard-controller": "^1.18.2",
     "react-native-pager-view": "6.8.1",
-    "react-native-worklets": "0.4.0",
+    "react-native-worklets": "0.4.1",
     "react-native-reanimated": "4.0.1",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "4.12.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3553,7 +3553,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNWorklets (0.4.0):
+  - RNWorklets (0.4.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3579,10 +3579,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets (= 0.4.0)
+    - RNWorklets/worklets (= 0.4.1)
     - SocketRocket
     - Yoga
-  - RNWorklets/worklets (0.4.0):
+  - RNWorklets/worklets (0.4.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3608,10 +3608,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets/apple (= 0.4.0)
+    - RNWorklets/worklets/apple (= 0.4.1)
     - SocketRocket
     - Yoga
-  - RNWorklets/worklets/apple (0.4.0):
+  - RNWorklets/worklets/apple (0.4.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -4493,7 +4493,7 @@ SPEC CHECKSUMS:
   RNReanimated: bc92d92315bde5372395f9f9b96e44bde14ea612
   RNScreens: c0f1e602f1c663c721a8faf7a10f48b9823e45f5
   RNSVG: 8d87cff016edf1b6ca409ed39804101836d75e90
-  RNWorklets: cdcb3e4f5e9aea5b946974d0f95e40d01d651033
+  RNWorklets: f0b4bfd581c55f18a8bea9beae9cef26650c8cda
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -79,7 +79,7 @@
     "react-native-maps": "1.24.13",
     "react-native-pager-view": "6.8.1",
     "react-native-paper": "^5.12.5",
-    "react-native-worklets": "0.4.0",
+    "react-native-worklets": "0.4.1",
     "react-native-reanimated": "4.0.1",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "4.12.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -145,7 +145,7 @@
     "react-native-maps": "1.24.13",
     "react-native-pager-view": "6.8.1",
     "react-native-paper": "^5.12.5",
-    "react-native-worklets": "0.4.0",
+    "react-native-worklets": "0.4.1",
     "react-native-reanimated": "4.0.1",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "4.12.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -100,7 +100,7 @@
   "react-native-keyboard-controller": "1.18.2",
   "react-native-maps": "1.24.13",
   "react-native-pager-view": "6.8.1",
-  "react-native-worklets": "~0.4.0",
+  "react-native-worklets": "~0.4.1",
   "react-native-reanimated": "~4.0.1",
   "react-native-screens": "~4.11.1",
   "react-native-safe-area-context": "5.5.2",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -33,7 +33,7 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.0-rc.3",
     "react-native-gesture-handler": "~2.26.0",
-    "react-native-worklets": "~0.4.0",
+    "react-native-worklets": "~0.4.1",
     "react-native-reanimated": "~4.0.1",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "~4.11.1",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -28,7 +28,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.0-rc.3",
-    "react-native-worklets": "~0.4.0",
+    "react-native-worklets": "~0.4.1",
     "react-native-reanimated": "~4.0.1",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "~4.11.1",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Based on https://github.com/expo/expo/pull/38380

To avoid https://github.com/software-mansion/react-native-reanimated/issues/7897, failing web export due to `Unable to determine short name for _$$_IMPORT_ALL2. The variables are not unique: g, r, i`, which was fixed in https://github.com/software-mansion/react-native-reanimated/releases/tag/worklets-0.4.1.

Reanimated 4.0.1 is compatible with Worklets `>=0.3.0`. (https://github.com/software-mansion/react-native-reanimated/blob/4.0.1/packages/react-native-reanimated/package.json#L96C1-L96C39

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

1. Create `npx create-expo-app@latest TestApp`
2. Pin `react-native-worklets@0.4.0`
3. Run `npx expo export -p web`

```
$ npx expo export -p web
Starting Metro Bundler
Static rendering is enabled. Learn more
SyntaxError: ../../node_modules/react-native-worklets/lib/module/initializers.js: Unable to determine short name for _$$_IMPORT_ALL2. The variables are not unique: g, r, i
ReferenceError: Unable to determine short name for _$$_IMPORT_ALL2. The variables are not unique: g, r, i
    at getShortName (/Users/krystofwoldrich/repos/expo/expo/node_modules/metro-transform-plugins/src/normalizePseudoGlobals.js:55:9)
    at /Users/krystofwoldrich/repos/expo/expo/node_modules/metro-transform-plugins/src/normalizePseudoGlobals.js:22:9
    at Array.map (<anonymous>)
    at Program (/Users/krystofwoldrich/repos/expo/expo/node_modules/metro-transform-plugins/src/normalizePseudoGlobals.js:20:39)
    at NodePath._call (/Users/krystofwoldrich/repos/expo/expo/node_modules/@babel/traverse/lib/path/context.js:49:20)
    at NodePath.call (/Users/krystofwoldrich/repos/expo/expo/node_modules/@babel/traverse/lib/path/context.js:39:18)
    at NodePath.visit (/Users/krystofwoldrich/repos/expo/expo/node_modules/@babel/traverse/lib/path/context.js:88:31)
    at TraversalContext.visitQueue (/Users/krystofwoldrich/repos/expo/expo/node_modules/@babel/traverse/lib/context.js:90:16)
    at TraversalContext.visitSingle (/Users/krystofwoldrich/repos/expo/expo/node_modules/@babel/traverse/lib/context.js:66:19)
    at TraversalContext.visit (/Users/krystofwoldrich/repos/expo/expo/node_modules/@babel/traverse/lib/context.js:113:19)
    at traverseNode (/Users/krystofwoldrich/repos/expo/expo/node_modules/@babel/traverse/lib/traverse-node.js:131:17)
    at traverse (/Users/krystofwoldrich/repos/expo/expo/node_modules/@babel/traverse/lib/index.js:53:34)
    at Object.normalizePseudoglobals (/Users/krystofwoldrich/repos/expo/expo/node_modules/metro-transform-plugins/src/normalizePseudoGlobals.js:8:3)
    at transformJS (/Users/krystofwoldrich/repos/expo/expo/packages/@expo/metro-config/build/transform-worker/metro-transform-worker.js:371:48)
    at transformJSWithBabel (/Users/krystofwoldrich/repos/expo/expo/packages/@expo/metro-config/build/transform-worker/metro-transform-worker.js:493:18)
```
