### PR TITLE
[go] Update react-native to 0.81.0-rc.3

### DIFF
--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -22,7 +22,7 @@
       },
       "ios": {
         "cache": {
-          "key": "sdk54-0.80.1",
+          "key": "sdk54-0.81.0-rc.3",
           "customPaths": ["../expo-go/ios/Pods"]
         },
         "image": "latest",
@@ -70,7 +70,7 @@
         "scheme": "Expo Go",
         "simulator": true,
         "buildConfiguration": "Release"
-      },
+      }
     },
     "release-client": {
       "extends": "versioned-client",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -485,8 +485,16 @@ PODS:
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
   - hermes-engine (0.81.0-rc.3):
-    - hermes-engine/Pre-built (= 0.81.0-rc.3)
-  - hermes-engine/Pre-built (0.81.0-rc.3)
+    - hermes-engine/cdp (= 0.81.0-rc.3)
+    - hermes-engine/Hermes (= 0.81.0-rc.3)
+    - hermes-engine/inspector (= 0.81.0-rc.3)
+    - hermes-engine/inspector_chrome (= 0.81.0-rc.3)
+    - hermes-engine/Public (= 0.81.0-rc.3)
+  - hermes-engine/cdp (0.81.0-rc.3)
+  - hermes-engine/Hermes (0.81.0-rc.3)
+  - hermes-engine/inspector (0.81.0-rc.3)
+  - hermes-engine/inspector_chrome (0.81.0-rc.3)
+  - hermes-engine/Public (0.81.0-rc.3)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -4356,7 +4364,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: b58e9627004f47043897eeae830c3ef023678f3b
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: cc20804c5f764b4c785deafa291b6fa77bbf71fd
+  hermes-engine: 78c48f2a4d740ac171d2b44f4b6da04dbe844eca
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8


### PR DESCRIPTION
# Why

Follow-up of https://github.com/expo/expo/pull/38437

# How

Updated our react-native fork to 0.81.0-rc and cherry-picked all commits (full logs at https://www.notion.so/expo/React-Native-fork-upgrade-log-241e5b57352480908b8cd554c330ec74 )

# Test Plan

Run Expo Go locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
