### PR TITLE
[docs] Explicitly mention prepared statements in the context of SQL injections

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -133,7 +133,7 @@ for await (const row of db.getEachAsync('SELECT * FROM test')) {
 
 ### Prepared statements
 
-Prepared statements allow you to compile your SQL query once and execute it multiple times with different parameters. You can get a prepared statement by calling [`prepareAsync()`](#prepareasyncsource) or [`prepareSync()`](#preparesyncsource) method on a database instance. The prepared statement can fulfill CRUD operations by calling [`executeAsync()`](#executeasyncparams) or [`executeSync()`](#executesyncparams) method.
+Prepared statements allow you to compile your SQL query once and execute it multiple times with different parameters. They automatically escape input parameters to defend against SQL injection attacks, and are recommended for queries that include user input. You can get a prepared statement by calling [`prepareAsync()`](#prepareasyncsource) or [`prepareSync()`](#preparesyncsource) method on a database instance. The prepared statement can fulfill CRUD operations by calling [`executeAsync()`](#executeasyncparams) or [`executeSync()`](#executesyncparams) method.
 
 > **Note:** Remember to call [`finalizeAsync()`](#finalizeasync) or [`finalizeSync()`](#finalizesync) method to release the prepared statement after you finish using the statement. `try-finally` block is recommended to ensure the prepared statement is finalized.
 
@@ -480,6 +480,10 @@ If you're currently using `@react-native-async-storage/async-storage` in your pr
 - import AsyncStorage from '@react-native-async-storage/async-storage';
 + import AsyncStorage from 'expo-sqlite/kv-store';
 ```
+
+## Security
+
+SQL injections are a class of vulnerabilities where attackers trick your app into executing user input as SQL code. You must escape all user input passed to SQLite to defend against SQL injections. [Prepared statements](#prepared-statements) are an effective defense against this problem. They explicitly separate a SQL query's logic from its input parameters, and SQLite automatically escapes inputs when executing prepared statements.
 
 ## Third-party library integrations
 


### PR DESCRIPTION
Why
===
When someone searches for how to defend against SQL injections but isn't thinking about keywords like "prepared statements" or "parameterized queries" we want them to find the right solution (prepared statements). Closes ENG-16810

How
===
Mentioned SQL injections in the prepared statements section, and added a new security section to the SQLite docs.

Test plan
===
yarn dev -> http://localhost:3002/versions/unversioned/sdk/sqlite/
