### PR TITLE
[ncl] Fix invalid video source in VideoThumbnails screen

### DIFF
--- a/apps/native-component-list/src/screens/VideoThumbnailsScreen.tsx
+++ b/apps/native-component-list/src/screens/VideoThumbnailsScreen.tsx
@@ -22,7 +22,9 @@ export default function VideoThumbnailsScreen() {
       <Text>{image}</Text>
       <Button
         onPress={() =>
-          generateThumbnail('https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4')
+          generateThumbnail(
+            'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4'
+          )
         }
         title="Check Valid Source"
       />


### PR DESCRIPTION
# Why

The source used as a valid source has stopped working

# How

Switched the source to a Big Buck Bunny link from expo-video

# Test Plan

Tested in BareExpo

