### PR TITLE
[CI] Use precompiled RNCore artifacts for updates E2E tests

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
@@ -103,7 +103,7 @@ jobs:
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          npx pod-install
+          yarn ios:pod-install
       - name: Compile TV project
         id: build
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
@@ -49,7 +49,7 @@ jobs:
         working_directory: ../../../updates-e2e
         run: |
           yarn generate-test-update-bundles ios test-update-1
-          npx pod-install
+          yarn ios:pod-install
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
@@ -49,7 +49,7 @@ jobs:
         working_directory: ../../../updates-e2e
         run: |
           yarn generate-test-update-bundles ios
-          npx pod-install
+          yarn ios:pod-install
       - name: Build E2E test app (debug)
         id: builddebug
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
@@ -63,7 +63,7 @@ jobs:
         working_directory: ../../../updates-e2e
         run: |
           yarn generate-test-update-bundles ios test-update-1
-          npx pod-install
+          yarn ios:pod-install
       - name: Build E2E test app (debug)
         id: builddebug
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
@@ -56,8 +56,8 @@ jobs:
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles
-          npx pod-install
+          yarn generate-test-update-bundles ios test-update-1
+          yarn ios:pod-install
       - name: Build E2E test app (debug)
         id: builddebug
         working_directory: ../../../updates-e2e
@@ -111,7 +111,7 @@ jobs:
         env:
           JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
         run: |
-          yarn generate-test-update-bundles
+          yarn generate-test-update-bundles android test-update-1
       - uses: eas/start_android_emulator
         with:
           device_name: pixel_4

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
@@ -73,7 +73,7 @@ jobs:
         working_directory: ../../../updates-e2e
         run: |
           yarn generate-test-update-bundles ios
-          npx pod-install
+          yarn ios:pod-install
       - name: Build E2E test app (debug)
         id: builddebug
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
@@ -49,7 +49,7 @@ jobs:
         working_directory: ../../../updates-e2e
         run: |
           yarn generate-test-update-bundles ios test-update-crashing
-          npx pod-install
+          yarn ios:pod-install
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
@@ -49,7 +49,7 @@ jobs:
         working_directory: ../../../updates-e2e
         run: |
           yarn generate-test-update-bundles ios test-update-1
-          npx pod-install
+          yarn ios:pod-install
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-old-arch.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-old-arch.yml
@@ -49,7 +49,7 @@ jobs:
         working_directory: ../../../updates-e2e
         run: |
           yarn generate-test-update-bundles ios
-          npx pod-install
+          yarn ios:pod-install
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
@@ -49,7 +49,7 @@ jobs:
         working_directory: ../../../updates-e2e
         run: |
           yarn generate-test-update-bundles ios test-update-1
-          npx pod-install
+          yarn ios:pod-install
       - name: Build E2E test app (debug)
         id: builddebug
         working_directory: ../../../updates-e2e

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -308,6 +308,7 @@ async function preparePackageJson(
   const extraScripts = configureE2E
     ? {
         start: 'expo start --private-key-path ./keys/private-key.pem',
+        'ios:pod-install': 'RCT_USE_PREBUILT_RNCORE=1 RCT_USE_RN_DEP=1 npx pod-install',
         'maestro:android:debug:build': 'cd android; ./gradlew :app:assembleDebug; cd ..',
         'maestro:android:debug:install':
           'adb install android/app/build/outputs/apk/debug/app-debug.apk',
@@ -385,7 +386,7 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@0.80.1-0',
+        'react-native': 'npm:react-native-tvos@0.81.0-0rc3',
         '@react-native-tvos/config-tv': '^0.1.3',
       },
       expo: {


### PR DESCRIPTION
# Why

Now that the main branch has moved to RN 0.81, we can use precompiled RN artifacts to make the iOS and tvOS tests faster.

# How

- Bump RNTV dependency to 0.81 in TV project generation
- Add package.json script to the project to run pod-install with the correct env settings
- Modify workflow files to use the new script

# Test Plan

CI should pass
