### PR TITLE
[sqlite] Support Apple TV

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Support Apple TV. ([#38475](https://github.com/expo/expo/pull/38475) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 - [Android] Fix nullability of binding params. ([#37200](https://github.com/expo/expo/pull/37200) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-sqlite/ios/ExpoSQLite.podspec
+++ b/packages/expo-sqlite/ios/ExpoSQLite.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '15.1',
+    :tvos => '15.1',
     :osx => '11.0'
   }
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -22,8 +22,13 @@ public final class SQLiteModule: Module {
     Name("ExpoSQLite")
 
     Constants {
+      #if os(tvOS)
+      let defaultDatabaseDirectory =
+        appContext?.config.cacheDirectory?.appendingPathComponent("SQLite").standardized.path
+      #else
       let defaultDatabaseDirectory =
         appContext?.config.documentDirectory?.appendingPathComponent("SQLite").standardized.path
+      #endif
       return [
         "defaultDatabaseDirectory": defaultDatabaseDirectory
       ]

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -72,6 +72,7 @@ function getExpoDependencyChunks({
             'expo-media-library',
             'expo-network',
             'expo-secure-store',
+            'expo-sqlite',
             'expo-symbols',
             'expo-system-ui',
             'expo-ui',


### PR DESCRIPTION
# Why

expo-sqlite can support Apple TV with a minimal set of changes.

# How

- Add tvOS to podspec
- Ensure caches directory is used on tvOS
- Add library to TV compile test

# Test Plan

CI should pass
