### PR TITLE
[android][ui] fix: expo ui compose view props

### DIFF
--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
@@ -24,7 +24,7 @@ open class ModuleDefinitionBuilderWithCompose(
     val viewDefinitionBuilder = ViewDefinitionBuilder(viewClass, LazyKType(classifier = T::class, kTypeProvider = { typeOf<T>() }))
     P::class.memberProperties.forEach { prop ->
       val kType = prop.returnType.arguments.first().type
-      if (kType != null && viewDefinitionBuilder.props[prop.name] != null) {
+      if (kType != null && viewDefinitionBuilder.props[prop.name] == null) {
         viewDefinitionBuilder.props[prop.name] = ComposeViewProp(prop.name, AnyType(kType), prop)
       }
     }


### PR DESCRIPTION
# Why
Expo UI compose view is not receiving props on the native side.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Someone needs to verify the fix, but i think the condition here should be `==`. Also the change was introduced in this PR - https://github.com/expo/expo/commit/20d597c6eff6f07e0d750d7884b476fe36470b13
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Please check Button, Switch Expo UI examples. They appear broken as props are not being applied on native side.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
