### PR TITLE
[tools][promote-packages] Assign sdk-xx tag when promoting bare-minimum

### DIFF
--- a/tools/src/promote-packages/tasks/promotePackages.ts
+++ b/tools/src/promote-packages/tasks/promotePackages.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import * as semver from 'semver';
 
 import { findPackagesToPromote } from './findPackagesToPromote';
 import { prepareParcels } from './prepareParcels';
@@ -46,6 +47,20 @@ export const promotePackages = new Task<TaskArgs>(
           await Npm.addTagAsync(pkg.packageName, pkg.packageVersion, options.tag, {
             stdio: requiresOTP ? 'inherit' : undefined,
           });
+        }
+        if (pkg.packageName === 'expo-template-bare-minimum') {
+          const sdkTag = `sdk-${semver.major(pkg.packageVersion)}`;
+          batch.log(
+            '    ',
+            action,
+            yellow(sdkTag),
+            formatVersionChange(versionToReplace, currentVersion)
+          );
+          if (!options.dry) {
+            await Npm.addTagAsync(pkg.packageName, pkg.packageVersion, sdkTag, {
+              stdio: requiresOTP ? 'inherit' : undefined,
+            });
+          }
         }
 
         // If the local version had any tags assigned, we can drop the old ones.


### PR DESCRIPTION
# Why

SDK tag (`sdk-xx`) on `expo-template-bare-minimum` is really important.

# How

Assign sdk-xx tag when promoting bare-minimum template.