### PR TITLE
[tools][pp] clean templates and improve logs

### DIFF
--- a/tools/src/publish-packages/tasks/addTemplateTarball.ts
+++ b/tools/src/publish-packages/tasks/addTemplateTarball.ts
@@ -1,12 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 
-import { selectPackagesToPublish } from './selectPackagesToPublish';
 import { TEMPLATES_DIR } from '../../Constants';
-import logger from '../../Logger';
 import { packToTarballAsync } from '../../Npm';
 import { Task } from '../../TasksRunner';
+import { runWithSpinner } from '../../Utils';
 import { Parcel, TaskArgs } from '../types';
+import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 /**
  * Add template tarball to Expo package.
@@ -23,16 +23,20 @@ export const addTemplateTarball = new Task<TaskArgs>(
       return;
     }
 
-    logger.info('\nCopying template tarball to Expo package...');
+    return await runWithSpinner(
+      'Copying template tarball to Expo package',
+      async (): Promise<any> => {
+        const templatePath = path.join(TEMPLATES_DIR, 'expo-template-bare-minimum');
+        const templateTarball = await packToTarballAsync(templatePath);
 
-    const templatePath = path.join(TEMPLATES_DIR, 'expo-template-bare-minimum');
-    const templateTarball = await packToTarballAsync(templatePath);
-
-    const tarballDestinationPath = path.join(expoPackage.pkg.path, 'template.tgz');
-    await fs.promises.rm(tarballDestinationPath, { force: true });
-    await fs.promises.copyFile(
-      path.join(templatePath, templateTarball.filename),
-      tarballDestinationPath
+        const tarballDestinationPath = path.join(expoPackage.pkg.path, 'template.tgz');
+        await fs.promises.rm(tarballDestinationPath, { force: true });
+        await fs.promises.copyFile(
+          path.join(templatePath, templateTarball.filename),
+          tarballDestinationPath
+        );
+      },
+      'Copied template tarball to Expo package'
     );
   }
 );

--- a/tools/src/publish-packages/tasks/addTemplateTarball.ts
+++ b/tools/src/publish-packages/tasks/addTemplateTarball.ts
@@ -25,7 +25,7 @@ export const addTemplateTarball = new Task<TaskArgs>(
 
     return await runWithSpinner(
       'Copying template tarball to Expo package',
-      async (): Promise<any> => {
+      async () => {
         const templatePath = path.join(TEMPLATES_DIR, 'expo-template-bare-minimum');
         const templateTarball = await packToTarballAsync(templatePath);
 

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -94,7 +94,7 @@ export const cleanWorkingTree = new Task<TaskArgs>(
         await Git.cleanAsync({
           recursive: true,
           force: true,
-          paths: ['packages/**/*.tgz', 'packages/**/local-maven-repo/**'],
+          paths: ['packages/**/*.tgz', 'packages/**/local-maven-repo/**', 'templates/**/*.tgz'],
         });
       },
       'Cleaned up the working tree'


### PR DESCRIPTION
# Why

I've setup a local npm registry to test https://github.com/expo/expo/pull/37366 without `--dry` and noticed some small issues. 

# How

* Improve `addTemplateTarball` logs
* Add templates to `cleanWorkingTree`

# Test Plan

`et pp`