### PR TITLE
fix android CI unit tests 

### DIFF
--- a/packages/expo-updates/android/src/test/resources/robolectric.properties
+++ b/packages/expo-updates/android/src/test/resources/robolectric.properties
@@ -1,0 +1,2 @@
+# TODO: Remove this once Robolectric 4.16 is released
+sdk=35

--- a/packages/expo/android/src/test/resources/robolectric.properties
+++ b/packages/expo/android/src/test/resources/robolectric.properties
@@ -1,0 +1,2 @@
+# TODO: Remove this once Robolectric 4.16 is released
+sdk=35


### PR DESCRIPTION
# Why
Android unit tests [CI](https://github.com/expo/expo/actions/runs/16682320512/job/47223690718?pr=38493) is failing after targetSDKVersion upgrade in RN 0.81. 
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

> NOTE Robolectric 4.15 does NOT support Android Baklava (SDK 36). Baklava will be supported in Robolectric 4.16.

Robotelectric does not support SDK 36 yet. So once 4.16 is released we should upgrade it, this PR adds temp fix to failing tests for now using [roboelectric.properties](https://robolectric.org/configuring/).
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Android unit tests should pass
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
