### PR TITLE
[docs] Fix relevant command on windows

### DIFF
--- a/docs/pages/troubleshooting/clear-cache-windows.mdx
+++ b/docs/pages/troubleshooting/clear-cache-windows.mdx
@@ -9,19 +9,19 @@ import { Terminal } from '~/ui/components/Snippet';
 
 There are a number of different caches associated with your project that can prevent your project from running as intended. Clearing a cache sometimes can help you work around issues related to stale or corrupt data and is often useful when troubleshooting and debugging.
 
+> If you want to use linux/shell commands on Windows, you can use Powershell, git bash or another shell environment. However these commands will correctly run on your environment.
+
 ## Expo CLI and Yarn
 
 {/* prettier-ignore */}
 <Terminal
   cmd={[
     '# With Yarn workspaces, you may need to delete node_modules in each workspace',
-    '$ rm -rf node_modules',
+    '$ rmdir /s node_modules',
     '',
     '$ yarn cache clean',
     '',
     '$ yarn',
-    '',
-    '$ watchman watch-del-all',
     '',
     '$ del %localappdata%\Temp\haste-map-*',
     '',
@@ -36,13 +36,11 @@ There are a number of different caches associated with your project that can pre
 {/* prettier-ignore */}
 <Terminal
   cmd={[
-    '$ rm -rf node_modules',
+    '$ rmdir /s node_modules',
     '',
     '$ npm cache clean --force',
     '',
     '$ npm install',
-    '',
-    '$ watchman watch-del-all',
     '',
     '$ del %localappdata%\Temp\haste-map-*',
     '',
@@ -58,13 +56,11 @@ There are a number of different caches associated with your project that can pre
 <Terminal
   cmd={[
     '# With Yarn workspaces, you may need to delete node_modules in each workspace',
-    '$ rm -rf node_modules',
+    '$ rmdir /s node_modules',
     '',
     '$ yarn cache clean',
     '',
     '$ yarn',
-    '',
-    '$ watchman watch-del-all',
     '',
     '$ del %localappdata%\Temp\haste-map-*',
     '',
@@ -79,13 +75,11 @@ There are a number of different caches associated with your project that can pre
 {/* prettier-ignore */}
 <Terminal
   cmd={[
-    '$ rm -rf node_modules',
+    '$ rmdir /s node_modules',
     '',
     '$ npm cache clean --force',
     '',
     '$ npm install',
-    '',
-    '$ watchman watch-del-all',
     '',
     '$ del %localappdata%\Temp\haste-map-*',
     '',
@@ -105,6 +99,5 @@ It is a good habit to understand commands you find on the internet before you ru
 | `yarn cache clean`                | Clear the global Yarn cache                                                   |
 | `npm cache clean --force`         | Clear the global npm cache                                                    |
 | `yarn`/`npm install`              | Reinstall all dependencies                                                    |
-| `watchman watch-del-all`          | Reset the `watchman` file watcher                                             |
 | `del %localappdata%\Temp/<cache>` | Clear the given packager/bundler cache file or directory                      |
 | `npx expo start --clear`          | Restart the development server and clear the JavaScript transformation caches |


### PR DESCRIPTION
# Why
Corrected wrong windows commands because they were not working on windows environment. closes #38507

# How
I removed wrong commands and wrote correct commands to fix it

# Test Plan
There is no need to test but any tester can run that commands i showed above on windows to test like `rmdir /s node_modules`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
