### PR TITLE
Removes `--dev` flag from the tsx installation command within the config plugin documentation

### DIFF
--- a/docs/pages/config-plugins/plugins.mdx
+++ b/docs/pages/config-plugins/plugins.mdx
@@ -137,7 +137,7 @@ We recommend writing config plugins in TypeScript, since this will provide intel
 
 Install `tsx` library by running the following command:
 
-<Terminal cmd={['$ npm install --save-dev tsx']} />
+<Terminal cmd={['$ npm install tsx']} />
 
 Then, change the static app config (**app.json**) to the [dynamic app config (**app.config.ts**)](/workflow/configuration/#dynamic-configuration) file. You can do this by renaming the **app.json** file to **app.config.ts** and changing the content of the file as shown below. Ensure to add the following import statement at the top of your **app.config.ts** file:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The `--dev` flag will not be honored when the application is being build in EAS with default settings. So if the user has created a custom config plugin, the `tsx` module will need to present during EAS builds.

# How

<!--
How did you build this feature or fix this bug and why?
-->

I created a config plugin that dynamically pulls in `.imageset` directories into the iOS build for a more custom Splashscreen. This is how I stumbled upon this.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Since this is a documentation update, there is no test plan.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
