### PR TITLE
Add Apple TV support to several packages

### DIFF
--- a/packages/expo-app-integrity/ios/ExpoAppIntegrity.podspec
+++ b/packages/expo-app-integrity/ios/ExpoAppIntegrity.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1'
   }
   s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-image-loader/CHANGELOG.md
+++ b/packages/expo-image-loader/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add Apple TV support. ([#38513](https://github.com/expo/expo/pull/38513) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-image-loader/ios/EXImageLoader.podspec
+++ b/packages/expo-image-loader/ios/EXImageLoader.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1'
   }
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add Apple TV support. ([#38513](https://github.com/expo/expo/pull/38513) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-image-manipulator/ios/ExpoImageManipulator.podspec
+++ b/packages/expo-image-manipulator/ios/ExpoImageManipulator.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1'
   }
   s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-insights/ios/ExpoInsights.podspec
+++ b/packages/expo-insights/ios/ExpoInsights.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1'
   }
   s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-insights/ios/InsightsModule.swift
+++ b/packages/expo-insights/ios/InsightsModule.swift
@@ -7,6 +7,20 @@ import EASClient
 private var wasAppLaunchEventDispatched = false
 
 public final class InsightsModule: Module {
+  #if os(iOS)
+  private let platform = "iOS"
+  #elseif os(tvOS)
+  private let platform = "tvOS"
+  #elseif os(macOS)
+  private let platform = "macOS"
+  #elseif os(visionOS)
+  private let platform = "visionOS"
+  #elseif os(macCatalyst)
+  private let platform = "macCatalyst"
+  #else
+  private let platform = "Unknown Apple platform"
+  #endif
+
   public func definition() -> ModuleDefinition {
     Name("ExpoInsights")
 
@@ -121,7 +135,7 @@ public final class InsightsModule: Module {
       "eas_client_id": EASClientID.uuid().uuidString,
       "project_id": projectId,
       "app_version": info?["CFBundleShortVersionString"] as? String,
-      "platform": "iOS",
+      "platform": platform,
       "os_version": UIDevice.current.systemVersion
     ]
   }

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add Apple TV support. ([#38513](https://github.com/expo/expo/pull/38513) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 - [android] add missing proguard-rules for `expo-task-manager` ([#37833](https://github.com/expo/expo/pull/37833) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-task-manager/ios/EXTaskManager.podspec
+++ b/packages/expo-task-manager/ios/EXTaskManager.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1'
   }
   s.source         = { git: 'https://github.com/expo/expo-task-manager.git' }
   s.static_framework = true

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
@@ -688,12 +688,14 @@ EX_REGISTER_SINGLETON_MODULE(TaskService)
   if (launchOptions[UIApplicationLaunchOptionsLocationKey]) {
     return EXTaskLaunchReasonLocation;
   }
+#if !TARGET_OS_TV
   if (launchOptions[UIApplicationLaunchOptionsNewsstandDownloadsKey]) {
     return EXTaskLaunchReasonNewsstandDownloads;
   }
   if (launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey]) {
     return EXTaskLaunchReasonRemoteNotification;
   }
+#endif
   return EXTaskLaunchReasonUnrecognized;
 }
 

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -36,6 +36,8 @@ function getExpoDependencyChunks({
     ['@expo/config'],
     ['@expo/config-plugins'],
     ['expo-modules-core'],
+    ['unimodules-app-loader'],
+    ['expo-task-manager'],
     ['@expo/cli', 'expo', 'expo-asset', 'expo-modules-autolinking'],
     ['expo-manifests'],
     ['@expo/prebuild-config', '@expo/metro-config', 'expo-constants'],
@@ -61,12 +63,16 @@ function getExpoDependencyChunks({
     ...(includeTV
       ? [
           [
+            'expo-app-integrity',
             'expo-audio',
             'expo-av',
             'expo-background-task',
             'expo-blur',
             'expo-crypto',
             'expo-image',
+            'expo-image-loader',
+            'expo-image-manipulator',
+            'expo-insights',
             'expo-linear-gradient',
             'expo-linking',
             'expo-localization',
@@ -78,6 +84,7 @@ function getExpoDependencyChunks({
             'expo-system-ui',
             'expo-ui',
             'expo-video',
+            'expo-video-thumbnails',
           ],
         ]
       : []),

--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add Apple TV support. ([#38513](https://github.com/expo/expo/pull/38513) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-video-thumbnails/ios/ExpoVideoThumbnails.podspec
+++ b/packages/expo-video-thumbnails/ios/ExpoVideoThumbnails.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1'
   }
   s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/unimodules-app-loader/CHANGELOG.md
+++ b/packages/unimodules-app-loader/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add Apple TV support. ([#38513](https://github.com/expo/expo/pull/38513) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/unimodules-app-loader/ios/UMAppLoader.podspec
+++ b/packages/unimodules-app-loader/ios/UMAppLoader.podspec
@@ -11,7 +11,8 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms      = {
-    :ios => '15.1'
+    :ios => '15.1',
+    :tvos => '15.1'
   }
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true


### PR DESCRIPTION
# Why

Add tvOS support to

- expo-app-integrity
- expo-image-loader
- expo-image-manipulator
- expo-insights
- expo-task-manager
- expo-video-thumbnails
- unimodules-app-loader

# How

- Add tvOS to podspecs
- One source change needed in expo-task-manager
- Add packages to TV compile test project

# Test Plan

CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
