### PR TITLE
[docs] fix expo-navigation-bar example import

### DIFF
--- a/docs/pages/develop/user-interface/system-bars.mdx
+++ b/docs/pages/develop/user-interface/system-bars.mdx
@@ -69,7 +69,7 @@ To control the `StatusBar` visibility, you can set the [`hidden`](/versions/late
 On Android devices, the Navigation Bar appears at the bottom of the screen. You can customize it using the [`expo-navigation-bar`](/versions/latest/sdk/navigation-bar) library. It provides a `NavigationBar` component that you can use to set the style of the navigation bar using the [`setStyle`](/versions/latest/sdk/navigation-bar/#navigationbarsetstylestyle) method:
 
 ```tsx app/_layout.tsx
-import { NavigationBar } from 'expo-navigation-bar';
+import * as NavigationBar from 'expo-navigation-bar';
 import { useEffect } from 'react';
 
 useEffect(() => {


### PR DESCRIPTION
# Why

The existing example uses a named import (`import { NavigationBar } from 'expo-navigation-bar'`) which no longer reflects the module’s actual exports and can lead to confusion or runtime errors. Switching to a namespace import ensures consistency with the library’s API, aligns with other Expo docs patterns, and prevents “undefined” import issues for both JavaScript and TypeScript users.

# How

Updated the code sample in `docs/pages/develop/user-interface/system-bars.mdx` to use:
```ts
import * as NavigationBar from 'expo-navigation-bar';
```

# Test Plan

yarn dev -> http://localhost:3002/develop/user-interface/system-bars/#navigation-bar-configuration-android-only