### PR TITLE
fix(ci): Add '@expo/server' adapters types to special types-only deps

### DIFF
--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -73,6 +73,12 @@ const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | v
     'react-native-reanimated/plugin': 'ignore-dev', // Checked via hasModule before requiring
     'expo/config': 'ignore-dev', // WARN: May need a reverse peer dependency
   },
+
+  '@expo/server': {
+    // Types used in adapters
+    express: 'types-only',
+    '@netlify/functions': 'types-only',
+  },
 };
 
 // NOTE: These are globally ignored dependencies, and this list shouldn't ever get longer


### PR DESCRIPTION
While working on different changes in `@expo/server` I've noticed the CI packages check started failing on the type dependencies which were not listed as type-only in the deps check.