### PR TITLE
fix(expo-modules-core): Add missing peers (react/react-native)

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [iOS] Support throwing errors in shared object constructor. ([#37618](https://github.com/expo/expo/pull/37618) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Remove boilerplate from function factories. ([#37884](https://github.com/expo/expo/pull/37884) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Remove react-native 0.74 support files ([#38216](https://github.com/expo/expo/pull/38216) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add missing peer dependencies for `react` and `react-native` ([#38528](https://github.com/expo/expo/pull/38528) by [@kitten](https://github.com/kitten))
 
 ## 2.5.0 - 2025-07-17
 

--- a/packages/expo-modules-core/package.json
+++ b/packages/expo-modules-core/package.json
@@ -41,6 +41,10 @@
   "dependencies": {
     "invariant": "^2.2.4"
   },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  },
   "devDependencies": {
     "@testing-library/react-native": "^13.1.0",
     "expo-module-scripts": "^4.1.7"

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -42,7 +42,6 @@ const IGNORED_PACKAGES = [
   'expo-av', // package: expo-asset
   'expo-font', // package: expo-asset
   'expo-gl', // package: react-dom, react-native-reanimated
-  'expo-modules-core', // package: react, react-native
   'expo-router', // package: @react-navigation/core, @react-navigation/routers, debug, escape-string-regexp, expect, expo-font, fast-deep-equal, nanoid, react, react-dom, react-native, react-native-web
   'expo-sqlite', // package: expo-asset
   'expo-store-review', // package: expo-constants


### PR DESCRIPTION
# Why

Both are depended on by `expo-modules-core` and are referenced in their code (not only as types). We should add them as peers. This shouldn't have any unexpected consequences since both are expected to be project root dependencies.

# How

- Add missing peer dependencies
- Update dependencies check

# Test Plan

- `yarn pack`
- Add resolution test project
- Install with pnpm (isolated, and non-isolated), Install with Yarn
- Observe if dependencies are duplicated or misaligned after a fresh install

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
