### PR TITLE
fix(@expo/metro-runtime): Add missing dependencies and optional peer on `react-dom`

### DIFF
--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Update dependencies to align with transitive dependencies ([#38532](https://github.com/expo/expo/pull/38532) by [@kitten](https://github.com/kitten))
+
 ## 5.0.4 — 2025-04-28
 
 ### 💡 Others

--- a/packages/@expo/metro-runtime/package.json
+++ b/packages/@expo/metro-runtime/package.json
@@ -36,6 +36,15 @@
   "peerDependencies": {
     "expo": "*",
     "react": "*",
+    "react-dom": "*",
     "react-native": "*"
+  },
+  "peerDependenciesMeta": {
+    "react-dom": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "react-dom": "19.1.0"
   }
 }

--- a/packages/@expo/metro-runtime/package.json
+++ b/packages/@expo/metro-runtime/package.json
@@ -34,6 +34,8 @@
     "url": "https://github.com/expo/expo.git"
   },
   "peerDependencies": {
+    "expo": "*",
+    "react": "*",
     "react-native": "*"
   }
 }

--- a/packages/@expo/metro-runtime/package.json
+++ b/packages/@expo/metro-runtime/package.json
@@ -45,7 +45,9 @@
     }
   },
   "dependencies": {
-    "stacktrace-parser": "^0.1.10"
+    "anser": "^1.4.9",
+    "stacktrace-parser": "^0.1.10",
+    "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
     "react-dom": "19.1.0"

--- a/packages/@expo/metro-runtime/package.json
+++ b/packages/@expo/metro-runtime/package.json
@@ -44,6 +44,9 @@
       "optional": true
     }
   },
+  "dependencies": {
+    "stacktrace-parser": "^0.1.10"
+  },
   "devDependencies": {
     "react-dom": "19.1.0"
   }

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -38,7 +38,6 @@ const IGNORED_PACKAGES = [
   '@expo/cli', // package: @react-native-community/cli-server-api, expo-modules-autolinking, expo-router, express, metro-*, webpack, webpack-dev-server
   '@expo/html-elements', // package: react, react-native, react-native-web
   '@expo/metro-config', // package: @babel/*, babel-preset-expo, hermes-parser, metro, metro-*
-  '@expo/metro-runtime', // package: anser, expo, expo-constants, metro-runtime, pretty-format, react, react-dom, react-native-web, react-refresh, stacktrace-parser
   'expo-av', // package: expo-asset
   'expo-font', // package: expo-asset
   'expo-gl', // package: react-dom, react-native-reanimated
@@ -64,6 +63,10 @@ const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | v
   '@expo/image-utils': {
     sharp: 'ignore-dev', // TODO: Mark as optional peer dep, if that's the intention
     'sharp-cli': 'ignore-dev',
+  },
+
+  '@expo/metro-runtime': {
+    'expo-constants': 'ignore-dev', // TODO: Should probably be a peer, but it's both installed in templates and also a dep of expo (needs discussion)
   },
 
   'babel-preset-expo': {


### PR DESCRIPTION
# Why

Similar and related to #38530

We're using transitive dependencies from `react-native` and are implicitly relying on `react-dom` in `NativeLogBox` for the web variant)

# How

- Add transitive dependencies by copying ranges from `react-native` (remain the same across `0.79.4-0.81.0-rc*`
- Add mising optional peer dependency on `react-dom`

We have a remaining ignored issue with the dependency on `expo-constants`. It's not re-exposed by `expo`, and adding a peer makes no sense while it's also a dependency of `expo`. This should be discussed and resolved separately.

# Test Plan

- n/a: CI checks this via E2E installs

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
