### PR TITLE
chore(tools,font): Ratchet dependencies checks (Part 2) and add missing `react-native` peer to `expo-font`

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 💡 Others
 
 - [web] remove deprecated style 'type' attribute ([#38114](https://github.com/expo/expo/pull/38114) by [@vonovak](https://github.com/vonovak))
+- Add missing `react-native` peer dependency ([#38540](https://github.com/expo/expo/pull/38540) by [@kitten](https://github.com/kitten))
 
 ## 13.3.2 - 2025-07-01
 

--- a/packages/expo-font/package.json
+++ b/packages/expo-font/package.json
@@ -56,6 +56,7 @@
   },
   "peerDependencies": {
     "expo": "*",
-    "react": "*"
+    "react": "*",
+    "react-native": "*"
   }
 }

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -37,8 +37,6 @@ type SourceFileImportRef = {
 const IGNORED_PACKAGES = [
   '@expo/html-elements', // package: react, react-native, react-native-web
   'expo-gl', // package: react-dom, react-native-reanimated
-  'expo-sqlite', // package: expo-asset
-  'expo-store-review', // package: expo-constants
   'expo-updates', // cli: @expo/plist, debug, getenv - utils: @expo/cli, @expo/metro-config, metro
 ];
 
@@ -78,6 +76,10 @@ const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | v
   },
 
   '@expo/metro-runtime': {
+    'expo-constants': 'ignore-dev', // TODO: Should probably be a peer, but it's both installed in templates and also a dep of expo (needs discussion)
+  },
+
+  'expo-store-review': {
     'expo-constants': 'ignore-dev', // TODO: Should probably be a peer, but it's both installed in templates and also a dep of expo (needs discussion)
   },
 

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -56,6 +56,11 @@ const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | v
     '@expo/config-plugins/build/utils/warnings.js': 'ignore-dev', // TODO: Remove
   },
 
+  'expo-font': {
+    '@expo/config-plugins/build/android/codeMod': 'ignore-dev', // TODO: Remove
+    '@expo/config-plugins/build/utils/generateCode': 'ignore-dev', // TODO: Remove
+  },
+
   '@expo/cli': {
     eslint: 'ignore-dev', // TODO: Switch to resolve-from / project root require
   },

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -36,8 +36,6 @@ type SourceFileImportRef = {
 // We are incrementally rolling this out, the sdk packages in this list are expected to be invalid
 const IGNORED_PACKAGES = [
   '@expo/html-elements', // package: react, react-native, react-native-web
-  'expo-av', // package: expo-asset
-  'expo-font', // package: expo-asset
   'expo-gl', // package: react-dom, react-native-reanimated
   'expo-sqlite', // package: expo-asset
   'expo-store-review', // package: expo-constants
@@ -95,6 +93,7 @@ const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | v
 // NOTE: These are globally ignored dependencies, and this list shouldn't ever get longer
 const IGNORED_IMPORTS: Record<string, IgnoreKind | void> = {
   'expo-modules-core': 'ignore-dev',
+  'expo-asset': 'ignore-dev',
 
   // This is force-resolved in the CLI and therefore, for Expo modules, is generally safe
   // See: https://github.com/expo/expo/blob/d63143c/packages/%40expo/cli/src/start/server/metro/withMetroMultiPlatform.ts#L603-L622


### PR DESCRIPTION
# Why

This basically inverts our dependency check to add an exception (like for `expo-modules-core`) for `expo-asset`, since both will have to be resolved across the full repo. And makes other dependency checks more granular, only adding granular ignores to "lock" the current issues in place.

We now only allow dependency regressions in:
- `@expo/html-elements`
- `expo-gl`
- `expo-updates`

The rest are either resolved or are shared problems in multiple packages

# How

- Remove remaining exceptions
- Add `expo-asset` exception
- Add missing peer dependency on `react-native` to `expo-font`
- Add individual `expo-font/plugin` exceptions

# Test Plan

- n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
