### PR TITLE
[core] open JavaScriptValue and add global event dispatcher

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Add missing peer dependencies for `react` and `react-native` ([#38528](https://github.com/expo/expo/pull/38528) by [@kitten](https://github.com/kitten))
 - Deprecate `Constants` in favor of `Constant` and `Property`. ([#38748](https://github.com/expo/expo/pull/38748) by [@jakex7](https://github.com/jakex7))
 - Refactor typings to replace `ExpoGlobal` with namespace and to preserve type+value overlay on re-exported core globals ([#38649](https://github.com/expo/expo/pull/38649) by [@kitten](https://github.com/kitten))
+- Fixed internal `JavaScriptValue` and added `props.globalEventDispatcher` for expo-ui. ([#38542](https://github.com/expo/expo/pull/38542) by [@kudo](https://github.com/kudo))
 
 ## 2.5.0 - 2025-07-17
 

--- a/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
@@ -123,7 +123,7 @@ internal protocol ClassAssociatedObject {}
 
 // Basically we only need these two
 extension JavaScriptObject: ClassAssociatedObject, AnyArgument, AnyJavaScriptValue {
-  internal static func convert(from value: JavaScriptValue, appContext: AppContext) throws -> Self {
+  public static func convert(from value: JavaScriptValue, appContext: AppContext) throws -> Self {
     guard value.kind == .object else {
       throw Conversions.ConvertingException<JavaScriptObject>(value)
     }

--- a/packages/expo-modules-core/ios/Core/JavaScriptFunction.swift
+++ b/packages/expo-modules-core/ios/Core/JavaScriptFunction.swift
@@ -53,7 +53,7 @@ public final class JavaScriptFunction<ReturnType>: AnyArgument, AnyJavaScriptVal
 
   // MARK: - AnyJavaScriptValue
 
-  internal static func convert(from value: JavaScriptValue, appContext: AppContext) throws -> Self {
+  public static func convert(from value: JavaScriptValue, appContext: AppContext) throws -> Self {
     guard value.kind == .function else {
       throw Conversions.ConvertingException<JavaScriptFunction<ReturnType>>(value)
     }

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -117,12 +117,14 @@ extension ExpoSwiftUI {
     }
 
     public override func getSupportedEventNames() -> [String] {
-      return dummyPropsMirror.children.compactMap { (label: String?, value: Any) in
+      let builtInEventNames = [GLOBAL_EVENT_NAME]
+      let propEventNames: [String] = dummyPropsMirror.children.compactMap { (label: String?, value: Any) in
         guard let event = value as? EventDispatcher else {
           return nil
         }
         return event.customName ?? convertLabelToKey(label)
       }
+      return builtInEventNames + propEventNames
     }
   }
 }

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewProps.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewProps.swift
@@ -2,6 +2,8 @@
 
 import SwiftUI
 
+internal let GLOBAL_EVENT_NAME = "onGlobalEvent"
+
 extension ExpoSwiftUI {
   /**
    Base implementation of the view props object for SwiftUI views.
@@ -15,6 +17,11 @@ extension ExpoSwiftUI {
      */
     @Field public var children: [any AnyChild]?
 
+    /**
+     A global event dispatcher that allows views to call `view.dispatchEvent(_:payload)` directly
+     */
+    public let globalEventDispatcher = EventDispatcher(GLOBAL_EVENT_NAME)
+
     internal func updateRawProps(_ rawProps: [String: Any], appContext: AppContext) throws {
       // Update the props just like the records
       try update(withDict: rawProps, appContext: appContext)
@@ -24,6 +31,10 @@ extension ExpoSwiftUI {
     }
 
     internal func setUpEvents(_ dispatcher: @escaping (_ eventName: String, _ payload: Any) -> Void) {
+      globalEventDispatcher.handler = { payload in
+        dispatcher(GLOBAL_EVENT_NAME, payload)
+      }
+
       Mirror(reflecting: self).children.forEach { (label: String?, value: Any) in
         guard let event = value as? EventDispatcher else {
           return

--- a/packages/expo-modules-core/ios/JSI/JavaScriptValue.swift
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptValue.swift
@@ -18,7 +18,7 @@ public enum JavaScriptValueKind: String {
 /**
  A protocol that JavaScript values, objects and functions can conform to.
  */
-protocol AnyJavaScriptValue: AnyArgument {
+public protocol AnyJavaScriptValue: AnyArgument {
   /**
    Tries to convert a raw JavaScript value to the conforming type.
    */
@@ -118,7 +118,7 @@ extension JavaScriptValue: AnyJavaScriptValue, AnyArgument {
 
   // MARK: - AnyJavaScriptValue
 
-  internal static func convert(from value: JavaScriptValue, appContext: AppContext) throws -> Self {
+  public static func convert(from value: JavaScriptValue, appContext: AppContext) throws -> Self {
     // It's already a `JavaScriptValue` so it should always pass through.
     if let value = value as? Self {
       return value


### PR DESCRIPTION
# Why

support swiftui modifiers support

# How

- make `JavaScriptValue` public that people can really have `Function("mutateMe") { (value: JavaScriptValue) in` outside of expo-modules-core
- add a swiftui `props.globalEventDispatcher` so that we don't have to add common EventDispatcher like `onTapGesture` for each view as a dedicated prop.

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
