### PR TITLE
[expo-router] Fix context menu updates

### DIFF
--- a/apps/router-e2e/__e2e__/link-preview/app/menu.tsx
+++ b/apps/router-e2e/__e2e__/link-preview/app/menu.tsx
@@ -1,5 +1,5 @@
 import { Link, usePathname } from 'expo-router';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Text, ScrollView } from 'react-native';
 
 import { useTimer } from '../utils/useTimer';
@@ -13,14 +13,21 @@ const Menus = () => {
 
   const timeOptions = useMemo(
     () =>
-      Array.from({ length: time }, (_, i) => ({
+      // Add new option every 5 seconds
+      Array.from({ length: Math.floor(time / 5) + 2 }, (_, i) => ({
         label: `Option ${i + 1}`,
         value: i + 1,
       })),
     [time]
   );
 
-  console.log(palette);
+  useEffect(() => {
+    console.log('Palette:', palette);
+  }, [palette]);
+
+  useEffect(() => {
+    console.log('Submenu:', submenu);
+  }, [submenu]);
 
   return (
     <ScrollView style={{ backgroundColor: '#fff' }} contentInsetAdjustmentBehavior="automatic">

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fix detents in web modal ([#38446](https://github.com/expo/expo/pull/38446) by [@Ubax](https://github.com/Ubax))
 - Fix Link Preview between two separate stacks ([#38299](https://github.com/expo/expo/pull/38299) by [@Ubax](https://github.com/Ubax))
 - Fix preloading of Unmatched screen ([#38556](https://github.com/expo/expo/pull/38556) by [@Ubax](https://github.com/Ubax))
+- Fix context menu updates ([#38561](https://github.com/expo/expo/pull/38561) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
@@ -1,6 +1,7 @@
 import ExpoModulesCore
 
-class NativeLinkPreviewView: ExpoView, UIContextMenuInteractionDelegate, LinkPreviewModalDismissible {
+class NativeLinkPreviewView: ExpoView, UIContextMenuInteractionDelegate,
+  LinkPreviewModalDismissible, LinkPreviewMenuUpdatable {
   private var trigger: NativeLinkPreviewTrigger?
   private var preview: NativeLinkPreviewContentView?
   private var interaction: UIContextMenuInteraction?
@@ -49,9 +50,7 @@ class NativeLinkPreviewView: ExpoView, UIContextMenuInteractionDelegate, LinkPre
           trigger.addInteraction(interaction)
         }
       } else if let actionView = childComponentView as? LinkPreviewNativeActionView {
-        actionView.updateMenuCallback = { [weak self] in
-          self?.updateMenu()
-        }
+        actionView.parentMenuUpdatable = self
         actions.append(actionView)
       } else {
         print(
@@ -170,7 +169,7 @@ class NativeLinkPreviewView: ExpoView, UIContextMenuInteractionDelegate, LinkPre
     return vc
   }
 
-  private func updateMenu() {
+  func updateMenu() {
     self.interaction?.updateVisibleMenu { _ in
       self.createContextMenu()
     }


### PR DESCRIPTION
# Why

When new action was added to context menu after initial render, it was not added to the native context menu.

## Before

https://github.com/user-attachments/assets/0d0d868a-1913-431d-a95f-da4385ac1da9

## After

https://github.com/user-attachments/assets/787736c5-41ff-46ee-bacc-2e184d30b995


# How

1. Updating cached menu action in `LinkPreviewNativeActionView`

# Test Plan

Manual testing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
