### PR TITLE
[docs] Resolve spacing issue when both default and see tags are used inside a table in Reference docs

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -240,7 +240,7 @@ button.
 not appear on the screen.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
         data-testid="callout-container"
       >
         <svg
@@ -3043,7 +3043,7 @@ After calling this function, the listener will no longer receive any events from
 which contains all of the pertinent user and credential information.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
         data-testid="callout-container"
       >
         <svg
@@ -3974,7 +3974,7 @@ may be
         A value to specify the style for formatting a name.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
         data-testid="callout-container"
       >
         <svg
@@ -4164,7 +4164,7 @@ for more details.
 You must include the ID string of the user whose credentials you'd like to refresh.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
         data-testid="callout-container"
       >
         <svg
@@ -4495,7 +4495,7 @@ OAuth 2.0 protocol
 None of these options are required.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
         data-testid="callout-container"
       >
         <svg
@@ -4846,7 +4846,7 @@ OAuth 2.0 protocol
 You must include the ID string of the user to sign out.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
         data-testid="callout-container"
       >
         <svg
@@ -5740,7 +5740,7 @@ OAuth 2.0 protocol
         .
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
         data-testid="callout-container"
       >
         <svg
@@ -6478,7 +6478,7 @@ You will still need to handle null values for any fields you request.
         </div>
       </blockquote>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
         data-testid="callout-container"
       >
         <svg
@@ -6722,7 +6722,7 @@ for more details.
         An enum whose values specify the system's best guess for how likely the current user is a real person.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0"
+        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [&_code]:bg-element bg-default [&_p]:!mb-0 shadow-none !mb-2.5 [table_&]:last:mb-0 [table_&]:mt-2"
         data-testid="callout-container"
       >
         <svg

--- a/docs/components/plugins/api/components/APICommentTextBlock.tsx
+++ b/docs/components/plugins/api/components/APICommentTextBlock.tsx
@@ -87,7 +87,7 @@ export const APICommentTextBlock = ({
   const see = getTagData('see', comment);
   const seeContent = see && (
     <InlineHelp
-      className={mergeClasses('shadow-none', `!${ELEMENT_SPACING}`)}
+      className={mergeClasses('shadow-none', `!${ELEMENT_SPACING}`, '[table_&]:mt-2')}
       size="sm"
       type="info-light">
       <ReactMarkdown components={mdComponents} remarkPlugins={[remarkGfm, remarkSupsub]}>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16897

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add a margin top to `@see` tags to ensure there's proper space between `@default` and `@see` tags when they are used one after the other in a package's type defintion.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/unversioned/sdk/build-properties/#pluginconfigtype

## Preview

<img width="2524" height="706" alt="CleanShot 2025-08-05 at 17 42 51@2x" src="https://github.com/user-attachments/assets/9be44541-24a4-46ec-8e5a-4030d820dced" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
