### PR TITLE
fix(expo-gl): Add missing optional peer dependencies on `react-dom` and `react-native-reanimated`

### DIFF
--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - Use pointerEvents style instead of prop for components on web. ([#38023](https://github.com/expo/expo/pull/38023) by [@EvanBacon](https://github.com/EvanBacon))
-- Add missing optional `react-dom` and `react-native-reanimated` peer dependencies
+- Add missing optional `react-dom` and `react-native-reanimated` peer dependencies ([#38569](https://github.com/expo/expo/pull/38569) by [@kitten](https://github.com/kitten))
 
 ## 15.1.7 - 2025-07-01
 

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Use pointerEvents style instead of prop for components on web. ([#38023](https://github.com/expo/expo/pull/38023) by [@EvanBacon](https://github.com/EvanBacon))
+- Add missing optional `react-dom` and `react-native-reanimated` peer dependencies
 
 ## 15.1.7 - 2025-07-01
 

--- a/packages/expo-gl/package.json
+++ b/packages/expo-gl/package.json
@@ -49,10 +49,18 @@
   "peerDependencies": {
     "expo": "*",
     "react": "*",
+    "react-dom": "*",
     "react-native": "*",
+    "react-native-reanimated": "*",
     "react-native-web": "*"
   },
   "peerDependenciesMeta": {
+    "react-dom": {
+      "optional": true
+    },
+    "react-native-reanimated": {
+      "optional": true
+    },
     "react-native-web": {
       "optional": true
     }

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -36,7 +36,6 @@ type SourceFileImportRef = {
 // We are incrementally rolling this out, the sdk packages in this list are expected to be invalid
 const IGNORED_PACKAGES = [
   '@expo/html-elements', // package: react, react-native, react-native-web
-  'expo-gl', // package: react-dom, react-native-reanimated
   'expo-updates', // cli: @expo/plist, debug, getenv - utils: @expo/cli, @expo/metro-config, metro
 ];
 


### PR DESCRIPTION
# Why

Missing and potentially not available with isolated dependencies in some rare cases.

@byCedric @EvanBacon: Not sure if this represents the intention here, but just opening a PR since it's an option to resolve this.

# How

- Add missing optional peer dependencies on `react-dom` and `react-native-reanimated`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
