### PR TITLE
[updates][e2e] Fix old arch tests

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-old-arch.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-old-arch.yml
@@ -49,7 +49,7 @@ jobs:
         working_directory: ../../../updates-e2e
         run: |
           yarn generate-test-update-bundles ios
-          yarn ios:pod-install
+          yarn ios:pod-install-old-arch
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -317,6 +317,7 @@ async function preparePackageJson(
   const extraScripts = configureE2E
     ? {
         start: 'expo start --private-key-path ./keys/private-key.pem',
+        'ios:pod-install-old-arch': 'npx pod-install',
         'ios:pod-install': 'RCT_USE_PREBUILT_RNCORE=1 RCT_USE_RN_DEP=1 npx pod-install',
         'maestro:android:debug:build': 'cd android; ./gradlew :app:assembleDebug; cd ..',
         'maestro:android:debug:install':


### PR DESCRIPTION
# Why

Precompiling react-native does not work for old architecture on iOS

# How

Add `ios:pod-install-old-arch` script to expo-updates e2e project setup

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
