### PR TITLE
[docs] Add copyable build server image names

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -7,8 +7,8 @@ description: Learn about the current build server infrastructure when using EAS.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
-import { BuildResourceList } from '~/ui/components/utils/infrastructure';
 import { CopyTextButton } from '~/ui/components/CopyableText';
+import { BuildResourceList } from '~/ui/components/utils/infrastructure';
 
 ## Builder IP addresses
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -1,5 +1,5 @@
 ---
-modificationDate: October 31st, 2024
+modificationDate: July 15th, 2025
 title: Build server infrastructure
 sidebar_title: Server infrastructure
 maxHeadingDepth: 4
@@ -8,6 +8,7 @@ description: Learn about the current build server infrastructure when using EAS.
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { BuildResourceList } from '~/ui/components/utils/infrastructure';
+import { CopyTextButton } from '~/ui/components/CopyableText';
 
 ## Builder IP addresses
 
@@ -68,7 +69,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 ### Android server images
 
-#### `ubuntu-22.04-jdk-17-ndk-r26b` (`latest`, `sdk-53`)
+#### <CopyTextButton>`ubuntu-22.04-jdk-17-ndk-r26b` (`latest`, `sdk-53`)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -84,7 +85,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### Legacy `ubuntu-22.04-jdk-17-ndk-r26b`-like (`sdk-51`, `sdk-52`)
+#### Legacy <CopyTextButton>`ubuntu-22.04-jdk-17-ndk-r26b`-like (`sdk-51`, `sdk-52`)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -100,7 +101,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-22.04-jdk-17-ndk-r25b` (`sdk-50`)
+#### <CopyTextButton>`ubuntu-22.04-jdk-17-ndk-r25b` (`sdk-50`)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -116,7 +117,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-22.04-jdk-11-ndk-r23b` (`sdk-49`)
+#### <CopyTextButton>`ubuntu-22.04-jdk-11-ndk-r23b` (`sdk-49`)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -132,7 +133,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-22.04-jdk-17-ndk-r21e`
+#### <CopyTextButton>`ubuntu-22.04-jdk-17-ndk-r21e`</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -148,7 +149,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-22.04-jdk-11-ndk-r21e`
+#### <CopyTextButton>`ubuntu-22.04-jdk-11-ndk-r21e`</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -164,7 +165,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-22.04-jdk-8-ndk-r21e` (deprecated)
+#### <CopyTextButton>`ubuntu-22.04-jdk-8-ndk-r21e` (deprecated)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -180,7 +181,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-20.04-jdk-11-ndk-r23b` (deprecated)
+#### <CopyTextButton>`ubuntu-20.04-jdk-11-ndk-r23b` (deprecated)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -196,7 +197,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-20.04-jdk-11-ndk-r21e` (deprecated)
+#### <CopyTextButton>`ubuntu-20.04-jdk-11-ndk-r21e` (deprecated)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -212,7 +213,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-20.04-jdk-8-ndk-r21e` (deprecated)
+#### <CopyTextButton>`ubuntu-20.04-jdk-8-ndk-r21e` (deprecated)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -228,7 +229,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-20.04-jdk-11-ndk-r19c` (deprecated)
+#### <CopyTextButton>`ubuntu-20.04-jdk-11-ndk-r19c` (deprecated)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -244,7 +245,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 </Collapsible>
 
-#### `ubuntu-20.04-jdk-8-ndk-r19c` (deprecated)
+#### <CopyTextButton>`ubuntu-20.04-jdk-8-ndk-r19c` (deprecated)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -288,7 +289,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 ### iOS server images
 
-#### `macos-sequoia-15.5-xcode-16.4` (`latest`, `sdk-53`)
+#### <CopyTextButton>`macos-sequoia-15.5-xcode-16.4` (`latest`, `sdk-53`)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -312,7 +313,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-sequoia-15.4-xcode-16.3`
+#### <CopyTextButton>`macos-sequoia-15.4-xcode-16.3`</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -336,7 +337,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-sequoia-15.3-xcode-16.2` (`sdk-52`)
+#### <CopyTextButton>`macos-sequoia-15.3-xcode-16.2` (`sdk-52`)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -354,7 +355,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-sonoma-14.6-xcode-16.1`
+#### <CopyTextButton>`macos-sonoma-14.6-xcode-16.1`</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -372,7 +373,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-sonoma-14.6-xcode-16.0`
+#### <CopyTextButton>`macos-sonoma-14.6-xcode-16.0`</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -390,7 +391,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-sonoma-14.5-xcode-15.4` (`sdk-51`, `sdk-50`, `sdk-49`)
+#### <CopyTextButton>`macos-sonoma-14.5-xcode-15.4` (`sdk-51`, `sdk-50`, `sdk-49`)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -408,7 +409,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-sonoma-14.4-xcode-15.3`
+#### <CopyTextButton>`macos-sonoma-14.4-xcode-15.3`</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -426,7 +427,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-ventura-13.6-xcode-15.2`
+#### <CopyTextButton>`macos-ventura-13.6-xcode-15.2`</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -444,7 +445,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-ventura-13.6-xcode-15.1`
+#### <CopyTextButton>`macos-ventura-13.6-xcode-15.1`</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -462,7 +463,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-ventura-13.6-xcode-15.0`
+#### <CopyTextButton>`macos-ventura-13.6-xcode-15.0`</CopyTextButton>
 
 <Collapsible summary="Details">
 

--- a/docs/ui/components/CopyableText/index.tsx
+++ b/docs/ui/components/CopyableText/index.tsx
@@ -1,29 +1,13 @@
 import { mergeClasses } from '@expo/styleguide';
 import { CheckIcon } from '@expo/styleguide-icons/outline/CheckIcon';
 import { ClipboardIcon } from '@expo/styleguide-icons/outline/ClipboardIcon';
-import { ReactNode, useState } from 'react';
+import { ReactNode, useState, useRef } from 'react';
 
 type CopyTextButtonProps = {
   children: ReactNode;
   copyText?: string;
   className?: string;
 };
-
-function extractTextFromChildren(children: ReactNode): string {
-  if (typeof children === 'string') {
-    return children;
-  }
-  if (typeof children === 'number') {
-    return children.toString();
-  }
-  if (Array.isArray(children)) {
-    return children.map(extractTextFromChildren).join('');
-  }
-  if (children && typeof children === 'object' && 'props' in children) {
-    return extractTextFromChildren((children as any).props.children);
-  }
-  return '';
-}
 
 function cleanTextForCopy(text: string): string {
   return text
@@ -38,9 +22,10 @@ function cleanTextForCopy(text: string): string {
 
 export function CopyTextButton({ children, copyText, className }: CopyTextButtonProps) {
   const [copied, setCopied] = useState(false);
+  const textRef = useRef<HTMLSpanElement>(null);
 
   const handleCopyAsync = async () => {
-    const textToCopy = copyText ?? cleanTextForCopy(extractTextFromChildren(children));
+    const textToCopy = copyText ?? cleanTextForCopy(textRef.current?.textContent ?? '');
 
     try {
       await navigator.clipboard.writeText(textToCopy);
@@ -59,7 +44,7 @@ export function CopyTextButton({ children, copyText, className }: CopyTextButton
 
   return (
     <span className={mergeClasses('group inline-flex items-center gap-1', className)}>
-      <span>{children}</span>
+      <span ref={textRef}>{children}</span>
       <button
         type="button"
         onClick={handleCopyAsync}

--- a/docs/ui/components/CopyableText/index.tsx
+++ b/docs/ui/components/CopyableText/index.tsx
@@ -1,0 +1,82 @@
+import { mergeClasses } from '@expo/styleguide';
+import { CheckIcon } from '@expo/styleguide-icons/outline/CheckIcon';
+import { ClipboardIcon } from '@expo/styleguide-icons/outline/ClipboardIcon';
+import { ReactNode, useState } from 'react';
+
+type CopyTextButtonProps = {
+  children: ReactNode;
+  copyText?: string;
+  className?: string;
+};
+
+function extractTextFromChildren(children: ReactNode): string {
+  if (typeof children === 'string') {
+    return children;
+  }
+  if (typeof children === 'number') {
+    return children.toString();
+  }
+  if (Array.isArray(children)) {
+    return children.map(extractTextFromChildren).join('');
+  }
+  if (children && typeof children === 'object' && 'props' in children) {
+    return extractTextFromChildren((children as any).props.children);
+  }
+  return '';
+}
+
+function cleanTextForCopy(text: string): string {
+  return text
+    .replace(/\s*\([^)]*\)/g, '')
+    .replace(/\s*\[[^\]]*]/g, '')
+    .replace(/`/g, '')
+    .replace(/-like$/g, '')
+    .replace(/^Legacy\s+/g, '')
+    .replace(/\s+(deprecated)$/g, '')
+    .trim();
+}
+
+export function CopyTextButton({ children, copyText, className }: CopyTextButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyAsync = async () => {
+    const textToCopy = copyText ?? cleanTextForCopy(extractTextFromChildren(children));
+
+    try {
+      await navigator.clipboard.writeText(textToCopy);
+      setCopied(true);
+      setTimeout(() => {
+        setCopied(false);
+      }, 1500);
+    } catch {
+      console.warn('Clipboard API not supported. Please copy manually:', textToCopy);
+      setCopied(true);
+      setTimeout(() => {
+        setCopied(false);
+      }, 1500);
+    }
+  };
+
+  return (
+    <span className={mergeClasses('group inline-flex items-center gap-1', className)}>
+      <span>{children}</span>
+      <button
+        type="button"
+        onClick={handleCopyAsync}
+        className={mergeClasses(
+          'rounded inline-flex items-center justify-center p-1 transition-colors',
+          'hover:bg-element focus-visible:bg-element',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-link',
+          copied && 'opacity-100'
+        )}
+        aria-label="Copy to clipboard"
+        title="Copy to clipboard">
+        {copied ? (
+          <CheckIcon className="icon-xs text-success" />
+        ) : (
+          <ClipboardIcon className="icon-xs text-icon-secondary hover:text-icon-default" />
+        )}
+      </button>
+    </span>
+  );
+}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-11188

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add `CopyTextButton` component that uses regex to allow copying build server image names on the Build server infrastructure page.
- Use `CopyTextButton` for H4s for image name.
- Also update the last modified date on the Build server infrastructure page for the latest image changes PR #38077.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview


https://github.com/user-attachments/assets/f73484cd-715b-4bd1-849b-1ecfbc2194da



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
