### PR TITLE
Upgrade React Native to 0.81.0-rc.5

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -736,12 +736,12 @@ PODS:
   - EXUpdatesInterface (1.1.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.81.0-rc.3)
+  - FBLazyVector (0.81.0-rc.5)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.81.0-rc.3):
-    - hermes-engine/Pre-built (= 0.81.0-rc.3)
-  - hermes-engine/Pre-built (0.81.0-rc.3)
+  - hermes-engine (0.81.0-rc.5):
+    - hermes-engine/Pre-built (= 0.81.0-rc.5)
+  - hermes-engine/Pre-built (0.81.0-rc.5)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -823,28 +823,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.81.0-rc.3)
-  - RCTRequired (0.81.0-rc.3)
-  - RCTTypeSafety (0.81.0-rc.3):
-    - FBLazyVector (= 0.81.0-rc.3)
-    - RCTRequired (= 0.81.0-rc.3)
-    - React-Core (= 0.81.0-rc.3)
+  - RCTDeprecation (0.81.0-rc.5)
+  - RCTRequired (0.81.0-rc.5)
+  - RCTTypeSafety (0.81.0-rc.5):
+    - FBLazyVector (= 0.81.0-rc.5)
+    - RCTRequired (= 0.81.0-rc.5)
+    - React-Core (= 0.81.0-rc.5)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.0-rc.3):
-    - React-Core (= 0.81.0-rc.3)
-    - React-Core/DevSupport (= 0.81.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.81.0-rc.3)
-    - React-RCTActionSheet (= 0.81.0-rc.3)
-    - React-RCTAnimation (= 0.81.0-rc.3)
-    - React-RCTBlob (= 0.81.0-rc.3)
-    - React-RCTImage (= 0.81.0-rc.3)
-    - React-RCTLinking (= 0.81.0-rc.3)
-    - React-RCTNetwork (= 0.81.0-rc.3)
-    - React-RCTSettings (= 0.81.0-rc.3)
-    - React-RCTText (= 0.81.0-rc.3)
-    - React-RCTVibration (= 0.81.0-rc.3)
-  - React-callinvoker (0.81.0-rc.3)
-  - React-Core (0.81.0-rc.3):
+  - React (0.81.0-rc.5):
+    - React-Core (= 0.81.0-rc.5)
+    - React-Core/DevSupport (= 0.81.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.81.0-rc.5)
+    - React-RCTActionSheet (= 0.81.0-rc.5)
+    - React-RCTAnimation (= 0.81.0-rc.5)
+    - React-RCTBlob (= 0.81.0-rc.5)
+    - React-RCTImage (= 0.81.0-rc.5)
+    - React-RCTLinking (= 0.81.0-rc.5)
+    - React-RCTNetwork (= 0.81.0-rc.5)
+    - React-RCTSettings (= 0.81.0-rc.5)
+    - React-RCTText (= 0.81.0-rc.5)
+    - React-RCTVibration (= 0.81.0-rc.5)
+  - React-callinvoker (0.81.0-rc.5)
+  - React-Core (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -854,7 +854,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.3)
+    - React-Core/Default (= 0.81.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -869,82 +869,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.81.0-rc.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.0-rc.3):
+  - React-Core/CoreModulesHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -969,7 +894,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.0-rc.3):
+  - React-Core/Default (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.81.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -994,7 +969,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.0-rc.3):
+  - React-Core/RCTAnimationHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1019,7 +994,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.0-rc.3):
+  - React-Core/RCTBlobHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1044,7 +1019,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.0-rc.3):
+  - React-Core/RCTImageHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1069,7 +1044,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.0-rc.3):
+  - React-Core/RCTLinkingHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1094,7 +1069,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.0-rc.3):
+  - React-Core/RCTNetworkHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1119,7 +1094,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.0-rc.3):
+  - React-Core/RCTSettingsHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1144,7 +1119,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.0-rc.3):
+  - React-Core/RCTTextHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1169,7 +1144,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.81.0-rc.3):
+  - React-Core/RCTVibrationHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1179,7 +1154,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -1194,7 +1169,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.81.0-rc.3):
+  - React-Core/RCTWebSocket (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1202,20 +1202,20 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.81.0-rc.3)
-    - React-Core/CoreModulesHeaders (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - RCTTypeSafety (= 0.81.0-rc.5)
+    - React-Core/CoreModulesHeaders (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.0-rc.3)
+    - React-RCTImage (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.81.0-rc.3):
+  - React-cxxreact (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1224,19 +1224,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-debug (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-debug (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
-    - React-timing (= 0.81.0-rc.3)
+    - React-timing (= 0.81.0-rc.5)
     - SocketRocket
-  - React-debug (0.81.0-rc.3)
-  - React-defaultsnativemodule (0.81.0-rc.3):
+  - React-debug (0.81.0-rc.5)
+  - React-defaultsnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1253,7 +1253,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.81.0-rc.3):
+  - React-domnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1273,7 +1273,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.81.0-rc.3):
+  - React-Fabric (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1287,23 +1287,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.0-rc.3)
-    - React-Fabric/attributedstring (= 0.81.0-rc.3)
-    - React-Fabric/bridging (= 0.81.0-rc.3)
-    - React-Fabric/componentregistry (= 0.81.0-rc.3)
-    - React-Fabric/componentregistrynative (= 0.81.0-rc.3)
-    - React-Fabric/components (= 0.81.0-rc.3)
-    - React-Fabric/consistency (= 0.81.0-rc.3)
-    - React-Fabric/core (= 0.81.0-rc.3)
-    - React-Fabric/dom (= 0.81.0-rc.3)
-    - React-Fabric/imagemanager (= 0.81.0-rc.3)
-    - React-Fabric/leakchecker (= 0.81.0-rc.3)
-    - React-Fabric/mounting (= 0.81.0-rc.3)
-    - React-Fabric/observers (= 0.81.0-rc.3)
-    - React-Fabric/scheduler (= 0.81.0-rc.3)
-    - React-Fabric/telemetry (= 0.81.0-rc.3)
-    - React-Fabric/templateprocessor (= 0.81.0-rc.3)
-    - React-Fabric/uimanager (= 0.81.0-rc.3)
+    - React-Fabric/animations (= 0.81.0-rc.5)
+    - React-Fabric/attributedstring (= 0.81.0-rc.5)
+    - React-Fabric/bridging (= 0.81.0-rc.5)
+    - React-Fabric/componentregistry (= 0.81.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.81.0-rc.5)
+    - React-Fabric/components (= 0.81.0-rc.5)
+    - React-Fabric/consistency (= 0.81.0-rc.5)
+    - React-Fabric/core (= 0.81.0-rc.5)
+    - React-Fabric/dom (= 0.81.0-rc.5)
+    - React-Fabric/imagemanager (= 0.81.0-rc.5)
+    - React-Fabric/leakchecker (= 0.81.0-rc.5)
+    - React-Fabric/mounting (= 0.81.0-rc.5)
+    - React-Fabric/observers (= 0.81.0-rc.5)
+    - React-Fabric/scheduler (= 0.81.0-rc.5)
+    - React-Fabric/telemetry (= 0.81.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.81.0-rc.5)
+    - React-Fabric/uimanager (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1315,32 +1315,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.81.0-rc.3):
+  - React-Fabric/animations (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1365,7 +1340,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.81.0-rc.3):
+  - React-Fabric/attributedstring (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1390,7 +1365,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.81.0-rc.3):
+  - React-Fabric/bridging (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1415,7 +1390,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.81.0-rc.3):
+  - React-Fabric/componentregistry (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1440,36 +1415,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.0-rc.3)
-    - React-Fabric/components/root (= 0.81.0-rc.3)
-    - React-Fabric/components/scrollview (= 0.81.0-rc.3)
-    - React-Fabric/components/view (= 0.81.0-rc.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.0-rc.3):
+  - React-Fabric/componentregistrynative (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1494,7 +1440,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.81.0-rc.3):
+  - React-Fabric/components (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.0-rc.5)
+    - React-Fabric/components/root (= 0.81.0-rc.5)
+    - React-Fabric/components/scrollview (= 0.81.0-rc.5)
+    - React-Fabric/components/view (= 0.81.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1519,7 +1494,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.81.0-rc.3):
+  - React-Fabric/components/root (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1544,7 +1519,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.81.0-rc.3):
+  - React-Fabric/components/scrollview (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1571,7 +1571,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.81.0-rc.3):
+  - React-Fabric/consistency (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1596,7 +1596,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.81.0-rc.3):
+  - React-Fabric/core (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1621,7 +1621,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.81.0-rc.3):
+  - React-Fabric/dom (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1646,7 +1646,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.81.0-rc.3):
+  - React-Fabric/imagemanager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1671,7 +1671,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.81.0-rc.3):
+  - React-Fabric/leakchecker (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1696,7 +1696,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.81.0-rc.3):
+  - React-Fabric/mounting (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1721,7 +1721,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.81.0-rc.3):
+  - React-Fabric/observers (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1735,7 +1735,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.0-rc.3)
+    - React-Fabric/observers/events (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1747,7 +1747,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.81.0-rc.3):
+  - React-Fabric/observers/events (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1772,7 +1772,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.81.0-rc.3):
+  - React-Fabric/scheduler (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1799,7 +1799,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.81.0-rc.3):
+  - React-Fabric/telemetry (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1824,7 +1824,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.81.0-rc.3):
+  - React-Fabric/templateprocessor (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1849,7 +1849,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.81.0-rc.3):
+  - React-Fabric/uimanager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1863,7 +1863,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.0-rc.3)
+    - React-Fabric/uimanager/consistency (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1876,7 +1876,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.81.0-rc.3):
+  - React-Fabric/uimanager/consistency (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1902,7 +1902,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.81.0-rc.3):
+  - React-FabricComponents (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1917,8 +1917,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.0-rc.3)
-    - React-FabricComponents/textlayoutmanager (= 0.81.0-rc.3)
+    - React-FabricComponents/components (= 0.81.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1931,7 +1931,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.81.0-rc.3):
+  - React-FabricComponents/components (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1946,16 +1946,16 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.0-rc.3)
-    - React-FabricComponents/components/iostextinput (= 0.81.0-rc.3)
-    - React-FabricComponents/components/modal (= 0.81.0-rc.3)
-    - React-FabricComponents/components/rncore (= 0.81.0-rc.3)
-    - React-FabricComponents/components/safeareaview (= 0.81.0-rc.3)
-    - React-FabricComponents/components/scrollview (= 0.81.0-rc.3)
-    - React-FabricComponents/components/text (= 0.81.0-rc.3)
-    - React-FabricComponents/components/textinput (= 0.81.0-rc.3)
-    - React-FabricComponents/components/unimplementedview (= 0.81.0-rc.3)
-    - React-FabricComponents/components/virtualview (= 0.81.0-rc.3)
+    - React-FabricComponents/components/inputaccessory (= 0.81.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.81.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.81.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.81.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.81.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.81.0-rc.5)
+    - React-FabricComponents/components/text (= 0.81.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.81.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.81.0-rc.5)
+    - React-FabricComponents/components/virtualview (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1968,34 +1968,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.0-rc.3):
+  - React-FabricComponents/components/inputaccessory (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2022,7 +1995,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.81.0-rc.3):
+  - React-FabricComponents/components/iostextinput (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2049,7 +2022,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.0-rc.3):
+  - React-FabricComponents/components/modal (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2076,7 +2049,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.0-rc.3):
+  - React-FabricComponents/components/rncore (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2103,7 +2076,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.0-rc.3):
+  - React-FabricComponents/components/safeareaview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2130,7 +2103,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.81.0-rc.3):
+  - React-FabricComponents/components/scrollview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2157,7 +2130,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.0-rc.3):
+  - React-FabricComponents/components/text (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2184,7 +2157,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.0-rc.3):
+  - React-FabricComponents/components/textinput (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2211,7 +2184,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.0-rc.3):
+  - React-FabricComponents/components/unimplementedview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2238,7 +2211,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.0-rc.3):
+  - React-FabricComponents/components/virtualview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2265,7 +2238,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.81.0-rc.3):
+  - React-FabricComponents/textlayoutmanager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2274,21 +2247,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.81.0-rc.3)
-    - RCTTypeSafety (= 0.81.0-rc.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.81.0-rc.5)
+    - RCTTypeSafety (= 0.81.0-rc.5)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.0-rc.3)
+    - React-jsiexecutor (= 0.81.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.81.0-rc.3):
+  - React-featureflags (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2297,7 +2297,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.81.0-rc.3):
+  - React-featureflagsnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2312,7 +2312,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.81.0-rc.3):
+  - React-graphics (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2325,7 +2325,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.81.0-rc.3):
+  - React-hermes (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2334,16 +2334,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.81.0-rc.3)
+    - React-jsiexecutor (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.81.0-rc.3):
+  - React-idlecallbacksnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2359,7 +2359,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.81.0-rc.3):
+  - React-ImageManager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2374,7 +2374,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.81.0-rc.3):
+  - React-jserrorhandler (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2389,7 +2389,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.81.0-rc.3):
+  - React-jsi (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2399,7 +2399,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.81.0-rc.3):
+  - React-jsiexecutor (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2408,15 +2408,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.81.0-rc.3):
+  - React-jsinspector (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2430,10 +2430,10 @@ PODS:
     - React-jsinspectorcdp
     - React-jsinspectornetwork
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.81.0-rc.3):
+  - React-jsinspectorcdp (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2442,7 +2442,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.81.0-rc.3):
+  - React-jsinspectornetwork (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2455,7 +2455,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.81.0-rc.3):
+  - React-jsinspectortracing (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2466,7 +2466,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.81.0-rc.3):
+  - React-jsitooling (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2474,16 +2474,16 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.81.0-rc.3):
+  - React-jsitracing (0.81.0-rc.5):
     - React-jsi
-  - React-logger (0.81.0-rc.3):
+  - React-logger (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2492,7 +2492,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.81.0-rc.3):
+  - React-Mapbuffer (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2502,7 +2502,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.81.0-rc.3):
+  - React-microtasksnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2805,7 +2805,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.81.0-rc.3):
+  - React-NativeModulesApple (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2825,8 +2825,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.81.0-rc.3)
-  - React-perflogger (0.81.0-rc.3):
+  - React-oscompat (0.81.0-rc.5)
+  - React-perflogger (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2835,7 +2835,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.81.0-rc.3):
+  - React-performancetimeline (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2848,9 +2848,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.81.0-rc.3):
-    - React-Core/RCTActionSheetHeaders (= 0.81.0-rc.3)
-  - React-RCTAnimation (0.81.0-rc.3):
+  - React-RCTActionSheet (0.81.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.81.0-rc.5)
+  - React-RCTAnimation (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2866,7 +2866,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.81.0-rc.3):
+  - React-RCTAppDelegate (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2900,7 +2900,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.81.0-rc.3):
+  - React-RCTBlob (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2919,7 +2919,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.81.0-rc.3):
+  - React-RCTFabric (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2954,7 +2954,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.0-rc.3):
+  - React-RCTFBReactNativeSpec (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2968,10 +2968,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.0-rc.3)
+    - React-RCTFBReactNativeSpec/components (= 0.81.0-rc.5)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.81.0-rc.3):
+  - React-RCTFBReactNativeSpec/components (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2994,7 +2994,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.81.0-rc.3):
+  - React-RCTImage (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3010,14 +3010,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.81.0-rc.3):
-    - React-Core/RCTLinkingHeaders (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+  - React-RCTLinking (0.81.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.0-rc.3)
-  - React-RCTNetwork (0.81.0-rc.3):
+    - ReactCommon/turbomodule/core (= 0.81.0-rc.5)
+  - React-RCTNetwork (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3035,7 +3035,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.81.0-rc.3):
+  - React-RCTRuntime (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3055,7 +3055,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.81.0-rc.3):
+  - React-RCTSettings (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3070,10 +3070,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.81.0-rc.3):
-    - React-Core/RCTTextHeaders (= 0.81.0-rc.3)
+  - React-RCTText (0.81.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.81.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.81.0-rc.3):
+  - React-RCTVibration (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3087,11 +3087,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.81.0-rc.3)
-  - React-renderercss (0.81.0-rc.3):
+  - React-rendererconsistency (0.81.0-rc.5)
+  - React-renderercss (0.81.0-rc.5):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.0-rc.3):
+  - React-rendererdebug (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3101,7 +3101,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.81.0-rc.3):
+  - React-RuntimeApple (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3130,7 +3130,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.81.0-rc.3):
+  - React-RuntimeCore (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3152,7 +3152,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.81.0-rc.3):
+  - React-runtimeexecutor (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3162,10 +3162,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.5)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.81.0-rc.3):
+  - React-RuntimeHermes (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3186,7 +3186,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.81.0-rc.3):
+  - React-runtimescheduler (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3208,8 +3208,8 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.81.0-rc.3)
-  - React-utils (0.81.0-rc.3):
+  - React-timing (0.81.0-rc.5)
+  - React-utils (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3219,11 +3219,11 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactAppDependencyProvider (0.81.0-rc.3):
+  - ReactAppDependencyProvider (0.81.0-rc.5):
     - ReactCodegen
-  - ReactCodegen (0.81.0-rc.3):
+  - ReactCodegen (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3249,7 +3249,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.81.0-rc.3):
+  - ReactCommon (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3257,9 +3257,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.81.0-rc.3)
+    - ReactCommon/turbomodule (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule (0.81.0-rc.3):
+  - ReactCommon/turbomodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3268,15 +3268,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
-    - ReactCommon/turbomodule/bridging (= 0.81.0-rc.3)
-    - ReactCommon/turbomodule/core (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.81.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.81.0-rc.3):
+  - ReactCommon/turbomodule/bridging (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3285,13 +3285,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.81.0-rc.3):
+  - ReactCommon/turbomodule/core (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3300,14 +3300,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-debug (= 0.81.0-rc.3)
-    - React-featureflags (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
-    - React-utils (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-debug (= 0.81.0-rc.5)
+    - React-featureflags (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
+    - React-utils (= 0.81.0-rc.5)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -4485,10 +4485,10 @@ SPEC CHECKSUMS:
   EXUpdates: bb5eb316f5d056510304948fcbff908e2b6bb9af
   EXUpdatesInterface: d6c802a2d1d11867523d03a95397957f9ba3d1c7
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: dff72c497c0f6de7c979d9d4f87dbba5663a8c92
+  FBLazyVector: 64579c0203cbc859de4536d54b4c6ed28fd03d42
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: cc20804c5f764b4c785deafa291b6fa77bbf71fd
+  hermes-engine: 8b7ef0f4e8363c2dfd6fd133979dd58f57b95825
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4498,39 +4498,39 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: 0747b2210cc36cd9d327a276d046834a2471def5
-  RCTRequired: 69fb68d08216b196c4ac982e3f4481532aeff4ab
-  RCTTypeSafety: 1e74a730ec76b072cd7226c5a29367187492cf89
+  RCTDeprecation: 3a51da4c0e2a533c893971c2171d164974bc5214
+  RCTRequired: d26a2245fa986ca16a6c93d91e41beeeb7a8aa3f
+  RCTTypeSafety: e9598921dd4338d6dcb7b4ba0b7b92f84cdcc25e
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 9e56bb37bb46ce3cdbdf20fd64e44ed6e8b37e82
-  React-callinvoker: 6e732fdd9322aa85920b7ab825b3a9a5d2f69ae7
-  React-Core: 99fee9f6aa1db5b405c4d0f12e048b75e8ec1e5c
-  React-CoreModules: e601e4ca8a860315d0a4edfd7840ff743005d21d
-  React-cxxreact: 2b775f50d54ff739587222cd1c5afc48c4d91bb9
-  React-debug: e780ad153ef3d2d6519d419391937a8c6b5308e0
-  React-defaultsnativemodule: 6d8035748ac95566f624b8818c76bd5369fa9600
-  React-domnativemodule: 9123ddf2081a33d981de7bb34ad7bf4eee792a11
-  React-Fabric: 58c335e8d849a993cde73c4711453943efb2b476
-  React-FabricComponents: 4ce82166c7eafccefc7222048af6a5e06d338499
-  React-FabricImage: 1608e3f58c753d795f578405b771ac18dc21cc63
-  React-featureflags: 4bf826207c670de55dde47b90e5a989963d29932
-  React-featureflagsnativemodule: b636a7d6b89780cf68525805b56f18de890c20c6
-  React-graphics: 5cf01a2c88eaa369a7a36757dcdbc596f255d56f
-  React-hermes: ce12df5b12de9541ac7d61469ac91ce39b091050
-  React-idlecallbacksnativemodule: 24993f2a70753d738c7c813e16e2d29a5471d572
-  React-ImageManager: bf5679bf50bdfe266fc9961525309a8f374db727
-  React-jserrorhandler: bfab33ef6f3bac3d48c387463f5a524adc523653
-  React-jsi: d0ea49291374c56c138984fc7838a3bfea82c11e
-  React-jsiexecutor: e5efd533f6d5acbc0a51450202d036f28b9f54aa
-  React-jsinspector: da6bd81bc804df27eaf1500a641ccc88831a7ae9
-  React-jsinspectorcdp: fc6b54d9fa3816e34cb3730cf0c19d029f9edb1c
-  React-jsinspectornetwork: 9ef6a5c765cb8614f23132f1541062976acbddda
-  React-jsinspectortracing: e121526fc088a96a0088112097f5ca13cc06934d
-  React-jsitooling: 1fc3be3ae4309387e89cd55229bff26e1b2c54bb
-  React-jsitracing: db70b9b57926f5a9e366956220d0710be3a19f17
-  React-logger: 96286cc9e6c073194274e4f5330a75d519c89d7a
-  React-Mapbuffer: 04e062c73315f3a40d4032178f9d396c059c9bb7
-  React-microtasksnativemodule: 3509d6a7d32ed14b91300854123965025f749fea
+  React: 713c6b114dfaddd4e58bc0e3804334f2a170b754
+  React-callinvoker: 4441303f80922bcab09bd3e401738c1a7f3ffe11
+  React-Core: 48eb931b5319893300e3766c6cc38481fa647dfa
+  React-CoreModules: 16160d86eee8183e615fc12e01a7b7d4037d0f11
+  React-cxxreact: 61e4deced1e2e89409d723baaf367da6d8eaf916
+  React-debug: 77c881c70aef8f5787761005eeb57e437a7d0a5b
+  React-defaultsnativemodule: 72ed284e13ab42903f492568e3db78dd708b06de
+  React-domnativemodule: b57bdf705c8f26762d70ddae2f917b6593622d7a
+  React-Fabric: 04dacebd7f35c74d648cadf8fda8c4dd105e1d56
+  React-FabricComponents: 0740d9d86edca91bbd3ab881ab9d139ccaff3513
+  React-FabricImage: 9d544dfe265a8cffaa7ef95023e3eb14eab7058a
+  React-featureflags: c33312b0812afb235add6add17e91b6f3a92222c
+  React-featureflagsnativemodule: 1db86f04957efcaecaec3957cc8d0de86ea573ab
+  React-graphics: f070009719fcac1854a3c4b3897b23e67b956ce2
+  React-hermes: b0d0cf1afcc6a5ea966d7841abbc89d0ec01526d
+  React-idlecallbacksnativemodule: 38c37267785b9d601dab87653edf2cf0c346bcc7
+  React-ImageManager: 578228cd0fbcef002207bf8acf0a42c712098906
+  React-jserrorhandler: 4da8855c5652652776eae535702b258fdc7e2693
+  React-jsi: 32ecda8451aac1f6a649e05dc94a0948ce2bb7d7
+  React-jsiexecutor: f4f3b47f4c1c076363ab8b65042a9a6177ef96b5
+  React-jsinspector: 24c8d6057c0ff37eccc72c855f198c6157893c78
+  React-jsinspectorcdp: 9a364f9cd548fc389ac91af4e5c38eae58f6548f
+  React-jsinspectornetwork: d7f3b19d53fe328dc139035ab0bba19aa68f2439
+  React-jsinspectortracing: 414014b64e0362eec726f3416cc9a02b9a8e9a16
+  React-jsitooling: 96c159a6a7cd6f29f208359554eec887b6fb27b9
+  React-jsitracing: 3c3d20d2dc74fc895411af104f9a9d103dc23794
+  React-logger: 3903016c02ae4dff7387d028501a3b03ba72879d
+  React-Mapbuffer: 48d6d8d0361ab4be5a7b4825006ddfff5e3686ec
+  React-microtasksnativemodule: bd7cfbd456840ebd272edad86b0e09595f2c80d5
   react-native-keyboard-controller: 2ea75136c309c43b5f1b9b02e332628e80c8d936
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: 5aa9fb30444ca4bbe382991b6783cc014ed5ca07
@@ -4539,36 +4539,36 @@ SPEC CHECKSUMS:
   react-native-slider: fe0add239ded49237c81fe25f3ad84adb3ce49c7
   react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
   react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
-  React-NativeModulesApple: 009989614b0619613138091469ae3bce6e4641ba
-  React-oscompat: 414b30e47074beddcae34ee27e12a679a4977f24
-  React-perflogger: 3b129928b67f9acfda95ede5a804b6b2401a3c00
-  React-performancetimeline: 53dea15bdb110b6a3233624088bc929661cec00b
-  React-RCTActionSheet: 3f0f8e164b87bd9882473de51858b89195671fe9
-  React-RCTAnimation: 44f4cfd42d0517b3e034bd4d68f37839eda95443
-  React-RCTAppDelegate: fd8321b41a0a1c24576ee096bdc03c54c7c34a1b
-  React-RCTBlob: 4926f838dda83d487ce3c923458ec7653161cdb3
-  React-RCTFabric: 8a0babd88206697aa0c24c1473987bd35edd2635
-  React-RCTFBReactNativeSpec: 5410c3b5fa7104ff0ab89c0af0b95c2261d69929
-  React-RCTImage: 1406393b9ad0e1a43a83126f819c836d9fd59056
-  React-RCTLinking: 5b34b419c9100be60d0af0bd5c136ed5c0e7d595
-  React-RCTNetwork: 5ff03669c88df8ec5658c9f4aefdbf2e57dbe67e
-  React-RCTRuntime: 478d50836f71058f1cecfd6aaacbeaa58f1e57dc
-  React-RCTSettings: f8b48c1600bf102b8c58fa330ace2138f9bc5a91
-  React-RCTText: 8529ba937639c0cc9898cae342992212fbbc3078
-  React-RCTVibration: 41fe096a7bbb9d3a85e9c19202a98dc95d2b4f95
-  React-rendererconsistency: 15fecabe65cd94bef28ac54d3d51746d345b1114
-  React-renderercss: 621275a9485b16fca4b435563e2a151155de0222
-  React-rendererdebug: 6771edc3c93d02d27f00dc998a19ee732d905523
-  React-RuntimeApple: 5387b9985af7842483ace93ffba3c83c68155dd0
-  React-RuntimeCore: bc67ebe24b0a282c2fd429bce3e9d741d6a5eb5e
-  React-runtimeexecutor: d553435a78433984d63e77d0f9f9e77dd4730ede
-  React-RuntimeHermes: e5b4069531c780a264fbfa3bfd46e6965f034753
-  React-runtimescheduler: c9ddd5b81dc1e58e300941d4e454053189d3531c
-  React-timing: e48ea4ff6e85c2535584362bf1e06f1dd72818e1
-  React-utils: 0a7fc86dbb19cf3a875bfed5ed5bc1f79e229ec3
-  ReactAppDependencyProvider: 0d7a405e9cdb2450aef75f8e3ff6fe9d079d2d27
-  ReactCodegen: 42da1a4ea6befd6d99d544dc8336bfa3095f0f5f
-  ReactCommon: 012d9b70f277c80620e562bc7d94fc3893b2afb4
+  React-NativeModulesApple: b7c71399d5a301dab362289d68747ff8c9b84c19
+  React-oscompat: e324ee1ba89eb09d59c8e346748c758cb87a2ce3
+  React-perflogger: 1a98c4a181ab1cf9e8cf955dae867abfac59a50d
+  React-performancetimeline: 1a508e57eb32cc6951ecc95ac795afe13f3c1499
+  React-RCTActionSheet: e995bcd8831351318c94bfa3e585178dc15934c8
+  React-RCTAnimation: eda5da34ef170a419bff522a58db9d5fb109acec
+  React-RCTAppDelegate: 26ebc3917638dde2ca20facec826e45a96f16d6c
+  React-RCTBlob: 8e905a0df8271c7405e5542f4ddc5f11bf7b3ef4
+  React-RCTFabric: 5c4a2e726a25dd007bffd3aa8ded58d8d58bad67
+  React-RCTFBReactNativeSpec: 125ec865d3b95360142f343075d0326c1f2188fd
+  React-RCTImage: fe502bd39bb9bb5b9cfa635e141bf3d602091b2f
+  React-RCTLinking: 2d9dad05c5ebddc5902a2c2c0177f72e8f6b93bd
+  React-RCTNetwork: 81ac1907ff907c3e0669c8702a1aae2a8356cf8d
+  React-RCTRuntime: b156f2c4f38023a065723d70dd3eb9468a523cc9
+  React-RCTSettings: 0887e903b7f06463ec5887df385ade35705c5151
+  React-RCTText: 4644d6c9bc18c05ea4d373c8434ad9dc2392e642
+  React-RCTVibration: f381c601f931888740383dc14f4baeebac945e94
+  React-rendererconsistency: fde6f437f72fb837be955c7d287c5f1a1fe47212
+  React-renderercss: 8ad27c2b7c138f27518702af50c4bacc85d67fc9
+  React-rendererdebug: 34b2305ff2a349e540b39354277ce2c457da8ec9
+  React-RuntimeApple: 347f9558b516c79bd0cfa2a237371843d0a22c25
+  React-RuntimeCore: d4e1654e01a1a6df3ede773b2ddbac83f39725a9
+  React-runtimeexecutor: 93e8ab92174058160232cd9283d354463255020d
+  React-RuntimeHermes: 2f477bc8fc39fff2d1e3a966a3d908bbde6c3fd5
+  React-runtimescheduler: 7d15929025e58a47cd73758c6c4f46d293d3dca5
+  React-timing: c6ce3a683af45aecee166b49348cd094170a7e36
+  React-utils: 3b356bfa4a83cd7e019b96b1de73e8340cef2bf9
+  ReactAppDependencyProvider: ad094d490c0b69fcd292806df86e007728d02f95
+  ReactCodegen: f08c2da52e7cd8ef345865bce934f85345a92906
+  ReactCommon: 3c95b5086d10c5da3d6d0fc920fc1ce6c984a496
   RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
   RNCMaskedView: 63268de1986a098b5f4d1fb5b1bc1e97fade0aee
   RNCPicker: 6da395ee9db8d67a38c6102d4128b5a0b9ec0e21
@@ -4585,7 +4585,7 @@ SPEC CHECKSUMS:
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   UMAppLoader: 90857e24b6b31ef0c87ade0688c6c4ca08d6201b
-  Yoga: 15c07d37869e68f295849c2af164cea21957f345
+  Yoga: 72ab8318e9f1910fbdd236b045eb5455c8415d92
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: f5d503a683b23e49517a81aa6eeffbc2b323828a

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -64,7 +64,7 @@
     "native-component-list": "*",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.0-rc.3",
+    "react-native": "0.81.0-rc.5",
     "react-native-edge-to-edge": "~1.6.1",
     "react-native-gesture-handler": "~2.26.0",
     "react-native-keyboard-controller": "^1.18.2",

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -22,7 +22,7 @@
       },
       "ios": {
         "cache": {
-          "key": "sdk54-0.81.0-rc.3",
+          "key": "sdk54-0.81.0-rc.5",
           "customPaths": ["../expo-go/ios/Pods"]
         },
         "image": "latest",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -363,7 +363,7 @@ PODS:
   - EXUpdatesInterface (1.1.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.81.0-rc.3)
+  - FBLazyVector (0.81.0-rc.5)
   - FirebaseAnalytics (11.11.0):
     - FirebaseAnalytics/AdIdSupport (= 11.11.0)
     - FirebaseCore (~> 11.11.0)
@@ -484,17 +484,17 @@ PODS:
   - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - hermes-engine (0.81.0-rc.3):
-    - hermes-engine/cdp (= 0.81.0-rc.3)
-    - hermes-engine/Hermes (= 0.81.0-rc.3)
-    - hermes-engine/inspector (= 0.81.0-rc.3)
-    - hermes-engine/inspector_chrome (= 0.81.0-rc.3)
-    - hermes-engine/Public (= 0.81.0-rc.3)
-  - hermes-engine/cdp (0.81.0-rc.3)
-  - hermes-engine/Hermes (0.81.0-rc.3)
-  - hermes-engine/inspector (0.81.0-rc.3)
-  - hermes-engine/inspector_chrome (0.81.0-rc.3)
-  - hermes-engine/Public (0.81.0-rc.3)
+  - hermes-engine (0.81.0-rc.5):
+    - hermes-engine/cdp (= 0.81.0-rc.5)
+    - hermes-engine/Hermes (= 0.81.0-rc.5)
+    - hermes-engine/inspector (= 0.81.0-rc.5)
+    - hermes-engine/inspector_chrome (= 0.81.0-rc.5)
+    - hermes-engine/Public (= 0.81.0-rc.5)
+  - hermes-engine/cdp (0.81.0-rc.5)
+  - hermes-engine/Hermes (0.81.0-rc.5)
+  - hermes-engine/inspector (0.81.0-rc.5)
+  - hermes-engine/inspector_chrome (0.81.0-rc.5)
+  - hermes-engine/Public (0.81.0-rc.5)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -572,28 +572,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.81.0-rc.3)
-  - RCTRequired (0.81.0-rc.3)
-  - RCTTypeSafety (0.81.0-rc.3):
-    - FBLazyVector (= 0.81.0-rc.3)
-    - RCTRequired (= 0.81.0-rc.3)
-    - React-Core (= 0.81.0-rc.3)
+  - RCTDeprecation (0.81.0-rc.5)
+  - RCTRequired (0.81.0-rc.5)
+  - RCTTypeSafety (0.81.0-rc.5):
+    - FBLazyVector (= 0.81.0-rc.5)
+    - RCTRequired (= 0.81.0-rc.5)
+    - React-Core (= 0.81.0-rc.5)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.0-rc.3):
-    - React-Core (= 0.81.0-rc.3)
-    - React-Core/DevSupport (= 0.81.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.81.0-rc.3)
-    - React-RCTActionSheet (= 0.81.0-rc.3)
-    - React-RCTAnimation (= 0.81.0-rc.3)
-    - React-RCTBlob (= 0.81.0-rc.3)
-    - React-RCTImage (= 0.81.0-rc.3)
-    - React-RCTLinking (= 0.81.0-rc.3)
-    - React-RCTNetwork (= 0.81.0-rc.3)
-    - React-RCTSettings (= 0.81.0-rc.3)
-    - React-RCTText (= 0.81.0-rc.3)
-    - React-RCTVibration (= 0.81.0-rc.3)
-  - React-callinvoker (0.81.0-rc.3)
-  - React-Core (0.81.0-rc.3):
+  - React (0.81.0-rc.5):
+    - React-Core (= 0.81.0-rc.5)
+    - React-Core/DevSupport (= 0.81.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.81.0-rc.5)
+    - React-RCTActionSheet (= 0.81.0-rc.5)
+    - React-RCTAnimation (= 0.81.0-rc.5)
+    - React-RCTBlob (= 0.81.0-rc.5)
+    - React-RCTImage (= 0.81.0-rc.5)
+    - React-RCTLinking (= 0.81.0-rc.5)
+    - React-RCTNetwork (= 0.81.0-rc.5)
+    - React-RCTSettings (= 0.81.0-rc.5)
+    - React-RCTText (= 0.81.0-rc.5)
+    - React-RCTVibration (= 0.81.0-rc.5)
+  - React-callinvoker (0.81.0-rc.5)
+  - React-Core (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -603,7 +603,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.3)
+    - React-Core/Default (= 0.81.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -618,82 +618,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.81.0-rc.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.0-rc.3):
+  - React-Core/CoreModulesHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -718,7 +643,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.0-rc.3):
+  - React-Core/Default (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.81.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -743,7 +718,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.0-rc.3):
+  - React-Core/RCTAnimationHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -768,7 +743,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.0-rc.3):
+  - React-Core/RCTBlobHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -793,7 +768,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.0-rc.3):
+  - React-Core/RCTImageHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -818,7 +793,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.0-rc.3):
+  - React-Core/RCTLinkingHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -843,7 +818,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.0-rc.3):
+  - React-Core/RCTNetworkHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -868,7 +843,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.0-rc.3):
+  - React-Core/RCTSettingsHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -893,7 +868,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.0-rc.3):
+  - React-Core/RCTTextHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -918,7 +893,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.81.0-rc.3):
+  - React-Core/RCTVibrationHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -928,7 +903,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -943,7 +918,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.81.0-rc.3):
+  - React-Core/RCTWebSocket (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -951,20 +951,20 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.81.0-rc.3)
-    - React-Core/CoreModulesHeaders (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - RCTTypeSafety (= 0.81.0-rc.5)
+    - React-Core/CoreModulesHeaders (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.0-rc.3)
+    - React-RCTImage (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.81.0-rc.3):
+  - React-cxxreact (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -973,19 +973,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-debug (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-debug (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
-    - React-timing (= 0.81.0-rc.3)
+    - React-timing (= 0.81.0-rc.5)
     - SocketRocket
-  - React-debug (0.81.0-rc.3)
-  - React-defaultsnativemodule (0.81.0-rc.3):
+  - React-debug (0.81.0-rc.5)
+  - React-defaultsnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1002,7 +1002,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.81.0-rc.3):
+  - React-domnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1022,7 +1022,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.81.0-rc.3):
+  - React-Fabric (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1036,23 +1036,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.0-rc.3)
-    - React-Fabric/attributedstring (= 0.81.0-rc.3)
-    - React-Fabric/bridging (= 0.81.0-rc.3)
-    - React-Fabric/componentregistry (= 0.81.0-rc.3)
-    - React-Fabric/componentregistrynative (= 0.81.0-rc.3)
-    - React-Fabric/components (= 0.81.0-rc.3)
-    - React-Fabric/consistency (= 0.81.0-rc.3)
-    - React-Fabric/core (= 0.81.0-rc.3)
-    - React-Fabric/dom (= 0.81.0-rc.3)
-    - React-Fabric/imagemanager (= 0.81.0-rc.3)
-    - React-Fabric/leakchecker (= 0.81.0-rc.3)
-    - React-Fabric/mounting (= 0.81.0-rc.3)
-    - React-Fabric/observers (= 0.81.0-rc.3)
-    - React-Fabric/scheduler (= 0.81.0-rc.3)
-    - React-Fabric/telemetry (= 0.81.0-rc.3)
-    - React-Fabric/templateprocessor (= 0.81.0-rc.3)
-    - React-Fabric/uimanager (= 0.81.0-rc.3)
+    - React-Fabric/animations (= 0.81.0-rc.5)
+    - React-Fabric/attributedstring (= 0.81.0-rc.5)
+    - React-Fabric/bridging (= 0.81.0-rc.5)
+    - React-Fabric/componentregistry (= 0.81.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.81.0-rc.5)
+    - React-Fabric/components (= 0.81.0-rc.5)
+    - React-Fabric/consistency (= 0.81.0-rc.5)
+    - React-Fabric/core (= 0.81.0-rc.5)
+    - React-Fabric/dom (= 0.81.0-rc.5)
+    - React-Fabric/imagemanager (= 0.81.0-rc.5)
+    - React-Fabric/leakchecker (= 0.81.0-rc.5)
+    - React-Fabric/mounting (= 0.81.0-rc.5)
+    - React-Fabric/observers (= 0.81.0-rc.5)
+    - React-Fabric/scheduler (= 0.81.0-rc.5)
+    - React-Fabric/telemetry (= 0.81.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.81.0-rc.5)
+    - React-Fabric/uimanager (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1064,32 +1064,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.81.0-rc.3):
+  - React-Fabric/animations (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1114,7 +1089,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.81.0-rc.3):
+  - React-Fabric/attributedstring (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1139,7 +1114,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.81.0-rc.3):
+  - React-Fabric/bridging (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1164,7 +1139,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.81.0-rc.3):
+  - React-Fabric/componentregistry (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1189,36 +1164,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.0-rc.3)
-    - React-Fabric/components/root (= 0.81.0-rc.3)
-    - React-Fabric/components/scrollview (= 0.81.0-rc.3)
-    - React-Fabric/components/view (= 0.81.0-rc.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.0-rc.3):
+  - React-Fabric/componentregistrynative (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1243,7 +1189,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.81.0-rc.3):
+  - React-Fabric/components (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.0-rc.5)
+    - React-Fabric/components/root (= 0.81.0-rc.5)
+    - React-Fabric/components/scrollview (= 0.81.0-rc.5)
+    - React-Fabric/components/view (= 0.81.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1268,7 +1243,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.81.0-rc.3):
+  - React-Fabric/components/root (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1293,7 +1268,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.81.0-rc.3):
+  - React-Fabric/components/scrollview (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1320,7 +1320,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.81.0-rc.3):
+  - React-Fabric/consistency (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1345,7 +1345,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.81.0-rc.3):
+  - React-Fabric/core (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1370,7 +1370,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.81.0-rc.3):
+  - React-Fabric/dom (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1395,7 +1395,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.81.0-rc.3):
+  - React-Fabric/imagemanager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1420,7 +1420,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.81.0-rc.3):
+  - React-Fabric/leakchecker (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1445,7 +1445,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.81.0-rc.3):
+  - React-Fabric/mounting (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1470,7 +1470,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.81.0-rc.3):
+  - React-Fabric/observers (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1484,7 +1484,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.0-rc.3)
+    - React-Fabric/observers/events (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1496,7 +1496,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.81.0-rc.3):
+  - React-Fabric/observers/events (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1521,7 +1521,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.81.0-rc.3):
+  - React-Fabric/scheduler (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1548,7 +1548,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.81.0-rc.3):
+  - React-Fabric/telemetry (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1573,7 +1573,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.81.0-rc.3):
+  - React-Fabric/templateprocessor (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1598,7 +1598,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.81.0-rc.3):
+  - React-Fabric/uimanager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1612,7 +1612,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.0-rc.3)
+    - React-Fabric/uimanager/consistency (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1625,7 +1625,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.81.0-rc.3):
+  - React-Fabric/uimanager/consistency (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1651,7 +1651,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.81.0-rc.3):
+  - React-FabricComponents (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1666,8 +1666,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.0-rc.3)
-    - React-FabricComponents/textlayoutmanager (= 0.81.0-rc.3)
+    - React-FabricComponents/components (= 0.81.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1680,7 +1680,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.81.0-rc.3):
+  - React-FabricComponents/components (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1695,16 +1695,16 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.0-rc.3)
-    - React-FabricComponents/components/iostextinput (= 0.81.0-rc.3)
-    - React-FabricComponents/components/modal (= 0.81.0-rc.3)
-    - React-FabricComponents/components/rncore (= 0.81.0-rc.3)
-    - React-FabricComponents/components/safeareaview (= 0.81.0-rc.3)
-    - React-FabricComponents/components/scrollview (= 0.81.0-rc.3)
-    - React-FabricComponents/components/text (= 0.81.0-rc.3)
-    - React-FabricComponents/components/textinput (= 0.81.0-rc.3)
-    - React-FabricComponents/components/unimplementedview (= 0.81.0-rc.3)
-    - React-FabricComponents/components/virtualview (= 0.81.0-rc.3)
+    - React-FabricComponents/components/inputaccessory (= 0.81.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.81.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.81.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.81.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.81.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.81.0-rc.5)
+    - React-FabricComponents/components/text (= 0.81.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.81.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.81.0-rc.5)
+    - React-FabricComponents/components/virtualview (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1717,34 +1717,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.0-rc.3):
+  - React-FabricComponents/components/inputaccessory (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1771,7 +1744,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.81.0-rc.3):
+  - React-FabricComponents/components/iostextinput (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1798,7 +1771,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.0-rc.3):
+  - React-FabricComponents/components/modal (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1825,7 +1798,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.0-rc.3):
+  - React-FabricComponents/components/rncore (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1852,7 +1825,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.0-rc.3):
+  - React-FabricComponents/components/safeareaview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1879,7 +1852,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.81.0-rc.3):
+  - React-FabricComponents/components/scrollview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1906,7 +1879,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.0-rc.3):
+  - React-FabricComponents/components/text (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1933,7 +1906,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.0-rc.3):
+  - React-FabricComponents/components/textinput (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1960,7 +1933,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.0-rc.3):
+  - React-FabricComponents/components/unimplementedview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1987,7 +1960,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.0-rc.3):
+  - React-FabricComponents/components/virtualview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2014,7 +1987,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.81.0-rc.3):
+  - React-FabricComponents/textlayoutmanager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2023,21 +1996,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.81.0-rc.3)
-    - RCTTypeSafety (= 0.81.0-rc.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.81.0-rc.5)
+    - RCTTypeSafety (= 0.81.0-rc.5)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.0-rc.3)
+    - React-jsiexecutor (= 0.81.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.81.0-rc.3):
+  - React-featureflags (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2046,7 +2046,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.81.0-rc.3):
+  - React-featureflagsnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2061,7 +2061,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.81.0-rc.3):
+  - React-graphics (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2074,7 +2074,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.81.0-rc.3):
+  - React-hermes (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2083,16 +2083,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.81.0-rc.3)
+    - React-jsiexecutor (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.81.0-rc.3):
+  - React-idlecallbacksnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2108,7 +2108,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.81.0-rc.3):
+  - React-ImageManager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2123,7 +2123,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.81.0-rc.3):
+  - React-jserrorhandler (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2138,7 +2138,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.81.0-rc.3):
+  - React-jsi (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2148,7 +2148,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.81.0-rc.3):
+  - React-jsiexecutor (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2157,15 +2157,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.81.0-rc.3):
+  - React-jsinspector (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2179,10 +2179,10 @@ PODS:
     - React-jsinspectorcdp
     - React-jsinspectornetwork
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.81.0-rc.3):
+  - React-jsinspectorcdp (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2191,7 +2191,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.81.0-rc.3):
+  - React-jsinspectornetwork (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2204,7 +2204,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.81.0-rc.3):
+  - React-jsinspectortracing (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2215,7 +2215,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.81.0-rc.3):
+  - React-jsitooling (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2223,16 +2223,16 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.81.0-rc.3):
+  - React-jsitracing (0.81.0-rc.5):
     - React-jsi
-  - React-logger (0.81.0-rc.3):
+  - React-logger (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2241,7 +2241,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.81.0-rc.3):
+  - React-Mapbuffer (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2251,7 +2251,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.81.0-rc.3):
+  - React-microtasksnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2673,7 +2673,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.81.0-rc.3):
+  - React-NativeModulesApple (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2693,8 +2693,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.81.0-rc.3)
-  - React-perflogger (0.81.0-rc.3):
+  - React-oscompat (0.81.0-rc.5)
+  - React-perflogger (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2703,7 +2703,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.81.0-rc.3):
+  - React-performancetimeline (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2716,9 +2716,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.81.0-rc.3):
-    - React-Core/RCTActionSheetHeaders (= 0.81.0-rc.3)
-  - React-RCTAnimation (0.81.0-rc.3):
+  - React-RCTActionSheet (0.81.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.81.0-rc.5)
+  - React-RCTAnimation (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2734,7 +2734,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.81.0-rc.3):
+  - React-RCTAppDelegate (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2768,7 +2768,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.81.0-rc.3):
+  - React-RCTBlob (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2787,7 +2787,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.81.0-rc.3):
+  - React-RCTFabric (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2822,7 +2822,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.0-rc.3):
+  - React-RCTFBReactNativeSpec (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2836,10 +2836,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.0-rc.3)
+    - React-RCTFBReactNativeSpec/components (= 0.81.0-rc.5)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.81.0-rc.3):
+  - React-RCTFBReactNativeSpec/components (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2862,7 +2862,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.81.0-rc.3):
+  - React-RCTImage (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2878,14 +2878,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.81.0-rc.3):
-    - React-Core/RCTLinkingHeaders (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+  - React-RCTLinking (0.81.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.0-rc.3)
-  - React-RCTNetwork (0.81.0-rc.3):
+    - ReactCommon/turbomodule/core (= 0.81.0-rc.5)
+  - React-RCTNetwork (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2903,7 +2903,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.81.0-rc.3):
+  - React-RCTRuntime (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2923,7 +2923,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.81.0-rc.3):
+  - React-RCTSettings (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2938,10 +2938,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.81.0-rc.3):
-    - React-Core/RCTTextHeaders (= 0.81.0-rc.3)
+  - React-RCTText (0.81.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.81.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.81.0-rc.3):
+  - React-RCTVibration (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2955,11 +2955,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.81.0-rc.3)
-  - React-renderercss (0.81.0-rc.3):
+  - React-rendererconsistency (0.81.0-rc.5)
+  - React-renderercss (0.81.0-rc.5):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.0-rc.3):
+  - React-rendererdebug (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2969,7 +2969,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.81.0-rc.3):
+  - React-RuntimeApple (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2998,7 +2998,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.81.0-rc.3):
+  - React-RuntimeCore (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3020,7 +3020,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.81.0-rc.3):
+  - React-runtimeexecutor (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3030,10 +3030,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.5)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.81.0-rc.3):
+  - React-RuntimeHermes (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3054,7 +3054,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.81.0-rc.3):
+  - React-runtimescheduler (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3076,8 +3076,8 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.81.0-rc.3)
-  - React-utils (0.81.0-rc.3):
+  - React-timing (0.81.0-rc.5)
+  - React-utils (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3087,11 +3087,11 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactAppDependencyProvider (0.81.0-rc.3):
+  - ReactAppDependencyProvider (0.81.0-rc.5):
     - ReactCodegen
-  - ReactCodegen (0.81.0-rc.3):
+  - ReactCodegen (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3117,7 +3117,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.81.0-rc.3):
+  - ReactCommon (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3125,9 +3125,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.81.0-rc.3)
+    - ReactCommon/turbomodule (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule (0.81.0-rc.3):
+  - ReactCommon/turbomodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3136,15 +3136,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
-    - ReactCommon/turbomodule/bridging (= 0.81.0-rc.3)
-    - ReactCommon/turbomodule/core (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.81.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.81.0-rc.3):
+  - ReactCommon/turbomodule/bridging (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3153,13 +3153,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.81.0-rc.3):
+  - ReactCommon/turbomodule/core (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -3168,14 +3168,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-debug (= 0.81.0-rc.3)
-    - React-featureflags (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
-    - React-utils (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-debug (= 0.81.0-rc.5)
+    - React-featureflags (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
+    - React-utils (= 0.81.0-rc.5)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -4382,7 +4382,7 @@ SPEC CHECKSUMS:
   EXUpdates: d7205503b033ad6f48ea2702a234db55c0ec45a5
   EXUpdatesInterface: d6c802a2d1d11867523d03a95397957f9ba3d1c7
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: dff72c497c0f6de7c979d9d4f87dbba5663a8c92
+  FBLazyVector: 64579c0203cbc859de4536d54b4c6ed28fd03d42
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
   FirebaseCore: 2321536f9c423b1f857e047a82b8a42abc6d9e2c
   FirebaseCoreExtension: 3a64994969dd05f4bcb7e6896c654eded238e75b
@@ -4398,7 +4398,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: b58e9627004f47043897eeae830c3ef023678f3b
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 261d5b1bb5c97bf83c1232a4bdbb5124eea14cb9
+  hermes-engine: b7bb3bbf7797b50c3be0abbd15a0a347e1bf4746
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4411,39 +4411,39 @@ SPEC CHECKSUMS:
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: 0747b2210cc36cd9d327a276d046834a2471def5
-  RCTRequired: 69fb68d08216b196c4ac982e3f4481532aeff4ab
-  RCTTypeSafety: 1e74a730ec76b072cd7226c5a29367187492cf89
+  RCTDeprecation: 3a51da4c0e2a533c893971c2171d164974bc5214
+  RCTRequired: d26a2245fa986ca16a6c93d91e41beeeb7a8aa3f
+  RCTTypeSafety: e9598921dd4338d6dcb7b4ba0b7b92f84cdcc25e
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 9e56bb37bb46ce3cdbdf20fd64e44ed6e8b37e82
-  React-callinvoker: 6e732fdd9322aa85920b7ab825b3a9a5d2f69ae7
-  React-Core: 99fee9f6aa1db5b405c4d0f12e048b75e8ec1e5c
-  React-CoreModules: e601e4ca8a860315d0a4edfd7840ff743005d21d
-  React-cxxreact: 2b775f50d54ff739587222cd1c5afc48c4d91bb9
-  React-debug: e780ad153ef3d2d6519d419391937a8c6b5308e0
-  React-defaultsnativemodule: 6d8035748ac95566f624b8818c76bd5369fa9600
-  React-domnativemodule: 9123ddf2081a33d981de7bb34ad7bf4eee792a11
-  React-Fabric: 58c335e8d849a993cde73c4711453943efb2b476
-  React-FabricComponents: 4ce82166c7eafccefc7222048af6a5e06d338499
-  React-FabricImage: 1608e3f58c753d795f578405b771ac18dc21cc63
-  React-featureflags: 4bf826207c670de55dde47b90e5a989963d29932
-  React-featureflagsnativemodule: b636a7d6b89780cf68525805b56f18de890c20c6
-  React-graphics: 5cf01a2c88eaa369a7a36757dcdbc596f255d56f
-  React-hermes: ce12df5b12de9541ac7d61469ac91ce39b091050
-  React-idlecallbacksnativemodule: 24993f2a70753d738c7c813e16e2d29a5471d572
-  React-ImageManager: bf5679bf50bdfe266fc9961525309a8f374db727
-  React-jserrorhandler: bfab33ef6f3bac3d48c387463f5a524adc523653
-  React-jsi: d0ea49291374c56c138984fc7838a3bfea82c11e
-  React-jsiexecutor: e5efd533f6d5acbc0a51450202d036f28b9f54aa
-  React-jsinspector: da6bd81bc804df27eaf1500a641ccc88831a7ae9
-  React-jsinspectorcdp: fc6b54d9fa3816e34cb3730cf0c19d029f9edb1c
-  React-jsinspectornetwork: 9ef6a5c765cb8614f23132f1541062976acbddda
-  React-jsinspectortracing: e121526fc088a96a0088112097f5ca13cc06934d
-  React-jsitooling: 1fc3be3ae4309387e89cd55229bff26e1b2c54bb
-  React-jsitracing: db70b9b57926f5a9e366956220d0710be3a19f17
-  React-logger: 96286cc9e6c073194274e4f5330a75d519c89d7a
-  React-Mapbuffer: 04e062c73315f3a40d4032178f9d396c059c9bb7
-  React-microtasksnativemodule: 3509d6a7d32ed14b91300854123965025f749fea
+  React: 713c6b114dfaddd4e58bc0e3804334f2a170b754
+  React-callinvoker: 4441303f80922bcab09bd3e401738c1a7f3ffe11
+  React-Core: 48eb931b5319893300e3766c6cc38481fa647dfa
+  React-CoreModules: 16160d86eee8183e615fc12e01a7b7d4037d0f11
+  React-cxxreact: 61e4deced1e2e89409d723baaf367da6d8eaf916
+  React-debug: 77c881c70aef8f5787761005eeb57e437a7d0a5b
+  React-defaultsnativemodule: 72ed284e13ab42903f492568e3db78dd708b06de
+  React-domnativemodule: b57bdf705c8f26762d70ddae2f917b6593622d7a
+  React-Fabric: 04dacebd7f35c74d648cadf8fda8c4dd105e1d56
+  React-FabricComponents: 0740d9d86edca91bbd3ab881ab9d139ccaff3513
+  React-FabricImage: 9d544dfe265a8cffaa7ef95023e3eb14eab7058a
+  React-featureflags: c33312b0812afb235add6add17e91b6f3a92222c
+  React-featureflagsnativemodule: 1db86f04957efcaecaec3957cc8d0de86ea573ab
+  React-graphics: f070009719fcac1854a3c4b3897b23e67b956ce2
+  React-hermes: b0d0cf1afcc6a5ea966d7841abbc89d0ec01526d
+  React-idlecallbacksnativemodule: 38c37267785b9d601dab87653edf2cf0c346bcc7
+  React-ImageManager: 578228cd0fbcef002207bf8acf0a42c712098906
+  React-jserrorhandler: 4da8855c5652652776eae535702b258fdc7e2693
+  React-jsi: 32ecda8451aac1f6a649e05dc94a0948ce2bb7d7
+  React-jsiexecutor: f4f3b47f4c1c076363ab8b65042a9a6177ef96b5
+  React-jsinspector: 24c8d6057c0ff37eccc72c855f198c6157893c78
+  React-jsinspectorcdp: 9a364f9cd548fc389ac91af4e5c38eae58f6548f
+  React-jsinspectornetwork: d7f3b19d53fe328dc139035ab0bba19aa68f2439
+  React-jsinspectortracing: 414014b64e0362eec726f3416cc9a02b9a8e9a16
+  React-jsitooling: 96c159a6a7cd6f29f208359554eec887b6fb27b9
+  React-jsitracing: 3c3d20d2dc74fc895411af104f9a9d103dc23794
+  React-logger: 3903016c02ae4dff7387d028501a3b03ba72879d
+  React-Mapbuffer: 48d6d8d0361ab4be5a7b4825006ddfff5e3686ec
+  React-microtasksnativemodule: bd7cfbd456840ebd272edad86b0e09595f2c80d5
   react-native-keyboard-controller: 2ea75136c309c43b5f1b9b02e332628e80c8d936
   react-native-maps: fece4020ca8007967fa5eb48c914a8f2c73e7d4c
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
@@ -4454,36 +4454,36 @@ SPEC CHECKSUMS:
   react-native-slider: fe0add239ded49237c81fe25f3ad84adb3ce49c7
   react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
   react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
-  React-NativeModulesApple: 009989614b0619613138091469ae3bce6e4641ba
-  React-oscompat: 414b30e47074beddcae34ee27e12a679a4977f24
-  React-perflogger: 3b129928b67f9acfda95ede5a804b6b2401a3c00
-  React-performancetimeline: 53dea15bdb110b6a3233624088bc929661cec00b
-  React-RCTActionSheet: 3f0f8e164b87bd9882473de51858b89195671fe9
-  React-RCTAnimation: 44f4cfd42d0517b3e034bd4d68f37839eda95443
-  React-RCTAppDelegate: fd8321b41a0a1c24576ee096bdc03c54c7c34a1b
-  React-RCTBlob: 4926f838dda83d487ce3c923458ec7653161cdb3
-  React-RCTFabric: 8a0babd88206697aa0c24c1473987bd35edd2635
-  React-RCTFBReactNativeSpec: 5410c3b5fa7104ff0ab89c0af0b95c2261d69929
-  React-RCTImage: 1406393b9ad0e1a43a83126f819c836d9fd59056
-  React-RCTLinking: 5b34b419c9100be60d0af0bd5c136ed5c0e7d595
-  React-RCTNetwork: 5ff03669c88df8ec5658c9f4aefdbf2e57dbe67e
-  React-RCTRuntime: 478d50836f71058f1cecfd6aaacbeaa58f1e57dc
-  React-RCTSettings: f8b48c1600bf102b8c58fa330ace2138f9bc5a91
-  React-RCTText: 8529ba937639c0cc9898cae342992212fbbc3078
-  React-RCTVibration: 41fe096a7bbb9d3a85e9c19202a98dc95d2b4f95
-  React-rendererconsistency: 15fecabe65cd94bef28ac54d3d51746d345b1114
-  React-renderercss: 621275a9485b16fca4b435563e2a151155de0222
-  React-rendererdebug: 6771edc3c93d02d27f00dc998a19ee732d905523
-  React-RuntimeApple: 5387b9985af7842483ace93ffba3c83c68155dd0
-  React-RuntimeCore: bc67ebe24b0a282c2fd429bce3e9d741d6a5eb5e
-  React-runtimeexecutor: d553435a78433984d63e77d0f9f9e77dd4730ede
-  React-RuntimeHermes: e5b4069531c780a264fbfa3bfd46e6965f034753
-  React-runtimescheduler: c9ddd5b81dc1e58e300941d4e454053189d3531c
-  React-timing: e48ea4ff6e85c2535584362bf1e06f1dd72818e1
-  React-utils: 0a7fc86dbb19cf3a875bfed5ed5bc1f79e229ec3
-  ReactAppDependencyProvider: 0d7a405e9cdb2450aef75f8e3ff6fe9d079d2d27
-  ReactCodegen: 9c6eb7accbce872922e3196143dc540133079942
-  ReactCommon: 012d9b70f277c80620e562bc7d94fc3893b2afb4
+  React-NativeModulesApple: b7c71399d5a301dab362289d68747ff8c9b84c19
+  React-oscompat: e324ee1ba89eb09d59c8e346748c758cb87a2ce3
+  React-perflogger: 1a98c4a181ab1cf9e8cf955dae867abfac59a50d
+  React-performancetimeline: 1a508e57eb32cc6951ecc95ac795afe13f3c1499
+  React-RCTActionSheet: e995bcd8831351318c94bfa3e585178dc15934c8
+  React-RCTAnimation: eda5da34ef170a419bff522a58db9d5fb109acec
+  React-RCTAppDelegate: 26ebc3917638dde2ca20facec826e45a96f16d6c
+  React-RCTBlob: 8e905a0df8271c7405e5542f4ddc5f11bf7b3ef4
+  React-RCTFabric: 5c4a2e726a25dd007bffd3aa8ded58d8d58bad67
+  React-RCTFBReactNativeSpec: 125ec865d3b95360142f343075d0326c1f2188fd
+  React-RCTImage: fe502bd39bb9bb5b9cfa635e141bf3d602091b2f
+  React-RCTLinking: 2d9dad05c5ebddc5902a2c2c0177f72e8f6b93bd
+  React-RCTNetwork: 81ac1907ff907c3e0669c8702a1aae2a8356cf8d
+  React-RCTRuntime: b156f2c4f38023a065723d70dd3eb9468a523cc9
+  React-RCTSettings: 0887e903b7f06463ec5887df385ade35705c5151
+  React-RCTText: 4644d6c9bc18c05ea4d373c8434ad9dc2392e642
+  React-RCTVibration: f381c601f931888740383dc14f4baeebac945e94
+  React-rendererconsistency: fde6f437f72fb837be955c7d287c5f1a1fe47212
+  React-renderercss: 8ad27c2b7c138f27518702af50c4bacc85d67fc9
+  React-rendererdebug: 34b2305ff2a349e540b39354277ce2c457da8ec9
+  React-RuntimeApple: 347f9558b516c79bd0cfa2a237371843d0a22c25
+  React-RuntimeCore: d4e1654e01a1a6df3ede773b2ddbac83f39725a9
+  React-runtimeexecutor: 93e8ab92174058160232cd9283d354463255020d
+  React-RuntimeHermes: 2f477bc8fc39fff2d1e3a966a3d908bbde6c3fd5
+  React-runtimescheduler: 7d15929025e58a47cd73758c6c4f46d293d3dca5
+  React-timing: c6ce3a683af45aecee166b49348cd094170a7e36
+  React-utils: 3b356bfa4a83cd7e019b96b1de73e8340cef2bf9
+  ReactAppDependencyProvider: ad094d490c0b69fcd292806df86e007728d02f95
+  ReactCodegen: 3e4dff28826e5bac0593f26c27d2dd2c3a6c66f2
+  ReactCommon: 3c95b5086d10c5da3d6d0fc920fc1ce6c984a496
   RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
   RNCMaskedView: 63268de1986a098b5f4d1fb5b1bc1e97fade0aee
   RNCPicker: 6da395ee9db8d67a38c6102d4128b5a0b9ec0e21
@@ -4509,7 +4509,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: d489e73bf790da1c74e642021475b1a09a4a4500
   StripeUICore: 723e5024c83acb5ba5e71335e110a471b182a74d
   UMAppLoader: 90857e24b6b31ef0c87ade0688c6c4ca08d6201b
-  Yoga: 15c07d37869e68f295849c2af164cea21957f345
+  Yoga: 72ab8318e9f1910fbdd236b045eb5455c8415d92
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 6c9d0ce09e0896f726dda0aeac28e43823a06e04

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -69,7 +69,7 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "19.1.0",
-    "react-native": "0.81.0-rc.3",
+    "react-native": "0.81.0-rc.5",
     "react-native-edge-to-edge": "1.6.0",
     "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~2.26.0",

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -9,6 +9,6 @@
     "expo": "~53.0.9",
     "expo-clipboard": "~7.1.4",
     "react": "19.1.0",
-    "react-native": "0.81.0-rc.3"
+    "react-native": "0.81.0-rc.5"
   }
 }

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -138,7 +138,7 @@
     "processing-js": "^1.6.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.0-rc.3",
+    "react-native": "0.81.0-rc.5",
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.26.0",
     "react-native-keyboard-controller": "^1.18.2",

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -493,12 +493,12 @@ PODS:
   - EXUpdatesInterface (1.1.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.81.0-rc.3)
+  - FBLazyVector (0.81.0-rc.5)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.81.0-rc.3):
-    - hermes-engine/Pre-built (= 0.81.0-rc.3)
-  - hermes-engine/Pre-built (0.81.0-rc.3)
+  - hermes-engine (0.81.0-rc.5):
+    - hermes-engine/Pre-built (= 0.81.0-rc.5)
+  - hermes-engine/Pre-built (0.81.0-rc.5)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -550,28 +550,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.81.0-rc.3)
-  - RCTRequired (0.81.0-rc.3)
-  - RCTTypeSafety (0.81.0-rc.3):
-    - FBLazyVector (= 0.81.0-rc.3)
-    - RCTRequired (= 0.81.0-rc.3)
-    - React-Core (= 0.81.0-rc.3)
+  - RCTDeprecation (0.81.0-rc.5)
+  - RCTRequired (0.81.0-rc.5)
+  - RCTTypeSafety (0.81.0-rc.5):
+    - FBLazyVector (= 0.81.0-rc.5)
+    - RCTRequired (= 0.81.0-rc.5)
+    - React-Core (= 0.81.0-rc.5)
   - ReachabilitySwift (5.0.0)
-  - React (0.81.0-rc.3):
-    - React-Core (= 0.81.0-rc.3)
-    - React-Core/DevSupport (= 0.81.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.81.0-rc.3)
-    - React-RCTActionSheet (= 0.81.0-rc.3)
-    - React-RCTAnimation (= 0.81.0-rc.3)
-    - React-RCTBlob (= 0.81.0-rc.3)
-    - React-RCTImage (= 0.81.0-rc.3)
-    - React-RCTLinking (= 0.81.0-rc.3)
-    - React-RCTNetwork (= 0.81.0-rc.3)
-    - React-RCTSettings (= 0.81.0-rc.3)
-    - React-RCTText (= 0.81.0-rc.3)
-    - React-RCTVibration (= 0.81.0-rc.3)
-  - React-callinvoker (0.81.0-rc.3)
-  - React-Core (0.81.0-rc.3):
+  - React (0.81.0-rc.5):
+    - React-Core (= 0.81.0-rc.5)
+    - React-Core/DevSupport (= 0.81.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.81.0-rc.5)
+    - React-RCTActionSheet (= 0.81.0-rc.5)
+    - React-RCTAnimation (= 0.81.0-rc.5)
+    - React-RCTBlob (= 0.81.0-rc.5)
+    - React-RCTImage (= 0.81.0-rc.5)
+    - React-RCTLinking (= 0.81.0-rc.5)
+    - React-RCTNetwork (= 0.81.0-rc.5)
+    - React-RCTSettings (= 0.81.0-rc.5)
+    - React-RCTText (= 0.81.0-rc.5)
+    - React-RCTVibration (= 0.81.0-rc.5)
+  - React-callinvoker (0.81.0-rc.5)
+  - React-Core (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -581,7 +581,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.3)
+    - React-Core/Default (= 0.81.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -596,82 +596,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.81.0-rc.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.0-rc.3):
+  - React-Core/CoreModulesHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -696,7 +621,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.0-rc.3):
+  - React-Core/Default (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.81.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -721,7 +696,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.0-rc.3):
+  - React-Core/RCTAnimationHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -746,7 +721,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.0-rc.3):
+  - React-Core/RCTBlobHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -771,7 +746,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.0-rc.3):
+  - React-Core/RCTImageHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -796,7 +771,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.0-rc.3):
+  - React-Core/RCTLinkingHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -821,7 +796,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.0-rc.3):
+  - React-Core/RCTNetworkHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -846,7 +821,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.0-rc.3):
+  - React-Core/RCTSettingsHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -871,7 +846,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.0-rc.3):
+  - React-Core/RCTTextHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -896,7 +871,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.81.0-rc.3):
+  - React-Core/RCTVibrationHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -906,7 +881,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -921,7 +896,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.81.0-rc.3):
+  - React-Core/RCTWebSocket (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -929,20 +929,20 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.81.0-rc.3)
-    - React-Core/CoreModulesHeaders (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - RCTTypeSafety (= 0.81.0-rc.5)
+    - React-Core/CoreModulesHeaders (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.0-rc.3)
+    - React-RCTImage (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.81.0-rc.3):
+  - React-cxxreact (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -951,19 +951,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-debug (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-debug (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
-    - React-timing (= 0.81.0-rc.3)
+    - React-timing (= 0.81.0-rc.5)
     - SocketRocket
-  - React-debug (0.81.0-rc.3)
-  - React-defaultsnativemodule (0.81.0-rc.3):
+  - React-debug (0.81.0-rc.5)
+  - React-defaultsnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -980,7 +980,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.81.0-rc.3):
+  - React-domnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1000,7 +1000,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.81.0-rc.3):
+  - React-Fabric (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1014,23 +1014,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.0-rc.3)
-    - React-Fabric/attributedstring (= 0.81.0-rc.3)
-    - React-Fabric/bridging (= 0.81.0-rc.3)
-    - React-Fabric/componentregistry (= 0.81.0-rc.3)
-    - React-Fabric/componentregistrynative (= 0.81.0-rc.3)
-    - React-Fabric/components (= 0.81.0-rc.3)
-    - React-Fabric/consistency (= 0.81.0-rc.3)
-    - React-Fabric/core (= 0.81.0-rc.3)
-    - React-Fabric/dom (= 0.81.0-rc.3)
-    - React-Fabric/imagemanager (= 0.81.0-rc.3)
-    - React-Fabric/leakchecker (= 0.81.0-rc.3)
-    - React-Fabric/mounting (= 0.81.0-rc.3)
-    - React-Fabric/observers (= 0.81.0-rc.3)
-    - React-Fabric/scheduler (= 0.81.0-rc.3)
-    - React-Fabric/telemetry (= 0.81.0-rc.3)
-    - React-Fabric/templateprocessor (= 0.81.0-rc.3)
-    - React-Fabric/uimanager (= 0.81.0-rc.3)
+    - React-Fabric/animations (= 0.81.0-rc.5)
+    - React-Fabric/attributedstring (= 0.81.0-rc.5)
+    - React-Fabric/bridging (= 0.81.0-rc.5)
+    - React-Fabric/componentregistry (= 0.81.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.81.0-rc.5)
+    - React-Fabric/components (= 0.81.0-rc.5)
+    - React-Fabric/consistency (= 0.81.0-rc.5)
+    - React-Fabric/core (= 0.81.0-rc.5)
+    - React-Fabric/dom (= 0.81.0-rc.5)
+    - React-Fabric/imagemanager (= 0.81.0-rc.5)
+    - React-Fabric/leakchecker (= 0.81.0-rc.5)
+    - React-Fabric/mounting (= 0.81.0-rc.5)
+    - React-Fabric/observers (= 0.81.0-rc.5)
+    - React-Fabric/scheduler (= 0.81.0-rc.5)
+    - React-Fabric/telemetry (= 0.81.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.81.0-rc.5)
+    - React-Fabric/uimanager (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1042,32 +1042,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.81.0-rc.3):
+  - React-Fabric/animations (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1092,7 +1067,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.81.0-rc.3):
+  - React-Fabric/attributedstring (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1117,7 +1092,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.81.0-rc.3):
+  - React-Fabric/bridging (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1142,7 +1117,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.81.0-rc.3):
+  - React-Fabric/componentregistry (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1167,36 +1142,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.0-rc.3)
-    - React-Fabric/components/root (= 0.81.0-rc.3)
-    - React-Fabric/components/scrollview (= 0.81.0-rc.3)
-    - React-Fabric/components/view (= 0.81.0-rc.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.0-rc.3):
+  - React-Fabric/componentregistrynative (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1221,7 +1167,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.81.0-rc.3):
+  - React-Fabric/components (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.0-rc.5)
+    - React-Fabric/components/root (= 0.81.0-rc.5)
+    - React-Fabric/components/scrollview (= 0.81.0-rc.5)
+    - React-Fabric/components/view (= 0.81.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1246,7 +1221,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.81.0-rc.3):
+  - React-Fabric/components/root (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1271,7 +1246,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.81.0-rc.3):
+  - React-Fabric/components/scrollview (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1298,7 +1298,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.81.0-rc.3):
+  - React-Fabric/consistency (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1323,7 +1323,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.81.0-rc.3):
+  - React-Fabric/core (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1348,7 +1348,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.81.0-rc.3):
+  - React-Fabric/dom (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1373,7 +1373,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.81.0-rc.3):
+  - React-Fabric/imagemanager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1398,7 +1398,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.81.0-rc.3):
+  - React-Fabric/leakchecker (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1423,7 +1423,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.81.0-rc.3):
+  - React-Fabric/mounting (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1448,7 +1448,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.81.0-rc.3):
+  - React-Fabric/observers (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1462,7 +1462,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.0-rc.3)
+    - React-Fabric/observers/events (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1474,7 +1474,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.81.0-rc.3):
+  - React-Fabric/observers/events (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1499,7 +1499,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.81.0-rc.3):
+  - React-Fabric/scheduler (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1526,7 +1526,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.81.0-rc.3):
+  - React-Fabric/telemetry (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1551,7 +1551,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.81.0-rc.3):
+  - React-Fabric/templateprocessor (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1576,7 +1576,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.81.0-rc.3):
+  - React-Fabric/uimanager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1590,7 +1590,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.0-rc.3)
+    - React-Fabric/uimanager/consistency (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1603,7 +1603,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.81.0-rc.3):
+  - React-Fabric/uimanager/consistency (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1629,7 +1629,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.81.0-rc.3):
+  - React-FabricComponents (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1644,8 +1644,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.0-rc.3)
-    - React-FabricComponents/textlayoutmanager (= 0.81.0-rc.3)
+    - React-FabricComponents/components (= 0.81.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1658,7 +1658,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.81.0-rc.3):
+  - React-FabricComponents/components (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1673,16 +1673,16 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.0-rc.3)
-    - React-FabricComponents/components/iostextinput (= 0.81.0-rc.3)
-    - React-FabricComponents/components/modal (= 0.81.0-rc.3)
-    - React-FabricComponents/components/rncore (= 0.81.0-rc.3)
-    - React-FabricComponents/components/safeareaview (= 0.81.0-rc.3)
-    - React-FabricComponents/components/scrollview (= 0.81.0-rc.3)
-    - React-FabricComponents/components/text (= 0.81.0-rc.3)
-    - React-FabricComponents/components/textinput (= 0.81.0-rc.3)
-    - React-FabricComponents/components/unimplementedview (= 0.81.0-rc.3)
-    - React-FabricComponents/components/virtualview (= 0.81.0-rc.3)
+    - React-FabricComponents/components/inputaccessory (= 0.81.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.81.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.81.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.81.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.81.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.81.0-rc.5)
+    - React-FabricComponents/components/text (= 0.81.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.81.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.81.0-rc.5)
+    - React-FabricComponents/components/virtualview (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1695,34 +1695,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.0-rc.3):
+  - React-FabricComponents/components/inputaccessory (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1749,7 +1722,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.81.0-rc.3):
+  - React-FabricComponents/components/iostextinput (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1776,7 +1749,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.0-rc.3):
+  - React-FabricComponents/components/modal (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1803,7 +1776,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.0-rc.3):
+  - React-FabricComponents/components/rncore (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1830,7 +1803,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.0-rc.3):
+  - React-FabricComponents/components/safeareaview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1857,7 +1830,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.81.0-rc.3):
+  - React-FabricComponents/components/scrollview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1884,7 +1857,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.0-rc.3):
+  - React-FabricComponents/components/text (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1911,7 +1884,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.0-rc.3):
+  - React-FabricComponents/components/textinput (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1938,7 +1911,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.0-rc.3):
+  - React-FabricComponents/components/unimplementedview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1965,7 +1938,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.0-rc.3):
+  - React-FabricComponents/components/virtualview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1992,7 +1965,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.81.0-rc.3):
+  - React-FabricComponents/textlayoutmanager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2001,21 +1974,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.81.0-rc.3)
-    - RCTTypeSafety (= 0.81.0-rc.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.81.0-rc.5)
+    - RCTTypeSafety (= 0.81.0-rc.5)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.0-rc.3)
+    - React-jsiexecutor (= 0.81.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.81.0-rc.3):
+  - React-featureflags (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2024,7 +2024,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.81.0-rc.3):
+  - React-featureflagsnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2039,7 +2039,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.81.0-rc.3):
+  - React-graphics (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2052,7 +2052,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.81.0-rc.3):
+  - React-hermes (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2061,16 +2061,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.81.0-rc.3)
+    - React-jsiexecutor (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.81.0-rc.3):
+  - React-idlecallbacksnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2086,7 +2086,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.81.0-rc.3):
+  - React-ImageManager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2101,7 +2101,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.81.0-rc.3):
+  - React-jserrorhandler (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2116,7 +2116,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.81.0-rc.3):
+  - React-jsi (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2126,7 +2126,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.81.0-rc.3):
+  - React-jsiexecutor (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2135,15 +2135,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.81.0-rc.3):
+  - React-jsinspector (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2157,10 +2157,10 @@ PODS:
     - React-jsinspectorcdp
     - React-jsinspectornetwork
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.81.0-rc.3):
+  - React-jsinspectorcdp (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2169,7 +2169,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.81.0-rc.3):
+  - React-jsinspectornetwork (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2182,7 +2182,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.81.0-rc.3):
+  - React-jsinspectortracing (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2193,7 +2193,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.81.0-rc.3):
+  - React-jsitooling (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2201,16 +2201,16 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.81.0-rc.3):
+  - React-jsitracing (0.81.0-rc.5):
     - React-jsi
-  - React-logger (0.81.0-rc.3):
+  - React-logger (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2219,7 +2219,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.81.0-rc.3):
+  - React-Mapbuffer (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2229,7 +2229,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.81.0-rc.3):
+  - React-microtasksnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2243,7 +2243,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-NativeModulesApple (0.81.0-rc.3):
+  - React-NativeModulesApple (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2263,8 +2263,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.81.0-rc.3)
-  - React-perflogger (0.81.0-rc.3):
+  - React-oscompat (0.81.0-rc.5)
+  - React-perflogger (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2273,7 +2273,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.81.0-rc.3):
+  - React-performancetimeline (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2286,9 +2286,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.81.0-rc.3):
-    - React-Core/RCTActionSheetHeaders (= 0.81.0-rc.3)
-  - React-RCTAnimation (0.81.0-rc.3):
+  - React-RCTActionSheet (0.81.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.81.0-rc.5)
+  - React-RCTAnimation (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2304,7 +2304,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.81.0-rc.3):
+  - React-RCTAppDelegate (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2338,7 +2338,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.81.0-rc.3):
+  - React-RCTBlob (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2357,7 +2357,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.81.0-rc.3):
+  - React-RCTFabric (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2392,7 +2392,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.0-rc.3):
+  - React-RCTFBReactNativeSpec (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2406,10 +2406,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.0-rc.3)
+    - React-RCTFBReactNativeSpec/components (= 0.81.0-rc.5)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.81.0-rc.3):
+  - React-RCTFBReactNativeSpec/components (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2432,7 +2432,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.81.0-rc.3):
+  - React-RCTImage (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2448,14 +2448,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.81.0-rc.3):
-    - React-Core/RCTLinkingHeaders (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+  - React-RCTLinking (0.81.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.0-rc.3)
-  - React-RCTNetwork (0.81.0-rc.3):
+    - ReactCommon/turbomodule/core (= 0.81.0-rc.5)
+  - React-RCTNetwork (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2473,7 +2473,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.81.0-rc.3):
+  - React-RCTRuntime (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2493,7 +2493,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.81.0-rc.3):
+  - React-RCTSettings (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2508,10 +2508,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.81.0-rc.3):
-    - React-Core/RCTTextHeaders (= 0.81.0-rc.3)
+  - React-RCTText (0.81.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.81.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.81.0-rc.3):
+  - React-RCTVibration (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2525,11 +2525,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.81.0-rc.3)
-  - React-renderercss (0.81.0-rc.3):
+  - React-rendererconsistency (0.81.0-rc.5)
+  - React-renderercss (0.81.0-rc.5):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.0-rc.3):
+  - React-rendererdebug (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2539,7 +2539,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.81.0-rc.3):
+  - React-RuntimeApple (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2568,7 +2568,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.81.0-rc.3):
+  - React-RuntimeCore (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2590,7 +2590,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.81.0-rc.3):
+  - React-runtimeexecutor (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2600,10 +2600,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.5)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.81.0-rc.3):
+  - React-RuntimeHermes (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2624,7 +2624,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.81.0-rc.3):
+  - React-runtimescheduler (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2646,8 +2646,8 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.81.0-rc.3)
-  - React-utils (0.81.0-rc.3):
+  - React-timing (0.81.0-rc.5)
+  - React-utils (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2657,11 +2657,11 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactAppDependencyProvider (0.81.0-rc.3):
+  - ReactAppDependencyProvider (0.81.0-rc.5):
     - ReactCodegen
-  - ReactCodegen (0.81.0-rc.3):
+  - ReactCodegen (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2687,7 +2687,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.81.0-rc.3):
+  - ReactCommon (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2695,9 +2695,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.81.0-rc.3)
+    - ReactCommon/turbomodule (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule (0.81.0-rc.3):
+  - ReactCommon/turbomodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2706,15 +2706,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
-    - ReactCommon/turbomodule/bridging (= 0.81.0-rc.3)
-    - ReactCommon/turbomodule/core (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.81.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.81.0-rc.3):
+  - ReactCommon/turbomodule/bridging (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2723,13 +2723,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.81.0-rc.3):
+  - ReactCommon/turbomodule/core (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2738,14 +2738,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-debug (= 0.81.0-rc.3)
-    - React-featureflags (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
-    - React-utils (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-debug (= 0.81.0-rc.5)
+    - React-featureflags (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
+    - React-utils (= 0.81.0-rc.5)
     - SocketRocket
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
@@ -3091,86 +3091,86 @@ SPEC CHECKSUMS:
   EXUpdates: bb5eb316f5d056510304948fcbff908e2b6bb9af
   EXUpdatesInterface: d6c802a2d1d11867523d03a95397957f9ba3d1c7
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: dff72c497c0f6de7c979d9d4f87dbba5663a8c92
+  FBLazyVector: 64579c0203cbc859de4536d54b4c6ed28fd03d42
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: cc20804c5f764b4c785deafa291b6fa77bbf71fd
+  hermes-engine: 8b7ef0f4e8363c2dfd6fd133979dd58f57b95825
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
-  RCTDeprecation: 0747b2210cc36cd9d327a276d046834a2471def5
-  RCTRequired: 69fb68d08216b196c4ac982e3f4481532aeff4ab
-  RCTTypeSafety: 1e74a730ec76b072cd7226c5a29367187492cf89
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
+  RCTDeprecation: 3a51da4c0e2a533c893971c2171d164974bc5214
+  RCTRequired: d26a2245fa986ca16a6c93d91e41beeeb7a8aa3f
+  RCTTypeSafety: e9598921dd4338d6dcb7b4ba0b7b92f84cdcc25e
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  React: 9e56bb37bb46ce3cdbdf20fd64e44ed6e8b37e82
-  React-callinvoker: 6e732fdd9322aa85920b7ab825b3a9a5d2f69ae7
-  React-Core: 99fee9f6aa1db5b405c4d0f12e048b75e8ec1e5c
-  React-CoreModules: e601e4ca8a860315d0a4edfd7840ff743005d21d
-  React-cxxreact: 2b775f50d54ff739587222cd1c5afc48c4d91bb9
-  React-debug: e780ad153ef3d2d6519d419391937a8c6b5308e0
-  React-defaultsnativemodule: 6d8035748ac95566f624b8818c76bd5369fa9600
-  React-domnativemodule: 9123ddf2081a33d981de7bb34ad7bf4eee792a11
-  React-Fabric: 58c335e8d849a993cde73c4711453943efb2b476
-  React-FabricComponents: 4ce82166c7eafccefc7222048af6a5e06d338499
-  React-FabricImage: 1608e3f58c753d795f578405b771ac18dc21cc63
-  React-featureflags: 4bf826207c670de55dde47b90e5a989963d29932
-  React-featureflagsnativemodule: b636a7d6b89780cf68525805b56f18de890c20c6
-  React-graphics: 5cf01a2c88eaa369a7a36757dcdbc596f255d56f
-  React-hermes: ce12df5b12de9541ac7d61469ac91ce39b091050
-  React-idlecallbacksnativemodule: 24993f2a70753d738c7c813e16e2d29a5471d572
-  React-ImageManager: bf5679bf50bdfe266fc9961525309a8f374db727
-  React-jserrorhandler: bfab33ef6f3bac3d48c387463f5a524adc523653
-  React-jsi: d0ea49291374c56c138984fc7838a3bfea82c11e
-  React-jsiexecutor: e5efd533f6d5acbc0a51450202d036f28b9f54aa
-  React-jsinspector: da6bd81bc804df27eaf1500a641ccc88831a7ae9
-  React-jsinspectorcdp: fc6b54d9fa3816e34cb3730cf0c19d029f9edb1c
-  React-jsinspectornetwork: 9ef6a5c765cb8614f23132f1541062976acbddda
-  React-jsinspectortracing: e121526fc088a96a0088112097f5ca13cc06934d
-  React-jsitooling: 1fc3be3ae4309387e89cd55229bff26e1b2c54bb
-  React-jsitracing: db70b9b57926f5a9e366956220d0710be3a19f17
-  React-logger: 96286cc9e6c073194274e4f5330a75d519c89d7a
-  React-Mapbuffer: 04e062c73315f3a40d4032178f9d396c059c9bb7
-  React-microtasksnativemodule: 3509d6a7d32ed14b91300854123965025f749fea
-  React-NativeModulesApple: 009989614b0619613138091469ae3bce6e4641ba
-  React-oscompat: 414b30e47074beddcae34ee27e12a679a4977f24
-  React-perflogger: 3b129928b67f9acfda95ede5a804b6b2401a3c00
-  React-performancetimeline: 53dea15bdb110b6a3233624088bc929661cec00b
-  React-RCTActionSheet: 3f0f8e164b87bd9882473de51858b89195671fe9
-  React-RCTAnimation: 44f4cfd42d0517b3e034bd4d68f37839eda95443
-  React-RCTAppDelegate: fd8321b41a0a1c24576ee096bdc03c54c7c34a1b
-  React-RCTBlob: 4926f838dda83d487ce3c923458ec7653161cdb3
-  React-RCTFabric: 8a0babd88206697aa0c24c1473987bd35edd2635
-  React-RCTFBReactNativeSpec: 5410c3b5fa7104ff0ab89c0af0b95c2261d69929
-  React-RCTImage: 1406393b9ad0e1a43a83126f819c836d9fd59056
-  React-RCTLinking: 5b34b419c9100be60d0af0bd5c136ed5c0e7d595
-  React-RCTNetwork: 5ff03669c88df8ec5658c9f4aefdbf2e57dbe67e
-  React-RCTRuntime: 478d50836f71058f1cecfd6aaacbeaa58f1e57dc
-  React-RCTSettings: f8b48c1600bf102b8c58fa330ace2138f9bc5a91
-  React-RCTText: 8529ba937639c0cc9898cae342992212fbbc3078
-  React-RCTVibration: 41fe096a7bbb9d3a85e9c19202a98dc95d2b4f95
-  React-rendererconsistency: 15fecabe65cd94bef28ac54d3d51746d345b1114
-  React-renderercss: 621275a9485b16fca4b435563e2a151155de0222
-  React-rendererdebug: 6771edc3c93d02d27f00dc998a19ee732d905523
-  React-RuntimeApple: 5387b9985af7842483ace93ffba3c83c68155dd0
-  React-RuntimeCore: bc67ebe24b0a282c2fd429bce3e9d741d6a5eb5e
-  React-runtimeexecutor: d553435a78433984d63e77d0f9f9e77dd4730ede
-  React-RuntimeHermes: e5b4069531c780a264fbfa3bfd46e6965f034753
-  React-runtimescheduler: c9ddd5b81dc1e58e300941d4e454053189d3531c
-  React-timing: e48ea4ff6e85c2535584362bf1e06f1dd72818e1
-  React-utils: 0a7fc86dbb19cf3a875bfed5ed5bc1f79e229ec3
-  ReactAppDependencyProvider: 0d7a405e9cdb2450aef75f8e3ff6fe9d079d2d27
-  ReactCodegen: ccd5d8b815099fd2fe3d088431a361cb49b7f787
-  ReactCommon: 012d9b70f277c80620e562bc7d94fc3893b2afb4
+  React: 713c6b114dfaddd4e58bc0e3804334f2a170b754
+  React-callinvoker: 4441303f80922bcab09bd3e401738c1a7f3ffe11
+  React-Core: 48eb931b5319893300e3766c6cc38481fa647dfa
+  React-CoreModules: 16160d86eee8183e615fc12e01a7b7d4037d0f11
+  React-cxxreact: 61e4deced1e2e89409d723baaf367da6d8eaf916
+  React-debug: 77c881c70aef8f5787761005eeb57e437a7d0a5b
+  React-defaultsnativemodule: 72ed284e13ab42903f492568e3db78dd708b06de
+  React-domnativemodule: b57bdf705c8f26762d70ddae2f917b6593622d7a
+  React-Fabric: 04dacebd7f35c74d648cadf8fda8c4dd105e1d56
+  React-FabricComponents: 0740d9d86edca91bbd3ab881ab9d139ccaff3513
+  React-FabricImage: 9d544dfe265a8cffaa7ef95023e3eb14eab7058a
+  React-featureflags: c33312b0812afb235add6add17e91b6f3a92222c
+  React-featureflagsnativemodule: 1db86f04957efcaecaec3957cc8d0de86ea573ab
+  React-graphics: f070009719fcac1854a3c4b3897b23e67b956ce2
+  React-hermes: b0d0cf1afcc6a5ea966d7841abbc89d0ec01526d
+  React-idlecallbacksnativemodule: 38c37267785b9d601dab87653edf2cf0c346bcc7
+  React-ImageManager: 578228cd0fbcef002207bf8acf0a42c712098906
+  React-jserrorhandler: 4da8855c5652652776eae535702b258fdc7e2693
+  React-jsi: 32ecda8451aac1f6a649e05dc94a0948ce2bb7d7
+  React-jsiexecutor: f4f3b47f4c1c076363ab8b65042a9a6177ef96b5
+  React-jsinspector: 24c8d6057c0ff37eccc72c855f198c6157893c78
+  React-jsinspectorcdp: 9a364f9cd548fc389ac91af4e5c38eae58f6548f
+  React-jsinspectornetwork: d7f3b19d53fe328dc139035ab0bba19aa68f2439
+  React-jsinspectortracing: 414014b64e0362eec726f3416cc9a02b9a8e9a16
+  React-jsitooling: 96c159a6a7cd6f29f208359554eec887b6fb27b9
+  React-jsitracing: 3c3d20d2dc74fc895411af104f9a9d103dc23794
+  React-logger: 3903016c02ae4dff7387d028501a3b03ba72879d
+  React-Mapbuffer: 48d6d8d0361ab4be5a7b4825006ddfff5e3686ec
+  React-microtasksnativemodule: bd7cfbd456840ebd272edad86b0e09595f2c80d5
+  React-NativeModulesApple: b7c71399d5a301dab362289d68747ff8c9b84c19
+  React-oscompat: e324ee1ba89eb09d59c8e346748c758cb87a2ce3
+  React-perflogger: 1a98c4a181ab1cf9e8cf955dae867abfac59a50d
+  React-performancetimeline: 1a508e57eb32cc6951ecc95ac795afe13f3c1499
+  React-RCTActionSheet: e995bcd8831351318c94bfa3e585178dc15934c8
+  React-RCTAnimation: eda5da34ef170a419bff522a58db9d5fb109acec
+  React-RCTAppDelegate: 26ebc3917638dde2ca20facec826e45a96f16d6c
+  React-RCTBlob: 8e905a0df8271c7405e5542f4ddc5f11bf7b3ef4
+  React-RCTFabric: 5c4a2e726a25dd007bffd3aa8ded58d8d58bad67
+  React-RCTFBReactNativeSpec: 125ec865d3b95360142f343075d0326c1f2188fd
+  React-RCTImage: fe502bd39bb9bb5b9cfa635e141bf3d602091b2f
+  React-RCTLinking: 2d9dad05c5ebddc5902a2c2c0177f72e8f6b93bd
+  React-RCTNetwork: 81ac1907ff907c3e0669c8702a1aae2a8356cf8d
+  React-RCTRuntime: b156f2c4f38023a065723d70dd3eb9468a523cc9
+  React-RCTSettings: 0887e903b7f06463ec5887df385ade35705c5151
+  React-RCTText: 4644d6c9bc18c05ea4d373c8434ad9dc2392e642
+  React-RCTVibration: f381c601f931888740383dc14f4baeebac945e94
+  React-rendererconsistency: fde6f437f72fb837be955c7d287c5f1a1fe47212
+  React-renderercss: 8ad27c2b7c138f27518702af50c4bacc85d67fc9
+  React-rendererdebug: 34b2305ff2a349e540b39354277ce2c457da8ec9
+  React-RuntimeApple: 347f9558b516c79bd0cfa2a237371843d0a22c25
+  React-RuntimeCore: d4e1654e01a1a6df3ede773b2ddbac83f39725a9
+  React-runtimeexecutor: 93e8ab92174058160232cd9283d354463255020d
+  React-RuntimeHermes: 2f477bc8fc39fff2d1e3a966a3d908bbde6c3fd5
+  React-runtimescheduler: 7d15929025e58a47cd73758c6c4f46d293d3dca5
+  React-timing: c6ce3a683af45aecee166b49348cd094170a7e36
+  React-utils: 3b356bfa4a83cd7e019b96b1de73e8340cef2bf9
+  ReactAppDependencyProvider: ad094d490c0b69fcd292806df86e007728d02f95
+  ReactCodegen: ed848e68148a12de49d2e6dadeff6cf89999962d
+  ReactCommon: 3c95b5086d10c5da3d6d0fc920fc1ce6c984a496
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 15c07d37869e68f295849c2af164cea21957f345
+  Yoga: 72ab8318e9f1910fbdd236b045eb5455c8415d92
 
 PODFILE CHECKSUM: 8ddd2ccfffc69dcd923b5d018edcbb077e9960a2
 

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -18,7 +18,7 @@
     "native-component-list": "*",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.0-rc.3"
+    "react-native": "0.81.0-rc.5"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -30,7 +30,7 @@
     "native-component-list": "*",
     "react-native-gesture-handler": "~2.26.0",
     "react": "19.1.0",
-    "react-native": "0.81.0-rc.3",
+    "react-native": "0.81.0-rc.5",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "4.14.0-nightly-20250803-1df3db25a"
   },

--- a/apps/paper-tester/ios/Podfile.lock
+++ b/apps/paper-tester/ios/Podfile.lock
@@ -342,12 +342,12 @@ PODS:
   - EXUpdatesInterface (1.1.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.81.0-rc.3)
+  - FBLazyVector (0.81.0-rc.5)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.81.0-rc.3):
-    - hermes-engine/Pre-built (= 0.81.0-rc.3)
-  - hermes-engine/Pre-built (0.81.0-rc.3)
+  - hermes-engine (0.81.0-rc.5):
+    - hermes-engine/Pre-built (= 0.81.0-rc.5)
+  - hermes-engine/Pre-built (0.81.0-rc.5)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -384,28 +384,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.81.0-rc.3)
-  - RCTRequired (0.81.0-rc.3)
-  - RCTTypeSafety (0.81.0-rc.3):
-    - FBLazyVector (= 0.81.0-rc.3)
-    - RCTRequired (= 0.81.0-rc.3)
-    - React-Core (= 0.81.0-rc.3)
+  - RCTDeprecation (0.81.0-rc.5)
+  - RCTRequired (0.81.0-rc.5)
+  - RCTTypeSafety (0.81.0-rc.5):
+    - FBLazyVector (= 0.81.0-rc.5)
+    - RCTRequired (= 0.81.0-rc.5)
+    - React-Core (= 0.81.0-rc.5)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.0-rc.3):
-    - React-Core (= 0.81.0-rc.3)
-    - React-Core/DevSupport (= 0.81.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.81.0-rc.3)
-    - React-RCTActionSheet (= 0.81.0-rc.3)
-    - React-RCTAnimation (= 0.81.0-rc.3)
-    - React-RCTBlob (= 0.81.0-rc.3)
-    - React-RCTImage (= 0.81.0-rc.3)
-    - React-RCTLinking (= 0.81.0-rc.3)
-    - React-RCTNetwork (= 0.81.0-rc.3)
-    - React-RCTSettings (= 0.81.0-rc.3)
-    - React-RCTText (= 0.81.0-rc.3)
-    - React-RCTVibration (= 0.81.0-rc.3)
-  - React-callinvoker (0.81.0-rc.3)
-  - React-Core (0.81.0-rc.3):
+  - React (0.81.0-rc.5):
+    - React-Core (= 0.81.0-rc.5)
+    - React-Core/DevSupport (= 0.81.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.81.0-rc.5)
+    - React-RCTActionSheet (= 0.81.0-rc.5)
+    - React-RCTAnimation (= 0.81.0-rc.5)
+    - React-RCTBlob (= 0.81.0-rc.5)
+    - React-RCTImage (= 0.81.0-rc.5)
+    - React-RCTLinking (= 0.81.0-rc.5)
+    - React-RCTNetwork (= 0.81.0-rc.5)
+    - React-RCTSettings (= 0.81.0-rc.5)
+    - React-RCTText (= 0.81.0-rc.5)
+    - React-RCTVibration (= 0.81.0-rc.5)
+  - React-callinvoker (0.81.0-rc.5)
+  - React-Core (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -415,7 +415,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.3)
+    - React-Core/Default (= 0.81.0-rc.5)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -430,82 +430,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.81.0-rc.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.0-rc.3):
+  - React-Core/CoreModulesHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -530,7 +455,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.0-rc.3):
+  - React-Core/Default (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.0-rc.5)
+    - React-Core/RCTWebSocket (= 0.81.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -555,7 +530,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.0-rc.3):
+  - React-Core/RCTAnimationHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -580,7 +555,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.0-rc.3):
+  - React-Core/RCTBlobHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -605,7 +580,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.0-rc.3):
+  - React-Core/RCTImageHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -630,7 +605,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.0-rc.3):
+  - React-Core/RCTLinkingHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -655,7 +630,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.0-rc.3):
+  - React-Core/RCTNetworkHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -680,7 +655,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.0-rc.3):
+  - React-Core/RCTSettingsHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -705,7 +680,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.0-rc.3):
+  - React-Core/RCTTextHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -730,7 +705,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.81.0-rc.3):
+  - React-Core/RCTVibrationHeaders (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -740,7 +715,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -755,7 +730,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.81.0-rc.3):
+  - React-Core/RCTWebSocket (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.0-rc.5)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -763,20 +763,20 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.81.0-rc.3)
-    - React-Core/CoreModulesHeaders (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - RCTTypeSafety (= 0.81.0-rc.5)
+    - React-Core/CoreModulesHeaders (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.0-rc.3)
+    - React-RCTImage (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.81.0-rc.3):
+  - React-cxxreact (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -785,19 +785,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-debug (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-debug (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
-    - React-timing (= 0.81.0-rc.3)
+    - React-timing (= 0.81.0-rc.5)
     - SocketRocket
-  - React-debug (0.81.0-rc.3)
-  - React-defaultsnativemodule (0.81.0-rc.3):
+  - React-debug (0.81.0-rc.5)
+  - React-defaultsnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -814,7 +814,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.81.0-rc.3):
+  - React-domnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -834,7 +834,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.81.0-rc.3):
+  - React-Fabric (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -848,23 +848,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.0-rc.3)
-    - React-Fabric/attributedstring (= 0.81.0-rc.3)
-    - React-Fabric/bridging (= 0.81.0-rc.3)
-    - React-Fabric/componentregistry (= 0.81.0-rc.3)
-    - React-Fabric/componentregistrynative (= 0.81.0-rc.3)
-    - React-Fabric/components (= 0.81.0-rc.3)
-    - React-Fabric/consistency (= 0.81.0-rc.3)
-    - React-Fabric/core (= 0.81.0-rc.3)
-    - React-Fabric/dom (= 0.81.0-rc.3)
-    - React-Fabric/imagemanager (= 0.81.0-rc.3)
-    - React-Fabric/leakchecker (= 0.81.0-rc.3)
-    - React-Fabric/mounting (= 0.81.0-rc.3)
-    - React-Fabric/observers (= 0.81.0-rc.3)
-    - React-Fabric/scheduler (= 0.81.0-rc.3)
-    - React-Fabric/telemetry (= 0.81.0-rc.3)
-    - React-Fabric/templateprocessor (= 0.81.0-rc.3)
-    - React-Fabric/uimanager (= 0.81.0-rc.3)
+    - React-Fabric/animations (= 0.81.0-rc.5)
+    - React-Fabric/attributedstring (= 0.81.0-rc.5)
+    - React-Fabric/bridging (= 0.81.0-rc.5)
+    - React-Fabric/componentregistry (= 0.81.0-rc.5)
+    - React-Fabric/componentregistrynative (= 0.81.0-rc.5)
+    - React-Fabric/components (= 0.81.0-rc.5)
+    - React-Fabric/consistency (= 0.81.0-rc.5)
+    - React-Fabric/core (= 0.81.0-rc.5)
+    - React-Fabric/dom (= 0.81.0-rc.5)
+    - React-Fabric/imagemanager (= 0.81.0-rc.5)
+    - React-Fabric/leakchecker (= 0.81.0-rc.5)
+    - React-Fabric/mounting (= 0.81.0-rc.5)
+    - React-Fabric/observers (= 0.81.0-rc.5)
+    - React-Fabric/scheduler (= 0.81.0-rc.5)
+    - React-Fabric/telemetry (= 0.81.0-rc.5)
+    - React-Fabric/templateprocessor (= 0.81.0-rc.5)
+    - React-Fabric/uimanager (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -876,32 +876,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.81.0-rc.3):
+  - React-Fabric/animations (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -926,7 +901,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.81.0-rc.3):
+  - React-Fabric/attributedstring (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -951,7 +926,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.81.0-rc.3):
+  - React-Fabric/bridging (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -976,7 +951,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.81.0-rc.3):
+  - React-Fabric/componentregistry (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1001,36 +976,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.0-rc.3)
-    - React-Fabric/components/root (= 0.81.0-rc.3)
-    - React-Fabric/components/scrollview (= 0.81.0-rc.3)
-    - React-Fabric/components/view (= 0.81.0-rc.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.0-rc.3):
+  - React-Fabric/componentregistrynative (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1055,7 +1001,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.81.0-rc.3):
+  - React-Fabric/components (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.0-rc.5)
+    - React-Fabric/components/root (= 0.81.0-rc.5)
+    - React-Fabric/components/scrollview (= 0.81.0-rc.5)
+    - React-Fabric/components/view (= 0.81.0-rc.5)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1080,7 +1055,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.81.0-rc.3):
+  - React-Fabric/components/root (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1105,7 +1080,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.81.0-rc.3):
+  - React-Fabric/components/scrollview (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1132,7 +1132,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.81.0-rc.3):
+  - React-Fabric/consistency (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1157,7 +1157,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.81.0-rc.3):
+  - React-Fabric/core (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1182,7 +1182,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.81.0-rc.3):
+  - React-Fabric/dom (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1207,7 +1207,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.81.0-rc.3):
+  - React-Fabric/imagemanager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1232,7 +1232,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.81.0-rc.3):
+  - React-Fabric/leakchecker (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1257,7 +1257,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.81.0-rc.3):
+  - React-Fabric/mounting (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1282,7 +1282,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.81.0-rc.3):
+  - React-Fabric/observers (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1296,7 +1296,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.0-rc.3)
+    - React-Fabric/observers/events (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1308,7 +1308,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.81.0-rc.3):
+  - React-Fabric/observers/events (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1333,7 +1333,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.81.0-rc.3):
+  - React-Fabric/scheduler (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1360,7 +1360,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.81.0-rc.3):
+  - React-Fabric/telemetry (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1385,7 +1385,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.81.0-rc.3):
+  - React-Fabric/templateprocessor (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1410,7 +1410,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.81.0-rc.3):
+  - React-Fabric/uimanager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1424,7 +1424,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.0-rc.3)
+    - React-Fabric/uimanager/consistency (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1437,7 +1437,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.81.0-rc.3):
+  - React-Fabric/uimanager/consistency (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1463,7 +1463,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.81.0-rc.3):
+  - React-FabricComponents (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1478,8 +1478,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.0-rc.3)
-    - React-FabricComponents/textlayoutmanager (= 0.81.0-rc.3)
+    - React-FabricComponents/components (= 0.81.0-rc.5)
+    - React-FabricComponents/textlayoutmanager (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1492,7 +1492,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.81.0-rc.3):
+  - React-FabricComponents/components (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1507,16 +1507,16 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.0-rc.3)
-    - React-FabricComponents/components/iostextinput (= 0.81.0-rc.3)
-    - React-FabricComponents/components/modal (= 0.81.0-rc.3)
-    - React-FabricComponents/components/rncore (= 0.81.0-rc.3)
-    - React-FabricComponents/components/safeareaview (= 0.81.0-rc.3)
-    - React-FabricComponents/components/scrollview (= 0.81.0-rc.3)
-    - React-FabricComponents/components/text (= 0.81.0-rc.3)
-    - React-FabricComponents/components/textinput (= 0.81.0-rc.3)
-    - React-FabricComponents/components/unimplementedview (= 0.81.0-rc.3)
-    - React-FabricComponents/components/virtualview (= 0.81.0-rc.3)
+    - React-FabricComponents/components/inputaccessory (= 0.81.0-rc.5)
+    - React-FabricComponents/components/iostextinput (= 0.81.0-rc.5)
+    - React-FabricComponents/components/modal (= 0.81.0-rc.5)
+    - React-FabricComponents/components/rncore (= 0.81.0-rc.5)
+    - React-FabricComponents/components/safeareaview (= 0.81.0-rc.5)
+    - React-FabricComponents/components/scrollview (= 0.81.0-rc.5)
+    - React-FabricComponents/components/text (= 0.81.0-rc.5)
+    - React-FabricComponents/components/textinput (= 0.81.0-rc.5)
+    - React-FabricComponents/components/unimplementedview (= 0.81.0-rc.5)
+    - React-FabricComponents/components/virtualview (= 0.81.0-rc.5)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1529,34 +1529,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.0-rc.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.0-rc.3):
+  - React-FabricComponents/components/inputaccessory (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1583,7 +1556,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.81.0-rc.3):
+  - React-FabricComponents/components/iostextinput (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1610,7 +1583,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.0-rc.3):
+  - React-FabricComponents/components/modal (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1637,7 +1610,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.0-rc.3):
+  - React-FabricComponents/components/rncore (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1664,7 +1637,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.0-rc.3):
+  - React-FabricComponents/components/safeareaview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1691,7 +1664,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.81.0-rc.3):
+  - React-FabricComponents/components/scrollview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1718,7 +1691,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.0-rc.3):
+  - React-FabricComponents/components/text (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1745,7 +1718,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.0-rc.3):
+  - React-FabricComponents/components/textinput (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1772,7 +1745,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.0-rc.3):
+  - React-FabricComponents/components/unimplementedview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1799,7 +1772,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.0-rc.3):
+  - React-FabricComponents/components/virtualview (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1826,7 +1799,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.81.0-rc.3):
+  - React-FabricComponents/textlayoutmanager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1835,21 +1808,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.81.0-rc.3)
-    - RCTTypeSafety (= 0.81.0-rc.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.81.0-rc.5):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.81.0-rc.5)
+    - RCTTypeSafety (= 0.81.0-rc.5)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.0-rc.3)
+    - React-jsiexecutor (= 0.81.0-rc.5)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.81.0-rc.3):
+  - React-featureflags (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1858,7 +1858,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.81.0-rc.3):
+  - React-featureflagsnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1873,7 +1873,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.81.0-rc.3):
+  - React-graphics (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1886,7 +1886,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.81.0-rc.3):
+  - React-hermes (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1895,16 +1895,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.5)
     - React-jsi
-    - React-jsiexecutor (= 0.81.0-rc.3)
+    - React-jsiexecutor (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.81.0-rc.3):
+  - React-idlecallbacksnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1920,7 +1920,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.81.0-rc.3):
+  - React-ImageManager (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1935,7 +1935,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.81.0-rc.3):
+  - React-jserrorhandler (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1950,7 +1950,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.81.0-rc.3):
+  - React-jsi (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1960,7 +1960,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.81.0-rc.3):
+  - React-jsiexecutor (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1969,15 +1969,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.81.0-rc.3):
+  - React-jsinspector (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1991,10 +1991,10 @@ PODS:
     - React-jsinspectorcdp
     - React-jsinspectornetwork
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.5)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.81.0-rc.3):
+  - React-jsinspectorcdp (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2003,7 +2003,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.81.0-rc.3):
+  - React-jsinspectornetwork (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2016,7 +2016,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.81.0-rc.3):
+  - React-jsinspectortracing (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2027,7 +2027,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.81.0-rc.3):
+  - React-jsitooling (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2035,16 +2035,16 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.81.0-rc.3):
+  - React-jsitracing (0.81.0-rc.5):
     - React-jsi
-  - React-logger (0.81.0-rc.3):
+  - React-logger (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2053,7 +2053,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.81.0-rc.3):
+  - React-Mapbuffer (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2063,7 +2063,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.81.0-rc.3):
+  - React-microtasksnativemodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2077,7 +2077,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-NativeModulesApple (0.81.0-rc.3):
+  - React-NativeModulesApple (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2097,8 +2097,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.81.0-rc.3)
-  - React-perflogger (0.81.0-rc.3):
+  - React-oscompat (0.81.0-rc.5)
+  - React-perflogger (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2107,7 +2107,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.81.0-rc.3):
+  - React-performancetimeline (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2120,9 +2120,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.81.0-rc.3):
-    - React-Core/RCTActionSheetHeaders (= 0.81.0-rc.3)
-  - React-RCTAnimation (0.81.0-rc.3):
+  - React-RCTActionSheet (0.81.0-rc.5):
+    - React-Core/RCTActionSheetHeaders (= 0.81.0-rc.5)
+  - React-RCTAnimation (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2138,7 +2138,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.81.0-rc.3):
+  - React-RCTAppDelegate (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2172,7 +2172,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.81.0-rc.3):
+  - React-RCTBlob (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2191,7 +2191,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.81.0-rc.3):
+  - React-RCTFabric (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2226,7 +2226,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.0-rc.3):
+  - React-RCTFBReactNativeSpec (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2240,10 +2240,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.0-rc.3)
+    - React-RCTFBReactNativeSpec/components (= 0.81.0-rc.5)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.81.0-rc.3):
+  - React-RCTFBReactNativeSpec/components (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2266,7 +2266,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.81.0-rc.3):
+  - React-RCTImage (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2282,14 +2282,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.81.0-rc.3):
-    - React-Core/RCTLinkingHeaders (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
+  - React-RCTLinking (0.81.0-rc.5):
+    - React-Core/RCTLinkingHeaders (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.0-rc.3)
-  - React-RCTNetwork (0.81.0-rc.3):
+    - ReactCommon/turbomodule/core (= 0.81.0-rc.5)
+  - React-RCTNetwork (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2307,7 +2307,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.81.0-rc.3):
+  - React-RCTRuntime (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2327,7 +2327,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.81.0-rc.3):
+  - React-RCTSettings (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2342,10 +2342,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.81.0-rc.3):
-    - React-Core/RCTTextHeaders (= 0.81.0-rc.3)
+  - React-RCTText (0.81.0-rc.5):
+    - React-Core/RCTTextHeaders (= 0.81.0-rc.5)
     - Yoga
-  - React-RCTVibration (0.81.0-rc.3):
+  - React-RCTVibration (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2359,11 +2359,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.81.0-rc.3)
-  - React-renderercss (0.81.0-rc.3):
+  - React-rendererconsistency (0.81.0-rc.5)
+  - React-renderercss (0.81.0-rc.5):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.0-rc.3):
+  - React-rendererdebug (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2373,7 +2373,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.81.0-rc.3):
+  - React-RuntimeApple (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2402,7 +2402,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.81.0-rc.3):
+  - React-RuntimeCore (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2424,7 +2424,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.81.0-rc.3):
+  - React-runtimeexecutor (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2434,10 +2434,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.5)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.81.0-rc.3):
+  - React-RuntimeHermes (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2458,7 +2458,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.81.0-rc.3):
+  - React-runtimescheduler (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2480,8 +2480,8 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.81.0-rc.3)
-  - React-utils (0.81.0-rc.3):
+  - React-timing (0.81.0-rc.5)
+  - React-utils (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2491,11 +2491,11 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactAppDependencyProvider (0.81.0-rc.3):
+  - ReactAppDependencyProvider (0.81.0-rc.5):
     - ReactCodegen
-  - ReactCodegen (0.81.0-rc.3):
+  - ReactCodegen (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2521,7 +2521,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.81.0-rc.3):
+  - ReactCommon (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2529,9 +2529,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.81.0-rc.3)
+    - ReactCommon/turbomodule (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule (0.81.0-rc.3):
+  - ReactCommon/turbomodule (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2540,15 +2540,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
-    - ReactCommon/turbomodule/bridging (= 0.81.0-rc.3)
-    - ReactCommon/turbomodule/core (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
+    - ReactCommon/turbomodule/bridging (= 0.81.0-rc.5)
+    - ReactCommon/turbomodule/core (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.81.0-rc.3):
+  - ReactCommon/turbomodule/bridging (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2557,13 +2557,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.81.0-rc.3):
+  - ReactCommon/turbomodule/core (0.81.0-rc.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -2572,14 +2572,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.3)
-    - React-cxxreact (= 0.81.0-rc.3)
-    - React-debug (= 0.81.0-rc.3)
-    - React-featureflags (= 0.81.0-rc.3)
-    - React-jsi (= 0.81.0-rc.3)
-    - React-logger (= 0.81.0-rc.3)
-    - React-perflogger (= 0.81.0-rc.3)
-    - React-utils (= 0.81.0-rc.3)
+    - React-callinvoker (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.5)
+    - React-debug (= 0.81.0-rc.5)
+    - React-featureflags (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.5)
+    - React-logger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.5)
+    - React-utils (= 0.81.0-rc.5)
     - SocketRocket
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
@@ -2933,83 +2933,83 @@ SPEC CHECKSUMS:
   EXUpdates: 6d4ff88b5bb2aede1e544a9332116850f4f94211
   EXUpdatesInterface: d6c802a2d1d11867523d03a95397957f9ba3d1c7
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: dff72c497c0f6de7c979d9d4f87dbba5663a8c92
+  FBLazyVector: 64579c0203cbc859de4536d54b4c6ed28fd03d42
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: cc20804c5f764b4c785deafa291b6fa77bbf71fd
+  hermes-engine: 8b7ef0f4e8363c2dfd6fd133979dd58f57b95825
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: 0747b2210cc36cd9d327a276d046834a2471def5
-  RCTRequired: 69fb68d08216b196c4ac982e3f4481532aeff4ab
-  RCTTypeSafety: 1e74a730ec76b072cd7226c5a29367187492cf89
+  RCTDeprecation: 3a51da4c0e2a533c893971c2171d164974bc5214
+  RCTRequired: d26a2245fa986ca16a6c93d91e41beeeb7a8aa3f
+  RCTTypeSafety: e9598921dd4338d6dcb7b4ba0b7b92f84cdcc25e
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 9e56bb37bb46ce3cdbdf20fd64e44ed6e8b37e82
-  React-callinvoker: 6e732fdd9322aa85920b7ab825b3a9a5d2f69ae7
-  React-Core: 99fee9f6aa1db5b405c4d0f12e048b75e8ec1e5c
-  React-CoreModules: e601e4ca8a860315d0a4edfd7840ff743005d21d
-  React-cxxreact: 2b775f50d54ff739587222cd1c5afc48c4d91bb9
-  React-debug: e780ad153ef3d2d6519d419391937a8c6b5308e0
-  React-defaultsnativemodule: 6d8035748ac95566f624b8818c76bd5369fa9600
-  React-domnativemodule: 9123ddf2081a33d981de7bb34ad7bf4eee792a11
-  React-Fabric: 58c335e8d849a993cde73c4711453943efb2b476
-  React-FabricComponents: 4ce82166c7eafccefc7222048af6a5e06d338499
-  React-FabricImage: 1608e3f58c753d795f578405b771ac18dc21cc63
-  React-featureflags: 4bf826207c670de55dde47b90e5a989963d29932
-  React-featureflagsnativemodule: b636a7d6b89780cf68525805b56f18de890c20c6
-  React-graphics: 5cf01a2c88eaa369a7a36757dcdbc596f255d56f
-  React-hermes: ce12df5b12de9541ac7d61469ac91ce39b091050
-  React-idlecallbacksnativemodule: 24993f2a70753d738c7c813e16e2d29a5471d572
-  React-ImageManager: bf5679bf50bdfe266fc9961525309a8f374db727
-  React-jserrorhandler: bfab33ef6f3bac3d48c387463f5a524adc523653
-  React-jsi: d0ea49291374c56c138984fc7838a3bfea82c11e
-  React-jsiexecutor: e5efd533f6d5acbc0a51450202d036f28b9f54aa
-  React-jsinspector: da6bd81bc804df27eaf1500a641ccc88831a7ae9
-  React-jsinspectorcdp: fc6b54d9fa3816e34cb3730cf0c19d029f9edb1c
-  React-jsinspectornetwork: 9ef6a5c765cb8614f23132f1541062976acbddda
-  React-jsinspectortracing: e121526fc088a96a0088112097f5ca13cc06934d
-  React-jsitooling: 1fc3be3ae4309387e89cd55229bff26e1b2c54bb
-  React-jsitracing: db70b9b57926f5a9e366956220d0710be3a19f17
-  React-logger: 96286cc9e6c073194274e4f5330a75d519c89d7a
-  React-Mapbuffer: 04e062c73315f3a40d4032178f9d396c059c9bb7
-  React-microtasksnativemodule: 3509d6a7d32ed14b91300854123965025f749fea
-  React-NativeModulesApple: 009989614b0619613138091469ae3bce6e4641ba
-  React-oscompat: 414b30e47074beddcae34ee27e12a679a4977f24
-  React-perflogger: 3b129928b67f9acfda95ede5a804b6b2401a3c00
-  React-performancetimeline: 53dea15bdb110b6a3233624088bc929661cec00b
-  React-RCTActionSheet: 3f0f8e164b87bd9882473de51858b89195671fe9
-  React-RCTAnimation: 44f4cfd42d0517b3e034bd4d68f37839eda95443
-  React-RCTAppDelegate: dc9ad62ef1311507e92bbc44ca7c990bf80ecaf4
-  React-RCTBlob: 4926f838dda83d487ce3c923458ec7653161cdb3
-  React-RCTFabric: 3535441347a46f5c39c7d8fd8ba4e9a717880772
-  React-RCTFBReactNativeSpec: ba4c4ffe86d8588aae23c991a6c5c0bce780e42f
-  React-RCTImage: 1406393b9ad0e1a43a83126f819c836d9fd59056
-  React-RCTLinking: 5b34b419c9100be60d0af0bd5c136ed5c0e7d595
-  React-RCTNetwork: 5ff03669c88df8ec5658c9f4aefdbf2e57dbe67e
-  React-RCTRuntime: 9f5ffa8d5b08b7fdf2308fb2f0c4bd1057da5151
-  React-RCTSettings: f8b48c1600bf102b8c58fa330ace2138f9bc5a91
-  React-RCTText: 8529ba937639c0cc9898cae342992212fbbc3078
-  React-RCTVibration: 41fe096a7bbb9d3a85e9c19202a98dc95d2b4f95
-  React-rendererconsistency: 15fecabe65cd94bef28ac54d3d51746d345b1114
-  React-renderercss: 621275a9485b16fca4b435563e2a151155de0222
-  React-rendererdebug: 6771edc3c93d02d27f00dc998a19ee732d905523
-  React-RuntimeApple: 5387b9985af7842483ace93ffba3c83c68155dd0
-  React-RuntimeCore: bc67ebe24b0a282c2fd429bce3e9d741d6a5eb5e
-  React-runtimeexecutor: d553435a78433984d63e77d0f9f9e77dd4730ede
-  React-RuntimeHermes: e5b4069531c780a264fbfa3bfd46e6965f034753
-  React-runtimescheduler: c9ddd5b81dc1e58e300941d4e454053189d3531c
-  React-timing: e48ea4ff6e85c2535584362bf1e06f1dd72818e1
-  React-utils: 0a7fc86dbb19cf3a875bfed5ed5bc1f79e229ec3
-  ReactAppDependencyProvider: 0d7a405e9cdb2450aef75f8e3ff6fe9d079d2d27
-  ReactCodegen: ccd5d8b815099fd2fe3d088431a361cb49b7f787
-  ReactCommon: 012d9b70f277c80620e562bc7d94fc3893b2afb4
+  React: 713c6b114dfaddd4e58bc0e3804334f2a170b754
+  React-callinvoker: 4441303f80922bcab09bd3e401738c1a7f3ffe11
+  React-Core: 48eb931b5319893300e3766c6cc38481fa647dfa
+  React-CoreModules: 16160d86eee8183e615fc12e01a7b7d4037d0f11
+  React-cxxreact: 61e4deced1e2e89409d723baaf367da6d8eaf916
+  React-debug: 77c881c70aef8f5787761005eeb57e437a7d0a5b
+  React-defaultsnativemodule: 72ed284e13ab42903f492568e3db78dd708b06de
+  React-domnativemodule: b57bdf705c8f26762d70ddae2f917b6593622d7a
+  React-Fabric: 04dacebd7f35c74d648cadf8fda8c4dd105e1d56
+  React-FabricComponents: 0740d9d86edca91bbd3ab881ab9d139ccaff3513
+  React-FabricImage: 9d544dfe265a8cffaa7ef95023e3eb14eab7058a
+  React-featureflags: c33312b0812afb235add6add17e91b6f3a92222c
+  React-featureflagsnativemodule: 1db86f04957efcaecaec3957cc8d0de86ea573ab
+  React-graphics: f070009719fcac1854a3c4b3897b23e67b956ce2
+  React-hermes: b0d0cf1afcc6a5ea966d7841abbc89d0ec01526d
+  React-idlecallbacksnativemodule: 38c37267785b9d601dab87653edf2cf0c346bcc7
+  React-ImageManager: 578228cd0fbcef002207bf8acf0a42c712098906
+  React-jserrorhandler: 4da8855c5652652776eae535702b258fdc7e2693
+  React-jsi: 32ecda8451aac1f6a649e05dc94a0948ce2bb7d7
+  React-jsiexecutor: f4f3b47f4c1c076363ab8b65042a9a6177ef96b5
+  React-jsinspector: 24c8d6057c0ff37eccc72c855f198c6157893c78
+  React-jsinspectorcdp: 9a364f9cd548fc389ac91af4e5c38eae58f6548f
+  React-jsinspectornetwork: d7f3b19d53fe328dc139035ab0bba19aa68f2439
+  React-jsinspectortracing: 414014b64e0362eec726f3416cc9a02b9a8e9a16
+  React-jsitooling: 96c159a6a7cd6f29f208359554eec887b6fb27b9
+  React-jsitracing: 3c3d20d2dc74fc895411af104f9a9d103dc23794
+  React-logger: 3903016c02ae4dff7387d028501a3b03ba72879d
+  React-Mapbuffer: 48d6d8d0361ab4be5a7b4825006ddfff5e3686ec
+  React-microtasksnativemodule: bd7cfbd456840ebd272edad86b0e09595f2c80d5
+  React-NativeModulesApple: b7c71399d5a301dab362289d68747ff8c9b84c19
+  React-oscompat: e324ee1ba89eb09d59c8e346748c758cb87a2ce3
+  React-perflogger: 1a98c4a181ab1cf9e8cf955dae867abfac59a50d
+  React-performancetimeline: 1a508e57eb32cc6951ecc95ac795afe13f3c1499
+  React-RCTActionSheet: e995bcd8831351318c94bfa3e585178dc15934c8
+  React-RCTAnimation: eda5da34ef170a419bff522a58db9d5fb109acec
+  React-RCTAppDelegate: 671a72235d944f1933dd0c2fecc1860138707547
+  React-RCTBlob: 8e905a0df8271c7405e5542f4ddc5f11bf7b3ef4
+  React-RCTFabric: 1a90fa3f47395deca0e7f2584b9bdfda56177284
+  React-RCTFBReactNativeSpec: 7131000657756071017e8b1658babf02f41cf081
+  React-RCTImage: fe502bd39bb9bb5b9cfa635e141bf3d602091b2f
+  React-RCTLinking: 2d9dad05c5ebddc5902a2c2c0177f72e8f6b93bd
+  React-RCTNetwork: 81ac1907ff907c3e0669c8702a1aae2a8356cf8d
+  React-RCTRuntime: cb10247c06891329de2d5ed8855b63ebc7819451
+  React-RCTSettings: 0887e903b7f06463ec5887df385ade35705c5151
+  React-RCTText: 4644d6c9bc18c05ea4d373c8434ad9dc2392e642
+  React-RCTVibration: f381c601f931888740383dc14f4baeebac945e94
+  React-rendererconsistency: fde6f437f72fb837be955c7d287c5f1a1fe47212
+  React-renderercss: 8ad27c2b7c138f27518702af50c4bacc85d67fc9
+  React-rendererdebug: 34b2305ff2a349e540b39354277ce2c457da8ec9
+  React-RuntimeApple: 347f9558b516c79bd0cfa2a237371843d0a22c25
+  React-RuntimeCore: d4e1654e01a1a6df3ede773b2ddbac83f39725a9
+  React-runtimeexecutor: 93e8ab92174058160232cd9283d354463255020d
+  React-RuntimeHermes: 2f477bc8fc39fff2d1e3a966a3d908bbde6c3fd5
+  React-runtimescheduler: 7d15929025e58a47cd73758c6c4f46d293d3dca5
+  React-timing: c6ce3a683af45aecee166b49348cd094170a7e36
+  React-utils: 3b356bfa4a83cd7e019b96b1de73e8340cef2bf9
+  ReactAppDependencyProvider: ad094d490c0b69fcd292806df86e007728d02f95
+  ReactCodegen: ed848e68148a12de49d2e6dadeff6cf89999962d
+  ReactCommon: 3c95b5086d10c5da3d6d0fc920fc1ce6c984a496
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 15c07d37869e68f295849c2af164cea21957f345
+  Yoga: 72ab8318e9f1910fbdd236b045eb5455c8415d92
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: d8fc4b5c95d74794b8b8eedef08ddd7d7fc165f2

--- a/apps/paper-tester/package.json
+++ b/apps/paper-tester/package.json
@@ -22,7 +22,7 @@
     "expo-video": "~2.1.9",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.0-rc.3",
+    "react-native": "0.81.0-rc.5",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {
@@ -31,7 +31,7 @@
   "private": true,
   "expo": {
     "autolinking": {
-      "exclude": [ ]
+      "exclude": []
     }
   }
 }

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -40,7 +40,7 @@
     "expo-speech": "~13.1.7",
     "expo-sqlite": "~15.2.10",
     "react": "19.1.0",
-    "react-native": "0.81.0-rc.3",
+    "react-native": "0.81.0-rc.5",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "4.14.0-nightly-20250803-1df3db25a",
     "react-native-webview": "13.13.5"

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -15,7 +15,7 @@
     "expo-router": "^5.0.7",
     "expo-splash-screen": "~0.30.8",
     "react": "19.1.0",
-    "react-native": "0.81.0-rc.3",
+    "react-native": "0.81.0-rc.5",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "4.11.1-nightly-20250611-8b82e081e"
   },

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -50,7 +50,7 @@
     "jasmine-core": "^2.4.1",
     "lodash": "^4.17.19",
     "react": "19.1.0",
-    "react-native": "0.81.0-rc.3",
+    "react-native": "0.81.0-rc.5",
     "react-native-gesture-handler": "~2.26.0",
     "sinon": "^7.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "resolutions": {
     "@expo/metro": "~0.1.0",
-    "react-native": "0.81.0-rc.3",
+    "react-native": "0.81.0-rc.5",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "@types/babel__core": "^7.20.5",

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -42,7 +42,7 @@
     "@expo/config-types": "^53.0.4",
     "@expo/image-utils": "^0.7.4",
     "@expo/json-file": "^9.1.4",
-    "@react-native/normalize-colors": "0.81.0-rc.3",
+    "@react-native/normalize-colors": "0.81.0-rc.5",
     "debug": "^4.3.1",
     "resolve-from": "^5.0.0",
     "semver": "^7.6.0",

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -673,6 +673,26 @@ exports[`built-in plugins introspects mods 1`] = `
           },
           {
             "type": "comment",
+            "value": "Use this property to enable edge-to-edge display support.",
+          },
+          {
+            "type": "comment",
+            "value": "This allows your app to draw behind system bars for an immersive UI.",
+          },
+          {
+            "type": "comment",
+            "value": "Note: Only works with ReactActivity and should not be used with custom Activity.",
+          },
+          {
+            "key": "edgeToEdgeEnabled",
+            "type": "property",
+            "value": "true",
+          },
+          {
+            "type": "empty",
+          },
+          {
+            "type": "comment",
             "value": "Enable GIF support in React Native images (~200 B increase)",
           },
           {

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -65,7 +65,7 @@
     "@babel/plugin-transform-parameters": "^7.24.7",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
-    "@react-native/babel-preset": "0.81.0-rc.3",
+    "@react-native/babel-preset": "0.81.0-rc.5",
     "babel-plugin-react-compiler": "^19.1.0-rc.2",
     "babel-plugin-react-native-web": "~0.21.0",
     "babel-plugin-transform-flow-enums": "^0.0.2",

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -46,7 +46,7 @@
     "expo-module-scripts": "^4.1.7",
     "fuse.js": "^6.4.6",
     "react": "19.1.0",
-    "react-native": "0.81.0-rc.3",
+    "react-native": "0.81.0-rc.5",
     "url": "^0.11.0",
     "use-subscription": "^1.8.0"
   },

--- a/packages/expo-module-template/$package.json
+++ b/packages/expo-module-template/$package.json
@@ -15,7 +15,7 @@
     "open:ios": "xed example/ios",
     "open:android": "open -a \"Android Studio\" example/android"
   },
-  "keywords": [ "react-native", "expo", "<%- project.slug %>", "<%- project.name %>" ],
+  "keywords": ["react-native", "expo", "<%- project.slug %>", "<%- project.name %>"],
   "repository": "<%- repo %>",
   "bugs": {
     "url": "<%- repo %>/issues"
@@ -23,12 +23,12 @@
   "author": "<%- author %>",
   "license": "<%- license %>",
   "homepage": "<%- repo %>#readme",
-  "dependencies": { },
+  "dependencies": {},
   "devDependencies": {
     "@types/react": "~19.1.0",
     "expo-module-scripts": "^4.1.7",
     "expo": "~53.0.0",
-    "react-native": "0.81.0-rc.3"
+    "react-native": "0.81.0-rc.5"
   },
   "peerDependencies": {
     "expo": "*",

--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/navigation-bar",
   "dependencies": {
-    "@react-native/normalize-colors": "0.81.0-rc.3",
+    "@react-native/normalize-colors": "0.81.0-rc.5",
     "debug": "^4.3.2",
     "react-native-is-edge-to-edge": "^1.1.6",
     "react-native-edge-to-edge": "1.6.0"

--- a/packages/expo-system-ui/package.json
+++ b/packages/expo-system-ui/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/system-ui",
   "dependencies": {
-    "@react-native/normalize-colors": "0.81.0-rc.3",
+    "@react-native/normalize-colors": "0.81.0-rc.5",
     "debug": "^4.3.2"
   },
   "jest": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -92,7 +92,7 @@
   "lottie-react-native": "~7.2.5",
   "react": "19.1.0",
   "react-dom": "19.1.0",
-  "react-native": "0.81.0-rc.3",
+  "react-native": "0.81.0-rc.5",
   "react-native-web": "~0.21.0",
   "react-native-edge-to-edge": "1.6.0",
   "react-native-gesture-handler": "~2.26.0",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -103,7 +103,7 @@
     "expo-module-scripts": "^4.1.7",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.0-rc.3",
+    "react-native": "0.81.0-rc.5",
     "web-streams-polyfill": "^3.3.2"
   },
   "peerDependencies": {

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -14,7 +14,7 @@
     "expo": "~53.0.11",
     "expo-status-bar": "~2.2.3",
     "react": "19.1.0",
-    "react-native": "0.81.0-rc.3"
+    "react-native": "0.81.0-rc.5"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -14,7 +14,7 @@
     "expo": "~53.0.11",
     "expo-status-bar": "~2.2.3",
     "react": "19.1.0",
-    "react-native": "0.81.0-rc.3"
+    "react-native": "0.81.0-rc.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -14,7 +14,7 @@
     "expo": "~53.0.11",
     "expo-status-bar": "~2.2.3",
     "react": "19.1.0",
-    "react-native": "0.81.0-rc.3"
+    "react-native": "0.81.0-rc.5"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -31,7 +31,7 @@
     "expo-web-browser": "~14.1.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.0-rc.3",
+    "react-native": "0.81.0-rc.5",
     "react-native-gesture-handler": "~2.26.0",
     "react-native-worklets": "~0.4.1",
     "react-native-reanimated": "~4.0.1",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "expo-web-browser": "~14.1.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.0-rc.3",
+    "react-native": "0.81.0-rc.5",
     "react-native-worklets": "~0.4.1",
     "react-native-reanimated": "~4.0.1",
     "react-native-safe-area-context": "5.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3180,23 +3180,23 @@
   resolved "https://registry.yarnpkg.com/@react-native-segmented-control/segmented-control/-/segmented-control-2.5.7.tgz#7c91ef7dede8752796a234321fafa2c604fc82af"
   integrity sha512-l84YeVX8xAU3lvOJSvV4nK/NbGhIm2gBfveYolwaoCbRp+/SLXtc6mYrQmM9ScXNwU14mnzjQTpTHWl5YPnkzQ==
 
-"@react-native/assets-registry@0.81.0-rc.3":
-  version "0.81.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.81.0-rc.3.tgz#daabc0775dfecd877d40e11a5dc856b4a423a17d"
-  integrity sha512-KEAzkLwXKTCeSvB9aORtYmG/dmOud6wJcKLZxvOvtuPdgYeLY0JMMKiZJmCXSIlAj6nIMPqijIW4B+KCwoFnnA==
+"@react-native/assets-registry@0.81.0-rc.5":
+  version "0.81.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.81.0-rc.5.tgz#fa0b7e9be88413576f6b9de9a241d2fe27a2c4f0"
+  integrity sha512-Cw3IrY6gXw/EsQ2gntfJerfbkSqVTNV18w37V8eGm0bdNb87uORs9gnqMMB5RQ4jbK13Uv9Lssn7sox9oNIUog==
 
-"@react-native/babel-plugin-codegen@0.81.0-rc.3":
-  version "0.81.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.0-rc.3.tgz#cdd80f4e51394983393aa81c09f05d93130b9c78"
-  integrity sha512-l7ZSLYtFzBwJ0660meCLH0UiX4gnRXlsfm5nVAP80itRMOpIhhzZ9IEc1ZHee2nrW6RLqiMYI48iy444WfCNqA==
+"@react-native/babel-plugin-codegen@0.81.0-rc.5":
+  version "0.81.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.0-rc.5.tgz#b32cbbf7fc455299ef2a26eaef603f7d3d8c0055"
+  integrity sha512-O+tGAsGwrJzRlGUsGG1ANhi/uHQBxu/VD6lYtvU98FbuZLS28vgE6lNKERMctPDZhlA72Q4XIYhP8ezrCcc7/A==
   dependencies:
     "@babel/traverse" "^7.25.3"
-    "@react-native/codegen" "0.81.0-rc.3"
+    "@react-native/codegen" "0.81.0-rc.5"
 
-"@react-native/babel-preset@0.81.0-rc.3":
-  version "0.81.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.81.0-rc.3.tgz#5d99a45c884d65264cf303d5a03f5d224afbefbe"
-  integrity sha512-YqhD0HNNMwp96O5hOOLamE7AuZCJ1sZRFb9BcPzYC0nkyINa/gWYW6K4F+fZZTvtATEftTqLpH7wqO2B69E32g==
+"@react-native/babel-preset@0.81.0-rc.5":
+  version "0.81.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.81.0-rc.5.tgz#06660ece47ffb308af8e9588887fdb068834a80e"
+  integrity sha512-dI46kx6D7uGsMCMC8/3cygndbuGnb2D5CyXazSyRt2wwTDtHwzagfWf9XhNCz9+eNeLUveAQARw3lrinvNPGLQ==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/plugin-proposal-export-default-from" "^7.24.7"
@@ -3239,15 +3239,15 @@
     "@babel/plugin-transform-typescript" "^7.25.2"
     "@babel/plugin-transform-unicode-regex" "^7.24.7"
     "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.81.0-rc.3"
+    "@react-native/babel-plugin-codegen" "0.81.0-rc.5"
     babel-plugin-syntax-hermes-parser "0.29.1"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
 
-"@react-native/codegen@0.81.0-rc.3":
-  version "0.81.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.81.0-rc.3.tgz#644a5fd7ca6fd229b5dd3e008223da5ef1258e0a"
-  integrity sha512-/FKsK9jPQL/0eAehlMuHXCuTRx6nvaEh0M/ZHZw9J9IRFW43aehGLU42+Xq+7iM4e0YULeDu5xS8bObsFnAd8g==
+"@react-native/codegen@0.81.0-rc.5":
+  version "0.81.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.81.0-rc.5.tgz#c2c68f8ffe50a080c236ec46d151270f4cea49c1"
+  integrity sha512-NRUB5YlqjrgLDwxy6zKzFZG4TZuhnhr8MLo8BfLkBz4T/r7oLa5dzOZO7dGP45T3lKf6QVBEFgQNNyIf7yOcow==
   dependencies:
     glob "^7.1.1"
     hermes-parser "0.29.1"
@@ -3255,12 +3255,12 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/community-cli-plugin@0.81.0-rc.3":
-  version "0.81.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.81.0-rc.3.tgz#37a654bf896e65d53fc2c85e381bdb91f454be91"
-  integrity sha512-D95GRfHybPESt8gcYYujpSBdXWhM7VWhR+UjBAItyViKB8LFcLAw8kN6IGAr2R8r8Hs8+0qlS2z9dQAejEgZrg==
+"@react-native/community-cli-plugin@0.81.0-rc.5":
+  version "0.81.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.81.0-rc.5.tgz#95fbf76a67c7ef50e67f46018603cb1d68b51cf3"
+  integrity sha512-U4fbBH9L+egK4a+rTkFz8we4zeHtA1GxBMv4QMqdgrpWmnFEDpqnbDmdJl8VYs7j45ksebNVX5tIUHH0GbDxIQ==
   dependencies:
-    "@react-native/dev-middleware" "0.81.0-rc.3"
+    "@react-native/dev-middleware" "0.81.0-rc.5"
     debug "^4.4.0"
     invariant "^2.2.4"
     metro "^0.83.1"
@@ -3273,10 +3273,10 @@
   resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.80.1.tgz#c21e6cf0deb5ebe628769277e60d1573006a66a0"
   integrity sha512-5dQJdX1ZS4dINNw51KNsDIL+A06sZQd2hqN2Pldq5SavxAwEJh5NxAx7K+lutKhwp1By5gxd6/9ruVt+9NCvKA==
 
-"@react-native/debugger-frontend@0.81.0-rc.3":
-  version "0.81.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.81.0-rc.3.tgz#569f765f4b758f53503fe5342b47019d9be484be"
-  integrity sha512-i1d/mRu0fyu+rgF0kjTDW4ZTBHwprVOyEhb65QPxN+EFnkWvTPJC/6VuaNQJ7rTkUZ9o47y0iG+xnep5NvUpBA==
+"@react-native/debugger-frontend@0.81.0-rc.5":
+  version "0.81.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.81.0-rc.5.tgz#58e3419a43279d683fd8b84258530985b1471223"
+  integrity sha512-CREp3f0rJUf9LsXDx4HHOz1SePQFbtKI+DK9bXB3kmfQ9RltEdjUyM/TdjdfqTq9hnF0YMD64BOwlFqhloaPLQ==
 
 "@react-native/dev-middleware@0.80.1":
   version "0.80.1"
@@ -3295,13 +3295,13 @@
     serve-static "^1.16.2"
     ws "^6.2.3"
 
-"@react-native/dev-middleware@0.81.0-rc.3":
-  version "0.81.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.81.0-rc.3.tgz#ef5584cb40d238e01da0d4c4c789af76084311e4"
-  integrity sha512-FTuEqnV8WEwSxkhVAjQ5J6m2YdGCWK3wXsqnOtI7LFfoStvQO2p7Torq8hbOZBW+JZHUOFQPI3nrQKvXBfWQAg==
+"@react-native/dev-middleware@0.81.0-rc.5":
+  version "0.81.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.81.0-rc.5.tgz#5db1bdedfc733e2885c8d1666d0f736027c096ea"
+  integrity sha512-pgAuTT5D0CArLUTjqB1nJ7gaK1fmLIaS0G8H834yIy9dPCXt0yPFuvI8tFREwej6XQD5q6vAky93fu72bTnq/Q==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.81.0-rc.3"
+    "@react-native/debugger-frontend" "0.81.0-rc.5"
     chrome-launcher "^0.15.2"
     chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
@@ -3312,30 +3312,30 @@
     serve-static "^1.16.2"
     ws "^6.2.3"
 
-"@react-native/gradle-plugin@0.81.0-rc.3":
-  version "0.81.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.81.0-rc.3.tgz#ca6e4a95590c3afcae2f7aabc986eb5e2330520e"
-  integrity sha512-EPjcbylJ8dXhJoTmu40d5qSgnh662b2E30gF/a+jY1V6aSVQ8SXlw1ndCdr+teg5BO6qTUs2nY87mYCi8RVX/w==
+"@react-native/gradle-plugin@0.81.0-rc.5":
+  version "0.81.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.81.0-rc.5.tgz#d3a16441db38129a1aab893e46467209216d7c12"
+  integrity sha512-XgK7GodMzhlpTi6KJTtvwbdzbaAh7sasA4CjL1hPmTIkR3SCELopwNKh23pzGj6WGmBvqs9Ewa7yDAFMAcPhZg==
 
-"@react-native/js-polyfills@0.81.0-rc.3":
-  version "0.81.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.81.0-rc.3.tgz#4a4bd93ff12ce9382f50294447537ab83632b859"
-  integrity sha512-zMEdGYvAx2g5SgZn262KGIjLa/ksRszBlSPL4eEVzWgcrfUYU3gutT+mm6M3rYIik5755s0unKEWOZig8UmzTA==
+"@react-native/js-polyfills@0.81.0-rc.5":
+  version "0.81.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.81.0-rc.5.tgz#11faaf0395b8bdf569e9d473a4bc69ddd66cceb5"
+  integrity sha512-aGb1afOUPS7FtEZAGW0c+8+t+63jS7GMkRu6fgfQ0exyhJpGjUybsrTS35h5C33ZYcoVLSyLl3HOnlBI+3Qh6A==
 
-"@react-native/normalize-colors@0.81.0-rc.3":
-  version "0.81.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.81.0-rc.3.tgz#bb5560cbeaf908e7377f443a8734a02087be0a0c"
-  integrity sha512-zNZDpr4wQ4h8rLEVUDRpzYrTEnOP1h4By1e053jDX6R95dA01lUVYH7B9C5KQ42/vKI+gkKT1lAeVCf5LeP7ZA==
+"@react-native/normalize-colors@0.81.0-rc.5":
+  version "0.81.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.81.0-rc.5.tgz#cf4fa0d7706812427cc095c89e97710422d6a6dc"
+  integrity sha512-yFnn7pvng7a0Ac108FpVGhltB7ZMd03gDLeDBhM3DwBpb4Yk47wbgM8GwmllnW9/p8HbGMuXMXJ56MKA+2hNZw==
 
 "@react-native/normalize-colors@^0.74.1":
   version "0.74.88"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.74.88.tgz#46f4c7270c8e6853281d7dd966e0eb362068e41a"
   integrity sha512-He5oTwPBxvXrxJ91dZzpxR7P+VYmc9IkJfhuH8zUiU50ckrt+xWNjtVugPdUv4LuVjmZ36Vk2EX8bl1gVn2dVA==
 
-"@react-native/virtualized-lists@0.81.0-rc.3":
-  version "0.81.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.81.0-rc.3.tgz#d6a8ca385801eb1ade610e65eb857f0a4238760e"
-  integrity sha512-wZeKPOcE5tys1eyUzpO6eXR/evtU5MjxODhDz+sR3uwxeSKFOu9uuG54vi3cygXZtvJr44V+pQPVMoMQtMTurg==
+"@react-native/virtualized-lists@0.81.0-rc.5":
+  version "0.81.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.81.0-rc.5.tgz#d3c633c72f5ef54f5767c3d91aa1e5145488f7c3"
+  integrity sha512-E8lbXtVquCR6XP6LRoF/Q85NxGYrPQp0AUucerqR/F6LcV1eBK0iyS4foYJK8ZxFoMiSaSs788h1jFRfSfTK0g==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -13675,19 +13675,19 @@ react-native-worklets@0.4.1:
     "@babel/preset-typescript" "^7.16.7"
     convert-source-map "^2.0.0"
 
-react-native@0.81.0-rc.3:
-  version "0.81.0-rc.3"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.81.0-rc.3.tgz#2112e58184908d498d064421115d3a5247190c4b"
-  integrity sha512-yTm+PrEeuEiNyvIAe2wb2+XoUxxRaFKX/48s01M0SrG50RG0DPamrRRfhZbhKCUBMQ7M3jJUj6DcdCsZylwDEA==
+react-native@0.81.0-rc.5:
+  version "0.81.0-rc.5"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.81.0-rc.5.tgz#16952f875e61277e24b4b2968e9b5cbab9b46a43"
+  integrity sha512-MLIc84+OS3cSAjrCZsyuuQFNH5N1TgBWc0jVPHDZshN7OAaS8kKKE2M8LUu5XLvRevOPO+7RLnNo7aUrXwPVZQ==
   dependencies:
     "@jest/create-cache-key-function" "^29.7.0"
-    "@react-native/assets-registry" "0.81.0-rc.3"
-    "@react-native/codegen" "0.81.0-rc.3"
-    "@react-native/community-cli-plugin" "0.81.0-rc.3"
-    "@react-native/gradle-plugin" "0.81.0-rc.3"
-    "@react-native/js-polyfills" "0.81.0-rc.3"
-    "@react-native/normalize-colors" "0.81.0-rc.3"
-    "@react-native/virtualized-lists" "0.81.0-rc.3"
+    "@react-native/assets-registry" "0.81.0-rc.5"
+    "@react-native/codegen" "0.81.0-rc.5"
+    "@react-native/community-cli-plugin" "0.81.0-rc.5"
+    "@react-native/gradle-plugin" "0.81.0-rc.5"
+    "@react-native/js-polyfills" "0.81.0-rc.5"
+    "@react-native/normalize-colors" "0.81.0-rc.5"
+    "@react-native/virtualized-lists" "0.81.0-rc.5"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/38437

# How 

- update package versions
  - `react-native  0.81.0-rc.3 -> 0.81.0-rc.5`  
  - `@react-native/normalize-colors 0.81.0-rc.3 ->  0.81.0-rc.5` 
  - `@react-native/babel-preset 0.81.0-rc.3 ->  0.81.0-rc.5` 
  - `@react-native/dev-middleware 0.81.0-rc.3 ->  0.81.0-rc.5`    

# Test Plan
 
bare-expo ios / android
paper-tester ios / android
ci passed

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
