### PR TITLE
fork away from react-native/Libraries/Core/Devtools/getDevServer import

### DIFF
--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 💡 Others
 
+- Fork `react-native/Libraries/Core/Devtools/getDevServer` to suppress warning.
 - noop unused code on native to suppress react-native import warnings. ([#38495](https://github.com/expo/expo/pull/38495) by [@EvanBacon](https://github.com/EvanBacon))
 - Update dependencies to align with transitive dependencies ([#38532](https://github.com/expo/expo/pull/38532) by [@kitten](https://github.com/kitten))
 

--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Fork `react-native/Libraries/Core/Devtools/getDevServer` to suppress warning.
+- Fork `react-native/Libraries/Core/Devtools/getDevServer` to suppress warning. ([#38588](https://github.com/expo/expo/pull/38588) by [@EvanBacon](https://github.com/EvanBacon))
 - noop unused code on native to suppress react-native import warnings. ([#38495](https://github.com/expo/expo/pull/38495) by [@EvanBacon](https://github.com/EvanBacon))
 - Update dependencies to align with transitive dependencies ([#38532](https://github.com/expo/expo/pull/38532) by [@kitten](https://github.com/kitten))
 

--- a/packages/@expo/metro-runtime/build/getDevServer.native.d.ts
+++ b/packages/@expo/metro-runtime/build/getDevServer.native.d.ts
@@ -1,3 +1,10 @@
-import getDevServer from 'react-native/Libraries/Core/Devtools/getDevServer';
-export default getDevServer;
+/**
+ * Many RN development tools rely on the development server (packager) running
+ * @return URL to packager with trailing slash
+ */
+export default function getDevServer(): {
+    url: string;
+    fullBundleUrl: string | null;
+    bundleLoadedFromServer: boolean;
+};
 //# sourceMappingURL=getDevServer.native.d.ts.map

--- a/packages/@expo/metro-runtime/build/getDevServer.native.d.ts.map
+++ b/packages/@expo/metro-runtime/build/getDevServer.native.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"getDevServer.native.d.ts","sourceRoot":"","sources":["../src/getDevServer.native.ts"],"names":[],"mappings":"AAAA,OAAO,YAAY,MAAM,mDAAmD,CAAC;AAE7E,eAAe,YAAY,CAAC"}
+{"version":3,"file":"getDevServer.native.d.ts","sourceRoot":"","sources":["../src/getDevServer.native.ts"],"names":[],"mappings":"AAUA;;;GAGG;AACH,MAAM,CAAC,OAAO,UAAU,YAAY,IAAI;IACtC,GAAG,EAAE,MAAM,CAAC;IACZ,aAAa,EAAE,MAAM,GAAG,IAAI,CAAC;IAC7B,sBAAsB,EAAE,OAAO,CAAC;CACjC,CAaA"}

--- a/packages/@expo/metro-runtime/src/getDevServer.native.ts
+++ b/packages/@expo/metro-runtime/src/getDevServer.native.ts
@@ -1,3 +1,32 @@
-import getDevServer from 'react-native/Libraries/Core/Devtools/getDevServer';
+import { TurboModuleRegistry } from 'react-native';
 
-export default getDevServer;
+const NativeSourceCode = TurboModuleRegistry.getEnforcing<{
+  getConstants: () => { scriptURL: string };
+}>('SourceCode');
+
+const FALLBACK = 'http://localhost:8081/';
+let cachedDevServerURL: string | null | undefined;
+let cachedFullBundleURL: string | null = null;
+
+/**
+ * Many RN development tools rely on the development server (packager) running
+ * @return URL to packager with trailing slash
+ */
+export default function getDevServer(): {
+  url: string;
+  fullBundleUrl: string | null;
+  bundleLoadedFromServer: boolean;
+} {
+  if (cachedDevServerURL === undefined) {
+    const scriptUrl = NativeSourceCode.getConstants().scriptURL;
+    const match = scriptUrl.match(/^https?:\/\/.*?\//);
+    cachedDevServerURL = match ? match[0] : null;
+    cachedFullBundleURL = match ? scriptUrl : null;
+  }
+
+  return {
+    url: cachedDevServerURL ?? FALLBACK,
+    fullBundleUrl: cachedFullBundleURL,
+    bundleLoadedFromServer: cachedDevServerURL !== null,
+  };
+}

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 💡 Others
 
-- Fork `react-native/Libraries/Core/Devtools/getDevServer` to suppress warning.
+- Fork `react-native/Libraries/Core/Devtools/getDevServer` to suppress warning. ([#38588](https://github.com/expo/expo/pull/38588) by [@EvanBacon](https://github.com/EvanBacon))
 - Fork `react-native/Libraries/Utilities/PolyfillFunctions` to suppress warning. ([#38495](https://github.com/expo/expo/pull/38495) by [@EvanBacon](https://github.com/EvanBacon))
 - Change how FormData is parsed in expo/fetch. ([#38160](https://github.com/expo/expo/pull/38160) by [@aleqsio](https://github.com/aleqsio))
 - Simplify expo-modules-core usage. ([#37588](https://github.com/expo/expo/pull/37588) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 💡 Others
 
+- Fork `react-native/Libraries/Core/Devtools/getDevServer` to suppress warning.
 - Fork `react-native/Libraries/Utilities/PolyfillFunctions` to suppress warning. ([#38495](https://github.com/expo/expo/pull/38495) by [@EvanBacon](https://github.com/EvanBacon))
 - Change how FormData is parsed in expo/fetch. ([#38160](https://github.com/expo/expo/pull/38160) by [@aleqsio](https://github.com/aleqsio))
 - Simplify expo-modules-core usage. ([#37588](https://github.com/expo/expo/pull/37588) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo/build/async-require/getDevServer.native.d.ts
+++ b/packages/expo/build/async-require/getDevServer.native.d.ts
@@ -1,3 +1,10 @@
-import getDevServer from 'react-native/Libraries/Core/Devtools/getDevServer';
-export default getDevServer;
+/**
+ * Many RN development tools rely on the development server (packager) running
+ * @return URL to packager with trailing slash
+ */
+export default function getDevServer(): {
+    url: string;
+    fullBundleUrl: string | null;
+    bundleLoadedFromServer: boolean;
+};
 //# sourceMappingURL=getDevServer.native.d.ts.map

--- a/packages/expo/build/async-require/getDevServer.native.d.ts.map
+++ b/packages/expo/build/async-require/getDevServer.native.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"getDevServer.native.d.ts","sourceRoot":"","sources":["../../src/async-require/getDevServer.native.ts"],"names":[],"mappings":"AACA,OAAO,YAAY,MAAM,mDAAmD,CAAC;AAE7E,eAAe,YAAY,CAAC"}
+{"version":3,"file":"getDevServer.native.d.ts","sourceRoot":"","sources":["../../src/async-require/getDevServer.native.ts"],"names":[],"mappings":"AAUA;;;GAGG;AACH,MAAM,CAAC,OAAO,UAAU,YAAY,IAAI;IACtC,GAAG,EAAE,MAAM,CAAC;IACZ,aAAa,EAAE,MAAM,GAAG,IAAI,CAAC;IAC7B,sBAAsB,EAAE,OAAO,CAAC;CACjC,CAaA"}

--- a/packages/expo/src/async-require/getDevServer.native.ts
+++ b/packages/expo/src/async-require/getDevServer.native.ts
@@ -1,4 +1,32 @@
-// @ts-expect-error
-import getDevServer from 'react-native/Libraries/Core/Devtools/getDevServer';
+import { TurboModuleRegistry } from 'react-native';
 
-export default getDevServer;
+const NativeSourceCode = TurboModuleRegistry.getEnforcing<{
+  getConstants: () => { scriptURL: string };
+}>('SourceCode');
+
+const FALLBACK = 'http://localhost:8081/';
+let cachedDevServerURL: string | null | undefined;
+let cachedFullBundleURL: string | null = null;
+
+/**
+ * Many RN development tools rely on the development server (packager) running
+ * @return URL to packager with trailing slash
+ */
+export default function getDevServer(): {
+  url: string;
+  fullBundleUrl: string | null;
+  bundleLoadedFromServer: boolean;
+} {
+  if (cachedDevServerURL === undefined) {
+    const scriptUrl = NativeSourceCode.getConstants().scriptURL;
+    const match = scriptUrl.match(/^https?:\/\/.*?\//);
+    cachedDevServerURL = match ? match[0] : null;
+    cachedFullBundleURL = match ? scriptUrl : null;
+  }
+
+  return {
+    url: cachedDevServerURL ?? FALLBACK,
+    fullBundleUrl: cachedFullBundleURL,
+    bundleLoadedFromServer: cachedDevServerURL !== null,
+  };
+}


### PR DESCRIPTION
# Why

Suppress more react-native warnings. Similar to https://github.com/expo/expo/pull/38587

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

instantiate the turbo module directly to get the dev server location.
