### PR TITLE
[expo-video] Fix inconsistent behavior of "replay" on iOS

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [Android] Fix accessing player.loop causes app to crash. ([#37928](https://github.com/expo/expo/pull/37928) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Setting `player.currentTime` doesn't seek to the correct time on some videos. ([#37672](https://github.com/expo/expo/pull/37300) by [@petrkonecny2](https://github.com/petrkonecny2))
 - [iOS] Fix tvOS compilation errors. ([#38085](https://github.com/expo/expo/pull/38085) by [@douglowder](https://github.com/douglowder))
+- [iOS] Fix inconsistent behavior of "replay" on iOS by calling "play()" after seeking to position 0. ([#38590](https://github.com/expo/expo/pull/38590)) by [@saviocmc](https://github.com/saviocmc)
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/VideoModule.swift
+++ b/packages/expo-video/ios/VideoModule.swift
@@ -339,6 +339,7 @@ public final class VideoModule: Module {
 
       Function("replay") { player in
         player.ref.seek(to: CMTime.zero)
+        player.ref.play()
       }
 
       AsyncFunction("generateThumbnailsAsync") { (player: VideoPlayer, times: [CMTime]?, options: VideoThumbnailOptions?) -> [VideoThumbnail] in


### PR DESCRIPTION
Add call to "play()" after seeking to position 0, like the implementation on android and the web. Fixes #37650.

# Why

On iOS, the implementation of "replay" only seeks to position 0. On android and the web, the method also call the "play" method to start the media playback again.

Minimal reproducible example: https://github.com/saviocmc/expo-video-inconsistent-replay

Here are the implementations of the method on each platform:

- **Android and Web (seek and play)**:
https://github.com/expo/expo/blob/e6e3d16a35440544cce8cabf48890b547e9fd960/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt#L313-L318
https://github.com/expo/expo/blob/e6e3d16a35440544cce8cabf48890b547e9fd960/packages/expo-video/src/VideoPlayer.web.tsx#L324-L330

- **iOS (only seek)**:
https://github.com/expo/expo/blob/e6e3d16a35440544cce8cabf48890b547e9fd960/packages/expo-video/ios/VideoModule.swift#L340-L342

# How

<!--
How did you build this feature or fix this bug and why?
-->
This PR fixes this inconsistency by also calling "play" on the iOS implementation of "replay".

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
To test just call the "replay" method on iOS when the video is stopped and observe it starts to play from position 0.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
