### PR TITLE
fix(expo-video)[android]: Fix: Respect accessibility settings for HLS subtitle sizing and system settings, added listener

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Add complete support for AirPlay streaming. Add a device selection button and `VideoPlayer.isExternalPlaybackActive` property and appropriate listeners. ([#37207](https://github.com/expo/expo/pull/37207) by [@behenate](https://github.com/behenate))
 - Add fullscreen orientation and auto-exit functionality. ([#36910](https://github.com/expo/expo/pull/36910) by [@behenate](https://github.com/behenate))
+- [Android] React to system wide subtitle changes in real time, does not require an app reload ([#38591](https://github.com/expo/expo/pull/38591) by [@hirbod](https://github.com/hirbod))
 
 ### 🐛 Bug fixes
 
@@ -17,6 +18,7 @@
 - [Android] Fix accessing player.loop causes app to crash. ([#37928](https://github.com/expo/expo/pull/37928) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Setting `player.currentTime` doesn't seek to the correct time on some videos. ([#37672](https://github.com/expo/expo/pull/37300) by [@petrkonecny2](https://github.com/petrkonecny2))
 - [iOS] Fix tvOS compilation errors. ([#38085](https://github.com/expo/expo/pull/38085) by [@douglowder](https://github.com/douglowder))
+- [Android] Fix: Respect accessibility settings for HLS subtitle sizing and system settings, added listener ([#38591](https://github.com/expo/expo/pull/38591) by [@hirbod](https://github.com/hirbod))
 - [iOS] Fix inconsistent behavior of "replay" on iOS by calling "play()" after seeking to position 0. ([#38590](https://github.com/expo/expo/pull/38590)) by [@saviocmc](https://github.com/saviocmc)
 
 ### 💡 Others

--- a/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
@@ -5,8 +5,10 @@ import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
+import android.content.Context
 import android.util.Log
 import android.view.View
+import android.view.accessibility.CaptioningManager
 import android.view.WindowInsets
 import android.view.WindowInsetsController
 import android.widget.ImageButton
@@ -15,6 +17,7 @@ import expo.modules.kotlin.exception.CodedException
 import expo.modules.video.player.VideoPlayer
 import expo.modules.video.records.FullscreenOptions
 import expo.modules.video.utils.FullscreenActivityOrientationHelper
+import expo.modules.video.utils.SubtitleUtils
 import expo.modules.video.utils.applyPiPParams
 import expo.modules.video.utils.applyRectHint
 import expo.modules.video.utils.calculatePiPAspectRatio
@@ -31,6 +34,7 @@ class FullscreenPlayerActivity : Activity() {
   private var wasAutoPaused = false
   private lateinit var options: FullscreenOptions
   private lateinit var orientationHelper: FullscreenActivityOrientationHelper
+  private var captioningChangeListener: CaptioningManager.CaptioningChangeListener? = null
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -93,6 +97,12 @@ class FullscreenPlayerActivity : Activity() {
     }
     playerView.setShowSubtitleButton(videoView.showsSubtitlesButton)
 
+    // Configure subtitle view to fix sizing issues with embedded styles (same as VideoView)
+    SubtitleUtils.configureSubtitleView(playerView, this)
+
+    // Set up listener for accessibility caption changes
+    setupCaptioningChangeListener()
+
     playerView.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
       applyRectHint(this, calculateRectHint(playerView))
     }
@@ -115,6 +125,8 @@ class FullscreenPlayerActivity : Activity() {
   override fun onResume() {
     orientationHelper.startOrientationEventListener()
     playerView.useController = videoView.useNativeControls
+    // Reconfigure subtitles when resuming (handles returning from settings)
+    SubtitleUtils.configureSubtitleView(playerView, this)
     super.onResume()
   }
 
@@ -132,6 +144,14 @@ class FullscreenPlayerActivity : Activity() {
 
   override fun onDestroy() {
     super.onDestroy()
+
+    // Clean up captioning change listener
+    captioningChangeListener?.let {
+      val captioningManager = getSystemService(Context.CAPTIONING_SERVICE) as? CaptioningManager
+      captioningManager?.removeCaptioningChangeListener(it)
+      captioningChangeListener = null
+    }
+
     videoView.exitFullscreen()
     VideoManager.unregisterFullscreenPlayerActivity(hashCode().toString())
     orientationHelper.stopOrientationEventListener()
@@ -173,6 +193,16 @@ class FullscreenPlayerActivity : Activity() {
           or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
           or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
         )
+    }
+  }
+
+  private fun setupCaptioningChangeListener() {
+    val captioningManager = getSystemService(Context.CAPTIONING_SERVICE) as? CaptioningManager
+
+    captioningChangeListener = SubtitleUtils.createCaptioningChangeListener(playerView, this)
+
+    captioningChangeListener?.let { listener ->
+      captioningManager?.addCaptioningChangeListener(listener)
     }
   }
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.graphics.Color
 import android.os.Build
 import android.util.Rational
+import android.view.accessibility.CaptioningManager
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
@@ -34,6 +35,7 @@ import expo.modules.video.records.VideoSource
 import expo.modules.video.records.VideoTrack
 import expo.modules.video.utils.applyPiPParams
 import expo.modules.video.records.FullscreenOptions
+import expo.modules.video.utils.SubtitleUtils
 import expo.modules.video.utils.applyRectHint
 import expo.modules.video.utils.calculatePiPAspectRatio
 import expo.modules.video.utils.calculateRectHint
@@ -73,6 +75,14 @@ open class VideoView(context: Context, appContext: AppContext, useTextureView: B
   private val rootViewChildrenOriginalVisibility: ArrayList<Int> = arrayListOf()
   private var pictureInPictureHelperTag: String? = null
   private var reactNativeEventDispatcher: EventDispatcher? = null
+  private var captioningChangeListener: CaptioningManager.CaptioningChangeListener? = null
+
+  private val windowFocusChangeListener = View.OnFocusChangeListener { _, hasFocus ->
+    if (hasFocus) {
+      // Reconfigure when window gains focus (returning from settings)
+      SubtitleUtils.configureSubtitleView(playerView, context)
+    }
+  }
 
   // We need to keep track of the target surface view visibility, but only apply it when `useExoShutter` is false.
   var shouldHideSurfaceView: Boolean = true
@@ -162,6 +172,9 @@ open class VideoView(context: Context, appContext: AppContext, useTextureView: B
     // Start with the SurfaceView being transparent to avoid any flickers when the prop value is delivered.
     this.playerView.setShutterBackgroundColor(Color.TRANSPARENT)
     this.playerView.videoSurfaceView?.alpha = 0f
+
+    // Configure subtitle view to fix sizing issues with embedded styles
+    SubtitleUtils.configureSubtitleView(playerView, context)
     addView(
       playerView,
       ViewGroup.LayoutParams(
@@ -319,7 +332,24 @@ open class VideoView(context: Context, appContext: AppContext, useTextureView: B
         .add(fragment, fragment.id)
         .commitAllowingStateLoss()
     }
+
+    // Set up listener for accessibility caption changes when attached to window
+    setupCaptioningChangeListener()
+    // Reconfigure when view is attached (handles returning from settings)
+    SubtitleUtils.configureSubtitleView(playerView, context)
+
+    // Set up window focus change listener
+    decorView.onFocusChangeListener = windowFocusChangeListener
+
     applyPiPParams(currentActivity, autoEnterPiP)
+  }
+
+  override fun onVisibilityChanged(changedView: View, visibility: Int) {
+    super.onVisibilityChanged(changedView, visibility)
+    if (visibility == View.VISIBLE) {
+      // Reconfigure subtitles when view becomes visible (immediate response)
+      SubtitleUtils.configureSubtitleView(playerView, context)
+    }
   }
 
   override fun onDetachedFromWindow() {
@@ -331,6 +361,17 @@ open class VideoView(context: Context, appContext: AppContext, useTextureView: B
         .remove(fragment)
         .commitAllowingStateLoss()
     }
+
+    // Clean up captioning change listener
+    captioningChangeListener?.let {
+      val captioningManager = context.getSystemService(Context.CAPTIONING_SERVICE) as? CaptioningManager
+      captioningManager?.removeCaptioningChangeListener(it)
+      captioningChangeListener = null
+    }
+
+    // Clean up window focus listener
+    decorView.onFocusChangeListener = null
+
     applyPiPParams(currentActivity, false)
   }
 
@@ -367,6 +408,16 @@ open class VideoView(context: Context, appContext: AppContext, useTextureView: B
       R.layout.texture_player_view
     } else {
       R.layout.surface_player_view
+    }
+  }
+
+  private fun setupCaptioningChangeListener() {
+    val captioningManager = context.getSystemService(Context.CAPTIONING_SERVICE) as? CaptioningManager
+
+    captioningChangeListener = SubtitleUtils.createCaptioningChangeListener(playerView, context)
+
+    captioningChangeListener?.let { listener ->
+      captioningManager?.addCaptioningChangeListener(listener)
     }
   }
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/SubtitleUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/SubtitleUtils.kt
@@ -1,0 +1,57 @@
+package expo.modules.video.utils
+
+import android.content.Context
+import android.util.TypedValue
+import android.view.accessibility.CaptioningManager
+import androidx.media3.ui.CaptionStyleCompat
+import androidx.media3.ui.PlayerView
+
+object SubtitleUtils {
+  /**
+   * Configures the PlayerView's subtitle view to fix sizing issues with embedded styles.
+   * Disables embedded HLS subtitle styling and applies Android accessibility settings
+   * with a reasonable base font size.
+   */
+  fun configureSubtitleView(playerView: PlayerView, context: Context) {
+    playerView.subtitleView?.apply {
+      setApplyEmbeddedStyles(false)
+      setApplyEmbeddedFontSizes(false)
+
+      // Apply system accessibility caption style but with reasonable base font size
+      val captioningManager = context.getSystemService(Context.CAPTIONING_SERVICE) as? CaptioningManager
+      val userStyle = captioningManager?.userStyle
+
+      if (userStyle != null) {
+        val systemStyle = CaptionStyleCompat.createFromCaptionStyle(userStyle)
+        setStyle(systemStyle)
+
+        val fontScale = captioningManager.fontScale
+        val baseFontSize = 16f // Reasonable base size
+        setFixedTextSize(TypedValue.COMPLEX_UNIT_SP, baseFontSize * fontScale)
+      }
+    }
+  }
+
+  /**
+   * Creates a CaptioningChangeListener that reconfigures subtitles when accessibility
+   * settings change.
+   */
+  fun createCaptioningChangeListener(
+    playerView: PlayerView,
+    context: Context
+  ): CaptioningManager.CaptioningChangeListener {
+    return object : CaptioningManager.CaptioningChangeListener() {
+      override fun onEnabledChanged(enabled: Boolean) {
+        configureSubtitleView(playerView, context)
+      }
+
+      override fun onUserStyleChanged(userStyle: android.view.accessibility.CaptioningManager.CaptionStyle) {
+        configureSubtitleView(playerView, context)
+      }
+
+      override fun onFontScaleChanged(fontScale: Float) {
+        configureSubtitleView(playerView, context)
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

* Some HLS streams (like Mux) have hardcoded subtitle styles that override Android’s accessibility settings. This led to subtitles showing up way too large, even for users who didn’t change any settings.
* People relying on accessibility couldn’t read them properly, and everyone else got massive, unusable text.
* Turns out, Media3’s `PlayerView` uses these embedded styles by default - including ridiculous font sizes.

Fixes #38567
Closes ENG-16901

# How

* Turned off embedded styling with `setApplyEmbeddedStyles(false)` and `setApplyEmbeddedFontSizes(false)`
* Now we apply Android’s system-wide caption styles using `CaptionStyleCompat`, and scale fonts based on the user’s accessibility settings (default base size is 16sp)
* Hooked into `CaptioningChangeListener` to react to live changes from system settings
* Also using `onVisibilityChanged()` to reapply settings when the user returns from changing system prefs
* The fix works for both `VideoView` (normal playback) and `FullscreenPlayerActivity`
* Created a `SubtitleUtils` helper to avoid duplicate config code


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Repro, bare-expo, expo-go

https://github.com/user-attachments/assets/225f4fe5-6342-4de9-bcd6-6a78f2d7c880



<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
