### PR TITLE
[docs] Add `github.commit_message` to workflows interpolation syntax

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -442,7 +442,8 @@ To ease the migration from GitHub Actions to EAS Workflows we expose some contex
   "sha": string,
   "ref": string, // e.g. refs/heads/main
   "ref_name": string, // e.g. main
-  "ref_type": "branch" | "tag" | "other"
+  "ref_type": "branch" | "tag" | "other",
+  "commit_message": string // Only available for push and schedule events
 }
 ```
 


### PR DESCRIPTION
# Why

Fix [ENG-16913](https://linear.app/expo/issue/ENG-16913/add-docs-for-githubcommit-message)

# How

Add a new variable `github.commit_message` to workflows interpolation syntax.

# Test Plan

Verified locally.

<img width="869" height="339" alt="image" src="https://github.com/user-attachments/assets/3d2b52bb-a101-4f68-bcb7-5724c8148bf6" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
