### PR TITLE
[core][Android] Start using experimental converters in properties

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [Android] Add `testID` support to `ExpoComposeView`. ([#38005](https://github.com/expo/expo/pull/38005) by [@mateoguzmana](https://github.com/mateoguzmana))
 - [iOS] Return proper dynamic type for AnyEither. ([#38072](https://github.com/expo/expo/pull/38072) by [@jakex7](https://github.com/jakex7))
 - [Android] Add VRUtilities for VR-related values and utils ([#37744](https://github.com/expo/expo/pull/37744) by [@behenate](https://github.com/behenate))
-- [Andorid] Start using experimental converters in properties.
+- [Andorid] Start using experimental converters in properties. ([#38597](https://github.com/expo/expo/pull/38597) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [Android] Add `testID` support to `ExpoComposeView`. ([#38005](https://github.com/expo/expo/pull/38005) by [@mateoguzmana](https://github.com/mateoguzmana))
 - [iOS] Return proper dynamic type for AnyEither. ([#38072](https://github.com/expo/expo/pull/38072) by [@jakex7](https://github.com/jakex7))
 - [Android] Add VRUtilities for VR-related values and utils ([#37744](https://github.com/expo/expo/pull/37744) by [@behenate](https://github.com/behenate))
+- [Andorid] Start using experimental converters in properties.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIPropertiesTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIPropertiesTest.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
 import expo.modules.kotlin.exception.JavaScriptEvaluateException
+import expo.modules.kotlin.sharedobjects.SharedObject
 import org.junit.Assert
 import org.junit.Test
 
@@ -72,5 +73,30 @@ internal class JSIPropertiesTest {
     }
     val p1 = property("p").getInt()
     Truth.assertThat(p1).isEqualTo(567)
+  }
+
+  @Test
+  fun returns_list_of_shared_objects() {
+    class MySharedObject : SharedObject()
+    withSingleModule({
+      Class<MySharedObject> {
+        Constructor { MySharedObject() }
+      }
+
+      Property("f") { ->
+        listOf(
+          MySharedObject(),
+          MySharedObject(),
+          MySharedObject()
+        )
+      }
+    }) {
+      val result = evaluateScript("$moduleRef.f").getArray()
+
+      Truth.assertThat(result.size).isEqualTo(3)
+      for (obj in result) {
+        Truth.assertThat(obj.isObject()).isTrue()
+      }
+    }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponent.kt
@@ -29,7 +29,7 @@ class PropertyComponent(
     val jniGetter = if (getter != null) {
       JNIFunctionBody { args ->
         val result = getter.callUserImplementation(args, appContext)
-        return@JNIFunctionBody JSTypeConverter.convertToJSValue(result)
+        return@JNIFunctionBody JSTypeConverter.convertToJSValue(result, useExperimentalConverter = true)
       }
     } else {
       null


### PR DESCRIPTION
# Why

Starts using experimental converters in properties.
Actually, we should probably rename experimental converters to just converters as they with as for a long time already. 

# Test Plan

- unit test ✅ 