### PR TITLE
feat(babel-preset-expo): Fork deep warnings plugin and exclude node modules

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Remove Babel value-imports instead only relying on types and the `@babel/core` instance passed to the preset and plugins ([#38171](https://github.com/expo/expo/pull/38171) by [@kitten](https://github.com/kitten))
 - Updated test snapshot. ([#38430](https://github.com/expo/expo/pull/38430) by [@kudo](https://github.com/kudo))
 - Replace `react-refresh` dependency with peer dependency fulfilled by `expo` ([#38562](https://github.com/expo/expo/pull/38562) by [@kitten](https://github.com/kitten))
+- Fork React Native's deep import warnings and redirect `disableDeepImportWarnings` option while disabling warnings for Node modules ([#38598](https://github.com/expo/expo/pull/38598) by [@kitten](https://github.com/kitten))
 
 ### ⚠️ Notices
 

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -193,7 +193,7 @@ function babelPresetExpo(api, options = {}) {
         extraPlugins.push([require('./detect-dynamic-exports').detectDynamicExports]);
     }
     // NOTE(@kitten): Forked from `@react-native/babel-preset`'s warning plugin
-    // We add exceptions to this plugin to ignore Expo sources
+    // We only allow warnings on modules that aren't in node modules
     if (isDev && !platformOptions.disableDeepImportWarnings) {
         extraPlugins.push(react_native_warn_on_deep_imports_plugin_1.reactNativeWarnOnDeepImportsPlugin);
     }

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -8,6 +8,7 @@ const expo_router_plugin_1 = require("./expo-router-plugin");
 const import_meta_transform_plugin_1 = require("./import-meta-transform-plugin");
 const inline_env_vars_1 = require("./inline-env-vars");
 const lazyImports_1 = require("./lazyImports");
+const react_native_warn_on_deep_imports_plugin_1 = require("./react-native-warn-on-deep-imports-plugin");
 const restricted_react_api_plugin_1 = require("./restricted-react-api-plugin");
 const server_actions_plugin_1 = require("./server-actions-plugin");
 const use_dom_directive_plugin_1 = require("./use-dom-directive-plugin");
@@ -191,6 +192,11 @@ function babelPresetExpo(api, options = {}) {
     if (platformOptions.disableImportExportTransform) {
         extraPlugins.push([require('./detect-dynamic-exports').detectDynamicExports]);
     }
+    // NOTE(@kitten): Forked from `@react-native/babel-preset`'s warning plugin
+    // We add exceptions to this plugin to ignore Expo sources
+    if (isDev && !platformOptions.disableDeepImportWarnings) {
+        extraPlugins.push(react_native_warn_on_deep_imports_plugin_1.reactNativeWarnOnDeepImportsPlugin);
+    }
     const polyfillImportMeta = platformOptions.unstable_transformImportMeta ?? isServerEnv;
     extraPlugins.push((0, import_meta_transform_plugin_1.expoImportMetaTransformPluginFactory)(polyfillImportMeta === true));
     return {
@@ -215,7 +221,7 @@ function babelPresetExpo(api, options = {}) {
                     // https://github.com/facebook/react-native/blob/a4a8695cec640e5cf12be36a0c871115fbce9c87/packages/react-native-babel-preset/src/configs/main.js#L151
                     withDevTools: false,
                     disableImportExportTransform: platformOptions.disableImportExportTransform,
-                    disableDeepImportWarnings: platformOptions.disableDeepImportWarnings,
+                    disableDeepImportWarnings: true, // See above for forked version of this option/plugin
                     lazyImportExportTransform: lazyImportsOption === true
                         ? (importModuleSpecifier) => {
                             // Do not lazy-initialize packages that are local imports (similar to `lazy: true`

--- a/packages/babel-preset-expo/build/react-native-warn-on-deep-imports-plugin.d.ts
+++ b/packages/babel-preset-expo/build/react-native-warn-on-deep-imports-plugin.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright © 2024 650 Industries.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import type { ConfigAPI, PluginObj, types as t } from '@babel/core';
+interface ImportRef {
+    source: string;
+    loc?: t.SourceLocation | null;
+}
+interface State {
+    filename: string;
+    isExcluded: boolean;
+    require: ImportRef[];
+    import: ImportRef[];
+    export: ImportRef[];
+}
+export declare const reactNativeWarnOnDeepImportsPlugin: ({ types: t, caller, }: ConfigAPI & typeof import("@babel/core")) => PluginObj<State>;
+export {};

--- a/packages/babel-preset-expo/build/react-native-warn-on-deep-imports-plugin.js
+++ b/packages/babel-preset-expo/build/react-native-warn-on-deep-imports-plugin.js
@@ -1,0 +1,102 @@
+"use strict";
+/**
+ * Copyright © 2024 650 Industries.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.reactNativeWarnOnDeepImportsPlugin = void 0;
+const common_1 = require("./common");
+function getWarningMessage(importPath, loc, source) {
+    const message = `Deep imports from the 'react-native' package are deprecated ('${importPath}').`;
+    if (source !== undefined) {
+        return `${message} Source: ${source} ${loc ? `${loc.start.line}:${loc.start.column}` : ''}`;
+    }
+    return message;
+}
+function createWarning(t, importPath, loc, source) {
+    const warningMessage = getWarningMessage(importPath, loc, source);
+    const warning = t.expressionStatement(t.callExpression(t.memberExpression(t.identifier('console'), t.identifier('warn')), [
+        t.stringLiteral(warningMessage),
+    ]));
+    return warning;
+}
+function isDeepReactNativeImport(source) {
+    const parts = source.split('/');
+    return parts.length > 1 && parts[0] === 'react-native';
+}
+function isInitializeCoreImport(source) {
+    return source === 'react-native/Libraries/Core/InitializeCore';
+}
+function withLocation(node, loc) {
+    if (!node.loc) {
+        return { ...node, loc };
+    }
+    return node;
+}
+const reactNativeWarnOnDeepImportsPlugin = ({ types: t, caller, }) => {
+    const isNodeModule = caller(common_1.getIsNodeModule);
+    return {
+        name: 'warn-on-deep-imports',
+        visitor: {
+            ImportDeclaration(path, state) {
+                const source = path.node.source.value;
+                if (!state.isExcluded &&
+                    isDeepReactNativeImport(source) &&
+                    !isInitializeCoreImport(source)) {
+                    const loc = path.node.loc;
+                    state.import.push({ source, loc });
+                }
+            },
+            CallExpression(path, state) {
+                const callee = path.get('callee');
+                const args = path.get('arguments');
+                if (!state.isExcluded &&
+                    callee.isIdentifier({ name: 'require' }) &&
+                    args.length === 1 &&
+                    args[0].isStringLiteral()) {
+                    const source = args[0].node.type === 'StringLiteral' ? args[0].node.value : '';
+                    if (isDeepReactNativeImport(source) && !isInitializeCoreImport(source)) {
+                        const loc = path.node.loc;
+                        state.require.push({ source, loc });
+                    }
+                }
+            },
+            ExportNamedDeclaration(path, state) {
+                const source = path.node.source;
+                if (source &&
+                    !state.isExcluded &&
+                    isDeepReactNativeImport(source.value) &&
+                    !isInitializeCoreImport(source.value) // NOTE: This contained a bug before (source v source.value)
+                ) {
+                    const loc = path.node.loc;
+                    state.export.push({ source: source.value, loc });
+                }
+            },
+            Program: {
+                enter(_path, state) {
+                    // NOTE(@kitten): We don't output warnings for node modules to the user
+                    // That's because users can do very little about these warnings, and it's redundant to show warnings to users, rather than library maintainers
+                    state.isExcluded = isNodeModule;
+                    state.require = [];
+                    state.import = [];
+                    state.export = [];
+                },
+                exit(path, state) {
+                    const { body } = path.node;
+                    if (state.isExcluded) {
+                        return;
+                    }
+                    const requireWarnings = state.require.map((value) => withLocation(createWarning(t, value.source, value.loc, state.filename), value.loc));
+                    const importWarnings = state.import.map((value) => withLocation(createWarning(t, value.source, value.loc, state.filename), value.loc));
+                    const exportWarnings = state.export.map((value) => withLocation(createWarning(t, value.source, value.loc, state.filename), value.loc));
+                    const warnings = [...requireWarnings, ...importWarnings, ...exportWarnings];
+                    body.push(...warnings);
+                },
+            },
+        },
+    };
+};
+exports.reactNativeWarnOnDeepImportsPlugin = reactNativeWarnOnDeepImportsPlugin;

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -350,7 +350,7 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
   }
 
   // NOTE(@kitten): Forked from `@react-native/babel-preset`'s warning plugin
-  // We add exceptions to this plugin to ignore Expo sources
+  // We only allow warnings on modules that aren't in node modules
   if (isDev && !platformOptions.disableDeepImportWarnings) {
     extraPlugins.push(reactNativeWarnOnDeepImportsPlugin);
   }

--- a/packages/babel-preset-expo/src/react-native-warn-on-deep-imports-plugin.ts
+++ b/packages/babel-preset-expo/src/react-native-warn-on-deep-imports-plugin.ts
@@ -1,0 +1,157 @@
+/**
+ * Copyright © 2024 650 Industries.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Original: https://github.com/facebook/react-native/blob/00175bd/packages/react-native-babel-preset/src/plugin-warn-on-deep-imports.js#L106
+
+import type { ConfigAPI, PluginObj, types as t } from '@babel/core';
+
+function getWarningMessage(
+  importPath: string,
+  loc: t.SourceLocation | undefined | null,
+  source: string,
+) {
+  const message = `Deep imports from the 'react-native' package are deprecated ('${importPath}').`;
+
+  if (source !== undefined) {
+    return `${message} Source: ${source} ${loc ? `${loc.start.line}:${loc.start.column}` : ''}`;
+  }
+
+  return message;
+}
+
+function createWarning(
+  t: typeof import('@babel/types'),
+  importPath: string,
+  loc: t.SourceLocation | undefined | null,
+  source: string
+) {
+  const warningMessage = getWarningMessage(importPath, loc, source);
+
+  const warning = t.expressionStatement(
+    t.callExpression(
+      t.memberExpression(t.identifier('console'), t.identifier('warn')),
+      [t.stringLiteral(warningMessage)],
+    ),
+  );
+
+  return warning;
+}
+
+function isDeepReactNativeImport(source: string) {
+  const parts = source.split('/');
+  return parts.length > 1 && parts[0] === 'react-native';
+}
+
+function isInitializeCoreImport(source: string) {
+  return source === 'react-native/Libraries/Core/InitializeCore';
+}
+
+function withLocation<T extends t.Node>(node: T, loc: t.SourceLocation | null | undefined): T {
+  if (!node.loc) {
+    return {...node, loc};
+  }
+  return node;
+}
+
+interface ImportRef {
+  source: string;
+  loc?: t.SourceLocation | null;
+}
+
+interface State {
+  filename: string;
+  require: ImportRef[];
+  import: ImportRef[];
+  export: ImportRef[];
+}
+
+export const reactNativeWarnOnDeepImportsPlugin =
+  ({ types: t }: ConfigAPI & typeof import('@babel/core')): PluginObj<State> => ({
+  name: 'warn-on-deep-imports',
+  visitor: {
+    ImportDeclaration(path, state) {
+      const source = path.node.source.value;
+
+      if (isDeepReactNativeImport(source) && !isInitializeCoreImport(source)) {
+        const loc = path.node.loc;
+        state.import.push({source, loc});
+      }
+    },
+    CallExpression(path, state) {
+      const callee = path.get('callee');
+      const args = path.get('arguments');
+
+      if (
+        callee.isIdentifier({name: 'require'}) &&
+        args.length === 1 &&
+        args[0].isStringLiteral()
+      ) {
+        const source =
+          args[0].node.type === 'StringLiteral' ? args[0].node.value : '';
+        if (
+          isDeepReactNativeImport(source) &&
+          !isInitializeCoreImport(source)
+        ) {
+          const loc = path.node.loc;
+          state.require.push({source, loc});
+        }
+      }
+    },
+    ExportNamedDeclaration(path, state) {
+      const source = path.node.source;
+
+      if (
+        source &&
+        isDeepReactNativeImport(source.value) &&
+        !isInitializeCoreImport(source.value) // NOTE: This contained a bug before (source v source.value)
+      ) {
+        const loc = path.node.loc;
+        state.export.push({source: source.value, loc});
+      }
+    },
+    Program: {
+      enter(path, state) {
+        state.require = [];
+        state.import = [];
+        state.export = [];
+      },
+      exit(path, state) {
+        const {body} = path.node;
+
+        const requireWarnings = state.require.map(value =>
+          withLocation(
+            createWarning(t, value.source, value.loc, state.filename),
+            value.loc,
+          ),
+        );
+
+        const importWarnings = state.import.map(value =>
+          withLocation(
+            createWarning(t, value.source, value.loc, state.filename),
+            value.loc,
+          ),
+        );
+
+        const exportWarnings = state.export.map(value =>
+          withLocation(
+            createWarning(t, value.source, value.loc, state.filename),
+            value.loc,
+          ),
+        );
+
+        const warnings = [
+          ...requireWarnings,
+          ...importWarnings,
+          ...exportWarnings,
+        ];
+
+        body.push(...warnings);
+      },
+    },
+  },
+});

--- a/packages/babel-preset-expo/src/react-native-warn-on-deep-imports-plugin.ts
+++ b/packages/babel-preset-expo/src/react-native-warn-on-deep-imports-plugin.ts
@@ -73,18 +73,6 @@ interface State {
   export: ImportRef[];
 }
 
-// NOTE(@kitten): We don't output warnings for these modules to the user
-// That's because users can do very little about these warnings, and it's redundant to show it to them, rather than the library maintainers
-const EXCLUDED_MODULES = [
-  '/@react-native/virtualized-lists/',
-  '/react-native-screens/',
-  '/react-native-safe-area-context/',
-  '/expo-asset/',
-  '/expo-router/',
-  '/@expo/',
-  '/expo/',
-];
-
 export const reactNativeWarnOnDeepImportsPlugin =
   ({ types: t, caller }: ConfigAPI & typeof import('@babel/core')): PluginObj<State> => {
   const isNodeModule = caller(getIsNodeModule);
@@ -135,7 +123,9 @@ export const reactNativeWarnOnDeepImportsPlugin =
       },
       Program: {
         enter(_path, state) {
-          state.isExcluded = isNodeModule && EXCLUDED_MODULES.some((exclusion) => state.filename.includes(exclusion));
+          // NOTE(@kitten): We don't output warnings for node modules to the user
+          // That's because users can do very little about these warnings, and it's redundant to show warnings to users, rather than library maintainers
+          state.isExcluded = isNodeModule;
           state.require = [];
           state.import = [];
           state.export = [];


### PR DESCRIPTION
# Why

This is an alternative approach to: https://github.com/expo/expo/pull/38588
Basically, we can prevent warnings for deep imports to `react-native`, which are usually output via `@react-native/babel-preset`'s deep warnings plugin by forking the plugin and excluding all Node modules.

Users can do very little about these warnings and spamming them with any warnings that are meant for library authors feels like it'd be detrimental to DX. We can, in the future, remove this warning and have our own in `@expo/cli` via the resolver. Having this in the Babel preset however will affect all users too aggressively.

Users generally cannot do anything about these warnings except to contribute or open an issue. But since users outnumber library authors by a lot, and many users wouldn't understand the purpose of the warning, it's better to disable it for now for Node modules imo

# How

- Fork `@react-native/babel-preset`'s deep warnings plugin
- Always pass `disableDeepImportWarnings: true` to `@react-native/babel-preset`
- Exclude Node modules in our own fork
- Respect `disableDeepImportWarnings` to disable the forked plugin

I originally kept a list of `EXCLUDE_MODULES` which contained only some modules, but I don't think the warning should be shown for any Node module, since there's not much actionable users can do. For library authors, if they're testing against React Native, they'll see it anyway.

# Test Plan

- Run any sample in `apps/router-e2e`
- Warnings will still be output for in-monorepo redirected packages but not for dependencies (e.g. `react-native-screens`)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
