### PR TITLE
fix(babel-preset-expo): Add explicit optional reverse peer dependency on `expo` for `expo/config` loading

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Remove Babel value-imports instead only relying on types and the `@babel/core` instance passed to the preset and plugins ([#38171](https://github.com/expo/expo/pull/38171) by [@kitten](https://github.com/kitten))
 - Updated test snapshot. ([#38430](https://github.com/expo/expo/pull/38430) by [@kudo](https://github.com/kudo))
 - Replace `react-refresh` dependency with peer dependency fulfilled by `expo` ([#38562](https://github.com/expo/expo/pull/38562) by [@kitten](https://github.com/kitten))
+- Add optional reverse peer dependency on `expo` (for inline-manifest plugin) ([#38600](https://github.com/expo/expo/pull/38600) by [@kitten](https://github.com/kitten))
 
 ### ⚠️ Notices
 

--- a/packages/babel-preset-expo/build/expo-inline-manifest-plugin.js
+++ b/packages/babel-preset-expo/build/expo-inline-manifest-plugin.js
@@ -1,7 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.expoInlineManifestPlugin = expoInlineManifestPlugin;
-const config_1 = require("expo/config");
 const common_1 = require("./common");
 const debug = require('debug')('expo:babel:inline-manifest');
 // Convert expo value to PWA value
@@ -29,18 +28,19 @@ const RESTRICTED_MANIFEST_FIELDS = [
     'assetBundlePatterns',
 ];
 function getExpoConstantsManifest(projectRoot) {
-    const { exp } = getConfigMemo(projectRoot);
-    const manifest = applyWebDefaults(exp);
+    const config = getConfigMemo(projectRoot);
+    if (!config)
+        return null;
+    const manifest = applyWebDefaults(config);
     for (const field of RESTRICTED_MANIFEST_FIELDS) {
         delete manifest[field];
     }
     return manifest;
 }
-function applyWebDefaults(appJSON) {
+function applyWebDefaults({ config, appName, webName }) {
+    const appJSON = config.exp;
     // For RN CLI support
     const { web: webManifest = {}, splash = {}, ios = {}, android = {} } = appJSON;
-    // rn-cli apps use a displayName value as well.
-    const { appName, webName } = (0, config_1.getNameFromConfig)(appJSON);
     const languageISOCode = webManifest.lang;
     const primaryColor = appJSON.primaryColor;
     const description = appJSON.description;
@@ -97,18 +97,42 @@ function getExpoAppManifest(projectRoot) {
         return process.env.APP_MANIFEST;
     }
     const exp = getExpoConstantsManifest(projectRoot);
-    debug('public manifest', exp);
-    return JSON.stringify(exp);
+    if (exp) {
+        debug('public manifest', exp);
+        return JSON.stringify(exp);
+    }
+    else {
+        debug('public manifest is null. `expo/config` is not available');
+        return null;
+    }
 }
-let config;
+let configMemo;
 function getConfigMemo(projectRoot) {
-    if (!config) {
-        config = (0, config_1.getConfig)(projectRoot, {
+    if (configMemo === undefined) {
+        let expoConfig;
+        try {
+            // This is an optional dependency. In practice, it will resolve in all Expo projects/apps
+            // since `expo` is a direct dependency in those. If `babel-preset-expo` is used independently
+            // this will fail and we won't return a config
+            expoConfig = require('expo/config');
+        }
+        catch {
+            return (configMemo = null);
+        }
+        const { getConfig, getNameFromConfig } = expoConfig;
+        const config = getConfig(projectRoot, {
             isPublicConfig: true,
             skipSDKVersionRequirement: true,
         });
+        // rn-cli apps use a displayName value as well.
+        const { appName, webName } = getNameFromConfig(config);
+        configMemo = {
+            config,
+            appName,
+            webName,
+        };
     }
-    return config;
+    return configMemo;
 }
 // Convert `process.env.APP_MANIFEST` to a modified web-specific variation of the app.json public manifest.
 function expoInlineManifestPlugin(api) {
@@ -142,7 +166,9 @@ function expoInlineManifestPlugin(api) {
                 }) &&
                     !parent.parentPath.isAssignmentExpression()) {
                     const manifest = getExpoAppManifest(projectRoot);
-                    parent.replaceWith(t.stringLiteral(manifest));
+                    if (manifest !== null) {
+                        parent.replaceWith(t.stringLiteral(manifest));
+                    }
                 }
             },
         },

--- a/packages/babel-preset-expo/build/expo-inline-manifest-plugin.js
+++ b/packages/babel-preset-expo/build/expo-inline-manifest-plugin.js
@@ -116,8 +116,11 @@ function getConfigMemo(projectRoot) {
             // this will fail and we won't return a config
             expoConfig = require('expo/config');
         }
-        catch {
-            return (configMemo = null);
+        catch (error) {
+            if ('code' in error && error.code === 'MODULE_NOT_FOUND') {
+                return (configMemo = null);
+            }
+            throw error;
         }
         const { getConfig, getNameFromConfig } = expoConfig;
         const config = getConfig(projectRoot, {

--- a/packages/babel-preset-expo/build/expo-inline-manifest-plugin.js
+++ b/packages/babel-preset-expo/build/expo-inline-manifest-plugin.js
@@ -128,7 +128,7 @@ function getConfigMemo(projectRoot) {
             skipSDKVersionRequirement: true,
         });
         // rn-cli apps use a displayName value as well.
-        const { appName, webName } = getNameFromConfig(config);
+        const { appName, webName } = getNameFromConfig(config.exp);
         configMemo = {
             config,
             appName,

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -41,7 +41,13 @@
     "extends": "universe/node"
   },
   "peerDependencies": {
-    "react-refresh": ">=0.14.0 <1.0.0"
+    "react-refresh": ">=0.14.0 <1.0.0",
+    "expo": "*"
+  },
+  "peerDependenciesMeta": {
+    "expo": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@babel/helper-module-imports": "^7.25.9",

--- a/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
+++ b/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
@@ -1,5 +1,5 @@
 import type { ConfigAPI, PluginObj } from '@babel/core';
-import { ExpoConfig, getConfig, getNameFromConfig, ProjectConfig } from 'expo/config';
+import type { ExpoConfig, ProjectConfig } from 'expo/config';
 
 import { getIsReactServer, getPlatform, getPossibleProjectRoot } from './common';
 
@@ -32,18 +32,18 @@ const RESTRICTED_MANIFEST_FIELDS: (keyof ExpoConfig)[] = [
 ];
 
 function getExpoConstantsManifest(projectRoot: string) {
-  const { exp } = getConfigMemo(projectRoot);
-  const manifest = applyWebDefaults(exp);
+  const config = getConfigMemo(projectRoot);
+  if (!config) return null;
+  const manifest = applyWebDefaults(config);
   for (const field of RESTRICTED_MANIFEST_FIELDS) {
     delete manifest[field];
   }
   return manifest;
 }
-function applyWebDefaults(appJSON: ExpoConfig) {
+function applyWebDefaults({ config, appName, webName }: ConfigMemo) {
+  const appJSON: ExpoConfig = config.exp;
   // For RN CLI support
   const { web: webManifest = {}, splash = {}, ios = {}, android = {} } = appJSON;
-  // rn-cli apps use a displayName value as well.
-  const { appName, webName } = getNameFromConfig(appJSON);
   const languageISOCode = webManifest.lang;
   const primaryColor = appJSON.primaryColor;
   const description = appJSON.description;
@@ -102,22 +102,48 @@ function getExpoAppManifest(projectRoot: string) {
   }
 
   const exp = getExpoConstantsManifest(projectRoot);
-
-  debug('public manifest', exp);
-
-  return JSON.stringify(exp);
+  if (exp) {
+    debug('public manifest', exp);
+    return JSON.stringify(exp);
+  } else {
+    debug('public manifest is null. `expo/config` is not available');
+    return null;
+  }
 }
 
-let config: undefined | ProjectConfig;
+interface ConfigMemo {
+  config: ProjectConfig;
+  appName: string | undefined;
+  webName: string | undefined;
+}
 
-function getConfigMemo(projectRoot: string) {
-  if (!config) {
-    config = getConfig(projectRoot, {
+let configMemo: undefined | null | ConfigMemo;
+
+function getConfigMemo(projectRoot: string): ConfigMemo | null {
+  if (configMemo === undefined) {
+    let expoConfig: typeof import('expo/config');
+    try {
+      // This is an optional dependency. In practice, it will resolve in all Expo projects/apps
+      // since `expo` is a direct dependency in those. If `babel-preset-expo` is used independently
+      // this will fail and we won't return a config
+      expoConfig = require('expo/config');
+    } catch {
+      return (configMemo = null);
+    }
+    const { getConfig, getNameFromConfig } = expoConfig;
+    const config = getConfig(projectRoot, {
       isPublicConfig: true,
       skipSDKVersionRequirement: true,
     });
+    // rn-cli apps use a displayName value as well.
+    const { appName, webName } = getNameFromConfig(config);
+    configMemo = {
+      config,
+      appName,
+      webName,
+    };
   }
-  return config;
+  return configMemo;
 }
 
 // Convert `process.env.APP_MANIFEST` to a modified web-specific variation of the app.json public manifest.
@@ -160,7 +186,9 @@ export function expoInlineManifestPlugin(api: ConfigAPI & typeof import('@babel/
           !parent.parentPath.isAssignmentExpression()
         ) {
           const manifest = getExpoAppManifest(projectRoot);
-          parent.replaceWith(t.stringLiteral(manifest));
+          if (manifest !== null) {
+            parent.replaceWith(t.stringLiteral(manifest));
+          }
         }
       },
     },

--- a/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
+++ b/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
@@ -127,8 +127,11 @@ function getConfigMemo(projectRoot: string): ConfigMemo | null {
       // since `expo` is a direct dependency in those. If `babel-preset-expo` is used independently
       // this will fail and we won't return a config
       expoConfig = require('expo/config');
-    } catch {
-      return (configMemo = null);
+    } catch (error: any) {
+      if ('code' in error && error.code === 'MODULE_NOT_FOUND') {
+        return (configMemo = null);
+      }
+      throw error;
     }
     const { getConfig, getNameFromConfig } = expoConfig;
     const config = getConfig(projectRoot, {

--- a/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
+++ b/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
@@ -139,7 +139,7 @@ function getConfigMemo(projectRoot: string): ConfigMemo | null {
       skipSDKVersionRequirement: true,
     });
     // rn-cli apps use a displayName value as well.
-    const { appName, webName } = getNameFromConfig(config);
+    const { appName, webName } = getNameFromConfig(config.exp);
     configMemo = {
       config,
       appName,

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -83,7 +83,6 @@ const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | v
     '@expo/metro-config/build/babel-transformer': 'types-only',
     'react-native-worklets/plugin': 'ignore-dev', // Checked via hasModule before requiring
     'react-native-reanimated/plugin': 'ignore-dev', // Checked via hasModule before requiring
-    'expo/config': 'ignore-dev', // WARN: May need a reverse peer dependency
   },
 };
 


### PR DESCRIPTION
# Why

A common failure case with Yarn Berry is that dependencies are hoisted past their dependents. This may happen more frequently with it because it opts to have a bottom-up hoister that may abort hoisting if any check-condition fails. Specifically, it may decide to start hoisting `babel-preset-expo` past `expo` (in a monorepo), but not hoist `expo`.

The dependency on `expo/config` may also be an issue in `babel-preset-expo`, if `babel-preset-expo` is used independently. We can gracefully skip this plugin as well for those cases. This is technically not supported, but the plugin feels like it shouldn't be in `babel-preset-expo` in that case and instead in `@expo/metro-config` or `@expo/cli`.

Either way, we'd like to establish a correct (reverse) dependency chain from `babel-preset-expo` to `expo`. In this case it's marked as optional since this is a bit of an edge case.

# How

- Add optional (reverse) peer dependency on `expo` to `babel-preset-expo`
- Refactor `expo-inline-manifest-plugin` to lazily require `expo/config` and to handle errors by defaulting to skipping its logic

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
