### PR TITLE
fix(@expo/cli): resolve extensionless routes as HTML in static server

### DIFF
--- a/apps/router-e2e/__e2e__/static-rendering/app/[post].tsx
+++ b/apps/router-e2e/__e2e__/static-rendering/app/[post].tsx
@@ -7,5 +7,5 @@ export async function generateStaticParams() {
 
 export default function Post() {
   const params = useGlobalSearchParams();
-  return <Text>Post: {params.post}</Text>;
+  return <Text testID="post-text">Post: {params.post}</Text>;
 }

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fix processing circular dependencies for inverse dependency resolver stack trace ([#38414](https://github.com/expo/expo/pull/38414) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Run prebuild only for the platforms specified in app config (if listed). ([#31752](https://github.com/expo/expo/pull/31752) by [@prathameshmm02](https://github.com/prathameshmm02))
 - Improve API Routes development errors (remove duplicates and misleading stack traces) ([#38465](https://github.com/expo/expo/pull/38465) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+- Resolve extensionless routes as HTML in static server ([#38610](https://github.com/expo/expo/pull/38610) by [@hassankhan](https://github.com/hassankhan))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/e2e/__tests__/utils.ts
+++ b/packages/@expo/cli/e2e/__tests__/utils.ts
@@ -242,6 +242,10 @@ export async function getPageHtml(output: string, route: string) {
   return htmlParser.parse(await getPage(output, route));
 }
 
+export function getHtml(html: string) {
+  return htmlParser.parse(html);
+}
+
 export function getRouterE2ERoot(): string {
   return path.join(__dirname, '../../../../../apps/router-e2e');
 }

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -66,6 +66,7 @@ async function startStaticServerAsync(dist: string, options: Options) {
     send(req, filePath, {
       root: dist,
       index: 'index.html',
+      extensions: ['html'],
     })
       .on('error', (err: any) => {
         if (err.status === 404) {


### PR DESCRIPTION
# Why

The static server in `@expo/server` was returning 404 errors when accessing routes without the `.html` extension (e.g., `/styled` instead of `/styled.html`). This made the static export behavior inconsistent with typical web
  server conventions where extensionless routes would resolve to their HTML files.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Added `extensions: ['html']` to the `send()` configuration in `startStaticServerAsync()`. 

The E2E test now uses `expo serve` (instead of `npx serve`) and has been improved to properly test the served HTML output.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Local testing + CI

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
