### PR TITLE
[sdk54] Update react-native-keyboard-controller to version 1.18.3

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2518,7 +2518,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-keyboard-controller (1.18.2):
+  - react-native-keyboard-controller (1.18.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2536,7 +2536,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-keyboard-controller/common (= 1.18.2)
+    - react-native-keyboard-controller/common (= 1.18.3)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2547,7 +2547,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-keyboard-controller/common (1.18.2):
+  - react-native-keyboard-controller/common (1.18.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -4538,7 +4538,7 @@ SPEC CHECKSUMS:
   React-logger: 3903016c02ae4dff7387d028501a3b03ba72879d
   React-Mapbuffer: 48d6d8d0361ab4be5a7b4825006ddfff5e3686ec
   React-microtasksnativemodule: bd7cfbd456840ebd272edad86b0e09595f2c80d5
-  react-native-keyboard-controller: 2ea75136c309c43b5f1b9b02e332628e80c8d936
+  react-native-keyboard-controller: bf7ec487800e1283b95532d1259bde1fdf7c4bd5
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: 5aa9fb30444ca4bbe382991b6783cc014ed5ca07
   react-native-safe-area-context: 5d8c627bc6296d018625948364c1a02d50d11bd4

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -67,7 +67,7 @@
     "react-native": "0.81.0-rc.5",
     "react-native-edge-to-edge": "~1.6.1",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-keyboard-controller": "^1.18.2",
+    "react-native-keyboard-controller": "^1.18.3",
     "react-native-pager-view": "6.8.1",
     "react-native-worklets": "0.4.1",
     "react-native-reanimated": "4.0.1",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -363,7 +363,7 @@ PODS:
   - EXUpdatesInterface (1.1.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.81.0-rc.5)
+  - FBLazyVector (0.81.0-rc.3)
   - FirebaseAnalytics (11.11.0):
     - FirebaseAnalytics/AdIdSupport (= 11.11.0)
     - FirebaseCore (~> 11.11.0)
@@ -484,17 +484,17 @@ PODS:
   - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - hermes-engine (0.81.0-rc.5):
-    - hermes-engine/cdp (= 0.81.0-rc.5)
-    - hermes-engine/Hermes (= 0.81.0-rc.5)
-    - hermes-engine/inspector (= 0.81.0-rc.5)
-    - hermes-engine/inspector_chrome (= 0.81.0-rc.5)
-    - hermes-engine/Public (= 0.81.0-rc.5)
-  - hermes-engine/cdp (0.81.0-rc.5)
-  - hermes-engine/Hermes (0.81.0-rc.5)
-  - hermes-engine/inspector (0.81.0-rc.5)
-  - hermes-engine/inspector_chrome (0.81.0-rc.5)
-  - hermes-engine/Public (0.81.0-rc.5)
+  - hermes-engine (0.81.0-rc.3):
+    - hermes-engine/cdp (= 0.81.0-rc.3)
+    - hermes-engine/Hermes (= 0.81.0-rc.3)
+    - hermes-engine/inspector (= 0.81.0-rc.3)
+    - hermes-engine/inspector_chrome (= 0.81.0-rc.3)
+    - hermes-engine/Public (= 0.81.0-rc.3)
+  - hermes-engine/cdp (0.81.0-rc.3)
+  - hermes-engine/Hermes (0.81.0-rc.3)
+  - hermes-engine/inspector (0.81.0-rc.3)
+  - hermes-engine/inspector_chrome (0.81.0-rc.3)
+  - hermes-engine/Public (0.81.0-rc.3)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -572,28 +572,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.81.0-rc.5)
-  - RCTRequired (0.81.0-rc.5)
-  - RCTTypeSafety (0.81.0-rc.5):
-    - FBLazyVector (= 0.81.0-rc.5)
-    - RCTRequired (= 0.81.0-rc.5)
-    - React-Core (= 0.81.0-rc.5)
+  - RCTDeprecation (0.81.0-rc.3)
+  - RCTRequired (0.81.0-rc.3)
+  - RCTTypeSafety (0.81.0-rc.3):
+    - FBLazyVector (= 0.81.0-rc.3)
+    - RCTRequired (= 0.81.0-rc.3)
+    - React-Core (= 0.81.0-rc.3)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.0-rc.5):
-    - React-Core (= 0.81.0-rc.5)
-    - React-Core/DevSupport (= 0.81.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.81.0-rc.5)
-    - React-RCTActionSheet (= 0.81.0-rc.5)
-    - React-RCTAnimation (= 0.81.0-rc.5)
-    - React-RCTBlob (= 0.81.0-rc.5)
-    - React-RCTImage (= 0.81.0-rc.5)
-    - React-RCTLinking (= 0.81.0-rc.5)
-    - React-RCTNetwork (= 0.81.0-rc.5)
-    - React-RCTSettings (= 0.81.0-rc.5)
-    - React-RCTText (= 0.81.0-rc.5)
-    - React-RCTVibration (= 0.81.0-rc.5)
-  - React-callinvoker (0.81.0-rc.5)
-  - React-Core (0.81.0-rc.5):
+  - React (0.81.0-rc.3):
+    - React-Core (= 0.81.0-rc.3)
+    - React-Core/DevSupport (= 0.81.0-rc.3)
+    - React-Core/RCTWebSocket (= 0.81.0-rc.3)
+    - React-RCTActionSheet (= 0.81.0-rc.3)
+    - React-RCTAnimation (= 0.81.0-rc.3)
+    - React-RCTBlob (= 0.81.0-rc.3)
+    - React-RCTImage (= 0.81.0-rc.3)
+    - React-RCTLinking (= 0.81.0-rc.3)
+    - React-RCTNetwork (= 0.81.0-rc.3)
+    - React-RCTSettings (= 0.81.0-rc.3)
+    - React-RCTText (= 0.81.0-rc.3)
+    - React-RCTVibration (= 0.81.0-rc.3)
+  - React-callinvoker (0.81.0-rc.3)
+  - React-Core (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -603,7 +603,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.5)
+    - React-Core/Default (= 0.81.0-rc.3)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -618,82 +618,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.81.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.81.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.81.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.5)
-    - React-Core/RCTWebSocket (= 0.81.0-rc.5)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.0-rc.5):
+  - React-Core/CoreModulesHeaders (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -718,7 +643,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.0-rc.5):
+  - React-Core/Default (0.81.0-rc.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.81.0-rc.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.0-rc.3)
+    - React-Core/RCTWebSocket (= 0.81.0-rc.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -743,7 +718,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.0-rc.5):
+  - React-Core/RCTAnimationHeaders (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -768,7 +743,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.0-rc.5):
+  - React-Core/RCTBlobHeaders (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -793,7 +768,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.0-rc.5):
+  - React-Core/RCTImageHeaders (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -818,7 +793,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.0-rc.5):
+  - React-Core/RCTLinkingHeaders (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -843,7 +818,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.0-rc.5):
+  - React-Core/RCTNetworkHeaders (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -868,7 +843,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.0-rc.5):
+  - React-Core/RCTSettingsHeaders (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -893,7 +868,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.0-rc.5):
+  - React-Core/RCTTextHeaders (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -918,7 +893,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.81.0-rc.5):
+  - React-Core/RCTVibrationHeaders (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -928,7 +903,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.0-rc.5)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -943,7 +918,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.81.0-rc.5):
+  - React-Core/RCTWebSocket (0.81.0-rc.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.0-rc.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -951,20 +951,20 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.81.0-rc.5)
-    - React-Core/CoreModulesHeaders (= 0.81.0-rc.5)
-    - React-jsi (= 0.81.0-rc.5)
+    - RCTTypeSafety (= 0.81.0-rc.3)
+    - React-Core/CoreModulesHeaders (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.0-rc.5)
+    - React-RCTImage (= 0.81.0-rc.3)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.81.0-rc.5):
+  - React-cxxreact (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -973,19 +973,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.5)
-    - React-debug (= 0.81.0-rc.5)
-    - React-jsi (= 0.81.0-rc.5)
+    - React-callinvoker (= 0.81.0-rc.3)
+    - React-debug (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.0-rc.5)
-    - React-perflogger (= 0.81.0-rc.5)
+    - React-logger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.3)
     - React-runtimeexecutor
-    - React-timing (= 0.81.0-rc.5)
+    - React-timing (= 0.81.0-rc.3)
     - SocketRocket
-  - React-debug (0.81.0-rc.5)
-  - React-defaultsnativemodule (0.81.0-rc.5):
+  - React-debug (0.81.0-rc.3)
+  - React-defaultsnativemodule (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1002,7 +1002,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.81.0-rc.5):
+  - React-domnativemodule (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1022,7 +1022,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.81.0-rc.5):
+  - React-Fabric (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1036,23 +1036,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.0-rc.5)
-    - React-Fabric/attributedstring (= 0.81.0-rc.5)
-    - React-Fabric/bridging (= 0.81.0-rc.5)
-    - React-Fabric/componentregistry (= 0.81.0-rc.5)
-    - React-Fabric/componentregistrynative (= 0.81.0-rc.5)
-    - React-Fabric/components (= 0.81.0-rc.5)
-    - React-Fabric/consistency (= 0.81.0-rc.5)
-    - React-Fabric/core (= 0.81.0-rc.5)
-    - React-Fabric/dom (= 0.81.0-rc.5)
-    - React-Fabric/imagemanager (= 0.81.0-rc.5)
-    - React-Fabric/leakchecker (= 0.81.0-rc.5)
-    - React-Fabric/mounting (= 0.81.0-rc.5)
-    - React-Fabric/observers (= 0.81.0-rc.5)
-    - React-Fabric/scheduler (= 0.81.0-rc.5)
-    - React-Fabric/telemetry (= 0.81.0-rc.5)
-    - React-Fabric/templateprocessor (= 0.81.0-rc.5)
-    - React-Fabric/uimanager (= 0.81.0-rc.5)
+    - React-Fabric/animations (= 0.81.0-rc.3)
+    - React-Fabric/attributedstring (= 0.81.0-rc.3)
+    - React-Fabric/bridging (= 0.81.0-rc.3)
+    - React-Fabric/componentregistry (= 0.81.0-rc.3)
+    - React-Fabric/componentregistrynative (= 0.81.0-rc.3)
+    - React-Fabric/components (= 0.81.0-rc.3)
+    - React-Fabric/consistency (= 0.81.0-rc.3)
+    - React-Fabric/core (= 0.81.0-rc.3)
+    - React-Fabric/dom (= 0.81.0-rc.3)
+    - React-Fabric/imagemanager (= 0.81.0-rc.3)
+    - React-Fabric/leakchecker (= 0.81.0-rc.3)
+    - React-Fabric/mounting (= 0.81.0-rc.3)
+    - React-Fabric/observers (= 0.81.0-rc.3)
+    - React-Fabric/scheduler (= 0.81.0-rc.3)
+    - React-Fabric/telemetry (= 0.81.0-rc.3)
+    - React-Fabric/templateprocessor (= 0.81.0-rc.3)
+    - React-Fabric/uimanager (= 0.81.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1064,32 +1064,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.81.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.81.0-rc.5):
+  - React-Fabric/animations (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1114,7 +1089,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.81.0-rc.5):
+  - React-Fabric/attributedstring (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1139,7 +1114,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.81.0-rc.5):
+  - React-Fabric/bridging (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1164,7 +1139,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.81.0-rc.5):
+  - React-Fabric/componentregistry (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1189,36 +1164,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.81.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.0-rc.5)
-    - React-Fabric/components/root (= 0.81.0-rc.5)
-    - React-Fabric/components/scrollview (= 0.81.0-rc.5)
-    - React-Fabric/components/view (= 0.81.0-rc.5)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.0-rc.5):
+  - React-Fabric/componentregistrynative (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1243,7 +1189,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.81.0-rc.5):
+  - React-Fabric/components (0.81.0-rc.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.0-rc.3)
+    - React-Fabric/components/root (= 0.81.0-rc.3)
+    - React-Fabric/components/scrollview (= 0.81.0-rc.3)
+    - React-Fabric/components/view (= 0.81.0-rc.3)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1268,7 +1243,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.81.0-rc.5):
+  - React-Fabric/components/root (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1293,7 +1268,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.81.0-rc.5):
+  - React-Fabric/components/scrollview (0.81.0-rc.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1320,7 +1320,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.81.0-rc.5):
+  - React-Fabric/consistency (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1345,7 +1345,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.81.0-rc.5):
+  - React-Fabric/core (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1370,7 +1370,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.81.0-rc.5):
+  - React-Fabric/dom (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1395,7 +1395,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.81.0-rc.5):
+  - React-Fabric/imagemanager (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1420,7 +1420,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.81.0-rc.5):
+  - React-Fabric/leakchecker (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1445,7 +1445,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.81.0-rc.5):
+  - React-Fabric/mounting (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1470,7 +1470,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.81.0-rc.5):
+  - React-Fabric/observers (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1484,7 +1484,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.0-rc.5)
+    - React-Fabric/observers/events (= 0.81.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1496,7 +1496,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.81.0-rc.5):
+  - React-Fabric/observers/events (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1521,7 +1521,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.81.0-rc.5):
+  - React-Fabric/scheduler (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1548,7 +1548,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.81.0-rc.5):
+  - React-Fabric/telemetry (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1573,7 +1573,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.81.0-rc.5):
+  - React-Fabric/templateprocessor (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1598,7 +1598,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.81.0-rc.5):
+  - React-Fabric/uimanager (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1612,7 +1612,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.0-rc.5)
+    - React-Fabric/uimanager/consistency (= 0.81.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1625,7 +1625,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.81.0-rc.5):
+  - React-Fabric/uimanager/consistency (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1651,7 +1651,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.81.0-rc.5):
+  - React-FabricComponents (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1666,8 +1666,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.0-rc.5)
-    - React-FabricComponents/textlayoutmanager (= 0.81.0-rc.5)
+    - React-FabricComponents/components (= 0.81.0-rc.3)
+    - React-FabricComponents/textlayoutmanager (= 0.81.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1680,7 +1680,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.81.0-rc.5):
+  - React-FabricComponents/components (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1695,16 +1695,16 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.0-rc.5)
-    - React-FabricComponents/components/iostextinput (= 0.81.0-rc.5)
-    - React-FabricComponents/components/modal (= 0.81.0-rc.5)
-    - React-FabricComponents/components/rncore (= 0.81.0-rc.5)
-    - React-FabricComponents/components/safeareaview (= 0.81.0-rc.5)
-    - React-FabricComponents/components/scrollview (= 0.81.0-rc.5)
-    - React-FabricComponents/components/text (= 0.81.0-rc.5)
-    - React-FabricComponents/components/textinput (= 0.81.0-rc.5)
-    - React-FabricComponents/components/unimplementedview (= 0.81.0-rc.5)
-    - React-FabricComponents/components/virtualview (= 0.81.0-rc.5)
+    - React-FabricComponents/components/inputaccessory (= 0.81.0-rc.3)
+    - React-FabricComponents/components/iostextinput (= 0.81.0-rc.3)
+    - React-FabricComponents/components/modal (= 0.81.0-rc.3)
+    - React-FabricComponents/components/rncore (= 0.81.0-rc.3)
+    - React-FabricComponents/components/safeareaview (= 0.81.0-rc.3)
+    - React-FabricComponents/components/scrollview (= 0.81.0-rc.3)
+    - React-FabricComponents/components/text (= 0.81.0-rc.3)
+    - React-FabricComponents/components/textinput (= 0.81.0-rc.3)
+    - React-FabricComponents/components/unimplementedview (= 0.81.0-rc.3)
+    - React-FabricComponents/components/virtualview (= 0.81.0-rc.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1717,34 +1717,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.0-rc.5):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.0-rc.5):
+  - React-FabricComponents/components/inputaccessory (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1771,7 +1744,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.81.0-rc.5):
+  - React-FabricComponents/components/iostextinput (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1798,7 +1771,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.0-rc.5):
+  - React-FabricComponents/components/modal (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1825,7 +1798,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.0-rc.5):
+  - React-FabricComponents/components/rncore (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1852,7 +1825,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.0-rc.5):
+  - React-FabricComponents/components/safeareaview (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1879,7 +1852,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.81.0-rc.5):
+  - React-FabricComponents/components/scrollview (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1906,7 +1879,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.0-rc.5):
+  - React-FabricComponents/components/text (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1933,7 +1906,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.0-rc.5):
+  - React-FabricComponents/components/textinput (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1960,7 +1933,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.0-rc.5):
+  - React-FabricComponents/components/unimplementedview (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1987,7 +1960,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.0-rc.5):
+  - React-FabricComponents/components/virtualview (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2014,7 +1987,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.81.0-rc.5):
+  - React-FabricComponents/textlayoutmanager (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2023,21 +1996,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.81.0-rc.5)
-    - RCTTypeSafety (= 0.81.0-rc.5)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.81.0-rc.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.81.0-rc.3)
+    - RCTTypeSafety (= 0.81.0-rc.3)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.0-rc.5)
+    - React-jsiexecutor (= 0.81.0-rc.3)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.81.0-rc.5):
+  - React-featureflags (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2046,7 +2046,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.81.0-rc.5):
+  - React-featureflagsnativemodule (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2061,7 +2061,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.81.0-rc.5):
+  - React-graphics (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2074,7 +2074,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.81.0-rc.5):
+  - React-hermes (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2083,16 +2083,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.3)
     - React-jsi
-    - React-jsiexecutor (= 0.81.0-rc.5)
+    - React-jsiexecutor (= 0.81.0-rc.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.3)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.81.0-rc.5):
+  - React-idlecallbacksnativemodule (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2108,7 +2108,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.81.0-rc.5):
+  - React-ImageManager (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2123,7 +2123,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.81.0-rc.5):
+  - React-jserrorhandler (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2138,7 +2138,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.81.0-rc.5):
+  - React-jsi (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2148,7 +2148,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.81.0-rc.5):
+  - React-jsiexecutor (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2157,15 +2157,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.5)
-    - React-jsi (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.3)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.81.0-rc.5):
+  - React-jsinspector (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2179,10 +2179,10 @@ PODS:
     - React-jsinspectorcdp
     - React-jsinspectornetwork
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.0-rc.5)
+    - React-perflogger (= 0.81.0-rc.3)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.81.0-rc.5):
+  - React-jsinspectorcdp (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2191,7 +2191,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.81.0-rc.5):
+  - React-jsinspectornetwork (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2204,7 +2204,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.81.0-rc.5):
+  - React-jsinspectortracing (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2215,7 +2215,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.81.0-rc.5):
+  - React-jsitooling (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2223,16 +2223,16 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.0-rc.5)
-    - React-jsi (= 0.81.0-rc.5)
+    - React-cxxreact (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.81.0-rc.5):
+  - React-jsitracing (0.81.0-rc.3):
     - React-jsi
-  - React-logger (0.81.0-rc.5):
+  - React-logger (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2241,7 +2241,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.81.0-rc.5):
+  - React-Mapbuffer (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2251,7 +2251,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.81.0-rc.5):
+  - React-microtasksnativemodule (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2265,7 +2265,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-keyboard-controller (1.18.2):
+  - react-native-keyboard-controller (1.18.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2283,7 +2283,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-keyboard-controller/common (= 1.18.2)
+    - react-native-keyboard-controller/common (= 1.18.3)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2294,7 +2294,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-keyboard-controller/common (1.18.2):
+  - react-native-keyboard-controller/common (1.18.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2673,7 +2673,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.81.0-rc.5):
+  - React-NativeModulesApple (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2693,8 +2693,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.81.0-rc.5)
-  - React-perflogger (0.81.0-rc.5):
+  - React-oscompat (0.81.0-rc.3)
+  - React-perflogger (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2703,7 +2703,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.81.0-rc.5):
+  - React-performancetimeline (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2716,9 +2716,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.81.0-rc.5):
-    - React-Core/RCTActionSheetHeaders (= 0.81.0-rc.5)
-  - React-RCTAnimation (0.81.0-rc.5):
+  - React-RCTActionSheet (0.81.0-rc.3):
+    - React-Core/RCTActionSheetHeaders (= 0.81.0-rc.3)
+  - React-RCTAnimation (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2734,7 +2734,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.81.0-rc.5):
+  - React-RCTAppDelegate (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2768,7 +2768,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.81.0-rc.5):
+  - React-RCTBlob (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2787,7 +2787,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.81.0-rc.5):
+  - React-RCTFabric (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2822,7 +2822,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.0-rc.5):
+  - React-RCTFBReactNativeSpec (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2836,10 +2836,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.0-rc.5)
+    - React-RCTFBReactNativeSpec/components (= 0.81.0-rc.3)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.81.0-rc.5):
+  - React-RCTFBReactNativeSpec/components (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2862,7 +2862,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.81.0-rc.5):
+  - React-RCTImage (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2878,14 +2878,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.81.0-rc.5):
-    - React-Core/RCTLinkingHeaders (= 0.81.0-rc.5)
-    - React-jsi (= 0.81.0-rc.5)
+  - React-RCTLinking (0.81.0-rc.3):
+    - React-Core/RCTLinkingHeaders (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.3)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.0-rc.5)
-  - React-RCTNetwork (0.81.0-rc.5):
+    - ReactCommon/turbomodule/core (= 0.81.0-rc.3)
+  - React-RCTNetwork (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2903,7 +2903,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.81.0-rc.5):
+  - React-RCTRuntime (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2923,7 +2923,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.81.0-rc.5):
+  - React-RCTSettings (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2938,10 +2938,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.81.0-rc.5):
-    - React-Core/RCTTextHeaders (= 0.81.0-rc.5)
+  - React-RCTText (0.81.0-rc.3):
+    - React-Core/RCTTextHeaders (= 0.81.0-rc.3)
     - Yoga
-  - React-RCTVibration (0.81.0-rc.5):
+  - React-RCTVibration (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2955,11 +2955,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.81.0-rc.5)
-  - React-renderercss (0.81.0-rc.5):
+  - React-rendererconsistency (0.81.0-rc.3)
+  - React-renderercss (0.81.0-rc.3):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.0-rc.5):
+  - React-rendererdebug (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2969,7 +2969,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.81.0-rc.5):
+  - React-RuntimeApple (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2998,7 +2998,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.81.0-rc.5):
+  - React-RuntimeCore (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3020,7 +3020,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.81.0-rc.5):
+  - React-runtimeexecutor (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3030,10 +3030,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.3)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.81.0-rc.5):
+  - React-RuntimeHermes (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3054,7 +3054,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.81.0-rc.5):
+  - React-runtimescheduler (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3076,8 +3076,8 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.81.0-rc.5)
-  - React-utils (0.81.0-rc.5):
+  - React-timing (0.81.0-rc.3)
+  - React-utils (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3087,11 +3087,11 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.81.0-rc.5)
+    - React-jsi (= 0.81.0-rc.3)
     - SocketRocket
-  - ReactAppDependencyProvider (0.81.0-rc.5):
+  - ReactAppDependencyProvider (0.81.0-rc.3):
     - ReactCodegen
-  - ReactCodegen (0.81.0-rc.5):
+  - ReactCodegen (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3117,7 +3117,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.81.0-rc.5):
+  - ReactCommon (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3125,9 +3125,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.81.0-rc.5)
+    - ReactCommon/turbomodule (= 0.81.0-rc.3)
     - SocketRocket
-  - ReactCommon/turbomodule (0.81.0-rc.5):
+  - ReactCommon/turbomodule (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3136,15 +3136,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.5)
-    - React-cxxreact (= 0.81.0-rc.5)
-    - React-jsi (= 0.81.0-rc.5)
-    - React-logger (= 0.81.0-rc.5)
-    - React-perflogger (= 0.81.0-rc.5)
-    - ReactCommon/turbomodule/bridging (= 0.81.0-rc.5)
-    - ReactCommon/turbomodule/core (= 0.81.0-rc.5)
+    - React-callinvoker (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.3)
+    - React-logger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.3)
+    - ReactCommon/turbomodule/bridging (= 0.81.0-rc.3)
+    - ReactCommon/turbomodule/core (= 0.81.0-rc.3)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.81.0-rc.5):
+  - ReactCommon/turbomodule/bridging (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3153,13 +3153,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.5)
-    - React-cxxreact (= 0.81.0-rc.5)
-    - React-jsi (= 0.81.0-rc.5)
-    - React-logger (= 0.81.0-rc.5)
-    - React-perflogger (= 0.81.0-rc.5)
+    - React-callinvoker (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.3)
+    - React-logger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.3)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.81.0-rc.5):
+  - ReactCommon/turbomodule/core (0.81.0-rc.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3168,14 +3168,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.0-rc.5)
-    - React-cxxreact (= 0.81.0-rc.5)
-    - React-debug (= 0.81.0-rc.5)
-    - React-featureflags (= 0.81.0-rc.5)
-    - React-jsi (= 0.81.0-rc.5)
-    - React-logger (= 0.81.0-rc.5)
-    - React-perflogger (= 0.81.0-rc.5)
-    - React-utils (= 0.81.0-rc.5)
+    - React-callinvoker (= 0.81.0-rc.3)
+    - React-cxxreact (= 0.81.0-rc.3)
+    - React-debug (= 0.81.0-rc.3)
+    - React-featureflags (= 0.81.0-rc.3)
+    - React-jsi (= 0.81.0-rc.3)
+    - React-logger (= 0.81.0-rc.3)
+    - React-perflogger (= 0.81.0-rc.3)
+    - React-utils (= 0.81.0-rc.3)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -4382,7 +4382,7 @@ SPEC CHECKSUMS:
   EXUpdates: d7205503b033ad6f48ea2702a234db55c0ec45a5
   EXUpdatesInterface: d6c802a2d1d11867523d03a95397957f9ba3d1c7
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: 64579c0203cbc859de4536d54b4c6ed28fd03d42
+  FBLazyVector: dff72c497c0f6de7c979d9d4f87dbba5663a8c92
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
   FirebaseCore: 2321536f9c423b1f857e047a82b8a42abc6d9e2c
   FirebaseCoreExtension: 3a64994969dd05f4bcb7e6896c654eded238e75b
@@ -4398,7 +4398,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: b58e9627004f47043897eeae830c3ef023678f3b
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 1631c0d1b00943a54db6d3003d924621239e506d
+  hermes-engine: 261d5b1bb5c97bf83c1232a4bdbb5124eea14cb9
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4411,40 +4411,40 @@ SPEC CHECKSUMS:
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: 3a51da4c0e2a533c893971c2171d164974bc5214
-  RCTRequired: d26a2245fa986ca16a6c93d91e41beeeb7a8aa3f
-  RCTTypeSafety: e9598921dd4338d6dcb7b4ba0b7b92f84cdcc25e
+  RCTDeprecation: 0747b2210cc36cd9d327a276d046834a2471def5
+  RCTRequired: 69fb68d08216b196c4ac982e3f4481532aeff4ab
+  RCTTypeSafety: 1e74a730ec76b072cd7226c5a29367187492cf89
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 713c6b114dfaddd4e58bc0e3804334f2a170b754
-  React-callinvoker: 4441303f80922bcab09bd3e401738c1a7f3ffe11
-  React-Core: 48eb931b5319893300e3766c6cc38481fa647dfa
-  React-CoreModules: 16160d86eee8183e615fc12e01a7b7d4037d0f11
-  React-cxxreact: 61e4deced1e2e89409d723baaf367da6d8eaf916
-  React-debug: 77c881c70aef8f5787761005eeb57e437a7d0a5b
-  React-defaultsnativemodule: 72ed284e13ab42903f492568e3db78dd708b06de
-  React-domnativemodule: b57bdf705c8f26762d70ddae2f917b6593622d7a
-  React-Fabric: 04dacebd7f35c74d648cadf8fda8c4dd105e1d56
-  React-FabricComponents: 0740d9d86edca91bbd3ab881ab9d139ccaff3513
-  React-FabricImage: 9d544dfe265a8cffaa7ef95023e3eb14eab7058a
-  React-featureflags: c33312b0812afb235add6add17e91b6f3a92222c
-  React-featureflagsnativemodule: 1db86f04957efcaecaec3957cc8d0de86ea573ab
-  React-graphics: f070009719fcac1854a3c4b3897b23e67b956ce2
-  React-hermes: b0d0cf1afcc6a5ea966d7841abbc89d0ec01526d
-  React-idlecallbacksnativemodule: 38c37267785b9d601dab87653edf2cf0c346bcc7
-  React-ImageManager: 578228cd0fbcef002207bf8acf0a42c712098906
-  React-jserrorhandler: 4da8855c5652652776eae535702b258fdc7e2693
-  React-jsi: 32ecda8451aac1f6a649e05dc94a0948ce2bb7d7
-  React-jsiexecutor: f4f3b47f4c1c076363ab8b65042a9a6177ef96b5
-  React-jsinspector: 24c8d6057c0ff37eccc72c855f198c6157893c78
-  React-jsinspectorcdp: 9a364f9cd548fc389ac91af4e5c38eae58f6548f
-  React-jsinspectornetwork: d7f3b19d53fe328dc139035ab0bba19aa68f2439
-  React-jsinspectortracing: 414014b64e0362eec726f3416cc9a02b9a8e9a16
-  React-jsitooling: 96c159a6a7cd6f29f208359554eec887b6fb27b9
-  React-jsitracing: 3c3d20d2dc74fc895411af104f9a9d103dc23794
-  React-logger: 3903016c02ae4dff7387d028501a3b03ba72879d
-  React-Mapbuffer: 48d6d8d0361ab4be5a7b4825006ddfff5e3686ec
-  React-microtasksnativemodule: bd7cfbd456840ebd272edad86b0e09595f2c80d5
-  react-native-keyboard-controller: 2ea75136c309c43b5f1b9b02e332628e80c8d936
+  React: 9e56bb37bb46ce3cdbdf20fd64e44ed6e8b37e82
+  React-callinvoker: 6e732fdd9322aa85920b7ab825b3a9a5d2f69ae7
+  React-Core: 99fee9f6aa1db5b405c4d0f12e048b75e8ec1e5c
+  React-CoreModules: e601e4ca8a860315d0a4edfd7840ff743005d21d
+  React-cxxreact: 2b775f50d54ff739587222cd1c5afc48c4d91bb9
+  React-debug: e780ad153ef3d2d6519d419391937a8c6b5308e0
+  React-defaultsnativemodule: 6d8035748ac95566f624b8818c76bd5369fa9600
+  React-domnativemodule: 9123ddf2081a33d981de7bb34ad7bf4eee792a11
+  React-Fabric: 58c335e8d849a993cde73c4711453943efb2b476
+  React-FabricComponents: 4ce82166c7eafccefc7222048af6a5e06d338499
+  React-FabricImage: 1608e3f58c753d795f578405b771ac18dc21cc63
+  React-featureflags: 4bf826207c670de55dde47b90e5a989963d29932
+  React-featureflagsnativemodule: b636a7d6b89780cf68525805b56f18de890c20c6
+  React-graphics: 5cf01a2c88eaa369a7a36757dcdbc596f255d56f
+  React-hermes: ce12df5b12de9541ac7d61469ac91ce39b091050
+  React-idlecallbacksnativemodule: 24993f2a70753d738c7c813e16e2d29a5471d572
+  React-ImageManager: bf5679bf50bdfe266fc9961525309a8f374db727
+  React-jserrorhandler: bfab33ef6f3bac3d48c387463f5a524adc523653
+  React-jsi: d0ea49291374c56c138984fc7838a3bfea82c11e
+  React-jsiexecutor: e5efd533f6d5acbc0a51450202d036f28b9f54aa
+  React-jsinspector: da6bd81bc804df27eaf1500a641ccc88831a7ae9
+  React-jsinspectorcdp: fc6b54d9fa3816e34cb3730cf0c19d029f9edb1c
+  React-jsinspectornetwork: 9ef6a5c765cb8614f23132f1541062976acbddda
+  React-jsinspectortracing: e121526fc088a96a0088112097f5ca13cc06934d
+  React-jsitooling: 1fc3be3ae4309387e89cd55229bff26e1b2c54bb
+  React-jsitracing: db70b9b57926f5a9e366956220d0710be3a19f17
+  React-logger: 96286cc9e6c073194274e4f5330a75d519c89d7a
+  React-Mapbuffer: 04e062c73315f3a40d4032178f9d396c059c9bb7
+  React-microtasksnativemodule: 3509d6a7d32ed14b91300854123965025f749fea
+  react-native-keyboard-controller: bf7ec487800e1283b95532d1259bde1fdf7c4bd5
   react-native-maps: fece4020ca8007967fa5eb48c914a8f2c73e7d4c
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: 5aa9fb30444ca4bbe382991b6783cc014ed5ca07
@@ -4454,36 +4454,36 @@ SPEC CHECKSUMS:
   react-native-slider: 95b11a80deb9ad503b01debf1a6c71f9ba6485b9
   react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
   react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
-  React-NativeModulesApple: b7c71399d5a301dab362289d68747ff8c9b84c19
-  React-oscompat: e324ee1ba89eb09d59c8e346748c758cb87a2ce3
-  React-perflogger: 1a98c4a181ab1cf9e8cf955dae867abfac59a50d
-  React-performancetimeline: 1a508e57eb32cc6951ecc95ac795afe13f3c1499
-  React-RCTActionSheet: e995bcd8831351318c94bfa3e585178dc15934c8
-  React-RCTAnimation: eda5da34ef170a419bff522a58db9d5fb109acec
-  React-RCTAppDelegate: 26ebc3917638dde2ca20facec826e45a96f16d6c
-  React-RCTBlob: 8e905a0df8271c7405e5542f4ddc5f11bf7b3ef4
-  React-RCTFabric: 5c4a2e726a25dd007bffd3aa8ded58d8d58bad67
-  React-RCTFBReactNativeSpec: 125ec865d3b95360142f343075d0326c1f2188fd
-  React-RCTImage: fe502bd39bb9bb5b9cfa635e141bf3d602091b2f
-  React-RCTLinking: 2d9dad05c5ebddc5902a2c2c0177f72e8f6b93bd
-  React-RCTNetwork: 81ac1907ff907c3e0669c8702a1aae2a8356cf8d
-  React-RCTRuntime: b156f2c4f38023a065723d70dd3eb9468a523cc9
-  React-RCTSettings: 0887e903b7f06463ec5887df385ade35705c5151
-  React-RCTText: 4644d6c9bc18c05ea4d373c8434ad9dc2392e642
-  React-RCTVibration: f381c601f931888740383dc14f4baeebac945e94
-  React-rendererconsistency: fde6f437f72fb837be955c7d287c5f1a1fe47212
-  React-renderercss: 8ad27c2b7c138f27518702af50c4bacc85d67fc9
-  React-rendererdebug: 34b2305ff2a349e540b39354277ce2c457da8ec9
-  React-RuntimeApple: 347f9558b516c79bd0cfa2a237371843d0a22c25
-  React-RuntimeCore: d4e1654e01a1a6df3ede773b2ddbac83f39725a9
-  React-runtimeexecutor: 93e8ab92174058160232cd9283d354463255020d
-  React-RuntimeHermes: 2f477bc8fc39fff2d1e3a966a3d908bbde6c3fd5
-  React-runtimescheduler: 7d15929025e58a47cd73758c6c4f46d293d3dca5
-  React-timing: c6ce3a683af45aecee166b49348cd094170a7e36
-  React-utils: 3b356bfa4a83cd7e019b96b1de73e8340cef2bf9
-  ReactAppDependencyProvider: ad094d490c0b69fcd292806df86e007728d02f95
-  ReactCodegen: 3e4dff28826e5bac0593f26c27d2dd2c3a6c66f2
-  ReactCommon: 3c95b5086d10c5da3d6d0fc920fc1ce6c984a496
+  React-NativeModulesApple: 009989614b0619613138091469ae3bce6e4641ba
+  React-oscompat: 414b30e47074beddcae34ee27e12a679a4977f24
+  React-perflogger: 3b129928b67f9acfda95ede5a804b6b2401a3c00
+  React-performancetimeline: 53dea15bdb110b6a3233624088bc929661cec00b
+  React-RCTActionSheet: 3f0f8e164b87bd9882473de51858b89195671fe9
+  React-RCTAnimation: 44f4cfd42d0517b3e034bd4d68f37839eda95443
+  React-RCTAppDelegate: fd8321b41a0a1c24576ee096bdc03c54c7c34a1b
+  React-RCTBlob: 4926f838dda83d487ce3c923458ec7653161cdb3
+  React-RCTFabric: 8a0babd88206697aa0c24c1473987bd35edd2635
+  React-RCTFBReactNativeSpec: 5410c3b5fa7104ff0ab89c0af0b95c2261d69929
+  React-RCTImage: 1406393b9ad0e1a43a83126f819c836d9fd59056
+  React-RCTLinking: 5b34b419c9100be60d0af0bd5c136ed5c0e7d595
+  React-RCTNetwork: 5ff03669c88df8ec5658c9f4aefdbf2e57dbe67e
+  React-RCTRuntime: 478d50836f71058f1cecfd6aaacbeaa58f1e57dc
+  React-RCTSettings: f8b48c1600bf102b8c58fa330ace2138f9bc5a91
+  React-RCTText: 8529ba937639c0cc9898cae342992212fbbc3078
+  React-RCTVibration: 41fe096a7bbb9d3a85e9c19202a98dc95d2b4f95
+  React-rendererconsistency: 15fecabe65cd94bef28ac54d3d51746d345b1114
+  React-renderercss: 621275a9485b16fca4b435563e2a151155de0222
+  React-rendererdebug: 6771edc3c93d02d27f00dc998a19ee732d905523
+  React-RuntimeApple: 5387b9985af7842483ace93ffba3c83c68155dd0
+  React-RuntimeCore: bc67ebe24b0a282c2fd429bce3e9d741d6a5eb5e
+  React-runtimeexecutor: d553435a78433984d63e77d0f9f9e77dd4730ede
+  React-RuntimeHermes: e5b4069531c780a264fbfa3bfd46e6965f034753
+  React-runtimescheduler: c9ddd5b81dc1e58e300941d4e454053189d3531c
+  React-timing: e48ea4ff6e85c2535584362bf1e06f1dd72818e1
+  React-utils: 0a7fc86dbb19cf3a875bfed5ed5bc1f79e229ec3
+  ReactAppDependencyProvider: 0d7a405e9cdb2450aef75f8e3ff6fe9d079d2d27
+  ReactCodegen: 9c6eb7accbce872922e3196143dc540133079942
+  ReactCommon: 012d9b70f277c80620e562bc7d94fc3893b2afb4
   RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
   RNCMaskedView: 63268de1986a098b5f4d1fb5b1bc1e97fade0aee
   RNCPicker: 6da395ee9db8d67a38c6102d4128b5a0b9ec0e21
@@ -4509,7 +4509,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: d489e73bf790da1c74e642021475b1a09a4a4500
   StripeUICore: 723e5024c83acb5ba5e71335e110a471b182a74d
   UMAppLoader: 90857e24b6b31ef0c87ade0688c6c4ca08d6201b
-  Yoga: 72ab8318e9f1910fbdd236b045eb5455c8415d92
+  Yoga: 15c07d37869e68f295849c2af164cea21957f345
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 8c02d6375ca9e94808af454e704b44d0ccf2c0af

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2560,7 +2560,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-slider (4.5.7):
+  - react-native-slider (5.0.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2578,7 +2578,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-slider/common (= 4.5.7)
+    - react-native-slider/common (= 5.0.0)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2589,7 +2589,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-slider/common (4.5.7):
+  - react-native-slider/common (5.0.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -4451,7 +4451,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 5d8c627bc6296d018625948364c1a02d50d11bd4
   react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
   react-native-skia: e4a1edd09e2e7bd95956683673ac18f911d63cfb
-  react-native-slider: fe0add239ded49237c81fe25f3ad84adb3ce49c7
+  react-native-slider: 95b11a80deb9ad503b01debf1a6c71f9ba6485b9
   react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
   react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
   React-NativeModulesApple: 009989614b0619613138091469ae3bce6e4641ba

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2560,7 +2560,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-slider (5.0.0):
+  - react-native-slider (4.5.7):
     - boost
     - DoubleConversion
     - fast_float
@@ -2578,7 +2578,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-slider/common (= 5.0.0)
+    - react-native-slider/common (= 4.5.7)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2589,7 +2589,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-slider/common (5.0.0):
+  - react-native-slider/common (4.5.7):
     - boost
     - DoubleConversion
     - fast_float
@@ -4451,7 +4451,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 5d8c627bc6296d018625948364c1a02d50d11bd4
   react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
   react-native-skia: e4a1edd09e2e7bd95956683673ac18f911d63cfb
-  react-native-slider: 95b11a80deb9ad503b01debf1a6c71f9ba6485b9
+  react-native-slider: fe0add239ded49237c81fe25f3ad84adb3ce49c7
   react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
   react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
   React-NativeModulesApple: 009989614b0619613138091469ae3bce6e4641ba

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -75,7 +75,7 @@
     "react-native-gesture-handler": "~2.28.0",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
-    "react-native-keyboard-controller": "^1.18.2",
+    "react-native-keyboard-controller": "^1.18.3",
     "react-native-maps": "1.24.13",
     "react-native-pager-view": "6.8.1",
     "react-native-paper": "^5.12.5",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -142,7 +142,7 @@
     "react-native": "0.81.0-rc.5",
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-keyboard-controller": "^1.18.2",
+    "react-native-keyboard-controller": "^1.18.3",
     "react-native-maps": "1.24.13",
     "react-native-pager-view": "6.8.1",
     "react-native-paper": "^5.12.5",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -97,7 +97,7 @@
   "react-native-edge-to-edge": "1.6.0",
   "react-native-gesture-handler": "~2.28.0",
   "react-native-get-random-values": "~1.11.0",
-  "react-native-keyboard-controller": "1.18.2",
+  "react-native-keyboard-controller": "1.18.3",
   "react-native-maps": "1.24.13",
   "react-native-pager-view": "6.8.1",
   "react-native-worklets": "~0.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7600,51 +7600,7 @@ eslint-visitor-keys@^4.2.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz#687bacb2af884fcdda8a6e7d65c606f46a14cd45"
   integrity sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==
 
-"eslint8@npm:eslint@^8.57.1":
-  version "8.57.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.1.tgz#7df109654aba7e3bbe5c8eae533c5e461d3c6ca9"
-  integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
-  dependencies:
-    "@eslint-community/eslint-utils" "^4.2.0"
-    "@eslint-community/regexpp" "^4.6.1"
-    "@eslint/eslintrc" "^2.1.4"
-    "@eslint/js" "8.57.1"
-    "@humanwhocodes/config-array" "^0.13.0"
-    "@humanwhocodes/module-importer" "^1.0.1"
-    "@nodelib/fs.walk" "^1.2.8"
-    "@ungap/structured-clone" "^1.2.0"
-    ajv "^6.12.4"
-    chalk "^4.0.0"
-    cross-spawn "^7.0.2"
-    debug "^4.3.2"
-    doctrine "^3.0.0"
-    escape-string-regexp "^4.0.0"
-    eslint-scope "^7.2.2"
-    eslint-visitor-keys "^3.4.3"
-    espree "^9.6.1"
-    esquery "^1.4.2"
-    esutils "^2.0.2"
-    fast-deep-equal "^3.1.3"
-    file-entry-cache "^6.0.1"
-    find-up "^5.0.0"
-    glob-parent "^6.0.2"
-    globals "^13.19.0"
-    graphemer "^1.4.0"
-    ignore "^5.2.0"
-    imurmurhash "^0.1.4"
-    is-glob "^4.0.0"
-    is-path-inside "^3.0.3"
-    js-yaml "^4.1.0"
-    json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.4.1"
-    lodash.merge "^4.6.2"
-    minimatch "^3.1.2"
-    natural-compare "^1.4.0"
-    optionator "^0.9.3"
-    strip-ansi "^6.0.1"
-    text-table "^0.2.0"
-
-eslint@^8.57.1:
+"eslint8@npm:eslint@^8.57.1", eslint@^8.57.1:
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.1.tgz#7df109654aba7e3bbe5c8eae533c5e461d3c6ca9"
   integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
@@ -13549,10 +13505,10 @@ react-native-keyboard-aware-scroll-view@^0.9.5:
     prop-types "^15.6.2"
     react-native-iphone-x-helper "^1.0.3"
 
-react-native-keyboard-controller@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.18.2.tgz#9ad16ed10f897d3ce7736a619406c71ebd7ed544"
-  integrity sha512-Cvg46QjKiI+xxeu8mZrNwAkcyvbT7ZCttp2ePW4O/V7jgvTkRfvz4Pm5sRK1C4yozgpwQRKCCIAW/oOErH1qrA==
+react-native-keyboard-controller@^1.18.3:
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.18.3.tgz#dc4b5d3e2d846710b44679babd099bf37134a7fb"
+  integrity sha512-Wea4Cq7Cns0kwFVvmW0BosI+j0sXUbRif29M9XkUjOjiJidti9i++80pQvna9wAi+hI0w3SJCrHveeVoY4zNOg==
   dependencies:
     react-native-is-edge-to-edge "^1.2.1"
 
@@ -15106,16 +15062,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15206,7 +15153,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15219,13 +15166,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -16817,7 +16757,7 @@ wordwrap@0.0.2:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
   integrity sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16830,15 +16770,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Why

New version released which fixes a crash on ios

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Update react-native-keyboard-controller to version 1.18.3 across multiple packages and update related dependencies in Podfile.lock and bundledNativeModules.json.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
