### PR TITLE
[go] Exclude Blob from expo go

### DIFF
--- a/apps/expo-go/android/settings.gradle
+++ b/apps/expo-go/android/settings.gradle
@@ -70,6 +70,7 @@ useExpoModules([
         'expo-maps',
         'expo-network-addons',
         'expo-splash-screen',
+        'expo-blob',
         '@expo/ui',
         'expo-mesh-gradient',
         '@expo/app-integrity'

--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -55,6 +55,7 @@ target 'Expo Go' do
       'expo-network-addons',
       'expo-insights',
       'expo-splash-screen',
+      'expo-blob',
       '@expo/ui',
       '@expo/app-integrity'
     ],


### PR DESCRIPTION
# Why

Blob should not be linked in Expo Go for now.

# How

Add Blob to excluded packages in Podfile and settings.gradle

# Test Plan

`et pods`