### PR TITLE
[ios][core] Add `ValueOrUndefined` type

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,7 +22,7 @@
 - [Android] Add VRUtilities for VR-related values and utils ([#37744](https://github.com/expo/expo/pull/37744) by [@behenate](https://github.com/behenate))
 - [Andorid] Start using experimental converters in properties. ([#38597](https://github.com/expo/expo/pull/38597) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Rethrow pending Jni exceptions. ([#38625](https://github.com/expo/expo/pull/38625) by [@jakex7](https://github.com/jakex7))
-- [iOS] Add new type - `ValueOrUndefined`.
+- [iOS] Add new type - `ValueOrUndefined`. ([#38620](https://github.com/expo/expo/pull/38620) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Android] Add VRUtilities for VR-related values and utils ([#37744](https://github.com/expo/expo/pull/37744) by [@behenate](https://github.com/behenate))
 - [Andorid] Start using experimental converters in properties. ([#38597](https://github.com/expo/expo/pull/38597) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Rethrow pending Jni exceptions. ([#38625](https://github.com/expo/expo/pull/38625) by [@jakex7](https://github.com/jakex7))
+- [iOS] Add new type - `ValueOrUndefined`.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ValueOrUndefinedSpec.swift
+++ b/packages/expo-modules-core/ValueOrUndefinedSpec.swift
@@ -1,0 +1,132 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class ValueOrUndefinedSpec: ExpoSpec {
+  override class func spec() {
+    describe("operators") {
+      it("==") {
+        expect(
+          ValueOrUndefined<Int>.undefinded == ValueOrUndefined<Int>.undefinded
+        ).to(beTrue())
+        expect(
+          ValueOrUndefined<Int>.value(unwrapped: 10) == ValueOrUndefined<Int>.value(unwrapped: 10)
+        ).to(beTrue())
+        expect(
+          ValueOrUndefined<Int>.value(unwrapped: 10) == ValueOrUndefined<Int>.undefinded
+        ).to(beFalse())
+        expect(
+          ValueOrUndefined<Int>.undefinded == ValueOrUndefined<Int>.value(unwrapped: 10)
+        ).to(beFalse())
+      }
+      
+      it("<") {
+        expect(
+          ValueOrUndefined<Int>.undefinded < ValueOrUndefined<Int>.undefinded
+        ).to(beFalse())
+        expect(
+          ValueOrUndefined<Int>.value(unwrapped: 10) < ValueOrUndefined<Int>.value(unwrapped: 10)
+        ).to(beFalse())
+        expect(
+          ValueOrUndefined<Int>.value(unwrapped: 10) < ValueOrUndefined<Int>.value(unwrapped: 20)
+        ).to(beTrue())
+        expect(
+          ValueOrUndefined<Int>.value(unwrapped: 10) < ValueOrUndefined<Int>.undefinded
+        ).to(beFalse())
+        expect(
+          ValueOrUndefined<Int>.undefinded == ValueOrUndefined<Int>.value(unwrapped: 10)
+        ).to(beFalse())
+      }
+    }
+    describe("module") {
+      let appContext = AppContext.create()
+      let runtime = try! appContext.runtime
+      
+      beforeSuite {
+        appContext.moduleRegistry.register(moduleType: UndefinedSpecModule.self)
+      }
+      
+      it("converts from undefined to ValueOrUndefinedSpec<Int>") {
+        let wasUndefinded = try runtime
+          .eval("expo.modules.ValueOrUndefinedModule.undefined_of_int(undefined)")
+          .asBool()
+        
+        expect(wasUndefinded).to(beTrue())
+      }
+      
+      it("converts from int to ValueOrUndefinedSpec<Int>") {
+        let wasUndefinded = try runtime
+          .eval("expo.modules.ValueOrUndefinedModule.undefined_of_int(10)")
+          .asBool()
+        
+        expect(wasUndefinded).to(beFalse())
+      }
+      
+      it("converts from undefined to ValueOrUndefinedSpec<Int?>") {
+        let wasUndefinded = try runtime
+          .eval("expo.modules.ValueOrUndefinedModule.undefined_of_optional_int(undefined, null)")
+          .asBool()
+        
+        expect(wasUndefinded).to(beTrue())
+      }
+      
+      it("converts from int to ValueOrUndefinedSpec<Int?>") {
+        let wasUndefinded = try runtime
+          .eval("expo.modules.ValueOrUndefinedModule.undefined_of_optional_int(10, 10)")
+          .asBool()
+        
+        expect(wasUndefinded).to(beFalse())
+      }
+      
+      it("converts from null to ValueOrUndefinedSpec<Int?>") {
+        let wasUndefinded = try runtime
+          .eval("expo.modules.ValueOrUndefinedModule.undefined_of_optional_int(null, null)")
+          .asBool()
+        
+        expect(wasUndefinded).to(beFalse())
+      }
+      
+      it("converts from array to [ValueOrUndefinedSpec<Int>]") {
+        let wereUndefinded = try runtime
+          .eval("expo.modules.ValueOrUndefinedModule.array_of_undefined_of_int([1, undefined, 2, undefined, 3])")
+          .asArray().map { try $0!.asBool() }
+        
+        expect(wereUndefinded).to(equal([false, true, false, true, false]))
+      }
+      
+      it("converts from array to [ValueOrUndefinedSpec<Int?>]") {
+        let wereUndefinded = try runtime
+          .eval("expo.modules.ValueOrUndefinedModule.array_of_undefined_of_optional_int([1, undefined, null, 2, undefined, null], [1, null, null, 2, null, null])")
+          .asArray().map { try $0!.asBool() }
+        
+        expect(wereUndefinded).to(equal([false, true, false, false, true, false]))
+      }
+    }
+  }
+}
+
+fileprivate final class UndefinedSpecModule: Module {
+  func definition() -> ModuleDefinition {
+    Name("ValueOrUndefinedModule")
+    
+    Function("undefined_of_int") { (value: ValueOrUndefined<Int>) in
+      return value.isUndefinded
+    }
+    
+    Function("undefined_of_optional_int") { (value: ValueOrUndefined<Int?>, expectedValue: Int?) in
+      expect(value.optional).to(expectedValue == nil ? beNil() : equal(expectedValue))
+      return value.isUndefinded
+    }
+    
+    Function("array_of_undefined_of_int") { (values: [ValueOrUndefined<Int>]) in
+      return values.map { $0.isUndefinded }
+    }
+    
+    Function("array_of_undefined_of_optional_int") { (values: [ValueOrUndefined<Int?>], expectedValues: [Int?]) in
+      expect(values.map{ $0.optional} ).to(equal(expectedValues))
+      return values.map { $0.isUndefinded }
+    }
+  }
+}

--- a/packages/expo-modules-core/ValueOrUndefinedSpec.swift
+++ b/packages/expo-modules-core/ValueOrUndefinedSpec.swift
@@ -9,22 +9,22 @@ final class ValueOrUndefinedSpec: ExpoSpec {
     describe("operators") {
       it("==") {
         expect(
-          ValueOrUndefined<Int>.undefinded == ValueOrUndefined<Int>.undefinded
+          ValueOrUndefined<Int>.undefined == ValueOrUndefined<Int>.undefined
         ).to(beTrue())
         expect(
           ValueOrUndefined<Int>.value(unwrapped: 10) == ValueOrUndefined<Int>.value(unwrapped: 10)
         ).to(beTrue())
         expect(
-          ValueOrUndefined<Int>.value(unwrapped: 10) == ValueOrUndefined<Int>.undefinded
+          ValueOrUndefined<Int>.value(unwrapped: 10) == ValueOrUndefined<Int>.undefined
         ).to(beFalse())
         expect(
-          ValueOrUndefined<Int>.undefinded == ValueOrUndefined<Int>.value(unwrapped: 10)
+          ValueOrUndefined<Int>.undefined == ValueOrUndefined<Int>.value(unwrapped: 10)
         ).to(beFalse())
       }
       
       it("<") {
         expect(
-          ValueOrUndefined<Int>.undefinded < ValueOrUndefined<Int>.undefinded
+          ValueOrUndefined<Int>.undefined < ValueOrUndefined<Int>.undefined
         ).to(beFalse())
         expect(
           ValueOrUndefined<Int>.value(unwrapped: 10) < ValueOrUndefined<Int>.value(unwrapped: 10)
@@ -33,10 +33,10 @@ final class ValueOrUndefinedSpec: ExpoSpec {
           ValueOrUndefined<Int>.value(unwrapped: 10) < ValueOrUndefined<Int>.value(unwrapped: 20)
         ).to(beTrue())
         expect(
-          ValueOrUndefined<Int>.value(unwrapped: 10) < ValueOrUndefined<Int>.undefinded
+          ValueOrUndefined<Int>.value(unwrapped: 10) < ValueOrUndefined<Int>.undefined
         ).to(beFalse())
         expect(
-          ValueOrUndefined<Int>.undefinded == ValueOrUndefined<Int>.value(unwrapped: 10)
+          ValueOrUndefined<Int>.undefined == ValueOrUndefined<Int>.value(unwrapped: 10)
         ).to(beFalse())
       }
     }

--- a/packages/expo-modules-core/ios/Core/Arguments/ValueOrUndefined.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/ValueOrUndefined.swift
@@ -1,0 +1,62 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+protocol AnyValueOrUndefined: AnyArgument {}
+
+public enum ValueOrUndefined<InnerType: AnyArgument>: AnyValueOrUndefined {
+  public static func getDynamicType() -> any AnyDynamicType {
+    return DynamicValueOrUndefinedType<InnerType>()
+  }
+
+  case undefinded
+  case value(unwrapped: InnerType)
+
+  var optional: InnerType? {
+    switch self {
+    // We want to produce Optional(nil) instead of nil - that's what DynamicOptionalType does
+    case .undefinded: return Any??.some(nil) as Any?? as! InnerType?
+    case .value(let value): return value
+    }
+  }
+
+  var isUndefinded: Bool {
+    if case .undefinded = self {
+      return true
+    }
+
+    return false
+  }
+}
+
+extension ValueOrUndefined: Equatable where InnerType: Equatable {
+  public static func == (lhs: ValueOrUndefined, rhs: ValueOrUndefined) -> Bool {
+    switch (lhs, rhs) {
+    case (.undefinded, .undefinded):
+      return true
+    case (.value(let lhsValue), .value(let rhsValue)):
+      return lhsValue == rhsValue
+    default:
+      return false
+    }
+  }
+}
+
+extension ValueOrUndefined: Comparable where InnerType: Comparable {
+  public static func < (lhs: ValueOrUndefined, rhs: ValueOrUndefined) -> Bool {
+    switch (lhs, rhs) {
+    case (.undefinded, .undefinded):
+      return false // undefined is considered equal to another undefined
+    case (.undefinded, _):
+      return false
+    case (_, .undefinded):
+      return false
+    case (.value(let lhsValue), .value(let rhsValue)):
+      return lhsValue < rhsValue
+    }
+  }
+}
+
+extension ValueOrUndefined {
+  public static func ?? <T>(valueOrUndefined: consuming ValueOrUndefined<T>, defaultValue: @autoclosure () -> T) -> T {
+    return valueOrUndefined.optional ?? defaultValue()
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Arguments/ValueOrUndefined.swift
+++ b/packages/expo-modules-core/ios/Core/Arguments/ValueOrUndefined.swift
@@ -7,19 +7,19 @@ public enum ValueOrUndefined<InnerType: AnyArgument>: AnyValueOrUndefined {
     return DynamicValueOrUndefinedType<InnerType>()
   }
 
-  case undefinded
+  case undefined
   case value(unwrapped: InnerType)
 
   var optional: InnerType? {
     switch self {
     // We want to produce Optional(nil) instead of nil - that's what DynamicOptionalType does
-    case .undefinded: return Any??.some(nil) as Any?? as! InnerType?
+    case .undefined: return Any??.some(nil) as Any?? as! InnerType?
     case .value(let value): return value
     }
   }
 
   var isUndefinded: Bool {
-    if case .undefinded = self {
+    if case .undefined = self {
       return true
     }
 
@@ -30,7 +30,7 @@ public enum ValueOrUndefined<InnerType: AnyArgument>: AnyValueOrUndefined {
 extension ValueOrUndefined: Equatable where InnerType: Equatable {
   public static func == (lhs: ValueOrUndefined, rhs: ValueOrUndefined) -> Bool {
     switch (lhs, rhs) {
-    case (.undefinded, .undefinded):
+    case (.undefined, .undefined):
       return true
     case (.value(let lhsValue), .value(let rhsValue)):
       return lhsValue == rhsValue
@@ -43,11 +43,11 @@ extension ValueOrUndefined: Equatable where InnerType: Equatable {
 extension ValueOrUndefined: Comparable where InnerType: Comparable {
   public static func < (lhs: ValueOrUndefined, rhs: ValueOrUndefined) -> Bool {
     switch (lhs, rhs) {
-    case (.undefinded, .undefinded):
+    case (.undefined, .undefined):
       return false // undefined is considered equal to another undefined
-    case (.undefinded, _):
+    case (.undefined, _):
       return false
-    case (_, .undefinded):
+    case (_, .undefined):
       return false
     case (.value(let lhsValue), .value(let rhsValue)):
       return lhsValue < rhsValue

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
@@ -53,6 +53,9 @@ private func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
   if let AnyEitherType = T.self as? AnyEither.Type {
     return AnyEitherType.getDynamicType()
   }
+  if let AnyValueOrUndefinedType = T.self as? AnyValueOrUndefined.Type {
+    return AnyValueOrUndefinedType.getDynamicType()
+  }
   return DynamicRawType(innerType: T.self)
 }
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicValueOrUndefinedType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicValueOrUndefinedType.swift
@@ -1,0 +1,34 @@
+// Copyright 2021-present 650 Industries. All rights reserved.
+
+internal struct DynamicValueOrUndefinedType<InnerType: AnyArgument>: AnyDynamicType {
+  let innerType: InnerType.Type = InnerType.self
+  let dynamicInnerType: AnyDynamicType = InnerType.getDynamicType()
+
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return innerType == type
+  }
+
+  func equals(_ type: any AnyDynamicType) -> Bool {
+    return type is Self
+  }
+
+  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    if jsValue.isUndefined() {
+      return ValueOrUndefined<InnerType>.undefinded
+    }
+
+    return try dynamicInnerType.cast(jsValue: jsValue, appContext: appContext)
+  }
+
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
+    if value is ValueOrUndefined<InnerType> {
+      return value
+    }
+
+    return ValueOrUndefined<InnerType>.value(unwrapped: try dynamicInnerType.cast(value, appContext: appContext) as! InnerType)
+  }
+
+  var description: String {
+    return "ValueOrUndefined<\(dynamicInnerType)>"
+  }
+}

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicValueOrUndefinedType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicValueOrUndefinedType.swift
@@ -14,7 +14,7 @@ internal struct DynamicValueOrUndefinedType<InnerType: AnyArgument>: AnyDynamicT
 
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
     if jsValue.isUndefined() {
-      return ValueOrUndefined<InnerType>.undefinded
+      return ValueOrUndefined<InnerType>.undefined
     }
 
     return try dynamicInnerType.cast(jsValue: jsValue, appContext: appContext)


### PR DESCRIPTION
# Why

Adds a new type - `ValueOrUndefined` to distinguish between `undefined` and null.

# How

- Added a new type that can hold information if the user passes `undefined` 
- Added a type converter 

Due to the current converter limitations, the `ValueOrUndefined` type should be used as the innermost type wherever possible (it can be nested inside collections). It does not work well with nullability:
```swift
let parameter: ValueOrUndefined<T?> // Correct usage

let parameter: ValueOrUndefined<T>? // Incorrect usage
// If the user passes `undefined`, the `DynamicOptionalType` converter converts it to null before the `DynamicValueOrUndefinedType` converter is triggered.
```
The issue highlighted in the example above can be fixed by adding more type checks within the `DynamicOptionalType`. However, the underlying problem persists - more complex nested structures will not function correctly, such as `Either<ValueOrUndefined<T>, U>?`.

# Test Plan

- unit tests ✅ 