### PR TITLE
[core][Android] Rethrow pending Jni exceptions

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [iOS] Return proper dynamic type for AnyEither. ([#38072](https://github.com/expo/expo/pull/38072) by [@jakex7](https://github.com/jakex7))
 - [Android] Add VRUtilities for VR-related values and utils ([#37744](https://github.com/expo/expo/pull/37744) by [@behenate](https://github.com/behenate))
 - [Andorid] Start using experimental converters in properties. ([#38597](https://github.com/expo/expo/pull/38597) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Rethrow pending Jni exceptions. ([#38625](https://github.com/expo/expo/pull/38625) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
 #include "JSIContext.h"
+#include "Exceptions.h"
 #include "ExpoModulesHostObject.h"
 #include "JavaReferencesCache.h"
 #include "JSReferencesCache.h"
@@ -155,7 +156,10 @@ JSIContext::callGetJavaScriptModuleObjectMethod(const std::string &moduleName) c
       "getJavaScriptModuleObject"
     );
 
-  return method(javaPart_, moduleName);
+  auto jniString = jni::make_jstring(moduleName);
+  auto result = jni::Environment::current()->CallObjectMethod(javaPart_.get(), method.getId(), jniString.get());
+  throwPendingJniExceptionAsCppException();
+  return jni::adopt_local(static_cast<JavaScriptModuleObject::javaobject>(result));
 }
 
 jni::local_ref<JavaScriptModuleObject::javaobject>
@@ -181,7 +185,10 @@ JSIContext::callGetJavaScriptModulesNames() const {
     ->getMethod<jni::local_ref<jni::JArrayClass<jni::JString>>()>(
       "getJavaScriptModulesName"
     );
-  return method(javaPart_);
+
+  auto result = jni::Environment::current()->CallObjectMethod(javaPart_.get(), method.getId());
+  throwPendingJniExceptionAsCppException();
+  return jni::adopt_local(static_cast<jni::JniType<jni::JArrayClass<jni::JString>>>(result));
 }
 
 bool JSIContext::callHasModule(const std::string &moduleName) const {
@@ -193,7 +200,10 @@ bool JSIContext::callHasModule(const std::string &moduleName) const {
     ->getMethod<jboolean(std::string)>(
       "hasModule"
     );
-  return (bool) method(javaPart_, moduleName);
+  auto jniString = jni::make_jstring(moduleName);
+  auto result = jni::Environment::current()->CallBooleanMethod(javaPart_.get(), method.getId(), jniString.get());
+  throwPendingJniExceptionAsCppException();
+  return static_cast<bool>(result);
 }
 
 jni::local_ref<JavaScriptModuleObject::javaobject>


### PR DESCRIPTION
# Why

Exception thrown on module creation completely crashes the app. 

# How

Rethrow pending jni exceptions as cpp exception

# Test Plan

Make an invalid DSL module, like removing `Record` (should throw `Cannot find type converter for '$forType'. Make sure the class implements `expo.modules.kotlin.records.Record` (i.e. `class MyObj : Record`).`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
