### PR TITLE
[updates] add setUpdateRequestHeadersOverride for ios

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Add `downloadProgress` state to the `useUpdates` hook to support listening to overall asset download progress. ([#38307](https://github.com/expo/expo/pull/38307)) by [@nishan](https://github.com/intergalacticspacehighway)
 - [iOS] dev-client support for Apple TV. ([#38388](https://github.com/expo/expo/pull/38388) by [@douglowder](https://github.com/douglowder))
 - Added reload support to `setUpdateURLAndRequestHeadersOverride`. ([#38167](https://github.com/expo/expo/pull/38167), [#38180](https://github.com/expo/expo/pull/38180) by [@kudo](https://github.com/kudo))
-- Added `setUpdateRequestHeadersOverride` to allow runtime `requestHeaders` override. ([#38623](https://github.com/expo/expo/pull/38623) by [@kudo](https://github.com/kudo))
+- Added `setUpdateRequestHeadersOverride` to allow runtime `requestHeaders` override. ([#38623](https://github.com/expo/expo/pull/38623), [#38628](https://github.com/expo/expo/pull/38628) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -175,6 +175,8 @@ public protocol InternalAppControllerInterface: AppControllerInterface {
     error errorBlockArg: @escaping (_ error: Exception) -> Void
   )
   func setUpdateURLAndRequestHeadersOverride(_ configOverride: UpdatesConfigOverride?) throws
+  func setUpdateURLOverride(_ updateUrl: URL?) throws
+  func setUpdateRequestHeadersOverride(_ requestHeaders: [String: String]?) throws
 }
 
 @objc(EXUpdatesAppControllerDelegate)

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -175,7 +175,6 @@ public protocol InternalAppControllerInterface: AppControllerInterface {
     error errorBlockArg: @escaping (_ error: Exception) -> Void
   )
   func setUpdateURLAndRequestHeadersOverride(_ configOverride: UpdatesConfigOverride?) throws
-  func setUpdateURLOverride(_ updateUrl: URL?) throws
   func setUpdateRequestHeadersOverride(_ requestHeaders: [String: String]?) throws
 }
 

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -355,6 +355,14 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
   public func setUpdateURLAndRequestHeadersOverride(_ configOverride: UpdatesConfigOverride?) throws {
     throw NotAvailableInDevClientException("Updates.setUpdateURLAndRequestHeadersOverride() is not supported in development builds.")
   }
+
+  public func setUpdateURLOverride(_ updateUrl: URL?) throws {
+    throw NotAvailableInDevClientException("Updates.setUpdateURLOverride() is not supported in development builds.")
+  }
+
+  public func setUpdateRequestHeadersOverride(_ requestHeaders: [String: String]?) throws {
+    throw NotAvailableInDevClientException("Updates.setUpdateRequestHeadersOverride() is not supported in development builds.")
+  }
 }
 
 // swiftlint:enable force_unwrapping

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -356,10 +356,6 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
     throw NotAvailableInDevClientException("Updates.setUpdateURLAndRequestHeadersOverride() is not supported in development builds.")
   }
 
-  public func setUpdateURLOverride(_ updateUrl: URL?) throws {
-    throw NotAvailableInDevClientException("Updates.setUpdateURLOverride() is not supported in development builds.")
-  }
-
   public func setUpdateRequestHeadersOverride(_ requestHeaders: [String: String]?) throws {
     throw NotAvailableInDevClientException("Updates.setUpdateRequestHeadersOverride() is not supported in development builds.")
   }

--- a/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
@@ -147,4 +147,12 @@ public class DisabledAppController: InternalAppControllerInterface {
   public func setUpdateURLAndRequestHeadersOverride(_ configOverride: UpdatesConfigOverride?) throws {
     throw UpdatesDisabledException("Updates.setUpdateURLAndRequestHeadersOverride() is not supported when expo-updates is not enabled.")
   }
+
+  public func setUpdateURLOverride(_ updateUrl: URL?) throws {
+    throw UpdatesDisabledException("Updates.setUpdateURLOverride() is not supported when expo-updates is not enabled.")
+  }
+
+  public func setUpdateRequestHeadersOverride(_ requestHeaders: [String: String]?) throws {
+    throw UpdatesDisabledException("Updates.setUpdateRequestHeadersOverride() is not supported when expo-updates is not enabled.")
+  }
 }

--- a/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
@@ -148,10 +148,6 @@ public class DisabledAppController: InternalAppControllerInterface {
     throw UpdatesDisabledException("Updates.setUpdateURLAndRequestHeadersOverride() is not supported when expo-updates is not enabled.")
   }
 
-  public func setUpdateURLOverride(_ updateUrl: URL?) throws {
-    throw UpdatesDisabledException("Updates.setUpdateURLOverride() is not supported when expo-updates is not enabled.")
-  }
-
   public func setUpdateRequestHeadersOverride(_ requestHeaders: [String: String]?) throws {
     throw UpdatesDisabledException("Updates.setUpdateRequestHeadersOverride() is not supported when expo-updates is not enabled.")
   }

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -259,6 +259,26 @@ public class EnabledAppController: InternalAppControllerInterface, StartupProced
     if !config.disableAntiBrickingMeasures {
       throw NotAllowedAntiBrickingMeasuresException()
     }
-    UpdatesConfigOverride.save(configOverride)
+    UpdatesConfigOverride.save(configOverride: configOverride)
     self.config = try UpdatesConfig.config(fromConfig: self.config, configOverride: configOverride)
-  }}
+  }
+
+  public func setUpdateURLOverride(_ updateUrl: URL?) throws {
+    if !config.disableAntiBrickingMeasures {
+      throw NotAllowedAntiBrickingMeasuresException()
+    }
+    let configOverride = UpdatesConfigOverride.save(updateUrl: updateUrl)
+    self.config = try UpdatesConfig.config(fromConfig: self.config, configOverride: configOverride)
+  }
+
+  public func setUpdateRequestHeadersOverride(_ requestHeaders: [String: String]?) throws {
+    if !UpdatesConfig.isValidRequestHeadersOverride(
+      originalEmbeddedRequestHeaders: config.originalEmbeddedRequestHeaders,
+      requestHeadersOverride: requestHeaders
+    ) {
+      throw InvalidRequestHeadersOverrideException(requestHeaders)
+    }
+    let configOverride = UpdatesConfigOverride.save(requestHeaders: requestHeaders)
+    self.config = try UpdatesConfig.config(fromConfig: self.config, configOverride: configOverride)
+  }
+}

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -263,14 +263,6 @@ public class EnabledAppController: InternalAppControllerInterface, StartupProced
     self.config = try UpdatesConfig.config(fromConfig: self.config, configOverride: configOverride)
   }
 
-  public func setUpdateURLOverride(_ updateUrl: URL?) throws {
-    if !config.disableAntiBrickingMeasures {
-      throw NotAllowedAntiBrickingMeasuresException()
-    }
-    let configOverride = UpdatesConfigOverride.save(updateUrl: updateUrl)
-    self.config = try UpdatesConfig.config(fromConfig: self.config, configOverride: configOverride)
-  }
-
   public func setUpdateRequestHeadersOverride(_ requestHeaders: [String: String]?) throws {
     if !UpdatesConfig.isValidRequestHeadersOverride(
       originalEmbeddedRequestHeaders: config.originalEmbeddedRequestHeaders,

--- a/packages/expo-updates/ios/EXUpdates/Exceptions.swift
+++ b/packages/expo-updates/ios/EXUpdates/Exceptions.swift
@@ -95,5 +95,4 @@ internal final class InvalidRequestHeadersOverrideException: Exception {
   }
 }
 
-
 // swiftlint:enable line_length

--- a/packages/expo-updates/ios/EXUpdates/Exceptions.swift
+++ b/packages/expo-updates/ios/EXUpdates/Exceptions.swift
@@ -78,4 +78,22 @@ internal final class NotAllowedAntiBrickingMeasuresException: Exception {
   }
 }
 
+internal final class InvalidRequestHeadersOverrideException: Exception {
+  private let requestHeaders: [String: String]?
+
+  internal init(_ requestHeaders: [String: String]?, file: String = #fileID, line: UInt = #line, function: String = #function) {
+    self.requestHeaders = requestHeaders
+    super.init(file: file, line: line, function: function)
+  }
+
+  override var code: String {
+    "ERR_UPDATES_RUNTIME_OVERRIDE"
+  }
+
+  override var reason: String {
+    "Invalid update requestHeaders override: \(String(describing: requestHeaders))"
+  }
+}
+
+
 // swiftlint:enable line_length

--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
@@ -407,9 +407,9 @@ public final class UpdatesConfig: NSObject {
         requestHeadersOverride: requestHeaders
       ) || getDisableAntiBrickingMeasures(fromDictionary: config) {
         return requestHeaders
-      } else {
-        NSLog("Invalid update requestHeaders override, fallback to embedded requestHeaders - override requestHeaders: %@", requestHeaders)
       }
+
+      NSLog("Invalid update requestHeaders override, fallback to embedded requestHeaders - override requestHeaders: %@", requestHeaders)
     }
     return getOriginalEmbeddedRequestHeaders(fromDictionary: config)
   }
@@ -435,7 +435,7 @@ public final class UpdatesConfig: NSObject {
 
     // ensure none are disallowed AND all are in the original set
     return overrideKeys.allSatisfy { !disallowHeaderKeys.contains($0) } &&
-           overrideKeys.allSatisfy { originalEmbeddedKeys.contains($0) }
+      overrideKeys.allSatisfy { originalEmbeddedKeys.contains($0) }
   }
 }
 

--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
@@ -401,15 +401,41 @@ public final class UpdatesConfig: NSObject {
     fromDictionary config: [String: Any],
     configOverride: UpdatesConfigOverride?
   ) -> [String: String] {
-    if getDisableAntiBrickingMeasures(fromDictionary: config),
-      let requestHeaders = configOverride?.requestHeaders {
-      return requestHeaders
+    if let requestHeaders = configOverride?.requestHeaders {
+      if isValidRequestHeadersOverride(
+        originalEmbeddedRequestHeaders: getOriginalEmbeddedRequestHeaders(fromDictionary: config),
+        requestHeadersOverride: requestHeaders
+      ) || getDisableAntiBrickingMeasures(fromDictionary: config) {
+        return requestHeaders
+      } else {
+        NSLog("Invalid update requestHeaders override, fallback to embedded requestHeaders - override requestHeaders: %@", requestHeaders)
+      }
     }
     return getOriginalEmbeddedRequestHeaders(fromDictionary: config)
   }
 
   private static func getOriginalEmbeddedRequestHeaders(fromDictionary config: [String: Any]) -> [String: String] {
     return config.optionalValue(forKey: EXUpdatesConfigRequestHeadersKey) ?? [:]
+  }
+
+  internal static func isValidRequestHeadersOverride(
+    originalEmbeddedRequestHeaders: [String: String],
+    requestHeadersOverride: [String: String]?
+  ) -> Bool {
+    guard let overrideHeaders = requestHeadersOverride else {
+      return true
+    }
+
+    let originalEmbeddedKeys = Set(originalEmbeddedRequestHeaders.keys.map { $0.lowercased() })
+
+    // disallow `Host` override to prevent malicious request rewrite
+    let disallowHeaderKeys: Set<String> = ["host"]
+
+    let overrideKeys = overrideHeaders.keys.map { $0.lowercased() }
+
+    // ensure none are disallowed AND all are in the original set
+    return overrideKeys.allSatisfy { !disallowHeaderKeys.contains($0) } &&
+           overrideKeys.allSatisfy { originalEmbeddedKeys.contains($0) }
   }
 }
 

--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
@@ -409,7 +409,7 @@ public final class UpdatesConfig: NSObject {
         return requestHeaders
       }
 
-      NSLog("Invalid update requestHeaders override, fallback to embedded requestHeaders - override requestHeaders: %@", requestHeaders)
+      NSLog("Invalid update requestHeaders override, falling back to embedded requestHeaders - override requestHeaders: %@", requestHeaders)
     }
     return getOriginalEmbeddedRequestHeaders(fromDictionary: config)
   }
@@ -426,12 +426,12 @@ public final class UpdatesConfig: NSObject {
       return true
     }
 
-    let originalEmbeddedKeys = Set(originalEmbeddedRequestHeaders.keys.map { $0.lowercased() })
+    let originalEmbeddedKeys = Set(originalEmbeddedRequestHeaders.keys.map { $0.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) })
 
     // disallow `Host` override to prevent malicious request rewrite
     let disallowHeaderKeys: Set<String> = ["host"]
 
-    let overrideKeys = overrideHeaders.keys.map { $0.lowercased() }
+    let overrideKeys = overrideHeaders.keys.map { $0.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) }
 
     // ensure none are disallowed AND all are in the original set
     return overrideKeys.allSatisfy { !disallowHeaderKeys.contains($0) } &&

--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfigOverride.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfigOverride.swift
@@ -31,16 +31,6 @@ public struct UpdatesConfigOverride: Codable {
     }
   }
 
-  internal static func save(updateUrl: URL?) -> UpdatesConfigOverride? {
-    let newOverride = UpdatesConfigOverride(
-      updateUrl: updateUrl,
-      requestHeaders: load()?.requestHeaders
-    )
-    let finalOverride = (newOverride.updateUrl != nil || newOverride.requestHeaders != nil) ? newOverride : nil
-    save(configOverride: finalOverride)
-    return finalOverride
-  }
-
   internal static func save(requestHeaders: [String: String]?) -> UpdatesConfigOverride? {
     let newOverride = UpdatesConfigOverride(
       updateUrl: load()?.updateUrl,

--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfigOverride.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfigOverride.swift
@@ -9,7 +9,7 @@ public struct UpdatesConfigOverride: Codable {
   private static let kUpdatesConfigOverride = "dev.expo.updates.updatesConfigOverride"
 
   let updateUrl: URL?
-  let requestHeaders: [String: String]
+  let requestHeaders: [String: String]?
 
   public static func load() -> UpdatesConfigOverride? {
     guard let data = UserDefaults.standard.data(forKey: kUpdatesConfigOverride) else {
@@ -19,7 +19,7 @@ public struct UpdatesConfigOverride: Codable {
     return try? decoder.decode(UpdatesConfigOverride.self, from: Data(data))
   }
 
-  internal static func save(_ configOverride: UpdatesConfigOverride?) {
+  internal static func save(configOverride: UpdatesConfigOverride?) {
     if let configOverride {
       let encoder = JSONEncoder()
       guard let data = try? encoder.encode(configOverride) else {
@@ -29,5 +29,25 @@ public struct UpdatesConfigOverride: Codable {
     } else {
       UserDefaults.standard.removeObject(forKey: kUpdatesConfigOverride)
     }
+  }
+
+  internal static func save(updateUrl: URL?) -> UpdatesConfigOverride? {
+    let newOverride = UpdatesConfigOverride(
+      updateUrl: updateUrl,
+      requestHeaders: load()?.requestHeaders
+    )
+    let finalOverride = (newOverride.updateUrl != nil || newOverride.requestHeaders != nil) ? newOverride : nil
+    save(configOverride: finalOverride)
+    return finalOverride
+  }
+
+  internal static func save(requestHeaders: [String: String]?) -> UpdatesConfigOverride? {
+    let newOverride = UpdatesConfigOverride(
+      updateUrl: load()?.updateUrl,
+      requestHeaders: requestHeaders
+    )
+    let finalOverride = (newOverride.updateUrl != nil || newOverride.requestHeaders != nil) ? newOverride : nil
+    save(configOverride: finalOverride)
+    return finalOverride
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
@@ -146,6 +146,14 @@ public final class UpdatesModule: Module, UpdatesEventManagerObserver {
       try AppController.sharedInstance.setUpdateURLAndRequestHeadersOverride(configOverride?.toUpdatesConfigOverride())
     }
 
+    Function("setUpdateURLOverride") { (updateUrl: URL?) in
+      try AppController.sharedInstance.setUpdateURLOverride(updateUrl)
+    }
+
+    Function("setUpdateRequestHeadersOverride") { (requestHeaders: [String: String]?) in
+      try AppController.sharedInstance.setUpdateRequestHeadersOverride(requestHeaders)
+    }
+
     AsyncFunction("showReloadScreen") { (options: ReloadScreenOptions?) in
 #if DEBUG
       if let reloadScreenManager = AppController.sharedInstance.reloadScreenManager {

--- a/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
@@ -146,10 +146,6 @@ public final class UpdatesModule: Module, UpdatesEventManagerObserver {
       try AppController.sharedInstance.setUpdateURLAndRequestHeadersOverride(configOverride?.toUpdatesConfigOverride())
     }
 
-    Function("setUpdateURLOverride") { (updateUrl: URL?) in
-      try AppController.sharedInstance.setUpdateURLOverride(updateUrl)
-    }
-
     Function("setUpdateRequestHeadersOverride") { (requestHeaders: [String: String]?) in
       try AppController.sharedInstance.setUpdateRequestHeadersOverride(requestHeaders)
     }

--- a/packages/expo-updates/ios/Tests/UpdatesConfigOverrideSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesConfigOverrideSpec.swift
@@ -1,0 +1,167 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import ExpoModulesTestCore
+
+@testable import EXUpdates
+
+class UpdatesConfigOverrideSpec: ExpoSpec {
+  override class func spec() {
+    beforeEach {
+      // Clear UserDefaults before each test
+      UserDefaults.standard.removeObject(forKey: "dev.expo.updates.updatesConfigOverride")
+    }
+
+    describe("UpdatesConfigOverride") {
+      describe("constructor") {
+        it("should create instance with provided values") {
+          let updateUrl = URL(string: "https://example.com/manifest")
+          let requestHeaders = ["Authorization": "Bearer token", "User-Agent": "ExpoApp"]
+
+          let override = UpdatesConfigOverride(updateUrl: updateUrl, requestHeaders: requestHeaders)
+
+          expect(override.updateUrl).to(equal(updateUrl))
+          expect(override.requestHeaders).to(equal(requestHeaders))
+        }
+
+        it("should create instance with null values") {
+          let override = UpdatesConfigOverride(updateUrl: nil, requestHeaders: nil)
+
+          expect(override.updateUrl).to(beNil())
+          expect(override.requestHeaders).to(beNil())
+        }
+      }
+
+      describe("load") {
+        it("should return nil when no stored configuration exists") {
+          let result = UpdatesConfigOverride.load()
+
+          expect(result).to(beNil())
+        }
+
+        it("should return configuration when stored configuration exists") {
+          let updateUrl = URL(string: "https://example.com/manifest")
+          let requestHeaders = ["Authorization": "Bearer token"]
+          let override = UpdatesConfigOverride(updateUrl: updateUrl, requestHeaders: requestHeaders)
+          UpdatesConfigOverride.save(configOverride: override)
+
+          let result = UpdatesConfigOverride.load()
+
+          expect(result).toNot(beNil())
+          expect(result?.updateUrl).to(equal(updateUrl))
+          expect(result?.requestHeaders).to(equal(requestHeaders))
+        }
+
+        it("should return configuration from partial stored configurations") {
+          let requestHeaders = ["Authorization": "Bearer token"]
+          let override = UpdatesConfigOverride(updateUrl: nil, requestHeaders: requestHeaders)
+          UpdatesConfigOverride.save(configOverride: override)
+
+          let result = UpdatesConfigOverride.load()
+
+          expect(result).toNot(beNil())
+          expect(result?.updateUrl).to(beNil())
+          expect(result?.requestHeaders).to(equal(requestHeaders))
+        }
+      }
+
+      describe("save") {
+        it("should store configuration when override is not null") {
+          let updateUrl = URL(string: "https://example.com/manifest")
+          let requestHeaders = ["Authorization": "Bearer token"]
+          let override = UpdatesConfigOverride(updateUrl: updateUrl, requestHeaders: requestHeaders)
+
+          UpdatesConfigOverride.save(configOverride: override)
+
+          let result = UpdatesConfigOverride.load()
+          expect(result).toNot(beNil())
+          expect(result?.updateUrl).to(equal(updateUrl))
+          expect(result?.requestHeaders).to(equal(requestHeaders))
+        }
+
+        it("should remove configuration when override is null") {
+          let override = UpdatesConfigOverride(updateUrl: URL(string: "https://example.com"), requestHeaders: ["key": "value"])
+          UpdatesConfigOverride.save(configOverride: override)
+
+          UpdatesConfigOverride.save(configOverride: nil)
+
+          let result = UpdatesConfigOverride.load()
+          expect(result).to(beNil())
+        }
+      }
+
+      describe("save with updateUrl") {
+        it("should create new override when none exists") {
+          let updateUrl = URL(string: "https://example.com/manifest")
+
+          let result = UpdatesConfigOverride.save(updateUrl: updateUrl)
+
+          expect(result).toNot(beNil())
+          expect(result?.updateUrl).to(equal(updateUrl))
+          expect(result?.requestHeaders).to(beNil())
+
+          let loaded = UpdatesConfigOverride.load()
+          expect(loaded?.updateUrl).to(equal(updateUrl))
+          expect(loaded?.requestHeaders).to(beNil())
+        }
+
+        it("should update existing override") {
+          let existingHeaders = ["Authorization": "Bearer token"]
+          let existingOverride = UpdatesConfigOverride(updateUrl: nil, requestHeaders: existingHeaders)
+          UpdatesConfigOverride.save(configOverride: existingOverride)
+
+          let newUpdateUrl = URL(string: "https://example.com/new-manifest")
+
+          let result = UpdatesConfigOverride.save(updateUrl: newUpdateUrl)
+
+          expect(result).toNot(beNil())
+          expect(result?.updateUrl).to(equal(newUpdateUrl))
+          expect(result?.requestHeaders).to(equal(existingHeaders))
+        }
+
+        it("should return nil when updateUrl is nil and no other values exist") {
+          let result = UpdatesConfigOverride.save(updateUrl: nil)
+
+          expect(result).to(beNil())
+          expect(UpdatesConfigOverride.load()).to(beNil())
+        }
+      }
+
+      describe("save with requestHeaders") {
+        it("should create new override when none exists") {
+          let requestHeaders = ["Authorization": "Bearer token"]
+
+          let result = UpdatesConfigOverride.save(requestHeaders: requestHeaders)
+
+          expect(result).toNot(beNil())
+          expect(result?.updateUrl).to(beNil())
+          expect(result?.requestHeaders).to(equal(requestHeaders))
+
+          let loaded = UpdatesConfigOverride.load()
+          expect(loaded?.updateUrl).to(beNil())
+          expect(loaded?.requestHeaders).to(equal(requestHeaders))
+        }
+
+        it("should update existing override") {
+          let existingUrl = URL(string: "https://example.com/manifest")
+          let existingOverride = UpdatesConfigOverride(updateUrl: existingUrl, requestHeaders: nil)
+          UpdatesConfigOverride.save(configOverride: existingOverride)
+
+          let newHeaders = ["User-Agent": "ExpoApp"]
+
+          let result = UpdatesConfigOverride.save(requestHeaders: newHeaders)
+
+          expect(result).toNot(beNil())
+          expect(result?.updateUrl).to(equal(existingUrl))
+          expect(result?.requestHeaders).to(equal(newHeaders))
+        }
+
+        it("should return nil when requestHeaders is nil and no other values exist") {
+          let result = UpdatesConfigOverride.save(requestHeaders: nil)
+
+          expect(result).to(beNil())
+          expect(UpdatesConfigOverride.load()).to(beNil())
+        }
+      }
+    }
+  }
+}

--- a/packages/expo-updates/ios/Tests/UpdatesConfigOverrideSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesConfigOverrideSpec.swift
@@ -64,7 +64,7 @@ class UpdatesConfigOverrideSpec: ExpoSpec {
         }
       }
 
-      describe("save") {
+      describe("save with configOverride") {
         it("should store configuration when override is not null") {
           let updateUrl = URL(string: "https://example.com/manifest")
           let requestHeaders = ["Authorization": "Bearer token"]
@@ -86,43 +86,6 @@ class UpdatesConfigOverrideSpec: ExpoSpec {
 
           let result = UpdatesConfigOverride.load()
           expect(result).to(beNil())
-        }
-      }
-
-      describe("save with updateUrl") {
-        it("should create new override when none exists") {
-          let updateUrl = URL(string: "https://example.com/manifest")
-
-          let result = UpdatesConfigOverride.save(updateUrl: updateUrl)
-
-          expect(result).toNot(beNil())
-          expect(result?.updateUrl).to(equal(updateUrl))
-          expect(result?.requestHeaders).to(beNil())
-
-          let loaded = UpdatesConfigOverride.load()
-          expect(loaded?.updateUrl).to(equal(updateUrl))
-          expect(loaded?.requestHeaders).to(beNil())
-        }
-
-        it("should update existing override") {
-          let existingHeaders = ["Authorization": "Bearer token"]
-          let existingOverride = UpdatesConfigOverride(updateUrl: nil, requestHeaders: existingHeaders)
-          UpdatesConfigOverride.save(configOverride: existingOverride)
-
-          let newUpdateUrl = URL(string: "https://example.com/new-manifest")
-
-          let result = UpdatesConfigOverride.save(updateUrl: newUpdateUrl)
-
-          expect(result).toNot(beNil())
-          expect(result?.updateUrl).to(equal(newUpdateUrl))
-          expect(result?.requestHeaders).to(equal(existingHeaders))
-        }
-
-        it("should return nil when updateUrl is nil and no other values exist") {
-          let result = UpdatesConfigOverride.save(updateUrl: nil)
-
-          expect(result).to(beNil())
-          expect(UpdatesConfigOverride.load()).to(beNil())
         }
       }
 

--- a/packages/expo-updates/ios/Tests/UpdatesConfigSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesConfigSpec.swift
@@ -77,5 +77,46 @@ class UpdatesConfigSpec : ExpoSpec {
         expect(UpdatesConfig.normalizedURLOrigin(url: urlOtherPort)) == "https://exp.host:47"
       }
     }
+
+    describe("isValidRequestHeadersOverride") {
+      it("should return true for headers matched with embedded headers") {
+        let originalHeaders = ["expo-channel-name": "default"]
+        let requestHeadersOverride = ["Expo-Channel-Name": "preview"]
+        let result = UpdatesConfig.isValidRequestHeadersOverride(
+          originalEmbeddedRequestHeaders: originalHeaders,
+          requestHeadersOverride: requestHeadersOverride
+        )
+        expect(result) == true
+      }
+
+      it("should return false for headers unmatched with embedded headers") {
+        let originalHeaders = ["expo-channel-name": "default"]
+        let requestHeadersOverride = [
+          "Expo-Channel-Name": "preview",
+          "X-Custom": "custom"
+        ]
+        let result = UpdatesConfig.isValidRequestHeadersOverride(
+          originalEmbeddedRequestHeaders: originalHeaders,
+          requestHeadersOverride: requestHeadersOverride
+        )
+        expect(result) == false
+      }
+
+      it("should return false for Host override header") {
+        let originalHeaders = [
+          "expo-channel-name": "default",
+          "Host": "example.org"
+        ]
+        let requestHeadersOverride = [
+          "Expo-Channel-Name": "preview",
+          "Host": "override.org"
+        ]
+        let result = UpdatesConfig.isValidRequestHeadersOverride(
+          originalEmbeddedRequestHeaders: originalHeaders,
+          requestHeadersOverride: requestHeadersOverride
+        )
+        expect(result) == false
+      }
+    }
   }
 }

--- a/packages/expo-updates/ios/Tests/UpdatesConfigSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesConfigSpec.swift
@@ -117,6 +117,22 @@ class UpdatesConfigSpec : ExpoSpec {
         )
         expect(result) == false
       }
+
+      it("should handle Host override header normalization") {
+        let originalHeaders = [
+          "expo-channel-name": "default",
+          " Host ": "example.org"
+        ]
+        let requestHeadersOverride = [
+          "Expo-Channel-Name": "preview",
+          " Host ": "override.org"
+        ]
+        let result = UpdatesConfig.isValidRequestHeadersOverride(
+          originalEmbeddedRequestHeaders: originalHeaders,
+          requestHeadersOverride: requestHeadersOverride
+        )
+        expect(result) == false
+      }
     }
   }
 }


### PR DESCRIPTION
# Why

#38623 for ios
close ENG-15936

# How

> - add `setUpdateRequestHeadersOverride` that allows overrides without custom build but we allow to override headers that matched with `update.requestHeaders` defined in app.conf (AndroidManifest.xml and Expo.plist)
> - disallow some special header overrides like `Host`, to reduce security risk

pretty much the same as #38623 but for ios

# Test Plan

- add unit test to `UpdatesConfig.isValidRequestHeadersOverride`
- add unit test to `UpdatesConfigOverrideSpec`
- e2e test on upstack pr

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
