### PR TITLE
[status-bar] Fix `expo-status-bar` source file name in GenerateDocsAPIData

### DIFF
--- a/tools/src/commands/GenerateDocsAPIData.ts
+++ b/tools/src/commands/GenerateDocsAPIData.ts
@@ -98,7 +98,7 @@ const PACKAGES_MAPPING: Record<string, CommandAdditionalParams> = {
   'expo-speech': ['Speech/Speech.ts'],
   'expo-splash-screen': ['index.ts'],
   'expo-sqlite': [['index.ts', 'Storage.ts'], 'expo-sqlite'],
-  'expo-status-bar': ['StatusBar.tsx'],
+  'expo-status-bar': ['StatusBar.ts'],
   'expo-store-review': ['StoreReview.ts'],
   'expo-symbols': ['index.ts'],
   'expo-system-ui': ['SystemUI.ts'],


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

<img width="1116" height="402" alt="CleanShot 2025-08-07 at 21 07 47" src="https://github.com/user-attachments/assets/7813029b-f450-4771-83e2-928b698a60d6" />

`expo-status-bar` source file name has changed from `StatusBar.tsx` to `StatusBar.ts`. This PR updates the value in `GenerateDocsAPIData.ts` file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Inside `expo/packages/expo-status-bar`, run `et gdad -p expo-status-bar` to ensure you receive the docs data success message. 

<img width="1105" height="96" alt="CleanShot 2025-08-07 at 21 35 35" src="https://github.com/user-attachments/assets/b34aae96-d84a-4418-b1c3-a27985077899" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
