### PR TITLE
[ios][expo-go] Fix updates build error

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -415,7 +415,7 @@ NS_ASSUME_NONNULL_BEGIN
   ];
   _selectionPolicy = [[EXUpdatesSelectionPolicy alloc]
                       initWithLauncherSelectionPolicy:[[EXExpoGoLauncherSelectionPolicyFilterAware alloc] initWithSdkVersions:sdkVersions]
-                      loaderSelectionPolicy:[EXUpdatesLoaderSelectionPolicyFilterAware new]
+                      loaderSelectionPolicy:[[EXUpdatesLoaderSelectionPolicyFilterAware alloc] initWithConfig:_config]
                       reaperSelectionPolicy:[EXUpdatesReaperSelectionPolicyDevelopmentClient new]];
 
   EXUpdatesAppLoaderTask *loaderTask = [[EXUpdatesAppLoaderTask alloc] initWithConfig:_config

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXDevelopmentHomeLoader.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXDevelopmentHomeLoader.m
@@ -237,7 +237,7 @@ NS_ASSUME_NONNULL_BEGIN
   ];
   EXUpdatesSelectionPolicy *selectionPolicy = [[EXUpdatesSelectionPolicy alloc]
                                                initWithLauncherSelectionPolicy:[[EXExpoGoLauncherSelectionPolicyFilterAware alloc] initWithSdkVersions:sdkVersions]
-                                               loaderSelectionPolicy:[EXUpdatesLoaderSelectionPolicyFilterAware new]
+                                               loaderSelectionPolicy:[[EXUpdatesLoaderSelectionPolicyFilterAware alloc] initWithConfig:config]
                                                reaperSelectionPolicy:[EXUpdatesReaperSelectionPolicyDevelopmentClient new]];
 
   EXHomeAppLoaderTask *loaderTask = [[EXHomeAppLoaderTask alloc] initWithManifestAndAssetRequestHeaders:self.manifestAndAssetRequestHeaders

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4398,7 +4398,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: b58e9627004f47043897eeae830c3ef023678f3b
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 261d5b1bb5c97bf83c1232a4bdbb5124eea14cb9
+  hermes-engine: 508aef00fe18a32c9a667e72afe990aa7f2829c5
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8


### PR DESCRIPTION
# Why
Fixes a build error after the changes in #38167

# How
`EXUpdatesLoaderSelectionPolicyFilterAware` initializer needs to be passed a config object.

# Test Plan
expo-go builds and runs correctly

