### PR TITLE
[go] fix build error on android

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -154,7 +154,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
     }
     val selectionPolicy = SelectionPolicy(
       ExpoGoLauncherSelectionPolicyFilterAware(sdkVersionsList),
-      LoaderSelectionPolicyFilterAware(),
+      LoaderSelectionPolicyFilterAware(configuration),
       ReaperSelectionPolicyDevelopmentClient()
     )
     val directory: File = try {


### PR DESCRIPTION
# Why

#38643 for android

# How

add `config` to `LoaderSelectionPolicyFilterAware`

# Test Plan

since expo-go build is breaking on main now, i've tried to rollback 99db6524946b4808b731d7f433628ae94d21e65a and test the build

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
