### PR TITLE
[ci] fix TS error in dev-client tests

### DIFF
--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- fix TS error when running tests ([#38660](https://github.com/expo/expo/pull/38660) by [@vonovak](https://github.com/vonovak))
+
 ## 5.2.4 - 2025-07-03
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-client/src/types.d.ts
+++ b/packages/expo-dev-client/src/types.d.ts
@@ -1,0 +1,3 @@
+// dev-client imports code that ends up using `react-native` globals, but it doesn't import `react-native` directly.
+// TS therefore doesn't recognize the RN globals, which is what this is for.
+/// <reference types="react-native/src/types/globals" />


### PR DESCRIPTION
# Why

```
et cp expo-dev-client
🔍 Checking expo-dev-client package
🏃‍♀️ Running yarn clean
🏃‍♀️ Running yarn build
🏃‍♀️ Running yarn test --watch false --passWithNoTests
test script failed, see process output:
stdout > yarn run v1.22.22
stdout > $ expo-module test --watch false --passWithNoTests
stdout > info Visit https://yarnpkg.com/en/docs/cli/exec for documentation about this command.
stdout > info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
stderr > PASS Node src/__tests__/DevClient-test.ts
stderr > PASS Web src/__tests__/DevClient-test.ts
stderr > FAIL Android src/__tests__/DevClient-test.ts
stderr >   ● Test suite failed to run
stderr > 
stderr >     ../expo/src/winter/installGlobal.ts:84:7 - error TS2304: Cannot find name '__DEV__'.
stderr > 
stderr >     84   if (__DEV__ && descriptor) {
stderr >              ~~~~~~~
stderr > 
stderr > FAIL iOS src/__tests__/DevClient-test.ts
stderr >   ● Test suite failed to run
stderr > 
stderr >     ../expo/src/winter/installGlobal.ts:84:7 - error TS2304: Cannot find name '__DEV__'.
stderr > 
stderr >     84   if (__DEV__ && descriptor) {
stderr >              ~~~~~~~
stderr > 
stderr > Test Suites: 2 failed, 2 passed, 4 total
stderr > Tests:       2 passed, 2 total
stderr > Snapshots:   0 total
stderr > Time:        3.363 s
stderr > Ran all test suites in 4 projects.
stderr > (node:60397) Warning: Accessing non-existent property 'then' of module exports inside circular dependency
stderr > (Use `node --trace-warnings ...` to show where the warning was created)
stderr > error Command failed.
stderr > Exit code: 1
stderr > Command: npx
stderr > Arguments: jest --watch false --passWithNoTests
stderr > Directory: /Users/vojta/_dev/2expo/packages/expo-dev-client
stderr > Output:
stderr > 
stderr > error Command failed with exit code 1.

🏁 0 packages passed, 1 package failed: expo-dev-client
```

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

instruct TS to find TS typings of RN core. Alternatively we can [remove the tests](https://github.com/expo/expo/blob/be5b308361a7acafa3cede58ad36dd9210fd16cf/packages/expo-dev-client/src/__tests__/DevClient-test.ts#L5) as they aren't terribly useful 🤷 

# Test Plan

`et cp expo-dev-client` succeeds

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
