### PR TITLE
[cli] Factor in no :hermes_enabled in Podfile

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Run prebuild only for the platforms specified in app config (if listed). ([#31752](https://github.com/expo/expo/pull/31752) by [@prathameshmm02](https://github.com/prathameshmm02))
 - Improve API Routes development errors (remove duplicates and misleading stack traces) ([#38465](https://github.com/expo/expo/pull/38465) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 - Resolve extensionless routes as HTML in static server ([#38610](https://github.com/expo/expo/pull/38610) by [@hassankhan](https://github.com/hassankhan))
+- Factor in no :hermes_enabled in Podfile ([#38664](https://github.com/expo/expo/pull/38664) by [@brentvatne](https://github.com/brentvatne))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/export/__tests__/exportHermes.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportHermes.test.ts
@@ -211,12 +211,12 @@ describe('maybeThrowFromInconsistentEngineAsync - ios', () => {
       `
   use_react_native!(
     :path => config[:reactNativePath],
-    hermes_enabled: true
+    hermes_enabled: false
   )`,
       `
   use_react_native!(
     :path => config[:reactNativePath],
-    hermes_enabled: true, // with comments
+    hermes_enabled: false, // with comments
   )`,
     ];
 
@@ -232,7 +232,7 @@ describe('maybeThrowFromInconsistentEngineAsync - ios', () => {
           'ios',
           /* isHermesManaged */ true
         )
-      ).resolves.toBeUndefined();
+      ).rejects.toThrow();
 
       expect(readPaths).toEqual(['/expo/ios/Podfile']);
     }

--- a/packages/@expo/cli/src/export/__tests__/exportHermes.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportHermes.test.ts
@@ -206,6 +206,38 @@ describe('maybeThrowFromInconsistentEngineAsync - android', () => {
 });
 
 describe('maybeThrowFromInconsistentEngineAsync - ios', () => {
+  it('should support either :hermes_enabled => true or hermes_enabled: true syntax', async () => {
+    const podfileTestCases = [
+      `
+  use_react_native!(
+    :path => config[:reactNativePath],
+    hermes_enabled: true
+  )`,
+      `
+  use_react_native!(
+    :path => config[:reactNativePath],
+    hermes_enabled: true, // with comments
+  )`,
+    ];
+
+    for (const content of podfileTestCases) {
+      const readPaths = addMockedFiles({
+        '/expo/ios/Podfile': content,
+      });
+
+      await expect(
+        maybeThrowFromInconsistentEngineAsync(
+          '/expo',
+          '/expo/app.json',
+          'ios',
+          /* isHermesManaged */ true
+        )
+      ).resolves.toBeUndefined();
+
+      expect(readPaths).toEqual(['/expo/ios/Podfile']);
+    }
+  });
+
   it('should resolve if ":hermes_enabled => true" in Podfile and "jsEngine: \'hermes\'" in app.json', async () => {
     const podfileTestCases = [
       `
@@ -266,10 +298,6 @@ describe('maybeThrowFromInconsistentEngineAsync - ios', () => {
     :path => config[:reactNativePath],
     :hermes_enabled => false
   )`,
-      `
-  use_react_native!(
-    :path => config[:reactNativePath],
-  )`,
     ];
 
     for (const content of podfileTestCases) {
@@ -290,21 +318,30 @@ describe('maybeThrowFromInconsistentEngineAsync - ios', () => {
     }
   });
 
-  it('should resolve if "expo.jsEngine": \'hermes\' in Podfile.properties.json and "jsEngine: \'hermes\'" in app.json', async () => {
-    const readPaths = addMockedFiles({
-      '/expo/ios/Podfile.properties.json': '{"expo.jsEngine":"hermes"}',
-    });
+  it('should not throw if :hermes_enabled is not present in Podfile and "jsEngine: \'hermes\'" in app.json', async () => {
+    const podfileTestCases = [
+      `
+  use_react_native!(
+    :path => config[:reactNativePath],
+  )`,
+    ];
 
-    await expect(
-      maybeThrowFromInconsistentEngineAsync(
-        '/expo',
-        '/expo/app.json',
-        'ios',
-        /* isHermesManaged */ true
-      )
-    ).resolves.toBeUndefined();
+    for (const content of podfileTestCases) {
+      const readPaths = addMockedFiles({
+        '/expo/ios/Podfile': content,
+      });
 
-    expect(readPaths).toEqual(['/expo/ios/Podfile.properties.json']);
+      await expect(
+        maybeThrowFromInconsistentEngineAsync(
+          '/expo',
+          '/expo/app.json',
+          'ios',
+          /* isHermesManaged */ true
+        )
+      ).resolves.toBeUndefined();
+
+      expect(readPaths).toEqual(['/expo/ios/Podfile']);
+    }
   });
 
   describe('should handle the inconsistency between Podfile and Podfile.properties.json', () => {

--- a/packages/@expo/cli/src/export/exportHermes.ts
+++ b/packages/@expo/cli/src/export/exportHermes.ts
@@ -92,26 +92,26 @@ export async function maybeThrowFromInconsistentEngineAsync(
   ) {
     throw new Error(
       `JavaScript engine configuration is inconsistent between ${configFileName} and Android native project.\n` +
-      `In ${configFileName}: Hermes is ${isHermesManaged ? 'enabled' : 'not enabled'}\n` +
-      `In Android native project: Hermes is ${isHermesManaged ? 'not enabled' : 'enabled'}\n` +
-      `Check the following files for inconsistencies:\n` +
-      `  - ${configFilePath}\n` +
-      `  - ${path.join(projectRoot, 'android', 'gradle.properties')}\n` +
-      `  - ${path.join(projectRoot, 'android', 'app', 'build.gradle')}\n` +
-      'Learn more: https://expo.fyi/hermes-android-config'
+        `In ${configFileName}: Hermes is ${isHermesManaged ? 'enabled' : 'not enabled'}\n` +
+        `In Android native project: Hermes is ${isHermesManaged ? 'not enabled' : 'enabled'}\n` +
+        `Check the following files for inconsistencies:\n` +
+        `  - ${configFilePath}\n` +
+        `  - ${path.join(projectRoot, 'android', 'gradle.properties')}\n` +
+        `  - ${path.join(projectRoot, 'android', 'app', 'build.gradle')}\n` +
+        'Learn more: https://expo.fyi/hermes-android-config'
     );
   }
 
   if (platform === 'ios' && (await maybeInconsistentEngineIosAsync(projectRoot, isHermesManaged))) {
     throw new Error(
       `JavaScript engine configuration is inconsistent between ${configFileName} and iOS native project.\n` +
-      `In ${configFileName}: Hermes is ${isHermesManaged ? 'enabled' : 'not enabled'}\n` +
-      `In iOS native project: Hermes is ${isHermesManaged ? 'not enabled' : 'enabled'}\n` +
-      `Check the following files for inconsistencies:\n` +
-      `  - ${configFilePath}\n` +
-      `  - ${path.join(projectRoot, 'ios', 'Podfile')}\n` +
-      `  - ${path.join(projectRoot, 'ios', 'Podfile.properties.json')}\n` +
-      'Learn more: https://expo.fyi/hermes-ios-config'
+        `In ${configFileName}: Hermes is ${isHermesManaged ? 'enabled' : 'not enabled'}\n` +
+        `In iOS native project: Hermes is ${isHermesManaged ? 'not enabled' : 'enabled'}\n` +
+        `Check the following files for inconsistencies:\n` +
+        `  - ${configFilePath}\n` +
+        `  - ${path.join(projectRoot, 'ios', 'Podfile')}\n` +
+        `  - ${path.join(projectRoot, 'ios', 'Podfile.properties.json')}\n` +
+        'Learn more: https://expo.fyi/hermes-ios-config'
     );
   }
 }


### PR DESCRIPTION
# Why

Re: https://exponent-internal.slack.com/archives/C013ZK4SA12/p1754407693037589

# How

Treat the absence of `:hermes_enabled` in Podfile as evidence that Hermes is enabled.

# Test Plan

Wrote unit tests. @keith-kurak can verify behavior in the flow he used to get to the state from the Slack link above. It should be verifiable by copying these changes directly to node_modules in the project that reproduces the issue. Once this is confirmed, we can backport to sdk-53 as well.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
