### PR TITLE
chore: Bump to `@expo/metro@0.1.1` (metro@0.83.1)

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -88,8 +88,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: 🧶 Install node modules in root dir
-        # Temporary disable the Node engines requirements due to unexpected Node requirement from React Native / Metro
-        run: yarn install --prefer-offline --frozen-lockfile --ignore-engines
+        run: yarn install --prefer-offline --frozen-lockfile
         env:
           YARN_IGNORE_SCRIPTS: 'true'
 
@@ -163,8 +162,7 @@ jobs:
 
       - name: 🧶 Install node modules in root dir
         # NOTE(cedric): yarn v1 on Windows has networking issues, we need to set `--network-timeout` to a higher value
-        # Temporary disable the Node engines requirements due to unexpected Node requirement from React Native / Metro
-        run: yarn install --prefer-offline --frozen-lockfile --network-timeout 1000000 --ignore-engines
+        run: yarn install --prefer-offline --frozen-lockfile --network-timeout 1000000
         env:
           YARN_IGNORE_SCRIPTS: 'true'
 
@@ -215,8 +213,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: 🧶 Install node modules in root dir
-        # Temporary disable the Node engines requirements due to unexpected Node requirement from React Native / Metro
-        run: yarn install --prefer-offline --frozen-lockfile --ignore-engines
+        run: yarn install --prefer-offline --frozen-lockfile
         env:
           YARN_IGNORE_SCRIPTS: 'true'
 
@@ -312,8 +309,7 @@ jobs:
 
       - name: 🧶 Install node modules in root dir
         # NOTE(cedric): yarn v1 on Windows has networking issues, we need to set `--network-timeout` to a higher value
-        # Temporary disable the Node engines requirements due to unexpected Node requirement from React Native / Metro
-        run: yarn install --prefer-offline --frozen-lockfile --network-timeout 1000000 --ignore-engines
+        run: yarn install --prefer-offline --frozen-lockfile --network-timeout 1000000
         env:
           YARN_IGNORE_SCRIPTS: 'true'
 

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -88,7 +88,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: 🧶 Install node modules in root dir
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
+        # Temporary disable the Node engines requirements due to unexpected Node requirement from React Native / Metro
         run: yarn install --prefer-offline --frozen-lockfile --ignore-engines
         env:
           YARN_IGNORE_SCRIPTS: 'true'
@@ -163,7 +163,7 @@ jobs:
 
       - name: 🧶 Install node modules in root dir
         # NOTE(cedric): yarn v1 on Windows has networking issues, we need to set `--network-timeout` to a higher value
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
+        # Temporary disable the Node engines requirements due to unexpected Node requirement from React Native / Metro
         run: yarn install --prefer-offline --frozen-lockfile --network-timeout 1000000 --ignore-engines
         env:
           YARN_IGNORE_SCRIPTS: 'true'
@@ -215,7 +215,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: 🧶 Install node modules in root dir
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
+        # Temporary disable the Node engines requirements due to unexpected Node requirement from React Native / Metro
         run: yarn install --prefer-offline --frozen-lockfile --ignore-engines
         env:
           YARN_IGNORE_SCRIPTS: 'true'
@@ -312,7 +312,7 @@ jobs:
 
       - name: 🧶 Install node modules in root dir
         # NOTE(cedric): yarn v1 on Windows has networking issues, we need to set `--network-timeout` to a higher value
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
+        # Temporary disable the Node engines requirements due to unexpected Node requirement from React Native / Metro
         run: yarn install --prefer-offline --frozen-lockfile --network-timeout 1000000 --ignore-engines
         env:
           YARN_IGNORE_SCRIPTS: 'true'

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -162,7 +162,8 @@ jobs:
 
       - name: 🧶 Install node modules in root dir
         # NOTE(cedric): yarn v1 on Windows has networking issues, we need to set `--network-timeout` to a higher value
-        run: yarn install --prefer-offline --frozen-lockfile --network-timeout 1000000
+        # NOTE(@kitten): --ignore-engines is needed due to Node 18 being required (see above)
+        run: yarn install --prefer-offline --frozen-lockfile --network-timeout 1000000 --ignore-engines
         env:
           YARN_IGNORE_SCRIPTS: 'true'
 
@@ -309,7 +310,8 @@ jobs:
 
       - name: 🧶 Install node modules in root dir
         # NOTE(cedric): yarn v1 on Windows has networking issues, we need to set `--network-timeout` to a higher value
-        run: yarn install --prefer-offline --frozen-lockfile --network-timeout 1000000
+        # NOTE(@kitten): --ignore-engines is needed due to Node 18 being required (see above)
+        run: yarn install --prefer-offline --frozen-lockfile --network-timeout 1000000 --ignore-engines
         env:
           YARN_IGNORE_SCRIPTS: 'true'
 

--- a/.github/workflows/client-android-eas.yml
+++ b/.github/workflows/client-android-eas.yml
@@ -43,8 +43,7 @@ jobs:
           yarn-tools: 'true'
       - name: 🧶 Yarn install
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: Install eas-cli
         run: npm install -g eas-cli
       - name: Generate local credentials.json

--- a/.github/workflows/client-ios-eas.yml
+++ b/.github/workflows/client-ios-eas.yml
@@ -53,8 +53,7 @@ jobs:
           yarn-tools: 'true'
       - name: 🧶 Yarn install
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: Install eas-cli
         run: npm install -g eas-cli
       - name: Build

--- a/.github/workflows/create-expo-app.yml
+++ b/.github/workflows/create-expo-app.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22]
+        node: [20, 22]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/create-expo-app.yml
+++ b/.github/workflows/create-expo-app.yml
@@ -54,8 +54,7 @@ jobs:
           yarn-workspace: 'true'
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: 🛠 Build create-expo
         run: yarn prepare
         working-directory: packages/create-expo

--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -38,8 +38,7 @@ jobs:
           ndk-version: ${{ matrix.ndk-version }}
       - name: 🧶 Yarn install
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: Init new expo app
         working-directory: ../
         run: yarn create expo-app ./development-client-android-test --yes
@@ -94,8 +93,7 @@ jobs:
           yarn-workspace: 'true'
       - name: 🧶 Yarn install
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: Init new expo app
         working-directory: ../
         run: yarn create expo-app ./development-client-ios-test --yes

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -65,8 +65,7 @@ jobs:
           native-tests-pods: 'true'
       - name: 🧶 Yarn install
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: 🥥 Install CocoaPods in `apps/native-tests/ios`
         if: steps.expo-caches.outputs.bare-expo-pods-hit != 'true'
         run: pod install

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -54,8 +54,7 @@ jobs:
           yarn-workspace: 'true'
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: Get the base commit
         id: base-commit
         run: |

--- a/.github/workflows/router-e2e.yml
+++ b/.github/workflows/router-e2e.yml
@@ -36,10 +36,7 @@ jobs:
             ${{ runner.os }}-yarn-cache-
 
       - name: Install dependencies
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
-        env:
-          YARN_IGNORE_SCRIPTS: 'true'
+        run: YARN_IGNORE_SCRIPTS=true yarn --frozen-lockfile
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -56,7 +56,7 @@ jobs:
           yarn-tools: 'true'
       - name: 🧶 Install workspace node modules
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
+        # Temporary disable the Node engines requirements due to unexpected Node requirement from React Native / Metro
         run: yarn install --frozen-lockfile --ignore-engines
       - name: 🧐 Check packages
         run: |

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -56,8 +56,7 @@ jobs:
           yarn-tools: 'true'
       - name: 🧶 Install workspace node modules
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # Temporary disable the Node engines requirements due to unexpected Node requirement from React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: 🧐 Check packages
         run: |
           echo "Checking packages according to the event name: ${{ github.event_name }}"

--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -53,8 +53,7 @@ jobs:
           key: ${{ runner.os }}-workspace-modules-${{ hashFiles('yarn.lock') }}
       - name: 🧶 Install node modules in root dir
         if: steps.workspace-modules-cache.outputs.cache-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: ⭐️ Create test-nightlies Project (New Architecture)
         run: yarn prepare && bun build/index.js --expo-repo ${{ github.workspace }} --no-install ${{ runner.temp }} --enable-new-architecture true
         working-directory: packages/create-expo-nightly
@@ -146,8 +145,7 @@ jobs:
           key: ${{ runner.os }}-workspace-modules-${{ hashFiles('yarn.lock') }}
       - name: 🧶 Install node modules in root dir
         if: steps.workspace-modules-cache.outputs.cache-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: ⭐️ Create test-nightlies Project (New Architecture)
         run: yarn prepare && bun build/index.js --expo-repo ${{ github.workspace }} --no-install ${{ runner.temp }} --enable-new-architecture true
         working-directory: packages/create-expo-nightly

--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -59,8 +59,7 @@ jobs:
           bare-expo-macos-pods: 'true'
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: 🕵️ Debug CocoaPods lockfiles
         run: git diff Podfile.lock Pods/Manifest.lock
         working-directory: apps/bare-expo/macos

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -105,8 +105,7 @@ jobs:
           yarn-workspace: 'true'
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: 🍏 Run iOS tests
         run: ./scripts/start-ios-e2e-test.js --test
         working-directory: apps/bare-expo
@@ -214,8 +213,7 @@ jobs:
           yarn-workspace: 'true'
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: 🤖 Run Android tests
         uses: ./.github/actions/use-android-emulator
         with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -53,8 +53,7 @@ jobs:
           bare-expo-pods: 'true'
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: 🕵️ Debug CocoaPods lockfiles
         run: git diff Podfile.lock Pods/Manifest.lock
         working-directory: apps/bare-expo/ios
@@ -124,8 +123,7 @@ jobs:
           yarn-workspace: 'true'
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: 🧪 Run tests
         run: ./scripts/start-ios-e2e-test.js --test
         working-directory: apps/bare-expo
@@ -241,8 +239,7 @@ jobs:
           yarn-workspace: 'true'
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        # TODO(@kitten): Remove `--ignore-engines` when Node 22+ requirement is dropped again in React Native / Metro
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
       - name: 🧪 Run tests
         uses: ./.github/actions/use-android-emulator
         with:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "resolutions": {
-    "@expo/metro": "~0.1.0",
+    "@expo/metro": "~0.1.1",
     "react-native": "0.81.0-rc.5",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -49,7 +49,7 @@
     "@expo/env": "~1.0.5",
     "@expo/image-utils": "^0.7.4",
     "@expo/json-file": "^9.1.4",
-    "@expo/metro": "~0.1.0",
+    "@expo/metro": "~0.1.1",
     "@expo/metro-config": "~0.20.14",
     "@expo/osascript": "^2.2.4",
     "@expo/package-manager": "^1.8.4",

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "^7.20.0",
     "@babel/generator": "^7.20.5",
     "@expo/config": "~11.0.10",
-    "@expo/metro": "~0.1.0",
+    "@expo/metro": "~0.1.1",
     "@expo/env": "~1.0.5",
     "@expo/json-file": "~9.1.4",
     "@expo/spawn-async": "^1.7.2",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -76,7 +76,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.0",
     "@types/babel__core": "^7.20.5",
-    "@expo/metro": "~0.1.0",
+    "@expo/metro": "~0.1.1",
     "expo-module-scripts": "^4.1.7",
     "jest": "^29.2.1",
     "react-refresh": "^0.14.2"

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -38,7 +38,7 @@
     "@expo/json-file": "~9.1.4",
     "@expo/schemer": "1.6.4",
     "@expo/spawn-async": "^1.7.2",
-    "@expo/metro": "~0.1.0",
+    "@expo/metro": "~0.1.1",
     "@types/debug": "^4.1.8",
     "@vercel/ncc": "0.38.1",
     "chalk": "^4.0.0",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -80,7 +80,7 @@
     "@expo/config-plugins": "~10.0.2",
     "@expo/devtools": "0.0.1",
     "@expo/fingerprint": "0.13.0",
-    "@expo/metro": "~0.1.0",
+    "@expo/metro": "~0.1.1",
     "@expo/metro-config": "0.20.14",
     "@expo/vector-icons": "^14.0.0",
     "babel-preset-expo": "~13.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1408,23 +1408,23 @@
     debug "^3.1.0"
     glob "^10.4.2"
 
-"@expo/metro@~0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@expo/metro/-/metro-0.1.0.tgz#492fadee742d3f976b8531dbd686ac4d2c2a26b2"
-  integrity sha512-gJ0Dou3QXXY5jp6r6jERYRFsXCvs9HQ7H+/QTL595iWV8i9DYTnQMVBw5M41TBQEq8CpaMDXm+DVpqL746Ek0g==
+"@expo/metro@~0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@expo/metro/-/metro-0.1.1.tgz#234099226509f88d3a431f386e83c21a64a01630"
+  integrity sha512-zvA9BE6myFoCxeiw/q3uE/kVkIwLTy27a+fDoEl7WQ7EvKfFeiXnRVhUplDMLGZIHH8VC38Gay6RBtVhnmOm5w==
   dependencies:
-    metro "0.83.0"
-    metro-babel-transformer "0.83.0"
-    metro-cache "0.83.0"
-    metro-cache-key "0.83.0"
-    metro-config "0.83.0"
-    metro-core "0.83.0"
-    metro-file-map "0.83.0"
-    metro-resolver "0.83.0"
-    metro-runtime "0.83.0"
-    metro-source-map "0.83.0"
-    metro-transform-plugins "0.83.0"
-    metro-transform-worker "0.83.0"
+    metro "0.83.1"
+    metro-babel-transformer "0.83.1"
+    metro-cache "0.83.1"
+    metro-cache-key "0.83.1"
+    metro-config "0.83.1"
+    metro-core "0.83.1"
+    metro-file-map "0.83.1"
+    metro-resolver "0.83.1"
+    metro-runtime "0.83.1"
+    metro-source-map "0.83.1"
+    metro-transform-plugins "0.83.1"
+    metro-transform-worker "0.83.1"
 
 "@expo/multipart-body-parser@^1.0.0":
   version "1.0.0"
@@ -11303,16 +11303,6 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-metro-babel-transformer@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.83.0.tgz#933839d581e61a2f107c708e0fbf4379a83fa1ca"
-  integrity sha512-ncYhd1WWElJj6W+uMgoi57mUgdWm8UZBLUg9/TYh6iFipJ6A78IuztOFbohAk+Zh5S376bF86TSDaeRouAzJkg==
-  dependencies:
-    "@babel/core" "^7.25.2"
-    flow-enums-runtime "^0.0.6"
-    hermes-parser "0.29.1"
-    nullthrows "^1.1.1"
-
 metro-babel-transformer@0.83.1:
   version "0.83.1"
   resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.83.1.tgz#77e548b4b8f087fe30ffcd112826b371f83b597d"
@@ -11323,29 +11313,12 @@ metro-babel-transformer@0.83.1:
     hermes-parser "0.29.1"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.83.0.tgz#73d6c4810454092ad833706ce39e3111171892c5"
-  integrity sha512-T0WmTe0NRt/7/kaWuDoUbeF5xlfqzLyVg5MO6X2XnXT8le42S2UxRWJgZOtojOXGvthdQhzdxZM2GCd+BQLfAQ==
-  dependencies:
-    flow-enums-runtime "^0.0.6"
-
 metro-cache-key@0.83.1:
   version "0.83.1"
   resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.83.1.tgz#18c59c7c6944cfa0856d57ff5ebbdc18dec12687"
   integrity sha512-ZUs+GD5CNeDLxx5UUWmfg26IL+Dnbryd+TLqTlZnDEgehkIa11kUSvgF92OFfJhONeXzV4rZDRGNXoo6JT+8Gg==
   dependencies:
     flow-enums-runtime "^0.0.6"
-
-metro-cache@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.83.0.tgz#595d9be2cc0e4bc674088a79965fb61ab6e54b36"
-  integrity sha512-t5ExK5od6PcI7Zc441oRNdnYoxWb9EuqBsgoVQUG2/DRsEAHCkK6EqwLYForgMABYwJOpBTGMw74f7EQMKakuw==
-  dependencies:
-    exponential-backoff "^3.1.1"
-    flow-enums-runtime "^0.0.6"
-    https-proxy-agent "^7.0.5"
-    metro-core "0.83.0"
 
 metro-cache@0.83.1:
   version "0.83.1"
@@ -11356,20 +11329,6 @@ metro-cache@0.83.1:
     flow-enums-runtime "^0.0.6"
     https-proxy-agent "^7.0.5"
     metro-core "0.83.1"
-
-metro-config@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.83.0.tgz#43bb29db0247c6b990993672b6acba52b67c36d5"
-  integrity sha512-fkuXgw8KXMOOGfPVwE1xULTeW2kfpyp8dtfD96PcBZHPxv8Pu0EAihTXkCPaKk1PKqIHenzEdW9s2MRUWvyRPA==
-  dependencies:
-    connect "^3.6.5"
-    cosmiconfig "^5.0.5"
-    flow-enums-runtime "^0.0.6"
-    jest-validate "^29.7.0"
-    metro "0.83.0"
-    metro-cache "0.83.0"
-    metro-core "0.83.0"
-    metro-runtime "0.83.0"
 
 metro-config@0.83.1, metro-config@^0.83.1:
   version "0.83.1"
@@ -11385,15 +11344,6 @@ metro-config@0.83.1, metro-config@^0.83.1:
     metro-core "0.83.1"
     metro-runtime "0.83.1"
 
-metro-core@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.83.0.tgz#d9fb3dffea49b07db75d735e23cd2528a0a66db5"
-  integrity sha512-LeWfVWejZVx/cEkOYrgQ11A+2cTPdq30Xm4SM31SfA64teKCnaUPa4k6CxU65AUou5EF4nCFo7B2XE5Q2jwBvg==
-  dependencies:
-    flow-enums-runtime "^0.0.6"
-    lodash.throttle "^4.1.1"
-    metro-resolver "0.83.0"
-
 metro-core@0.83.1, metro-core@^0.83.1:
   version "0.83.1"
   resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.83.1.tgz#fbedf8c6cfdcc58eaec7011718f1041ac9562cff"
@@ -11402,21 +11352,6 @@ metro-core@0.83.1, metro-core@^0.83.1:
     flow-enums-runtime "^0.0.6"
     lodash.throttle "^4.1.1"
     metro-resolver "0.83.1"
-
-metro-file-map@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.83.0.tgz#6b1bc47848caccc403896eb8c81a4699c39c934c"
-  integrity sha512-vWbimPJ/sPwSFfYJcwSbgsM+x3E6mELFnm8WqwrvTvRm55NR05noAzx1HG/X0PJUylptHlQAbguPEA7F4jd/ug==
-  dependencies:
-    debug "^4.4.0"
-    fb-watchman "^2.0.0"
-    flow-enums-runtime "^0.0.6"
-    graceful-fs "^4.2.4"
-    invariant "^2.2.4"
-    jest-worker "^29.7.0"
-    micromatch "^4.0.4"
-    nullthrows "^1.1.1"
-    walker "^1.0.7"
 
 metro-file-map@0.83.1:
   version "0.83.1"
@@ -11433,14 +11368,6 @@ metro-file-map@0.83.1:
     nullthrows "^1.1.1"
     walker "^1.0.7"
 
-metro-minify-terser@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.83.0.tgz#c84c0eae701ecd7e4cf3c595e1f483e8a5e813ad"
-  integrity sha512-jsVzWnkl43Kb18iQvEn0Keq0n5WQwAiAHn9vCFE6roM6E4fVLDKlzDNoWyFzs9GyodlVYkbjAuz9PCpEzBfq5Q==
-  dependencies:
-    flow-enums-runtime "^0.0.6"
-    terser "^5.15.0"
-
 metro-minify-terser@0.83.1:
   version "0.83.1"
   resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.83.1.tgz#227f534876fb8eb089b64d7bff8cf77d1817c8f4"
@@ -11449,26 +11376,11 @@ metro-minify-terser@0.83.1:
     flow-enums-runtime "^0.0.6"
     terser "^5.15.0"
 
-metro-resolver@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.83.0.tgz#a4dc88b192c886c02343703127fef80e3a03ca83"
-  integrity sha512-TGwPrU4lpKwmvpfnN9WA4RMECpSsZ+GAtiKQRjNh6ek0f7XUR8RuGPTWc4VidTo973C0syfbYVoD/iv1hFgAiw==
-  dependencies:
-    flow-enums-runtime "^0.0.6"
-
 metro-resolver@0.83.1:
   version "0.83.1"
   resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.83.1.tgz#2e14c8b0762883f3568f41cde08f4a48893021ce"
   integrity sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g==
   dependencies:
-    flow-enums-runtime "^0.0.6"
-
-metro-runtime@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.83.0.tgz#495d28160784c303c98c1d32ef936b2e5524c445"
-  integrity sha512-35q73Hz4X8JcNa2jgHdRy7zLggyEM2tPhkw+xjfuoRXO8TtFLGl7gKug/lF3GVYWEI6I9wEf5BGsnAoE5MZ4tQ==
-  dependencies:
-    "@babel/runtime" "^7.25.0"
     flow-enums-runtime "^0.0.6"
 
 metro-runtime@0.83.1, metro-runtime@^0.83.1:
@@ -11478,22 +11390,6 @@ metro-runtime@0.83.1, metro-runtime@^0.83.1:
   dependencies:
     "@babel/runtime" "^7.25.0"
     flow-enums-runtime "^0.0.6"
-
-metro-source-map@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.83.0.tgz#a9c807a6c7cf43448e6f55e280dab8aafadf0586"
-  integrity sha512-XsQl5MhXo249q0ImDCFatBaWzU4K6ksso9n2MKoreuMPrgmVwzOAkVvJRUxuPvjW0DzBZKwqpk3ubC5MYRalfQ==
-  dependencies:
-    "@babel/traverse" "^7.25.3"
-    "@babel/traverse--for-generate-function-map" "npm:@babel/traverse@^7.25.3"
-    "@babel/types" "^7.25.2"
-    flow-enums-runtime "^0.0.6"
-    invariant "^2.2.4"
-    metro-symbolicate "0.83.0"
-    nullthrows "^1.1.1"
-    ob1 "0.83.0"
-    source-map "^0.5.6"
-    vlq "^1.0.0"
 
 metro-source-map@0.83.1, metro-source-map@^0.83.1:
   version "0.83.1"
@@ -11511,18 +11407,6 @@ metro-source-map@0.83.1, metro-source-map@^0.83.1:
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-symbolicate@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.83.0.tgz#05938d2ecbf6c8318185d7b631f9938dcaa115d5"
-  integrity sha512-pPu73T3y4TWpmGgUIJBF8b4bPjxV9LHcqEqAc6Gd7xqN1Wquu6onhdmi72XLHxhk+mZBF2mtVIr/QKI3tOyRLg==
-  dependencies:
-    flow-enums-runtime "^0.0.6"
-    invariant "^2.2.4"
-    metro-source-map "0.83.0"
-    nullthrows "^1.1.1"
-    source-map "^0.5.6"
-    vlq "^1.0.0"
-
 metro-symbolicate@0.83.1:
   version "0.83.1"
   resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.83.1.tgz#c03edc8e7c0e8b44821f2a807c0a8342aaeb77eb"
@@ -11535,18 +11419,6 @@ metro-symbolicate@0.83.1:
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.83.0.tgz#0204405be0f5ffbcd73443ac15408b1285052894"
-  integrity sha512-HLUB+CduKt9KOUwW6zS3YezcIAUal3mmxEi6PW6/SqpqQIqR7Ij83UswCy/LRhY2Lx6IwucR8Zg9Oo+d0cCvzA==
-  dependencies:
-    "@babel/core" "^7.25.2"
-    "@babel/generator" "^7.25.0"
-    "@babel/template" "^7.25.0"
-    "@babel/traverse" "^7.25.3"
-    flow-enums-runtime "^0.0.6"
-    nullthrows "^1.1.1"
-
 metro-transform-plugins@0.83.1:
   version "0.83.1"
   resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.83.1.tgz#879b8ff34c3720d387889da60c03923394457988"
@@ -11557,25 +11429,6 @@ metro-transform-plugins@0.83.1:
     "@babel/template" "^7.25.0"
     "@babel/traverse" "^7.25.3"
     flow-enums-runtime "^0.0.6"
-    nullthrows "^1.1.1"
-
-metro-transform-worker@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.83.0.tgz#40822fdaf7b37ed18478948e1714acbd4c2c8a92"
-  integrity sha512-z9ZGlVMcw562mFqcJrU12yAgjntdRCsQV98rOyIOLF00/ui9un+xbQjqarjYmXpO3fM8SMGD1EjhuSGFN6MmWA==
-  dependencies:
-    "@babel/core" "^7.25.2"
-    "@babel/generator" "^7.25.0"
-    "@babel/parser" "^7.25.3"
-    "@babel/types" "^7.25.2"
-    flow-enums-runtime "^0.0.6"
-    metro "0.83.0"
-    metro-babel-transformer "0.83.0"
-    metro-cache "0.83.0"
-    metro-cache-key "0.83.0"
-    metro-minify-terser "0.83.0"
-    metro-source-map "0.83.0"
-    metro-transform-plugins "0.83.0"
     nullthrows "^1.1.1"
 
 metro-transform-worker@0.83.1:
@@ -11596,52 +11449,6 @@ metro-transform-worker@0.83.1:
     metro-source-map "0.83.1"
     metro-transform-plugins "0.83.1"
     nullthrows "^1.1.1"
-
-metro@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.83.0.tgz#0837569b1c34e543fc3d4af262863c49725d9398"
-  integrity sha512-qQoLKhFzZH1AjO81BDftQBUUI5FNzpKC6Bv9QGcZf1YiK034yl6aLQWg6HnNEkKkGNiMwgGlEJAzn40HjQtZmw==
-  dependencies:
-    "@babel/code-frame" "^7.24.7"
-    "@babel/core" "^7.25.2"
-    "@babel/generator" "^7.25.0"
-    "@babel/parser" "^7.25.3"
-    "@babel/template" "^7.25.0"
-    "@babel/traverse" "^7.25.3"
-    "@babel/types" "^7.25.2"
-    accepts "^1.3.7"
-    chalk "^4.0.0"
-    ci-info "^2.0.0"
-    connect "^3.6.5"
-    debug "^4.4.0"
-    error-stack-parser "^2.0.6"
-    flow-enums-runtime "^0.0.6"
-    graceful-fs "^4.2.4"
-    hermes-parser "0.29.1"
-    image-size "^1.0.2"
-    invariant "^2.2.4"
-    jest-worker "^29.7.0"
-    jsc-safe-url "^0.2.2"
-    lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.83.0"
-    metro-cache "0.83.0"
-    metro-cache-key "0.83.0"
-    metro-config "0.83.0"
-    metro-core "0.83.0"
-    metro-file-map "0.83.0"
-    metro-resolver "0.83.0"
-    metro-runtime "0.83.0"
-    metro-source-map "0.83.0"
-    metro-symbolicate "0.83.0"
-    metro-transform-plugins "0.83.0"
-    metro-transform-worker "0.83.0"
-    mime-types "^2.1.27"
-    nullthrows "^1.1.1"
-    serialize-error "^2.1.0"
-    source-map "^0.5.6"
-    throat "^5.0.0"
-    ws "^7.5.10"
-    yargs "^17.6.2"
 
 metro@0.83.1, metro@^0.83.1:
   version "0.83.1"
@@ -12308,13 +12115,6 @@ nwsapi@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.2.tgz#e5418863e7905df67d51ec95938d67bf801f0bb0"
   integrity sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==
-
-ob1@0.83.0:
-  version "0.83.0"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.83.0.tgz#4c3dda1fa32ae3ccfa2cf34a73624648b458c307"
-  integrity sha512-uLomnfaQcMEvUnvnf7frI8YO6qe8F4pDPvatBxqLuams9BYVA9YvZqM7xJjx7cw+nYgXjreOxsIJjNsM4a6A1A==
-  dependencies:
-    flow-enums-runtime "^0.0.6"
 
 ob1@0.83.1:
   version "0.83.1"


### PR DESCRIPTION
Bump to `metro@0.83.1`. This removes the `engines.node` restriction.