### PR TITLE
refactor(cli): Move sticky resolver over to new autolinking API

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
@@ -6,6 +6,26 @@ import type { ExpoCustomMetroResolver } from './withMetroResolvers';
 
 const debug = require('debug')('expo:start:server:metro:sticky-resolver') as typeof console.log;
 
+// This is a list of known modules we want to always include in sticky resolution
+const AUTOLINKING_MODULES = [
+  // NOTE: react-native won't be in autolinking output, since it's special
+  // We include it here manually, since we know it should be an unduplicated direct dependency
+  'react-native',
+  // Peer dependencies from expo
+  'react-native-webview',
+  '@expo/dom-webview',
+  // Dependencies from expo
+  'expo-asset',
+  'expo-constants',
+  'expo-file-system',
+  'expo-font',
+  'expo-keep-awake',
+  'expo-modules-core',
+  // Peer dependencies from expo-router
+  'react-native-gesture-handler',
+  'react-native-reanimated',
+];
+
 const AUTOLINKING_PLATFORMS = ['android', 'ios'] as const;
 type AutolinkingPlatform = (typeof AUTOLINKING_PLATFORMS)[number];
 
@@ -72,10 +92,14 @@ export async function createStickyModuleResolverInput({
         .map(async (platform) => {
           const dependencies = await autolinking.scanDependencyResolutionsForPlatform(
             linker,
-            platform
+            platform,
+            AUTOLINKING_MODULES
           );
           const moduleDescription = toPlatformModuleDescription(dependencies, platform);
-          return [platform, moduleDescription] satisfies [AutolinkingPlatform, PlatformModuleDescription];
+          return [platform, moduleDescription] satisfies [
+            AutolinkingPlatform,
+            PlatformModuleDescription,
+          ];
         })
     )
   ) as StickyModuleResolverInput;

--- a/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
@@ -7,7 +7,11 @@ import type { ExpoCustomMetroResolver } from './withMetroResolvers';
 const debug = require('debug')('expo:start:server:metro:sticky-resolver') as typeof console.log;
 
 // This is a list of known modules we want to always include in sticky resolution
-const AUTOLINKING_MODULES = [
+// Specifying these skips platform- and module-specific checks and always includes them in the output
+const KNOWN_STICKY_DEPENDENCIES = [
+  // NOTE: react and react-dom aren't native modules, but must also be deduplicated in bundles
+  'react',
+  'react-dom',
   // NOTE: react-native won't be in autolinking output, since it's special
   // We include it here manually, since we know it should be an unduplicated direct dependency
   'react-native',
@@ -93,7 +97,7 @@ export async function createStickyModuleResolverInput({
           const dependencies = await autolinking.scanDependencyResolutionsForPlatform(
             linker,
             platform,
-            AUTOLINKING_MODULES
+            KNOWN_STICKY_DEPENDENCIES
           );
           const moduleDescription = toPlatformModuleDescription(dependencies, platform);
           return [platform, moduleDescription] satisfies [

--- a/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoStickyResolver.ts
@@ -143,7 +143,7 @@ export function createStickyModuleResolver(
         originModulePath: resolvedModulePath,
       };
       const res = getStrictResolver(context, platform)(moduleName);
-      debug(`Sticky resolution for ${platform}: ${moduleName} -> ${resolvedModulePath}`);
+      debug(`Sticky resolution for ${platform}: ${moduleName} -> from: ${resolvedModulePath}`);
       return res;
     }
 


### PR DESCRIPTION
# Why

See original PR implementing sticky resolution: #37201

This uses the API added in #38680 for the sticky resolution input generated in `createExpoStickyResolver`. Nothing else has changed.

To recap what this does: The sticky resolver is experimental and activated with the `EXPO_USE_STICKY_RESOLVER=1` environment variable. It uses autolinking's discovered dependencies to intercept resolution requests in Metro that are about to enter standard Node resolution, and instead redirects them to the same target path that autolinking has resolved to.

# How

- Replace import of `expo-modules-autolinking` internals via `expo` with `expo-modules-autolinking/exports` reexported at `expo/unstable-autolinking-exports`
- Swap to new API (which replaces a lot of the manual logic that was here before)

### Noteworthy changes

- **This PR disables sticky resolution for web**
  - We should add a proper autolinking resolver for this. Since `expo-modules-autolinking` filters by platform, we don't have logic that would accept all native modules for web
- We manually add `react` and `react-dom` to the list of force-resolved node modules, since both are singleton modules, despite being JS-only

# Test Plan

- Rebuild `packages/@expo/cli`
- Go to `apps/router-e2e`
- Run `DEBUG=expo:start:server:metro:sticky-resolver EXPO_USE_STICKY_RESOLVER=1 yarn start:05-use-dom`
- Make sure you see the sticky resolver's debug output and that modules are resolving from it

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
