### PR TITLE
[docs] Add `macos-sequoia-15.5-xcode-26.0` image

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -289,6 +289,30 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 ### iOS server images
 
+#### <CopyTextButton>`macos-sequoia-15.5-xcode-26.0`</CopyTextButton>
+
+<Collapsible summary="Details">
+
+- macOS Sequoia 15.5
+- Xcode 26.0 Beta 4 (17A5285i)
+- Node.js 20.19.2
+- Bun 1.2.19
+- Yarn 1.22.22
+- pnpm 9.15.9
+- npm 10.8.2
+- fastlane 2.228.0
+- CocoaPods 1.16.2
+- Ruby 3.2
+- node-gyp 11.2.0
+- jq 1.8.0
+- Azul Zulu JDK 17.58.21 (OpenJDK 17.0.15)
+- Git 2.49.0
+- Git LFS 3.6.1
+- applesimutils 0.9.12
+- idb-companion 1.1.8
+
+</Collapsible>
+
 #### <CopyTextButton>`macos-sequoia-15.5-xcode-16.4` (`latest`, `sdk-53`)</CopyTextButton>
 
 <Collapsible summary="Details">


### PR DESCRIPTION
# Why

https://exponent-internal.slack.com/archives/C02123T524U/p1754676667486759?thread_ts=1753225752.966439&cid=C02123T524U

# How

Started the image up, checked the tools versions with SSH.

# Test Plan

<img width="1078" height="773" alt="Zrzut ekranu 2025-08-8 o 23 00 27" src="https://github.com/user-attachments/assets/d034587a-7014-43d4-b13f-359566befc66" />
