### PR TITLE
fix(expo-audio) [android]: Handle exceptions when retrieving maxAmplitude from MediaRecorder

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add shallow state comparison to prevent unnecessary re-renders in `useAudioRecorderState`. ([#38273](https://github.com/expo/expo/pull/38273) by [@alanjhughes](https://github.com/alanjhughes))
 - [web] Fixed broken player state when `replace` was called while audio was running, added missing `updateInterval` to web, and improved audio status event emitting. ([#38505](https://github.com/expo/expo/pull/38505) by [@hirbod](https://github.com/hirbod))
 - [android][iOS][web] Fix recordForDuration status updates and add new record() options API ([#38612](https://github.com/expo/expo/pull/38612) by [@hirbod](https://github.com/hirbod))
+- [android]: Handle exceptions when retrieving maxAmplitude from MediaRecorder ([#38690](https://github.com/expo/expo/pull/38690) by [@hirbod](https://github.com/hirbod))
 
 ### 💡 Others
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
@@ -49,7 +49,15 @@ class AudioRecorder(
       return null
     }
 
-    val amplitude: Int = recorder?.maxAmplitude ?: 0
+    val amplitude: Int = try {
+      recorder?.maxAmplitude ?: 0
+    } catch (e: Exception) {
+      // MediaRecorder maxAmplitude can throw various exceptions:
+      // - IllegalStateException: invalid recorder state/race condition
+      // - RuntimeException: getMaxAmplitude failed (hardware/driver issues)
+      // We return 0 (silence) as fallback for any amplitude reading failure
+      0
+    }
     return if (amplitude == 0) {
       -160.0
     } else {


### PR DESCRIPTION
# Why

Multiple useAudioRecorderState hooks with different intervals (100ms, 105ms) create concurrent calls to AudioRecorder.getStatus(), which internally calls MediaRecorder.getMaxAmplitude(). This Android API method can throw exceptions during:
  - Invalid recorder states (IllegalStateException)
  - Hardware/driver failures (RuntimeException: "getMaxAmplitude failed")
  - State transitions and concurrent access

Closes ENG-16952
Fixes #38586
Fixes #37289

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Added a try-catch block to safely handle potential exceptions when accessing the maxAmplitude property of the MediaRecorder. 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

repro, bare-expo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
