### PR TITLE
 [docs] Update autolinking docs and references (SDK 54)

### DIFF
--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -160,7 +160,6 @@ Once the `expo` package is installed and configured in your project, you can use
 
 The following Expo modules are brought in as dependencies of the `expo` package:
 
-- [`expo-application`](/versions/latest/sdk/application) - Generates the installation id in remote logging in development. This module is optional and can be safely removed if you do not use `expo-dev-client`.
 - [`expo-asset`](/versions/latest/sdk/asset) - A JavaScript-only package that builds around `expo-file-system` and provides a common foundation for assets across all Expo modules.
 - [`expo-constants`](/versions/latest/sdk/constants) - Provides access to the manifest.
 - [`expo-file-system`](/versions/latest/sdk/filesystem) - Interact with the device file system. Used by `expo-asset` and many other Expo modules. Commonly used directly by developers in application code.

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -18,17 +18,18 @@ The core implementation can be found in the [`expo-modules-autolinking`](https:/
 2. code that integrates with the Gradle build system for Android
 3. code that integrates with CocoaPods for iOS
 
-Since SDK 52, Expo Autolinking not only links Expo modules, but also React Native modules. To use the React Native community CLI autolinking instead, refer to this page's guide on [opting out of Expo Autolinking for React Native modules].
+Since SDK 52, Expo Autolinking not only links Expo modules, but also React Native modules. To use the React Native community CLI autolinking instead, see [opting out of Expo Autolinking for React Native modules](#opting-out-of-expo-autolinking-for-react-native-modules) section.
 
-## Linking Behavior
+## Linking behavior
 
-Expo Autolinking is integrated into the Gradle build system for Android, and CocoaPods for iOS. When building your app, the Expo Autolinking CLI is called and searches for Expo and React Native modules to autolink.
+Expo Autolinking is integrated into the Gradle build system for Android and CocoaPods for iOS. When building your app, the Expo Autolinking CLI is called and searches for Expo and React Native modules to autolink.
+
 This module resolution searches for candidate dependencies to autolink in four separate steps:
 
 1. For React Native modules only, it considers any `dependencies` in your project root's **react-native.config.js** that contain an explicit `root` path. This file is optional and doesn't exist in most Expo projects.
 2. It searches all directories specified in your autolinking configuration's `searchPaths` option.
 3. It searches local modules in the directory specified in your autolinking configuration's `nativeModulesDir` option, which defaults to `./modules/`.
-4. It resolves the dependencies of your app, and any dependency or peer dependency recursively. This matches the [Node.js resolution algorithm](https://nodejs.org/api/modules.html#loading-from-node_modules-folders).
+4. It resolves the dependencies of your app and any dependency or peer dependency recursively. This matches the [Node.js resolution algorithm](https://nodejs.org/api/modules.html#loading-from-node_modules-folders).
 
 The autolinked modules are automatically added to the build, which usually means that your app's dependencies that contain native (platform-specific) code are set up automatically.
 
@@ -77,8 +78,7 @@ A path relative to the app's root directory that Expo Autolinking should search 
 </PaddedAPIBox>
 <PaddedAPIBox header="exclude">
 
-A list of package names to exclude from autolinking.
-This is useful if you don't want to link some packages that specific platforms aren't using to reduce the binary size.
+A list of package names to exclude from autolinking. This is useful if you don't want to link some packages that specific platforms aren't using to reduce the binary size.
 The following config in **package.json** will exclude `expo-random` and `third-party-expo-module` from autolinking on Android:
 
 ```json package.json
@@ -144,8 +144,7 @@ use_expo_modules!({
 </PaddedAPIBox>
 <PaddedAPIBox header="buildFromSource" platforms={["android"]}>
 
-A list of package names to opt out of prebuilt Expo modules.
-For complete reference, see [Prebuilt Expo Modules for Android](/guides/prebuilt-expo-modules/#selectively-opt-out).
+A list of package names to opt out of prebuilt Expo modules. For complete reference, see [Prebuilt Expo Modules for Android](/guides/prebuilt-expo-modules/#selectively-opt-out).
 
 </PaddedAPIBox>
 <PaddedAPIBox header="legacy_shallowReactNativeLinking">
@@ -185,11 +184,11 @@ The above command returns an object in JSON format with Expo modules that Expo A
 </PaddedAPIBox>
 <PaddedAPIBox header="resolve">
 
-This command is called by the build system during the second phase of autolinking. It outputs an object with more (platform-specific) details for each Expo module, such as the path to the podspec or **build.gradle** files and module classes to link.
+This command is called by the build system during the second phase of autolinking. It outputs an object with more (platform-specific) details for each Expo module, such as the path to the **build.gradle** or podspec files and module classes to link.
 
 <Terminal cmd={['$ npx expo-modules-autolinking resolve --platform <apple|android>']} />
 
-For example, with the `--platform apple` option it returns an object in JSON format with an array of modules and resolved details for the platform:
+For example, with the `--platform apple` option, it returns an object in JSON format with an array of modules and resolved details for the platform:
 
 ```json
 {
@@ -224,11 +223,11 @@ Verifies the search results by checking for duplicate Expo modules. Warnings are
 </PaddedAPIBox>
 <PaddedAPIBox header="react-native-config">
 
-This command is called by the build system when autolinking React Native modules. It outputs an object with more platform-specific details for each React Native module, such as the path to the podspec or gradle files.
+This command is called by the build system when autolinking React Native modules. It outputs an object with more platform-specific details for each React Native module, such as the path to the gradle or podspec files.
 
 <Terminal cmd={['$ npx expo-modules-autolinking react-native-config']} />
 
-For example, with the `--platform ios` option it returns an object in **react-native.config.js**'s output format with information about each React Native dependency, and the path to the React Native installation.
+For example, with the `--platform ios` option, it returns an object in **react-native.config.js**'s output format with information about each React Native dependency and the path to the React Native installation.
 
 ```json
 {
@@ -274,6 +273,6 @@ It's also necessary to include supported platforms in the `platforms` array — 
 
 ### Opting out of Expo Autolinking for React Native modules
 
-Starting from SDK 52, Expo Autolinking replaces the React Native community CLI autolinking by default. If you would like to use the React Native community CLI's autolinking instead, set `EXPO_USE_COMMUNITY_AUTOLINKING=1` and add `@react-native-community/cli` as a dev dependency to your project.
+Starting from SDK 52, Expo Autolinking replaces the React Native community CLI autolinking by default. If you would like to use the React Native community CLI's autolinking instead, set the environment variable `EXPO_USE_COMMUNITY_AUTOLINKING=1` and add `@react-native-community/cli` as a dev dependency to your project.
 
 With this environment variable set, Expo Autolinking will not be used to resolve React Native modules, but will continue to autolink Expo modules.

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -44,9 +44,9 @@ The behavior of the module resolution can be customized using some configuration
 
 ### `searchPaths`
 
-A list of paths relative to the app's root directory where the autolinking script should search for Expo modules.
-It defaults to a list of all **node_modules** directories found when traversing up through a monorepo, starting from the app's root directory.
+A list of paths relative to the app's root directory that Expo Autolinking should search for modules to autolink.
 Useful when your project has a custom structure or you want to link local packages from directories different than **node_modules**.
+The paths you specify must still be structured like **node_modules** directories.
 
 ```json package.json
 {
@@ -58,17 +58,16 @@ Useful when your project has a custom structure or you want to link local packag
 }
 ```
 
-When used with the CLI, you can pass the search paths as command arguments like this:
-
-<Terminal cmd={['$ npx expo-modules-autolinking search ../../packages']} />
+> **info** Before **SDK 54**, this list defaulted to the your app's **node_modules** directory, and all **node_modules** directories above it in monorepos.
+> To opt back into to the old behavior, set this list to your app's **node_modules** directories, for example: `["../../node_modules", "./node_modules"]`.
 
 </PaddedAPIBox>
 <PaddedAPIBox>
 
 ### `exclude`
 
-A list of package names to exclude from autolinking. These packages will not be autolinked even if they are found in the search paths.
-For example, you may want not to link some packages that you don't use on the specific platform to reduce the binary size.
+A list of package names to exclude from autolinking.
+This is useful if you don't want to link some packages that specific platforms aren't using to reduce the binary size.
 The following config in **package.json** will exclude `expo-random` and `third-party-expo-module` from autolinking on Android:
 
 ```json package.json
@@ -83,7 +82,7 @@ The following config in **package.json** will exclude `expo-random` and `third-p
 }
 ```
 
-Note that the `exclude` option is for excluding the autolinking of Expo packages. To exclude the autolinking for any other packages, create **react-native.config.js** at the root directory of your project and apply the configuration as shown in the example below:
+React Native modules can also be excluded by creating a **react-native.config.js** in the root directory of your project and setting the platform's configuration that the module should be excluded from to `null`. The following config will exclude `library-name` from autolinking on Android:
 
 ```js react-native.config.js
 module.exports = {
@@ -96,6 +95,8 @@ module.exports = {
   },
 };
 ```
+
+> **info** Before **SDK 54**, the `exclude` option only applied to Expo modules and not React Native modules. React Native modules could only be excluded using a **react-native.config.js** file in the root directory of your project.
 
 </PaddedAPIBox>
 <PaddedAPIBox platforms={['ios']}>
@@ -130,6 +131,23 @@ use_expo_modules!({
 ```
 
 </CodeBlocksTable>
+
+</PaddedAPIBox>
+<PaddedAPIBox platforms={['android']}>
+
+### `buildFromSource`
+
+A list of package names to opt out of prebuilt Expo modules.
+For complete reference, see [Prebuilt Expo Modules for Android](/guides/prebuilt-expo-modules/#selectively-opt-out).
+
+</PaddedAPIBox>
+<PaddedAPIBox>
+
+### `legacy_shallowReactNativeLinking`
+
+When resolving your app's React Native modules, Expo Autolinking searches your app's dependencies, and those dependencies' dependencies recursively (matching the [Node.js resolution algorithm](https://nodejs.org/api/modules.html#loading-from-node_modules-folders)). Before **SDK 54**, Expo Autolinking didn't search dependencies recursively and only resolved your app's direct dependencies.
+
+When enabled, this flag opts you out of the new behavior and restores the behavior from before **SDK 54**, only searching your app's direct dependencies for React Native modules. This option isn't considered when resolving Expo modules.
 
 </PaddedAPIBox>
 

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -222,11 +222,13 @@ It's also necessary to include supported platforms in the `platforms` array — 
 
 ### How is it different from React Native community CLI autolinking?
 
-- Expo Autolinking comes in with built-in support for monorepos, Yarn workspaces and transitive dependencies.
-- It's also significantly faster, even though the module resolution algorithm is more complex to be more reliable and match the Node's module resolution.
-- Expo module resolution is also capable of detecting the duplicates which is a common issue in monorepos.
-- Last but not least, it integrates well with all the features offered by Expo Modules APIs.
+- Expo Autolinking comes with built-in support for monorepos, package manager workspaces, transitive dependencies, and isolated dependencies installations.
+- It's also significantly faster, although the module resolution algorithm is more complex to be more reliable and match Node.js's module resolution.
+- Expo module resolution is also capable of detecting duplicate dependencies, which is a common issue in monorepos.
+- Last but not least, it integrates well with the features offered by Expo Modules APIs and supports React Native modules.
 
 ### Opting out of Expo Autolinking for React Native modules
 
-Starting from SDK 52, Expo Autolinking comes enabled by default, if you would like to use the React Native community CLI autolinking instead, set `EXPO_USE_COMMUNITY_AUTOLINKING=1` and add `@react-native-community/cli` as a dev dependency to your project.
+Starting from SDK 52, Expo Autolinking replaces the React Native community CLI autolinking by default. If you would like to use the React Native community CLI's autolinking instead, set `EXPO_USE_COMMUNITY_AUTOLINKING=1` and add `@react-native-community/cli` as a dev dependency to your project.
+
+With this environment variable set, Expo Autolinking will not be used to resolve React Native modules, but will continue to autolink Expo modules.

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -145,11 +145,11 @@ When enabled, this flag opts you out of the new behavior and restores the behavi
 
 <PaddedAPIBox header="search">
 
-Searching is the first phase of resolving the Expo modules installed in a project. Its implementation is shared between all platforms. It finds all modules marked as Expo modules and determines which version is of the highest precedence (in case of duplicates).
+This command is called by the build system to resolve Expo modules during the first phase of autolinking. Its implementation is shared between all platforms. The output from `search` will contain a list of `duplicates` per package, if any duplicates were found.
 
 <Terminal cmd={['$ npx expo-modules-autolinking search']} />
 
-The above command returns an object in JSON format with modules that have been found as dependencies:
+The above command returns an object in JSON format with Expo modules that Expo Autolinking found:
 
 ```json
 {
@@ -158,12 +158,11 @@ The above command returns an object in JSON format with modules that have been f
     "version": "13.0.0",
     "config": {
       // Contents of `expo-module.config.json`
-      "platforms": ["ios", "android"],
-      "ios": { "modules": ["RandomModule"] },
-      "android": { "modules": ["expo.modules.random.RandomModule"] }
     },
-    "duplicates": [] // An array of other revisions (with lower precedence) of the same module
-  }
+    "duplicates": [
+      // List of conflicting duplicates for this module (with lower precedence)
+    ]
+  },
   // more modules...
 }
 ```
@@ -171,7 +170,7 @@ The above command returns an object in JSON format with modules that have been f
 </PaddedAPIBox>
 <PaddedAPIBox header="resolve">
 
-Resolving is the second phase based on the results from the `search` command. It resolves each search result to an object with more (platform-specific) details, such as the path to the podspec or **build.gradle** files and module classes to link.
+This command is called by the build system during the second phase of autolinking. It outputs an object with more (platform-specific) details for each Expo module, such as the path to the podspec or **build.gradle** files and module classes to link.
 
 <Terminal cmd={['$ npx expo-modules-autolinking resolve --platform <apple|android>']} />
 
@@ -203,9 +202,40 @@ For example, with the `--platform apple` option it returns an object in JSON for
 </PaddedAPIBox>
 <PaddedAPIBox header="verify">
 
-Verifies the search results by checking whether there are no duplicate packages, otherwise an appropriate warning is shown.
+Verifies the search results by checking for duplicate Expo modules. Warnings are shown for each conflicting, duplicate installation.
 
 <Terminal cmd={['$ npx expo-modules-autolinking verify']} />
+
+</PaddedAPIBox>
+<PaddedAPIBox header="react-native-config">
+
+This command is called by the build system when autolinking React Native modules. It outputs an object with more platform-specific details for each React Native module, such as the path to the podspec or gradle files.
+
+<Terminal cmd={['$ npx expo-modules-autolinking react-native-config']} />
+
+For example, with the `--platform ios` option it returns an object in **react-native.config.js**'s output format with information about each React Native dependency, and the path to the React Native installation.
+
+```json
+{
+  root: '/absolute/path/to',
+  reactNativePath: '/absolute/path/to/node_modules/react-native',
+  dependencies: {
+    '@react-native-async-storage/async-storage': {
+      root: '/absolute/path/to/node_modules/@react-native-async-storage/async-storage',
+      name: '@react-native-async-storage/async-storage',
+      platforms: {
+        ios: {
+          podspecPath: '/absolute/path/to/node_modules/@react-native-async-storage/async-storage/RNCAsyncStorage.podspec',
+          version: '',
+          configurations: [],
+          scriptPhases: []
+        }
+      }
+    },
+    // more modules...
+  }
+}
+```
 
 </PaddedAPIBox>
 

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -162,7 +162,7 @@ The above command returns an object in JSON format with Expo modules that Expo A
     "duplicates": [
       // List of conflicting duplicates for this module (with lower precedence)
     ]
-  },
+  }
   // more modules...
 }
 ```
@@ -217,21 +217,21 @@ For example, with the `--platform ios` option it returns an object in **react-na
 
 ```json
 {
-  root: '/absolute/path/to',
-  reactNativePath: '/absolute/path/to/node_modules/react-native',
-  dependencies: {
-    '@react-native-async-storage/async-storage': {
-      root: '/absolute/path/to/node_modules/@react-native-async-storage/async-storage',
-      name: '@react-native-async-storage/async-storage',
-      platforms: {
-        ios: {
-          podspecPath: '/absolute/path/to/node_modules/@react-native-async-storage/async-storage/RNCAsyncStorage.podspec',
-          version: '',
-          configurations: [],
-          scriptPhases: []
+  "root": "/absolute/path/to",
+  "reactNativePath": "/absolute/path/to/node_modules/react-native",
+  "dependencies": {
+    "@react-native-async-storage/async-storage": {
+      "root": "/absolute/path/to/node_modules/@react-native-async-storage/async-storage",
+      "name": "@react-native-async-storage/async-storage",
+      "platforms": {
+        "ios": {
+          "podspecPath": "/absolute/path/to/node_modules/@react-native-async-storage/async-storage/RNCAsyncStorage.podspec",
+          "version": "",
+          "configurations": [],
+          "scriptPhases": []
         }
       }
-    },
+    }
     // more modules...
   }
 }

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -40,9 +40,7 @@ The behavior of the module resolution can be customized using some configuration
 - per platform overrides with `expo.autolinking.ios` and `expo.autolinking.android` objects
 - options provided to the CLI command, the `use_expo_modules!` method in the **Podfile** or `useExpoModules` function in the **settings.gradle**
 
-<PaddedAPIBox>
-
-### `searchPaths`
+<PaddedAPIBox header="searchPaths">
 
 A list of paths relative to the app's root directory that Expo Autolinking should search for modules to autolink.
 Useful when your project has a custom structure or you want to link local packages from directories different than **node_modules**.
@@ -62,9 +60,7 @@ The paths you specify must still be structured like **node_modules** directories
 > To opt back into to the old behavior, set this list to your app's **node_modules** directories, for example: `["../../node_modules", "./node_modules"]`.
 
 </PaddedAPIBox>
-<PaddedAPIBox>
-
-### `exclude`
+<PaddedAPIBox header="exclude">
 
 A list of package names to exclude from autolinking.
 This is useful if you don't want to link some packages that specific platforms aren't using to reduce the binary size.
@@ -99,9 +95,7 @@ module.exports = {
 > **info** Before **SDK 54**, the `exclude` option only applied to Expo modules and not React Native modules. React Native modules could only be excluded using a **react-native.config.js** file in the root directory of your project.
 
 </PaddedAPIBox>
-<PaddedAPIBox platforms={['ios']}>
-
-### `flags`
+<PaddedAPIBox header="flags" platforms={["ios"]}>
 
 CocoaPods flags to pass to each autolinked pod. `inhibit_warnings` is likely the only flag most developers want to use, to inhibit Xcode warnings produced when compiling the autolinked modules.
 You can refer to the [CocoaPods Podfile documentation](https://guides.cocoapods.org/syntax/podfile.html#pod) for available flags.
@@ -133,17 +127,13 @@ use_expo_modules!({
 </CodeBlocksTable>
 
 </PaddedAPIBox>
-<PaddedAPIBox platforms={['android']}>
-
-### `buildFromSource`
+<PaddedAPIBox header="buildFromSource" platforms={["android"]}>
 
 A list of package names to opt out of prebuilt Expo modules.
 For complete reference, see [Prebuilt Expo Modules for Android](/guides/prebuilt-expo-modules/#selectively-opt-out).
 
 </PaddedAPIBox>
-<PaddedAPIBox>
-
-### `legacy_shallowReactNativeLinking`
+<PaddedAPIBox header="legacy_shallowReactNativeLinking">
 
 When resolving your app's React Native modules, Expo Autolinking searches your app's dependencies, and those dependencies' dependencies recursively (matching the [Node.js resolution algorithm](https://nodejs.org/api/modules.html#loading-from-node_modules-folders)). Before **SDK 54**, Expo Autolinking didn't search dependencies recursively and only resolved your app's direct dependencies.
 
@@ -153,9 +143,7 @@ When enabled, this flag opts you out of the new behavior and restores the behavi
 
 ## CLI commands
 
-<PaddedAPIBox>
-
-### `search`
+<PaddedAPIBox header="search">
 
 Searching is the first phase of resolving the Expo modules installed in a project. Its implementation is shared between all platforms. It finds all modules marked as Expo modules and determines which version is of the highest precedence (in case of duplicates).
 
@@ -181,9 +169,7 @@ The above command returns an object in JSON format with modules that have been f
 ```
 
 </PaddedAPIBox>
-<PaddedAPIBox>
-
-### `resolve`
+<PaddedAPIBox header="resolve">
 
 Resolving is the second phase based on the results from the `search` command. It resolves each search result to an object with more (platform-specific) details, such as the path to the podspec or **build.gradle** files and module classes to link.
 
@@ -215,17 +201,13 @@ For example, with the `--platform apple` option it returns an object in JSON for
 ```
 
 </PaddedAPIBox>
-<PaddedAPIBox>
-
-### `verify`
+<PaddedAPIBox header="verify">
 
 Verifies the search results by checking whether there are no duplicate packages, otherwise an appropriate warning is shown.
 
 <Terminal cmd={['$ npx expo-modules-autolinking verify']} />
 
 </PaddedAPIBox>
-
-
 
 ## Common questions
 

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -60,6 +60,21 @@ The paths you specify must still be structured like **node_modules** directories
 > To opt back into to the old behavior, set this list to your app's **node_modules** directories, for example: `["../../node_modules", "./node_modules"]`.
 
 </PaddedAPIBox>
+<PaddedAPIBox header="nativeModulesDir">
+
+A path relative to the app's root directory that Expo Autolinking should search for local modules to autolink. This option defaults to `"./modules"`. Changing this option is only useful if you need to change the path [for local Expo modules](/modules/get-started/).
+
+```json package.json
+{
+  "expo": {
+    "autolinking": {
+      "nativeModulesDir": "./modules"
+    }
+  }
+}
+```
+
+</PaddedAPIBox>
 <PaddedAPIBox header="exclude">
 
 A list of package names to exclude from autolinking.

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -14,9 +14,11 @@ installing a library will require configuring even up to three different package
 Expo Autolinking is a mechanism that automates this process and reduces the library installation process to the minimum — usually just installing the package from `npm` and re-running `pod install`.
 The core implementation can be found in the [`expo-modules-autolinking`](https://github.com/expo/expo/tree/main/packages/expo-modules-autolinking) package and is divided into three parts:
 
-1. common JavaScript CLI tool with the module resolution algorithm
-2. code that integrates with the Gradle build system for Android platform
-3. Ruby script that integrates with CocoaPods for iOS platform
+1. a CLI command with the module resolution algorithms
+2. code that integrates with the Gradle build system for Android
+3. code that integrates with CocoaPods for iOS
+
+Since SDK 52, Expo Autolinking not only links Expo modules, but also React Native modules. To use the React Native community CLI autolinking instead, refer to this page's guide on [opting out of Expo Autolinking for React Native modules].
 
 ## Configuration
 
@@ -213,6 +215,6 @@ It's also necessary to include supported platforms in the `platforms` array — 
 - Expo module resolution is also capable of detecting the duplicates which is a common issue in monorepos.
 - Last but not least, it integrates well with all the features offered by Expo Modules APIs.
 
-### Opting out of Expo Autolinking
+### Opting out of Expo Autolinking for React Native modules
 
 Starting from SDK 52, Expo Autolinking comes enabled by default, if you would like to use the React Native community CLI autolinking instead, set `EXPO_USE_COMMUNITY_AUTOLINKING=1` and add `@react-native-community/cli` as a dev dependency to your project.

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -18,80 +18,6 @@ The core implementation can be found in the [`expo-modules-autolinking`](https:/
 2. code that integrates with the Gradle build system for Android platform
 3. Ruby script that integrates with CocoaPods for iOS platform
 
-## CLI commands
-
-<PaddedAPIBox>
-
-### `search`
-
-Searching is the first phase of resolving the Expo modules installed in a project. Its implementation is shared between all platforms. It finds all modules marked as Expo modules and determines which version is of the highest precedence (in case of duplicates).
-
-<Terminal cmd={['$ npx expo-modules-autolinking search']} />
-
-The above command returns an object in JSON format with modules that have been found as dependencies:
-
-```json
-{
-  "expo-random": {
-    "path": "/absolute/path/to/node_modules/expo-random",
-    "version": "13.0.0",
-    "config": {
-      // Contents of `expo-module.config.json`
-      "platforms": ["ios", "android"],
-      "ios": { "modules": ["RandomModule"] },
-      "android": { "modules": ["expo.modules.random.RandomModule"] }
-    },
-    "duplicates": [] // An array of other revisions (with lower precedence) of the same module
-  }
-  // more modules...
-}
-```
-
-</PaddedAPIBox>
-<PaddedAPIBox>
-
-### `resolve`
-
-Resolving is the second phase based on the results from the `search` command. It resolves each search result to an object with more (platform-specific) details, such as the path to the podspec or **build.gradle** files and module classes to link.
-
-<Terminal cmd={['$ npx expo-modules-autolinking resolve --platform <apple|android>']} />
-
-For example, with the `--platform apple` option it returns an object in JSON format with an array of modules and resolved details for the platform:
-
-```json
-{
-  "modules": [
-    {
-      "packageName": "expo-random",
-      "packageVersion": "13.0.0",
-      "pods": [
-        {
-          "podName": "ExpoRandom",
-          "podspecDir": "/absolute/path/to/node_modules/expo-random/ios"
-        }
-      ],
-      "swiftModuleNames": ["ExpoRandom"],
-      "modules": ["RandomModule"],
-      "appDelegateSubscribers": [],
-      "reactDelegateHandlers": [],
-      "debugOnly": false
-    }
-    // more modules...
-  ]
-}
-```
-
-</PaddedAPIBox>
-<PaddedAPIBox>
-
-### `verify`
-
-Verifies the search results by checking whether there are no duplicate packages, otherwise an appropriate warning is shown.
-
-<Terminal cmd={['$ npx expo-modules-autolinking verify']} />
-
-</PaddedAPIBox>
-
 ## Configuration
 
 The behavior of the module resolution can be customized using some configuration options. These options can be defined in three different places, from the lowest to the highest precedence:
@@ -192,6 +118,82 @@ use_expo_modules!({
 </CodeBlocksTable>
 
 </PaddedAPIBox>
+
+## CLI commands
+
+<PaddedAPIBox>
+
+### `search`
+
+Searching is the first phase of resolving the Expo modules installed in a project. Its implementation is shared between all platforms. It finds all modules marked as Expo modules and determines which version is of the highest precedence (in case of duplicates).
+
+<Terminal cmd={['$ npx expo-modules-autolinking search']} />
+
+The above command returns an object in JSON format with modules that have been found as dependencies:
+
+```json
+{
+  "expo-random": {
+    "path": "/absolute/path/to/node_modules/expo-random",
+    "version": "13.0.0",
+    "config": {
+      // Contents of `expo-module.config.json`
+      "platforms": ["ios", "android"],
+      "ios": { "modules": ["RandomModule"] },
+      "android": { "modules": ["expo.modules.random.RandomModule"] }
+    },
+    "duplicates": [] // An array of other revisions (with lower precedence) of the same module
+  }
+  // more modules...
+}
+```
+
+</PaddedAPIBox>
+<PaddedAPIBox>
+
+### `resolve`
+
+Resolving is the second phase based on the results from the `search` command. It resolves each search result to an object with more (platform-specific) details, such as the path to the podspec or **build.gradle** files and module classes to link.
+
+<Terminal cmd={['$ npx expo-modules-autolinking resolve --platform <apple|android>']} />
+
+For example, with the `--platform apple` option it returns an object in JSON format with an array of modules and resolved details for the platform:
+
+```json
+{
+  "modules": [
+    {
+      "packageName": "expo-random",
+      "packageVersion": "13.0.0",
+      "pods": [
+        {
+          "podName": "ExpoRandom",
+          "podspecDir": "/absolute/path/to/node_modules/expo-random/ios"
+        }
+      ],
+      "swiftModuleNames": ["ExpoRandom"],
+      "modules": ["RandomModule"],
+      "appDelegateSubscribers": [],
+      "reactDelegateHandlers": [],
+      "debugOnly": false
+    }
+    // more modules...
+  ]
+}
+```
+
+</PaddedAPIBox>
+<PaddedAPIBox>
+
+### `verify`
+
+Verifies the search results by checking whether there are no duplicate packages, otherwise an appropriate warning is shown.
+
+<Terminal cmd={['$ npx expo-modules-autolinking verify']} />
+
+</PaddedAPIBox>
+
+
 
 ## Common questions
 

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -20,6 +20,18 @@ The core implementation can be found in the [`expo-modules-autolinking`](https:/
 
 Since SDK 52, Expo Autolinking not only links Expo modules, but also React Native modules. To use the React Native community CLI autolinking instead, refer to this page's guide on [opting out of Expo Autolinking for React Native modules].
 
+## Linking Behavior
+
+Expo Autolinking is integrated into the Gradle build system for Android, and CocoaPods for iOS. When building your app, the Expo Autolinking CLI is called and searches for Expo and React Native modules to autolink.
+This module resolution searches for candidate dependencies to autolink in four separate steps:
+
+1. For React Native modules only, it considers any `dependencies` in your project root's **react-native.config.js** that contain an explicit `root` path. This file is optional and doesn't exist in most Expo projects.
+2. It searches all directories specified in your autolinking configuration's `searchPaths` option.
+3. It searches local modules in the directory specified in your autolinking configuration's `nativeModulesDir` option, which defaults to `./modules/`.
+4. It resolves the dependencies of your app, and any dependency or peer dependency recursively. This matches the [Node.js resolution algorithm](https://nodejs.org/api/modules.html#loading-from-node_modules-folders).
+
+The autolinked modules are automatically added to the build, which usually means that your app's dependencies that contain native (platform-specific) code are set up automatically.
+
 ## Configuration
 
 The behavior of the module resolution can be customized using some configuration options. These options can be defined in three different places, from the lowest to the highest precedence:

--- a/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
@@ -38,14 +38,16 @@ Once you have set up the basic monorepo structure, create a new module using `cr
 
 <Step label="2">
 
-### Set up workspace
+### Set up a workspace dependency
 
-Configure `autolinking` so your apps can use the new module. Add the following block to the **package.json** file in each app inside the **apps** directory:
+Add your native module from **packages** to your apps' dependencies. Update the **package.json** file in each app inside the **apps** directory that will use your native module and add your native module to the existing entries of dependencies:
 
 ```json package.json
-"expo": {
-  "autolinking": {
-    "nativeModulesDir": "../../packages"
+{
+  "dependencies": {
+    // ...
+    "expo-settings": "*",
+    // ...
   }
 }
 ```

--- a/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
@@ -45,9 +45,9 @@ Add your native module from **packages** to your apps' dependencies. Update the 
 ```json package.json
 {
   "dependencies": {
-    // ...
+    /* @hide ... */ /* @end */
     "expo-settings": "*"
-    // ...
+    /* @hide ... */ /* @end */
   }
 }
 ```

--- a/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
@@ -46,7 +46,7 @@ Add your native module from **packages** to your apps' dependencies. Update the 
 {
   "dependencies": {
     // ...
-    "expo-settings": "*",
+    "expo-settings": "*"
     // ...
   }
 }


### PR DESCRIPTION
This applies and documents changes for #38635 and #38282.

The main page that has changed is the "Expo Autolinking" page. I've added a new section that explains how modules are resolved in an app and added more references to the React Native module linking behavior.

The React Native linking behavior is subject to some newer changes (and a new config flag), so we can't leave it out anymore. It'll also be supported by every SDK in our support window (52–54).

I've also added notes where SDK 54 has changed the default behaviour (two places) in the Configuration reference section.

Minor fixes in this PR include:
- Removing `expo-application` from list of expo dependencies mentioned in a doc
- When we're telling users how to set up a monorepo for Expo modules, tell them to add a regular dependency rather than altering the `searchPaths` (this worked prior to SDK 54 too)
- Add a missing cross-link for `buildFromSource`

