### PR TITLE
feat(doctor): Add more packages to direct package install check

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Switch Metro imports to `@expo/metro` wrapper package ([#38166](https://github.com/expo/expo/pull/38166) by [@kitten](https://github.com/kitten))
+- Add missing packages to `DirectPackageInstallCheck` ([#38701](https://github.com/expo/expo/pull/38701) by [@kitten](https://github.com/kitten))
 
 ## 1.13.5 - 2025-07-03
 

--- a/packages/expo-doctor/src/checks/DirectPackageInstallCheck.ts
+++ b/packages/expo-doctor/src/checks/DirectPackageInstallCheck.ts
@@ -25,7 +25,6 @@ const shouldBeInstalledGloballyItem = {
 };
 
 export const directPackageInstallCheckItems: DirectPackageInstallCheckItem[] = [
-  { packageName: 'expo-modules-core', ...baseCheckItem },
   { packageName: 'expo-modules-autolinking', ...baseCheckItem },
   { packageName: 'expo-dev-launcher', ...baseCheckItem },
   { packageName: 'expo-dev-menu', ...baseCheckItem },
@@ -55,6 +54,32 @@ export const directPackageInstallCheckItems: DirectPackageInstallCheckItem[] = [
         'https://docs.expo.dev/versions/latest/sdk/splash-screen/'
       )}`,
     sdkVersionRange: '>=49.0.0',
+  },
+  {
+    packageName: '@expo/prebuild-config',
+    ...baseCheckItem,
+    // This has been true for a while, but I can't predict if removing it will cause issues in past SDK versions
+    sdkVersionRange: '>=53.0.0',
+  },
+  {
+    packageName: 'expo-modules-core',
+    getMessage: () =>
+      `The package "expo-modules-core" should not be installed directly in your project. You should instead use the exported API from the expo package.`,
+    sdkVersionRange: '*',
+  },
+  {
+    packageName: '@expo/config-plugins',
+    getMessage: () =>
+      `The package "@expo/config-plugins" should not be installed directly in your project. You should instead use "expo/config-plugins" which is a sub-export of the expo package.`,
+    // See: https://github.com/expo/expo/pull/18855
+    sdkVersionRange: '>=48.0.0',
+  },
+  {
+    packageName: '@expo/metro-config',
+    getMessage: () =>
+      `The package "@expo/metro-config" should not be installed directly in your project. You should instead use "expo/metro-config" which is a sub-export of the expo package.`,
+    // See: https://github.com/expo/expo/pull/18855
+    sdkVersionRange: '*',
   },
 ];
 

--- a/packages/expo-doctor/src/checks/DirectPackageInstallCheck.ts
+++ b/packages/expo-doctor/src/checks/DirectPackageInstallCheck.ts
@@ -70,7 +70,8 @@ export const directPackageInstallCheckItems: DirectPackageInstallCheckItem[] = [
   {
     packageName: '@expo/config-plugins',
     getMessage: () =>
-      `The package "@expo/config-plugins" should not be installed directly in your project. You should instead use "expo/config-plugins" which is a sub-export of the expo package.`,
+      `The package "@expo/config-plugins" should not be installed directly in your project. You should instead use "expo/config-plugins" which is a sub-export of the expo package.\n` +
+        `If you installed "@expo/config-plugins" to fulfill a peer dependency for a config plugin, the plugin's maintainer should switch to the "expo/config-plugins" import, and you can ignore this warning.`,
     // See: https://github.com/expo/expo/pull/18855
     sdkVersionRange: '>=48.0.0',
   },

--- a/packages/expo-doctor/src/checks/DirectPackageInstallCheck.ts
+++ b/packages/expo-doctor/src/checks/DirectPackageInstallCheck.ts
@@ -71,7 +71,7 @@ export const directPackageInstallCheckItems: DirectPackageInstallCheckItem[] = [
     packageName: '@expo/config-plugins',
     getMessage: () =>
       `The package "@expo/config-plugins" should not be installed directly in your project. You should instead use "expo/config-plugins" which is a sub-export of the expo package.\n` +
-        `If you installed "@expo/config-plugins" to fulfill a peer dependency for a config plugin, the plugin's maintainer should switch to the "expo/config-plugins" import, and you can ignore this warning.`,
+      `If you installed "@expo/config-plugins" to fulfill a peer dependency for a config plugin, the plugin's maintainer should switch to the "expo/config-plugins" import, and you can ignore this warning.`,
     // See: https://github.com/expo/expo/pull/18855
     sdkVersionRange: '>=48.0.0',
   },

--- a/packages/expo-doctor/src/checks/GlobalPackageInstalledLocallyCheck.ts
+++ b/packages/expo-doctor/src/checks/GlobalPackageInstalledLocallyCheck.ts
@@ -10,7 +10,7 @@ export class GlobalPackageInstalledLocallyCheck implements DoctorCheck {
     const issues: string[] = [];
     const advice: string[] = [];
 
-    const warning = await getDeepDependenciesWarningAsync({ name: 'expo-cli' }, projectRoot);
+    let warning = await getDeepDependenciesWarningAsync({ name: 'expo-cli' }, projectRoot);
     if (warning) {
       issues.push(
         `Expo CLI is now part of the expo package. Having expo-cli in your project dependencies may cause issues, such as “error: unknown option --fix” when running npx expo install --fix`
@@ -18,10 +18,18 @@ export class GlobalPackageInstalledLocallyCheck implements DoctorCheck {
       advice.push(`Remove expo-cli from your project dependencies.`);
     }
 
+    warning = await getDeepDependenciesWarningAsync({ name: 'eas-cli' }, projectRoot);
+    if (warning) {
+      issues.push(
+        `EAS CLI should not be installed in your project. Instead, install it globally or use "npx", "pnpx", or "bunx" depending on your preferred package manager.`
+      );
+      advice.push(`Remove eas-cli from your project dependencies.`);
+    }
+
     return {
       isSuccessful: !issues.length,
       issues,
-      advice: issues.length ? [`Remove expo-cli from your project dependencies.`] : [],
+      advice,
     };
   }
 }

--- a/packages/expo-doctor/src/checks/MetroConfigCheck.ts
+++ b/packages/expo-doctor/src/checks/MetroConfigCheck.ts
@@ -20,7 +20,7 @@ export class MetroConfigCheck implements DoctorCheck {
         !metroConfig.transformer.hasOwnProperty('_expoRelativeProjectRoot')
       ) {
         issues.push(
-          'It looks like that you are using a custom metro.config.js that does not extend @expo/metro-config. This can lead to unexpected and hard to debug issues. ' +
+          'It looks like that you are using a custom metro.config.js that does not extend "expo/metro-config". This can lead to unexpected and hard to debug issues. ' +
             learnMore('https://docs.expo.dev/guides/customizing-metro/')
         );
       }
@@ -29,7 +29,7 @@ export class MetroConfigCheck implements DoctorCheck {
     return {
       isSuccessful: !issues.length,
       issues,
-      advice: issues.length ? [`Update your metro.config.js to extend @expo/metro-config.`] : [],
+      advice: issues.length ? [`Update your metro.config.js to extend "expo/metro-config".`] : [],
     };
   }
 }

--- a/packages/expo-doctor/src/checks/SupportPackageVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/SupportPackageVersionCheck.ts
@@ -22,7 +22,7 @@ export class SupportPackageVersionCheck implements DoctorCheck {
   description =
     'Check that native modules use compatible support package versions for installed Expo SDK';
 
-  sdkVersionRange = '>=45.0.0';
+  sdkVersionRange = '>=45.0.0 <54.0.0';
 
   async runAsync({ exp, pkg, projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
     let issues: string[] = [];

--- a/packages/expo-doctor/src/checks/__tests__/DirectPackageInstallCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/DirectPackageInstallCheck.test.ts
@@ -14,7 +14,7 @@ const additionalProjectProps = {
   exp: {
     name: 'name',
     slug: 'slug',
-    sdkVersion: '50.0.0',
+    sdkVersion: '53.0.0',
   },
   projectRoot,
   hasUnusedStaticConfig: false,


### PR DESCRIPTION
# Why

I've seen a lot of `package.json`s on Discord that seem to install `@expo/prebuild-config` and `@expo/config-plugins`. Starting from SDK 54 this will be less of an issue, but we should still discourage this.

I've also added notes for `expo-modules-core` and `@expo/metro-config`.

I've never seen a user have a good reason to install these. If they do, except for `@expo/prebuild-config` all added packages have an alternative entrypoint that's safe and intended.

# How

- Add note to `expo-modules-config` about the re-exported APIs in the `expo` package
- Add `@expo/prebuild-config` to list
- Add `@expo/config-plugins` pointing out `expo/config-plugins` (there's still a lot of third-party Expo config plugins that import from there. Not sure what we could do about those)
- Add note for `@expo/metro-config` since `expo/metro-config` is available

Separately, for the `GlobalPackageInstalledLocallyCheck`, we should add `eas-cli`. I still see this package installed directly by a few people. In SDKs prior to 54 this will almost certainly cause issues sooner or later.

This PR also adds a small (admittedly unrelated) change to disable the `SupportPackageVersionCheck` in SDK 54 and onwards.

# Test Plan

- Bumped `sdkVersion` in tests. Existing tests cover this

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
