### PR TITLE
[docs] Fix `platforms` on PaddedAPIBox (APISectionPlatformTags) being ignored

### DIFF
--- a/docs/components/plugins/api/components/APISectionPlatformTags.tsx
+++ b/docs/components/plugins/api/components/APISectionPlatformTags.tsx
@@ -34,11 +34,12 @@ export const APISectionPlatformTags = ({
   const experimentalData = getAllTagData('experimental', comment);
 
   const platformNames =
-    (userProvidedPlatforms ?? platformsData.length > 0)
+    userProvidedPlatforms ??
+    (platformsData.length > 0
       ? platformsData?.map(platformData => getCommentContent(platformData.content))
       : isCompatibleVersion && !disableFallback
         ? defaultPlatforms?.map(platform => platform.replace('*', ''))
-        : [];
+        : []);
 
   if (experimentalData.length === 0 && !platformNames?.length) {
     return null;


### PR DESCRIPTION
This restores the platform tags on `PaddedAPIBox` which seem to not have worked due to a condition typo.

<img width="245" height="101" alt="image" src="https://github.com/user-attachments/assets/c99d2aef-d608-4dc2-b275-1cefac02e83d" />


This might show up in reverse order, since some usages of `PaddedAPIBox` don't correctly specify `header`, instead using `platforms` together with a manual header.

<img width="371" alt="image" src="https://github.com/user-attachments/assets/42402ccc-2e6e-403e-be00-759f0fbe287a" />

We could just not pass them when `header` isn't set and enforce that via a type?
Or the occurrences, could be fixed up, like in: https://github.com/expo/expo/pull/38691
