### PR TITLE
[github] Use Xcode 16.4 on iOS Static Frameworks workflow

### DIFF
--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: 🔨 Switch to Xcode 16.4
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 💎 Setup Ruby


### PR DESCRIPTION
# Why

iOS Static Frameworks workflow is failing (https://github.com/expo/expo/runs/47747151323) because of the react-native upgrade, 0.81 now requires XCode >= 16.1

# How

Use Xcode 16.4 on iOS Static Frameworks workflow

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
