### PR TITLE
[task-manager][iOS] Rethrow obj-c exception as swift error

### DIFF
--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Rethrow obj-c exception as swift error. ([#38714](https://github.com/expo/expo/pull/38714) by [@jakex7](https://github.com/jakex7))
+
 ### 💡 Others
 
 ## 13.1.6 - 2025-07-01

--- a/packages/expo-background-fetch/ios/BackgroundFetchModule.swift
+++ b/packages/expo-background-fetch/ios/BackgroundFetchModule.swift
@@ -32,7 +32,9 @@ public class BackgroundFetchModule: Module {
     }
 
     AsyncFunction("unregisterTaskAsync") { (name: String) in
-      taskManager?.unregisterTask(withName: name, consumerClass: BackgroundFetchTaskConsumer.self)
+      try EXUtilities.catchException {
+        self.taskManager?.unregisterTask(withName: name, consumerClass: BackgroundFetchTaskConsumer.self)
+      }
     }
   }
 

--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Rethrow obj-c exception as swift error. ([#38714](https://github.com/expo/expo/pull/38714) by [@jakex7](https://github.com/jakex7))
+
 ### 💡 Others
 
 ## 0.2.8 - 2025-07-01

--- a/packages/expo-background-task/ios/BackgroundTaskModule.swift
+++ b/packages/expo-background-task/ios/BackgroundTaskModule.swift
@@ -45,7 +45,9 @@ public class BackgroundTaskModule: Module {
         throw BackgroundTasksNotConfigured()
       }
 
-      taskManager.unregisterTask(withName: name, consumerClass: BackgroundTaskConsumer.self)
+      try EXUtilities.catchException {
+        taskManager.unregisterTask(withName: name, consumerClass: BackgroundTaskConsumer.self)
+      }
     }
 
     AsyncFunction("getStatusAsync") {

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [android] add missing proguard-rules for `expo-notifications` ([#37833](https://github.com/expo/expo/pull/37833) by [@chrfalch](https://github.com/chrfalch))
+- [iOS] Rethrow obj-c exception as swift error. ([#38714](https://github.com/expo/expo/pull/38714) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 
@@ -687,9 +688,11 @@ _This version does not introduce any user-facing changes._
 - Changed class responsible for handling Firebase events from `FirebaseMessagingService` to `.service.NotificationsService` on Android. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override `FirebaseMessagingService` to implement some custom handling logic.
+
 - Changed how you can override ways in which a notification is reinterpreted from a [`StatusBarNotification`](https://developer.android.com/reference/android/service/notification/StatusBarNotification) and in which a [`Notification`](https://developer.android.com/reference/android/app/Notification.html?hl=en) is built from defining an `expo.modules.notifications#NotificationsScoper` meta-data value in `AndroidManifest.xml` to implementing a `BroadcastReceiver` subclassing `NotificationsService` delegating those responsibilities to your custom `PresentationDelegate` instance. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override those methods to implement some custom handling logic.
+
 - Removed `removeAllNotificationListeners` method. You can (and should) still remove listeners using `remove` method on `Subscription` objects returned by `addNotification…Listener`. ([#10883](https://github.com/expo/expo/pull/10883) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier being used to fetch Expo push token being backed up on Android which resulted in multiple devices having the same `deviceId` (and eventually, Expo push token). ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier used when fetching Expo push token being different than `Constants.installationId` in managed workflow apps which resulted in different Expo push tokens returned for the same experience across old and new Expo API and the device push token not being automatically updated on Expo push servers which lead to Expo push tokens corresponding to outdated Firebase tokens. ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -688,11 +688,9 @@ _This version does not introduce any user-facing changes._
 - Changed class responsible for handling Firebase events from `FirebaseMessagingService` to `.service.NotificationsService` on Android. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override `FirebaseMessagingService` to implement some custom handling logic.
-
 - Changed how you can override ways in which a notification is reinterpreted from a [`StatusBarNotification`](https://developer.android.com/reference/android/service/notification/StatusBarNotification) and in which a [`Notification`](https://developer.android.com/reference/android/app/Notification.html?hl=en) is built from defining an `expo.modules.notifications#NotificationsScoper` meta-data value in `AndroidManifest.xml` to implementing a `BroadcastReceiver` subclassing `NotificationsService` delegating those responsibilities to your custom `PresentationDelegate` instance. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override those methods to implement some custom handling logic.
-
 - Removed `removeAllNotificationListeners` method. You can (and should) still remove listeners using `remove` method on `Subscription` objects returned by `addNotification…Listener`. ([#10883](https://github.com/expo/expo/pull/10883) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier being used to fetch Expo push token being backed up on Android which resulted in multiple devices having the same `deviceId` (and eventually, Expo push token). ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier used when fetching Expo push token being different than `Constants.installationId` in managed workflow apps which resulted in different Expo push tokens returned for the same experience across old and new Expo API and the device push token not being automatically updated on Expo push servers which lead to Expo push tokens corresponding to outdated Firebase tokens. ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Background/BackgroundModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Background/BackgroundModule.swift
@@ -40,7 +40,9 @@ public class BackgroundModule: Module {
     }
 
     AsyncFunction("unregisterTaskAsync") {(name: String, promise: Promise) in
-      taskManager?.unregisterTask(withName: name, consumerClass: NotificationsBackgroundTaskConsumer.self)
+      try EXUtilities.catchException {
+        self.taskManager?.unregisterTask(withName: name, consumerClass: NotificationsBackgroundTaskConsumer.self)
+      }
       promise.resolve(nil)
     }
   }

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [android] add missing proguard-rules for `expo-task-manager` ([#37833](https://github.com/expo/expo/pull/37833) by [@chrfalch](https://github.com/chrfalch))
+- [iOS] Rethrow obj-c exception as swift error. ([#38714](https://github.com/expo/expo/pull/38714) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
@@ -113,12 +113,14 @@ EX_REGISTER_SINGLETON_MODULE(TaskService)
   
   if (!task) {
     NSString *reason = [NSString stringWithFormat:@"Task '%@' not found for app ID '%@'.", taskName, appId];
-    @throw [NSException exceptionWithName:@"E_TASK_NOT_FOUND" reason:reason userInfo:nil];
+    NSDictionary<NSString *, id> *errorInfo = @{NSLocalizedDescriptionKey: reason};
+    @throw [NSException exceptionWithName:@"E_TASK_NOT_FOUND" reason:reason userInfo:errorInfo];
   }
   
   if (consumerClass != nil && ![task.consumer isMemberOfClass:[self _unversionedClassFromClass:consumerClass]]) {
     NSString *reason = [NSString stringWithFormat:@"Invalid task consumer. Cannot unregister task with name '%@' because it is associated with different consumer class.", taskName];
-    @throw [NSException exceptionWithName:@"E_INVALID_TASK_CONSUMER" reason:reason userInfo:nil];
+    NSDictionary<NSString *, id> *errorInfo = @{NSLocalizedDescriptionKey: reason};
+    @throw [NSException exceptionWithName:@"E_INVALID_TASK_CONSUMER" reason:reason userInfo:errorInfo];
   }
   
   NSMutableDictionary *appTasks = [[self _getTasksForAppId:appId] mutableCopy];


### PR DESCRIPTION
# Why

This exceptions should not crash the app, instead we should be able to handle these errors in catch blocks. 

# How

Rethrow NSException as NSError using `EXUtilities.catchException`.

# Test Plan

test-suite -> `TaskManager` should not crash the app ✅

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
