### PR TITLE
docs: Replace alert with onPress prop for documentation

### DIFF
--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -118,7 +118,7 @@ export default function Button({ label, theme, /* @tutinfo Pass this prop to tri
 
   return (
     <View style={styles.buttonContainer}>
-      <Pressable style={styles.button} onPress={() => alert('You pressed a button.')}>
+      <Pressable style={styles.button} onPress={/* @tutinfo */onPress/* @end */}>
         <Text style={styles.buttonLabel}>{label}</Text>
       </Pressable>
     </View>


### PR DESCRIPTION
# Why

<img width="777" height="723" alt="image" src="https://github.com/user-attachments/assets/2578af1d-8535-4acb-864f-e33482331c17" />


This change ensures consistency across the Button component by updating both Pressable instances to use the onPress prop instead of hardcoded alert behavior. Previously, only one Pressable was updated to use the prop-based approach while the other still contained the hardcoded alert('You pressed a button.') implementation. This inconsistency would cause different behavior depending on the theme condition, which could lead to confusion and unpredictable component behavior. By making both Pressable components use the same onPress prop, the Button component now behaves consistently regardless of the theme and properly delegates the press handling to the parent component as intended.

# How

- Replaced onPress={() => alert('You pressed a button.')} with onPress={onPress} in the Pressable component
- This change allows the parent component to define the button's behavior through props
Makes the component more reusable and follows React best practices for component composition

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
