### PR TITLE
[expo] Bump `reanimated` to `4.0.2`

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -444,9 +444,6 @@ PODS:
     - ExpoModulesCore
   - ExpoFileSystem (18.1.10):
     - ExpoModulesCore
-  - ExpoFileSystem/Tests (18.1.10):
-    - ExpoModulesCore
-    - ExpoModulesTestCore
   - ExpoFont (13.3.1):
     - ExpoModulesCore
   - ExpoGL (15.1.5):
@@ -3509,7 +3506,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNReanimated (4.0.1):
+  - RNReanimated (4.0.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3536,11 +3533,11 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 4.0.1)
+    - RNReanimated/reanimated (= 4.0.2)
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNReanimated/reanimated (4.0.1):
+  - RNReanimated/reanimated (4.0.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3567,11 +3564,11 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 4.0.1)
+    - RNReanimated/reanimated/apple (= 4.0.2)
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNReanimated/reanimated/apple (4.0.1):
+  - RNReanimated/reanimated/apple (4.0.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3868,7 +3865,6 @@ DEPENDENCIES:
   - ExpoDocumentPicker (from `../../../packages/expo-document-picker/ios`)
   - "ExpoDomWebView (from `../../../packages/@expo/dom-webview/ios`)"
   - ExpoFileSystem (from `../../../packages/expo-file-system/ios`)
-  - ExpoFileSystem/Tests (from `../../../packages/expo-file-system/ios`)
   - ExpoFont (from `../../../packages/expo-font/ios`)
   - ExpoGL (from `../../../packages/expo-gl`)
   - ExpoHaptics (from `../../../packages/expo-haptics/ios`)
@@ -4445,85 +4441,85 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  BenchmarkingModule: dd9fa2864151fba1e4ff39b20cba3c11e77483ab
+  BenchmarkingModule: 435c5eaca15a680e5b9eec8d978cac1a2e2f29e6
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EASClient: 01c089e5fa07184477aed2944d7650062cd3c37f
-  EXApplication: f5eb4ca614699d70809fc2681c9b367f991886c5
-  EXAV: 6ef85347ee2dba74841f79f8ce3f65a69268bfba
-  EXConstants: 0c911c420c4944c3c1d06f7a339b2dd4a7472361
-  EXImageLoader: 468799c831a3076af4de6a56422524b3ce897c1f
+  EASClient: cca4fa0bf58b32a99476e9d9f80cbeebcb57df90
+  EXApplication: 2da4660569e086f4f18722758b52d7e7792631ab
+  EXAV: 0809cbb31eba2111d5413f2dbb547ba9727478ee
+  EXConstants: 72e8e04dc4d7d97c74a618d44753ea4a7437a2b6
+  EXImageLoader: d2b81b29509ee86ad8bdf0d2cc9ff5d86051d68b
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: f2f18db6a798d69a20f7d6beda6f9e0252b921db
-  EXNotifications: f0c7597a22645faf9ce9e74f1b1078c16fb7575f
-  Expo: 3db18bab43ebf2df061fa5493c07514122e75aa3
-  expo-dev-client: 52851adb66e9e82310d11a2c3a099afbb576bf50
-  expo-dev-launcher: c1bed34ae29dd5e2bb773b446758431ed7016fe2
-  expo-dev-menu: 156c67468263e89e0e2a5c3736835c7d6a6c9d0a
+  EXManifests: bf76658edfbfa3e3fb67f940ade98d7803490789
+  EXNotifications: f0f1c97d04f06c51ea073d7b2396431e5611c1ea
+  Expo: 50f261cb88416e897c42707a176dd6bfc02e3ff6
+  expo-dev-client: 9d51a3fdb2aa8284614eb814d560604beecd1451
+  expo-dev-launcher: 01965720c5f143534dd1367131a2a6aba8012993
+  expo-dev-menu: a22e83e35c8c902609ff7328142e9c95ed939e03
   expo-dev-menu-interface: e4289a7d41317f5d727949a95e3d94553d3ba056
-  ExpoAppIntegrity: 3a11ee0fb559964cc3d3267505769c5454670732
-  ExpoAppleAuthentication: 76db051d8d312fae4c513b24aa6283770ab7fd9b
-  ExpoAsset: b876ebe84926f3b683c5b616bd27dcaa127e2c72
-  ExpoAudio: 4691418ee15d1f0743c69d264eb937547f0faf5e
-  ExpoBackgroundFetch: 6ea99684804a3a264b08f18cbb3b45a0ecd410ed
-  ExpoBackgroundTask: e3a8b3feaffa1a40e1a373460094d54656cc7512
-  ExpoBattery: 766e12ad7fc8c7a09356d2f593c4f81ce421fb4f
-  ExpoBlob: 8c6c1afdb19a8ddb48cc8ec3d5e1dddf64d80be8
-  ExpoBlur: 7f9379db213e4a56aeceda82e94a7fea1b1d8c48
-  ExpoBrightness: c335c6ccc082d5249a4b38dba5cd9a08aa0bf62b
-  ExpoCalendar: f5f94ea8dcd957b1434beb4e1c0da1af063322e6
-  ExpoCamera: 316809537daad6a5bd2c04b98e0589304beb5551
-  ExpoCellular: c54250f4fdbf76850d5c33461ae06b0a204c403e
-  ExpoClipboard: d8ee7c30c60c6aac4f059ec3cbd5e9bea5b46133
-  ExpoContacts: 3dd51c3c53017b4ca05f18e786d1eb1ace729ef3
-  ExpoCrypto: 5a9209f80c4b5f96e0eb77baa7473d8b0fbbab34
-  ExpoDevice: f9ac04e9e3cec3ad82bf6379a061a33823b51d43
-  ExpoDocumentPicker: a5d292a473c1414f551ce45fac0a9d373bbeb54c
-  ExpoDomWebView: b410c8aa6a0a41988586046dba0a5497ee18a0d6
-  ExpoFileSystem: f4f896dc547a1e0e3b72bb6a9fae94e03620d90e
-  ExpoFont: 5aa2bc9e816911fb87b80792e5b643bdddeff751
-  ExpoGL: 91fc38ca1ffc07b29c6848b396a5a793ac0304cf
-  ExpoHaptics: beef56ed756455d4390a939234fb37b0449fd362
-  ExpoImage: e4a46c3a72b0c72f259a25629c01f550ed3fff6a
-  ExpoImageManipulator: 7f44b0d9be947203d516ffd14972775c490951b9
-  ExpoImagePicker: b6fa79d678c0f86be51585d144d87edd2843fdaa
-  ExpoInsights: 54b7c40c17a9eef9633bfcedc88b988ffa569910
-  ExpoKeepAwake: 184e9fa683b7ce421d0e8a0221bc60189d3f96cd
-  ExpoLinearGradient: 9a5a52c22b2db7103db35ef09134b491e0e46f58
-  ExpoLinking: b85ff4eafeae6fc638c6cace60007ae521af0ef4
-  ExpoLivePhoto: 8e2df0f48566aaa0835ad26290c16739d21f02a0
-  ExpoLocalAuthentication: 39794e59dda1954fa822d2ab1ae017e8a3e75f37
-  ExpoLocalization: 344cfcb14b9ae5f2a5baa52f021a07bc7178657e
-  ExpoLocation: a319a1b2c00b82c29e8a24227e0f00d1e19662c5
-  ExpoMailComposer: f8829ee4452ec27ef3c34d1b99fcc2553570ed02
-  ExpoMaps: ed4f8fd09939db5dca875e6f9bfbdb69e164644c
-  ExpoMediaLibrary: ef14f0390b06ddecca98118eb7332e92efe4765a
-  ExpoMeshGradient: f77f7b26471768000d89662713b7f1c8496e890b
-  ExpoModulesCore: c1aaa7b175e331c6e99479de43fc261c2ad7f59b
-  ExpoModulesTestCore: 6bcb44cd94befcfb9ca181500e8f58b7da1751ad
-  ExpoNetwork: 92cac43c13a2d9e9c1470ec8804836574ff34068
-  ExpoPrint: 37a906e6b0ba98a7c1709c96cc0b20398ae04aba
-  ExpoScreenCapture: b2fc30f94eb3402d4fd225578475345394fe6afb
-  ExpoScreenOrientation: cea50e5cf3316e1fd2667acbf70b948b38a22c1b
-  ExpoSecureStore: 775b325aacd4befc4a34515fb30ff85355e5b69e
-  ExpoSensors: 3a783157907ea57f1497b97a635ac1ae1837cba2
-  ExpoSharing: 2e20ca3a89d60b389aab84e4d57e9537a280e45e
-  ExpoSMS: a6cb0b2d122b2155518568b625ff584706241aa1
-  ExpoSpeech: 7c8e24a2dade507ecff6acc42cfb0f01d847fed2
-  ExpoSplashScreen: f524572afd81522e40850eaa7163e2ae99cce783
-  ExpoSQLite: 78b6c89eaf10afa16a6e5d8c36da044305648f8b
-  ExpoStoreReview: 1810e2ca51bdd976c2e9835b8ef20ca863a305da
-  ExpoSymbols: a0976bee6b4a097de61353f08dc6e53ace90346e
-  ExpoSystemUI: 10faac77830ad0a70e52641b8a749e9b8ea75be4
-  ExpoTrackingTransparency: 368fa25c00c36e35f6a1f74edb6b2450218fdb15
-  ExpoUI: 7c347a8fc4240c0f6ac725bf0a5430f70d2eaf5f
-  ExpoVideo: 3061817cc0f433e5ad81ff226ec7621a90562e98
-  ExpoVideoThumbnails: 375f8c0166c25011f352ce4c0f651270821bf8fe
-  ExpoWebBrowser: d3208126d5d8a2da4c5aa04c839b112d0a40da80
+  ExpoAppIntegrity: 3dc8bc7a3a7e056cbed75af112969e52e7f45e66
+  ExpoAppleAuthentication: 69a48d4633024124a33fda650dba706c216d6c76
+  ExpoAsset: b5bfc6425d1e9a09e8e1368646b98fe5ae7ed074
+  ExpoAudio: f6bcc6868e643e6fa74b6e20fd7d20ecc89b4e28
+  ExpoBackgroundFetch: 76c48b3cd9a4ee46e5267614a30fac804de6f33e
+  ExpoBackgroundTask: 63e54818a257ad36aeff7e04ef67598e68c18fbb
+  ExpoBattery: 6229d981d12dffb00c9e8e48181162729febb541
+  ExpoBlob: b1f107944873fb5803aab930b44bac388373ca32
+  ExpoBlur: 5d95f7ca771a0f3b9618466525dd68e46dc95f3a
+  ExpoBrightness: 05e750736f8886dcf235212b0caf85b0f605fc88
+  ExpoCalendar: 660542dc1c5ef98f46bedcc8745aa707df5d501a
+  ExpoCamera: e88fc30631e63e5504ce19d52c563a6ec49e17d2
+  ExpoCellular: 9310e19e8052da7d861b31450e46b1db4821b20c
+  ExpoClipboard: 77842a5542aa7ad5dcd9cc03d34442b1b2d857ea
+  ExpoContacts: 870a98e359ee83ab9fa15eee40c66d15731747a8
+  ExpoCrypto: d79e7fb137efb093a9c144974d7a165009a1b11f
+  ExpoDevice: 3a4e4dc5cca31c1c731731cf11717dc3f7fff211
+  ExpoDocumentPicker: 0b9848ccbb414d27491a478a013ea9d434613d84
+  ExpoDomWebView: 290738a4948cf54d58a70191f31aedce6113a9a6
+  ExpoFileSystem: 95ecce2f02e751a3c40d082fc605fbc271564038
+  ExpoFont: 370a9897880ac279fbd4e478dede18ec4f723d1a
+  ExpoGL: 8f7f43291e400621ef9aeb7af347816c2051ddc7
+  ExpoHaptics: 581bbb680c566b8afef68fd50f1efb883972b150
+  ExpoImage: 736d4bf4e14437d0e0c7dafdd3aa169c17d447a7
+  ExpoImageManipulator: d889b5a58e217657dd5ef4fbc23441f2be12463e
+  ExpoImagePicker: 235489a513df4c70c402f2a49a47fdd94053d63d
+  ExpoInsights: a349f1545051a3693da28d7c719e3c81586e2349
+  ExpoKeepAwake: 95037f8576ba678db79cbf558b933400c81997a7
+  ExpoLinearGradient: 110244a240361e3351756225e5fcc4c6c07f5431
+  ExpoLinking: 5d151d4a497d7e375308602f0a89b4e8acf7b5f8
+  ExpoLivePhoto: e2d46bcd19046da559d4a690244382ad1c6bd699
+  ExpoLocalAuthentication: def09053225f6395574fbff9b385ff707a870f2b
+  ExpoLocalization: 3d73d7d77ec4277b533cbc19b74ac0f009151985
+  ExpoLocation: afc197fce1045ac7325f095b0c149308e1653aab
+  ExpoMailComposer: 502cb45610367987f741db89ad5e1e45497b52b0
+  ExpoMaps: 11e31ba05d35cefd551731b18d3cb8703f715727
+  ExpoMediaLibrary: ad61cd80ca07da02be3d676e3d9b04b311a82c2c
+  ExpoMeshGradient: d0c68837d2abe38a7ed9b9c800f084be0f03ed1b
+  ExpoModulesCore: 9faf069f091ef2dd979ba7b605ffdb07f0819d1a
+  ExpoModulesTestCore: eb1c0976fd260b9b56f1224c4508522e3acd3e03
+  ExpoNetwork: 9fdbef259f313a1ba7ede5fa977ee3dfed6fe653
+  ExpoPrint: ad01049aadc3a5315afc95e483548d8cce4192d1
+  ExpoScreenCapture: dc8bd55d68fac61ae677c1cc31fa1bc1f6c6913e
+  ExpoScreenOrientation: 3567ed658dea636f98f0d22f4eee19a95cd19d6b
+  ExpoSecureStore: b2b179bc106f683f7a1ce61a46dd2dce6a6c715f
+  ExpoSensors: 391133ad6430712d61a7797454ae326e0e8755e0
+  ExpoSharing: 4390db7ff14bc5db4d41879d529d729230204f91
+  ExpoSMS: 78241dca635906b6aefcfa9d3d2e499b7fa8d05f
+  ExpoSpeech: f7b35627d6665edec6580144d8070316b261eea6
+  ExpoSplashScreen: c39151354ff0fa6d0f5e7dde07a234abd5550e69
+  ExpoSQLite: e1fef6b50e3f1b7c3fc725b5b43a484f2dc9d9a9
+  ExpoStoreReview: d8004651736a31ed37cb69e4799d0f18fd6e362b
+  ExpoSymbols: c5fd6904f2adda427e4a5ac1a4cbad060dec6f53
+  ExpoSystemUI: b9294916cc916a704d21c8bb745d6e27871fdbb7
+  ExpoTrackingTransparency: 37880a2e6f317c938f1b50cd05c094571e317ba5
+  ExpoUI: 3aa8b32e10230a7b2aca7b3e8199f4e2461c3267
+  ExpoVideo: 0e9cd59d0bd301e0f33a8fa7b0e3f1a497f60f81
+  ExpoVideoThumbnails: 78229366987270a271cd57e2cda857003e32ebda
+  ExpoWebBrowser: 41dc1db6ed9185a3b80a9f917ba3c62dafd22eec
   EXStructuredHeaders: 1c799cb91e8057e0671610635e5b2109fa295114
-  EXTaskManager: 38a18adc5f8ddaeeae6381effd8f972a29a8007c
-  EXUpdates: 2c3a6fc7ee35fb7bc0f54a571ccea52d8d3d1680
-  EXUpdatesInterface: 5149921d084a7da7bd97dfc321b8302b03ceb83f
+  EXTaskManager: d767bbb4ea832f4b7781244bcc8e01c94d27aa60
+  EXUpdates: bb5eb316f5d056510304948fcbff908e2b6bb9af
+  EXUpdatesInterface: d6c802a2d1d11867523d03a95397957f9ba3d1c7
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 64579c0203cbc859de4536d54b4c6ed28fd03d42
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
@@ -4533,93 +4529,93 @@ SPEC CHECKSUMS:
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: de18e94574402f8687b61b5ead1faa302b09abbf
+  lottie-react-native: 89a3dc7200168d4f98f43780afe082a637be9dcb
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: 3a51da4c0e2a533c893971c2171d164974bc5214
   RCTRequired: d26a2245fa986ca16a6c93d91e41beeeb7a8aa3f
   RCTTypeSafety: e9598921dd4338d6dcb7b4ba0b7b92f84cdcc25e
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
   React: 713c6b114dfaddd4e58bc0e3804334f2a170b754
   React-callinvoker: 4441303f80922bcab09bd3e401738c1a7f3ffe11
-  React-Core: 1647c97526fa4f1ea42365283e03649a53297d2e
-  React-CoreModules: 4c3d70d404ab9b87c7775e0293f53f9926663039
-  React-cxxreact: a51f7392e614e975f03845504cc253c812014a95
+  React-Core: 48eb931b5319893300e3766c6cc38481fa647dfa
+  React-CoreModules: 16160d86eee8183e615fc12e01a7b7d4037d0f11
+  React-cxxreact: 61e4deced1e2e89409d723baaf367da6d8eaf916
   React-debug: 77c881c70aef8f5787761005eeb57e437a7d0a5b
-  React-defaultsnativemodule: e6b4fadf89fd6c8b8f5a3e04d5c2643ccdfe82b8
-  React-domnativemodule: 935765aae2d5cee829e14ef7f68bae607b985262
-  React-Fabric: 51b47e25e8ea701e0de18df49ecfacde647dcef0
-  React-FabricComponents: 3563263621533b915a6634cd7634f3bac316c302
-  React-FabricImage: 81f78d0cc89a824c6842493b19c20d50d5e0eacd
-  React-featureflags: ccf1419c575fa7fd7cc558781bdd71ef9f671735
-  React-featureflagsnativemodule: 6e11d8ae01637ee30a2be5c65cb9363c672f4e7c
-  React-graphics: 211215400fa45680369a528e33f8a1bd0c53e06c
-  React-hermes: bdbe62b8a2faee475a82783785a4dc5d523d86fc
-  React-idlecallbacksnativemodule: 1a569d82993b763b2fabe1e1632bb733f9d67f30
-  React-ImageManager: 7ec5c6e6cd9b9025f2c0a5ac60469fd5a41b87a0
-  React-jserrorhandler: 98669ab3fc66c77862c5e757a44f8d7a6569ee3a
-  React-jsi: dfa0088e5654a951995d4deac1bb9fcdb3f4caf7
-  React-jsiexecutor: 2afac999079f68d80d3af10bfff584f52c754a13
-  React-jsinspector: ed95bb4e7e40f5b217007635dd138b0bec18ee5c
-  React-jsinspectorcdp: ceba155d82ef6be17948c6dd719af7d76ccc7849
-  React-jsinspectornetwork: 3d24ed2f68f45e644a2cd1b58a2e7f2a6c2362bf
-  React-jsinspectortracing: 16f01f653a451f0180e0dd9c3d18adf35611bb89
-  React-jsitooling: 4bd008cf273ba5615f3d27ea29cbd984dd22c0d7
-  React-jsitracing: d2ee2605ab10432c31c42a3b1a8c7dd2d387f3d3
-  React-logger: ce833a4ee1f377d1b27d6a70db5e49f539dd3fc6
-  React-Mapbuffer: f0c91e870f86a23ccf80ab9527d95f37e834e24e
-  React-microtasksnativemodule: be6fa55f64e8de5a53f3e9d01feb91d6682af78d
-  react-native-keyboard-controller: 72bf29521cd5269a3a5d45f48123d57472de7ce7
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-pager-view: f8f63370fc0f4174f7510863b4812b8e034d2d0d
-  react-native-safe-area-context: 84a754cad3fbb25117482cde6b8defca6c6f6a53
-  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
-  react-native-skia: cf7b995d1431caf7d7a9b2e1274b6b32ff2f8d9c
-  react-native-slider: 27ecfb62634ccbbfc1d4562ab8a5ca5c7f4da03a
-  react-native-view-shot: 6c008e58f4720de58370848201c5d4a082c6d4ca
-  react-native-webview: 4cbb7f05f2c50671a7dcff4012d3e85faad271e4
-  React-NativeModulesApple: f75e771a53921934a0c6120e2bc7ee7dfb7c8728
+  React-defaultsnativemodule: 72ed284e13ab42903f492568e3db78dd708b06de
+  React-domnativemodule: b57bdf705c8f26762d70ddae2f917b6593622d7a
+  React-Fabric: 04dacebd7f35c74d648cadf8fda8c4dd105e1d56
+  React-FabricComponents: 0740d9d86edca91bbd3ab881ab9d139ccaff3513
+  React-FabricImage: 9d544dfe265a8cffaa7ef95023e3eb14eab7058a
+  React-featureflags: c33312b0812afb235add6add17e91b6f3a92222c
+  React-featureflagsnativemodule: 1db86f04957efcaecaec3957cc8d0de86ea573ab
+  React-graphics: f070009719fcac1854a3c4b3897b23e67b956ce2
+  React-hermes: b0d0cf1afcc6a5ea966d7841abbc89d0ec01526d
+  React-idlecallbacksnativemodule: 38c37267785b9d601dab87653edf2cf0c346bcc7
+  React-ImageManager: 578228cd0fbcef002207bf8acf0a42c712098906
+  React-jserrorhandler: 4da8855c5652652776eae535702b258fdc7e2693
+  React-jsi: 32ecda8451aac1f6a649e05dc94a0948ce2bb7d7
+  React-jsiexecutor: f4f3b47f4c1c076363ab8b65042a9a6177ef96b5
+  React-jsinspector: 24c8d6057c0ff37eccc72c855f198c6157893c78
+  React-jsinspectorcdp: 9a364f9cd548fc389ac91af4e5c38eae58f6548f
+  React-jsinspectornetwork: d7f3b19d53fe328dc139035ab0bba19aa68f2439
+  React-jsinspectortracing: 414014b64e0362eec726f3416cc9a02b9a8e9a16
+  React-jsitooling: 96c159a6a7cd6f29f208359554eec887b6fb27b9
+  React-jsitracing: 3c3d20d2dc74fc895411af104f9a9d103dc23794
+  React-logger: 3903016c02ae4dff7387d028501a3b03ba72879d
+  React-Mapbuffer: 48d6d8d0361ab4be5a7b4825006ddfff5e3686ec
+  React-microtasksnativemodule: bd7cfbd456840ebd272edad86b0e09595f2c80d5
+  react-native-keyboard-controller: bf7ec487800e1283b95532d1259bde1fdf7c4bd5
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-pager-view: 5aa9fb30444ca4bbe382991b6783cc014ed5ca07
+  react-native-safe-area-context: 5d8c627bc6296d018625948364c1a02d50d11bd4
+  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
+  react-native-skia: d87cc491f5f560ea5a159b9972ba782a435ea0e3
+  react-native-slider: 95b11a80deb9ad503b01debf1a6c71f9ba6485b9
+  react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
+  react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
+  React-NativeModulesApple: b7c71399d5a301dab362289d68747ff8c9b84c19
   React-oscompat: e324ee1ba89eb09d59c8e346748c758cb87a2ce3
-  React-perflogger: 08d464e4b97e53f74e6d8a1e4199e96f6ef8fd97
-  React-performancetimeline: b35d1855146b516a8a45639ea2809379d6990a50
+  React-perflogger: 1a98c4a181ab1cf9e8cf955dae867abfac59a50d
+  React-performancetimeline: 1a508e57eb32cc6951ecc95ac795afe13f3c1499
   React-RCTActionSheet: e995bcd8831351318c94bfa3e585178dc15934c8
-  React-RCTAnimation: 0bf88d7b156c5c47cdb74fe630e521bcbb9baa9c
-  React-RCTAppDelegate: 910087f517dc84af72c85d17973ccc1c1118a297
-  React-RCTBlob: 57f0deea9e2b6acc4165c4fd85d1515ed572da82
-  React-RCTFabric: 93ce57846073175be95690ea04cd31326b05ed58
-  React-RCTFBReactNativeSpec: 1aeba7991a5dcead5b2698f43b0f6c7f43105109
-  React-RCTImage: 07f30e864a1329886d3f1b870e795c2be9bee4a6
-  React-RCTLinking: d1431042ba333062262e0238f8337afb929976d8
-  React-RCTNetwork: 5e4f2515221b263a2131fb34382c6c4486f8b31b
-  React-RCTRuntime: adde7ead94b95216b2ed43923dd6111c4a9b9bbd
-  React-RCTSettings: 7f123bcbf1feb7747dd62343231bdfaba42542bc
-  React-RCTText: fb56147304f7e3ffc790310a83a099ade9d1f930
-  React-RCTVibration: 12044b012f28bcdf52d1b3bcef0c2645a56dda1b
+  React-RCTAnimation: eda5da34ef170a419bff522a58db9d5fb109acec
+  React-RCTAppDelegate: 26ebc3917638dde2ca20facec826e45a96f16d6c
+  React-RCTBlob: 8e905a0df8271c7405e5542f4ddc5f11bf7b3ef4
+  React-RCTFabric: 5c4a2e726a25dd007bffd3aa8ded58d8d58bad67
+  React-RCTFBReactNativeSpec: 125ec865d3b95360142f343075d0326c1f2188fd
+  React-RCTImage: fe502bd39bb9bb5b9cfa635e141bf3d602091b2f
+  React-RCTLinking: 2d9dad05c5ebddc5902a2c2c0177f72e8f6b93bd
+  React-RCTNetwork: 81ac1907ff907c3e0669c8702a1aae2a8356cf8d
+  React-RCTRuntime: b156f2c4f38023a065723d70dd3eb9468a523cc9
+  React-RCTSettings: 0887e903b7f06463ec5887df385ade35705c5151
+  React-RCTText: 4644d6c9bc18c05ea4d373c8434ad9dc2392e642
+  React-RCTVibration: f381c601f931888740383dc14f4baeebac945e94
   React-rendererconsistency: fde6f437f72fb837be955c7d287c5f1a1fe47212
-  React-renderercss: c57968265fbec6bbd00af273bac6f795874b3148
-  React-rendererdebug: a28985b812b04903f7e13d9aff7748bc3ec7a72d
-  React-RuntimeApple: f4888b94562b29f18ff96b18f6e3cf958dfbc1a9
-  React-RuntimeCore: c49192fe880e0452d96b16c729064d1d489a0e8e
-  React-runtimeexecutor: 15eb9796b1efe4eee86e020799026723dc4c99cc
-  React-RuntimeHermes: 41b97445036fc60f2447c5c69b9f1639de65292b
-  React-runtimescheduler: eee88df3c5fb6a30a220e524fd282e44a282a1ca
+  React-renderercss: 8ad27c2b7c138f27518702af50c4bacc85d67fc9
+  React-rendererdebug: 34b2305ff2a349e540b39354277ce2c457da8ec9
+  React-RuntimeApple: 347f9558b516c79bd0cfa2a237371843d0a22c25
+  React-RuntimeCore: d4e1654e01a1a6df3ede773b2ddbac83f39725a9
+  React-runtimeexecutor: 93e8ab92174058160232cd9283d354463255020d
+  React-RuntimeHermes: 2f477bc8fc39fff2d1e3a966a3d908bbde6c3fd5
+  React-runtimescheduler: 7d15929025e58a47cd73758c6c4f46d293d3dca5
   React-timing: c6ce3a683af45aecee166b49348cd094170a7e36
-  React-utils: 082cd4a9663f63b4138bc2e068a5a93dc7e0adff
-  ReactAppDependencyProvider: 3b7ece00025ce3482570139b0dbe115e639688ca
-  ReactCodegen: 79ed1430cec297c1adc17ae6cab59b77944bcfe4
-  ReactCommon: 61fd53636b15a5dc300d5e31105a76f773a918fd
-  RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
-  RNCMaskedView: 5ef8c95cbab95334a32763b72896a7b7d07e6299
-  RNCPicker: 66c392786945ecee5275242c148e6a4601221d3a
-  RNDateTimePicker: 510d9822e8a6d02de332ef1f68a8fc53f3d35497
-  RNFlashList: b1f92e77d19aca4f9112bd977ca2ff8a2d61bf69
-  RNGestureHandler: 3a73f098d74712952870e948b3d9cf7b6cae9961
-  RNReanimated: e353576b032a79ac1ec1860df1062e6147d35db0
-  RNScreens: 51d1b1d9ecf9db095abb24525be038da0ef48747
-  RNSVG: 6f39605a4c4d200b11435c35bd077553c6b5963a
-  RNWorklets: 32ea3225502c57b559c76f684fc2abac865b7728
+  React-utils: 3b356bfa4a83cd7e019b96b1de73e8340cef2bf9
+  ReactAppDependencyProvider: ad094d490c0b69fcd292806df86e007728d02f95
+  ReactCodegen: f08c2da52e7cd8ef345865bce934f85345a92906
+  ReactCommon: 3c95b5086d10c5da3d6d0fc920fc1ce6c984a496
+  RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
+  RNCMaskedView: 63268de1986a098b5f4d1fb5b1bc1e97fade0aee
+  RNCPicker: 6da395ee9db8d67a38c6102d4128b5a0b9ec0e21
+  RNDateTimePicker: 5e3503a3a82a9710b0269fa6617e27f7896509bd
+  RNFlashList: 3b0c6a34ba86318f897ff55ff7482b7e8ae18996
+  RNGestureHandler: 4f7cc97a71d4fe0fcba38c94acdd969f5f17c91c
+  RNReanimated: 3b8ec43aaef0389e702878e7725608128daa2053
+  RNScreens: fc90db67db667de4fa6caf1355d679e04fe4c30f
+  RNSVG: 8d87cff016edf1b6ca409ed39804101836d75e90
+  RNWorklets: f0b4bfd581c55f18a8bea9beae9cef26650c8cda
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -71,7 +71,7 @@
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.3",
     "react-native-pager-view": "6.8.1",
-    "react-native-reanimated": "4.0.1",
+    "react-native-reanimated": "4.0.2",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "4.14.0-nightly-20250803-1df3db25a",
     "react-native-svg": "15.12.1",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -103,9 +103,6 @@ PODS:
     - ExpoModulesCore
   - ExpoFileSystem (18.1.10):
     - ExpoModulesCore
-  - ExpoFileSystem/Tests (18.1.10):
-    - ExpoModulesCore
-    - ExpoModulesTestCore
   - ExpoFont (13.3.1):
     - ExpoModulesCore
   - ExpoGL (15.1.5):
@@ -3345,7 +3342,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNReanimated (4.0.1):
+  - RNReanimated (4.0.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3372,11 +3369,11 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 4.0.1)
+    - RNReanimated/reanimated (= 4.0.2)
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNReanimated/reanimated (4.0.1):
+  - RNReanimated/reanimated (4.0.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3403,11 +3400,11 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 4.0.1)
+    - RNReanimated/reanimated/apple (= 4.0.2)
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNReanimated/reanimated/apple (4.0.1):
+  - RNReanimated/reanimated/apple (4.0.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3792,7 +3789,6 @@ DEPENDENCIES:
   - ExpoDocumentPicker (from `../../../packages/expo-document-picker/ios`)
   - "ExpoDomWebView (from `../../../packages/@expo/dom-webview/ios`)"
   - ExpoFileSystem (from `../../../packages/expo-file-system/ios`)
-  - ExpoFileSystem/Tests (from `../../../packages/expo-file-system/ios`)
   - ExpoFont (from `../../../packages/expo-font/ios`)
   - ExpoGL (from `../../../packages/expo-gl`)
   - ExpoHaptics (from `../../../packages/expo-haptics/ios`)
@@ -4313,73 +4309,73 @@ SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EASClient: 01c089e5fa07184477aed2944d7650062cd3c37f
-  EXApplication: f5eb4ca614699d70809fc2681c9b367f991886c5
-  EXAV: 6ef85347ee2dba74841f79f8ce3f65a69268bfba
-  EXConstants: 0c911c420c4944c3c1d06f7a339b2dd4a7472361
-  EXImageLoader: 468799c831a3076af4de6a56422524b3ce897c1f
+  EASClient: cca4fa0bf58b32a99476e9d9f80cbeebcb57df90
+  EXApplication: 2da4660569e086f4f18722758b52d7e7792631ab
+  EXAV: 0809cbb31eba2111d5413f2dbb547ba9727478ee
+  EXConstants: 72e8e04dc4d7d97c74a618d44753ea4a7437a2b6
+  EXImageLoader: d2b81b29509ee86ad8bdf0d2cc9ff5d86051d68b
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: f2f18db6a798d69a20f7d6beda6f9e0252b921db
-  EXNotifications: f0c7597a22645faf9ce9e74f1b1078c16fb7575f
-  Expo: 3db18bab43ebf2df061fa5493c07514122e75aa3
-  ExpoAppleAuthentication: 76db051d8d312fae4c513b24aa6283770ab7fd9b
-  ExpoAsset: b876ebe84926f3b683c5b616bd27dcaa127e2c72
-  ExpoAudio: 4691418ee15d1f0743c69d264eb937547f0faf5e
-  ExpoBackgroundFetch: 6ea99684804a3a264b08f18cbb3b45a0ecd410ed
-  ExpoBackgroundTask: e3a8b3feaffa1a40e1a373460094d54656cc7512
-  ExpoBattery: 766e12ad7fc8c7a09356d2f593c4f81ce421fb4f
-  ExpoBlur: 7f9379db213e4a56aeceda82e94a7fea1b1d8c48
-  ExpoBrightness: c335c6ccc082d5249a4b38dba5cd9a08aa0bf62b
-  ExpoCalendar: f5f94ea8dcd957b1434beb4e1c0da1af063322e6
-  ExpoCamera: 316809537daad6a5bd2c04b98e0589304beb5551
-  ExpoCellular: c54250f4fdbf76850d5c33461ae06b0a204c403e
-  ExpoClipboard: d8ee7c30c60c6aac4f059ec3cbd5e9bea5b46133
-  ExpoContacts: 3dd51c3c53017b4ca05f18e786d1eb1ace729ef3
-  ExpoCrypto: 5a9209f80c4b5f96e0eb77baa7473d8b0fbbab34
-  ExpoDevice: f9ac04e9e3cec3ad82bf6379a061a33823b51d43
-  ExpoDocumentPicker: a5d292a473c1414f551ce45fac0a9d373bbeb54c
-  ExpoDomWebView: b410c8aa6a0a41988586046dba0a5497ee18a0d6
-  ExpoFileSystem: f4f896dc547a1e0e3b72bb6a9fae94e03620d90e
-  ExpoFont: 5aa2bc9e816911fb87b80792e5b643bdddeff751
-  ExpoGL: 91fc38ca1ffc07b29c6848b396a5a793ac0304cf
-  ExpoHaptics: beef56ed756455d4390a939234fb37b0449fd362
-  ExpoHead: 64d6aa313b01baa86bc32d90300705e656da227e
-  ExpoImage: e4a46c3a72b0c72f259a25629c01f550ed3fff6a
-  ExpoImageManipulator: 7f44b0d9be947203d516ffd14972775c490951b9
-  ExpoImagePicker: b6fa79d678c0f86be51585d144d87edd2843fdaa
-  ExpoKeepAwake: 184e9fa683b7ce421d0e8a0221bc60189d3f96cd
-  ExpoLinearGradient: 9a5a52c22b2db7103db35ef09134b491e0e46f58
-  ExpoLinking: b85ff4eafeae6fc638c6cace60007ae521af0ef4
-  ExpoLivePhoto: 8e2df0f48566aaa0835ad26290c16739d21f02a0
-  ExpoLocalAuthentication: 39794e59dda1954fa822d2ab1ae017e8a3e75f37
-  ExpoLocalization: 344cfcb14b9ae5f2a5baa52f021a07bc7178657e
-  ExpoLocation: a319a1b2c00b82c29e8a24227e0f00d1e19662c5
-  ExpoMailComposer: f8829ee4452ec27ef3c34d1b99fcc2553570ed02
-  ExpoMediaLibrary: ef14f0390b06ddecca98118eb7332e92efe4765a
-  ExpoMeshGradient: f77f7b26471768000d89662713b7f1c8496e890b
-  ExpoModulesCore: c1aaa7b175e331c6e99479de43fc261c2ad7f59b
-  ExpoModulesTestCore: 6bcb44cd94befcfb9ca181500e8f58b7da1751ad
-  ExpoNetwork: 92cac43c13a2d9e9c1470ec8804836574ff34068
-  ExpoPrint: 37a906e6b0ba98a7c1709c96cc0b20398ae04aba
-  ExpoScreenCapture: b2fc30f94eb3402d4fd225578475345394fe6afb
-  ExpoScreenOrientation: cea50e5cf3316e1fd2667acbf70b948b38a22c1b
-  ExpoSecureStore: 775b325aacd4befc4a34515fb30ff85355e5b69e
-  ExpoSensors: 3a783157907ea57f1497b97a635ac1ae1837cba2
-  ExpoSharing: 2e20ca3a89d60b389aab84e4d57e9537a280e45e
-  ExpoSMS: a6cb0b2d122b2155518568b625ff584706241aa1
-  ExpoSpeech: 7c8e24a2dade507ecff6acc42cfb0f01d847fed2
-  ExpoSQLite: 78b6c89eaf10afa16a6e5d8c36da044305648f8b
-  ExpoStoreReview: 1810e2ca51bdd976c2e9835b8ef20ca863a305da
-  ExpoSymbols: a0976bee6b4a097de61353f08dc6e53ace90346e
-  ExpoSystemUI: 10faac77830ad0a70e52641b8a749e9b8ea75be4
-  ExpoTrackingTransparency: 368fa25c00c36e35f6a1f74edb6b2450218fdb15
-  ExpoVideo: 3061817cc0f433e5ad81ff226ec7621a90562e98
-  ExpoVideoThumbnails: 375f8c0166c25011f352ce4c0f651270821bf8fe
-  ExpoWebBrowser: d3208126d5d8a2da4c5aa04c839b112d0a40da80
+  EXManifests: bf76658edfbfa3e3fb67f940ade98d7803490789
+  EXNotifications: f0f1c97d04f06c51ea073d7b2396431e5611c1ea
+  Expo: 50f261cb88416e897c42707a176dd6bfc02e3ff6
+  ExpoAppleAuthentication: 69a48d4633024124a33fda650dba706c216d6c76
+  ExpoAsset: b5bfc6425d1e9a09e8e1368646b98fe5ae7ed074
+  ExpoAudio: f6bcc6868e643e6fa74b6e20fd7d20ecc89b4e28
+  ExpoBackgroundFetch: 76c48b3cd9a4ee46e5267614a30fac804de6f33e
+  ExpoBackgroundTask: 63e54818a257ad36aeff7e04ef67598e68c18fbb
+  ExpoBattery: 6229d981d12dffb00c9e8e48181162729febb541
+  ExpoBlur: 5d95f7ca771a0f3b9618466525dd68e46dc95f3a
+  ExpoBrightness: 05e750736f8886dcf235212b0caf85b0f605fc88
+  ExpoCalendar: 660542dc1c5ef98f46bedcc8745aa707df5d501a
+  ExpoCamera: e88fc30631e63e5504ce19d52c563a6ec49e17d2
+  ExpoCellular: 9310e19e8052da7d861b31450e46b1db4821b20c
+  ExpoClipboard: 77842a5542aa7ad5dcd9cc03d34442b1b2d857ea
+  ExpoContacts: 870a98e359ee83ab9fa15eee40c66d15731747a8
+  ExpoCrypto: d79e7fb137efb093a9c144974d7a165009a1b11f
+  ExpoDevice: 3a4e4dc5cca31c1c731731cf11717dc3f7fff211
+  ExpoDocumentPicker: 0b9848ccbb414d27491a478a013ea9d434613d84
+  ExpoDomWebView: 290738a4948cf54d58a70191f31aedce6113a9a6
+  ExpoFileSystem: 95ecce2f02e751a3c40d082fc605fbc271564038
+  ExpoFont: 370a9897880ac279fbd4e478dede18ec4f723d1a
+  ExpoGL: 8f7f43291e400621ef9aeb7af347816c2051ddc7
+  ExpoHaptics: 581bbb680c566b8afef68fd50f1efb883972b150
+  ExpoHead: 94585b2fec8aea34aff1372910f1b47917727173
+  ExpoImage: 736d4bf4e14437d0e0c7dafdd3aa169c17d447a7
+  ExpoImageManipulator: d889b5a58e217657dd5ef4fbc23441f2be12463e
+  ExpoImagePicker: 235489a513df4c70c402f2a49a47fdd94053d63d
+  ExpoKeepAwake: 95037f8576ba678db79cbf558b933400c81997a7
+  ExpoLinearGradient: 110244a240361e3351756225e5fcc4c6c07f5431
+  ExpoLinking: 5d151d4a497d7e375308602f0a89b4e8acf7b5f8
+  ExpoLivePhoto: e2d46bcd19046da559d4a690244382ad1c6bd699
+  ExpoLocalAuthentication: def09053225f6395574fbff9b385ff707a870f2b
+  ExpoLocalization: 3d73d7d77ec4277b533cbc19b74ac0f009151985
+  ExpoLocation: afc197fce1045ac7325f095b0c149308e1653aab
+  ExpoMailComposer: 502cb45610367987f741db89ad5e1e45497b52b0
+  ExpoMediaLibrary: ad61cd80ca07da02be3d676e3d9b04b311a82c2c
+  ExpoMeshGradient: d0c68837d2abe38a7ed9b9c800f084be0f03ed1b
+  ExpoModulesCore: 9faf069f091ef2dd979ba7b605ffdb07f0819d1a
+  ExpoModulesTestCore: eb1c0976fd260b9b56f1224c4508522e3acd3e03
+  ExpoNetwork: 9fdbef259f313a1ba7ede5fa977ee3dfed6fe653
+  ExpoPrint: ad01049aadc3a5315afc95e483548d8cce4192d1
+  ExpoScreenCapture: dc8bd55d68fac61ae677c1cc31fa1bc1f6c6913e
+  ExpoScreenOrientation: 3567ed658dea636f98f0d22f4eee19a95cd19d6b
+  ExpoSecureStore: b2b179bc106f683f7a1ce61a46dd2dce6a6c715f
+  ExpoSensors: 391133ad6430712d61a7797454ae326e0e8755e0
+  ExpoSharing: 4390db7ff14bc5db4d41879d529d729230204f91
+  ExpoSMS: 78241dca635906b6aefcfa9d3d2e499b7fa8d05f
+  ExpoSpeech: f7b35627d6665edec6580144d8070316b261eea6
+  ExpoSQLite: e1fef6b50e3f1b7c3fc725b5b43a484f2dc9d9a9
+  ExpoStoreReview: d8004651736a31ed37cb69e4799d0f18fd6e362b
+  ExpoSymbols: c5fd6904f2adda427e4a5ac1a4cbad060dec6f53
+  ExpoSystemUI: b9294916cc916a704d21c8bb745d6e27871fdbb7
+  ExpoTrackingTransparency: 37880a2e6f317c938f1b50cd05c094571e317ba5
+  ExpoVideo: 0e9cd59d0bd301e0f33a8fa7b0e3f1a497f60f81
+  ExpoVideoThumbnails: 78229366987270a271cd57e2cda857003e32ebda
+  ExpoWebBrowser: 41dc1db6ed9185a3b80a9f917ba3c62dafd22eec
   EXStructuredHeaders: 1c799cb91e8057e0671610635e5b2109fa295114
-  EXTaskManager: 38a18adc5f8ddaeeae6381effd8f972a29a8007c
-  EXUpdates: 1a188620bf504c6a2062077a9366f11f3bde9af8
-  EXUpdatesInterface: 5149921d084a7da7bd97dfc321b8302b03ceb83f
+  EXTaskManager: d767bbb4ea832f4b7781244bcc8e01c94d27aa60
+  EXUpdates: d7205503b033ad6f48ea2702a234db55c0ec45a5
+  EXUpdatesInterface: d6c802a2d1d11867523d03a95397957f9ba3d1c7
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 64579c0203cbc859de4536d54b4c6ed28fd03d42
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
@@ -4397,109 +4393,109 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: b58e9627004f47043897eeae830c3ef023678f3b
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 508aef00fe18a32c9a667e72afe990aa7f2829c5
+  hermes-engine: 790b2815cecb6ba805c62c77bf7e29df4ea64e8d
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: de18e94574402f8687b61b5ead1faa302b09abbf
+  lottie-react-native: 89a3dc7200168d4f98f43780afe082a637be9dcb
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: 3a51da4c0e2a533c893971c2171d164974bc5214
   RCTRequired: d26a2245fa986ca16a6c93d91e41beeeb7a8aa3f
   RCTTypeSafety: e9598921dd4338d6dcb7b4ba0b7b92f84cdcc25e
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
   React: 713c6b114dfaddd4e58bc0e3804334f2a170b754
   React-callinvoker: 4441303f80922bcab09bd3e401738c1a7f3ffe11
-  React-Core: 1647c97526fa4f1ea42365283e03649a53297d2e
-  React-CoreModules: 4c3d70d404ab9b87c7775e0293f53f9926663039
-  React-cxxreact: a51f7392e614e975f03845504cc253c812014a95
+  React-Core: 48eb931b5319893300e3766c6cc38481fa647dfa
+  React-CoreModules: 16160d86eee8183e615fc12e01a7b7d4037d0f11
+  React-cxxreact: 61e4deced1e2e89409d723baaf367da6d8eaf916
   React-debug: 77c881c70aef8f5787761005eeb57e437a7d0a5b
-  React-defaultsnativemodule: e6b4fadf89fd6c8b8f5a3e04d5c2643ccdfe82b8
-  React-domnativemodule: 935765aae2d5cee829e14ef7f68bae607b985262
-  React-Fabric: 51b47e25e8ea701e0de18df49ecfacde647dcef0
-  React-FabricComponents: 3563263621533b915a6634cd7634f3bac316c302
-  React-FabricImage: 81f78d0cc89a824c6842493b19c20d50d5e0eacd
-  React-featureflags: ccf1419c575fa7fd7cc558781bdd71ef9f671735
-  React-featureflagsnativemodule: 6e11d8ae01637ee30a2be5c65cb9363c672f4e7c
-  React-graphics: 211215400fa45680369a528e33f8a1bd0c53e06c
-  React-hermes: bdbe62b8a2faee475a82783785a4dc5d523d86fc
-  React-idlecallbacksnativemodule: 1a569d82993b763b2fabe1e1632bb733f9d67f30
-  React-ImageManager: 7ec5c6e6cd9b9025f2c0a5ac60469fd5a41b87a0
-  React-jserrorhandler: 98669ab3fc66c77862c5e757a44f8d7a6569ee3a
-  React-jsi: dfa0088e5654a951995d4deac1bb9fcdb3f4caf7
-  React-jsiexecutor: 2afac999079f68d80d3af10bfff584f52c754a13
-  React-jsinspector: ed95bb4e7e40f5b217007635dd138b0bec18ee5c
-  React-jsinspectorcdp: ceba155d82ef6be17948c6dd719af7d76ccc7849
-  React-jsinspectornetwork: 3d24ed2f68f45e644a2cd1b58a2e7f2a6c2362bf
-  React-jsinspectortracing: 16f01f653a451f0180e0dd9c3d18adf35611bb89
-  React-jsitooling: 4bd008cf273ba5615f3d27ea29cbd984dd22c0d7
-  React-jsitracing: d2ee2605ab10432c31c42a3b1a8c7dd2d387f3d3
-  React-logger: ce833a4ee1f377d1b27d6a70db5e49f539dd3fc6
-  React-Mapbuffer: f0c91e870f86a23ccf80ab9527d95f37e834e24e
-  React-microtasksnativemodule: be6fa55f64e8de5a53f3e9d01feb91d6682af78d
-  react-native-keyboard-controller: 72bf29521cd5269a3a5d45f48123d57472de7ce7
-  react-native-maps: 05e86963c50aef9fe5736dcf163e0e16055a2a52
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-pager-view: f8f63370fc0f4174f7510863b4812b8e034d2d0d
-  react-native-safe-area-context: 84a754cad3fbb25117482cde6b8defca6c6f6a53
-  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
-  react-native-skia: a3f5566cde7cad24c97b88739786b238c531b6db
-  react-native-slider: 27ecfb62634ccbbfc1d4562ab8a5ca5c7f4da03a
-  react-native-view-shot: 6c008e58f4720de58370848201c5d4a082c6d4ca
-  react-native-webview: 4cbb7f05f2c50671a7dcff4012d3e85faad271e4
-  React-NativeModulesApple: f75e771a53921934a0c6120e2bc7ee7dfb7c8728
+  React-defaultsnativemodule: 72ed284e13ab42903f492568e3db78dd708b06de
+  React-domnativemodule: b57bdf705c8f26762d70ddae2f917b6593622d7a
+  React-Fabric: 04dacebd7f35c74d648cadf8fda8c4dd105e1d56
+  React-FabricComponents: 0740d9d86edca91bbd3ab881ab9d139ccaff3513
+  React-FabricImage: 9d544dfe265a8cffaa7ef95023e3eb14eab7058a
+  React-featureflags: c33312b0812afb235add6add17e91b6f3a92222c
+  React-featureflagsnativemodule: 1db86f04957efcaecaec3957cc8d0de86ea573ab
+  React-graphics: f070009719fcac1854a3c4b3897b23e67b956ce2
+  React-hermes: b0d0cf1afcc6a5ea966d7841abbc89d0ec01526d
+  React-idlecallbacksnativemodule: 38c37267785b9d601dab87653edf2cf0c346bcc7
+  React-ImageManager: 578228cd0fbcef002207bf8acf0a42c712098906
+  React-jserrorhandler: 4da8855c5652652776eae535702b258fdc7e2693
+  React-jsi: 32ecda8451aac1f6a649e05dc94a0948ce2bb7d7
+  React-jsiexecutor: f4f3b47f4c1c076363ab8b65042a9a6177ef96b5
+  React-jsinspector: 24c8d6057c0ff37eccc72c855f198c6157893c78
+  React-jsinspectorcdp: 9a364f9cd548fc389ac91af4e5c38eae58f6548f
+  React-jsinspectornetwork: d7f3b19d53fe328dc139035ab0bba19aa68f2439
+  React-jsinspectortracing: 414014b64e0362eec726f3416cc9a02b9a8e9a16
+  React-jsitooling: 96c159a6a7cd6f29f208359554eec887b6fb27b9
+  React-jsitracing: 3c3d20d2dc74fc895411af104f9a9d103dc23794
+  React-logger: 3903016c02ae4dff7387d028501a3b03ba72879d
+  React-Mapbuffer: 48d6d8d0361ab4be5a7b4825006ddfff5e3686ec
+  React-microtasksnativemodule: bd7cfbd456840ebd272edad86b0e09595f2c80d5
+  react-native-keyboard-controller: bf7ec487800e1283b95532d1259bde1fdf7c4bd5
+  react-native-maps: fece4020ca8007967fa5eb48c914a8f2c73e7d4c
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-pager-view: 5aa9fb30444ca4bbe382991b6783cc014ed5ca07
+  react-native-safe-area-context: 5d8c627bc6296d018625948364c1a02d50d11bd4
+  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
+  react-native-skia: e4a1edd09e2e7bd95956683673ac18f911d63cfb
+  react-native-slider: 95b11a80deb9ad503b01debf1a6c71f9ba6485b9
+  react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
+  react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
+  React-NativeModulesApple: b7c71399d5a301dab362289d68747ff8c9b84c19
   React-oscompat: e324ee1ba89eb09d59c8e346748c758cb87a2ce3
-  React-perflogger: 08d464e4b97e53f74e6d8a1e4199e96f6ef8fd97
-  React-performancetimeline: b35d1855146b516a8a45639ea2809379d6990a50
+  React-perflogger: 1a98c4a181ab1cf9e8cf955dae867abfac59a50d
+  React-performancetimeline: 1a508e57eb32cc6951ecc95ac795afe13f3c1499
   React-RCTActionSheet: e995bcd8831351318c94bfa3e585178dc15934c8
-  React-RCTAnimation: 0bf88d7b156c5c47cdb74fe630e521bcbb9baa9c
-  React-RCTAppDelegate: 910087f517dc84af72c85d17973ccc1c1118a297
-  React-RCTBlob: 57f0deea9e2b6acc4165c4fd85d1515ed572da82
-  React-RCTFabric: 93ce57846073175be95690ea04cd31326b05ed58
-  React-RCTFBReactNativeSpec: 1aeba7991a5dcead5b2698f43b0f6c7f43105109
-  React-RCTImage: 07f30e864a1329886d3f1b870e795c2be9bee4a6
-  React-RCTLinking: d1431042ba333062262e0238f8337afb929976d8
-  React-RCTNetwork: 5e4f2515221b263a2131fb34382c6c4486f8b31b
-  React-RCTRuntime: adde7ead94b95216b2ed43923dd6111c4a9b9bbd
-  React-RCTSettings: 7f123bcbf1feb7747dd62343231bdfaba42542bc
-  React-RCTText: fb56147304f7e3ffc790310a83a099ade9d1f930
-  React-RCTVibration: 12044b012f28bcdf52d1b3bcef0c2645a56dda1b
+  React-RCTAnimation: eda5da34ef170a419bff522a58db9d5fb109acec
+  React-RCTAppDelegate: 26ebc3917638dde2ca20facec826e45a96f16d6c
+  React-RCTBlob: 8e905a0df8271c7405e5542f4ddc5f11bf7b3ef4
+  React-RCTFabric: 5c4a2e726a25dd007bffd3aa8ded58d8d58bad67
+  React-RCTFBReactNativeSpec: 125ec865d3b95360142f343075d0326c1f2188fd
+  React-RCTImage: fe502bd39bb9bb5b9cfa635e141bf3d602091b2f
+  React-RCTLinking: 2d9dad05c5ebddc5902a2c2c0177f72e8f6b93bd
+  React-RCTNetwork: 81ac1907ff907c3e0669c8702a1aae2a8356cf8d
+  React-RCTRuntime: b156f2c4f38023a065723d70dd3eb9468a523cc9
+  React-RCTSettings: 0887e903b7f06463ec5887df385ade35705c5151
+  React-RCTText: 4644d6c9bc18c05ea4d373c8434ad9dc2392e642
+  React-RCTVibration: f381c601f931888740383dc14f4baeebac945e94
   React-rendererconsistency: fde6f437f72fb837be955c7d287c5f1a1fe47212
-  React-renderercss: c57968265fbec6bbd00af273bac6f795874b3148
-  React-rendererdebug: a28985b812b04903f7e13d9aff7748bc3ec7a72d
-  React-RuntimeApple: f4888b94562b29f18ff96b18f6e3cf958dfbc1a9
-  React-RuntimeCore: c49192fe880e0452d96b16c729064d1d489a0e8e
-  React-runtimeexecutor: 15eb9796b1efe4eee86e020799026723dc4c99cc
-  React-RuntimeHermes: 41b97445036fc60f2447c5c69b9f1639de65292b
-  React-runtimescheduler: eee88df3c5fb6a30a220e524fd282e44a282a1ca
+  React-renderercss: 8ad27c2b7c138f27518702af50c4bacc85d67fc9
+  React-rendererdebug: 34b2305ff2a349e540b39354277ce2c457da8ec9
+  React-RuntimeApple: 347f9558b516c79bd0cfa2a237371843d0a22c25
+  React-RuntimeCore: d4e1654e01a1a6df3ede773b2ddbac83f39725a9
+  React-runtimeexecutor: 93e8ab92174058160232cd9283d354463255020d
+  React-RuntimeHermes: 2f477bc8fc39fff2d1e3a966a3d908bbde6c3fd5
+  React-runtimescheduler: 7d15929025e58a47cd73758c6c4f46d293d3dca5
   React-timing: c6ce3a683af45aecee166b49348cd094170a7e36
-  React-utils: 082cd4a9663f63b4138bc2e068a5a93dc7e0adff
-  ReactAppDependencyProvider: 3b7ece00025ce3482570139b0dbe115e639688ca
-  ReactCodegen: fa5fbc0b69b8f64c7c04afb57e3bf4303e8bf0ca
-  ReactCommon: 61fd53636b15a5dc300d5e31105a76f773a918fd
-  RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
-  RNCMaskedView: 5ef8c95cbab95334a32763b72896a7b7d07e6299
-  RNCPicker: 66c392786945ecee5275242c148e6a4601221d3a
-  RNDateTimePicker: 510d9822e8a6d02de332ef1f68a8fc53f3d35497
-  RNFlashList: b1f92e77d19aca4f9112bd977ca2ff8a2d61bf69
-  RNGestureHandler: 3a73f098d74712952870e948b3d9cf7b6cae9961
-  RNReanimated: e353576b032a79ac1ec1860df1062e6147d35db0
-  RNScreens: 51d1b1d9ecf9db095abb24525be038da0ef48747
-  RNSVG: 6f39605a4c4d200b11435c35bd077553c6b5963a
-  RNWorklets: 32ea3225502c57b559c76f684fc2abac865b7728
+  React-utils: 3b356bfa4a83cd7e019b96b1de73e8340cef2bf9
+  ReactAppDependencyProvider: ad094d490c0b69fcd292806df86e007728d02f95
+  ReactCodegen: 3e4dff28826e5bac0593f26c27d2dd2c3a6c66f2
+  ReactCommon: 3c95b5086d10c5da3d6d0fc920fc1ce6c984a496
+  RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
+  RNCMaskedView: 63268de1986a098b5f4d1fb5b1bc1e97fade0aee
+  RNCPicker: 6da395ee9db8d67a38c6102d4128b5a0b9ec0e21
+  RNDateTimePicker: 5e3503a3a82a9710b0269fa6617e27f7896509bd
+  RNFlashList: 3b0c6a34ba86318f897ff55ff7482b7e8ae18996
+  RNGestureHandler: 4f7cc97a71d4fe0fcba38c94acdd969f5f17c91c
+  RNReanimated: 3b8ec43aaef0389e702878e7725608128daa2053
+  RNScreens: fc90db67db667de4fa6caf1355d679e04fe4c30f
+  RNSVG: 8d87cff016edf1b6ca409ed39804101836d75e90
+  RNWorklets: f0b4bfd581c55f18a8bea9beae9cef26650c8cda
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Stripe: ae1b368097280ad027c1ec4a817a0a78bb74a6ee
-  stripe-react-native: 557f1623d00f14e6699d77bffebdbe98b21f0bc2
+  stripe-react-native: f588f4932eb81c3c38782411302c032f258c46ff
   StripeApplePay: 66dc43ec1284904a2cf4c5a0906f86296d23afbd
   StripeCore: f3a62397cecaf4da1827bcf07de7312ec1f3b96e
   StripeFinancialConnections: ca4584ba0e08649787d7672b9ca4bb3c972e3d43

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -80,7 +80,7 @@
     "react-native-pager-view": "6.8.1",
     "react-native-paper": "^5.12.5",
     "react-native-worklets": "0.4.1",
-    "react-native-reanimated": "4.0.1",
+    "react-native-reanimated": "4.0.2",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "4.14.0-nightly-20250803-1df3db25a",
     "react-native-svg": "15.12.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -147,7 +147,7 @@
     "react-native-pager-view": "6.8.1",
     "react-native-paper": "^5.12.5",
     "react-native-worklets": "0.4.1",
-    "react-native-reanimated": "4.0.1",
+    "react-native-reanimated": "4.0.2",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "4.14.0-nightly-20250803-1df3db25a",
     "react-native-svg": "15.12.1",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -101,7 +101,7 @@
   "react-native-maps": "1.24.13",
   "react-native-pager-view": "6.8.1",
   "react-native-worklets": "~0.4.1",
-  "react-native-reanimated": "~4.0.1",
+  "react-native-reanimated": "~4.0.2",
   "react-native-screens": "4.14.0-nightly-20250803-1df3db25a",
   "react-native-safe-area-context": "5.5.2",
   "react-native-svg": "15.12.1",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -34,7 +34,7 @@
     "react-native": "0.81.0-rc.5",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-worklets": "~0.4.1",
-    "react-native-reanimated": "~4.0.1",
+    "react-native-reanimated": "~4.0.2",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.21.0",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -25,7 +25,7 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.0-rc.5",
     "react-native-worklets": "~0.4.1",
-    "react-native-reanimated": "~4.0.1",
+    "react-native-reanimated": "~4.0.2",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13577,10 +13577,10 @@ react-native-paper@^5.12.5:
     color "^3.1.2"
     use-latest-callback "^0.1.5"
 
-react-native-reanimated@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-4.0.1.tgz#6cb8bca007baa18d75e0ef8b03e969d2777cd5e8"
-  integrity sha512-SZmIpxVd1yijV1MA8KB9S9TUj6JpdU4THjVB0WCkfV9p6F8oR3YxO4e+GRKbNci3mODp7plW095LhjaCB9bqZQ==
+react-native-reanimated@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-4.0.2.tgz#c986bff36ce90cd1df83506d6fb5d62db6f2d3b7"
+  integrity sha512-RVD/jeTWrkloRVJmTAEtgXtihEnfA7aO6SgoaTBy3jbU1zblE3Oztq0ktVO5q/rxl96l9w2+6LLcuZ6N8D7aKQ==
   dependencies:
     react-native-is-edge-to-edge "^1.2.1"
     semver "7.7.2"


### PR DESCRIPTION
# Why

Bumps `reanimated` to `4.0.2`.

# Test Plan

- bare-expo ✅ 