### PR TITLE
[doctor] Hide "no metadata available" if it's the only issue (RND check)

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Switch Metro imports to `@expo/metro` wrapper package ([#38166](https://github.com/expo/expo/pull/38166) by [@kitten](https://github.com/kitten))
 - Add missing packages to `DirectPackageInstallCheck` ([#38701](https://github.com/expo/expo/pull/38701) by [@kitten](https://github.com/kitten))
+- Hide "no metadata available" for React Native Directory output if it's the only reported issue ([#38728](https://github.com/expo/expo/pull/38728) by [@kitten](https://github.com/kitten))
 
 ## 1.13.5 - 2025-07-03
 

--- a/packages/expo-doctor/src/__mocks__/chalk.ts
+++ b/packages/expo-doctor/src/__mocks__/chalk.ts
@@ -7,17 +7,20 @@ type ChalkMock = jest.Mock<string, [string]> & {
   red?: jest.Mock<string, [string]>;
   yellow?: jest.Mock<string, [string]>;
   underline?: jest.Mock<string, [string]>;
+  bold?: jest.Mock<string, [string]>;
 };
 
 const green = jest.fn((str) => str);
 const red = jest.fn((str) => str);
 const yellow = jest.fn((str) => str);
 const underline = jest.fn((str) => str);
+const bold = jest.fn((str) => str);
 
 const chalk: ChalkMock = jest.fn((str) => str);
 chalk.green = green;
 chalk.red = red;
 chalk.yellow = yellow;
 chalk.underline = underline;
+chalk.bold = bold;
 
 export default chalk;

--- a/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts
@@ -99,24 +99,43 @@ export class ReactNativeDirectoryCheck implements DoctorCheck {
       };
     }
 
+    let hasCriticalIssues = false;
+
     if (newArchUnsupportedPackages.length > 0) {
+      hasCriticalIssues = true;
       issues.push(
         `${chalk.bold(`  Unsupported on New Architecture:`)} ${newArchUnsupportedPackages.join(', ')}`
       );
     }
 
     if (newArchUntestedPackages.length > 0) {
+      hasCriticalIssues = true;
       issues.push(
         `${chalk.bold(`  Untested on New Architecture:`)} ${newArchUntestedPackages.join(', ')}`
       );
     }
 
     if (unmaintainedPackages.length > 0) {
+      hasCriticalIssues = true;
       issues.push(`${chalk.bold(`  Unmaintained:`)} ${unmaintainedPackages.join(', ')}`);
     }
 
-    if (listUnknownPackagesEnabled && unknownPackages.length > 0) {
+    if (
+      (listUnknownPackagesEnabled === null || listUnknownPackagesEnabled) &&
+      unknownPackages.length > 0
+    ) {
       issues.push(`${chalk.bold(`  No metadata available`)}: ${unknownPackages.join(', ')}`);
+    }
+    
+    if (!hasCriticalIssues && listUnknownPackagesEnabled === null) {
+      // NOTE(@kitten): We shouldn't output just "no metadata available" packages with no other
+      // issues, if the user hasn't explicitly opted-in or opted-out, since it adds to the output
+      // noise of doctor
+      return {
+        isSuccessful: true,
+        issues: [],
+        advice: [],
+      };
     }
 
     if (issues.length) {

--- a/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts
@@ -5,6 +5,7 @@ import {
   getReactNativeDirectoryCheckExcludes,
   getReactNativeDirectoryCheckListUnknownPackagesEnabled,
 } from '../utils/doctorConfig';
+import { checkLibraries } from '../utils/reactNativeDirectoryApi';
 
 // Filter out common packages that don't make sense for us to validate on the directory.
 export const DEFAULT_PACKAGES_TO_IGNORE = [
@@ -50,54 +51,34 @@ export class ReactNativeDirectoryCheck implements DoctorCheck {
       ...userDefinedIgnoredPackages,
     ]);
 
-    try {
-      const response = await fetch('https://reactnative.directory/api/libraries/check', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ packages: packageNames }),
-      });
-
-      if (!response.ok) {
-        return {
-          isSuccessful: false,
-          issues: [
-            `Directory check failed with unexpected server response: ${response.statusText}`,
-          ],
-          advice: [],
-        };
-      }
-
-      const packageMetadata = (await response.json()) as Record<
-        string,
-        ReactNativeDirectoryCheckResult
-      >;
-
-      packageNames.forEach((packageName) => {
-        const metadata = packageMetadata[packageName];
-        if (!metadata) {
-          unknownPackages.push(packageName);
-          return;
-        }
-
-        if (metadata.unmaintained) {
-          unmaintainedPackages.push(packageName);
-        }
-
-        if (metadata.newArchitecture === 'untested') {
-          newArchUntestedPackages.push(packageName);
-        }
-
-        if (metadata.newArchitecture === 'unsupported') {
-          newArchUnsupportedPackages.push(packageName);
-        }
-      });
-    } catch (error) {
+    const packageMetadata = await checkLibraries(packageNames);
+    if (!packageMetadata) {
       return {
         isSuccessful: false,
-        issues: [`Directory check failed with error: ${error}`],
+        issues: ['Directory check failed with unexpected server response'],
         advice: [],
       };
     }
+
+    packageNames.forEach((packageName) => {
+      const metadata = packageMetadata[packageName];
+      if (!metadata) {
+        unknownPackages.push(packageName);
+        return;
+      }
+
+      if (metadata.unmaintained) {
+        unmaintainedPackages.push(packageName);
+      }
+
+      if (metadata.newArchitecture === 'untested') {
+        newArchUntestedPackages.push(packageName);
+      }
+
+      if (metadata.newArchitecture === 'unsupported') {
+        newArchUnsupportedPackages.push(packageName);
+      }
+    });
 
     let hasCriticalIssues = false;
 
@@ -176,10 +157,3 @@ export class ReactNativeDirectoryCheck implements DoctorCheck {
     };
   }
 }
-
-// See: https://github.com/react-native-community/directory/blob/1fb5e7b899e021a18f14b3c32b79d8d5995022d6/pages/api/libraries/check.ts#L8-L17
-type ReactNativeDirectoryCheckResult = {
-  unmaintained: boolean;
-  // See: https://github.com/react-native-community/directory/blob/1fb5e7b899e021a18f14b3c32b79d8d5995022d6/util/newArchStatus.ts#L3-L7
-  newArchitecture: 'supported' | 'unsupported' | 'untested';
-};

--- a/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts
@@ -126,7 +126,7 @@ export class ReactNativeDirectoryCheck implements DoctorCheck {
     ) {
       issues.push(`${chalk.bold(`  No metadata available`)}: ${unknownPackages.join(', ')}`);
     }
-    
+
     if (!hasCriticalIssues && listUnknownPackagesEnabled === null) {
       // NOTE(@kitten): We shouldn't output just "no metadata available" packages with no other
       // issues, if the user hasn't explicitly opted-in or opted-out, since it adds to the output

--- a/packages/expo-doctor/src/checks/__tests__/DirectoryCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/DirectoryCheck.test.ts
@@ -1,4 +1,13 @@
-import { DEFAULT_PACKAGES_TO_IGNORE, filterPackages } from '../ReactNativeDirectoryCheck';
+import { checkLibraries } from '../../utils/reactNativeDirectoryApi';
+import {
+  DEFAULT_PACKAGES_TO_IGNORE,
+  filterPackages,
+  ReactNativeDirectoryCheck,
+} from '../ReactNativeDirectoryCheck';
+
+jest.mock('../../utils/reactNativeDirectoryApi', () => ({
+  checkLibraries: jest.fn().mockResolvedValue(null),
+}));
 
 describe('filterPackages', () => {
   it('returns all packages if no ignored packages are provided', () => {
@@ -26,5 +35,103 @@ describe('filterPackages', () => {
         DEFAULT_PACKAGES_TO_IGNORE
       )
     ).toEqual([]);
+  });
+});
+
+const additionalProjectProps = {
+  exp: {
+    name: 'name',
+    slug: 'slug',
+    sdkVersion: '50.0.0',
+  },
+  projectRoot: '/root/project',
+  hasUnusedStaticConfig: false,
+  staticConfigPath: null,
+  dynamicConfigPath: null,
+};
+
+describe('ReactNativeDirectoryCheck', () => {
+  it('returns errors as expected', async () => {
+    jest.mocked(checkLibraries).mockResolvedValueOnce({
+      unmaintained: { unmaintained: true, newArchitecture: 'untested' },
+      unsupported: { unmaintained: false, newArchitecture: 'unsupported' },
+      working: { unmaintained: false, newArchitecture: 'supported' },
+    });
+
+    const check = new ReactNativeDirectoryCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          unmaintained: '*',
+          unsupported: '*',
+          working: '*',
+        },
+      },
+      ...additionalProjectProps,
+    });
+
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.issues).toMatchInlineSnapshot(`
+      [
+        "The following issues were found when validating your dependencies against React Native Directory:",
+        "  Unsupported on New Architecture: unsupported",
+        "  Untested on New Architecture: unmaintained",
+        "  Unmaintained: unmaintained",
+      ]
+    `);
+  });
+
+  it('outputs unknown libraries when other issues were found', async () => {
+    jest.mocked(checkLibraries).mockResolvedValueOnce({
+      working: { unmaintained: false, newArchitecture: 'supported' },
+      unsupported: { unmaintained: false, newArchitecture: 'unsupported' },
+    });
+
+    const check = new ReactNativeDirectoryCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          unknown: '*', // NOTE: This library isn't in the result above
+          unsupported: '*',
+          working: '*',
+        },
+      },
+      ...additionalProjectProps,
+    });
+
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.issues).toMatchInlineSnapshot(`
+      [
+        "The following issues were found when validating your dependencies against React Native Directory:",
+        "  Unsupported on New Architecture: unsupported",
+        "  No metadata available: unknown",
+      ]
+    `);
+  });
+
+  it('success and no errors if only unknown libraries are in the result', async () => {
+    jest.mocked(checkLibraries).mockResolvedValueOnce({
+      working: { unmaintained: false, newArchitecture: 'supported' },
+    });
+
+    const check = new ReactNativeDirectoryCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          unknown: '*', // NOTE: This library isn't in the result above
+          working: '*',
+        },
+      },
+      ...additionalProjectProps,
+    });
+
+    expect(result.isSuccessful).toBeTruthy();
+    expect(result.issues).toEqual([]);
   });
 });

--- a/packages/expo-doctor/src/utils/__tests__/doctorConfig.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/doctorConfig.test.ts
@@ -119,7 +119,7 @@ describe('getReactNativeDirectoryCheckEnabled', () => {
 describe('getReactNativeDirectoryCheckListUnknownPackagesEnabled', () => {
   it('returns true if the config is empty', () => {
     expect(getReactNativeDirectoryCheckListUnknownPackagesEnabled({ expo: { doctor: {} } })).toBe(
-      true
+      null
     );
   });
 

--- a/packages/expo-doctor/src/utils/doctorConfig.ts
+++ b/packages/expo-doctor/src/utils/doctorConfig.ts
@@ -71,13 +71,13 @@ export function getReactNativeDirectoryCheckEnabled(exp: ExpoConfig, pkg: Packag
   return pkgJsonConfigSetting ?? isEnabledByDefault;
 }
 
-export function getReactNativeDirectoryCheckListUnknownPackagesEnabled(pkg: any) {
+export function getReactNativeDirectoryCheckListUnknownPackagesEnabled(pkg: any): boolean | null {
   const config = getDoctorConfig(pkg);
   const listUnknownPackages = config.reactNativeDirectoryCheck?.listUnknownPackages;
 
-  // Default to true if config is missing
+  // Default to null if config is missing
   if (typeof listUnknownPackages !== 'boolean') {
-    return true;
+    return null;
   }
 
   return listUnknownPackages;

--- a/packages/expo-doctor/src/utils/reactNativeDirectoryApi.ts
+++ b/packages/expo-doctor/src/utils/reactNativeDirectoryApi.ts
@@ -1,0 +1,25 @@
+export const checkLibraries = async (
+  packageNames: string[]
+): Promise<Record<string, ReactNativeDirectoryCheckResult> | null> => {
+  try {
+    const response = await fetch('https://reactnative.directory/api/libraries/check', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ packages: packageNames }),
+    });
+    if (response.ok) {
+      return (await response.json()) as Record<string, ReactNativeDirectoryCheckResult>;
+    } else {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+};
+
+// See: https://github.com/react-native-community/directory/blob/1fb5e7b899e021a18f14b3c32b79d8d5995022d6/pages/api/libraries/check.ts#L8-L17
+export type ReactNativeDirectoryCheckResult = {
+  unmaintained: boolean;
+  // See: https://github.com/react-native-community/directory/blob/1fb5e7b899e021a18f14b3c32b79d8d5995022d6/util/newArchStatus.ts#L3-L7
+  newArchitecture: 'supported' | 'unsupported' | 'untested';
+};


### PR DESCRIPTION
# Why

The output from `expo-doctor` can be pretty noisy if many issues are present. We also currently colour all output and I believe it might be overwhelming some users.

Because the React Native Directory checks are of difference importance, we can hide some of them in some cases. We shouldn't report "No metadata available" when there's no specific config to display/hide them. Instead, if it's **the only** issue that the check found, we should just abort the check successfully.

# How

- Only output "No metadata available" when it's explicitly enabled and not the only issue found

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
