### PR TITLE
[audio][ios] Report correct playback rate.

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [web] Fixed broken player state when `replace` was called while audio was running, added missing `updateInterval` to web, and improved audio status event emitting. ([#38505](https://github.com/expo/expo/pull/38505) by [@hirbod](https://github.com/hirbod))
 - [android][iOS][web] Fix recordForDuration status updates and add new record() options API ([#38612](https://github.com/expo/expo/pull/38612) by [@hirbod](https://github.com/hirbod))
 - [android]: Handle exceptions when retrieving maxAmplitude from MediaRecorder ([#38690](https://github.com/expo/expo/pull/38690) by [@hirbod](https://github.com/hirbod))
+- [iOS] Report correct playback rate. ([#38729](https://github.com/expo/expo/pull/38729) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -135,7 +135,11 @@ public class AudioModule: Module {
       }
 
       Property("playbackRate") { player in
-        player.ref.rate
+        return if player.isPlaying {
+          player.ref.rate
+        } else {
+          player.currentRate
+        }
       }
 
       Property("paused") { player in

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -82,6 +82,7 @@ public class AudioPlayer: SharedRef<AVPlayer> {
 
   func currentStatus() -> [String: Any] {
     let currentDuration = ref.status == .readyToPlay ? duration : 0.0
+    let rate = isPlaying ? ref.rate : currentRate
     return [
       "id": id,
       "currentTime": currentTime,
@@ -94,7 +95,7 @@ public class AudioPlayer: SharedRef<AVPlayer> {
       "loop": isLooping,
       "didJustFinish": false,
       "isLoaded": isLoaded,
-      "playbackRate": ref.rate,
+      "playbackRate": rate,
       "shouldCorrectPitch": shouldCorrectPitch,
       "isBuffering": isBuffering
     ]


### PR DESCRIPTION
# Why

<img width="631" height="121" alt="image" src="https://github.com/user-attachments/assets/06649826-2e58-477f-b1bf-5c1209a31123" />

Fixes failing tests

# How

Changed it so that it always reports rate, if player is paused it reports the saved rate.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
