### PR TITLE
[expo][android][1/n] Use React Native's edge-to-edge - Respect `enableEdgeToEdge` in Expo projects

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix missing CDP headers when using static frameworks. ([#37448](https://github.com/expo/expo/pull/37448) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fix React Native's `enableEdgeToEdge` Gradle property being ignored. ([#38734](https://github.com/expo/expo/pull/38734) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

Currently Expo projects don't respect the new `enableEdgeToEdge` Gradle property. That's because we override the `ReactActivityDelegate.onCreate`  and don't call the original method, where the property is read and applied.

# How

Got React Native's internal edge-to-edge methods with reflection and launched them in our `onCreate` implementation.

# Test Plan

Tested in BareExpo in Android SDK 34 emulator. 
