### PR TITLE
[expo-router] add unstable-native-tabs to files in package.json

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Fix issues with link preview in heavy views ([#38534](https://github.com/expo/expo/pull/38534) by [@Ubax](https://github.com/Ubax))
 - Fix Link Preview navigation in NativeTabs ([#38283](https://github.com/expo/expo/pull/38283) by [@Ubax](https://github.com/Ubax))
 - add option to hide label and show empty badge ([#38668](https://github.com/expo/expo/pull/38668) by [@Ubax](https://github.com/Ubax))
+- add unstable-native-tabs to files in package.json ([#38742](https://github.com/expo/expo/pull/38742) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -35,6 +35,8 @@
     "html.js",
     "index.d.ts",
     "ios",
+    "unstable-native-tabs.js",
+    "unstable-native-tabs.d.ts",
     "node",
     "plugin",
     "rsc",


### PR DESCRIPTION
# Why

unstable-native-tabs were missing in package.json

# How

Adds     "unstable-native-tabs.js",  "unstable-native-tabs.d.ts"

# Test Plan


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
