### PR TITLE
[core] Deprecate Constants in favor of Constant and Property

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [iOS] Remove boilerplate from function factories. ([#37884](https://github.com/expo/expo/pull/37884) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Remove react-native 0.74 support files ([#38216](https://github.com/expo/expo/pull/38216) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Add missing peer dependencies for `react` and `react-native` ([#38528](https://github.com/expo/expo/pull/38528) by [@kitten](https://github.com/kitten))
+- Deprecate `Constants` in favor of `Constant` and `Property`. ([#38748](https://github.com/expo/expo/pull/38748) by [@jakex7](https://github.com/jakex7))
 
 ## 2.5.0 - 2025-07-17
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -86,6 +86,7 @@ open class ObjectDefinitionBuilder(
   /**
    * Definition function setting the module's constants to export.
    */
+  @Deprecated("Use `Constant` or `Property` instead")
   fun Constants(legacyConstantsProvider: () -> Map<String, Any?>) {
     this.legacyConstantsProvider = legacyConstantsProvider
   }
@@ -93,6 +94,7 @@ open class ObjectDefinitionBuilder(
   /**
    * Definition of the module's constants to export.
    */
+  @Deprecated("Use `Constant` or `Property` instead")
   fun Constants(vararg constants: Pair<String, Any?>) {
     legacyConstantsProvider = { constants.toMap() }
   }

--- a/packages/expo-modules-core/ios/Api/Factories/ObjectFactories.swift
+++ b/packages/expo-modules-core/ios/Api/Factories/ObjectFactories.swift
@@ -12,6 +12,7 @@ public func Object(@ObjectDefinitionBuilder @_implicitSelfCapture _ body: () -> 
 /**
  Definition function setting the module's constants to export.
  */
+@available(*, deprecated, message: "Use `Constant` or `Property` instead")
 public func Constants(@_implicitSelfCapture _ body: @escaping () -> [String: Any?]) -> AnyDefinition {
   return ConstantsDefinition(body: body)
 }
@@ -19,6 +20,7 @@ public func Constants(@_implicitSelfCapture _ body: @escaping () -> [String: Any
 /**
  Definition function setting the module's constants to export.
  */
+@available(*, deprecated, message: "Use `Constant` or `Property` instead")
 public func Constants(@_implicitSelfCapture _ body: @autoclosure @escaping () -> [String: Any?]) -> AnyDefinition {
   return ConstantsDefinition(body: body)
 }


### PR DESCRIPTION
# Why

`Constants` is a legacy structure that should be removed in the future. 

# How

Mark `Constants` as deprecated in favor of
* `Property` that can have getter and setter
* `Constant` lazy initialized, read only value

I'll make follow up PRs to replace the Constants across the codebase

# Test Plan

Nothing should change except the warning.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
