### PR TITLE
[go] fix eas expo go build crashlytics upload step

### DIFF
--- a/apps/eas-expo-go/scripts/eas-build-on-success.sh
+++ b/apps/eas-expo-go/scripts/eas-build-on-success.sh
@@ -34,7 +34,7 @@ upload_crashlytics_symbols() {
 
 if [[ "$EAS_BUILD_PROFILE" == "release-client" ]]; then
   if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
-    upload_crashlytics_symbols "Release"
+    upload_crashlytics_symbols "MobileRelease"
   fi
 
   SLUG="release-client"
@@ -57,7 +57,7 @@ fi
 
 if [[ "$EAS_BUILD_PROFILE" == "publish-client" ]]; then
   if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
-    upload_crashlytics_symbols "Release"
+    upload_crashlytics_symbols "MobileRelease"
   fi
 
   SLUG="publish-client"

--- a/apps/expo-go/android/app/build.gradle
+++ b/apps/expo-go/android/app/build.gradle
@@ -104,13 +104,10 @@ android {
 
   applicationVariants.all { variant ->
     if (variant.buildType.name == 'release') {
-      def shouldUploadCrashlytics = System.getenv("EAS_BUILD") != null
-      variant.buildType.firebaseCrashlytics {
-        nativeSymbolUploadEnabled shouldUploadCrashlytics
-        unstrippedNativeLibsDir file("${buildDir}/intermediates/merged_native_libs/${variant.name}/merge${variant.name.capitalize()}NativeLibs/out/lib")
-      }
+      variant.buildType.firebaseCrashlytics.unstrippedNativeLibsDir = file("${buildDir}/intermediates/merged_native_libs/${variant.name}/merge${variant.name.capitalize()}NativeLibs/out/lib")
     }
   }
+
 
   lintOptions {
     abortOnError false
@@ -282,7 +279,6 @@ apply plugin: 'com.google.gms.google-services'
 
 def ensureCrashlyticsDir = tasks.register('ensureCrashlyticsDir') {
   doLast {
-    // Create directories for all release variants
     Files.createDirectories(Paths.get("${buildDir}/intermediates/merged_native_libs/mobileRelease/mergeMobileReleaseNativeLibs/out/lib"))
     Files.createDirectories(Paths.get("${buildDir}/intermediates/merged_native_libs/questRelease/mergeQuestReleaseNativeLibs/out/lib"))
   }

--- a/apps/expo-go/android/app/build.gradle
+++ b/apps/expo-go/android/app/build.gradle
@@ -98,7 +98,16 @@ android {
       def shouldUploadCrashlytics = System.getenv("EAS_BUILD") != null
       firebaseCrashlytics {
         nativeSymbolUploadEnabled shouldUploadCrashlytics
-        unstrippedNativeLibsDir file("${buildDir}/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib")
+      }
+    }
+  }
+
+  applicationVariants.all { variant ->
+    if (variant.buildType.name == 'release') {
+      def shouldUploadCrashlytics = System.getenv("EAS_BUILD") != null
+      variant.buildType.firebaseCrashlytics {
+        nativeSymbolUploadEnabled shouldUploadCrashlytics
+        unstrippedNativeLibsDir file("${buildDir}/intermediates/merged_native_libs/${variant.name}/merge${variant.name.capitalize()}NativeLibs/out/lib")
       }
     }
   }
@@ -273,7 +282,9 @@ apply plugin: 'com.google.gms.google-services'
 
 def ensureCrashlyticsDir = tasks.register('ensureCrashlyticsDir') {
   doLast {
-    Files.createDirectories(Paths.get("${buildDir}/intermediates/merged_native_libs/release/mergeReleaseNativeLibs/out/lib"))
+    // Create directories for all release variants
+    Files.createDirectories(Paths.get("${buildDir}/intermediates/merged_native_libs/mobileRelease/mergeMobileReleaseNativeLibs/out/lib"))
+    Files.createDirectories(Paths.get("${buildDir}/intermediates/merged_native_libs/questRelease/mergeQuestReleaseNativeLibs/out/lib"))
   }
 }
 preBuild.dependsOn(ensureCrashlyticsDir)


### PR DESCRIPTION
# Why

We added quest support in this [PR](https://github.com/expo/expo/pulls?q=is%3Apr+quest+is%3Aclosed). We need to change the directory structure for the same in crashlytics upload step which is failing [currently](https://expo.dev/accounts/expo-ci/projects/release-expo-go/builds/689d8715-1a79-4606-980a-6c121bc3878a)
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Change the output directory structure to accommodate questRelease and mobileRelease variants.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Build with below changes [work](https://expo.dev/accounts/expo-ci/projects/release-expo-go/builds/ee633a31-fc57-4219-9223-8884ee0ca1ab). Check build success hook step.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
