### PR TITLE
[docs] add workflow testflight pre-packaged job

### DIFF
--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -588,7 +588,7 @@ Here are some practical examples of using the TestFlight job:
 
 <Collapsible summary="Full distribution with internal and external groups">
 
-This workflow distributes to both internal and external TestFlight groups with changelog.
+This workflow distributes to both internal and external TestFlight groups with a changelog.
 
 ```yaml .eas/workflows/testflight-full.yml
 name: TestFlight Distribution

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -619,7 +619,7 @@ jobs:
 
 <Collapsible summary="Upload with changelog only">
 
-This workflow uploads a build with changelog but without specifying any groups to explicitly ådd the build to. The build will only get added to internal groups with "auto-distribute" enabled
+This workflow uploads a build with a changelog but without specifying any groups to explicitly add the build to. The build will only get added to internal groups with "auto-distribute" enabled.
 
 ```yaml .eas/workflows/testflight-changelog.yml
 name: TestFlight with Changelog

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -466,10 +466,10 @@ jobs:
 
 You can pass the following parameters into the `params` list:
 
-| Parameter | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| build_id  | string   | Required. The ID of the build to submit.                                                                                                                                                                                                                                                                                                                                                                                     |
-| profile   | string   | Optional. The submit profile to use. Defaults to `production`.                                                                                                                                                                                                                                                                                                                                                               |
+| Parameter | Type   | Description                                                    |
+| --------- | ------ | -------------------------------------------------------------- |
+| build_id  | string | Required. The ID of the build to submit.                       |
+| profile   | string | Optional. The submit profile to use. Defaults to `production`. |
 
 #### Outputs
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -570,7 +570,7 @@ You can pass the following parameters into the `params` list:
 | profile            | string   | Optional. The submit profile to use. Defaults to `production`.                                                                              |
 | internal_groups    | string[] | Optional. An array of TestFlight internal group names to add the build to. Only include groups without automatic distribution enabled.      |
 | external_groups    | string[] | Optional. An array of TestFlight external group names to add the build to.                                                                  |
-| changelog          | string   | Optional. Test notes (“What to Test”) for TestFlight testers.                                                                               |
+| changelog          | string   | Optional. Test notes ("What to Test") for TestFlight testers.                                                                               |
 | submit_beta_review | boolean  | Optional. Whether to submit for Beta App Review. If not specified, defaults to `true` when external_groups are provided, `false` otherwise. |
 
 #### Outputs

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -543,7 +543,7 @@ Distribute iOS builds to TestFlight internal and external testing groups. This i
 
 ### Prerequisites
 
-TestFlight jobs require an iOS build created with `distribution: store`. You'll need to have your Apple Developer account configured. See our [TestFlight submission guide](/submit/ios/#submitting-your-app-using-cicd-services) for more information.
+TestFlight jobs require an iOS build created with `distribution: store`. You'll need to have your Apple Developer account configured. See the [TestFlight submission guide](/submit/ios/#submitting-your-app-using-cicd-services) for more information.
 
 ### Syntax
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -460,7 +460,6 @@ jobs:
     params:
       build_id: string # required
       profile: string # optional, default: production
-      groups: string[] # optional
 ```
 
 #### Parameters
@@ -471,7 +470,6 @@ You can pass the following parameters into the `params` list:
 | --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | build_id  | string   | Required. The ID of the build to submit.                                                                                                                                                                                                                                                                                                                                                                                     |
 | profile   | string   | Optional. The submit profile to use. Defaults to `production`.                                                                                                                                                                                                                                                                                                                                                               |
-| groups    | string[] | Optional. An array of TestFlight internal group names to add the build to (only affects iOS submissions; for Android, this parameter is ignored). Overrides `groups` in the [submit profile](/eas/json/#ios-specific-options-1). Note: On top of the groups you provide here, the build will be automatically added to the groups that have been created with the "Enable automatic distribution" App Store Connect setting. |
 
 #### Outputs
 
@@ -535,6 +533,123 @@ jobs:
     params:
       build_id: ${{ needs.build_android.outputs.build_id }}
       profile: production
+```
+
+</Collapsible>
+
+## TestFlight
+
+Distribute iOS builds to TestFlight internal and external testing groups. This is an alternative to the iOS submit job for when you need more advanced TestFlight features. If you need to control test groups, changelog, or Beta App Review submission, use the testflight job instead of submit.
+
+### Prerequisites
+
+TestFlight jobs require an iOS build created with `distribution: store`. You'll need to have your Apple Developer account configured. See our [TestFlight submission guide](/submit/ios/#submitting-your-app-using-cicd-services) for more information.
+
+### Syntax
+
+```yaml
+jobs:
+  testflight_distribution:
+    type: testflight
+    params:
+      build_id: string # required
+      profile: string # optional, default: production
+      internal_groups: string[] # optional
+      external_groups: string[] # optional
+      changelog: string # optional
+      submit_beta_review: boolean # optional
+```
+
+#### Parameters
+
+You can pass the following parameters into the `params` list:
+
+| Parameter          | Type     | Description                                                                                                                                 |
+| ------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| build_id           | string   | Required. The ID of the iOS build to distribute.                                                                                            |
+| profile            | string   | Optional. The submit profile to use. Defaults to `production`.                                                                              |
+| internal_groups    | string[] | Optional. An array of TestFlight internal group names to add the build to. Only include groups without automatic distribution enabled.      |
+| external_groups    | string[] | Optional. An array of TestFlight external group names to add the build to.                                                                  |
+| changelog          | string   | Optional. Test notes (what to test) for TestFlight testers.                                                                                 |
+| submit_beta_review | boolean  | Optional. Whether to submit for Beta App Review. If not specified, defaults to `true` when external_groups are provided, `false` otherwise. |
+
+#### Outputs
+
+You can reference the following outputs in subsequent jobs:
+
+| Output                | Type   | Description                                       |
+| --------------------- | ------ | ------------------------------------------------- |
+| apple_app_id          | string | The Apple App ID of the submitted build.          |
+| ios_bundle_identifier | string | The iOS bundle identifier of the submitted build. |
+
+### Examples
+
+Here are some practical examples of using the TestFlight job:
+
+<Collapsible summary="Full distribution with internal and external groups">
+
+This workflow distributes to both internal and external TestFlight groups with changelog.
+
+```yaml .eas/workflows/testflight-full.yml
+name: TestFlight Distribution
+
+jobs:
+  build_ios:
+    name: Build iOS
+    type: build
+    params:
+      platform: ios
+      profile: production
+
+  testflight:
+    name: Distribute to TestFlight
+    type: testflight
+    needs: [build_ios]
+    params:
+      build_id: ${{ needs.build_ios.outputs.build_id }}
+      internal_groups: ['QA Team']
+      external_groups: ['Public Beta']
+      changelog: |
+        What's new in this release:
+        - New features
+        - Bug fixes
+```
+
+</Collapsible>
+
+<Collapsible summary="External groups without Beta App Review">
+
+This workflow distributes to external groups but skips Beta App Review by setting `submit_beta_review` to false.
+
+```yaml .eas/workflows/testflight-no-review.yml
+name: TestFlight External No Review
+
+jobs:
+  testflight:
+    name: Distribute without Beta Review
+    type: testflight
+    params:
+      build_id: ${{ needs.build_ios.outputs.build_id }}
+      external_groups: ['Beta Testers']
+      submit_beta_review: false
+```
+
+</Collapsible>
+
+<Collapsible summary="Upload with changelog only">
+
+This workflow uploads a build with changelog but without specifying any groups.
+
+```yaml .eas/workflows/testflight-changelog.yml
+name: TestFlight with Changelog
+
+jobs:
+  testflight:
+    name: Upload with Changelog
+    type: testflight
+    params:
+      build_id: ${{ needs.build_ios.outputs.build_id }}
+      changelog: 'Please test the new features and report any issues.'
 ```
 
 </Collapsible>

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -570,7 +570,7 @@ You can pass the following parameters into the `params` list:
 | profile            | string   | Optional. The submit profile to use. Defaults to `production`.                                                                              |
 | internal_groups    | string[] | Optional. An array of TestFlight internal group names to add the build to. Only include groups without automatic distribution enabled.      |
 | external_groups    | string[] | Optional. An array of TestFlight external group names to add the build to.                                                                  |
-| changelog          | string   | Optional. Test notes (“What to Test”) for TestFlight testers.                                                                                 |
+| changelog          | string   | Optional. Test notes (“What to Test”) for TestFlight testers.                                                                               |
 | submit_beta_review | boolean  | Optional. Whether to submit for Beta App Review. If not specified, defaults to `true` when external_groups are provided, `false` otherwise. |
 
 #### Outputs

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -617,25 +617,6 @@ jobs:
 
 </Collapsible>
 
-<Collapsible summary="External groups without Beta App Review">
-
-This workflow distributes to external groups but skips Beta App Review by setting `submit_beta_review` to false.
-
-```yaml .eas/workflows/testflight-no-review.yml
-name: TestFlight External No Review
-
-jobs:
-  testflight:
-    name: Distribute without Beta Review
-    type: testflight
-    params:
-      build_id: ${{ needs.build_ios.outputs.build_id }}
-      external_groups: ['Beta Testers']
-      submit_beta_review: false
-```
-
-</Collapsible>
-
 <Collapsible summary="Upload with changelog only">
 
 This workflow uploads a build with changelog but without specifying any groups to explicitly ådd the build to. The build will only get added to internal groups with "auto-distribute" enabled

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -630,7 +630,8 @@ jobs:
     type: testflight
     params:
       build_id: ${{ needs.build_ios.outputs.build_id }}
-      changelog: 'Please test the new features and report any issues.'
+      changelog: "${{ github.commit_message || 'Bug fixes' }}"
+      # github.commit_message only available in push & schedule events.
 ```
 
 </Collapsible>

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -638,7 +638,7 @@ jobs:
 
 <Collapsible summary="Upload with changelog only">
 
-This workflow uploads a build with changelog but without specifying any groups.
+This workflow uploads a build with changelog but without specifying any groups to explicitly ådd the build to. The build will only get added to internal groups with "auto-distribute" enabled
 
 ```yaml .eas/workflows/testflight-changelog.yml
 name: TestFlight with Changelog

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -570,7 +570,7 @@ You can pass the following parameters into the `params` list:
 | profile            | string   | Optional. The submit profile to use. Defaults to `production`.                                                                              |
 | internal_groups    | string[] | Optional. An array of TestFlight internal group names to add the build to. Only include groups without automatic distribution enabled.      |
 | external_groups    | string[] | Optional. An array of TestFlight external group names to add the build to.                                                                  |
-| changelog          | string   | Optional. Test notes (what to test) for TestFlight testers.                                                                                 |
+| changelog          | string   | Optional. Test notes (“What to Test”) for TestFlight testers.                                                                                 |
 | submit_beta_review | boolean  | Optional. Whether to submit for Beta App Review. If not specified, defaults to `true` when external_groups are provided, `false` otherwise. |
 
 #### Outputs

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -539,7 +539,7 @@ jobs:
 
 ## TestFlight
 
-Distribute iOS builds to TestFlight internal and external testing groups. This is an alternative to the iOS submit job for when you need more advanced TestFlight features. If you need to control test groups, changelog, or Beta App Review submission, use the testflight job instead of submit.
+Distribute iOS builds to TestFlight internal and external testing groups. This is an alternative to the iOS submit job for when you need more advanced TestFlight features. If you need to control test groups, changelog, or Beta App Review submission, use the `testflight` job instead of submit.
 
 ### Prerequisites
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -726,6 +726,34 @@ This job outputs the following properties:
 }
 ```
 
+#### `testflight`
+
+Distributes iOS builds to TestFlight internal and external testing groups. See [TestFlight job documentation](/eas/workflows/pre-packaged-jobs#testflight) for detailed information and examples.
+
+```yaml
+jobs:
+  my_job:
+    # @info #
+    type: testflight
+    # @end #
+    params:
+      build_id: string # required
+      profile: string # optional, default: production
+      internal_groups: string[] # optional
+      external_groups: string[] # optional
+      changelog: string # optional
+      submit_beta_review: boolean # optional
+```
+
+This job outputs the following properties:
+
+```json
+{
+  "apple_app_id": string | null, // Apple App ID. https://expo.fyi/asc-app-id
+  "ios_bundle_identifier": string | null // iOS bundle identifier of the submitted build. https://expo.fyi/bundle-identifier
+}
+```
+
 #### `update`
 
 Publishes an update using [EAS Update](/eas-update/introduction/). See [Update job documentation](/eas/workflows/pre-packaged-jobs#update) for detailed information and examples.


### PR DESCRIPTION
# Why

We're introducing the TestFlight job as a premium feature that offers more capabilities (test groups, changelog, Beta App Review control) but uses more CI minutes. To preserve the Submit job as a lightning-fast, free option for existing users, we removed the groups parameter from its documentation (changelog reduces speed/increases CI minutes). This separation guides users with advanced needs to the TestFlight job while keeping Submit job simple and fast.

# How

  - Added documentation for the new testflight job type with all parameters (build_id, profile, internal_groups, external_groups, changelog,
  submit_beta_review)
  - Included three practical usage examples
  - Removed groups parameter from Submit job documentation to keep it lightweight

# Test Plan

Tested locally.

<img width="602" height="863" alt="image" src="https://github.com/user-attachments/assets/7b4fdd87-117a-45e2-ac71-e2d79540c37b" />


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
