### PR TITLE
[core][iOS] Add StaticFunction and StaticAsyncFunction to Class in modules API

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,7 +13,7 @@
 - [Android] Add experimental formatters API. ([#38946](https://github.com/expo/expo/pull/38946) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Add `convertResult` to `Convertible`. ([#40302](https://github.com/expo/expo/pull/40302) by [@jakex7](https://github.com/jakex7))
 - [iOS] Adopted Swift 6 ([#40369](https://github.com/expo/expo/pull/40369) by [@tsapeta](https://github.com/tsapeta))
-- [Android] Add StaticFunction and StaticAsyncFunction to Class in modules API. ([#39228](https://github.com/expo/expo/pull/39228) by [@jakex7](https://github.com/jakex7))
+- Add StaticFunction and StaticAsyncFunction to Class in modules API. ([#39228](https://github.com/expo/expo/pull/39228), [#38754](https://github.com/expo/expo/pull/38754) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Api/Factories/StaticFunctionFactories.swift
+++ b/packages/expo-modules-core/ios/Api/Factories/StaticFunctionFactories.swift
@@ -1,0 +1,61 @@
+/**
+ Static synchronous function without arguments.
+ */
+public func StaticFunction<R>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping () throws -> R
+) -> StaticSyncFunctionDefinition<(), Void, R> {
+  return StaticSyncFunctionDefinition(
+    name,
+    firstArgType: Void.self,
+    dynamicArgumentTypes: [],
+    returnType: ~R.self,
+    closure
+  )
+}
+
+/**
+ Static synchronous function with one or more arguments.
+ */
+public func StaticFunction<R, A0: AnyArgument, each A: AnyArgument>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping (A0, repeat each A) throws -> R
+) -> StaticSyncFunctionDefinition<(A0, repeat each A), A0, R> {
+  return StaticSyncFunctionDefinition(
+    name,
+    firstArgType: A0.self,
+    dynamicArgumentTypes: buildDynamicTypes(A0.self, repeat (each A).self),
+    returnType: ~R.self,
+    closure
+  )
+}
+
+/**
+ Static asynchronous function without arguments.
+ */
+public func StaticAsyncFunction<R>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping () throws -> R
+) -> StaticAsyncFunctionDefinition<(), Void, R> {
+  return StaticAsyncFunctionDefinition(
+    name,
+    firstArgType: Void.self,
+    dynamicArgumentTypes: [],
+    closure
+  )
+}
+
+/**
+ Static asynchronous function with one or more arguments.
+ */
+public func StaticAsyncFunction<R, A0: AnyArgument, each A: AnyArgument>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping (A0, repeat each A) throws -> R
+) -> StaticAsyncFunctionDefinition<(A0, repeat each A), A0, R> {
+  return StaticAsyncFunctionDefinition(
+    name,
+    firstArgType: A0.self,
+    dynamicArgumentTypes: buildDynamicTypes(A0.self, repeat (each A).self),
+    closure
+  )
+}

--- a/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
@@ -95,6 +95,8 @@ public final class ClassDefinition: ObjectDefinition {
   }
 
   public override func decorate(object: JavaScriptObject, appContext: AppContext) throws {
+    try decorateWithStaticFunctions(object: object, appContext: appContext)
+
     // Here we actually don't decorate the input object (constructor) but its prototype.
     // Properties are intentionally skipped here — they have to decorate an instance instead of the prototype.
     let prototype = object.getProperty("prototype").getObject()

--- a/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
@@ -21,7 +21,7 @@ private let defaultQueue = DispatchQueue(label: "expo.modules.AsyncFunctionQueue
 /**
  Represents a function that can only be called asynchronously, thus its JavaScript equivalent returns a Promise.
  */
-public final class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyAsyncFunctionDefinition, @unchecked Sendable {
+public class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyAsyncFunctionDefinition, @unchecked Sendable {
   typealias ClosureType = (Args) throws -> ReturnType
 
   /**

--- a/packages/expo-modules-core/ios/Core/Functions/StaticFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/StaticFunctionDefinition.swift
@@ -17,12 +17,12 @@ public final class StaticSyncFunctionDefinition<Args, FirstArgType, ReturnType>:
   var isStatic: Bool {
     get { true }
   }
-  
+
   override func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext) throws -> Any {
     return try super.call(by: nil, withArguments: args, appContext: appContext)
   }
-  
-  override func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> ()) {
+
+  override func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> Void) {
     return super.call(by: nil, withArguments: args, appContext: appContext, callback: callback)
   }
 }
@@ -35,7 +35,7 @@ public final class StaticAsyncFunctionDefinition<Args, FirstArgType, ReturnType>
     get { true }
   }
 
-  override func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> ()) {
+  override func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> Void) {
     return super.call(by: nil, withArguments: args, appContext: appContext, callback: callback)
   }
 }

--- a/packages/expo-modules-core/ios/Core/Functions/StaticFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/StaticFunctionDefinition.swift
@@ -1,0 +1,41 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+/**
+ A protocol for static any type-erased function.
+ */
+internal protocol AnyStaticFunctionDefinition: AnyFunctionDefinition {
+  /**
+   Indicates whether the function is static.
+   */
+  var isStatic: Bool { get }
+}
+
+/**
+ Represents a static function that can only be called synchronously.
+ */
+public final class StaticSyncFunctionDefinition<Args, FirstArgType, ReturnType>: SyncFunctionDefinition<Args, FirstArgType, ReturnType>, AnyStaticFunctionDefinition {
+  var isStatic: Bool {
+    get { true }
+  }
+  
+  override func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext) throws -> Any {
+    return try super.call(by: nil, withArguments: args, appContext: appContext)
+  }
+  
+  override func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> ()) {
+    return super.call(by: nil, withArguments: args, appContext: appContext, callback: callback)
+  }
+}
+
+/**
+ Represents a static function that can only be called asynchronously, thus its JavaScript equivalent returns a Promise.
+ */
+public final class StaticAsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AsyncFunctionDefinition<Args, FirstArgType, ReturnType>, AnyStaticFunctionDefinition {
+  var isStatic: Bool {
+    get { true }
+  }
+
+  override func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> ()) {
+    return super.call(by: nil, withArguments: args, appContext: appContext, callback: callback)
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Functions/StaticFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/StaticFunctionDefinition.swift
@@ -14,7 +14,7 @@ internal protocol AnyStaticFunctionDefinition: AnyFunctionDefinition {
  Represents a static function that can only be called synchronously.
  */
 public final class StaticSyncFunctionDefinition<Args, FirstArgType, ReturnType>:
-  SyncFunctionDefinition<Args, FirstArgType, ReturnType>, AnyStaticFunctionDefinition {
+  SyncFunctionDefinition<Args, FirstArgType, ReturnType>, AnyStaticFunctionDefinition, @unchecked Sendable {
   let isStatic = true
 
   override func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext) throws -> Any {
@@ -30,10 +30,16 @@ public final class StaticSyncFunctionDefinition<Args, FirstArgType, ReturnType>:
  Represents a static function that can only be called asynchronously, thus its JavaScript equivalent returns a Promise.
  */
 public final class StaticAsyncFunctionDefinition<Args, FirstArgType, ReturnType>:
-  AsyncFunctionDefinition<Args, FirstArgType, ReturnType>, AnyStaticFunctionDefinition {
+  AsyncFunctionDefinition<Args, FirstArgType, ReturnType>, AnyStaticFunctionDefinition, @unchecked Sendable {
   let isStatic = true
 
-  override func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> Void) {
+  override func call(
+    by owner: AnyObject?,
+    withArguments args: [Any],
+    appContext: AppContext,
+    callback: @Sendable @escaping (FunctionCallResult) -> ()
+  ) {
+
     return super.call(by: nil, withArguments: args, appContext: appContext, callback: callback)
   }
 }

--- a/packages/expo-modules-core/ios/Core/Functions/StaticFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/StaticFunctionDefinition.swift
@@ -13,10 +13,9 @@ internal protocol AnyStaticFunctionDefinition: AnyFunctionDefinition {
 /**
  Represents a static function that can only be called synchronously.
  */
-public final class StaticSyncFunctionDefinition<Args, FirstArgType, ReturnType>: SyncFunctionDefinition<Args, FirstArgType, ReturnType>, AnyStaticFunctionDefinition {
-  var isStatic: Bool {
-    get { true }
-  }
+public final class StaticSyncFunctionDefinition<Args, FirstArgType, ReturnType>:
+  SyncFunctionDefinition<Args, FirstArgType, ReturnType>, AnyStaticFunctionDefinition {
+  let isStatic = true
 
   override func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext) throws -> Any {
     return try super.call(by: nil, withArguments: args, appContext: appContext)
@@ -30,10 +29,9 @@ public final class StaticSyncFunctionDefinition<Args, FirstArgType, ReturnType>:
 /**
  Represents a static function that can only be called asynchronously, thus its JavaScript equivalent returns a Promise.
  */
-public final class StaticAsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AsyncFunctionDefinition<Args, FirstArgType, ReturnType>, AnyStaticFunctionDefinition {
-  var isStatic: Bool {
-    get { true }
-  }
+public final class StaticAsyncFunctionDefinition<Args, FirstArgType, ReturnType>:
+  AsyncFunctionDefinition<Args, FirstArgType, ReturnType>, AnyStaticFunctionDefinition {
+  let isStatic = true
 
   override func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> Void) {
     return super.call(by: nil, withArguments: args, appContext: appContext, callback: callback)

--- a/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
@@ -26,7 +26,7 @@ internal protocol AnySyncFunctionDefinition: AnyFunctionDefinition {
 /**
  Represents a function that can only be called synchronously.
  */
-public final class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySyncFunctionDefinition, @unchecked Sendable {
+public class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySyncFunctionDefinition, @unchecked Sendable {
   typealias ClosureType = (Args) throws -> ReturnType
 
   /**

--- a/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
@@ -10,7 +10,7 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
   let functions: [String: AnyFunctionDefinition]
 
   /**
-   A dictionary of functions defined by the object.
+   A dictionary of static functions defined by the object.
    */
   let staticFunctions: [String: AnyFunctionDefinition]
 
@@ -40,7 +40,7 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
   init(definitions: [AnyDefinition]) {
     self.functions = definitions
       .compactMap { $0 as? AnyFunctionDefinition }
-      .filter { !($0 is AnyStaticFunctionDefinition) } 
+      .filter { !($0 is AnyStaticFunctionDefinition) }
       .reduce(into: [String: AnyFunctionDefinition]()) { dict, function in
         dict[function.name] = function
       }


### PR DESCRIPTION
# Why

It should be possible to create a static functions on SharedObjects

# How

Add `StaticFunction` and `StaticAsyncFunction` in DSL and decorate the class constructor with them. 

# Test Plan

* Tests should pass
* Add static functions to shared object

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
