### PR TITLE
[sdk-54] Upgrade `react-native-maps` to `1.25.3`

### DIFF
--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2319,7 +2319,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-maps/Generated (1.24.13):
+  - react-native-maps/Generated (1.25.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2347,7 +2347,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-maps/Google (1.24.13):
+  - react-native-maps/Google (1.25.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2379,7 +2379,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-maps/Maps (1.24.13):
+  - react-native-maps/Maps (1.25.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -4409,7 +4409,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: f0c91e870f86a23ccf80ab9527d95f37e834e24e
   React-microtasksnativemodule: be6fa55f64e8de5a53f3e9d01feb91d6682af78d
   react-native-keyboard-controller: 2d559e821da2dbcfb2781646f5f443e846e3f05b
-  react-native-maps: 05e86963c50aef9fe5736dcf163e0e16055a2a52
+  react-native-maps: 3c38079016e522c62d3d47fae32601ec704649d0
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-pager-view: a0516effb17ca5120ac2113bfd21b91130ad5748
   react-native-safe-area-context: a72764e0eb5d6b79b7450e5d0ae919eb1a4567b4

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -75,7 +75,7 @@
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-keyboard-controller": "^1.18.4",
-    "react-native-maps": "1.24.13",
+    "react-native-maps": "1.25.3",
     "react-native-pager-view": "6.9.1",
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "4.0.2",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -143,7 +143,7 @@
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.4",
-    "react-native-maps": "1.24.13",
+    "react-native-maps": "1.25.3",
     "react-native-pager-view": "6.9.1",
     "react-native-paper": "^5.12.5",
     "react-native-worklets": "0.4.1",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -98,7 +98,7 @@
   "react-native-gesture-handler": "~2.28.0",
   "react-native-get-random-values": "~1.11.0",
   "react-native-keyboard-controller": "1.18.4",
-  "react-native-maps": "1.24.13",
+  "react-native-maps": "1.25.3",
   "react-native-pager-view": "6.9.1",
   "react-native-worklets": "~0.4.1",
   "react-native-reanimated": "~4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13632,10 +13632,10 @@ react-native-keyboard-controller@^1.18.4:
   dependencies:
     react-native-is-edge-to-edge "^1.2.1"
 
-react-native-maps@1.24.13:
-  version "1.24.13"
-  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-1.24.13.tgz#dc1c2025f663fbc6e5eab80d910de3c9919d694f"
-  integrity sha512-Otj+HTQTmwdpKHtRmigpfIm2yg2t+MfuDxMq8RwPVruCLuqhvoYJgBJpLsgBOKCF/1rFRbeoiY0Q0ou7b4mSMw==
+react-native-maps@1.25.3:
+  version "1.25.3"
+  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-1.25.3.tgz#33f7914cec76d7b765d68266b63b2615183b5eda"
+  integrity sha512-Mi/uPvBBWqEJYj/wNIM40bIf7tnVWm8dM52X6LWiiN7cajozXtydKoVeuShHpK07cvi565maY+3QiB5yTxmb0w==
   dependencies:
     "@types/geojson" "^7946.0.13"
 


### PR DESCRIPTION
# Why
Upgrades `react-native-maps` to `1.25.3`

# Test Plan
Maps screen in NCL using Expo go
