### PR TITLE
[ios][camera] Fix quality issue

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fix barcode options to correctly handle empty barcodeTypes ([#38100](https://github.com/expo/expo/pull/38100) by [@LeonDvlpmnt](https://github.com/LeonDvlpmnt))
 - [Android] Add dismissScanner to module to prevent undefined error. ([#38129](https://github.com/expo/expo/pull/38129) by [@LeonDvlpmnt](https://github.com/LeonDvlpmnt))
 - [Android] Correctly handle errors when using `launchScanner`. ([#38322](https://github.com/expo/expo/pull/38322) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix `videoQuality` also affecting pictures.
+- [iOS] Fix `videoQuality` and `pictureSize` affecting modes they don't apply too.
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fix barcode options to correctly handle empty barcodeTypes ([#38100](https://github.com/expo/expo/pull/38100) by [@LeonDvlpmnt](https://github.com/LeonDvlpmnt))
 - [Android] Add dismissScanner to module to prevent undefined error. ([#38129](https://github.com/expo/expo/pull/38129) by [@LeonDvlpmnt](https://github.com/LeonDvlpmnt))
 - [Android] Correctly handle errors when using `launchScanner`. ([#38322](https://github.com/expo/expo/pull/38322) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix `videoQuality` and `pictureSize` affecting modes they don't apply too.
+- [iOS] Fix `videoQuality` and `pictureSize` affecting modes they don't apply too. ([#38757](https://github.com/expo/expo/pull/38757) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix barcode options to correctly handle empty barcodeTypes ([#38100](https://github.com/expo/expo/pull/38100) by [@LeonDvlpmnt](https://github.com/LeonDvlpmnt))
 - [Android] Add dismissScanner to module to prevent undefined error. ([#38129](https://github.com/expo/expo/pull/38129) by [@LeonDvlpmnt](https://github.com/LeonDvlpmnt))
 - [Android] Correctly handle errors when using `launchScanner`. ([#38322](https://github.com/expo/expo/pull/38322) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix `videoQuality` also affecting pictures.
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/CameraSessionManager.swift
+++ b/packages/expo-camera/ios/Current/CameraSessionManager.swift
@@ -341,7 +341,10 @@ class CameraSessionManager: NSObject {
       self.photoOutput = photoOutput
     }
 
-    session.sessionPreset = delegate.mode == .video ? delegate.pictureSize.toCapturePreset() : .photo
+    session.sessionPreset = delegate.mode == .video
+    ? delegate.videoQuality.toPreset()
+    : delegate.pictureSize.toCapturePreset()
+
     session.commitConfiguration()
     addErrorNotification()
     delegate.changePreviewOrientation()

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -39,7 +39,9 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
   var videoQuality: VideoQuality = .video1080p {
     didSet {
       sessionQueue.async {
-        self.sessionManager.updateSessionPreset(preset: self.videoQuality.toPreset())
+        if self.mode == .video {
+          self.sessionManager.updateSessionPreset(preset: self.videoQuality.toPreset())
+        }
       }
     }
   }
@@ -89,6 +91,8 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
     didSet {
       sessionQueue.async {
         self.sessionManager.setCameraMode()
+        let preset = self.mode == .video ? self.videoQuality.toPreset() : self.pictureSize.toCapturePreset()
+        self.sessionManager.updateSessionPreset(preset: preset)
       }
     }
   }
@@ -201,8 +205,11 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
   private func updatePictureSize() {
 #if !targetEnvironment(simulator)
     sessionQueue.async {
-      let preset = self.pictureSize.toCapturePreset()
-      self.sessionManager.updateSessionPreset(preset: preset)
+      // Only update session preset for picture size when in picture mode
+      if self.mode == .picture {
+        let preset = self.pictureSize.toCapturePreset()
+        self.sessionManager.updateSessionPreset(preset: preset)
+      }
     }
 #endif
   }

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -205,7 +205,6 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
   private func updatePictureSize() {
 #if !targetEnvironment(simulator)
     sessionQueue.async {
-      // Only update session preset for picture size when in picture mode
       if self.mode == .picture {
         let preset = self.pictureSize.toCapturePreset()
         self.sessionManager.updateSessionPreset(preset: preset)


### PR DESCRIPTION
# Why
Closes #38756

# How
Setting `videoQuality` or `pictureSize` both target the same `AVCaptureSession.Preset` property on the camera session. Because of this you can have issues like setting a `pictureSize` and having it impact the next video recording.

- Only set these properties on the session if we are in the appropriate mode
- When starting the session after changing the mode, reset the preset to the default or whatever the user has selected

# Test Plan
Bare-expo ✅

