### PR TITLE
[packages/expo][expo-doctor] bump suggested Sentry RN version to 6.19.0 to support integration

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -112,6 +112,6 @@
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "2.2.3",
   "@shopify/flash-list": "2.0.2",
-  "@sentry/react-native": "~6.14.0",
+  "@sentry/react-native": "~6.19.0",
   "react-native-bootsplash": "^6.3.7"
 }


### PR DESCRIPTION
# Why

6.19.0 is the most recent version of the Sentry RN package, and it's also the version required to get full functionality out of the Sentry integration on expo.dev. Currently, expo-doctor complains if your Sentry version is 6.19.0, which isn't ideal.

# How

I bumped the version in packages/expo/bundledNativeModules.json to 6.19.0