### PR TITLE
[docs] update setUpdateRequestHeadersOverride doc

### DIFF
--- a/docs/pages/eas-update/override.mdx
+++ b/docs/pages/eas-update/override.mdx
@@ -6,19 +6,48 @@ description: Learn how to override the update URL and request headers at runtime
 
 import { Collapsible } from '~/ui/components/Collapsible';
 
-> **warning** The features described in this guide are available in Expo SDK 52 with the `expo-updates` version 0.27.0 and later. Using the `disableAntiBrickingMeasures` option is not recommended for production apps, it is currently primarily intended for preview environments.
-
 The typical way to use EAS Update is to have a single update URL and a set of request headers (such as update channel name) embedded in a build of your app. To control which update is loaded you make changes on the server through the `eas update` command or the EAS dashboard. For example, you publish a new update to a channel that your build is pointing to, then the build fetches that update on the next launch. Updates published to a channel different from the one your build is pointing to will not be downloaded with this approach.
 
 This guide explains how you can change the update URL and request headers at runtime, making it possible to load a specific update by ID or change the channel that updates are pulled from without creating and installing a new build.
 
-## Use cases for changing the update URL and request headers at runtime
+## Override request headers
 
-The primary use case that this is intended for is to **enable switching between updates in a preview build**, similar to what is possible in a development build. This is useful to enable non-technical stakeholders to test and validate updates of work-in-progress (such as from a pull request or different feature branches) without having to use a development build or create a separate preview build for each change.
+> **warning** The feature described in this section is available in Expo SDK 54 with the `expo-updates` version 0.29.0 and later.
 
-Another potential use case is to provide different updates to different users, for example so that a group of internal users (such as employees) receive updates before end-users. It is important to be familiar with the [security considerations](#security-considerations) before deciding to use this feature in production. In the future, we may add support for a more restricted version of the feature that would be more suitable for this use case.
+The primary use case for this feature is to **enable switching between update channels in a production build**. This is useful to enable non-technical stakeholders to test and validate updates of work-in-progress (such as from a pull request or different feature branches) without having to use a development build or create a separate preview build for each change.
 
-## How it works
+For example, if you have a `default` channel for production updates and a `preview` channel for preview updates, you can override the `expo-channel-name` request header to point to the `preview` channel. This enables you to test preview updates in your current production builds.
+
+Another potential use case is to provide different updates to different users, for example so that a group of internal users (such as employees) receive updates before end-users.
+
+### How it works
+
+You can override the `expo-channel-name` request header by calling [`Updates.setUpdateRequestHeadersOverride`](/versions/latest/sdk/updates/#updatessetupdaterequestheadersoverriderequestheaders). This will override update requests to fetch updates from the specified channel.
+
+Somewhere in your app, you would provide a way for users to trigger the change to request headers. This may be in a hidden menu that only trusted users have access to, or some other mechanism depending on your use case. After the parameters are changes, you can call [`fetchUpdateAsync()`](/versions/latest/sdk/updates/#updatesfetchupdateasync) to fetch the update, and then [`reloadAsync()`](/versions/latest/sdk/updates/#updatesreloadasyncoptions) to reload the app. Or you can wait for the next launch, which will automatically fetch and install the update.
+
+```js
+import * as Updates from 'expo-updates';
+
+// Where you call this method depends on your use case - it may make sense to
+// have a menu in your preview builds that allows testers to pick from available channels,
+// for example:
+Updates.setUpdateRequestHeadersOverride({ 'expo-channel-name': 'preview' });
+
+// You can fetch and reload the update immediately, or wait for the next launch
+await Updates.fetchUpdateAsync();
+await Updates.reloadAsync();
+```
+
+## Override both update URL and request headers
+
+> **warning** The feature described in this section is available in Expo SDK 52 with the `expo-updates` version 0.27.0 and later. Using the `disableAntiBrickingMeasures` option is not recommended for production apps, it is currently primarily intended for preview environments.
+
+Similar to [override request headers](#override-request-headers), if you want to further override the update URL to a specific update, you can use the [`Updates.setUpdateURLAndRequestHeadersOverride`](/versions/latest/sdk/updates/#override-both-update-url-and-request-headers) method. This allows you to load a specific update by ID, even the update is published before the current build is created.
+
+It is important to be familiar with the [security considerations](#security-considerations) before deciding to use this feature in production. In the future, we may add support for a more restricted version of the feature that would be more suitable for this use case.
+
+### How it works
 
 There are two relevant APIs:
 
@@ -30,7 +59,7 @@ How to use these APIs:
 1. **Override the update URL/headers, instruct user to close the app**: Somewhere in your app, you would provide a way for users to trigger the change to the URL and/or request headers. This may be in a hidden menu that only trusted users have access to, or some other mechanism depending on your use case. When the parameters are changed, notify the user that they need to close and re-open the app, such as via an alert. The `expo-updates` library, with methods like `checkForUpdateAsync()`, will not use the new overridden URL and request headers until the app is closed and reopened.
 2. **The new update will be downloaded and launched on the next app open**: After the app is completely closed ("killed" and not just backgrounded) and re-opened, the update and its related assets will all be downloaded. Once they are ready, the app will launch. While it's downloading, the user will have to wait on the splash screen. We understand that waiting on the splash screen is not ideal, and we intend to improve this experience in the future if this feature is widely used. For the currently recommended use case (previews), this is likely an acceptable compromise.
 
-## Security considerations
+### Security considerations
 
 The anti-bricking measures that can be disabled with `disableAntiBrickingMeasures` ensure that, no matter what update is published, you can always publish another update afterwards that will be applied. By disabling the anti-bricking measures, certain categories of attacks and exploits become possible, especially around in-house (compromised employee) publishing of malicious updates. For example, an employee with the ability to publish updates could publish a malicious update that changes the update URL and request headers to point to their own server, and take over installations of the app. This risk can be mitigated, but not eliminated, by using [code signing](/eas-update/code-signing/) for production updates and limiting access to the key.
 
@@ -40,7 +69,7 @@ Yes. CodePush allowed developers to swap deployment keys with `sync({ deployment
 
 </Collapsible>
 
-## Example code
+### Example code
 
 Here's an example of how you might use these APIs:
 
@@ -52,8 +81,8 @@ import * as Updates from 'expo-updates';
 // pull requests, for example.
 function overrideUpdateURLAndHeaders() {
   Updates.setUpdateURLAndRequestHeadersOverride({
-    url: '<https://u.expo.dev/>...',
-    requestHeaders: { 'expo-channel-name': 'pr-123' },
+    url: 'https://u.expo.dev/{updateId}/group/{groupId}',
+    requestHeaders: {},
   });
 
   alert('Close and re-open the app to load the latest version.');

--- a/docs/pages/eas-update/override.mdx
+++ b/docs/pages/eas-update/override.mdx
@@ -18,13 +18,13 @@ The primary use case for this feature is to **enable switching between update ch
 
 For example, if you have a `default` channel for production updates and a `preview` channel for preview updates, you can override the `expo-channel-name` request header to point to the `preview` channel. This enables you to test preview updates in your current production builds.
 
-Another potential use case is to provide different updates to different users, for example so that a group of internal users (such as employees) receive updates before end-users.
+Another potential use case is to provide different updates to different users, for example, so that a group of internal users (such as employees) receive updates before end-users.
 
 ### How it works
 
-You can override the `expo-channel-name` request header by calling [`Updates.setUpdateRequestHeadersOverride`](/versions/latest/sdk/updates/#updatessetupdaterequestheadersoverriderequestheaders). This will override update requests to fetch updates from the specified channel.
+You can override the `expo-channel-name` request header by calling [`Updates.setUpdateRequestHeadersOverride`](/versions/unversioned/sdk/updates/#updatessetupdaterequestheadersoverriderequestheaders). This will override update requests to fetch updates from the specified channel.
 
-Somewhere in your app, you would provide a way for users to trigger the change to request headers. This may be in a hidden menu that only trusted users have access to, or some other mechanism depending on your use case. After the parameters are changes, you can call [`fetchUpdateAsync()`](/versions/latest/sdk/updates/#updatesfetchupdateasync) to fetch the update, and then [`reloadAsync()`](/versions/latest/sdk/updates/#updatesreloadasyncoptions) to reload the app. Or you can wait for the next launch, which will automatically fetch and install the update.
+Somewhere in your app, you would provide a way for users to trigger the change to request headers. This may be in a hidden menu that only trusted users have access to, or some other mechanism, depending on your use case. After the parameters are changed, you can call [`fetchUpdateAsync()`](/versions/latest/sdk/updates/#updatesfetchupdateasync) to fetch the update, and then [`reloadAsync()`](/versions/unversioned/sdk/updates/#updatesreloadasyncoptions) to reload the app. Or you can wait for the next launch, which will automatically fetch and install the update.
 
 ```js
 import * as Updates from 'expo-updates';
@@ -43,7 +43,7 @@ await Updates.reloadAsync();
 
 > **warning** The feature described in this section is available in Expo SDK 52 with the `expo-updates` version 0.27.0 and later. Using the `disableAntiBrickingMeasures` option is not recommended for production apps, it is currently primarily intended for preview environments.
 
-Similar to [override request headers](#override-request-headers), if you want to further override the update URL to a specific update, you can use the [`Updates.setUpdateURLAndRequestHeadersOverride`](/versions/latest/sdk/updates/#override-both-update-url-and-request-headers) method. This allows you to load a specific update by ID, even the update is published before the current build is created.
+Similar to [override request headers](#override-request-headers), if you want to further override the update URL to a specific update, you can use the [`Updates.setUpdateURLAndRequestHeadersOverride`](/versions/latest/sdk/updates/#updatessetupdateurlandrequestheadersoverrideconfigoverride) method. This allows you to load a specific update by ID, even if the update is published before the current build is created.
 
 It is important to be familiar with the [security considerations](#security-considerations) before deciding to use this feature in production. In the future, we may add support for a more restricted version of the feature that would be more suitable for this use case.
 


### PR DESCRIPTION
# Why

update doc for `Updates.setUpdateRequestHeadersOverride`

# How

add a new section for "Override request headers" and refine the original section. i didn't update the previous doc to describe that `setUpdateURLAndRequestHeadersOverride` doesn't require relaunch from sdk 54. because the doc here is unversioned. i think the new `setUpdateRequestHeadersOverride` is good enough for most people

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
