### PR TITLE
[expo-router] remove clip to bounds for Link.Preview

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Fix Link Preview navigation in NativeTabs ([#38283](https://github.com/expo/expo/pull/38283) by [@Ubax](https://github.com/Ubax))
 - add option to hide label and show empty badge ([#38668](https://github.com/expo/expo/pull/38668) by [@Ubax](https://github.com/Ubax))
 - add unstable-native-tabs to files in package.json ([#38742](https://github.com/expo/expo/pull/38742) by [@Ubax](https://github.com/Ubax))
+- remove clip to bounds for Link.Preview ([#38763](https://github.com/expo/expo/pull/38763) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativePreviewView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativePreviewView.swift
@@ -6,7 +6,6 @@ class NativeLinkPreviewContentView: ExpoView {
 
   required init(appContext: AppContext? = nil) {
     super.init(appContext: appContext)
-    clipsToBounds = true
   }
 
   func setInitialSize(bounds: CGRect) {

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeTriggerView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeTriggerView.swift
@@ -4,6 +4,5 @@ import WebKit
 class NativeLinkPreviewTrigger: ExpoView {
   required init(appContext: AppContext? = nil) {
     super.init(appContext: appContext)
-    clipsToBounds = true
   }
 }


### PR DESCRIPTION
# Why

The clipToBounds were limiting the styling for link trigger. This is not needed as system will automatically clip the contents for preview

# How

Remove clipToBounds

# Test Plan

Manual testing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
