### PR TITLE
Fix bundle directory access on iOS

### DIFF
--- a/apps/test-suite/tests/FileSystem.ts
+++ b/apps/test-suite/tests/FileSystem.ts
@@ -133,6 +133,12 @@ export async function test({ describe, expect, it, ...t }) {
       });
     });
 
+    it('Allows reading files from assets', () => {
+      const dir = new Directory(Paths.bundle);
+      expect(dir.list().map((i) => i.name)).toContain('Info.plist');
+      expect(new File(Paths.bundle, 'Info.plist').size > 2000).toBe(true);
+    });
+
     describe('Works with %, # and space characters in names', () => {
       it('Works with spaces as filename', () => {
         const outputFile = new File(testDirectory, 'my new file.txt');

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Add support for asset uris.
+- Add support for asset uris. ([#38785](https://github.com/expo/expo/pull/38785) by [@aleqsio](https://github.com/aleqsio))
 - Make file implement blob interface directly. ([#38160](https://github.com/expo/expo/pull/38160) by [@aleqsio](https://github.com/aleqsio))
 - Add directory info function ([#37910](https://github.com/expo/expo/pull/37910) by [@Wenszel](https://github.com/Wenszel))
 - Add total and available sizes, directory sizes. ([#37594](https://github.com/expo/expo/pull/37594) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- Add support for asset uris.
 - Make file implement blob interface directly. ([#38160](https://github.com/expo/expo/pull/38160) by [@aleqsio](https://github.com/aleqsio))
 - Add directory info function ([#37910](https://github.com/expo/expo/pull/37910) by [@Wenszel](https://github.com/Wenszel))
 - Add total and available sizes, directory sizes. ([#37594](https://github.com/expo/expo/pull/37594) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-file-system/ios/FileSystemExceptions.swift
+++ b/packages/expo-file-system/ios/FileSystemExceptions.swift
@@ -66,3 +66,9 @@ internal final class DestinationAlreadyExistsException: Exception {
     "Destination already exists"
   }
 }
+
+internal final class MissingPermissionException: GenericException<String> {
+  override var reason: String {
+    "Missing permission for uri: \(param)"
+  }
+}

--- a/packages/expo-file-system/ios/FileSystemPath.swift
+++ b/packages/expo-file-system/ios/FileSystemPath.swift
@@ -9,15 +9,14 @@ internal class FileSystemPath: SharedObject {
     self.url = standardizedUrl
   }
 
-  func validatePermission(_ flag: EXFileSystemPermissionFlags) throws {
-    try ensurePathPermission(appContext, path: url.path, flag: flag)
+  func validatePermission(_ flag: FileSystemPermissionFlags) throws {
+    if !checkPermission(flag) {
+      throw MissingPermissionException(url.absoluteString)
+    }
   }
 
-  func checkPermission(_ flag: EXFileSystemPermissionFlags) -> Bool {
-    guard let permissionsManager: EXFilePermissionModuleInterface = appContext?.legacyModule(implementing: EXFilePermissionModuleInterface.self) else {
-      return false
-    }
-    return permissionsManager.getPathPermissions(url.path).contains(flag)
+  func checkPermission(_ flag: FileSystemPermissionFlags) -> Bool {
+    return FileSystemUtilities.permissions(appContext, for: url).contains(flag)
   }
 
   func validateCanCreate(_ options: CreateOptions) throws {

--- a/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemUtilities.swift
+++ b/packages/expo-modules-core/ios/FileSystemUtilities/FileSystemUtilities.swift
@@ -71,7 +71,7 @@ public struct FileSystemUtilities {
       guard let dir else {
         continue
       }
-      if standardizedPath.hasPrefix(dir.appendingPathComponent("/").absoluteString) || standardizedPath == dir.absoluteString {
+      if standardizedPath.hasPrefix(dir.appendingPathComponent("/").path) || standardizedPath == dir.path {
         return [.read, .write]
       }
     }


### PR DESCRIPTION
# Why

This PR adds support for reading files from the app bundle in the iOS implementation of `expo-file-system`. 

It also moves to the new permission module on iOS and fixes path handling in permission checks.

# How

- Added a test case to verify reading files from assets in the bundle directory
- Refactored the permission validation logic in `FileSystemPath` to use a more consistent approach
- Fixed path comparison in `FileSystemUtilities` to properly handle URL paths vs. strings

# Test Plan

The added test case verifies that:
1. We can list files in the bundle directory
2. We can access specific files (like Info.plist) from the bundle
3. File size information is correctly retrieved

The test can be run in the test-suite app to verify the functionality works as expected.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)