### PR TITLE
[expo-router] fix link preview native navigation without tabs

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -52,6 +52,7 @@
 - fix native tabs transitions with heavy views ([#38761](https://github.com/expo/expo/pull/38761) by [@Ubax](https://github.com/Ubax))
 - remove clip to bounds for Link.Preview ([#38763](https://github.com/expo/expo/pull/38763) by [@Ubax](https://github.com/Ubax))
 - fix preloading of protected routes ([#38789](https://github.com/expo/expo/pull/38789) by [@Ubax](https://github.com/Ubax))
+- fix link preview native navigation without tabs ([#38787](https://github.com/expo/expo/pull/38787) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeView.swift
@@ -40,10 +40,11 @@ class NativeLinkPreviewView: ExpoView, UIContextMenuInteractionDelegate,
   // MARK: - Props
 
   func performUpdateOfPreloadedView() {
-    if nextScreenId == nil || tabPath?.path.isEmpty != false {
+    if nextScreenId == nil && tabPath?.path.isEmpty != false {
+      // If we have no tab to change and no screen to push, then we can't update the preloaded view
       return
     }
-      print("Perform update \(nextScreenId) \(tabPath) \(self)")
+    // However if one these is defined then we can perform the native update
     linkPreviewNativeNavigation.updatePreloadedView(
       screenId: nextScreenId, tabPath: tabPath, responder: self)
   }


### PR DESCRIPTION
# Why

In https://github.com/expo/expo/pull/38283 wrong check was added for when to perform native naviagtion.
The check checked for both tabPath - tabs to change - and screenId - the screen to push on stack.

This broke stack only link preview, with no tabs present - tabPath was always empty.

# How

Change the check to perform native navigation when one or both of conditions are true:
- There is tab to change - for example if link preview navigates to different tab
- There is screen to push

# Test Plan

Manual testing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
