### PR TITLE
[babel-preset-expo] Fix `@babel/runtime` default minimum version (`7.0.0-beta.0`) breaking async generator to generator transform

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Define default `@babel/runtime` minimum version as `^7.20.0` by default ([#38790](https://github.com/expo/expo/pull/38790) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 - Upgrade react-compiler to `19.1.0-rc.2`. ([#38309](https://github.com/expo/expo/pull/38309) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -12,9 +12,12 @@ const restricted_react_api_plugin_1 = require("./restricted-react-api-plugin");
 const server_actions_plugin_1 = require("./server-actions-plugin");
 const use_dom_directive_plugin_1 = require("./use-dom-directive-plugin");
 // NOTE(@kitten): This shouldn't be higher than `expo/package.json`'s `@babel/runtime` version
-// (the lowest version constraint we have). In theory, we should pass an absolute runtime path
+// (the lowest version constraint we have).
+// TODO(@kitten): This is a hotfix! In theory, we should pass an absolute runtime path
 // and skip the internal resolution, which would mean we'd be able to guarantee a version here,
 // but for now, we don't
+// WARN: This does not reproduce in the expo/expo monorepo and we're not sure why. If you're changing this, run `expo export -p android` against this reproduction:
+// - https://github.com/kitten/expo-bug-nested-async-generator-function-repro
 const BABEL_RUNTIME_RANGE = '^7.20.0';
 function getOptions(options, platform) {
     const tag = platform === 'web' ? 'web' : 'native';
@@ -205,10 +208,10 @@ function babelPresetExpo(api, options = {}) {
                     // Defaults to undefined, set to `true` to disable `@babel/plugin-transform-flow-strip-types`
                     disableFlowStripTypesTransform: platformOptions.disableFlowStripTypesTransform,
                     // Defaults to undefined, set to `false` to disable `@babel/plugin-transform-runtime`
-                    enableBabelRuntime: !platformOptions.enableBabelRuntime ||
-                        typeof platformOptions.enableBabelRuntime === 'string'
-                        ? platformOptions.enableBabelRuntime
-                        : BABEL_RUNTIME_RANGE,
+                    // Passed on unchanged in most cases, except when `true` where we pass `BABEL_RUNTIME_RANGE` to avoid the 7.0.0-beta.0 default
+                    enableBabelRuntime: platformOptions.enableBabelRuntime === true
+                        ? BABEL_RUNTIME_RANGE
+                        : platformOptions.enableBabelRuntime,
                     // This reduces the amount of transforms required, as Hermes supports many modern language features.
                     unstable_transformProfile: platformOptions.unstable_transformProfile,
                     // Set true to disable `@babel/plugin-transform-react-jsx` and

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -11,6 +11,11 @@ const lazyImports_1 = require("./lazyImports");
 const restricted_react_api_plugin_1 = require("./restricted-react-api-plugin");
 const server_actions_plugin_1 = require("./server-actions-plugin");
 const use_dom_directive_plugin_1 = require("./use-dom-directive-plugin");
+// NOTE(@kitten): This shouldn't be higher than `expo/package.json`'s `@babel/runtime` version
+// (the lowest version constraint we have). In theory, we should pass an absolute runtime path
+// and skip the internal resolution, which would mean we'd be able to guarantee a version here,
+// but for now, we don't
+const BABEL_RUNTIME_RANGE = '^7.20.0';
 function getOptions(options, platform) {
     const tag = platform === 'web' ? 'web' : 'native';
     return {
@@ -200,7 +205,10 @@ function babelPresetExpo(api, options = {}) {
                     // Defaults to undefined, set to `true` to disable `@babel/plugin-transform-flow-strip-types`
                     disableFlowStripTypesTransform: platformOptions.disableFlowStripTypesTransform,
                     // Defaults to undefined, set to `false` to disable `@babel/plugin-transform-runtime`
-                    enableBabelRuntime: platformOptions.enableBabelRuntime,
+                    enableBabelRuntime: !platformOptions.enableBabelRuntime ||
+                        typeof platformOptions.enableBabelRuntime === 'string'
+                        ? platformOptions.enableBabelRuntime
+                        : BABEL_RUNTIME_RANGE,
                     // This reduces the amount of transforms required, as Hermes supports many modern language features.
                     unstable_transformProfile: platformOptions.unstable_transformProfile,
                     // Set true to disable `@babel/plugin-transform-react-jsx` and

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -25,6 +25,12 @@ import { environmentRestrictedReactAPIsPlugin } from './restricted-react-api-plu
 import { reactServerActionsPlugin } from './server-actions-plugin';
 import { expoUseDomDirectivePlugin } from './use-dom-directive-plugin';
 
+// NOTE(@kitten): This shouldn't be higher than `expo/package.json`'s `@babel/runtime` version
+// (the lowest version constraint we have). In theory, we should pass an absolute runtime path
+// and skip the internal resolution, which would mean we'd be able to guarantee a version here,
+// but for now, we don't
+const BABEL_RUNTIME_RANGE = '^7.20.0';
+
 type BabelPresetExpoPlatformOptions = {
   /** Disable or configure the `@babel/plugin-proposal-decorators` plugin. */
   decorators?: false | { legacy?: boolean; version?: number };
@@ -359,7 +365,11 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
           // Defaults to undefined, set to `true` to disable `@babel/plugin-transform-flow-strip-types`
           disableFlowStripTypesTransform: platformOptions.disableFlowStripTypesTransform,
           // Defaults to undefined, set to `false` to disable `@babel/plugin-transform-runtime`
-          enableBabelRuntime: platformOptions.enableBabelRuntime,
+          enableBabelRuntime:
+            !platformOptions.enableBabelRuntime ||
+            typeof platformOptions.enableBabelRuntime === 'string'
+              ? platformOptions.enableBabelRuntime
+              : BABEL_RUNTIME_RANGE,
           // This reduces the amount of transforms required, as Hermes supports many modern language features.
           unstable_transformProfile: platformOptions.unstable_transformProfile,
           // Set true to disable `@babel/plugin-transform-react-jsx` and

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -26,9 +26,12 @@ import { reactServerActionsPlugin } from './server-actions-plugin';
 import { expoUseDomDirectivePlugin } from './use-dom-directive-plugin';
 
 // NOTE(@kitten): This shouldn't be higher than `expo/package.json`'s `@babel/runtime` version
-// (the lowest version constraint we have). In theory, we should pass an absolute runtime path
+// (the lowest version constraint we have).
+// TODO(@kitten): This is a hotfix! In theory, we should pass an absolute runtime path
 // and skip the internal resolution, which would mean we'd be able to guarantee a version here,
 // but for now, we don't
+// WARN: This does not reproduce in the expo/expo monorepo and we're not sure why. If you're changing this, run `expo export -p android` against this reproduction:
+// - https://github.com/kitten/expo-bug-nested-async-generator-function-repro
 const BABEL_RUNTIME_RANGE = '^7.20.0';
 
 type BabelPresetExpoPlatformOptions = {

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -368,11 +368,11 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
           // Defaults to undefined, set to `true` to disable `@babel/plugin-transform-flow-strip-types`
           disableFlowStripTypesTransform: platformOptions.disableFlowStripTypesTransform,
           // Defaults to undefined, set to `false` to disable `@babel/plugin-transform-runtime`
+          // Passed on unchanged in most cases, except when `true` where we pass `BABEL_RUNTIME_RANGE` to avoid the 7.0.0-beta.0 default
           enableBabelRuntime:
-            !platformOptions.enableBabelRuntime ||
-            typeof platformOptions.enableBabelRuntime === 'string'
-              ? platformOptions.enableBabelRuntime
-              : BABEL_RUNTIME_RANGE,
+            platformOptions.enableBabelRuntime === true
+              ? BABEL_RUNTIME_RANGE
+              : platformOptions.enableBabelRuntime,
           // This reduces the amount of transforms required, as Hermes supports many modern language features.
           unstable_transformProfile: platformOptions.unstable_transformProfile,
           // Set true to disable `@babel/plugin-transform-react-jsx` and


### PR DESCRIPTION
# Why

There's some kind of bug in the `@babel/plugin-transform-async-generator-functions` plugin which fails to transform async generator functions **if** they're anonymous functions inside of other async generators **and** the runtime helper fails to be injected (for unknown reasons; suspected babel bug)

We should've used an absolute path for the runtime (via `transform-runtime`), disabled `transform-runtime` in the RN preset, and guaranteed a fixed version of it. However, this change would be too involved to test in a hotfix.

This also now seems to correctly add non-inline-helpers for some other things (wildcard require helper)

Gut feeling is that we should:
- backport this hotfix 53
- for 54 stable, we should aim to define the absolute path / replace how this plugin is loaded

# How

- Specify minimum `version` for `transform-runtime` set to `expo/package.json`'s version range of `@babel/runtime` (since it's the lowest in all dependencies in an Expo project)

# Test Plan

- `expo export -p android --no-minify` fails in this reproduction without this change: https://github.com/kitten/expo-bug-nested-async-generator-function-repro

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
