### PR TITLE
[tools] Fix promote versions

### DIFF
--- a/tools/src/commands/PromoteVersionsToProduction.ts
+++ b/tools/src/commands/PromoteVersionsToProduction.ts
@@ -29,7 +29,7 @@ async function action() {
 
   if (isCorrect) {
     // Promote staging configuration to production.
-    await Versions.setVersionsAsync(versionsStaging);
+    await Versions.setVersionsAsync(versionsStaging, Versions.VersionsApiHost.PRODUCTION);
 
     console.log(
       chalk.green('\nSuccessfully updated production config. You can check it out on'),


### PR DESCRIPTION
# Why
Running `et promote-versions` does not update the production endpoint. This is because we are not passing the `apiHost` argument to `setVersionsAsync` which then defaults to staging.

# Test Plan
`et promote-versions` correctly updates the production endpoint.

