### PR TITLE
[ios][image] Fix images not displaying in Material Top Tabs navigator

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [Web] Fix `alt` as an alias for `accessibilityLabel` ([#37682](https://github.com/expo/expo/pull/37682) by [@huextrat](https://github.com/huextrat))
 - [iOS] Fix caching resized images from Photo Library. ([#38105](https://github.com/expo/expo/pull/38105) by [@jakex7](https://github.com/jakex7))
 - [iOS] Fix `generatePlaceholder` method syntax error by removing unwanted trailing comma. ([#38318](https://github.com/expo/expo/pull/38318) by [@bortolilucas](https://github.com/bortolilucas))
+- [iOS] Fix images not displaying in Material Top Tabs navigator. ([#38798](https://github.com/expo/expo/pull/38798) by [@vicprz](https://github.com/vicprz))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -121,10 +121,12 @@ public final class ImageView: ExpoView {
     if window == nil {
       // Cancel pending requests when the view is unmounted.
       cancelPendingOperation()
-      return
+    } else if !bounds.isEmpty {
+      // Reload the image after mounting the view with non-empty bounds.
+      reload()
+    } else {
+      loadPlaceholderIfNecessary()
     }
-
-    loadPlaceholderIfNecessary()
   }
 
   public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {


### PR DESCRIPTION
# Why

In #37987, the reload of the image after mounting the view with non-empty bounds was removed.
However, I found that this change causes the bug described in issue #38783.

# How

I reverted #37987.
@lukmccall, feel free to share any thoughts 🙂

# Test Plan

- ✅ client app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
