### PR TITLE
chore(create-expo,create-expo-nightly,expo-doctor,expo-updates): Bump `@vercel/ncc`

### DIFF
--- a/packages/create-expo-nightly/package.json
+++ b/packages/create-expo-nightly/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.2",
-    "@vercel/ncc": "^0.38.0",
+    "@vercel/ncc": "^0.38.3",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "expo-module-scripts": "^5.0.0",

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump `@vercel/ncc` build ([#38801](https://github.com/expo/expo/pull/38801) by [@kitten](https://github.com/kitten))
+
 ## 3.5.0 — 2025-08-13
 
 _This version does not introduce any user-facing changes._

--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^22.14.0",
     "@types/picomatch": "^2.3.3",
     "@types/prompts": "2.0.14",
-    "@vercel/ncc": "^0.38.1",
+    "@vercel/ncc": "^0.38.3",
     "arg": "^5.0.2",
     "chalk": "^4.0.0",
     "debug": "^4.3.4",

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump `@vercel/ncc` build ([#38801](https://github.com/expo/expo/pull/38801) by [@kitten](https://github.com/kitten))
+
 ## 1.14.0 — 2025-08-13
 
 ### 🎉 New features

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -40,7 +40,7 @@
     "@expo/spawn-async": "^1.7.2",
     "@expo/metro": "~0.1.1",
     "@types/debug": "^4.1.8",
-    "@vercel/ncc": "0.38.1",
+    "@vercel/ncc": "0.38.3",
     "chalk": "^4.0.0",
     "debug": "^4.3.4",
     "expo-module-scripts": "^5.0.0",

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump `@vercel/ncc` build ([#38801](https://github.com/expo/expo/pull/38801) by [@kitten](https://github.com/kitten))
+
 ## 29.0.0 — 2025-08-13
 
 ### 🎉 New features

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^22.14.0",
     "@types/node-forge": "^1.0.0",
     "@types/picomatch": "^4.0.0",
-    "@vercel/ncc": "^0.38.1",
+    "@vercel/ncc": "^0.38.3",
     "expo-module-scripts": "^5.0.0",
     "express": "^5.1.0",
     "form-data": "^4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4880,10 +4880,10 @@
     "@urql/core" "^5.0.0"
     wonka "^6.3.2"
 
-"@vercel/ncc@0.38.1", "@vercel/ncc@^0.38.0", "@vercel/ncc@^0.38.1":
-  version "0.38.1"
-  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.38.1.tgz#13f08738111e1d9e8a22fd6141f3590e54d9a60e"
-  integrity sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==
+"@vercel/ncc@0.38.3", "@vercel/ncc@^0.38.3":
+  version "0.38.3"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.38.3.tgz#5475eeee3ac0f1a439f237596911525a490a88b5"
+  integrity sha512-rnK6hJBS6mwc+Bkab+PGPs9OiS0i/3kdTO+CkI8V0/VrW3vmz7O2Pxjw/owOlmo6PKEIxRSeZKv/kuL9itnpYA==
 
 "@webgpu/types@0.1.21":
   version "0.1.21"


### PR DESCRIPTION
# Why

The latest `next` release of `expo-doctor` seems to fail on private class field annotations. Bumping `@vercel/ncc` resolved this for me.

Syntax Error in this section:
<img width="797" height="93" alt="image" src="https://github.com/user-attachments/assets/d64771cf-e84e-4952-8d25-7f45099e2c44" />

# How

- Bump `@vercel/ncc` patch version

Changelog entries from `@vercel/ncc` for this bump:
- add missing --asset-builds to cli help message
- deps: update webpack to v5.94.0, terser to v5.33.0
- sourcemap sources removes webpack path

# Test Plan

- Compare a build of `expo-doctor` from this branch against `npx expo-doctor@next`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
