### PR TITLE
[tools][publish-packages] Skip adding `gitHead` to templates

### DIFF
--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -207,6 +207,10 @@ export class Package {
     return !!this.expoModuleConfig;
   }
 
+  isTemplate() {
+    return !!this.path.startsWith(TEMPLATES_DIR);
+  }
+
   containsPodspecFile() {
     return [
       ...fs.readdirSync(this.path),

--- a/tools/src/publish-packages/tasks/publishPackages.ts
+++ b/tools/src/publish-packages/tasks/publishPackages.ts
@@ -50,7 +50,9 @@ export const publishPackages = new Task<TaskArgs>(
 
       // Update `gitHead` property so it will be available to read using `npm view --json`.
       // Next publish will depend on this to properly get changes made after that.
-      await JsonFile.setAsync(packageJsonPath, 'gitHead', gitHead);
+      if (!pkg.isTemplate()) {
+        await JsonFile.setAsync(packageJsonPath, 'gitHead', gitHead);
+      }
 
       // Publish the package.
       try {


### PR DESCRIPTION
# Why

ENG-17017

# How

Omit adding `gitHead` to templates when publishing

# Test Plan

Publish template