### PR TITLE
[tools][publish-packages] Fix forced template release version

### DIFF
--- a/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
+++ b/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
@@ -98,8 +98,11 @@ export const selectPackagesToPublish = new Task<TaskArgs>(
       const templateParcel = await createParcelAsync(bareTemplateNode);
 
       // Template don't not have changelog so we need to match Expo's release type.
+      const newExpoVersion = expoParcel.state.releaseVersion || '';
       templateParcel.minReleaseType =
-        semver.patch(expoParcel.state.releaseVersion || '') === 0
+        semver.minor(newExpoVersion) === 0 &&
+        semver.patch(newExpoVersion) === 0 &&
+        !semver.prerelease(newExpoVersion)
           ? ReleaseType.MAJOR
           : ReleaseType.PATCH;
       const { releaseVersion } = await resolveReleaseTypeAndVersion(templateParcel, options);


### PR DESCRIPTION
# Why

When publishing `expo` package, `expo-template-bare-minimum` update is forced, regardless of selected options to keep the integrity, however it's version is based on `expo` update version. When the version is not a major, template version should be patch.

# How

Updated the condition for release type. 

# Test Plan

Publish `expo` package as prerelease or minor without any additional packages and check the logs. 
The output should be
```
📦 expo-template-bare-minimum is required to be published with expo package, will be published as 54.0.1.
```
instead of
```
📦 expo-template-bare-minimum is required to be published with expo package, will be published as 55.0.0.
```