### PR TITLE
[tools][promote-packages] Assign sdk-xx tag to all templates

### DIFF
--- a/tools/src/promote-packages/tasks/promotePackages.ts
+++ b/tools/src/promote-packages/tasks/promotePackages.ts
@@ -48,7 +48,7 @@ export const promotePackages = new Task<TaskArgs>(
             stdio: requiresOTP ? 'inherit' : undefined,
           });
         }
-        if (pkg.packageName === 'expo-template-bare-minimum') {
+        if (pkg.isTemplate()) {
           const sdkTag = `sdk-${semver.major(pkg.packageVersion)}`;
           batch.log(
             '    ',


### PR DESCRIPTION
# Why

`sdk-xx` tag should be added to all templates, not just `expo-template-bare-minimum`

# How

Check if package is a template.

# Test Plan

Publish template other than `expo-template-bare-minimum`