### PR TITLE
[tools] Auto-update devDependencies for templates

### DIFF
--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -45,6 +45,6 @@
     "@types/react": "~19.1.0",
     "typescript": "~5.9.2",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~9.2.0"
+    "eslint-config-expo": "~10.0.0"
   }
 }

--- a/templates/expo-template-tabs-react-navigation/package.json
+++ b/templates/expo-template-tabs-react-navigation/package.json
@@ -42,7 +42,7 @@
     "@babel/core": "^7.20.0",
     "@types/react": "~19.1.0",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~9.2.0",
+    "eslint-config-expo": "~10.0.0",
     "typescript": "~5.9.2"
   },
   "private": true

--- a/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
+++ b/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
@@ -8,6 +8,7 @@ import { getAvailableProjectTemplatesAsync } from '../../ProjectTemplates';
 import { Task } from '../../TasksRunner';
 import * as Workspace from '../../Workspace';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
+import { DependencyKind } from '../../Packages';
 
 const { green, yellow, cyan } = chalk;
 
@@ -29,7 +30,9 @@ export const updateWorkspaceProjects = new Task<TaskArgs>(
     templates.forEach((template) => {
       workspaceInfo[template.packageName] = {
         location: template.path.replace(EXPO_DIR, ''),
-        workspaceDependencies: template.getDependencies().map((dep) => dep.name),
+        workspaceDependencies: template
+          .getDependencies([DependencyKind.Normal, DependencyKind.Dev])
+          .map((dep) => dep.name),
         mismatchedWorkspaceDependencies: [],
         workspacePeerDependencies: [],
         workspaceOptionalDependencies: [],

--- a/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
+++ b/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
@@ -4,11 +4,11 @@ import path from 'path';
 
 import { EXPO_DIR } from '../../Constants';
 import logger from '../../Logger';
+import { DependencyKind } from '../../Packages';
 import { getAvailableProjectTemplatesAsync } from '../../ProjectTemplates';
 import { Task } from '../../TasksRunner';
 import * as Workspace from '../../Workspace';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-import { DependencyKind } from '../../Packages';
 
 const { green, yellow, cyan } = chalk;
 


### PR DESCRIPTION
# Why

Publishing packages should also sync them when they are template `devDependencies`, like `eslint-config-expo` is a dev dep of `expo-template-default` and `expo-template-tabs-react-navigation`.

# How

Add `DependencyKind.Dev` to template dependencies. 

# Test Plan

Publish `eslint-config-expo` and check if it's version got updated in `expo-template-default`