### PR TITLE
[ios][dev-launcher] Fix tvOS breakages after UI refresh, fix SwiftLint

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fix tvOS and Swiftlint after UI refresh. ([#38808](https://github.com/expo/expo/pull/38808) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 ## 6.0.0 — 2025-08-13

--- a/packages/expo-dev-launcher/ios/SwiftUI/CrashReportView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/CrashReportView.swift
@@ -1,4 +1,5 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
+// swiftlint:disable closure_body_length
 
 import SwiftUI
 import React
@@ -35,7 +36,9 @@ struct CrashReportView: View {
       }
       .padding()
     }
+    #if !os(tvOS)
     .background(Color(.systemBackground))
+    #endif
     .navigationBarHidden(true)
   }
 
@@ -108,9 +111,9 @@ struct CrashReportView: View {
               .font(.system(.caption, design: .monospaced))
               .foregroundColor(.primary)
               .fixedSize(horizontal: true, vertical: false)
-#if !os(tvOS)
+              #if !os(tvOS)
               .textSelection(.enabled)
-#endif
+              #endif
           } else if let stack = error.stack, !stack.isEmpty {
             ForEach(Array(stack.enumerated()), id: \.offset) { _, frame in
               StackFrameView(frame: frame)
@@ -128,7 +131,9 @@ struct CrashReportView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
       }
       .frame(maxHeight: 200)
+      #if !os(tvOS)
       .background(Color(.secondarySystemGroupedBackground))
+      #endif
       .cornerRadius(8)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
@@ -146,7 +151,9 @@ struct CrashReportView: View {
           return nil
         }
         let file = frame.file ?? "Unknown file"
-        return "\tat \(methodName) (\(file):\(frame.lineNumber):\(frame.column))"}.joined(separator: "\n")
+        return "\tat \(methodName) (\(file):\(frame.lineNumber):\(frame.column))"
+      }
+      .joined(separator: "\n")
       stackTrace = "\(stackString)"
     } else {
       stackTrace = "No stack trace available"
@@ -173,3 +180,4 @@ struct CrashReportView: View {
     return Date()
   }
 }
+// swiftlint:enable closure_body_length

--- a/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
@@ -1,4 +1,5 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
+// swiftlint:disable closure_body_length
 
 import SwiftUI
 
@@ -64,7 +65,9 @@ struct HomeTabView: View {
         .padding()
     }
     .buttonStyle(PlainButtonStyle())
+    #if !os(tvOS)
     .background(Color(.secondarySystemGroupedBackground))
+    #endif
     .cornerRadius(18)
   }
 }
@@ -72,3 +75,4 @@ struct HomeTabView: View {
 #Preview {
   HomeTabView()
 }
+// swiftlint:enable closure_body_length

--- a/packages/expo-dev-launcher/ios/SwiftUI/Navigation/Navigation.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/Navigation/Navigation.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable closure_body_length
 import SwiftUI
 
 class DevLauncherNavigation: ObservableObject {
@@ -129,3 +130,5 @@ struct DevLauncherNavigationHeader: View {
     }
   }
 }
+
+// swiftlint:enable closure_body_length

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -2,6 +2,7 @@
 
 import SwiftUI
 
+// swiftlint:disable:next line_length
 private let selectedGesturesInfoMessage = "Selected gestures will toggle the developer menu while inside a preview. The menu allows you to reload or return to home and exposes developer tools."
 
 struct SettingsTabView: View {

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
@@ -14,13 +14,9 @@ onFlowStart:
     label: Tap on "Enter URL manually"
     text: Enter URL manually
 - tapOn:
-    label: Tap on "Updates URL" text field for iOS
-    text: "http://10.0.0.25:8081"
-    optional: true
-- tapOn:
-    label: Tap on "Updates URL" text field for Android
+    label: Tap on "Updates URL" text field
+    text: '.*http:.*'
     below: Enter URL manually
-    optional: true
 - inputText:
     label: Input local update server URL
     text: "http://localhost:4747/update\n"

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
@@ -14,8 +14,13 @@ onFlowStart:
     label: Tap on "Enter URL manually"
     text: Enter URL manually
 - tapOn:
-    label: Tap on "Updates URL" text field
+    label: Tap on "Updates URL" text field for iOS
+    text: "http://10.0.0.25:8081"
+    optional: true
+- tapOn:
+    label: Tap on "Updates URL" text field for Android
     below: Enter URL manually
+    optional: true
 - inputText:
     label: Input local update server URL
     text: "http://localhost:4747/update\n"
@@ -34,6 +39,7 @@ onFlowStart:
 - tapOn:
     label: Tap on reload
     text: Reload
+    optional: true
 - copyTextFrom:
     label: Copy text from update string
     id: updateString

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -396,7 +396,7 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@0.81.0-0rc3',
+        'react-native': 'npm:react-native-tvos@0.81.0-0',
         '@react-native-tvos/config-tv': '^0.1.3',
       },
       expo: {


### PR DESCRIPTION
# Why

After UI refresh there were some tvOS compile errors. Also, there were several SwiftLint violations (unrelated to tvOS).

# How

Fix the issues.

# Test Plan

CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
