### PR TITLE
[tools][publish-packages] Restore upt as part of the pp

### DIFF
--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -19,6 +19,7 @@ import { updateBundledNativeModulesFile } from './updateBundledNativeModulesFile
 import { updateIosProjects } from './updateIosProjects';
 import { updateModuleTemplate } from './updateModuleTemplate';
 import { updatePackageVersions } from './updatePackageVersions';
+import { updateProjectTemplates } from './updateProjectTemplates';
 import { updateWorkspaceProjects } from './updateWorkspaceProjects';
 import Git from '../../Git';
 import logger from '../../Logger';
@@ -77,6 +78,7 @@ export const publishPackagesPipeline = new Task<TaskArgs>(
       selectPackagesToPublish,
       updatePackageVersions,
       updateBundledNativeModulesFile,
+      updateProjectTemplates,
       updateModuleTemplate,
       updateWorkspaceProjects,
       updateAndroidProjects,

--- a/tools/src/publish-packages/tasks/updateProjectTemplates.ts
+++ b/tools/src/publish-packages/tasks/updateProjectTemplates.ts
@@ -1,0 +1,111 @@
+import JsonFile from '@expo/json-file';
+import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import path from 'path';
+
+import { PACKAGES_DIR } from '../../Constants';
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
+import { selectPackagesToPublish } from './selectPackagesToPublish';
+
+const { magenta, green, blue, cyan } = chalk;
+
+const BUNDLED_NATIVE_MODULES_PATH = path.join(PACKAGES_DIR, 'expo', 'bundledNativeModules.json');
+const DEPENDENCIES_KEYS = ['dependencies', 'devDependencies', 'peerDependencies'];
+
+/**
+ * Finds target version.
+ *
+ * @param targetVersionRange Version range that exists in `bundledNativeModules.json` file.
+ * @param currentVersion Version range that is currenty used in the template.
+ */
+function resolveTargetVersionRange(targetVersionRange: string, currentVersion: string) {
+  if (currentVersion === '*') {
+    return currentVersion;
+  }
+  return targetVersionRange;
+}
+
+/**
+ * Updates single project template.
+ *
+ * @param template Template object containing name and path.
+ * @param modulesToUpdate An object with module names to update and their version ranges.
+ */
+async function updateTemplateAsync(parcel: Parcel, modulesToUpdate: Record<string, string>) {
+  logger.info('  ', `${green.bold(parcel.pkg.packageName)}...`);
+
+  const packageJsonPath = path.join(parcel.pkg.path, 'package.json');
+  const packageJson = require(packageJsonPath);
+
+  for (const dependencyKey of DEPENDENCIES_KEYS) {
+    const dependencies = packageJson[dependencyKey];
+    if (!dependencies) {
+      continue;
+    }
+    for (const dependencyName in dependencies) {
+      const currentVersion = dependencies[dependencyName];
+      const targetVersion = resolveTargetVersionRange(
+        modulesToUpdate[dependencyName],
+        currentVersion
+      );
+      if (!targetVersion || targetVersion === currentVersion) {
+        continue;
+      }
+      logger.log(
+        '    >',
+        `Updating ${blue(dependencyName)} from ${cyan(currentVersion)} to ${cyan(targetVersion)}...`
+      );
+      dependencies[dependencyName] = targetVersion;
+    }
+  }
+  await JsonFile.writeAsync(packageJsonPath, packageJson);
+}
+
+/**
+ * Removes template's `yarn.lock` and runs `yarn`.
+ *
+ * @param templatePath Root path of the template.
+ */
+async function yarnTemplateAsync(templatePath: string): Promise<void> {
+  logger.log('    >', 'Yarning...');
+
+  const yarnLockPath = path.join(templatePath, 'yarn.lock');
+
+  if (await fs.pathExists(yarnLockPath)) {
+    // We do want to always install the newest possible versions that match bundledNativeModules versions,
+    // so let's remove yarn.lock before updating re-yarning dependencies.
+    await fs.remove(yarnLockPath);
+  }
+  await spawnAsync('yarn', [], {
+    stdio: 'ignore',
+    cwd: templatePath,
+    env: process.env,
+  });
+}
+
+/**
+ * Updates project templates to use a versions specified in the `BundledNativeModules`.
+ */
+export const updateProjectTemplates = new Task<TaskArgs>(
+  {
+    name: 'updateProjectTemplates',
+    dependsOn: [selectPackagesToPublish],
+    filesToStage: ['templates/**/package.json'],
+  },
+  async (parcels: Parcel[], options: CommandOptions) => {
+    const bundledNativeModules = require(BUNDLED_NATIVE_MODULES_PATH);
+
+    logger.info(`\n🆙 Updating ${magenta.bold('templates')} with bundledNativeModules...`);
+
+    for (const parcel of parcels) {
+      if (!parcel.pkg.isTemplate()) {
+        continue;
+      }
+      await updateTemplateAsync(parcel, bundledNativeModules);
+      await yarnTemplateAsync(parcel.pkg.path);
+    }
+  }
+);

--- a/tools/src/publish-packages/tasks/updateProjectTemplates.ts
+++ b/tools/src/publish-packages/tasks/updateProjectTemplates.ts
@@ -1,7 +1,5 @@
 import JsonFile from '@expo/json-file';
-import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
-import fs from 'fs-extra';
 import path from 'path';
 
 import { PACKAGES_DIR } from '../../Constants';
@@ -65,28 +63,6 @@ async function updateTemplateAsync(parcel: Parcel, modulesToUpdate: Record<strin
 }
 
 /**
- * Removes template's `yarn.lock` and runs `yarn`.
- *
- * @param templatePath Root path of the template.
- */
-async function yarnTemplateAsync(templatePath: string): Promise<void> {
-  logger.log('    >', 'Yarning...');
-
-  const yarnLockPath = path.join(templatePath, 'yarn.lock');
-
-  if (await fs.pathExists(yarnLockPath)) {
-    // We do want to always install the newest possible versions that match bundledNativeModules versions,
-    // so let's remove yarn.lock before updating re-yarning dependencies.
-    await fs.remove(yarnLockPath);
-  }
-  await spawnAsync('yarn', [], {
-    stdio: 'ignore',
-    cwd: templatePath,
-    env: process.env,
-  });
-}
-
-/**
  * Updates project templates to use a versions specified in the `BundledNativeModules`.
  */
 export const updateProjectTemplates = new Task<TaskArgs>(
@@ -105,7 +81,6 @@ export const updateProjectTemplates = new Task<TaskArgs>(
         continue;
       }
       await updateTemplateAsync(parcel, bundledNativeModules);
-      await yarnTemplateAsync(parcel.pkg.path);
     }
   }
 );


### PR DESCRIPTION
# Why

Sometimes we need to update templates dependencies to the `BundledNativeModules` versions (mostly when someone forgot to update external dependencies there).

# How

Restores slightly modified version of https://github.com/expo/expo/blob/702a4f0ec7d46d31cb1d2704db6af5c388bb63c9/tools/src/commands/UpdateProjectTemplates.ts as part of the `publish-packages` pipeline.

# Test Plan

Run `et pp expo-template-default` and check if `react-native-screens` version was updated to the version specified in `bundledNativeModules.json`