### PR TITLE
[go] fix simulator build upload from EAS

### DIFF
--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -431,7 +431,12 @@ async function androidApkUploadAsync() {
   const appVersion = await androidAppVersionAsync();
   await confirmPromptIfOverridingRemoteFileAsync(getAndroidApkUrl(appVersion), appVersion);
   const projectDir = EAS_EXPO_GO_PROJECT_DIR;
-  const archivePath = await downloadBuildArtifactAsync(projectDir, 'android', appVersion);
+  const archivePath = await downloadBuildArtifactAsync(
+    projectDir,
+    'android',
+    appVersion,
+    sdkVersion
+  );
 
   logger.info(`Build archive downloaded to: ${archivePath}`);
 
@@ -499,7 +504,12 @@ async function iosSimulatorUploadAsync() {
   const sdkVersion = await enforceRunningOnSdkReleaseBranchAsync();
   await confirmPromptIfOverridingRemoteFileAsync(getIosSimulatorUrl(appVersion), appVersion);
   const projectDir = EAS_EXPO_GO_PROJECT_DIR;
-  const tempArchivePath = await downloadBuildArtifactAsync(projectDir, 'ios', appVersion);
+  const tempArchivePath = await downloadBuildArtifactAsync(
+    projectDir,
+    'ios',
+    appVersion,
+    sdkVersion
+  );
   const archivePath = await processIosTarArchiveAsync(tempArchivePath, projectDir);
 
   const repoOwner = REPO_OWNER;
@@ -573,7 +583,8 @@ export async function iosSimulatorBuildAsync() {
 async function downloadBuildArtifactAsync(
   projectDir: string,
   platform: 'ios' | 'android',
-  appVersion: string
+  appVersion: string,
+  sdkVersion: string
 ) {
   const buildInfo = await spawnAsync(
     'eas',
@@ -589,6 +600,8 @@ async function downloadBuildArtifactAsync(
       'finished',
       '--profile',
       PUBLISH_CLIENT_BUILD_PROFILE,
+      '--sdk-version',
+      sdkVersion,
     ],
     {
       cwd: projectDir,


### PR DESCRIPTION
# Why

Expo go install via CLI is broken for sdk 54 preview release. I have fixed it by uploading expected tar.gz format to GitHub for now.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

When uploading simulator build to GitHub from EAS we need to extract the app and then upload the contents instead of uploading the tar.gz. I added a processing step in case the tar.gz is from EAS vs a Cloudfront or any other link.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested the tar.gz format when uploaded from EAS and Cloudfront.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
