### PR TITLE
[ci] fix ios unit test build

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -177,7 +177,7 @@ platform :ios do
     run_tests(
       workspace: workspace,
       scheme: generated_scheme,
-      devices: ["iPhone 16 Pro (18.0)"],
+      devices: ["iPhone 16 Pro (18.5)"],
       configuration: 'Debug',
       clean: false,
       skip_build: true,


### PR DESCRIPTION
# Why

ios unit tests on main currently won't build: https://github.com/expo/expo/actions/workflows/ios-unit-tests.yml (seems GH updated the macos image)

There's a bunch of `error: module map file '/tmp/ExpoUnitTestsDerivedData/Build/Products/Debug-iphoneos/EASClient/EASClient.modulemap' not found (in target 'NativeTests' from project 'NativeTests')` and etc but the real error is `No simulators found that are equal to the version of specifier (18.0)`

# How

bump ios device version

# Test Plan

- ios-unit-tests.yml builds, though later fails on some test cases

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
