### PR TITLE
[docs] Add missing Sentry token to docs-push workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,6 +66,9 @@ jobs:
         working-directory: docs
         run: yarn export
         timeout-minutes: 20
+        env:
+          # NOTE(@krystofwoldrich): Missing token won't fail the build
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       - name: 🔗 Lint pages links
         working-directory: docs
         run: yarn lint-links --quiet


### PR DESCRIPTION
- Follow up to https://github.com/expo/expo/pull/38771

Sentry Token is also needed in the docs push workflow which deploys docs from main.