### PR TITLE
[android][expo-go] Remove FAB from menu on mobile

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
@@ -94,7 +94,7 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
       debuggerMap.putBoolean("isEnabled", devSupportManager.devSupportEnabled)
       items.putBundle("dev-remote-debug", debuggerMap)
     }
-    
+
     if (VRUtilities.isQuest()) {
       if (devSettings != null && devSupportManager.devSupportEnabled) {
         val label = if (devSettings.isFloatingActionButtonEnabled) {

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
@@ -10,6 +10,7 @@ import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.devsupport.DevInternalSettings
 import com.facebook.react.devsupport.HMRClient
 import com.facebook.react.devsupport.interfaces.DevSupportManager
+import expo.modules.core.utilities.VRUtilities
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.experience.ExperienceActivity
@@ -93,17 +94,19 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
       debuggerMap.putBoolean("isEnabled", devSupportManager.devSupportEnabled)
       items.putBundle("dev-remote-debug", debuggerMap)
     }
-
-    if (devSettings != null && devSupportManager.devSupportEnabled) {
-      val label = if (devSettings.isFloatingActionButtonEnabled) {
-        getString(R.string.devmenu_hide_fab)
-      } else {
-        getString(R.string.devmenu_show_fab)
+    
+    if (VRUtilities.isQuest()) {
+      if (devSettings != null && devSupportManager.devSupportEnabled) {
+        val label = if (devSettings.isFloatingActionButtonEnabled) {
+          getString(R.string.devmenu_hide_fab)
+        } else {
+          getString(R.string.devmenu_show_fab)
+        }
+        fabMap.putString("label", label)
+        fabMap.putBoolean("isEnabled", true)
       }
-      fabMap.putString("label", label)
-      fabMap.putBoolean("isEnabled", true)
+      items.putBundle("dev-fab", fabMap)
     }
-    items.putBundle("dev-fab", fabMap)
 
     if (devSettings != null && devSupportManager.devSupportEnabled && devSettings is DevInternalSettings) {
       hmrMap.putString("label", getString(if (devSettings.isHotModuleReplacementEnabled) R.string.devmenu_disable_fast_refresh else R.string.devmenu_enable_fast_refresh))


### PR DESCRIPTION
# Why
Seems to be an issue with assets at the moment causing the `Show developer action button` item in the menu to have no icon. We don't need this item on mobile so let's remove it for now

# How
Only add the item when running on quest.

# Test Plan
Expo go

