### PR TITLE
[docs] Clean up and add `isNew` field for docs under Reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/background-task.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-task.mdx
@@ -4,7 +4,6 @@ description: A library that provides an API for running background tasks.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-background-task'
 packageName: 'expo-background-task'
 platforms: ['android', 'ios', 'tvos']
-isNew: true
 hasVideoLink: true
 ---
 

--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-file-system
 packageName: 'expo-file-system'
 iconUrl: '/static/images/packages/expo-file-system.png'
 platforms: ['android', 'ios', 'tvos']
+isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/mesh-gradient.mdx
+++ b/docs/pages/versions/unversioned/sdk/mesh-gradient.mdx
@@ -5,7 +5,6 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-mesh-gradie
 packageName: 'expo-mesh-gradient'
 iconUrl: '/static/images/packages/expo-mesh-gradient.png'
 platforms: ['ios', 'tvos']
-isNew: true
 ---
 
 import APISection from '~/components/plugins/APISection';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Clean up and add `isNew` field for docs under Reference.
# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="562" height="1460" alt="CleanShot 2025-08-14 at 16 33 27@2x" src="https://github.com/user-attachments/assets/bb554827-3362-4031-a7b6-05ba28c5b257" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
