### PR TITLE
[eslint-plugin-expo] [babel-preset-expo] Inline env vars with bracket notation

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Support inlining environment variables with bracket notation.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Support inlining environment variables with bracket notation.
+- Support inlining environment variables with bracket notation. ([#38826](https://github.com/expo/expo/pull/38826) by [@kadikraman](https://github.com/kadikraman))
 
 ### 🐛 Bug fixes
 

--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/inline-env-vars.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/inline-env-vars.test.ts.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`handles bracket notation for EXPO_PUBLIC environment variables 1`] = `
+{
+  "code": "var _env2 = require("expo/virtual/env");
+var foo = _env2.env.EXPO_PUBLIC_URL;
+var bar = _env2.env.EXPO_PUBLIC_NODE_ENV;
+var baz = _env2.env.EXPO_PUBLIC_FOO;
+
+function App() {
+  console.log(_env2.env.EXPO_PUBLIC_URL);
+  console.log(_env2.env.EXPO_PUBLIC_NODE_ENV);
+  console.log(_env2.env.EXPO_PUBLIC_FOO);
+}",
+  "hasCjsExports": undefined,
+  "metadata": {
+    "publicEnvVars": [
+      "EXPO_PUBLIC_URL",
+      "EXPO_PUBLIC_NODE_ENV",
+      "EXPO_PUBLIC_FOO",
+    ],
+  },
+}
+`;
+
 exports[`inlines environment variables 1`] = `
 "
 var foo = process.env.JEST_WORKER_ID;

--- a/packages/babel-preset-expo/src/__tests__/inline-env-vars.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/inline-env-vars.test.ts
@@ -213,3 +213,34 @@ function App() {
 
   expect(contents).toMatchSnapshot();
 });
+
+it(`handles bracket notation for EXPO_PUBLIC environment variables`, () => {
+  process.env.EXPO_PUBLIC_NODE_ENV = 'development';
+  process.env.EXPO_PUBLIC_FOO = 'bar';
+
+  const sourceCode = `
+const foo = process.env["EXPO_PUBLIC_URL"];
+const bar = process.env['EXPO_PUBLIC_NODE_ENV'];
+const baz = process.env[\`EXPO_PUBLIC_FOO\`];
+
+function App() {
+  console.log(process.env["EXPO_PUBLIC_URL"]);
+  console.log(process.env['EXPO_PUBLIC_NODE_ENV']);
+  console.log(process.env[\`EXPO_PUBLIC_FOO\`]);
+}
+`;
+
+  const contents = transformTest(sourceCode, {
+    caller: getCaller({
+      ...ENABLED_CALLER,
+      isDev: true,
+    }),
+  });
+
+  expect(contents.code).toMatch('expo/virtual/env');
+  expect(contents.metadata).toEqual({
+    publicEnvVars: ['EXPO_PUBLIC_URL', 'EXPO_PUBLIC_NODE_ENV', 'EXPO_PUBLIC_FOO'],
+  });
+
+  expect(contents).toMatchSnapshot();
+});

--- a/packages/babel-preset-expo/src/inline-env-vars.ts
+++ b/packages/babel-preset-expo/src/inline-env-vars.ts
@@ -31,11 +31,14 @@ export function expoInlineEnvVars(api: ConfigAPI & typeof import('@babel/core'))
         if (path.get('object').matchesPattern('process.env')) {
           const key = path.toComputedKey();
           if (
-            t.isStringLiteral(key) &&
+            (t.isStringLiteral(key) || t.isTemplateLiteral(key)) &&
             !isFirstInAssign(path) &&
-            key.value.startsWith('EXPO_PUBLIC_')
+            ((t.isStringLiteral(key) && key.value.startsWith('EXPO_PUBLIC_')) ||
+              (t.isTemplateLiteral(key) &&
+                key.quasis.length === 1 &&
+                key.quasis[0].value.raw.startsWith('EXPO_PUBLIC_')))
           ) {
-            const envVar = key.value;
+            const envVar = t.isStringLiteral(key) ? key.value : key.quasis[0].value.raw;
             debug(
               `${isProduction ? 'Inlining' : 'Referencing'} environment variable in %s: %s`,
               filename,

--- a/packages/eslint-plugin-expo/CHANGELOG.md
+++ b/packages/eslint-plugin-expo/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 ### 💡 Others
-- Allow accessing env vars with bracket notation.
+- Allow accessing env vars with bracket notation. ([#38826](https://github.com/expo/expo/pull/38826) by [@kadikraman](https://github.com/kadikraman))
 
 ## 1.0.0 — 2025-08-13
 

--- a/packages/eslint-plugin-expo/CHANGELOG.md
+++ b/packages/eslint-plugin-expo/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 ### 💡 Others
+- Allow accessing env vars with bracket notation.
 
 ## 1.0.0 — 2025-08-13
 

--- a/packages/eslint-plugin-expo/docs/rules/no-dynamic-env-var.md
+++ b/packages/eslint-plugin-expo/docs/rules/no-dynamic-env-var.md
@@ -9,21 +9,19 @@ This rule aims to prevent users from encountering errors due to dynamically acce
 Examples of **incorrect** code for this rule:
 
 ```js
-
-const myVar = process.env["MY_VAR"]
-
-
 const dynamicVar = "MY_VAR";
 const myVar = process.env[dynamicVar];
 
+const myVar = process.env[`MY_${VAR}`];
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-
 const myVar = process.env.MY_VAR;
-
+const myVar = process.env["MY_VAR"];
+const myVar = process.env['MY_VAR'];
+const myVar = process.env[`MY_VAR`];
 ```
 
 ## When Not To Use It

--- a/packages/eslint-plugin-expo/src/__tests__/no-dynamic-env-var.test.ts
+++ b/packages/eslint-plugin-expo/src/__tests__/no-dynamic-env-var.test.ts
@@ -13,19 +13,13 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run('noDynamicEnvVar', noDynamicEnvVar, {
-  valid: [{ code: 'const myVar = process.env.MY_VAR;' }],
+  valid: [
+    { code: 'const myVar = process.env.MY_VAR;' },
+    { code: 'const myVar = process.env["MY_VAR"];' },
+    { code: "const myVar = process.env['MY_VAR'];" },
+    { code: 'const myVar = process.env[`MY_VAR`];' },
+  ],
   invalid: [
-    {
-      code: 'const myVar = process.env["MY_VAR"]',
-      errors: [
-        {
-          messageId: 'unexpectedDynamicAccess',
-          data: {
-            value: 'MY_VAR',
-          },
-        },
-      ],
-    },
     {
       code: 'const dynamicVar = "MY_VAR"; const myVar = process.env[dynamicVar];',
       errors: [
@@ -33,6 +27,17 @@ ruleTester.run('noDynamicEnvVar', noDynamicEnvVar, {
           messageId: 'unexpectedDynamicAccess',
           data: {
             value: 'dynamicVar',
+          },
+        },
+      ],
+    },
+    {
+      code: 'const myVar = process.env[`MY_${VAR}`];',
+      errors: [
+        {
+          messageId: 'unexpectedDynamicAccess',
+          data: {
+            value: '',
           },
         },
       ],

--- a/packages/eslint-plugin-expo/src/rules/no-dynamic-env-var.ts
+++ b/packages/eslint-plugin-expo/src/rules/no-dynamic-env-var.ts
@@ -31,6 +31,20 @@ export const noDynamicEnvVar = createRule({
           node.init.object.property.name === 'env';
 
         if (isProcessEnv && node.init?.type === 'MemberExpression' && node.init.computed) {
+          if (
+            node.init.property.type === 'Literal' &&
+            typeof node.init.property.value === 'string'
+          ) {
+            return;
+          }
+
+          if (node.init.property.type === 'TemplateLiteral') {
+            const templateLiteral = node.init.property;
+            if (templateLiteral.expressions.length === 0) {
+              return;
+            }
+          }
+
           const identifierName =
             node.init.property.type === 'Identifier' ? node.init.property.name : '';
           const literalValue =


### PR DESCRIPTION
# Why

`@tsconfig/strictest` wants `process.env['thing']` instead of `process.env.thing`, which conflicts with expo cli’s processing of bundler env vars.

The actual rule it's conflicting with is `noUncheckedIndexedAccess`: https://www.typescriptlang.org/tsconfig/#noPropertyAccessFromIndexSignature

Note that the rule would also be satisfied if typing the global env object.

Internal context from [Slack](https://exponent-internal.slack.com/archives/C5ERY0TAR/p1754948566951249).

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Inline env vars added with bracket notation in the babel plugin.
Update the eslint plugin to allow this.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Unit tests

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
