### PR TITLE
[docs] Update upgrade steps for reliability

### DIFF
--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -24,7 +24,7 @@ Install the new version of the Expo package:
 
 <Tabs>
   <Tab label="npm">
-    <Terminal cmd={['$ npm install --save expo@^53.0.0']} />
+    <Terminal cmd={['$ npm install expo@^53.0.0']} />
   </Tab>
   <Tab label="Yarn">
     <Terminal cmd={['$ yarn add expo@^53.0.0']} />

--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -45,9 +45,9 @@ Depending on which SDK you're upgrading to, substitute the `expo@^53.0.0` with t
 
 ### Upgrade dependencies
 
-Upgrade all dependencies to match the installed SDK version. Then run [expo-doctor](/develop/tools/#expo-doctor) to check for common problems.
+Upgrade all dependencies to match the installed SDK version. Then run [`expo-doctor`](/develop/tools/#expo-doctor) command to check for common problems.
 
-<Terminal cmd={['$ npx expo install --fix', '$ npx expo-doctor']} />
+<Terminal cmd={['$ npx expo install --fix', '', '$ npx expo-doctor']} />
 
 </Step>
 

--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -23,34 +23,21 @@ If you are looking to install a specific version of Expo Go, visit [expo.dev/go]
 Install the new version of the Expo package:
 
 <Tabs>
-<Tab label="npm">
-
-<Terminal
-  cmd={[
-    '# Install latest',
-    '$ npx expo install expo@latest',
-    '',
-    '# Install a specific SDK version (for example, SDK 53)',
-    '$ npx expo install expo@^53.0.0',
-  ]}
-/>
-
-</Tab>
-
-<Tab label="Yarn">
-
-<Terminal
-  cmd={[
-    '# Install latest',
-    '$ yarn expo install expo@latest',
-    '',
-    '# Install a specific SDK version (for example, SDK 53)',
-    '$ yarn expo install expo@^53.0.0',
-  ]}
-/>
-
-</Tab>
+  <Tab label="npm">
+    <Terminal cmd={['$ npm install --save expo@^53.0.0']} />
+  </Tab>
+  <Tab label="Yarn">
+    <Terminal cmd={['$ yarn add expo@^53.0.0']} />
+  </Tab>
+  <Tab label="pnpm">
+    <Terminal cmd={['$ pnpm add expo@^53.0.0']} />
+  </Tab>
+  <Tab label="Bun">
+    <Terminal cmd={['$ bun install expo@^53.0.0']} />
+  </Tab>
 </Tabs>
+
+Depending on which SDK you're upgrading to, substitute the `expo@^53.0.0` with the version range of the Expo SDK version you're targeting. For example, `expo@^53.0.0` stands for SDK 53.
 
 </Step>
 
@@ -58,9 +45,9 @@ Install the new version of the Expo package:
 
 ### Upgrade dependencies
 
-Upgrade all dependencies to match the installed SDK version.
+Upgrade all dependencies to match the installed SDK version. Then run [expo-doctor](/develop/tools/#expo-doctor) to check for common problems.
 
-<Terminal cmd={['$ npx expo install --fix']} />
+<Terminal cmd={['$ npx expo install --fix', '$ npx expo-doctor']} />
 
 </Step>
 


### PR DESCRIPTION
# Why

In the docs, since we have the ability to show tabs, there's no need to recommend users to use `npx expo install expo`. I think it's a little redundant, and given we instruct users to run `expo install --fix` (which they have to after) this doesn't add any clarity. In fact, it can fail in some cases.

We were also missing a step for users to run `expo-doctor` after uprgading. This should, imho, always be done, as there's new problems it may catch after an SDK upgrade, since it does dependency checks.

Might be controversial, and we haven't been super consistent in giving people these instructions, but this is the most reliable sequence for upgrading, as far as I'm aware. The only gotcha here would be that in a Beta, `npx expo-doctor` would have to be replaced with `npx expo-doctor@next`

# How

- Fan out install instructions for SDK versions
- Remove `@latest` variant, since I don't think we should recommend a blind upgrade to latest
- Add `expo-doctor` after `npx expo install --fix`
