### PR TITLE
[docs] Fix app config schema file reference for SDK 53

### DIFF
--- a/docs/pages/versions/v53.0.0/config/app.mdx
+++ b/docs/pages/versions/v53.0.0/config/app.mdx
@@ -6,7 +6,7 @@ maxHeadingDepth: 5
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
-import schema from '~/public/static/schemas/unversioned/app-config-schema.json';
+import schema from '~/public/static/schemas/v53.0.0/app-config-schema.json';
 import AppConfigSchemaTable from '~/ui/components/AppConfigSchemaTable';
 import { BoxLink } from '~/ui/components/BoxLink';
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

App config schema file reference points to `unversioned` in SDK 53, which is incorrect.

# How

<!--
How did you build this feature or fix this bug and why?
-->

In `v53.0.0/config/app.mdx`, update the `schema` reference to SDK 53.0.0 versioned file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs app locally and visit: http://localhost:3002/versions/v53.0.0/config/app/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
