### PR TITLE
[metro-runtime]: Add upstream fix for promise rejection tracking

### DIFF
--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Show `console.error` and LogBox for unhandled promise rejection in development ([#38834](https://github.com/expo/expo/pull/38834) by [@krystofwoldrich](https://github.com/krystofwoldrich))
+
 ### 💡 Others
 
 ## 6.0.0 — 2025-08-13

--- a/packages/@expo/metro-runtime/build/promiseRejectionTracking.d.ts
+++ b/packages/@expo/metro-runtime/build/promiseRejectionTracking.d.ts
@@ -1,0 +1,2 @@
+export declare function enablePromiseRejectionTracking(): void;
+//# sourceMappingURL=promiseRejectionTracking.d.ts.map

--- a/packages/@expo/metro-runtime/build/promiseRejectionTracking.d.ts.map
+++ b/packages/@expo/metro-runtime/build/promiseRejectionTracking.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"promiseRejectionTracking.d.ts","sourceRoot":"","sources":["../src/promiseRejectionTracking.ts"],"names":[],"mappings":"AACA,wBAAgB,8BAA8B,SAAK"}

--- a/packages/@expo/metro-runtime/build/promiseRejectionTracking.native.d.ts
+++ b/packages/@expo/metro-runtime/build/promiseRejectionTracking.native.d.ts
@@ -1,0 +1,2 @@
+export declare function enablePromiseRejectionTracking(): void;
+//# sourceMappingURL=promiseRejectionTracking.native.d.ts.map

--- a/packages/@expo/metro-runtime/build/promiseRejectionTracking.native.d.ts.map
+++ b/packages/@expo/metro-runtime/build/promiseRejectionTracking.native.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"promiseRejectionTracking.native.d.ts","sourceRoot":"","sources":["../src/promiseRejectionTracking.native.ts"],"names":[],"mappings":"AAgBA,wBAAgB,8BAA8B,SA8C7C"}
+{"version":3,"file":"promiseRejectionTracking.native.d.ts","sourceRoot":"","sources":["../src/promiseRejectionTracking.native.ts"],"names":[],"mappings":"AAgBA,wBAAgB,8BAA8B,SAwD7C"}

--- a/packages/@expo/metro-runtime/build/promiseRejectionTracking.native.d.ts.map
+++ b/packages/@expo/metro-runtime/build/promiseRejectionTracking.native.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"promiseRejectionTracking.native.d.ts","sourceRoot":"","sources":["../src/promiseRejectionTracking.native.ts"],"names":[],"mappings":"AAgBA,wBAAgB,8BAA8B,SA8C7C"}

--- a/packages/@expo/metro-runtime/package.json
+++ b/packages/@expo/metro-runtime/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "anser": "^1.4.9",
     "stacktrace-parser": "^0.1.10",
+    "pretty-format": "^29.7.0",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/@expo/metro-runtime/src/index.ts
+++ b/packages/@expo/metro-runtime/src/index.ts
@@ -9,12 +9,10 @@ import './location/install';
 
 import '@expo/metro-runtime/rsc/runtime';
 
-import { enablePromiseRejectionTracking } from './promiseRejectionTracking';
-
 if (__DEV__) {
   // TODO: Remove when fixed upstream. Expected in RN 0.82.
   // https://github.com/facebook/react-native/commit/c4082c9ce208a324c2d011823ca2ba432411aafc
-  enablePromiseRejectionTracking();
+  require('./promiseRejectionTracking').enablePromiseRejectionTracking();
 }
 
 if (__DEV__) {

--- a/packages/@expo/metro-runtime/src/index.ts
+++ b/packages/@expo/metro-runtime/src/index.ts
@@ -9,6 +9,14 @@ import './location/install';
 
 import '@expo/metro-runtime/rsc/runtime';
 
+import { enablePromiseRejectionTracking } from './promiseRejectionTracking';
+
+if (__DEV__) {
+  // TODO: Remove when fixed upstream. Expected in RN 0.82.
+  // https://github.com/facebook/react-native/commit/c4082c9ce208a324c2d011823ca2ba432411aafc
+  enablePromiseRejectionTracking();
+}
+
 if (__DEV__) {
   // @ts-expect-error: TODO: Remove this when we remove the log box.
   globalThis.__expo_dev_resetErrors = require('./error-overlay/LogBox').default.clearAllLogs;

--- a/packages/@expo/metro-runtime/src/promiseRejectionTracking.ts
+++ b/packages/@expo/metro-runtime/src/promiseRejectionTracking.ts
@@ -1,0 +1,2 @@
+// NOTE(@krystofwoldrich): This is only needed for native runtimes (hermes)
+export function enablePromiseRejectionTracking() {}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Changes to general error and rejection handling are coming in RN 0.82 -> https://github.com/facebook/react-native/pull/51594#issuecomment-3084710875

- https://github.com/facebook/react-native/pull/51594#issuecomment-3084710875

Since SDK 54 will ship with RN 0.81. This PR pick the upstream fix I did in RN and add it to the `@expo/metro-runtime`. 

Having the code here also let us change handling of the stack traces, as I believe the logbox should primarily show the rejection stack if available. The stack of the wrapper error won't be useful to the user.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Pull https://github.com/facebook/react-native/commit/c4082c9ce208a324c2d011823ca2ba432411aafc changes and adjust error stack handling.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Before this PR, there would be no console log and no logbox for uncaught promise rejection.

After this PR the are both.

Example: 

 
<img width="216" alt="Screenshot 2025-08-14 at 15 59 19" src="https://github.com/user-attachments/assets/6ae205e9-5e73-4e4a-9c31-16d36278a974" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
