### PR TITLE
[docs] add sdk 54+ info to link preview

### DIFF
--- a/docs/pages/router/reference/link-preview.mdx
+++ b/docs/pages/router/reference/link-preview.mdx
@@ -5,6 +5,8 @@ description: Learn how to add a preview to your link on iOS when using Expo Rout
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
+> **important** Link preview is an iOS-only feature available in SDK 54 and above.
+
 <ContentSpotlight
   alt="A video presenting the link preview feature in Expo Router."
   file="expo-router/link-preview.mp4"


### PR DESCRIPTION
# Why

The info about SDK 54 was missing from link preview docs

<!-- disable:changelog-checks -->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
