### PR TITLE
[eas-expo-go] avoid unintended shell command execution

### DIFF
--- a/apps/eas-expo-go/scripts/eas-build-on-success.sh
+++ b/apps/eas-expo-go/scripts/eas-build-on-success.sh
@@ -71,8 +71,8 @@ if [[ "$EAS_BUILD_PROFILE" == "publish-client" ]]; then
 
   source $ROOT_DIR/secrets/expotools.env
   if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
-    notify_slack "Successful Expo Go Android APK build. Run `et eas android-apk-upload` to upload to GitHub" "$MESSAGE"
+    notify_slack "Successful Expo Go Android APK build. Run \`et eas android-apk-upload\` to upload to GitHub" "$MESSAGE"
   elif [[ "$EAS_BUILD_PLATFORM" == "ios" ]]; then
-    notify_slack "Successful Expo Go iOS simulator build. Run et `eas ios-simulator-upload` to upload to GitHub" "$MESSAGE"
+    notify_slack "Successful Expo Go iOS simulator build. Run \`et eas ios-simulator-upload\` to upload to GitHub" "$MESSAGE"
   fi
 fi


### PR DESCRIPTION
# Why

fix `./scripts/eas-build-on-success.sh` script by properly escaping backticks around command examples. Currently, the shell attempts to execute what's in the backticks: `./scripts/eas-build-on-success.sh: line 76: eas: command not found`

# How

Added proper escaping to the backticks to avoid execution.

# Test Plan

- tested locally with 
```
echo "Successful Expo Go Android APK build. Run `et eas android-apk-upload` to upload to GitHub"
```

(fails)

```
echo "Successful Expo Go Android APK build. Run \`et eas android-apk-upload\` to upload to GitHub"
```

(works)


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)