### PR TITLE
[build-properties] Add ios.reactNativeReleaseLevel option

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `ios.reactNativeReleaseLevel` option ([#38840](https://github.com/expo/expo/pull/38840) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-build-properties/build/ios.d.ts
+++ b/packages/expo-build-properties/build/ios.d.ts
@@ -2,3 +2,4 @@ import { ConfigPlugin } from 'expo/config-plugins';
 import type { PluginConfigType } from './pluginConfig';
 export declare const withIosBuildProperties: ConfigPlugin<PluginConfigType>;
 export declare const withIosDeploymentTarget: ConfigPlugin<PluginConfigType>;
+export declare const withIosInfoPlist: ConfigPlugin<PluginConfigType>;

--- a/packages/expo-build-properties/build/ios.js
+++ b/packages/expo-build-properties/build/ios.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.withIosDeploymentTarget = exports.withIosBuildProperties = void 0;
+exports.withIosInfoPlist = exports.withIosDeploymentTarget = exports.withIosBuildProperties = void 0;
 const config_plugins_1 = require("expo/config-plugins");
 const { createBuildPodfilePropsConfigPlugin } = config_plugins_1.IOSConfig.BuildProperties;
 exports.withIosBuildProperties = createBuildPodfilePropsConfigPlugin([
@@ -8,7 +8,8 @@ exports.withIosBuildProperties = createBuildPodfilePropsConfigPlugin([
         propName: 'newArchEnabled',
         propValueGetter: (config) => {
             if (config.ios?.newArchEnabled !== undefined) {
-                config_plugins_1.WarningAggregator.addWarningIOS('withIosBuildProperties', 'ios.newArchEnabled is deprecated, use app config `newArchEnabled` instead.', 'https://docs.expo.dev/versions/latest/config/app/#newarchenabled');
+                config_plugins_1.WarningAggregator.addWarningIOS('withIosBuildProperties', 'ios.newArchEnabled is deprecated, use app config `newArchEnabled` instead.\n' +
+                    'https://docs.expo.dev/versions/latest/config/app/#newarchenabled');
             }
             return config.ios?.newArchEnabled?.toString();
         },
@@ -53,6 +54,20 @@ const withIosDeploymentTarget = (config, props) => {
     return config;
 };
 exports.withIosDeploymentTarget = withIosDeploymentTarget;
+const withIosInfoPlist = (config, props) => {
+    const reactNativeReleaseLevel = props.ios?.reactNativeReleaseLevel;
+    if (reactNativeReleaseLevel) {
+        config = withIosReactNativeReleaseLevel(config, { reactNativeReleaseLevel });
+    }
+    return config;
+};
+exports.withIosInfoPlist = withIosInfoPlist;
+const withIosReactNativeReleaseLevel = (config, { reactNativeReleaseLevel }) => {
+    return (0, config_plugins_1.withInfoPlist)(config, (config) => {
+        config.modResults['ReactNativeReleaseLevel'] = reactNativeReleaseLevel;
+        return config;
+    });
+};
 const withIosDeploymentTargetXcodeProject = (config, props) => {
     return (0, config_plugins_1.withXcodeProject)(config, (config) => {
         config.modResults = updateDeploymentTargetXcodeProject(config.modResults, props.deploymentTarget);

--- a/packages/expo-build-properties/build/pluginConfig.d.ts
+++ b/packages/expo-build-properties/build/pluginConfig.d.ts
@@ -339,6 +339,13 @@ export interface PluginConfigTypeIos {
      * @deprecated Use `buildReactNativeFromSource` instead.
      */
     buildFromSource?: boolean;
+    /**
+     * The React Native release level to use for the project.
+     * This can be used to enable different sets of internal React Native feature flags.
+     *
+     * @default 'stable'
+     */
+    reactNativeReleaseLevel?: 'stable' | 'canary' | 'experimental';
 }
 /**
  * Interface representing extra CocoaPods dependency.

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -182,6 +182,11 @@ const schema = {
                 },
                 buildReactNativeFromSource: { type: 'boolean', nullable: true },
                 buildFromSource: { type: 'boolean', nullable: true },
+                reactNativeReleaseLevel: {
+                    type: 'string',
+                    enum: ['stable', 'canary', 'experimental'],
+                    nullable: true,
+                },
             },
             nullable: true,
         },

--- a/packages/expo-build-properties/build/withBuildProperties.js
+++ b/packages/expo-build-properties/build/withBuildProperties.js
@@ -26,6 +26,7 @@ const withBuildProperties = (config, props) => {
     config = (0, android_1.withAndroidDayNightTheme)(config, pluginConfig);
     config = (0, ios_1.withIosBuildProperties)(config, pluginConfig);
     config = (0, ios_1.withIosDeploymentTarget)(config, pluginConfig);
+    config = (0, ios_1.withIosInfoPlist)(config, pluginConfig);
     return config;
 };
 exports.withBuildProperties = withBuildProperties;

--- a/packages/expo-build-properties/src/ios.ts
+++ b/packages/expo-build-properties/src/ios.ts
@@ -1,9 +1,10 @@
 import {
-  IOSConfig,
   ConfigPlugin,
-  withXcodeProject,
-  XcodeProject,
+  IOSConfig,
   WarningAggregator,
+  XcodeProject,
+  withInfoPlist,
+  withXcodeProject,
 } from 'expo/config-plugins';
 
 import type { PluginConfigType } from './pluginConfig';
@@ -18,8 +19,8 @@ export const withIosBuildProperties = createBuildPodfilePropsConfigPlugin<Plugin
         if (config.ios?.newArchEnabled !== undefined) {
           WarningAggregator.addWarningIOS(
             'withIosBuildProperties',
-            'ios.newArchEnabled is deprecated, use app config `newArchEnabled` instead.',
-            'https://docs.expo.dev/versions/latest/config/app/#newarchenabled'
+            'ios.newArchEnabled is deprecated, use app config `newArchEnabled` instead.\n' +
+              'https://docs.expo.dev/versions/latest/config/app/#newarchenabled'
           );
         }
         return config.ios?.newArchEnabled?.toString();
@@ -70,6 +71,24 @@ export const withIosDeploymentTarget: ConfigPlugin<PluginConfigType> = (config, 
   config = withIosDeploymentTargetPodfile(config, props);
 
   return config;
+};
+
+export const withIosInfoPlist: ConfigPlugin<PluginConfigType> = (config, props) => {
+  const reactNativeReleaseLevel = props.ios?.reactNativeReleaseLevel;
+  if (reactNativeReleaseLevel) {
+    config = withIosReactNativeReleaseLevel(config, { reactNativeReleaseLevel });
+  }
+
+  return config;
+};
+
+const withIosReactNativeReleaseLevel: ConfigPlugin<{
+  reactNativeReleaseLevel: 'stable' | 'canary' | 'experimental';
+}> = (config, { reactNativeReleaseLevel }) => {
+  return withInfoPlist(config, (config) => {
+    config.modResults['ReactNativeReleaseLevel'] = reactNativeReleaseLevel;
+    return config;
+  });
 };
 
 const withIosDeploymentTargetXcodeProject: ConfigPlugin<{ deploymentTarget: string }> = (

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -395,6 +395,14 @@ export interface PluginConfigTypeIos {
    * @deprecated Use `buildReactNativeFromSource` instead.
    */
   buildFromSource?: boolean;
+
+  /**
+   * The React Native release level to use for the project.
+   * This can be used to enable different sets of internal React Native feature flags.
+   *
+   * @default 'stable'
+   */
+  reactNativeReleaseLevel?: 'stable' | 'canary' | 'experimental';
 }
 
 /**
@@ -750,6 +758,11 @@ const schema: JSONSchemaType<PluginConfigType> = {
         },
         buildReactNativeFromSource: { type: 'boolean', nullable: true },
         buildFromSource: { type: 'boolean', nullable: true },
+        reactNativeReleaseLevel: {
+          type: 'string',
+          enum: ['stable', 'canary', 'experimental'],
+          nullable: true,
+        },
       },
       nullable: true,
     },

--- a/packages/expo-build-properties/src/withBuildProperties.ts
+++ b/packages/expo-build-properties/src/withBuildProperties.ts
@@ -2,14 +2,14 @@ import { ConfigPlugin } from 'expo/config-plugins';
 
 import {
   withAndroidBuildProperties,
+  withAndroidCleartextTraffic,
+  withAndroidDayNightTheme,
   withAndroidProguardRules,
   withAndroidPurgeProguardRulesOnce,
-  withAndroidCleartextTraffic,
   withAndroidQueries,
-  withAndroidDayNightTheme,
   withAndroidSettingsGradle,
 } from './android';
-import { withIosBuildProperties, withIosDeploymentTarget } from './ios';
+import { withIosBuildProperties, withIosDeploymentTarget, withIosInfoPlist } from './ios';
 import { PluginConfigType, validateConfig } from './pluginConfig';
 
 /**
@@ -37,6 +37,7 @@ export const withBuildProperties: ConfigPlugin<PluginConfigType> = (config, prop
 
   config = withIosBuildProperties(config, pluginConfig);
   config = withIosDeploymentTarget(config, pluginConfig);
+  config = withIosInfoPlist(config, pluginConfig);
 
   return config;
 };

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -86,7 +86,7 @@
     self.shouldPreferUpdatesInterfaceSourceUrl = NO;
 
     self.dependencyProvider = [RCTAppDependencyProvider new];
-    self.reactNativeFactory = [[EXDevLauncherReactNativeFactory alloc] initWithDelegate:self];
+    self.reactNativeFactory = [[EXDevLauncherReactNativeFactory alloc] initWithDelegate:self releaseLevel:[self getReactNativeReleaseLevel]];
   }
   return self;
 }
@@ -340,12 +340,12 @@
 
   [self _addInitModuleObserver];
 #endif
-  
+
   DevLauncherViewController *swiftUIViewController = [[DevLauncherViewController alloc] init];
-  
+
   _window.rootViewController = swiftUIViewController;
   [_window makeKeyAndVisible];
-  
+
   dispatch_async(dispatch_get_main_queue(), ^{
     [self onAppContentDidAppear];
   });
@@ -716,6 +716,25 @@
   NSString *buildVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
   NSString *appVersion = [NSString stringWithFormat:@"%@ (%@)", shortVersion, buildVersion];
   return appVersion;
+}
+
+-(RCTReleaseLevel)getReactNativeReleaseLevel
+{
+//  @TODO: Read this value from the main react-native factory instance on 0.82
+  NSString *releaseLevelString = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"ReactNativeReleaseLevel"];
+  RCTReleaseLevel releaseLevel = Stable;
+  if ([releaseLevelString isKindOfClass:[NSString class]]) {
+    NSString *lower = [releaseLevelString lowercaseString];
+    if ([lower isEqualToString:@"canary"]) {
+      releaseLevel = Canary;
+    } else if ([lower isEqualToString:@"experimental"]) {
+      releaseLevel = Experimental;
+    } else if ([lower isEqualToString:@"stable"]) {
+      releaseLevel = Stable;
+    }
+  }
+
+  return releaseLevel;
 }
 
 -(void)copyToClipboard:(NSString *)content {

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -5,6 +5,19 @@ import React
 @MainActor public class ExpoReactNativeFactory: RCTReactNativeFactory {
   private let reactDelegate = ExpoReactDelegate(handlers: ExpoAppDelegateSubscriberRepository.reactDelegateHandlers)
 
+  @objc public override init(delegate: any RCTReactNativeFactoryDelegate) {
+    let releaseLevel = (Bundle.main.object(forInfoDictionaryKey: "ReactNativeReleaseLevel") as? String)
+      .flatMap { [
+        "canary": RCTReleaseLevel.Canary,
+        "experimental": RCTReleaseLevel.Experimental,
+        "stable": RCTReleaseLevel.Stable
+      ][$0.lowercased()]
+      }
+    ?? RCTReleaseLevel.Stable
+
+    super.init(delegate: delegate, releaseLevel: releaseLevel)
+  }
+
   @objc func createRCTRootViewFactory() -> RCTRootViewFactory {
     // Alan: This is temporary. We need to cast to ExpoReactNativeFactoryDelegate here because currently, if you extend RCTReactNativeFactory
     // from Swift, customizeRootView will not work on the new arch because the cast to RCTRootView will never


### PR DESCRIPTION
# Why

iOS implementation of https://github.com/expo/expo/pull/38698

Meta recently introduced a release-level configuration into react native in order to allow users to enable a specific set of feature flags. This will be used to test fixes for things such as the starvation bug in the new architecture faced by Reanimated.
Given this context, we should allow CNG users to set a custom release level.

# How

Add `ios.reactNativeReleaseLevel` option to build-properties and updated `ExpoReactNativeFactory.swift` and `EXDevLauncherController.m` classes to read the configured value from info.plist

# Test Plan

In the sandbox folder: `npx expo prebuild -p ios --clean`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
