### PR TITLE
[ios][dev-launcher] Recent apps server status

### DIFF
--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
@@ -77,7 +77,7 @@ struct RecentlyOpenedAppRow: View {
     let port = url.port else {
       return false
     }
-    
+
     return viewModel.devServers.contains { server in
       guard let serverURL = URL(string: server.url),
         let serverPort = serverURL.port else {

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
@@ -70,6 +70,22 @@ public struct DevLauncherRootView: View {
 struct RecentlyOpenedAppRow: View {
   let app: RecentlyOpenedApp
   let onTap: () -> Void
+  @EnvironmentObject var viewModel: DevLauncherViewModel
+
+  private var isServerActive: Bool {
+    guard let url = URL(string: app.url),
+    let port = url.port else {
+      return false
+    }
+    
+    return viewModel.devServers.contains { server in
+      guard let serverURL = URL(string: server.url),
+        let serverPort = serverURL.port else {
+        return false
+      }
+      return serverPort == port
+    }
+  }
 
   var body: some View {
     Button {
@@ -77,7 +93,7 @@ struct RecentlyOpenedAppRow: View {
     } label: {
       HStack(alignment: .center) {
         Circle()
-          .fill(Color.green)
+          .fill(isServerActive ? Color.green : Color.gray)
           .frame(width: 12, height: 12)
         VStack(alignment: .leading) {
           Text(app.name)


### PR DESCRIPTION
# Why
https://exponent-internal.slack.com/archives/C011V63429H/p1755179802832699

# How
We should compare the servers in the active list to the ones in the recently opened apps to determine whether we show that app has an active server running on that port.

# Test Plan

<img width="350" height="759" alt="Simulator Screenshot - iPhone 16 - 2025-08-14 at 15 25 33" src="https://github.com/user-attachments/assets/adffd9e0-4935-4583-b99c-c3480b79bf85" />

