### PR TITLE
[ios][dev-launcher] Fix colors in dark mode

### DIFF
--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
@@ -112,7 +112,7 @@ struct RecentlyOpenedAppRow: View {
       }
       .padding()
 #if !os(tvOS)
-      .background(Color(.systemGroupedBackground))
+      .background(Color(.secondarySystemBackground))
 #endif
       .clipShape(RoundedRectangle(cornerRadius: 12))
     }

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -90,7 +90,7 @@ struct DevServersView: View {
     .animation(.easeInOut, value: showingURLInput)
     .padding()
 #if !os(tvOS)
-    .background(Color(showingURLInput ? .systemGroupedBackground : .systemBackground))
+    .background(Color(showingURLInput ? .secondarySystemBackground : .systemBackground))
 #endif
     .clipShape(RoundedRectangle(cornerRadius: 12))
   }
@@ -173,7 +173,7 @@ struct DevServerRow: View {
       }
       .padding()
 #if !os(tvOS)
-      .background(Color(.systemGroupedBackground))
+      .background(Color(.secondarySystemBackground))
 #endif
       .clipShape(RoundedRectangle(cornerRadius: 12))
     }

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -69,7 +69,7 @@ struct SettingsTabView: View {
     }
     .padding()
 #if !os(tvOS)
-    .background(Color(.systemGroupedBackground))
+    .background(Color(.secondarySystemBackground))
 #endif
     .cornerRadius(12)
   }
@@ -81,7 +81,7 @@ struct SettingsTabView: View {
         Image(systemName: "gearshape")
           .resizable()
           .frame(width: 56, height: 56)
-          .foregroundColor(.black.opacity(0.3))
+          .opacity(0.3)
 
         Text("Settings")
           .font(.title2)
@@ -119,7 +119,7 @@ struct SettingsTabView: View {
         .padding()
       }
 #if !os(tvOS)
-      .background(Color(.systemGroupedBackground))
+      .background(Color(.secondarySystemBackground))
 #endif
       .cornerRadius(12)
     }

--- a/packages/expo-dev-menu/ios/SwiftUI/CustomItems.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/CustomItems.swift
@@ -27,7 +27,7 @@ struct CustomItems: View {
             .padding()
           }
           #if !os(tvOS)
-          .background(Color(.systemGroupedBackground))
+          .background(Color(.secondarySystemBackground))
           #endif
           .clipShape(RoundedRectangle(cornerRadius: 12))
         }


### PR DESCRIPTION
# Why
Fixes some background colors that became invisible in dark mode

# Test Plan
<img width="350" height="759" alt="Simulator Screenshot - iPhone 16 - 2025-08-14 at 16 02 45" src="https://github.com/user-attachments/assets/19504c93-198b-4a8f-98f6-08ebe85fce88" />
<img width="350" height="759" alt="Simulator Screenshot - iPhone 16 - 2025-08-14 at 16 02 43" src="https://github.com/user-attachments/assets/a83d5864-86ef-48d0-91dd-d2e0d50e1a85" />


