### PR TITLE
chore: Fix `typescript@5.9.2` type errors in tests

### DIFF
--- a/packages/eslint-config-universe/__tests__/__snapshots__/typescript-analysis-test.js.snap
+++ b/packages/eslint-config-universe/__tests__/__snapshots__/typescript-analysis-test.js.snap
@@ -27,14 +27,14 @@ exports[`lints: fixtures/typescript-analysis-00.ts 1`] = `
     },
     {
       "column": 3,
-      "endColumn": 33,
+      "endColumn": 53,
       "endLine": 24,
       "fix": {
         "range": [
           312,
-          342,
+          362,
         ],
-        "text": "foo?.a?.b.method",
+        "text": "foo?.a?.b.method?.()",
       },
       "line": 24,
       "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",

--- a/packages/eslint-config-universe/flat/__tests__/__snapshots__/typescript-analysis-test.js.snap
+++ b/packages/eslint-config-universe/flat/__tests__/__snapshots__/typescript-analysis-test.js.snap
@@ -27,14 +27,14 @@ exports[`lints: fixtures/typescript-analysis-00.ts 1`] = `
     },
     {
       "column": 3,
-      "endColumn": 33,
+      "endColumn": 53,
       "endLine": 24,
       "fix": {
         "range": [
           312,
-          342,
+          362,
         ],
-        "text": "foo?.a?.b.method",
+        "text": "foo?.a?.b.method?.()",
       },
       "line": 24,
       "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",

--- a/packages/expo/src/winter/fetch/__tests__/RequestUtils-test.ts
+++ b/packages/expo/src/winter/fetch/__tests__/RequestUtils-test.ts
@@ -5,7 +5,7 @@
 
 import { TextDecoder, TextEncoder } from 'node:util';
 import RNFormData from 'react-native/Libraries/Network/FormData';
-import { ReadableStream } from 'web-streams-polyfill';
+import { ReadableStream as WebReadableStream } from 'web-streams-polyfill';
 
 import { type NativeHeadersType } from '../NativeRequest';
 import {
@@ -25,12 +25,12 @@ globalThis.TextEncoder ??= TextEncoder;
 
 describe(convertReadableStreamToUint8ArrayAsync, () => {
   it('should convert a readable stream to a Uint8Array', async () => {
-    const stream = new ReadableStream<Uint8Array>({
+    const stream = new WebReadableStream<Uint8Array>({
       start(controller) {
         controller.enqueue(new TextEncoder().encode('Hello, world!'));
         controller.close();
       },
-    });
+    }) as ReadableStream<Uint8Array>;
 
     const result = await convertReadableStreamToUint8ArrayAsync(stream);
     const resultString = new TextDecoder().decode(result);
@@ -38,22 +38,22 @@ describe(convertReadableStreamToUint8ArrayAsync, () => {
   });
 
   it('should handle an empty readable stream', async () => {
-    const stream = new ReadableStream({
+    const stream = new WebReadableStream({
       start(controller) {
         controller.close();
       },
-    });
+    }) as ReadableStream;
 
     const result = await convertReadableStreamToUint8ArrayAsync(stream);
     expect(result).toEqual(new Uint8Array());
   });
 
   it('should handle errors in the readable stream', async () => {
-    const stream = new ReadableStream({
+    const stream = new WebReadableStream({
       start(controller) {
         controller.error(new Error('Stream error'));
       },
-    });
+    }) as ReadableStream;
 
     await expect(convertReadableStreamToUint8ArrayAsync(stream)).rejects.toThrow('Stream error');
   });


### PR DESCRIPTION
# Why

Follow-up to #38833

Some types in jest are failing as a result

# How

- Fix `expo` test `web-stream-polyfills`' ReadableStream not matching TS' type anymore
- Update typescript snapshots for `eslint-config-universe`

# Test Plan

- CI should run changed tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
