### PR TITLE
[autolinking][tests] Fix typo

### DIFF
--- a/packages/expo-modules-autolinking/src/reactNativeConfig/__tests__/config-test.ts
+++ b/packages/expo-modules-autolinking/src/reactNativeConfig/__tests__/config-test.ts
@@ -27,7 +27,7 @@ describe(loadConfigAsync, () => {
   // This test case should be the first of react-native.config.ts test cases.
   // Because we cache the resolved typescript module, as long as typescript is resolved,
   // we have no longer to resolve typescript as mocked undefined result.
-  it('should return null for react-native.confif.ts if typescript is not found', async () => {
+  it('should return null for react-native.config.ts if typescript is not found', async () => {
     await jest.isolateModulesAsync(async () => {
       vol.fromJSON({
         '/app/react-native.config.ts': 'module.exports = { version: "1.0.0" };',


### PR DESCRIPTION
# Why

Just a nit that I notice while working on autolinking

# How

Fix typo in test description

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
