### PR TITLE
chore: clean up template more and use better SDK 54 features

### DIFF
--- a/templates/expo-template-default/app.json
+++ b/templates/expo-template-default/app.json
@@ -20,7 +20,6 @@
       "predictiveBackGestureEnabled": true
     },
     "web": {
-      "bundler": "metro",
       "output": "static",
       "favicon": "./assets/images/favicon.png"
     },

--- a/templates/expo-template-default/components/external-link.tsx
+++ b/templates/expo-template-default/components/external-link.tsx
@@ -1,7 +1,6 @@
 import { Href, Link } from 'expo-router';
-import { openBrowserAsync } from 'expo-web-browser';
+import { openBrowserAsync, WebBrowserPresentationStyle } from 'expo-web-browser';
 import { type ComponentProps } from 'react';
-import { Platform } from 'react-native';
 
 type Props = Omit<ComponentProps<typeof Link>, 'href'> & { href: Href & string };
 
@@ -12,11 +11,13 @@ export function ExternalLink({ href, ...rest }: Props) {
       {...rest}
       href={href}
       onPress={async (event) => {
-        if (Platform.OS !== 'web') {
+        if (process.env.EXPO_OS !== 'web') {
           // Prevent the default behavior of linking to the default browser on native.
           event.preventDefault();
           // Open the link in an in-app browser.
-          await openBrowserAsync(href);
+          await openBrowserAsync(href, {
+            presentationStyle: WebBrowserPresentationStyle.AUTOMATIC,
+          });
         }
       }}
     />

--- a/templates/expo-template-default/components/hello-wave.tsx
+++ b/templates/expo-template-default/components/hello-wave.tsx
@@ -1,27 +1,19 @@
-import { StyleSheet } from 'react-native';
 import Animated from 'react-native-reanimated';
-import { ThemedText } from '@/components/themed-text';
 
 export function HelloWave() {
   return (
-    <Animated.View
+    <Animated.Text
       style={{
+        fontSize: 28,
+        lineHeight: 32,
+        marginTop: -6,
         animationName: {
           '50%': { transform: [{ rotate: '25deg' }] },
         },
-        animationFillMode: 'none',
         animationIterationCount: 4,
         animationDuration: '300ms',
       }}>
-      <ThemedText style={styles.text}>👋</ThemedText>
-    </Animated.View>
+      👋
+    </Animated.Text>
   );
 }
-
-const styles = StyleSheet.create({
-  text: {
-    fontSize: 28,
-    lineHeight: 32,
-    marginTop: -6,
-  },
-});

--- a/templates/expo-template-default/components/parallax-scroll-view.tsx
+++ b/templates/expo-template-default/components/parallax-scroll-view.tsx
@@ -9,6 +9,7 @@ import Animated, {
 
 import { ThemedView } from '@/components/themed-view';
 import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useThemeColor } from '@/hooks/use-theme-color';
 
 const HEADER_HEIGHT = 250;
 
@@ -22,6 +23,7 @@ export default function ParallaxScrollView({
   headerImage,
   headerBackgroundColor,
 }: Props) {
+  const backgroundColor = useThemeColor({}, 'background');
   const colorScheme = useColorScheme() ?? 'light';
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
   const scrollOffset = useScrollOffset(scrollRef);
@@ -43,19 +45,20 @@ export default function ParallaxScrollView({
   });
 
   return (
-    <ThemedView style={styles.container}>
-      <Animated.ScrollView ref={scrollRef} scrollEventThrottle={16}>
-        <Animated.View
-          style={[
-            styles.header,
-            { backgroundColor: headerBackgroundColor[colorScheme] },
-            headerAnimatedStyle,
-          ]}>
-          {headerImage}
-        </Animated.View>
-        <ThemedView style={styles.content}>{children}</ThemedView>
-      </Animated.ScrollView>
-    </ThemedView>
+    <Animated.ScrollView
+      ref={scrollRef}
+      style={{ backgroundColor, flex: 1 }}
+      scrollEventThrottle={16}>
+      <Animated.View
+        style={[
+          styles.header,
+          { backgroundColor: headerBackgroundColor[colorScheme] },
+          headerAnimatedStyle,
+        ]}>
+        {headerImage}
+      </Animated.View>
+      <ThemedView style={styles.content}>{children}</ThemedView>
+    </Animated.ScrollView>
   );
 }
 


### PR DESCRIPTION
# Why

- hello wave with one view.
- use automatic presentation for web browser.
- remove Platform.OS constant.
- remove wrapper view for scroll view—better stack header and tab handling.
- remove `bundler: "metro"` as it's the default unless expo/webpack is installed.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
