### PR TITLE
chore(CLI): use relative paths in missing imports errors

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- use relative paths in missing imports errors ([#38853](https://github.com/expo/expo/pull/38853) by [@EvanBacon](https://github.com/EvanBacon))
+
 ## 0.25.0 — 2025-08-13
 
 ### 🛠 Breaking changes

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -671,7 +671,7 @@ export function withExtendedResolver(
             )
           ) {
             throw new FailedToResolvePathError(
-              `Importing native-only module "${moduleName}" on web from: ${context.originModulePath}`
+              `Importing native-only module "${moduleName}" on web from: ${path.relative(config.projectRoot, context.originModulePath)}`
             );
           }
 


### PR DESCRIPTION
# Why

- Make the errors a bit more normalized and reduce unused context.
