### PR TITLE
[ios][dev-menu] Fast refresh toggle

### DIFF
--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
@@ -92,7 +92,6 @@ class DevMenuViewModel: ObservableObject {
 
   func toggleFastRefresh() {
     devMenuManager.toggleFastRefresh()
-    devMenuManager.closeMenu()
     loadDevSettings()
   }
 


### PR DESCRIPTION
# Why
https://exponent-internal.slack.com/archives/C011V63429H/p1755200291633339
It makes sense to keep the dev menu open when toggling fast refresh because it uses a visual toggle. 

# How
Remove function call to close the menu

# Test Plan
Bare expo

