### PR TITLE
chore: re-align `@types/react` for `react@19.1.0`

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -82,7 +82,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@types/react": "~19.0.10",
+    "@types/react": "~19.1.10",
     "babel-plugin-module-resolver": "^5.0.2",
     "babel-preset-expo": "~14.0.0",
     "expo-module-scripts": "^5.0.0",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -100,7 +100,7 @@
     "@graphql-codegen/typescript-react-apollo": "^3.2.1",
     "@types/dedent": "^0.7.0",
     "@types/jest": "^29.2.1",
-    "@types/react": "~19.0.10",
+    "@types/react": "~19.1.10",
     "@types/semver": "^7.5.8",
     "expo-module-scripts": "^5.0.0"
   },

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -164,7 +164,7 @@
     "@types/fbemitter": "^2.0.32",
     "@types/i18n-js": "^3.0.1",
     "@types/pixi.js": "^4.8.6",
-    "@types/react": "~19.0.10",
+    "@types/react": "~19.1.10",
     "@types/three": "^0.137.0",
     "babel-jest": "^29.2.1",
     "expo-module-scripts": "^5.0.0",

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@types/jest": "^29.5.12",
-    "@types/react": "~19.0.10"
+    "@types/react": "~19.1.10"
   },
   "resolutions": {
     "react-test-renderer": "19.0.0"

--- a/packages/expo-maps/package.json
+++ b/packages/expo-maps/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "@types/react": "~19.0.10",
+    "@types/react": "~19.1.10",
     "expo-module-scripts": "^5.0.0"
   },
   "peerDependencies": {

--- a/packages/expo-mesh-gradient/package.json
+++ b/packages/expo-mesh-gradient/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "@types/react": "~19.0.10",
+    "@types/react": "~19.1.10",
     "expo-module-scripts": "^5.0.0"
   },
   "peerDependencies": {

--- a/packages/expo-ui/package.json
+++ b/packages/expo-ui/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
-    "@types/react": "~19.0.10",
+    "@types/react": "~19.1.10",
     "expo-module-scripts": "^5.0.0"
   },
   "peerDependencies": {

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -97,8 +97,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
-    "@types/react": "~19.0.10",
-    "@types/react-test-renderer": "^19.1.0",
+    "@types/react": "~19.1.10",
+    "@types/react-test-renderer": "~19.1.0",
     "expo-module-scripts": "^5.0.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4633,17 +4633,17 @@
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
 
-"@types/react-test-renderer@^19.1.0":
+"@types/react-test-renderer@~19.1.0":
   version "19.1.0"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz#1d0af8f2e1b5931e245b8b5b234d1502b854dc10"
   integrity sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@~19.0.10":
-  version "19.0.10"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.0.10.tgz#d0c66dafd862474190fe95ce11a68de69ed2b0eb"
-  integrity sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==
+"@types/react@*", "@types/react@~19.1.10":
+  version "19.1.10"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.1.10.tgz#a05015952ef328e1b85579c839a71304b07d21d9"
+  integrity sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==
   dependencies:
     csstype "^3.0.2"
 


### PR DESCRIPTION
# Why

The `react-native@0.81` upgrade brought us at `react@19.1.0`, but some workspaces still refered to `@types/react@19.0`.

# How

- Bumped up `@types/react` to `19.1.0` where `react` was set to `~19.1.0` as well

# Test Plan

See CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
