### PR TITLE
[android][screen-capture] Catch error when accessing event emitter

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Prevent hard crash when we cannot access the event emitter.
+- [Android] Prevent hard crash when we cannot access the event emitter. ([#38869](https://github.com/expo/expo/pull/38869) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Prevent hard crash when we cannot access the event emitter.
+
 ### 💡 Others
 
 ## 8.0.0 — 2025-08-13

--- a/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenCaptureModule.kt
+++ b/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenCaptureModule.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.os.Build
+import android.util.Log
 import android.view.WindowManager
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.kotlin.Promise
@@ -32,6 +33,14 @@ class ScreenCaptureModule : Module() {
   private var screenshotEventEmitter: ScreenshotEventEmitter? = null
   private var isRegistered = false
 
+  private fun emitEvent() {
+    try {
+      sendEvent(eventName)
+    } catch (error: Throwable) {
+      Log.e("ExpoScreenCapture", "Failed to emit event $eventName: ${error.message}")
+    }
+  }
+
   override fun definition() = ModuleDefinition {
     Name("ExpoScreenCapture")
 
@@ -40,13 +49,13 @@ class ScreenCaptureModule : Module() {
     OnCreate {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
         screenCaptureCallback = Activity.ScreenCaptureCallback {
-          sendEvent(eventName)
+          emitEvent()
         }
         // Let's try to register the callback
         registerCallback()
       } else {
         screenshotEventEmitter = ScreenshotEventEmitter(context) {
-          sendEvent(eventName)
+          emitEvent()
         }
       }
     }


### PR DESCRIPTION
# Why
Because we capture the `sendEvent` function in a lambda that we don't control, we can't be sure the event emitter will be accessible when it is called. Similar to `TaskManager` we should catch this error to prevent a hard crash.

# How
Wrap in try/catch

# Test Plan
Hard to reproduce as it's a timing issue

