### PR TITLE
[templates] upgrade react-native-screens to 4.14

### DIFF
--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -34,7 +34,7 @@
     "react-native-worklets": "~0.4.1",
     "react-native-reanimated": "~4.0.2",
     "react-native-safe-area-context": "5.5.2",
-    "react-native-screens": "~4.11.1",
+    "react-native-screens": "~4.14.0",
     "react-native-web": "~0.21.0",
     "react-native-webview": "13.15.0"
   },

--- a/templates/expo-template-tabs-react-navigation/package.json
+++ b/templates/expo-template-tabs-react-navigation/package.json
@@ -35,7 +35,7 @@
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "~4.10.0",
+    "react-native-screens": "~4.14.0",
     "react-native-web": "^0.20.0"
   },
   "devDependencies": {

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "react-native-worklets": "~0.4.1",
     "react-native-reanimated": "~4.0.2",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "~4.11.1",
+    "react-native-screens": "~4.14.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/38804, we need react-native-screens to use 4.14 in order to run react-native 0.81.0

# How

Upgrade react-native-screens to 4.14

# Test Plan

`tar -zcvf expo-template-bare-default.tar.gz expo-template-default`
`npx expo prebuild  --template /Users/gabriel/Workspace/expo/expo/templates/expo-template-default.tar.gz`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
