### PR TITLE
[doctor] link to changelog based on sdk version

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Link to changelogs based on the project's SDK version. ([#38877](https://github.com/expo/expo/pull/38877) by [@betomoedano](https://github.com/betomoedano))
+
 ### 💡 Others
 
 - Bump `@vercel/ncc` build ([#38801](https://github.com/expo/expo/pull/38801) by [@kitten](https://github.com/kitten))

--- a/packages/expo-doctor/src/checks/InstalledDependencyVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/InstalledDependencyVersionCheck.ts
@@ -51,7 +51,7 @@ export class InstalledDependencyVersionCheck implements DoctorCheck {
       }
 
       const initialIssuesCount = issues.length;
-      parseInstallCheckOutput(commandResult.stdout, issues);
+      parseInstallCheckOutput(commandResult.stdout, issues, projectMajorSdkVersion);
 
       // If no issues were added from stdout, fall back to stderr
       if (issues.length === initialIssuesCount && commandResult.stderr.trim()) {

--- a/packages/expo-doctor/src/utils/__tests__/parseInstallCheckOutput.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/parseInstallCheckOutput.test.ts
@@ -23,7 +23,7 @@ describe('parseInstallCheckOutput', () => {
 
   it('should handle empty stdout', () => {
     const issues: string[] = [];
-    parseInstallCheckOutput('', issues);
+    parseInstallCheckOutput('', issues, 54);
     expect(issues).toHaveLength(0);
   });
 
@@ -33,7 +33,7 @@ describe('parseInstallCheckOutput', () => {
       dependencies: [],
     });
     const issues: string[] = [];
-    parseInstallCheckOutput(stdout, issues);
+    parseInstallCheckOutput(stdout, issues, 54);
     expect(issues).toHaveLength(0);
   });
 
@@ -49,7 +49,7 @@ describe('parseInstallCheckOutput', () => {
       ],
     });
     const issues: string[] = [];
-    parseInstallCheckOutput(stdout, issues);
+    parseInstallCheckOutput(stdout, issues, 54);
 
     expect(issues).toHaveLength(1);
     const output = issues[0];
@@ -72,7 +72,7 @@ describe('parseInstallCheckOutput', () => {
       ],
     });
     const issues: string[] = [];
-    parseInstallCheckOutput(stdout, issues);
+    parseInstallCheckOutput(stdout, issues, 54);
 
     expect(issues).toHaveLength(1);
     const output = issues[0];
@@ -94,7 +94,7 @@ describe('parseInstallCheckOutput', () => {
       ],
     });
     const issues: string[] = [];
-    parseInstallCheckOutput(stdout, issues);
+    parseInstallCheckOutput(stdout, issues, 54);
 
     expect(issues).toHaveLength(1);
     const output = issues[0];
@@ -121,13 +121,13 @@ describe('parseInstallCheckOutput', () => {
       ],
     });
     const issues: string[] = [];
-    parseInstallCheckOutput(stdout, issues);
+    parseInstallCheckOutput(stdout, issues, 54);
 
     expect(issues).toHaveLength(1);
     const output = issues[0];
     expect(output).toContain('Changelogs:');
     expect(output).toContain(
-      'expo-image → https://github.com/expo/expo/blob/main/packages/expo-image/CHANGELOG.md'
+      'expo-image → https://github.com/expo/expo/blob/sdk-54/packages/expo-image/CHANGELOG.md'
     );
     expect(output).not.toContain('react →');
     expect(output).toContain('2 packages out of date');
@@ -160,7 +160,7 @@ describe('parseInstallCheckOutput', () => {
       ],
     });
     const issues: string[] = [];
-    parseInstallCheckOutput(stdout, issues);
+    parseInstallCheckOutput(stdout, issues, 54);
 
     expect(issues).toHaveLength(1);
     const output = issues[0];
@@ -203,7 +203,7 @@ describe('parseInstallCheckOutput', () => {
       ],
     });
     const issues: string[] = [];
-    parseInstallCheckOutput(stdout, issues);
+    parseInstallCheckOutput(stdout, issues, 54);
 
     expect(issues).toHaveLength(1);
     const output = issues[0];
@@ -220,7 +220,7 @@ Another warning line
 More text after JSON
     `;
     const issues: string[] = [];
-    parseInstallCheckOutput(stdout, issues);
+    parseInstallCheckOutput(stdout, issues, 54);
 
     expect(issues).toHaveLength(1);
     const output = issues[0];
@@ -232,7 +232,7 @@ More text after JSON
   it('should fallback to raw output when JSON parsing fails', () => {
     const stdout = 'This is not JSON output';
     const issues: string[] = [];
-    parseInstallCheckOutput(stdout, issues);
+    parseInstallCheckOutput(stdout, issues, 54);
 
     expect(issues).toHaveLength(1);
     expect(issues[0]).toBe('This is not JSON output');
@@ -244,7 +244,7 @@ More text after JSON
       dependencies: [],
     });
     const issues: string[] = [];
-    parseInstallCheckOutput(stdout, issues);
+    parseInstallCheckOutput(stdout, issues, 54);
 
     expect(issues).toHaveLength(0);
   });

--- a/packages/expo-doctor/src/utils/parseInstallCheckOutput.ts
+++ b/packages/expo-doctor/src/utils/parseInstallCheckOutput.ts
@@ -7,8 +7,13 @@ import semver from 'semver';
  *
  * @param stdout - Raw stdout from `npx expo install --check --json` command
  * @param issues - Array to append formatted issue messages to
+ * @param projectMajorSdkVersion - The major version of the project's SDK
  */
-export function parseInstallCheckOutput(stdout: string, issues: string[]): void {
+export function parseInstallCheckOutput(
+  stdout: string,
+  issues: string[],
+  projectMajorSdkVersion: number
+): void {
   if (!stdout.trim()) return;
 
   try {
@@ -70,11 +75,6 @@ export function parseInstallCheckOutput(stdout: string, issues: string[]): void 
 
       const pad = (s: string, n: number) => s.padEnd(n, ' ');
 
-      const header =
-        chalk.bold('Run ') +
-        chalk.cyan('npx expo install --check') +
-        chalk.bold(' to review and fix the mismatches below:\n');
-
       const formatSection = (
         title: string,
         rws: Row[],
@@ -106,7 +106,7 @@ export function parseInstallCheckOutput(stdout: string, issues: string[]): void 
         .filter((r) => r.isExpo)
         .map(
           (r) =>
-            `- ${r.name} → https://github.com/expo/expo/blob/main/packages/${r.name}/CHANGELOG.md`
+            `- ${r.name} → https://github.com/expo/expo/blob/sdk-${projectMajorSdkVersion}/packages/${r.name}/CHANGELOG.md`
         );
       const sections = [
         formatSection('Major version mismatches', major, chalk.yellow, '❗'),


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up from #38765

# How

- Pass sdk version as parameter when conforming the changelog link

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Ran locally and updated test
<img width="728" height="235" alt="Screenshot 2025-08-15 at 11 03 38 AM" src="https://github.com/user-attachments/assets/00b47724-4984-41dc-ad88-7a526bc80add" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
