### PR TITLE
[tools] Various improvements to project publishing

### DIFF
--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -2,7 +2,7 @@
   "name": "expo-template-blank-typescript",
   "description": "The Blank project template includes the minimum dependencies to run and an empty root component.",
   "license": "0BSD",
-  "version": "54.0.1",
+  "version": "54.0.2",
   "main": "index.ts",
   "scripts": {
     "start": "expo start",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -2,7 +2,7 @@
   "name": "expo-template-blank",
   "description": "The Blank project template includes the minimum dependencies to run and an empty root component.",
   "license": "0BSD",
-  "version": "54.0.1",
+  "version": "54.0.2",
   "main": "index.js",
   "scripts": {
     "start": "expo start",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -2,7 +2,7 @@
   "name": "expo-template-default",
   "license": "0BSD",
   "main": "expo-router/entry",
-  "version": "54.0.1",
+  "version": "54.0.2",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -3,7 +3,7 @@
   "main": "expo-router/entry",
   "description": "The Tab Navigation project template includes several example screens.",
   "license": "0BSD",
-  "version": "54.0.1",
+  "version": "54.0.2",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",

--- a/tools/src/publish-packages/tasks/loadRequestedParcels.ts
+++ b/tools/src/publish-packages/tasks/loadRequestedParcels.ts
@@ -45,6 +45,11 @@ export const loadRequestedParcels = new Task<TaskArgs>(
     const filteredPackages = allPackages.filter((pkg) => {
       const isPrivate = pkg.packageJson.private;
       const isIncluded = packageNames.length === 0 || packageNames.includes(pkg.packageName);
+      const isTemplate = pkg.isTemplate();
+      if (options.templatesOnly) {
+        // Only include templates when the flag is on
+        return !isPrivate && isIncluded && isTemplate;
+      }
       return !isPrivate && isIncluded;
     });
 
@@ -60,7 +65,7 @@ export const loadRequestedParcels = new Task<TaskArgs>(
 
         // Include dependencies if only some specific packages were requested.
         const dependenciesParcels =
-          options.deps && packageNames.length > 0
+          options.deps && !options.templatesOnly && packageNames.length > 0
             ? await createParcelsForDependenciesOf(requestedParcels)
             : new Set<Parcel>();
 

--- a/tools/src/publish-packages/tasks/publishAndroidPackages.ts
+++ b/tools/src/publish-packages/tasks/publishAndroidPackages.ts
@@ -18,6 +18,11 @@ export const publishAndroidArtifacts = new Task<TaskArgs>(
     dependsOn: [updateAndroidProjects],
   },
   async (parcels: Parcel[], options: CommandOptions) => {
+    // If only templates are being published, skip Android artifacts step entirely
+    if (options.templatesOnly) {
+      logger.log('\n🤖 Skipping publishing Android artifacts (templates-only).');
+      return;
+    }
     if (options.skipAndroidArtifacts) {
       logger.log('\n🤖 Skipping publishing Android artifacts.');
       return;

--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -96,6 +96,11 @@ export const publishPackagesPipeline = new Task<TaskArgs>(
     ],
   },
   async (parcels: Parcel[], options: CommandOptions) => {
+    // If templates-only and nothing but templates are selected, skip Android/iOS project updates
+    if (options.templatesOnly) {
+      // Filter to templates-only parcels just to be explicit for downstream tasks if used elsewhere
+      parcels = parcels.filter((p) => p.pkg.isTemplate());
+    }
     const packagesCount = parcels.length;
     logger.success(
       `\n✅ Successfully published ${cyan.bold(packagesCount)} package${packagesCount > 1 ? 's' : ''}.\n`

--- a/tools/src/publish-packages/tasks/updateIosProjects.ts
+++ b/tools/src/publish-packages/tasks/updateIosProjects.ts
@@ -20,7 +20,11 @@ export const updateIosProjects = new Task<TaskArgs>(
     dependsOn: [selectPackagesToPublish],
     filesToStage: ['apps/*/ios/**'],
   },
-  async (parcels: Parcel[]) => {
+  async (parcels: Parcel[], options) => {
+    // Skip when publishing templates only
+    if (options.templatesOnly) {
+      return;
+    }
     logger.info('\n🍎 Updating iOS projects...');
 
     const nativeApps = Workspace.getNativeApps();

--- a/tools/src/publish-packages/tasks/updateProjectTemplates.ts
+++ b/tools/src/publish-packages/tasks/updateProjectTemplates.ts
@@ -36,7 +36,8 @@ async function updateTemplateAsync(parcel: Parcel, modulesToUpdate: Record<strin
   logger.info('  ', `${green.bold(parcel.pkg.packageName)}...`);
 
   const packageJsonPath = path.join(parcel.pkg.path, 'package.json');
-  const packageJson = require(packageJsonPath);
+  // Read fresh JSON from disk to avoid Node's require cache returning stale data.
+  const packageJson = await JsonFile.readAsync(packageJsonPath);
 
   for (const dependencyKey of DEPENDENCIES_KEYS) {
     const dependencies = packageJson[dependencyKey];

--- a/tools/src/publish-packages/tasks/updateProjectTemplates.ts
+++ b/tools/src/publish-packages/tasks/updateProjectTemplates.ts
@@ -41,11 +41,12 @@ async function updateTemplateAsync(parcel: Parcel, modulesToUpdate: Record<strin
 
   for (const dependencyKey of DEPENDENCIES_KEYS) {
     const dependencies = packageJson[dependencyKey];
-    if (!dependencies) {
+    if (!dependencies || typeof dependencies !== 'object' || Array.isArray(dependencies)) {
       continue;
     }
-    for (const dependencyName in dependencies) {
-      const currentVersion = dependencies[dependencyName];
+    const deps = dependencies as Record<string, string>;
+    for (const dependencyName of Object.keys(deps)) {
+      const currentVersion = deps[dependencyName];
       const targetVersion = resolveTargetVersionRange(
         modulesToUpdate[dependencyName],
         currentVersion
@@ -57,7 +58,7 @@ async function updateTemplateAsync(parcel: Parcel, modulesToUpdate: Record<strin
         '    >',
         `Updating ${blue(dependencyName)} from ${cyan(currentVersion)} to ${cyan(targetVersion)}...`
       );
-      dependencies[dependencyName] = targetVersion;
+      deps[dependencyName] = targetVersion;
     }
   }
   await JsonFile.writeAsync(packageJsonPath, packageJson);

--- a/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
+++ b/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
@@ -23,6 +23,11 @@ export const updateWorkspaceProjects = new Task<TaskArgs>(
   async (parcels: Parcel[], options: CommandOptions) => {
     logger.info('\n📤 Updating workspace projects...');
 
+    if (options.templatesOnly) {
+      logger.info('  Skipping workspace updates (templates-only).');
+      return;
+    }
+
     const workspaceInfo = await Workspace.getInfoAsync();
 
     // Append project templates as they're not yarn workspaces.

--- a/tools/src/publish-packages/types.ts
+++ b/tools/src/publish-packages/types.ts
@@ -19,6 +19,8 @@ export type CommandOptions = {
   force: boolean;
   canary: boolean;
   deps: boolean;
+  /** Publish only template packages under `templates/` */
+  templatesOnly: boolean;
   skipAndroidArtifacts: boolean;
   /**
    * When true, automatically selects packages whose current package.json version


### PR DESCRIPTION
# Why

- Skip dot directories in the templates directory, so the publish command doesn't error eg: if you have `expo/templates/.cursor` directory 
- Add `--templates-only` flag that allows you to publish just templates, except for the bare template since it must now be published alongside the `expo` package (note: we might want to add an override here if it ever is the case that we want to publish it for testing purposes by manually specifying the package version in the prebuild template param)
- Fix issue where template versions were not being bumped by publish script

# How

GPT-5 with @alanjhughes and I reading over the output and manually testing it

# Test Plan

I ran `et publish --templates-only` and it did what I expected