### PR TITLE
[ios][dev-menu] Prevent crash when getting app icon

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Prevent crash when getting app icon. ([#38888](https://github.com/expo/expo/pull/38888) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 ## 7.0.1 — 2025-08-15

--- a/packages/expo-dev-menu/ios/EXDevMenuAppInfo.m
+++ b/packages/expo-dev-menu/ios/EXDevMenuAppInfo.m
@@ -64,7 +64,12 @@
 +(NSString *)getAppIcon
 {
   NSString *appIcon = @"";
-  NSString *appIconName = [[[[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIcons"] objectForKey:@"CFBundlePrimaryIcon"] objectForKey:@"CFBundleIconFiles"]  lastObject];
+  NSString *appIconName = nil;
+  // For some projects, the CFBundlePrimaryIcon value can be a string, leading to a crash
+  // We wrap this in a try/catch to prevent the crash
+  @try {
+    appIconName = [[[[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIcons"] objectForKey:@"CFBundlePrimaryIcon"] objectForKey:@"CFBundleIconFiles"]  lastObject];
+  } @catch(NSException *_e) {}
 
   if (appIconName != nil) {
     NSString *resourcePath = [[NSBundle mainBundle] resourcePath];


### PR DESCRIPTION
# Why

For some projects (including a TV project), the dictionary dereferencing to get the app icon in expo-dev-menu can crash.

# How

Wrap the code in a try/catch to prevent the crash.

# Test Plan

Tested in a SDK 54 preview project.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
