### PR TITLE
[docs] Fix assertion warning in next.config.ts file

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -22,7 +22,7 @@ import navigation from './public/static/constants/navigation.json';
 import { VERSIONS } from './public/static/constants/versions.json';
 import createSitemap from './scripts/create-sitemap.js';
 
-const betaVersion = 'betaVersion' in packageJson ? (packageJson.betaVersion as string) : undefined;
+const betaVersion = 'betaVersion' in packageJson ? packageJson.betaVersion : undefined;
 const latestVersion = 'version' in packageJson ? packageJson.version : undefined;
 const newestVersion = betaVersion ?? latestVersion;
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes the below assertion warning in next.config.ts file:

<img width="2612" height="540" alt="CleanShot 2025-08-16 at 03 45 59@2x" src="https://github.com/user-attachments/assets/98cc4076-9941-46e0-b1e8-740742bb049e" />

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
