### PR TITLE
[templates] update expo version in expo-module-template during publishing

### DIFF
--- a/tools/src/publish-packages/tasks/updateModuleTemplate.ts
+++ b/tools/src/publish-packages/tasks/updateModuleTemplate.ts
@@ -11,7 +11,7 @@ import { CommandOptions, Parcel, TaskArgs } from '../types';
 const { cyan, green } = chalk;
 const MODULE_TEMPLATE_PKG_NAME = 'expo-module-template';
 const TEMPLATE_PACKAGE_JSON_FILENAME = '$package.json';
-const PACKAGES_TO_UPDATE = ['expo-modules-core', 'expo-module-scripts'];
+const PACKAGES_TO_UPDATE = ['expo-modules-core', 'expo-module-scripts', 'expo'];
 
 /**
  * Updates the module template if necessary.


### PR DESCRIPTION
# Why

expo version should be automatically updated in the expo-module-template, this is a follow up for https://github.com/expo/expo/pull/36474

# How

Added expo package to `PACKAGES_TO_UPDATE`

# Test Plan

Commented out all irrelevant pipeline tasks locally:

```
  {
    name: 'publishPackagesPipeline',
    dependsOn: [
      // checkEnvironmentTask,
      // checkRepositoryStatus,
      loadRequestedParcels,
      // checkPackagesIntegrity,
      selectPackagesToPublish,
      // updatePackageVersions,
      // updateBundledNativeModulesFile,
      // updateProjectTemplates,
      updateModuleTemplate,
      // updateWorkspaceProjects,
      // updateAndroidProjects,
      // publishAndroidArtifacts,
      // updateIosProjects,
      // addTemplateTarball,
      // cutOffChangelogs,
      // commitStagedChanges,
      // pushCommittedChanges,
      // publishPackages,
      // grantTeamAccessToPackages,
      // addPublishedLabelToPullRequests,
      // cleanWorkingTree,
      // commentOnIssuesTask,
    ],
  },
  ```
  
  Result:
  
  ```
    "devDependencies": {
    "@types/react": "~19.1.0",
    "expo-module-scripts": "^5.0.2",
    "expo": "^54.0.0-preview.2",
    "react-native": "0.81.0"
  },
  ```
  
  @types/react and react-native still need to be updated manually though
  
# Checklist
- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
