### PR TITLE
Remove orphaned launch-tests.yml and fix client-install

### DIFF
--- a/apps/router-e2e/launch-tests.yml
+++ b/apps/router-e2e/launch-tests.yml
@@ -1,5 +1,0 @@
-appId: host.exp.Exponent
----
-- stopApp: host.exp.Exponent
-- openLink:
-    link: ${MAESTRO_APP_URL}/?_TEST_URL=1


### PR DESCRIPTION
- **Remove `apps/router-e2e/launch-tests.yml`** — this Maestro launch config was left behind when the Router Maestro E2E workflow was removed in #41205. It is not referenced anywhere in the repo.
- **Fix tar extraction in `ClientInstall.ts`** — replace the `tar` npm package with a `tar` CLI spawn via `@expo/spawn-async`. This avoids issues with the npm `tar` package when extracting Expo Go builds during `et client-install`. Also propagate install errors instead of silently swallowing them.