### PR TITLE
[ios] Simplify colors in dev menu and dev launcher

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [ios] Wrap system color references for dev client. ([#38912](https://github.com/expo/expo/pull/38912) by [@douglowder](https://github.com/douglowder))
+
 ## 6.0.2 — 2025-08-16
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -699,7 +699,10 @@
 -(NSString *)getAppIcon
 {
   NSString *appIcon = @"";
-  NSString *appIconName = [[[[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIcons"] objectForKey:@"CFBundlePrimaryIcon"] objectForKey:@"CFBundleIconFiles"]  lastObject];
+  NSString *appIconName = nil;
+  @try {
+    appIconName = [[[[[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIcons"] objectForKey:@"CFBundlePrimaryIcon"] objectForKey:@"CFBundleIconFiles"]  lastObject];
+  } @catch(NSException *_e) {}
 
   if (appIconName != nil) {
     NSString *resourcePath = [[NSBundle mainBundle] resourcePath];

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
@@ -111,9 +111,7 @@ struct RecentlyOpenedAppRow: View {
           .foregroundColor(.secondary)
       }
       .padding()
-#if !os(tvOS)
-      .background(Color(.secondarySystemBackground))
-#endif
+      .background(Color.expoSecondarySystemBackground)
       .clipShape(RoundedRectangle(cornerRadius: 12))
     }
     .buttonStyle(PlainButtonStyle())

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServerInfoModal.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServerInfoModal.swift
@@ -28,9 +28,7 @@ struct DevServerInfoModal: View {
       info
     }
     .padding(20)
-    #if !os(tvOS)
-    .background(Color(.systemBackground))
-    #endif
+    .background(Color.expoSystemBackground)
     .clipShape(RoundedRectangle(cornerRadius: 16))
     .shadow(color: .black.opacity(0.1), radius: 10, x: 0, y: 5)
     .padding(.horizontal, 40)
@@ -52,14 +50,6 @@ struct DevServerInfoModal: View {
     }
   }
 
-  #if os(tvOS)
-  let systemGray6 = Color(.systemGray)
-  let systemGray4 = Color(.systemGray)
-  #else
-  let systemGray6 = Color(.systemGray6)
-  let systemGray4 = Color(.systemGray4)
-  #endif
-
   private var info: some View {
     VStack(alignment: .leading, spacing: 12) {
       Text("Start a local development server with:")
@@ -70,11 +60,11 @@ struct DevServerInfoModal: View {
         .font(.system(.callout, design: .monospaced))
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(systemGray6)
+        .background(Color.expoSystemGray6)
         .clipShape(RoundedRectangle(cornerRadius: 6))
         .overlay(
           RoundedRectangle(cornerRadius: 6)
-            .stroke(systemGray4, lineWidth: 1)
+            .stroke(Color.expoSystemGray4, lineWidth: 1)
         )
 
       Text("Then, select the local server when it appears here.")

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -3,6 +3,8 @@
 import SwiftUI
 import Combine
 
+// swiftlint:disable closure_body_length
+
 private func sanitizeUrlString(_ urlString: String) -> String? {
   var sanitizedUrl = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -64,7 +66,11 @@ struct DevServersView: View {
           Image(systemName: showingURLInput ? "chevron.down" : "chevron.right")
             .font(.headline)
           Text("Enter URL manually")
+            #if os(tvOS)
+            .font(.system(size: 28))
+            #else
             .font(.system(size: 14))
+            #endif
           Spacer()
         }
       }
@@ -79,7 +85,7 @@ struct DevServersView: View {
         #if !os(tvOS)
           .overlay(
             RoundedRectangle(cornerRadius: 5)
-              .stroke(Color(.systemGray4), lineWidth: 1)
+              .stroke(Color.expoSystemGray4, lineWidth: 1)
           )
         #endif
           .clipShape(RoundedRectangle(cornerRadius: 5))
@@ -89,9 +95,9 @@ struct DevServersView: View {
     }
     .animation(.easeInOut, value: showingURLInput)
     .padding()
-#if !os(tvOS)
-    .background(Color(showingURLInput ? .secondarySystemBackground : .systemBackground))
-#endif
+    .background(showingURLInput ?
+      Color.expoSecondarySystemBackground :
+      Color.expoSystemBackground)
     .clipShape(RoundedRectangle(cornerRadius: 12))
   }
 
@@ -107,7 +113,11 @@ struct DevServersView: View {
         showingInfoDialog = true
       } label: {
         Text("info".uppercased())
+          #if os(tvOS)
+          .font(.system(size: 24))
+          #else
           .font(.system(size: 12))
+          #endif
       }
       .buttonStyle(.automatic)
     }
@@ -172,11 +182,10 @@ struct DevServerRow: View {
           .foregroundColor(.secondary)
       }
       .padding()
-#if !os(tvOS)
-      .background(Color(.secondarySystemBackground))
-#endif
+      .background(Color.expoSecondarySystemBackground)
       .clipShape(RoundedRectangle(cornerRadius: 12))
     }
     .buttonStyle(PlainButtonStyle())
   }
 }
+// swiftlint:enable closure_body_length

--- a/packages/expo-dev-launcher/ios/SwiftUI/ErrorView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/ErrorView.swift
@@ -8,16 +8,6 @@ struct ErrorView: View {
   let onReload: () -> Void
   let onGoHome: () -> Void
 
-#if os(tvOS)
-  let systemGray6 = Color(.systemGray)
-  let systemGray4 = Color(.systemGray)
-  let systemBackground = Color(.white)
-#else
-  let systemGray6 = Color(.systemGray6)
-  let systemGray4 = Color(.systemGray4)
-  let systemBackground = Color(.systemBackground)
-#endif
-
   var body: some View {
     VStack(spacing: 0) {
       VStack(alignment: .leading, spacing: 12) {
@@ -38,7 +28,7 @@ struct ErrorView: View {
 
       actions
     }
-    .background(systemBackground)
+    .background(Color.expoSystemBackground)
     .navigationBarHidden(true)
   }
 
@@ -59,7 +49,7 @@ struct ErrorView: View {
       .padding()
       .frame(maxWidth: .infinity, alignment: .leading)
     }
-    .background(systemGray6)
+    .background(Color.expoSystemGray6)
     .cornerRadius(8)
   }
 
@@ -81,14 +71,12 @@ struct ErrorView: View {
           .foregroundColor(.black)
           .frame(maxWidth: .infinity)
           .padding()
-#if !os(tvOS)
-          .background(Color(.systemGray5))
-#endif
+          .background(Color.expoSystemGray5)
           .cornerRadius(8)
       }
     }
     .padding(.horizontal, 20)
     .padding(.vertical, 20)
-    .background(systemBackground)
+    .background(Color.expoSystemBackground)
   }
 }

--- a/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
@@ -30,7 +30,11 @@ struct HomeTabView: View {
                 Button("reset".uppercased()) {
                   viewModel.clearRecentlyOpenedApps()
                 }
+                #if os(tvOS)
+                .font(.system(size: 24))
+                #else
                 .font(.system(size: 12))
+                #endif
               }
 
               LazyVStack(spacing: 6) {
@@ -65,9 +69,7 @@ struct HomeTabView: View {
         .padding()
     }
     .buttonStyle(PlainButtonStyle())
-    #if !os(tvOS)
-    .background(Color(.secondarySystemGroupedBackground))
-    #endif
+    .background(Color.expoSecondarySystemGroupedBackground)
     .cornerRadius(18)
   }
 }

--- a/packages/expo-dev-launcher/ios/SwiftUI/Navigation/Navigation.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/Navigation/Navigation.swift
@@ -58,9 +58,7 @@ struct DevLauncherNavigationHeader: View {
         } else {
           ZStack {
             Circle()
-            #if !os(tvOS)
-              .fill(Color(.systemGray6))
-            #endif
+              .fill(Color.expoSystemGray6)
               .frame(width: 36, height: 36)
 
             Image("user-icon", bundle: getDevLauncherBundle())
@@ -72,9 +70,7 @@ struct DevLauncherNavigationHeader: View {
     }
     .padding(.horizontal)
     .padding(.vertical, 8)
-    #if !os(tvOS)
-    .background(Color(.systemBackground))
-    #endif
+    .background(Color.expoSystemBackground)
   }
 
   @ViewBuilder
@@ -103,9 +99,7 @@ struct DevLauncherNavigationHeader: View {
           .aspectRatio(contentMode: .fill)
       } placeholder: {
         Circle()
-        #if !os(tvOS)
-          .fill(Color(.systemGray5))
-        #endif
+          .fill(Color.expoSystemGray5)
           .overlay(
             Image(systemName: "person")
               .font(.system(size: 16))

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -68,9 +68,7 @@ struct SettingsTabView: View {
       Toggle("Show menu at launch", isOn: $viewModel.showOnLaunch)
     }
     .padding()
-#if !os(tvOS)
-    .background(Color(.secondarySystemBackground))
-#endif
+    .background(Color.expoSecondarySystemBackground)
     .cornerRadius(12)
   }
 
@@ -118,9 +116,7 @@ struct SettingsTabView: View {
         }
         .padding()
       }
-#if !os(tvOS)
-      .background(Color(.secondarySystemBackground))
-#endif
+      .background(Color.expoSecondarySystemBackground)
       .cornerRadius(12)
     }
   }

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
@@ -41,9 +41,7 @@ struct UpdatesListView: View {
         }
       }
     }
-    #if !os(tvOS)
-    .background(Color(.systemGroupedBackground))
-    #endif
+    .background(Color.expoSystemGroupedBackground)
     .onChange(of: filterByCompatibility) { _ in
       applyFilters()
     }

--- a/packages/expo-dev-launcher/ios/SwiftUI/Utils/Utils.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/Utils/Utils.swift
@@ -51,11 +51,7 @@ extension Text {
 
 extension View {
   func systemGroupedBackground() -> some View {
-    #if os(tvOS)
-    return self
-    #else
-    return self.background(Color(.systemGroupedBackground))
-    #endif
+    return self.background(Color.expoSystemGroupedBackground)
   }
 }
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [ios] Wrap system color references for dev client. ([#38912](https://github.com/expo/expo/pull/38912) by [@douglowder](https://github.com/douglowder))
+
 ## 7.0.2 — 2025-08-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-menu/ios/DevMenuGestureRecognizer.swift
+++ b/packages/expo-dev-menu/ios/DevMenuGestureRecognizer.swift
@@ -35,10 +35,12 @@ class DevMenuGestureRecognizer: UILongPressGestureRecognizer {
   init() {
     super.init(target: DevMenuGestureRecognizer.gestureDelegate, action: #selector(DevMenuGestureRecognizer.gestureDelegate.handleLongPress(_:)))
 
-    #if !os(tvOS)
+    #if os(tvOS)
+    minimumPressDuration = 2.0
+    #else
     numberOfTouchesRequired = 3
-    #endif
     minimumPressDuration = 0.5
+    #endif
     allowableMovement = 30
   }
 }

--- a/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
@@ -25,6 +25,15 @@ public class DevMenuPreferences: Module {
    and applying some preferences to static classes like interceptors.
    */
   static func setup() {
+    #if os(tvOS)
+    UserDefaults.standard.register(defaults: [
+      motionGestureEnabledKey: false,
+      touchGestureEnabledKey: false,
+      keyCommandsEnabledKey: true,
+      showsAtLaunchKey: false,
+      isOnboardingFinishedKey: true
+    ])
+    #else
     UserDefaults.standard.register(defaults: [
       motionGestureEnabledKey: true,
       touchGestureEnabledKey: true,
@@ -32,6 +41,7 @@ public class DevMenuPreferences: Module {
       showsAtLaunchKey: false,
       isOnboardingFinishedKey: false
     ])
+    #endif
 
     /*
      We don't want to uninstall `DevMenuMotionInterceptor`, because otherwise, the app on shake gesture will bring up the dev-menu from the RN.

--- a/packages/expo-dev-menu/ios/SwiftUI/CustomItems.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/CustomItems.swift
@@ -26,9 +26,7 @@ struct CustomItems: View {
             }
             .padding()
           }
-          #if !os(tvOS)
-          .background(Color(.secondarySystemBackground))
-          #endif
+          .background(Color.expoSecondarySystemBackground)
           .clipShape(RoundedRectangle(cornerRadius: 12))
         }
       }

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuActions.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuActions.swift
@@ -12,9 +12,7 @@ struct DevMenuActions: View {
         icon: "arrow.clockwise",
         action: onReload
       )
-      #if !os(tvOS)
-      .background(Color(.secondarySystemBackground))
-      #endif
+      .background(Color.expoSecondarySystemBackground)
       .cornerRadius(18)
 
       if isDevLauncherInstalled {
@@ -23,9 +21,7 @@ struct DevMenuActions: View {
           icon: "house.fill",
           action: onGoHome
         )
-        #if !os(tvOS)
-        .background(Color(.secondarySystemBackground))
-        #endif
+        .background(Color.expoSecondarySystemBackground)
         .cornerRadius(18)
       }
     }

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuAppInfo.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuAppInfo.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+// swiftlint:disable closure_body_length
+
 struct DevMenuAppInfo: View {
   @EnvironmentObject var viewModel: DevMenuViewModel
 
@@ -41,9 +43,7 @@ struct DevMenuAppInfo: View {
           .disabled(viewModel.clipboardMessage != nil)
         }
       }
-#if !os(tvOS)
-      .background(Color(.systemBackground))
-#endif
+      .background(Color.expoSystemBackground)
       .cornerRadius(18)
     }
   }
@@ -67,3 +67,4 @@ struct InfoRow: View {
     .padding(.vertical)
   }
 }
+// swiftlint:enable closure_body_length

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuButtons.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuButtons.swift
@@ -30,9 +30,7 @@ struct DevMenuActionButton: View {
       .padding()
     }
     .disabled(disabled)
-#if !os(tvOS)
-    .background(Color(.secondarySystemBackground))
-#endif
+    .background(Color.expoSecondarySystemBackground)
     .opacity(disabled ? 0.6 : 1.0)
   }
 }
@@ -71,9 +69,7 @@ struct DevMenuToggleButton: View {
       .disabled(disabled)
     }
     .padding()
-#if !os(tvOS)
-    .background(Color(.secondarySystemBackground))
-#endif
+    .background(Color.expoSecondarySystemBackground)
     .opacity(disabled ? 0.6 : 1.0)
   }
 }

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+// swiftlint:disable closure_body_length
+
 struct DevMenuDeveloperTools: View {
   @EnvironmentObject var viewModel: DevMenuViewModel
 
@@ -46,9 +48,7 @@ struct DevMenuDeveloperTools: View {
           disabled: !(viewModel.devSettings?.isHotLoadingAvailable ?? true)
         )
       }
-#if !os(tvOS)
-      .background(Color(.systemBackground))
-#endif
+      .background(Color.expoSystemBackground)
       .cornerRadius(18)
     }
   }
@@ -57,3 +57,5 @@ struct DevMenuDeveloperTools: View {
 #Preview {
   DevMenuDeveloperTools()
 }
+
+// swiftlint:enable closure_body_length

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuRNDevMenu.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuRNDevMenu.swift
@@ -14,9 +14,7 @@ struct DevMenuRNDevMenu: View {
       }
       .padding()
     }
-#if !os(tvOS)
-    .background(Color(.secondarySystemBackground))
-#endif
+    .background(Color.expoSecondarySystemBackground)
     .cornerRadius(18)
   }
 }

--- a/packages/expo-dev-menu/ios/SwiftUI/HeaderView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/HeaderView.swift
@@ -30,9 +30,7 @@ struct HeaderView: View {
       } label: {
         ZStack {
           Circle()
-          #if !os(tvOS)
-            .fill(Color(.systemGray6))
-          #endif
+            .fill(Color.expoSystemGray6)
             .frame(width: 36, height: 36)
 
           Image(systemName: "xmark")

--- a/packages/expo-dev-menu/ios/SwiftUI/HostUrl.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/HostUrl.swift
@@ -27,9 +27,7 @@ struct HostUrl: View {
           .foregroundColor(.secondary.opacity(0.7))
       }
       .padding()
-#if !os(tvOS)
-      .background(Color(.secondarySystemBackground))
-#endif
+      .background(Color.expoSecondarySystemBackground)
       .cornerRadius(20)
     }
     .buttonStyle(.plain)

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [ios] Wrap system color references for dev client. ([#38912](https://github.com/expo/expo/pull/38912) by [@douglowder](https://github.com/douglowder))
+
 ## 3.0.2 — 2025-08-16
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/ExpoSystemColors.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/ExpoSystemColors.swift
@@ -1,0 +1,36 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+// Wrap system colors to hide platform differences
+
+public extension Color {
+  #if os(tvOS)
+  private static let _systemGray6: Color = Color(.systemGray.withAlphaComponent(0.5))
+  private static let _systemGray5: Color = Color(.systemGray.withAlphaComponent(0.6))
+  private static let _systemGray4: Color = Color(.systemGray.withAlphaComponent(0.7))
+  private static let _systemBackground: Color = .clear
+  private static let _systemGroupedBackground: Color = .white
+  private static let _secondaryLabel: Color = .secondary
+  private static let _secondarySystemBackground: Color = Color(.systemGray.withAlphaComponent(0.1))
+  private static let _secondarySystemGroupedBackground: Color = Color(.systemGray.withAlphaComponent(0.2))
+  #else
+  private static let _systemGray6: Color = Color(.systemGray6)
+  private static let _systemGray5: Color = Color(.systemGray5)
+  private static let _systemGray4 = Color(.systemGray4)
+  private static let _systemBackground: Color = Color(.systemBackground)
+  private static let _systemGroupedBackground: Color = Color(.systemGroupedBackground)
+  private static let _secondaryLabel: Color = Color(.secondaryLabel)
+  private static let _secondarySystemBackground: Color = Color(.secondarySystemBackground)
+  private static let _secondarySystemGroupedBackground: Color = Color(.secondarySystemGroupedBackground)
+  #endif
+
+  static let expoSystemBackground: Color = _systemBackground
+  static let expoSystemGroupedBackground: Color = _systemGroupedBackground
+  static let expoSecondaryLabel: Color = _secondaryLabel
+  static let expoSecondarySystemBackground: Color = _secondarySystemBackground
+  static let expoSecondarySystemGroupedBackground: Color = _secondarySystemGroupedBackground
+  static let expoSystemGray4: Color = _systemGray4
+  static let expoSystemGray5: Color = _systemGray5
+  static let expoSystemGray6: Color = _systemGray6
+}

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -35,6 +35,7 @@ function getExpoDependencyChunks({
     ['@expo/config-types', '@expo/env', '@expo/json-file'],
     ['@expo/config'],
     ['@expo/config-plugins'],
+    ['@expo/plist'],
     ['expo-modules-core'],
     ['unimodules-app-loader'],
     ['expo-task-manager'],


### PR DESCRIPTION
# Why

Most of the special `#if os(tvOS)` clauses in dev menu and dev launcher are to handle colors that are different on different platforms.

This can be fixed by adding a layer of indirection, so that system colors are only referenced in one place.

# How

- Add a new Color extension in expo-modules-core SwiftUI code
- Modify system color references in dev menu and dev-launcher
- Some additional fixes for app icon on dev launcher, and dev menu gesture handling on tvOS

# Test Plan

- Everything should work with the Skia example project
- CI should pass

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
