### PR TITLE
[install-expo-modules] Use latest SDK for unsupported React Native versions

### DIFF
--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Use latest SDK for unsupported React Native versions ([#38918](https://github.com/expo/expo/pull/38918) by [@hyochan](https://github.com/hyochan))
+
 ### 💡 Others
 
 ## 0.13.2 — 2025-08-16

--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -106,9 +106,10 @@ export function getDefaultSdkVersion(projectRoot: string): VersionInfo {
     semver.satisfies(reactNativeVersion, info.reactNativeVersionRange)
   );
   if (!versionInfo) {
-    throw new Error(
-      `Unable to find compatible expo sdk version - reactNativeVersion[${reactNativeVersion}]`
+    console.warn(
+      `⚠️  React Native ${reactNativeVersion} is not yet officially supported. Using the latest Expo SDK version.`
     );
+    return getLatestSdkVersion();
   }
   return versionInfo;
 }
@@ -129,6 +130,11 @@ export function getSdkVersion(reactNativeVersion: string): string {
   const versionInfo = ExpoVersionMappings.find((info) =>
     semver.satisfies(reactNativeVersion, info.reactNativeVersionRange)
   );
-  assert(versionInfo, `Unsupported react-native version: ${reactNativeVersion}`);
-  return versionInfo?.sdkVersion;
+  if (!versionInfo) {
+    console.warn(
+      `⚠️  React Native ${reactNativeVersion} is not yet officially supported. Using the latest Expo SDK version.`
+    );
+    return getLatestSdkVersion().sdkVersion;
+  }
+  return versionInfo.sdkVersion;
 }


### PR DESCRIPTION
## Why

When trying to resolve client issues like https://github.com/hyochan/expo-iap/discussions/150#discussioncomment-14113296 in the latest React Native projects, I discovered that `npx install-expo-modules` kept installing Expo SDK 51 instead of the latest version. This happens because React Native 0.81 was just released and isn't yet in the version mapping table.

In such cases, it would be more reasonable to install the latest Expo SDK version rather than throwing an error or installing an incompatible version.

## How

- Modified `getDefaultSdkVersion()` to fallback to the latest SDK version when the React Native version isn't found in the mapping table
- Added a warning message to inform users that their React Native version isn't officially supported yet
- Applied the same pattern to `getSdkVersion()` for consistency

## Test Plan

- [x] Run `npx install-expo-modules` in a React Native 0.81 project
- [x] Verify that it shows a warning message about unsupported React Native version
- [x] Confirm that it installs the latest Expo SDK (53.0.0) instead of failing
- [x] Test with a supported React Native version to ensure existing behavior still works

## Checklist

- [x] Documentation is up to date to reflect these changes (if applicable)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin)