### PR TITLE
Update internal-distribution-builds.mdx

### DIFF
--- a/docs/pages/tutorial/eas/internal-distribution-builds.mdx
+++ b/docs/pages/tutorial/eas/internal-distribution-builds.mdx
@@ -158,7 +158,7 @@ If so, make sure to point your **credentials.json** to an ad hoc or enterprise p
 Once the build finishes, the Build artifact section gets updated, indicating that the build is complete. This section provides the methods available for running the development build on an iOS device: Expo Orbit and Install button.
 
 - Open the build's detail page. If you are sharing the build with someone else, you can send them the link to the build. They'll be able to open the build's detail page or build artifact details which include Expo Orbit.
-- Connect the Android or iOS device to our machine using USB.
+- Connect the Android or iOS device to your machine using USB.
 - Open the Orbit menu bar app.
 - Select the **Device** in the Orbit app.
 - Under **Build artifact**, click the **Open with Orbit**.


### PR DESCRIPTION
# Why

I believe there is a typo on the documentation stating `our machine using USB`, and I belive the correct should be `your machine using USB`. Developers would not connect to the Expo's computers.

# How

Changing `our` to `your`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
