### PR TITLE
[ci] refactor repeating of e2e tests

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,4 +1,4 @@
-name: Test Suite
+name: Test Suite e2e
 
 on:
   workflow_dispatch: {}
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 16.0
+      - name: 🔨 Switch to Xcode 16.4
         run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: 🍺 Install required tools
         run: |
@@ -71,7 +71,7 @@ jobs:
           RCT_USE_PREBUILT_RNCORE: 1
           RCT_USE_RN_DEP: 1
         working-directory: apps/bare-expo/ios
-      - name: 🏗️ Build iOS project
+      - name: 🏗️ Build iOS project (bare-expo)
         run: ./scripts/start-ios-e2e-test.js --build
         working-directory: apps/bare-expo
         timeout-minutes: 55
@@ -93,9 +93,9 @@ jobs:
           channel: '#expo-ios'
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
-          author_name: Test Suite (iOS)
+          author_name: Test Suite e2e (iOS)
 
-  ios-test:
+  ios-test-e2e:
     needs: ios-build
     runs-on: macos-15
     steps:
@@ -124,7 +124,7 @@ jobs:
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
-      - name: 🧪 Run tests
+      - name: 🧪 Run e2e tests (bare-expo)
         run: ./scripts/start-ios-e2e-test.js --test
         working-directory: apps/bare-expo
         timeout-minutes: 30
@@ -147,7 +147,7 @@ jobs:
           channel: '#expo-ios'
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
-          author_name: Test Suite (iOS)
+          author_name: Test Suite e2e (iOS)
 
   android-build:
     runs-on: ubuntu-24.04
@@ -189,7 +189,7 @@ jobs:
       - name: 🏗️ Gradle prebuild for Android project (workaround to fix build error)
         run: ./gradlew preBuild
         working-directory: apps/bare-expo/android
-      - name: 🏗️ Build Android project
+      - name: 🏗️ Build Android project (bare-expo)
         run: ./scripts/start-android-e2e-test.js --build
         working-directory: apps/bare-expo
         timeout-minutes: 35
@@ -212,9 +212,9 @@ jobs:
           channel: '#expo-android'
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
-          author_name: Test Suite (Android)
+          author_name: Test Suite e2e (Android)
 
-  android-test:
+  android-test-e2e:
     needs: android-build
     runs-on: ubuntu-24.04
     strategy:
@@ -240,7 +240,7 @@ jobs:
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
-      - name: 🧪 Run tests
+      - name: 🧪 Run e2e tests (bare-expo)
         uses: ./.github/actions/use-android-emulator
         with:
           avd-api: ${{ matrix.api-level }}
@@ -267,4 +267,4 @@ jobs:
           channel: '#expo-android'
           status: ${{ job.status }}
           fields: job,message,ref,eventName,author,took
-          author_name: Test Suite (Android)
+          author_name: Test Suite e2e (Android)

--- a/apps/bare-expo/scripts/lib/e2e-common.js
+++ b/apps/bare-expo/scripts/lib/e2e-common.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 const fs = require('fs/promises');
+const path = require('path');
 
 /**
  * Parse the start mode from the command line arguments.
@@ -24,11 +25,7 @@ function getStartMode(programFilename) {
  * @param {{ appId: string; workflowFile: string; confirmFirstRunPrompt?: boolean; }} params
  * @returns {Promise<void>}
  */
-async function createMaestroFlowAsync({
-  appId,
-  workflowFile,
-  confirmFirstRunPrompt,
-}) {
+async function createMaestroFlowAsync({ appId, workflowFile, confirmFirstRunPrompt }) {
   const inputFile = require('../../e2e/TestSuite-test.native.js');
   const testCases = inputFile.TESTS;
   const contents = [
@@ -83,21 +80,17 @@ async function ensureDirAsync(dirPath) {
 /**
  * Retry an async function a number of times with a delay between each attempt.
  * @template T
- * @param {() => Promise<T>} fn
+ * @param {(retryNumber: number) => Promise<T>} fn
  * @param {number} retries
  * @param {number=} delayAfterErrorMs
  * @returns {Promise<T>}
  */
-async function retryAsync(
-  fn,
-  retries,
-  delayAfterErrorMs = 5000
-) {
+async function retryAsync(fn, retries, delayAfterErrorMs = 5000) {
   /** @types {Error | undefined} */
   let lastError;
   for (let i = 0; i < retries; ++i) {
     try {
-      return await fn();
+      return await fn(i);
     } catch (e) {
       lastError = e;
       await delayAsync(delayAfterErrorMs);
@@ -124,6 +117,15 @@ async function delayAsync(timeMs) {
   return new Promise((resolve) => setTimeout(resolve, timeMs));
 }
 
+/**
+ * @param {string} projectRoot
+ * @returns {string}
+ */
+const getMaestroFlowFilePath = (projectRoot) => {
+  const MAESTRO_GENERATED_FLOW = 'e2e/maestro-generated.yaml';
+  return path.join(projectRoot, MAESTRO_GENERATED_FLOW);
+};
+
 module.exports = {
   getStartMode,
   createMaestroFlowAsync,
@@ -131,4 +133,5 @@ module.exports = {
   fileExistsAsync,
   retryAsync,
   delayAsync,
+  getMaestroFlowFilePath,
 };

--- a/apps/bare-expo/scripts/start-android-e2e-test.js
+++ b/apps/bare-expo/scripts/start-android-e2e-test.js
@@ -10,12 +10,13 @@ const {
   fileExistsAsync,
   getStartMode,
   retryAsync,
+  getMaestroFlowFilePath,
 } = require('./lib/e2e-common.js');
 
 const APP_ID = 'dev.expo.payments';
-const MAESTRO_GENERATED_FLOW = 'e2e/maestro-generated.yaml';
 const OUTPUT_APP_PATH = 'android/app/build/outputs/apk/release/app-release.apk';
 const MAESTRO_DRIVER_STARTUP_TIMEOUT = '120000'; // Wait 2 minutes for Maestro driver to start
+const NUM_OF_RETRIES = 6; // Number of retries for the suite
 
 (async () => {
   try {
@@ -39,7 +40,17 @@ const MAESTRO_DRIVER_STARTUP_TIMEOUT = '120000'; // Wait 2 minutes for Maestro d
       if (!deviceId) {
         throw new Error(`No connected Android device found`);
       }
-      await retryAsync(() => testAsync(projectRoot, deviceId, appBinaryPath, adbPath), 6);
+      const maestroFlowFilePath = getMaestroFlowFilePath(projectRoot);
+      await createMaestroFlowAsync({
+        appId: APP_ID,
+        workflowFile: maestroFlowFilePath,
+        confirmFirstRunPrompt: true,
+      });
+
+      await retryAsync((retryNumber) => {
+        console.log(`Test suite attempt ${retryNumber + 1} of ${NUM_OF_RETRIES}`);
+        return testAsync(maestroFlowFilePath, deviceId, appBinaryPath, adbPath);
+      }, NUM_OF_RETRIES);
     }
   } catch (e) {
     console.error('Uncaught Error', e);
@@ -57,26 +68,16 @@ async function buildAsync(projectRoot) {
 }
 
 /**
-  * @param {string} projectRoot
-  * @param {string} deviceId
-  * @param {string} appBinaryPath
-  * @param {string} adbPath
-  * @returns {Promise<void>}
-  */
-async function testAsync(
-  projectRoot,
-  deviceId,
-  appBinaryPath,
-  adbPath
-) {
+ * @param {string} maestroFlowFilePath
+ * @param {string} deviceId
+ * @param {string} appBinaryPath
+ * @param {string} adbPath
+ * @returns {Promise<void>}
+ */
+async function testAsync(maestroFlowFilePath, deviceId, appBinaryPath, adbPath) {
   console.log(`\n🔌 Installing App - appBinaryPath[${appBinaryPath}]`);
   await spawnAsync(adbPath, ['-s', deviceId, 'install', '-r', appBinaryPath]);
 
-  const maestroFlowFilePath = path.join(projectRoot, MAESTRO_GENERATED_FLOW);
-  await createMaestroFlowAsync({
-    appId: APP_ID,
-    workflowFile: maestroFlowFilePath,
-  });
   console.log(`\n📷 Starting Maestro tests - maestroFlowFilePath[${maestroFlowFilePath}]`);
   await spawnAsync('maestro', ['--platform', 'android', 'test', maestroFlowFilePath], {
     stdio: 'inherit',
@@ -105,9 +106,9 @@ async function findAdbAsync() {
 }
 
 /**
-  * @param {string} adbPath
-  * @returns {Promise<string | null>}
-  */
+ * @param {string} adbPath
+ * @returns {Promise<string | null>}
+ */
 async function queryDeviceIdAsync(adbPath) {
   const { stdout } = await spawnAsync(adbPath, ['devices']);
   const lines = stdout.split('\n');

--- a/apps/bare-expo/scripts/start-ios-e2e-test.js
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.js
@@ -6,14 +6,20 @@ const spawnAsync = require('@expo/spawn-async');
 const fs = require('fs/promises');
 const path = require('path');
 
-const { createMaestroFlowAsync, ensureDirAsync, getStartMode, retryAsync } = require('./lib/e2e-common.js');
+const {
+  createMaestroFlowAsync,
+  ensureDirAsync,
+  getStartMode,
+  retryAsync,
+  getMaestroFlowFilePath,
+} = require('./lib/e2e-common.js');
 
 const TARGET_DEVICE = 'iPhone 16 Pro';
 const TARGET_DEVICE_IOS_VERSION = 18;
 const APP_ID = 'dev.expo.Payments';
-const MAESTRO_GENERATED_FLOW = 'e2e/maestro-generated.yaml';
 const OUTPUT_APP_PATH = 'ios/build/BareExpo.app';
 const MAESTRO_DRIVER_STARTUP_TIMEOUT = '120000'; // Wait 2 minutes for Maestro driver to start
+const NUM_OF_RETRIES = 6; // Number of retries for the suite
 
 (async () => {
   try {
@@ -32,7 +38,17 @@ const MAESTRO_DRIVER_STARTUP_TIMEOUT = '120000'; // Wait 2 minutes for Maestro d
       await fs.cp(binaryPath, appBinaryPath, { recursive: true });
     }
     if (startMode === 'TEST' || startMode === 'BUILD_AND_TEST') {
-      await retryAsync(() => testAsync(projectRoot, deviceId, appBinaryPath), 6);
+      const maestroFlowFilePath = getMaestroFlowFilePath(projectRoot);
+      await createMaestroFlowAsync({
+        appId: APP_ID,
+        workflowFile: maestroFlowFilePath,
+        confirmFirstRunPrompt: true,
+      });
+
+      await retryAsync((retryNumber) => {
+        console.log(`Test suite attempt ${retryNumber + 1} of ${NUM_OF_RETRIES}`);
+        return testAsync(maestroFlowFilePath, deviceId, appBinaryPath);
+      }, NUM_OF_RETRIES);
     }
   } catch (e) {
     console.error('Uncaught Error', e);
@@ -41,10 +57,10 @@ const MAESTRO_DRIVER_STARTUP_TIMEOUT = '120000'; // Wait 2 minutes for Maestro d
 })();
 
 /**
-  * @param {string} projectRoot
-  * @param {string} deviceId
-  * @returns {Promise<string>}
-  */
+ * @param {string} projectRoot
+ * @param {string} deviceId
+ * @returns {Promise<string>}
+ */
 async function buildAsync(projectRoot, deviceId) {
   console.log('\n💿 Building App');
   const buildOutput = await XcodeBuild.buildAsync({
@@ -71,16 +87,12 @@ async function buildAsync(projectRoot, deviceId) {
 }
 
 /**
-  * @param {string} projectRoot
-  * @param {string} deviceId
-  * @param {string} appBinaryPath
-  * @returns {Promise<void>}
-  */
-async function testAsync(
-  projectRoot,
-  deviceId,
-  appBinaryPath
-) {
+ * @param {string} maestroFlowFilePath
+ * @param {string} deviceId
+ * @param {string} appBinaryPath
+ * @returns {Promise<void>}
+ */
+async function testAsync(maestroFlowFilePath, deviceId, appBinaryPath) {
   try {
     console.log(`\n📱 Starting Device - name[${TARGET_DEVICE}] udid[${deviceId}]`);
     await spawnAsync('xcrun', ['simctl', 'bootstatus', deviceId, '-b'], { stdio: 'inherit' });
@@ -91,12 +103,6 @@ async function testAsync(
     console.log(`\n🔌 Installing App - appBinaryPath[${appBinaryPath}]`);
     await spawnAsync('xcrun', ['simctl', 'install', deviceId, appBinaryPath], { stdio: 'inherit' });
 
-    const maestroFlowFilePath = path.join(projectRoot, MAESTRO_GENERATED_FLOW);
-    await createMaestroFlowAsync({
-      appId: APP_ID,
-      workflowFile: maestroFlowFilePath,
-      confirmFirstRunPrompt: true,
-    });
     console.log(`\n📷 Starting Maestro tests - maestroFlowFilePath[${maestroFlowFilePath}]`);
     await spawnAsync('maestro', ['--device', deviceId, 'test', maestroFlowFilePath], {
       stdio: 'inherit',
@@ -112,9 +118,9 @@ async function testAsync(
 
 /**
  * Query simulator UDID
-  * @param {number} iosVersion
-  * @param {string} device
-  * @returns {Promise<string | null>}
+ * @param {number} iosVersion
+ * @param {string} device
+ * @returns {Promise<string | null>}
  */
 async function queryDeviceIdAsync(iosVersion, device) {
   const { stdout } = await spawnAsync('xcrun', [
@@ -128,9 +134,7 @@ async function queryDeviceIdAsync(iosVersion, device) {
   const { devices: deviceWithRuntimes } = JSON.parse(stdout);
 
   // Try to find the target device first
-  for (const [runtime, devices] of Object.entries(
-    deviceWithRuntimes
-  )) {
+  for (const [runtime, devices] of Object.entries(deviceWithRuntimes)) {
     if (runtime.startsWith(`com.apple.CoreSimulator.SimRuntime.iOS-${iosVersion}-`)) {
       for (const { name, udid } of devices) {
         if (name === device) {


### PR DESCRIPTION
# Why

This PR renames the GitHub Actions workflow to "Test Suite e2e" to better distinguish it from other types of tests.

# How

- Renamed the workflow from "Test Suite" to "Test Suite e2e"
- Updated job names to include "e2e" for clarity (ios-test → ios-test-e2e, android-test → android-test-e2e)
- Refactored the e2e testing scripts to:
  - Move Maestro flow creation before the retry loop to generate it only once
  - Add retry attempt logging to show progress during test runs (when running locally it got me a little confused and I though tests were running in an endless loop at first 😅 )

# Test Plan

- green CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)