### PR TITLE
[docs] Add React version to compatibility table

### DIFF
--- a/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
+++ b/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
@@ -18,6 +18,7 @@ export const ReactNativeCompatibilityTable = () => {
         <Row>
           <HeaderCell>Expo SDK version</HeaderCell>
           <HeaderCell>React Native version</HeaderCell>
+          <HeaderCell>React version</HeaderCell>
           <HeaderCell>React Native Web version</HeaderCell>
         </Row>
       </TableHead>
@@ -26,6 +27,7 @@ export const ReactNativeCompatibilityTable = () => {
           <Row key={version.sdk}>
             <Cell>{version.sdk}</Cell>
             <Cell>{version['react-native']}</Cell>
+            <Cell>{version['react']}</Cell>
             <Cell>{version['react-native-web']}</Cell>
           </Row>
         ))}

--- a/docs/ui/components/SDKTables/sdk-versions.json
+++ b/docs/ui/components/SDKTables/sdk-versions.json
@@ -8,7 +8,8 @@
       "ios": "15.1+",
       "xcode": "16.1+",
       "react-native": "0.81",
-      "react-native-web": "0.21.0"
+      "react-native-web": "0.21.0",
+      "react": "19.1.0"
     },
     {
       "sdk": "53.0.0",
@@ -18,7 +19,8 @@
       "ios": "15.1+",
       "xcode": "16.0+",
       "react-native": "0.79",
-      "react-native-web": "0.20.0"
+      "react-native-web": "0.20.0",
+      "react": "19.0.0"
     },
     {
       "sdk": "52.0.0",
@@ -28,7 +30,8 @@
       "ios": "15.1+",
       "xcode": "16.0+",
       "react-native": "0.76",
-      "react-native-web": "0.19.13"
+      "react-native-web": "0.19.13",
+      "react": "18.3.1"
     },
     {
       "sdk": "51.0.0",
@@ -38,7 +41,8 @@
       "ios": "13.4+",
       "xcode": "15.4 - 16.2",
       "react-native": "0.74",
-      "react-native-web": "0.19.10"
+      "react-native-web": "0.19.10",
+      "react": "18.2.0"
     },
     {
       "sdk": "50.0.0",
@@ -48,7 +52,8 @@
       "ios": "13.4+",
       "xcode": "15.4",
       "react-native": "0.73",
-      "react-native-web": "0.19.6"
+      "react-native-web": "0.19.6",
+      "react": "18.2.0"
     },
     {
       "sdk": "49.0.0",
@@ -58,7 +63,8 @@
       "ios": "13+",
       "xcode": "15.4",
       "react-native": "0.72",
-      "react-native-web": "0.19.6"
+      "react-native-web": "0.19.6",
+      "react": "18.2.0"
     }
   ]
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17031

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add `react` versions to the compatibility table for each Expo SDK.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="2376" height="638" alt="CleanShot 2025-08-18 at 17 43 41@2x" src="https://github.com/user-attachments/assets/b062106a-b16e-4c8c-aaeb-df85a7567267" />

<img width="2378" height="622" alt="CleanShot 2025-08-18 at 17 43 34@2x" src="https://github.com/user-attachments/assets/dd491e5b-f598-4350-b415-796fcbfbea15" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
