### PR TITLE
[expo-go] fix linux and macOS tar compatibility issues.

### DIFF
--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -715,16 +715,24 @@ async function processIosTarArchiveAsync(archivePath: string, projectDir: string
     const appBundle = extractedContents.find((item) => item.endsWith('.app'));
     if (appBundle) {
       const appBundlePath = path.join(tempExtractDir, appBundle);
-      await spawnAsync('tar', ['-zcvf', archivePath, '-C', appBundlePath, '.'], {
-        stdio: 'pipe',
-      });
+      await spawnAsync(
+        'tar',
+        ['--disable-copyfile', '--no-xattrs', '-zcvf', archivePath, '-C', appBundlePath, '.'],
+        {
+          stdio: 'pipe',
+        }
+      );
       logger.info(`Created tar from .app bundle contents: ${archivePath}`);
     }
     // If no .app file, check if it's a valid iOS app bundle. tar.gz could be from Cloudfront URL.
     else if (fs.existsSync(path.join(tempExtractDir, 'Info.plist'))) {
-      await spawnAsync('tar', ['-zcvf', archivePath, '-C', tempExtractDir, '.'], {
-        stdio: 'pipe',
-      });
+      await spawnAsync(
+        'tar',
+        ['--disable-copyfile', '--no-xattrs', '-zcvf', archivePath, '-C', tempExtractDir, '.'],
+        {
+          stdio: 'pipe',
+        }
+      );
       logger.info(`Created tar from extracted contents: ${archivePath}`);
     } else {
       throw new Error('Unknown archive format');


### PR DESCRIPTION
# Why

macOS created BSD tar files can create issues when extracted in a GNU tar compatible Linux/Ubuntu system. As shown below, extracting BSD tars produced by macOS in linux can create warnings which can lead to build failures. EAS uses `node-tar` so it does not suffer with these issues. 

<img width="300" height="577" alt="Screenshot 2025-08-18 at 5 13 40 PM" src="https://github.com/user-attachments/assets/c628c306-2529-4ce6-9408-6ee9848ca216" />

https://github.com/expo/snack/actions/runs/17036705515/job/48290781982

https://exponent-internal.slack.com/archives/C1QP38NQ5/p1755509541736859?thread_ts=1755506784.232949&cid=C1QP38NQ5

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Use node-tar, similar to EAS builds.

Alternative solutions (seems brittle) -> Pass [appropriate](https://apple.stackexchange.com/questions/478547/macos-tar-why-is-disable-copyfile-and-no-xattrs-required-for-gnu-compatib) flags to remove additional metadata files added by macOS.


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Created a tar, uploaded to github and tested on Ubuntu, macOS, iOS simulator installs. Reproed the issue and confirmed the fix.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
