### PR TITLE
[core][templates] Update android sdk versions across the repo

### DIFF
--- a/packages/expo-module-template-local/android/build.gradle
+++ b/packages/expo-module-template-local/android/build.gradle
@@ -23,10 +23,10 @@ if (useManagedAndroidSdkVersions) {
     }
   }
   project.android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 34)
+    compileSdkVersion safeExtGet("compileSdkVersion", 36)
     defaultConfig {
-      minSdkVersion safeExtGet("minSdkVersion", 21)
-      targetSdkVersion safeExtGet("targetSdkVersion", 34)
+      minSdkVersion safeExtGet("minSdkVersion", 24)
+      targetSdkVersion safeExtGet("targetSdkVersion", 36)
     }
   }
 }

--- a/packages/expo-module-template/android/build.gradle
+++ b/packages/expo-module-template/android/build.gradle
@@ -23,10 +23,10 @@ if (useManagedAndroidSdkVersions) {
     }
   }
   project.android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 34)
+    compileSdkVersion safeExtGet("compileSdkVersion", 36)
     defaultConfig {
-      minSdkVersion safeExtGet("minSdkVersion", 21)
-      targetSdkVersion safeExtGet("targetSdkVersion", 34)
+      minSdkVersion safeExtGet("minSdkVersion", 24)
+      targetSdkVersion safeExtGet("targetSdkVersion", 36)
     }
   }
 }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - [ios] Wrap system color references for dev client. ([#38912](https://github.com/expo/expo/pull/38912) by [@douglowder](https://github.com/douglowder))
+- [Android] Update min, target, and compile SDK versions. ([#38938](https://github.com/expo/expo/pull/38938) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 3.0.2 — 2025-08-16
 

--- a/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+++ b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
@@ -62,11 +62,11 @@ ext.applyKspJvmToolchain = {
 // Setup build options that are common for all modules
 ext.useDefaultAndroidSdkVersions = {
   project.android {
-    compileSdkVersion project.ext.safeExtGet("compileSdkVersion", 34)
+    compileSdkVersion project.ext.safeExtGet("compileSdkVersion", 36)
 
     defaultConfig {
-      minSdkVersion project.ext.safeExtGet("minSdkVersion", 23)
-      targetSdkVersion project.ext.safeExtGet("targetSdkVersion", 34)
+      minSdkVersion project.ext.safeExtGet("minSdkVersion", 24)
+      targetSdkVersion project.ext.safeExtGet("targetSdkVersion", 36)
     }
 
     lintOptions {


### PR DESCRIPTION
# Why
Closes ENG-17030
Sync the min, target and compile sdks on android with 0.81 https://github.com/facebook/react-native/blob/0.81-stable/packages/react-native/gradle/libs.versions.toml

# Test Plan
bare-expo builds without issue

