### PR TITLE
[ios][dev-menu] OnboardingView animation

### DIFF
--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuOnboardingView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuOnboardingView.swift
@@ -5,14 +5,12 @@ struct DevMenuOnboardingView: View {
   @State private var isVisible = true
 
   var body: some View {
-    if isVisible {
-      Rectangle()
-        .fill(.ultraThinMaterial)
-        .ignoresSafeArea()
-        .overlay(onboardingOverlay)
-        .opacity(isVisible ? 1.0 : 0.0)
-        .animation(.easeInOut(duration: 0.3), value: isVisible)
-    }
+    Rectangle()
+      .fill(.ultraThinMaterial)
+      .ignoresSafeArea()
+      .overlay(onboardingOverlay)
+      .offset(x: 0, y: isVisible ? 0.0 : 650.0)
+      .animation(.easeInOut(duration: 0.5), value: isVisible)
   }
 
   private var onboardingOverlay: some View {


### PR DESCRIPTION
# Why
The current fade out animation on the onboarding view doesn't look great. I've replaced with a sliding animation. 

# Test Plan

https://github.com/user-attachments/assets/4c8ffba9-710a-4628-b608-8d43c923c9f5
