### PR TITLE
[modules-core] Fix array offset

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix invalid array buffer offset in typed arrays.
+- [Android] Fix invalid array buffer offset in typed arrays. ([#38958](https://github.com/expo/expo/pull/38958) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix invalid array buffer offset in typed arrays.
+
 ### 💡 Others
 
 - [ios] Wrap system color references for dev client. ([#38912](https://github.com/expo/expo/pull/38912) by [@douglowder](https://github.com/douglowder))

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptTypedArrayTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptTypedArrayTest.kt
@@ -376,18 +376,18 @@ internal class JavaScriptTypedArrayTest {
 
   @Test
   fun direct_buffer_should_return_correct_buffer() = withJSIInterop {
-      val subArray = evaluateScript("new Uint8Array(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).buffer, 3, 5)").getTypedArray()
-      
-      val buffer = subArray.toDirectBuffer()
-      
-      Truth.assertThat(buffer.isDirect).isTrue()
-      Truth.assertThat(buffer.isReadOnly).isFalse()
+    val subArray = evaluateScript("new Uint8Array(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).buffer, 3, 5)").getTypedArray()
 
-      Truth.assertThat(buffer.capacity()).isEqualTo(5)
-      
-      buffer.order(ByteOrder.nativeOrder())
-      Truth.assertThat(buffer.get(0)).isEqualTo(3.toByte())
-      Truth.assertThat(buffer.get(4)).isEqualTo(7.toByte())
+    val buffer = subArray.toDirectBuffer()
+
+    Truth.assertThat(buffer.isDirect).isTrue()
+    Truth.assertThat(buffer.isReadOnly).isFalse()
+
+    Truth.assertThat(buffer.capacity()).isEqualTo(5)
+
+    buffer.order(ByteOrder.nativeOrder())
+    Truth.assertThat(buffer.get(0)).isEqualTo(3.toByte())
+    Truth.assertThat(buffer.get(4)).isEqualTo(7.toByte())
   }
 
   private fun wrapBytes(array: ByteArray): ByteBuffer = ByteBuffer.wrap(array).order(ByteOrder.nativeOrder())

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptTypedArrayTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptTypedArrayTest.kt
@@ -374,5 +374,21 @@ internal class JavaScriptTypedArrayTest {
     Truth.assertThat(typedArray.length).isEqualTo(16)
   }
 
+  @Test
+  fun direct_buffer_should_return_correct_buffer() = withJSIInterop {
+      val subArray = evaluateScript("new Uint8Array(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).buffer, 3, 5)").getTypedArray()
+      
+      val buffer = subArray.toDirectBuffer()
+      
+      Truth.assertThat(buffer.isDirect).isTrue()
+      Truth.assertThat(buffer.isReadOnly).isFalse()
+
+      Truth.assertThat(buffer.capacity()).isEqualTo(5)
+      
+      buffer.order(ByteOrder.nativeOrder())
+      Truth.assertThat(buffer.get(0)).isEqualTo(3.toByte())
+      Truth.assertThat(buffer.get(4)).isEqualTo(7.toByte())
+  }
+
   private fun wrapBytes(array: ByteArray): ByteBuffer = ByteBuffer.wrap(array).order(ByteOrder.nativeOrder())
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.cpp
@@ -57,11 +57,10 @@ jni::local_ref<jni::JByteBuffer> JavaScriptTypedArray::toDirectBuffer() {
   jsi::Runtime &jsRuntime = runtimeHolder.getJSRuntime();
 
   auto byteLength = typedArrayWrapper->byteLength(jsRuntime);
-  auto byteOffset = typedArrayWrapper->byteOffset(jsRuntime);
 
   auto byteBuffer = jni::JByteBuffer::wrapBytes(
     static_cast<uint8_t *>(typedArrayWrapper->getRawPointer(jsRuntime)),
-    byteLength - byteOffset
+    byteLength
   );
 
   byteBuffer->order(jni::JByteOrder::nativeOrder());

--- a/packages/expo-modules-core/ios/Tests/TypedArraysSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/TypedArraysSpec.swift
@@ -99,6 +99,14 @@ final class TypedArraysSpec: ExpoSpec {
         expect(values.filter({ $0 != 0 }).count) >= 1
       }
 
+      it("returns a correct slice when created from a buffer") {
+        let array = try runtime.eval("new Uint8Array(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).buffer, 3, 5)").asTypedArray()
+        expect(array.getProperty("byteOffset").getInt()) == 3
+        expect(array.getProperty("byteLength").getInt()) == 5
+        expect(array.getProperty("0").getInt()) == 3
+        expect(array.getProperty("4").getInt()) == 7
+      }
+
       // TODO: Test throwing NotTypedArrayException and ArrayTypeMismatchException
     }
   }


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/38709

Note the `buffer` accessor – this was something that took me a while to figure out – the constructor that accepts byteOffset and byteLength only accepts buffers, not typedArrays.

Luckily it's also marked invalid by TS.

# Test Plan

Made a native test to verify this.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
