### PR TITLE
[doctor] Adding bun to lock file checks

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unpublished
 
+### 🎉 New features
+
+- Add check for lock-files. ([#38963](https://github.com/expo/expo/pull/38963) by [@entiendonull](https://github.com/entiendonull))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-doctor/src/checks/LockfileCheck.ts
+++ b/packages/expo-doctor/src/checks/LockfileCheck.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+
+export class LockfileCheck implements DoctorCheck {
+  description = 'Check for lock file';
+
+  sdkVersionRange = '*';
+
+  async runAsync({ projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    const issues: string[] = [];
+    const advice: string[] = [];
+
+    const lockfileCheckResults = await Promise.all(
+      ['pnpm-lock.yaml', 'yarn.lock', 'package-lock.json', 'bun.lockb', 'bun.lock'].map(
+        (lockfile) => {
+          return { lockfile, exists: fs.existsSync(`${projectRoot}/${lockfile}`) };
+        }
+      )
+    );
+
+    const lockfiles = lockfileCheckResults
+      .filter((result) => result.exists)
+      .map((result) => result.lockfile);
+
+    if (lockfiles.length === 0) {
+      issues.push(`No lock file detected.`);
+      advice.push(
+        `Install dependencies using the package manager of your choice to a generate a lock file.`
+      );
+    }
+
+    if (lockfiles.length > 1) {
+      issues.push(
+        `Multiple lock files detected (${lockfiles.join(
+          ', '
+        )}). This may result in unexpected behavior in CI environments, such as EAS Build, which infer the package manager from the lock file.`
+      );
+      advice.push(`Remove any lock files for package managers you are not using.`);
+    }
+
+    return { isSuccessful: issues.length === 0, issues, advice };
+  }
+}

--- a/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
+++ b/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
@@ -41,29 +41,6 @@ export class ProjectSetupCheck implements DoctorCheck {
       }
     }
 
-    /* Check for multiple lockfiles. */
-
-    const lockfileCheckResults = await Promise.all(
-      ['pnpm-lock.yaml', 'yarn.lock', 'package-lock.json', 'bun.lockb', 'bun.lock'].map(
-        (lockfile) => {
-          return { lockfile, exists: fs.existsSync(`${projectRoot}/${lockfile}`) };
-        }
-      )
-    );
-
-    const lockfiles = lockfileCheckResults
-      .filter((result) => result.exists)
-      .map((result) => result.lockfile);
-
-    if (lockfiles.length > 1) {
-      issues.push(
-        `Multiple lock files detected (${lockfiles.join(
-          ', '
-        )}). This may result in unexpected behavior in CI environments, such as EAS Build, which infer the package manager from the lock file.`
-      );
-      advice.push(`Remove any lock files for package managers you are not using.`);
-    }
-
     return { isSuccessful: issues.length === 0, issues, advice };
   }
 }

--- a/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
+++ b/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
@@ -44,9 +44,11 @@ export class ProjectSetupCheck implements DoctorCheck {
     /* Check for multiple lockfiles. */
 
     const lockfileCheckResults = await Promise.all(
-      ['pnpm-lock.yaml', 'yarn.lock', 'package-lock.json'].map((lockfile) => {
-        return { lockfile, exists: fs.existsSync(`${projectRoot}/${lockfile}`) };
-      })
+      ['pnpm-lock.yaml', 'yarn.lock', 'package-lock.json', 'bun.lockb', 'bun.lock'].map(
+        (lockfile) => {
+          return { lockfile, exists: fs.existsSync(`${projectRoot}/${lockfile}`) };
+        }
+      )
     );
 
     const lockfiles = lockfileCheckResults

--- a/packages/expo-doctor/src/checks/__tests__/LockfileCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/LockfileCheck.test.ts
@@ -1,0 +1,86 @@
+import { glob, GlobOptions } from 'glob';
+import { vol } from 'memfs';
+
+import { isFileIgnoredAsync } from '../../utils/files';
+import { LockfileCheck } from '../LockfileCheck';
+
+jest.mock('fs');
+jest.mock('glob');
+jest.mock('../../utils/files');
+
+const projectRoot = '/tmp/project';
+
+// required by runAsync
+const additionalProjectProps = {
+  exp: {
+    name: 'name',
+    slug: 'slug',
+  },
+  projectRoot,
+  hasUnusedStaticConfig: false,
+  staticConfigPath: null,
+  dynamicConfigPath: null,
+};
+
+/**
+ * Helper to mock the results of isFileIgnoredAsync for all matching files.
+ */
+function mockIsFileIgnoredResult(isFileIgnored: boolean) {
+  (isFileIgnoredAsync as jest.Mock).mockResolvedValue(isFileIgnored);
+}
+
+describe('runAsync', () => {
+  afterEach(() => {
+    vol.reset();
+    jest.resetAllMocks();
+  });
+
+  it('returns result with isSuccessful = false if no lockfile', async () => {
+    vol.fromJSON({});
+    const check = new LockfileCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+
+  // multiple lock files
+  it('returns result with isSuccessful = true if just one lock file', async () => {
+    vol.fromJSON({
+      [projectRoot + '/yarn.lock']: 'test',
+    });
+    const check = new LockfileCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('returns result with isSuccessful = false if more than one lockfile (yarn + npm)', async () => {
+    vol.fromJSON({
+      [projectRoot + '/yarn.lock']: 'test',
+      [projectRoot + '/package-lock.json']: 'test',
+    });
+    const check = new LockfileCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+
+  it('returns result with isSuccessful = false if more than one lockfile (yarn + pnpm)', async () => {
+    vol.fromJSON({
+      [projectRoot + '/yarn.lock']: 'test',
+      [projectRoot + '/pnpm-lock.yaml']: 'test',
+    });
+    const check = new LockfileCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+  });
+});

--- a/packages/expo-doctor/src/checks/__tests__/ProjectSetupCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/ProjectSetupCheck.test.ts
@@ -179,43 +179,4 @@ describe('runAsync', () => {
     );
     expect(isFileIgnoredAsync).toHaveBeenCalledWith(androidPath, expect.anything());
   });
-
-  // multiple lock files
-  it('returns result with isSuccessful = true if just one lock file', async () => {
-    vol.fromJSON({
-      [projectRoot + '/yarn.lock']: 'test',
-    });
-    const check = new ProjectSetupCheck();
-    const result = await check.runAsync({
-      pkg: { name: 'name', version: '1.0.0' },
-      ...additionalProjectProps,
-    });
-    expect(result.isSuccessful).toBeTruthy();
-  });
-
-  it('returns result with isSuccessful = false if more than one lockfile (yarn + npm)', async () => {
-    vol.fromJSON({
-      [projectRoot + '/yarn.lock']: 'test',
-      [projectRoot + '/package-lock.json']: 'test',
-    });
-    const check = new ProjectSetupCheck();
-    const result = await check.runAsync({
-      pkg: { name: 'name', version: '1.0.0' },
-      ...additionalProjectProps,
-    });
-    expect(result.isSuccessful).toBeFalsy();
-  });
-
-  it('returns result with isSuccessful = false if more than one lockfile (yarn + pnpm)', async () => {
-    vol.fromJSON({
-      [projectRoot + '/yarn.lock']: 'test',
-      [projectRoot + '/pnpm-lock.yaml']: 'test',
-    });
-    const check = new ProjectSetupCheck();
-    const result = await check.runAsync({
-      pkg: { name: 'name', version: '1.0.0' },
-      ...additionalProjectProps,
-    });
-    expect(result.isSuccessful).toBeFalsy();
-  });
 });

--- a/packages/expo-doctor/src/utils/checkResolver.ts
+++ b/packages/expo-doctor/src/utils/checkResolver.ts
@@ -25,6 +25,7 @@ import { ReactNativeDirectoryCheck } from '../checks/ReactNativeDirectoryCheck';
 import { StoreCompatibilityCheck } from '../checks/StoreCompatibilityCheck';
 import { SupportPackageVersionCheck } from '../checks/SupportPackageVersionCheck';
 import { DoctorCheck } from '../checks/checks.types';
+import { LockfileCheck } from '../checks/LockfileCheck';
 
 /**
  * Resolves the checks that should be run for a given project.
@@ -38,6 +39,7 @@ export function resolveChecksInScope(exp: ExpoConfig, pkg: PackageJSONConfig): D
     // Project Structure Checks
     new ProjectSetupCheck(),
     new PackageJsonCheck(),
+    new LockfileCheck(),
     new ExpoConfigSchemaCheck(),
     new ExpoConfigCommonIssueCheck(),
     new MetroConfigCheck(),


### PR DESCRIPTION
# Why

Fix [ENG-15831](https://linear.app/expo/issue/ENG-15831)

# How

Added `bun.lockb` and `bun.lock` to the existing checks.

**Edit:**
Split up lock file checks to it's own class - `LockfileCheck`. Added additional check for missing lock files as well.

# Test Plan

Ran tests, updated current tests and added new ones.

Ran it on a test project with various lock files and got the expected result.

**Multiple .lock-files:**
```
✖ Check for common project setup issues
Multiple lock files detected (yarn.lock, bun.lock). This may result in unexpected behavior in CI environments, such as EAS Build, which infer the package manager from the lock file.
Advice:
Remove any lock files for package managers you are not using.

1 check failed, indicating possible issues with the project.
```

**One .lock-file**
```
16/16 checks passed. No issues detected!
```

**No .lock-file**
```
✖ Check for lock file
No lock file detected.
Advice:
Install dependencies using the package manager of your choice to a generate a lock file.
```

# Checklist


- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
