### PR TITLE
[docs] Add Node.js version to docs SDK compatibility table

### DIFF
--- a/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
+++ b/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
@@ -1,3 +1,6 @@
+import { InfoCircleDuotoneIcon } from '@expo/styleguide-icons/duotone/InfoCircleDuotoneIcon';
+import { useState } from 'react';
+
 import { usePageApiVersion } from '~/providers/page-api-version';
 import versions from '~/public/static/constants/versions.json';
 import { TableHead, Row, Cell, Table, HeaderCell } from '~/ui/components/Table';
@@ -13,6 +16,7 @@ export const ReactNativeCompatibilityTable = () => {
   const resolvedVersion =
     version === 'latest' || version === 'unversioned' ? LATEST_VERSION : version;
   const versionsToShow = getThreeVersions(resolvedVersion);
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
   return (
     <Table>
@@ -23,17 +27,34 @@ export const ReactNativeCompatibilityTable = () => {
           <HeaderCell>React version</HeaderCell>
           <HeaderCell>React Native Web version</HeaderCell>
           <HeaderCell>
-            <Tooltip.Root delayDuration={500}>
-              <Tooltip.Trigger asChild>
-                <span className="cursor-help">Node.js version (?)</span>
-              </Tooltip.Trigger>
-              <Tooltip.Content side="top" className="max-w-[300px]">
-                <FOOTNOTE>
-                  This is the recommended Node.js version. The Expo SDK is not strictly compatible
-                  only with this version.
-                </FOOTNOTE>
-              </Tooltip.Content>
-            </Tooltip.Root>
+            <div className="flex items-center gap-1.5">
+              <span>Node.js version</span>
+              <Tooltip.Root
+                open={isTooltipOpen}
+                onOpenChange={setIsTooltipOpen}
+                delayDuration={100}>
+                <Tooltip.Trigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setIsTooltipOpen(!isTooltipOpen);
+                    }}
+                    className="inline-flex items-center justify-center rounded-full p-1 text-icon-secondary hover:text-icon-default focus:outline-none focus:ring-2 focus:ring-link focus:ring-offset-1 active:text-icon-default">
+                    <InfoCircleDuotoneIcon className="icon-xs" />
+                  </button>
+                </Tooltip.Trigger>
+                <Tooltip.Content
+                  side="top"
+                  className="max-w-[300px]"
+                  sideOffset={8}
+                  collisionPadding={{ left: 16, right: 16 }}>
+                  <FOOTNOTE>
+                    This is the recommended Node.js version. The Expo SDK is not strictly compatible
+                    only with this version.
+                  </FOOTNOTE>
+                </Tooltip.Content>
+              </Tooltip.Root>
+            </div>
           </HeaderCell>
         </Row>
       </TableHead>

--- a/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
+++ b/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
@@ -49,8 +49,9 @@ export const ReactNativeCompatibilityTable = () => {
                   sideOffset={8}
                   collisionPadding={{ left: 16, right: 16 }}>
                   <FOOTNOTE>
-                    This is the recommended Node.js version. The Expo SDK is not strictly compatible
-                    only with this version.
+                    This is the recommended Node.js version, and it corresponds with the active LTS
+                    at the time of the SDK release. The Expo SDK is not strictly compatible only
+                    with this version, but you should use the specified version or higher.
                   </FOOTNOTE>
                 </Tooltip.Content>
               </Tooltip.Root>

--- a/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
+++ b/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
@@ -1,6 +1,8 @@
 import { usePageApiVersion } from '~/providers/page-api-version';
 import versions from '~/public/static/constants/versions.json';
 import { TableHead, Row, Cell, Table, HeaderCell } from '~/ui/components/Table';
+import { FOOTNOTE } from '~/ui/components/Text';
+import * as Tooltip from '~/ui/components/Tooltip';
 
 import { getThreeVersions } from './utils';
 
@@ -20,7 +22,19 @@ export const ReactNativeCompatibilityTable = () => {
           <HeaderCell>React Native version</HeaderCell>
           <HeaderCell>React version</HeaderCell>
           <HeaderCell>React Native Web version</HeaderCell>
-          <HeaderCell>Node.js version</HeaderCell>
+          <HeaderCell>
+            <Tooltip.Root delayDuration={500}>
+              <Tooltip.Trigger asChild>
+                <span className="cursor-help">Node.js version (?)</span>
+              </Tooltip.Trigger>
+              <Tooltip.Content side="top" className="max-w-[300px]">
+                <FOOTNOTE>
+                  This is the recommended Node.js version. The Expo SDK is not strictly compatible
+                  only with this version.
+                </FOOTNOTE>
+              </Tooltip.Content>
+            </Tooltip.Root>
+          </HeaderCell>
         </Row>
       </TableHead>
       <tbody>

--- a/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
+++ b/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
@@ -28,7 +28,7 @@ export const ReactNativeCompatibilityTable = () => {
           <HeaderCell>React Native Web version</HeaderCell>
           <HeaderCell>
             <div className="flex items-center gap-1.5">
-              <span>Node.js version</span>
+              <span>Minimum Node.js version</span>
               <Tooltip.Root
                 open={isTooltipOpen}
                 onOpenChange={setIsTooltipOpen}
@@ -49,9 +49,10 @@ export const ReactNativeCompatibilityTable = () => {
                   sideOffset={8}
                   collisionPadding={{ left: 16, right: 16 }}>
                   <FOOTNOTE>
-                    This is the recommended Node.js version, and it corresponds with the active LTS
-                    at the time of the SDK release. The Expo SDK is not strictly compatible only
-                    with this version, but you should use the specified version or higher.
+                    This is the minimum recommended Node.js version, and it corresponds with the
+                    active LTS at the time of the SDK release. The Expo SDK is not strictly
+                    compatible only with this version, but you should use the specified version or
+                    higher.
                   </FOOTNOTE>
                 </Tooltip.Content>
               </Tooltip.Root>

--- a/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
+++ b/docs/ui/components/SDKTables/ReactNativeCompatibilityTable.tsx
@@ -20,6 +20,7 @@ export const ReactNativeCompatibilityTable = () => {
           <HeaderCell>React Native version</HeaderCell>
           <HeaderCell>React version</HeaderCell>
           <HeaderCell>React Native Web version</HeaderCell>
+          <HeaderCell>Node.js version</HeaderCell>
         </Row>
       </TableHead>
       <tbody>
@@ -29,6 +30,7 @@ export const ReactNativeCompatibilityTable = () => {
             <Cell>{version['react-native']}</Cell>
             <Cell>{version['react']}</Cell>
             <Cell>{version['react-native-web']}</Cell>
+            <Cell>{version['node']}</Cell>
           </Row>
         ))}
       </tbody>

--- a/docs/ui/components/SDKTables/sdk-versions.json
+++ b/docs/ui/components/SDKTables/sdk-versions.json
@@ -10,7 +10,7 @@
       "react-native": "0.81",
       "react-native-web": "0.21.0",
       "react": "19.1.0",
-      "node": "22.18.x"
+      "node": "20.19.x"
     },
     {
       "sdk": "53.0.0",
@@ -22,7 +22,7 @@
       "react-native": "0.79",
       "react-native-web": "0.20.0",
       "react": "19.0.0",
-      "node": "22.15.x"
+      "node": "20.18.x"
     },
     {
       "sdk": "52.0.0",

--- a/docs/ui/components/SDKTables/sdk-versions.json
+++ b/docs/ui/components/SDKTables/sdk-versions.json
@@ -9,7 +9,8 @@
       "xcode": "16.1+",
       "react-native": "0.81",
       "react-native-web": "0.21.0",
-      "react": "19.1.0"
+      "react": "19.1.0",
+      "node": "22.18.0"
     },
     {
       "sdk": "53.0.0",
@@ -20,7 +21,8 @@
       "xcode": "16.0+",
       "react-native": "0.79",
       "react-native-web": "0.20.0",
-      "react": "19.0.0"
+      "react": "19.0.0",
+      "node": "22.15.0"
     },
     {
       "sdk": "52.0.0",
@@ -31,7 +33,8 @@
       "xcode": "16.0+",
       "react-native": "0.76",
       "react-native-web": "0.19.13",
-      "react": "18.3.1"
+      "react": "18.3.1",
+      "node": "20.18.0"
     },
     {
       "sdk": "51.0.0",
@@ -42,7 +45,8 @@
       "xcode": "15.4 - 16.2",
       "react-native": "0.74",
       "react-native-web": "0.19.10",
-      "react": "18.2.0"
+      "react": "18.2.0",
+      "node": "18.20.5"
     },
     {
       "sdk": "50.0.0",
@@ -53,7 +57,8 @@
       "xcode": "15.4",
       "react-native": "0.73",
       "react-native-web": "0.19.6",
-      "react": "18.2.0"
+      "react": "18.2.0",
+      "node": "18.19.0"
     },
     {
       "sdk": "49.0.0",
@@ -64,7 +69,8 @@
       "xcode": "15.4",
       "react-native": "0.72",
       "react-native-web": "0.19.6",
-      "react": "18.2.0"
+      "react": "18.2.0",
+      "node": "16.20.2"
     }
   ]
 }

--- a/docs/ui/components/SDKTables/sdk-versions.json
+++ b/docs/ui/components/SDKTables/sdk-versions.json
@@ -10,7 +10,7 @@
       "react-native": "0.81",
       "react-native-web": "0.21.0",
       "react": "19.1.0",
-      "node": "22.18.0"
+      "node": "22.18.x"
     },
     {
       "sdk": "53.0.0",
@@ -22,7 +22,7 @@
       "react-native": "0.79",
       "react-native-web": "0.20.0",
       "react": "19.0.0",
-      "node": "22.15.0"
+      "node": "22.15.x"
     },
     {
       "sdk": "52.0.0",
@@ -34,7 +34,7 @@
       "react-native": "0.76",
       "react-native-web": "0.19.13",
       "react": "18.3.1",
-      "node": "20.18.0"
+      "node": "20.18.x"
     },
     {
       "sdk": "51.0.0",
@@ -46,7 +46,7 @@
       "react-native": "0.74",
       "react-native-web": "0.19.10",
       "react": "18.2.0",
-      "node": "18.20.5"
+      "node": "18.20.x"
     },
     {
       "sdk": "50.0.0",
@@ -58,7 +58,7 @@
       "react-native": "0.73",
       "react-native-web": "0.19.6",
       "react": "18.2.0",
-      "node": "18.19.0"
+      "node": "18.19.x"
     },
     {
       "sdk": "49.0.0",
@@ -70,7 +70,7 @@
       "react-native": "0.72",
       "react-native-web": "0.19.6",
       "react": "18.2.0",
-      "node": "16.20.2"
+      "node": "16.20.x"
     }
   ]
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17029

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add `node` versions to the compatibility table for each Expo SDK.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="1183" height="448" alt="CleanShot 2025-08-19 at 23 27 44" src="https://github.com/user-attachments/assets/11c2b585-60db-43f2-bb1c-51908070e3d6" />

<img width="1138" height="293" alt="CleanShot 2025-08-19 at 23 27 41" src="https://github.com/user-attachments/assets/824e4e88-f284-4af2-ae47-515c1b729c18" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
