### PR TITLE
[ci][filesystem] don't run android tests on other platforms

### DIFF
--- a/apps/test-suite/tests/FileSystem.ts
+++ b/apps/test-suite/tests/FileSystem.ts
@@ -12,9 +12,13 @@ import { isDeviceFarm } from '../utils/Environment';
 export const name = 'FileSystem';
 
 export async function test({ describe, expect, it, ...t }) {
-  const shouldSkipTestsRequiringPermissions =
-    (await TestUtils.shouldSkipTestsRequiringPermissionsAsync()) || isDeviceFarm();
-  const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : describe;
+  const shouldSkipTestsRequiringPermissionsAndroidOnly =
+    (await TestUtils.shouldSkipTestsRequiringPermissionsAsync()) ||
+    isDeviceFarm() ||
+    Platform.OS !== 'android';
+  const describeWithPermissionsAndroidOnly = shouldSkipTestsRequiringPermissionsAndroidOnly
+    ? t.xdescribe
+    : describe;
 
   const testDirectory = FS.documentDirectory + 'tests/';
   t.beforeEach(async () => {
@@ -44,7 +48,7 @@ export async function test({ describe, expect, it, ...t }) {
       });
     }
 
-    describeWithPermissions('picker operations', () => {
+    describeWithPermissionsAndroidOnly('picker operations', () => {
       let originalTimeout;
       t.beforeAll(async () => {
         originalTimeout = t.jasmine.DEFAULT_TIMEOUT_INTERVAL;


### PR DESCRIPTION
# Why

Some Android tests were executed on other platforms.

# How

Updated the condition for skipping tests in `FileSystem.ts` to include a check for `Platform.OS !== 'android'`, ensuring picker operation tests only run on Android devices. 

# Test Plan

- green CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)