### PR TITLE
[docs] Add support for Blob interface properties

### DIFF
--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -40,12 +40,19 @@ const CLASSES_TO_IGNORE_INHERITED_PROPS = [
   'SharedRef',
 ] as const;
 
-const isProp = (child: PropData) =>
-  child.kind &&
-  [TypeDocKind.Property, TypeDocKind.Accessor].includes(child.kind) &&
-  !child.overwrites &&
-  !child.name.startsWith('_') &&
-  !child.implementationOf;
+const isProp = (child: PropData) => {
+  const isImplementationOfBlobInterface =
+    child.implementationOf?.type === 'reference' &&
+    child.implementationOf?.name?.startsWith('Blob.');
+
+  return (
+    child.kind &&
+    [TypeDocKind.Property, TypeDocKind.Accessor].includes(child.kind) &&
+    !child.overwrites &&
+    !child.name.startsWith('_') &&
+    (!child.implementationOf || isImplementationOfBlobInterface)
+  );
+};
 
 const isMethod = (child: PropData, allowOverwrites: boolean = false) =>
   child.kind &&

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -54,12 +54,19 @@ const isProp = (child: PropData) => {
   );
 };
 
-const isMethod = (child: PropData, allowOverwrites: boolean = false) =>
-  child.kind &&
-  [TypeDocKind.Method, TypeDocKind.Function].includes(child.kind) &&
-  (allowOverwrites || !child.overwrites) &&
-  !child.name.startsWith('_') &&
-  !child?.implementationOf;
+const isMethod = (child: PropData, allowOverwrites: boolean = false) => {
+  const isImplementationOfBlobInterface =
+    child.implementationOf?.type === 'reference' &&
+    child.implementationOf?.name?.startsWith('Blob.');
+
+  return (
+    child.kind &&
+    [TypeDocKind.Method, TypeDocKind.Function].includes(child.kind) &&
+    (allowOverwrites || !child.overwrites) &&
+    !child.name.startsWith('_') &&
+    (!child?.implementationOf || isImplementationOfBlobInterface)
+  );
+};
 
 // This is intended to filter out inherited properties from some
 // common classes that are documented inside the `expo` package docs.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

In #38966, @aleqsio pointed out that Expo FileSystem has a missing `type` property that is being filtered out in Expo FileSystem reference doc.

The solution is to allow properties that implement Blob interface methods (like `type` ) to be shown in the File class documentation instead of being  filtered out.

# How

<!--
How did you build this feature or fix this bug and why?
-->

In `APISectionClasses.tsx`, replace blanket `!child.implementationOf` filter with conditional logic that allows properties implementing `Blob.*` methods to pass through.

This exposes File class properties like `type`, `size`, etc., while still filtering out other implementation details.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally and visit: http://localhost:3002/versions/v54.0.0/sdk/filesystem/#type

## Preview

<img width="912" height="134" alt="CleanShot 2025-08-19 at 19 38 38" src="https://github.com/user-attachments/assets/0cef23f4-bb0c-414d-93e9-d8e9c471cbab" />

<img width="267" height="665" alt="CleanShot 2025-08-19 at 19 39 19" src="https://github.com/user-attachments/assets/b0ecbb96-2983-4150-9cfa-3a979e38b361" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
