### PR TITLE
[app-integrity][docs] Fix API name in title

### DIFF
--- a/docs/pages/versions/unversioned/sdk/app-integrity.mdx
+++ b/docs/pages/versions/unversioned/sdk/app-integrity.mdx
@@ -1,5 +1,5 @@
 ---
-title: App Integrity
+title: AppIntegrity
 description: A library that provides access to Google's Play Integrity API on Android and Apple's App Attest service on iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-app-integrity'
 packageName: '@expo/app-integrity'

--- a/docs/pages/versions/v54.0.0/sdk/app-integrity.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/app-integrity.mdx
@@ -1,5 +1,5 @@
 ---
-title: App Integrity
+title: AppIntegrity
 description: A library that provides access to Google's Play Integrity API on Android and Apple's App Attest service on iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-app-integrity'
 packageName: '@expo/app-integrity'


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While scanning through AppIntegrity reference page, found that we don't use the API name in the page's title. This is a pattern we follow for all Expo Packages (except some exceptions) where API name is used in the page's title. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the title so it is reflected correcty on the page and the sidebar. This can also be verified by going through the API section for `@expo/app-integrity`:

<img width="895" height="129" alt="CleanShot 2025-08-19 at 22 15 33" src="https://github.com/user-attachments/assets/a207e1b8-d9da-4837-a363-2338d447f339" />

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="1508" height="1026" alt="CleanShot 2025-08-19 at 22 12 50" src="https://github.com/user-attachments/assets/efe1f7b1-9b0d-4dd4-9085-6751c61bcf2e" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
