### PR TITLE
[contacts][iOS] Fix issue with missing instantMessageAddresses on iOS

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed issue with missing `instantMessageAddresses` on iOS ([#38985](https://github.com/expo/expo/pull/38985) by [@hryhoriiK97](https://github.com/hryhoriiK97)
+
 ### 💡 Others
 
 ## 15.0.2 — 2025-08-16

--- a/packages/expo-contacts/ios/Serialization.swift
+++ b/packages/expo-contacts/ios/Serialization.swift
@@ -308,7 +308,7 @@ func serializeContact(person: CNContact, keys: [String]?, directory: URL?) throw
     }
   }
   if keysToFetch.contains(CNContactInstantMessageAddressesKey) {
-    let values = socialProfilesFor(contact: person)
+    let values = instantMessageAddressesFor(contact: person)
     if let values {
       contact[ContactsKey.instantMessageAddresses] = values
     }


### PR DESCRIPTION
# Why
Currently, in our project, we are migrating from `react-native-contacts` to `expo-contacts`. We found that instantMessageAddresses on iOS is always undefined. After a quick debugging session, I discovered an incorrect usage of socialProfilesFor for CNContactInstantMessageAddressesKey in Serialization.swift.

# How
I simply replaced socialProfilesFor with instantMessageAddressesFor.

# Test Plan
It should be sufficient to add instantMessageAddresses to the contact, then navigate to the ContactsScreen to ensure they are visible.

#Before
<img width="150" height="300" alt="before" src="https://github.com/user-attachments/assets/60aaf64d-b2a4-4053-9135-19950b779c4b" />

#After
<img width="150" height="300" alt="after" src="https://github.com/user-attachments/assets/ecdff48f-ee40-42e4-8c5e-95734eff4f99" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
