### PR TITLE
[tools][pp] Assign sdk-x tag when publishing

### DIFF
--- a/tools/src/promote-packages/tasks/promotePackages.ts
+++ b/tools/src/promote-packages/tasks/promotePackages.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import * as semver from 'semver';
 
 import { findPackagesToPromote } from './findPackagesToPromote';
 import { prepareParcels } from './prepareParcels';

--- a/tools/src/promote-packages/tasks/promotePackages.ts
+++ b/tools/src/promote-packages/tasks/promotePackages.ts
@@ -48,20 +48,6 @@ export const promotePackages = new Task<TaskArgs>(
             stdio: requiresOTP ? 'inherit' : undefined,
           });
         }
-        if (pkg.isTemplate()) {
-          const sdkTag = `sdk-${semver.major(pkg.packageVersion)}`;
-          batch.log(
-            '    ',
-            action,
-            yellow(sdkTag),
-            formatVersionChange(versionToReplace, currentVersion)
-          );
-          if (!options.dry) {
-            await Npm.addTagAsync(pkg.packageName, pkg.packageVersion, sdkTag, {
-              stdio: requiresOTP ? 'inherit' : undefined,
-            });
-          }
-        }
 
         // If the local version had any tags assigned, we can drop the old ones.
         if (options.drop && state.distTags && !state.distTags.includes(options.tag)) {

--- a/tools/src/publish-packages/tasks/publishPackages.ts
+++ b/tools/src/publish-packages/tasks/publishPackages.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import inquirer from 'inquirer';
 import path from 'path';
+import semver from 'semver';
 
 import { checkPackageAccess } from './checkPackageAccess';
 import { selectPackagesToPublish } from './selectPackagesToPublish';
@@ -64,6 +65,16 @@ export const publishPackages = new Task<TaskArgs>(
             stdio: requiresOTP ? 'inherit' : undefined,
           },
         });
+        // Assign SDK tag when package is a template
+        if (pkg.isTemplate()) {
+          const sdkTag = `sdk-${semver.major(pkg.packageVersion)}`;
+          logger.log('  ', `Assigning ${yellow(sdkTag)} tag to ${green(pkg.packageName)}`);
+          if (!options.dry) {
+            await Npm.addTagAsync(pkg.packageName, pkg.packageVersion, sdkTag, {
+              stdio: requiresOTP ? 'inherit' : undefined,
+            });
+          }
+        }
       } catch (error) {
         if (error.stderr.includes('You cannot publish over the previously published versions:')) {
           const { confirmed } = await inquirer.prompt<{ confirmed: boolean }>([


### PR DESCRIPTION
# Why

Assigning sdk-x tag when publishing the templates are more convenient as next version should also have sdk tag

# How

Assign `sdk-x` tag on `et pp` 

# Test Plan

Publish template with `et pp expo-template-default --dry` and check console for the `Assigning sdk-54 tag to expo-template-default`