### PR TITLE
[tools][pp] Dont assign sdk tags for canaries

### DIFF
--- a/tools/src/publish-packages/tasks/publishPackages.ts
+++ b/tools/src/publish-packages/tasks/publishPackages.ts
@@ -66,7 +66,7 @@ export const publishPackages = new Task<TaskArgs>(
           },
         });
         // Assign SDK tag when package is a template
-        if (pkg.isTemplate()) {
+        if (pkg.isTemplate() && !options.canary) {
           const sdkTag = `sdk-${semver.major(pkg.packageVersion)}`;
           logger.log('  ', `Assigning ${yellow(sdkTag)} tag to ${green(pkg.packageName)}`);
           if (!options.dry) {


### PR DESCRIPTION
# Why

Follow up to https://github.com/expo/expo/pull/38988

# How

Canaries should **not** have `sdk-x` tag assigned.