### PR TITLE
docs: fix broken markdown link in EAS tutorial

### DIFF
--- a/docs/pages/tutorial/eas/team-development.mdx
+++ b/docs/pages/tutorial/eas/team-development.mdx
@@ -124,7 +124,7 @@ Instead of creating a new build to share this change with our team for testing, 
 
 <Terminal cmd={['$ eas update --channel development --message "Change first button label"']} />
 
-In the command above, we used the `development` channel. Every update is associated with a [channel name]](/eas-update/how-it-works/#publishing-an-update). It is similar to every commit that we make with git, which is associated with a git branch.
+In the command above, we used the `development` channel. Every update is associated with a [channel name](/eas-update/how-it-works/#publishing-an-update). It is similar to every commit that we make with git, which is associated with a git branch.
 
 So, by using the channel `development` in our build profile and then publishing an, we're asking EAS to deliver this update to builds with the `development` channel. When we make an EAS Update channel it automatically gets mapped to a branch with the same name.
 


### PR DESCRIPTION
# Why

Reported to us

# How

- Fixed the broken link

# Test Plan

Docs change only 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
