### PR TITLE
Fix unexpected ',' separator issue

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Resolve `unexpected ',' separator Refer to "Xcode Logs" below for additional, more detailed logs` issue.
+
 ### 💡 Others
 
 ## 6.0.0-beta.4 — 2025-08-19

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Resolve `unexpected ',' separator Refer to "Xcode Logs" below for additional, more detailed logs` issue.
+- Resolve `unexpected ',' separator Refer to "Xcode Logs" below for additional, more detailed logs` issue. ([#38998](https://github.com/expo/expo/pull/38998) by [@Phil9l](https://github.com/Phil9l))
 
 ### 💡 Others
 

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeModule.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeModule.swift
@@ -19,7 +19,7 @@ public class LinkPreviewNativeModule: Module {
         "onWillPreviewOpen",
         "onDidPreviewOpen",
         "onPreviewWillClose",
-        "onPreviewDidClose",
+        "onPreviewDidClose"
       )
     }
 


### PR DESCRIPTION
The "Run fastlane" step failed because of an error in the Xcode build process. We automatically detected following errors in your Xcode build logs:
- unexpected ',' separator Refer to "Xcode Logs" below for additional, more detailed logs.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
