### PR TITLE
chore: add back `_vscode` to include vscode config in templates

### DIFF
--- a/templates/expo-template-default/_vscode/extensions.json
+++ b/templates/expo-template-default/_vscode/extensions.json
@@ -1,0 +1,1 @@
+{ "recommendations": ["expo.vscode-expo-tools"] }

--- a/templates/expo-template-default/_vscode/settings.json
+++ b/templates/expo-template-default/_vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit",
+    "source.organizeImports": "explicit",
+    "source.sortMembers": "explicit"
+  }
+}

--- a/templates/expo-template-tabs-react-navigation/_vscode/extensions.json
+++ b/templates/expo-template-tabs-react-navigation/_vscode/extensions.json
@@ -1,0 +1,1 @@
+{ "recommendations": ["expo.vscode-expo-tools"] }

--- a/templates/expo-template-tabs-react-navigation/_vscode/settings.json
+++ b/templates/expo-template-tabs-react-navigation/_vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit",
+    "source.organizeImports": "explicit",
+    "source.sortMembers": "explicit"
+  }
+}

--- a/templates/expo-template-tabs/_vscode/extensions.json
+++ b/templates/expo-template-tabs/_vscode/extensions.json
@@ -1,0 +1,1 @@
+{ "recommendations": ["expo.vscode-expo-tools"] }

--- a/templates/expo-template-tabs/_vscode/settings.json
+++ b/templates/expo-template-tabs/_vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit",
+    "source.organizeImports": "explicit",
+    "source.sortMembers": "explicit"
+  }
+}


### PR DESCRIPTION
# Why

I think we removed this by accident, the `.vscode` folder is for the `expo/expo` repository when working on the template files from `expo/expo` (not sure if this is picked up properly though). 

The `_vscode` folder is the config that gets packed with the template itself, meaning we get a `.vscode` folder when using `bun create expo`. We can't tarball files or folders starting with a `.` character, due to npm limitations. But we have special logic that handles this in [`create-expo`](https://github.com/expo/expo/blob/dea42a190290b6ba0a9063c91103ad68b938788f/packages/create-expo/src/__tests__/createFileTransformer.test.ts#L4-L10).

# How

- Copied `.vscode` folders to `_vscode` to get back `.vscode` in created projects

# Test Plan

- `bun create expo ./test-project --template https://github.com/expo/expo/tree/%40bycedric%2Ftemplates%2Fadd-back-vscode-config-for-templates/templates/expo-template-default`
- `cd ./test-project`
- Should have a `.vscode` folder

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
