### PR TITLE
fix(create-expo): rename `_vscode`, `_eas`, `_github`, and `_cursor` folders to dot-equivalent

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Modify `_eas`, `_vscode`, `_github`, and `_cursor` parent folders to avoid creating an empty directory.
+
 ### 💡 Others
 
 ## 3.5.2 — 2025-08-16

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Modify `_eas`, `_vscode`, `_github`, and `_cursor` parent folders to avoid creating an empty directory.
+- Modify `_eas`, `_vscode`, `_github`, and `_cursor` parent folders to avoid creating an empty directory. ([#39002](https://github.com/expo/expo/pull/39002) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/create-expo/src/__tests__/createFileTransformer.test.ts
+++ b/packages/create-expo/src/__tests__/createFileTransformer.test.ts
@@ -4,6 +4,14 @@ describe(modifyFileDuringPipe, () => {
   it(`renames _vscode to .vscode`, () => {
     expect(
       modifyFileDuringPipe({
+        path: 'package/_vscode/',
+        type: 'File',
+      }).path
+    ).toEqual('package/.vscode/');
+  });
+  it(`renames files within _vscode to .vscode`, () => {
+    expect(
+      modifyFileDuringPipe({
         path: 'package/_vscode/settings.json',
         type: 'File',
       }).path


### PR DESCRIPTION
# Why

When using a github repository as template, e.g. #38999, the `_vscode` folder was not mutated. This resulted in `_vscode` folder being created when using github repositories as a template.

# How

- Also rewrite `_vscode` directory to `.vscode` to avoid creating `_vscode` folders

# Test Plan

See added tests, and:

- `bun create expo ./test-project --template https://github.com/expo/expo/tree/%40bycedric%2Ftemplates%2Fadd-back-vscode-config-for-templates/templates/expo-template-default`
- `cd ./test-project`
- Should have a `.vscode` folder, but not `_vscode`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
