### PR TITLE
[android][audio] Emit initial state update

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Emit state update after reload.
+- [Android] Emit state update after reload. ([#39003](https://github.com/expo/expo/pull/39003) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Emit state update after reload.
+
 ### 💡 Others
 
 ## 1.0.3 — 2025-08-18

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.UUID
@@ -92,6 +93,9 @@ class AudioPlayer(
         delay(updateInterval.toLong())
       }
     }
+      .onStart {
+        sendPlayerUpdate()
+      }
       .onEach {
         if (playing) {
           sendPlayerUpdate()


### PR DESCRIPTION
# Why
Closes #38962

# How
After a reload the state is not correct. This is because the hook does not refresh after a reload because the player id has not changed and none of the callbacks in the `Player.Listener` are triggered. To fix this, we should emit an initial state update when we start the updateFlow. 

# Test Plan
Bare-expo and in the provided repro. The state from `useAudioPlayerStatus` and `currentStatus` are now always in sync.

