### PR TITLE
[go][home] Add basic Native Bottom Tabs

### DIFF
--- a/apps/expo-go/src/navigation/BottomTabNavigator.ts
+++ b/apps/expo-go/src/navigation/BottomTabNavigator.ts
@@ -1,27 +1,19 @@
 import { darkTheme, lightTheme } from '@expo/styleguide-native';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { ComponentProps } from 'react';
-import { StyleSheet } from 'react-native';
 
-const BottomTabNavigator = createBottomTabNavigator();
+import { createNativeBottomTabsNavigator } from './NativeBottomTabsNavigator';
+
+const BottomTabNavigator = createNativeBottomTabsNavigator();
 export default BottomTabNavigator;
 
 export const getNavigatorProps = (props: {
   theme: string;
 }): Partial<ComponentProps<typeof BottomTabNavigator.Navigator>> => ({
-  screenOptions: {
-    headerShown: false,
-    tabBarLabelStyle: { fontFamily: 'Inter-SemiBold' },
-    tabBarHideOnKeyboard: false,
-    tabBarStyle: {
-      backgroundColor:
-        props.theme === 'dark' ? darkTheme.background.default : lightTheme.background.default,
-      borderTopColor: props.theme === 'dark' ? darkTheme.border.default : lightTheme.border.default,
-      borderTopWidth: StyleSheet.hairlineWidth,
-    },
-    tabBarActiveTintColor:
-      props.theme === 'dark' ? darkTheme.link.default : lightTheme.link.default,
-    tabBarInactiveTintColor:
-      props.theme === 'dark' ? darkTheme.icon.default : lightTheme.icon.default,
+  tabBarStyle: {
+    backgroundColor:
+      props.theme === 'dark' ? darkTheme.background.default : lightTheme.background.default,
   },
+  tabBarActiveTintColor: props.theme === 'dark' ? darkTheme.link.default : lightTheme.link.default,
+  tabBarInactiveTintColor:
+    props.theme === 'dark' ? darkTheme.icon.default : lightTheme.icon.default,
 });

--- a/apps/expo-go/src/navigation/NativeBottomTabsNavigator.tsx
+++ b/apps/expo-go/src/navigation/NativeBottomTabsNavigator.tsx
@@ -1,0 +1,91 @@
+import {
+  createNavigatorFactory,
+  type NavigatorTypeBagBase,
+  type ParamListBase,
+  type StackNavigationState,
+  type StaticConfig,
+  TabRouter,
+  type TypedNavigator,
+  useNavigationBuilder,
+} from '@react-navigation/native';
+import * as React from 'react';
+import { BottomTabs, BottomTabsScreen } from 'react-native-screens';
+
+function NativeBottomTabsNavigator({
+  id,
+  initialRouteName,
+  children,
+  layout,
+  screenListeners,
+  screenOptions,
+  screenLayout,
+  router,
+  ...rest
+}: any) {
+  const { state, descriptors, navigation } = useNavigationBuilder(TabRouter, {
+    id,
+    initialRouteName,
+    children,
+    layout,
+    screenListeners,
+    screenOptions,
+    screenLayout,
+  });
+  const { routes } = state;
+  const deferredFocusedIndex = React.useDeferredValue(state.index);
+
+  return (
+    <BottomTabs
+      tabBarBackgroundColor={rest.tabBarStyle?.backgroundColor}
+      tabBarTintColor={rest.tabBarActiveTintColor}
+      onNativeFocusChange={({ nativeEvent: { tabKey } }) => {
+        const descriptor = descriptors[tabKey];
+        const route = descriptor.route;
+        navigation.dispatch({
+          type: 'JUMP_TO',
+          target: state.key,
+          payload: {
+            name: route.name,
+          },
+        });
+      }}>
+      {routes
+        .map((route, index) => ({ route, index }))
+        .map(({ route, index }) => {
+          const descriptor = descriptors[route.key];
+          const isFocused = index === deferredFocusedIndex;
+
+          return (
+            <BottomTabsScreen
+              {...descriptor.options}
+              key={route.key}
+              tabKey={route.key}
+              title={descriptor.options.tabBarLabel ?? route.name}
+              isFocused={isFocused}
+              icon={descriptor.options.tabBarIcon()}>
+              {descriptor.render()}
+            </BottomTabsScreen>
+          );
+        })}
+    </BottomTabs>
+  );
+}
+
+export function createNativeBottomTabsNavigator<
+  const ParamList extends ParamListBase,
+  const NavigatorID extends string | undefined = undefined,
+  const TypeBag extends NavigatorTypeBagBase = {
+    ParamList: ParamList;
+    NavigatorID: NavigatorID;
+    State: StackNavigationState<ParamList>;
+    ScreenOptions: any;
+    EventMap: any;
+    NavigationList: {
+      [RouteName in keyof ParamList]: any;
+    };
+    Navigator: any;
+  },
+  const Config extends StaticConfig<TypeBag> = StaticConfig<TypeBag>,
+>(config?: Config): TypedNavigator<TypeBag, Config> {
+  return createNavigatorFactory(NativeBottomTabsNavigator)(config);
+}

--- a/apps/expo-go/src/navigation/Navigation.tsx
+++ b/apps/expo-go/src/navigation/Navigation.tsx
@@ -131,7 +131,12 @@ function TabNavigator(props: { theme: string }) {
         name="HomeStack"
         component={HomeStackScreen}
         options={{
-          tabBarIcon: ({ color }) => <HomeFilledIcon style={styles.icon} color={color} size={24} />,
+          tabBarIcon: (props: any) =>
+            Platform.OS === 'ios' ? (
+              { sfSymbolName: 'house.fill' }
+            ) : (
+              <HomeFilledIcon {...props} style={styles.icon} size={24} />
+            ),
           tabBarLabel: 'Home',
         }}
       />
@@ -141,7 +146,12 @@ function TabNavigator(props: { theme: string }) {
           name="DiagnosticsStack"
           component={DiagnosticsStackScreen}
           options={{
-            tabBarIcon: (props) => <DiagnosticsIcon {...props} style={styles.icon} size={24} />,
+            tabBarIcon: (props: any) =>
+              Platform.OS === 'ios' ? (
+                { sfSymbolName: 'ecg.text.page.fill' }
+              ) : (
+                <DiagnosticsIcon {...props} style={styles.icon} size={24} />
+              ),
             tabBarLabel: 'Diagnostics',
           }}
         />
@@ -151,7 +161,12 @@ function TabNavigator(props: { theme: string }) {
         component={SettingsStackScreen}
         options={{
           title: 'Settings',
-          tabBarIcon: (props) => <SettingsFilledIcon {...props} style={styles.icon} size={24} />,
+          tabBarIcon: (props: any) =>
+            Platform.OS === 'ios' ? (
+              { sfSymbolName: 'gearshape.fill' }
+            ) : (
+              <SettingsFilledIcon {...props} style={styles.icon} size={24} />
+            ),
           tabBarLabel: 'Settings',
         }}
       />


### PR DESCRIPTION
# Why

ENG-17046

# How

Actually, adding `react-native-bottom-tabs` would break `expo-image` so I've made a basic navigator for the `react-native-screens` native bottom tabs. It's poorly typed, but it should be fine since it's only for one SDK version, and it's working. 


https://github.com/user-attachments/assets/3909e43c-a5f8-4414-8f44-500c142c0019

# Test Plan

Build Expo Go and open Home app