### PR TITLE
[doctor] ignored files check

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unpublished
 
+### 🎉 New features
+
+- Add EAS platform detection, Android gitignore validation, and .expo gitignore check to project setup. ([#39007](https://github.com/expo/expo/pull/39007) by [@entiendonull](https://github.com/entiendonull))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-doctor/src/checks/AppConfigFieldsNotSyncedToNativeProjectsCheck.ts
+++ b/packages/expo-doctor/src/checks/AppConfigFieldsNotSyncedToNativeProjectsCheck.ts
@@ -3,8 +3,8 @@ import path from 'path';
 
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 import { learnMore } from '../utils/TerminalLink';
-import { existsAndIsNotIgnoredAsync } from '../utils/files';
 import { env } from '../utils/env';
+import { existsAndIsNotIgnoredAsync } from '../utils/files';
 
 const appConfigFieldsToSyncWithNative = [
   'ios',

--- a/packages/expo-doctor/src/checks/LockfileCheck.ts
+++ b/packages/expo-doctor/src/checks/LockfileCheck.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 
 export class LockfileCheck implements DoctorCheck {

--- a/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
+++ b/packages/expo-doctor/src/checks/ProjectSetupCheck.ts
@@ -3,7 +3,7 @@ import { glob, GlobOptions } from 'glob';
 import path from 'path';
 
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
-import { isFileIgnoredAsync } from '../utils/files';
+import { existsAndIsNotIgnoredAsync, isFileIgnoredAsync } from '../utils/files';
 
 export class ProjectSetupCheck implements DoctorCheck {
   description = 'Check for common project setup issues';
@@ -38,6 +38,18 @@ export class ProjectSetupCheck implements DoctorCheck {
         advice.push(
           `Use patterns like "/android" and "/ios" in your .gitignore file to exclude only the top-level "android" and "ios" directories, and not those in the modules directory.`
         );
+      }
+    }
+
+    // Check that the .expo directory IS gitignored
+    const expoDir = path.join(projectRoot, '.expo');
+    if (fs.existsSync(expoDir)) {
+      const isIgnored = await isFileIgnoredAsync(expoDir, false);
+      if (!isIgnored) {
+        issues.push(
+          `The .expo directory is not ignored by Git. It contains machine-specific device history and development server settings and should not be committed.`
+        );
+        advice.push(`Add ".expo/" to your .gitignore to avoid committing local Expo state.`);
       }
     }
 

--- a/packages/expo-doctor/src/checks/__tests__/AppConfigFieldsNotSyncedToNativeProjectsCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/AppConfigFieldsNotSyncedToNativeProjectsCheck.test.ts
@@ -1,8 +1,9 @@
 import { vol } from 'memfs';
 import * as path from 'path';
+
+import { env } from '../../utils/env';
 import { existsAndIsNotIgnoredAsync } from '../../utils/files';
 import { AppConfigFieldsNotSyncedToNativeProjectsCheck } from '../AppConfigFieldsNotSyncedToNativeProjectsCheck';
-import { env } from '../../utils/env';
 
 jest.mock('fs');
 jest.mock('../../utils/files');

--- a/packages/expo-doctor/src/utils/checkResolver.ts
+++ b/packages/expo-doctor/src/utils/checkResolver.ts
@@ -15,6 +15,7 @@ import { ExpoConfigSchemaCheck } from '../checks/ExpoConfigSchemaCheck';
 import { GlobalPackageInstalledLocallyCheck } from '../checks/GlobalPackageInstalledLocallyCheck';
 import { IllegalPackageCheck } from '../checks/IllegalPackageCheck';
 import { InstalledDependencyVersionCheck } from '../checks/InstalledDependencyVersionCheck';
+import { LockfileCheck } from '../checks/LockfileCheck';
 import { MetroConfigCheck } from '../checks/MetroConfigCheck';
 import { NativeToolingVersionCheck } from '../checks/NativeToolingVersionCheck';
 import { PackageJsonCheck } from '../checks/PackageJsonCheck';
@@ -25,7 +26,6 @@ import { ReactNativeDirectoryCheck } from '../checks/ReactNativeDirectoryCheck';
 import { StoreCompatibilityCheck } from '../checks/StoreCompatibilityCheck';
 import { SupportPackageVersionCheck } from '../checks/SupportPackageVersionCheck';
 import { DoctorCheck } from '../checks/checks.types';
-import { LockfileCheck } from '../checks/LockfileCheck';
 
 /**
  * Resolves the checks that should be run for a given project.

--- a/packages/expo-doctor/src/utils/env.ts
+++ b/packages/expo-doctor/src/utils/env.ts
@@ -34,6 +34,12 @@ class Env {
   get EXPO_DOCTOR_WARN_ON_NETWORK_ERRORS() {
     return boolish('EXPO_DOCTOR_WARN_ON_NETWORK_ERRORS', false);
   }
+
+  /** EAS Build Platform */
+  get EAS_BUILD_PLATFORM(): 'android' | 'ios' | null {
+    const easPlatform = process.env.EAS_BUILD_PLATFORM;
+    return easPlatform === 'android' || easPlatform === 'ios' ? easPlatform : null;
+  }
 }
 
 export const env = new Env();


### PR DESCRIPTION
# Why

Resolves ENG-16976

# How
**.expo**
Added a check in `ProjectSetupCheck` to verify whether the .expo directory is gitignored.

**/android/.gradle**
Extended the current logic to see if the project is configured for EAS. 

When the project is built on EAS, @keith-kurak suggested we determine the current build platform by using [EAS_BUILD_PLATFORM](https://docs.expo.dev/eas/environment-variables/#built-in-environment-variables). This allows us to provide platform-specific information.

- The advice message now displays the actual platform name (`android` or `ios`)
- For Android, it performs an additional check: if the android/ directory is not gitignored, it verifies whether the `.gradle` directory is ignored. If it isn't, additional advice is shown.

By default, creating a native Android project includes its own .gitignore under /android/.gitignore, which ignores the .gradle directory.

# Test Plan

**Everything OK**
```
17/17 checks passed. No issues detected!
```

**.expo not ignored**
```
✖ Check for common project setup issues
The .expo directory is not ignored by Git. It contains machine-specific device history and development server settings and should not be committed.
Advice:
Add ".expo/" to your .gitignore to avoid committing local Expo state.
```

**Native projects present, not gitignored:**
```
✖ Check for app config fields that may not be synced in a non-CNG project
This project contains native project folders but also has native configuration properties in app.json, indicating it is configured to use Prebuild. When the android/ios folders are present, if you don't run prebuild in your build pipeline, the following properties will not be synced: orientation, icon, scheme, userInterfaceStyle, ios, android, plugins, androidStatusBar. 
```

**With EAS_BUILD_PLATFORM set to android and .gradle in gitignore:**
```
✖ Check for app config fields that may not be synced in a non-CNG project
This project contains native project folders but also has native configuration properties in app.json, indicating it is configured to use Prebuild. When the android/ios folders are present, EAS Build will not sync the following properties: orientation, icon, scheme, userInterfaceStyle, ios, android, plugins, androidStatusBar. 

Advice:
Add '/android' to your .gitignore file if you intend to use CNG / Prebuild. Learn more: https://docs.expo.dev/workflow/prebuild/#usage-with-eas-build
```

_What changed?_ 
It's specific about what platform, before it said '/android' and '/ios'

**With EAS_BUILD_PLATFORM set to android and .gradle NOT in gitignore:**
```
✖ Check for app config fields that may not be synced in a non-CNG project
This project contains native project folders but also has native configuration properties in app.json, indicating it is configured to use Prebuild. When the android/ios folders are present, EAS Build will not sync the following properties: orientation, icon, scheme, userInterfaceStyle, ios, android, plugins, androidStatusBar. 

Advice:
Add '/android' to your .gitignore file if you intend to use CNG / Prebuild. Learn more: https://docs.expo.dev/workflow/prebuild/#usage-with-eas-build
If you intend to not use CNG, add '/android/.gradle' to your .gitignore to avoid committing Gradle caches
```

_What changed?_
Added additional advice "If you intend to not use CNG [...]"

**With EAS_BUILD_PLATFORM set to ios**
```
✖ Check for app config fields that may not be synced in a non-CNG project
This project contains native project folders but also has native configuration properties in app.json, indicating it is configured to use Prebuild. When the android/ios folders are present, EAS Build will not sync the following properties: orientation, icon, scheme, userInterfaceStyle, ios, android, plugins, androidStatusBar. 

Advice:
Add '/ios' to your .gitignore file if you intend to use CNG / Prebuild. Learn more: https://docs.expo.dev/workflow/prebuild/#usage-with-eas-build
```

_What changed?_ 
It's specific about what platform, before it said '/android' and '/ios'

---

Test locally by adjusting the gitignore files and run EAS_BUILD_PLATFORM=[platform] nexpo-doctor

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
