### PR TITLE
[docs] Update app icon info for iOS 26

### DIFF
--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -202,7 +202,20 @@ You may also want to provide a separate icon for older Android devices that do n
 
 #### iOS
 
-For iOS, your app's icon should follow the [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/app-icons/). You should also:
+For iOS, your app's icon should follow the [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/app-icons/).
+You can use the [icon composer](https://developer.apple.com/icon-composer/) app to create your app icon. This will output a `.icon` directory that you can add to your projects `assets`. You can then provide the path to this directory in your app config. Adding support for dark mode is handled in icon composer, you do not need to provide variants when using this approach.
+
+```json app.json
+{
+  "expo": {
+    "ios": {
+      "icon": "./assets/app.icon"
+    }
+  }
+}
+```
+
+Alternatively, the previous approach of providing an image is still supported. You should:
 
 - Use a **.png** file.
 - 1024x1024 is a good size. If you have an Expo project created using `npx create-expo-app`, [EAS Build](/build/setup/) will generate the other sizes for you. In case of a bare React Native project, generate the icons on your own. The largest size EAS Build generates is 1024x1024.

--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -202,8 +202,7 @@ You may also want to provide a separate icon for older Android devices that do n
 
 #### iOS
 
-For iOS, your app's icon should follow the [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/app-icons/).
-You can use the [icon composer](https://developer.apple.com/icon-composer/) app to create your app icon. This will output a `.icon` directory that you can add to your projects `assets`. You can then provide the path to this directory in your app config. Adding support for dark mode is handled in icon composer, you do not need to provide variants when using this approach.
+For iOS, your app's icon should follow the [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/app-icons/). You can use the [Icon Composer](https://developer.apple.com/icon-composer/) app to create your app icon. This will output a **.icon** directory that you can add to your project's **assets** directory. You can then provide the path to this directory in your app config. Adding support for dark mode is handled in Icon Composer, so you do not need to provide variants when using this approach.
 
 ```json app.json
 {


### PR DESCRIPTION
# Why
Closes ENG-17044

Updates our app icon documentation to provide direction on using liquid glass icons with iOS 26. The HIG now defaults to info about icon composer and liquid glass

# Test Plan

<img width="984" height="532" alt="Screenshot 2025-08-20 at 13 50 31" src="https://github.com/user-attachments/assets/278a1782-987a-41db-98f0-eae157967ebd" />

