### PR TITLE
[notifications] fix setBadgeCountAsync(0) clearing notifications

### DIFF
--- a/apps/native-component-list/src/screens/NotificationScreen.tsx
+++ b/apps/native-component-list/src/screens/NotificationScreen.tsx
@@ -359,10 +359,13 @@ export default class NotificationScreen extends React.Component<
   };
 
   _incrementIconBadgeNumberAsync = async () => {
-    const currentNumber = await Notifications.getBadgeCountAsync();
-    await Notifications.setBadgeCountAsync(currentNumber + 1);
+    const previousNumber = await Notifications.getBadgeCountAsync();
+    const didIncrement = await Notifications.setBadgeCountAsync(previousNumber + 1);
     const actualNumber = await Notifications.getBadgeCountAsync();
-    Alert.alert(`Set the badge number to ${actualNumber}`);
+    const message = didIncrement
+      ? `Incremented from ${previousNumber} to ${actualNumber} (expected: ${previousNumber + 1}).`
+      : "You don't have notification permissions.";
+    Alert.alert(message);
   };
 
   _clearIconBadgeAsync = async () => {

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] fix `setBadgeCountAsync(0)` also cleared notifications ([#39009](https://github.com/expo/expo/pull/39009) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 ## 0.32.2 — 2025-08-16


### PR DESCRIPTION
# Why

closes #37017

# How

- refactor badge module to new apis

# Test Plan

- bare expo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
