### PR TITLE
upgrade react-native-screens to 4.15.0

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2733,7 +2733,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNScreens (4.14.0):
+  - RNScreens (4.15.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2755,9 +2755,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNScreens/common (= 4.14.0)
+    - RNScreens/common (= 4.15.0)
     - Yoga
-  - RNScreens/common (4.14.0):
+  - RNScreens/common (4.15.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3683,7 +3683,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 6fdd63f5d1e0f21faf4cc8674957c52958a7efae
   RNGestureHandler: 6a488ce85c88e82d8610db1108daf04e9b2d5162
   RNReanimated: 98a3da83c44675f5ac6ee39a8f1c74e7f473cac9
-  RNScreens: d6b31648c5c954f6f52f6d17013dc5c0010bf40f
+  RNScreens: 2300f78cc25603268848c94561ae43099e030cb9
   RNSVG: 2825ee146e0f6a16221e852299943e4cceef4528
   RNWorklets: 135b6c5652935a876524216e6f83584be1ad8121
   SDWebImage: f29024626962457f3470184232766516dee8dfea

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -73,7 +73,7 @@
     "react-native-pager-view": "6.9.1",
     "react-native-reanimated": "4.0.2",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.14.0",
+    "react-native-screens": "4.15.0",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3325,7 +3325,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNScreens (4.14.0):
+  - RNScreens (4.15.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3352,10 +3352,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.14.0)
+    - RNScreens/common (= 4.15.0)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.14.0):
+  - RNScreens/common (4.15.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -4377,7 +4377,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: c4a42c6a77d474f05162d61a4ab4253d13008277
   RNGestureHandler: 4f7cc97a71d4fe0fcba38c94acdd969f5f17c91c
   RNReanimated: 3b8ec43aaef0389e702878e7725608128daa2053
-  RNScreens: c12236cebe3a06dbf879a6258432dc6657f3eabf
+  RNScreens: 30c3a80300269e7dad3479f1c328883e3064be4d
   RNSVG: 8d87cff016edf1b6ca409ed39804101836d75e90
   RNWorklets: f0b4bfd581c55f18a8bea9beae9cef26650c8cda
   SDWebImage: f29024626962457f3470184232766516dee8dfea

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -80,7 +80,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "4.0.2",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.14.0",
+    "react-native-screens": "4.15.0",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -149,7 +149,7 @@
     "react-native-worklets": "0.4.1",
     "react-native-reanimated": "4.0.2",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.14.0",
+    "react-native-screens": "4.15.0",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-web": "~0.21.0",

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -32,7 +32,7 @@
     "react": "19.1.0",
     "react-native": "0.81.0",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.14.0"
+    "react-native-screens": "4.15.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -46,7 +46,7 @@
     "react": "19.1.0",
     "react-native": "0.81.0",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.14.0",
+    "react-native-screens": "4.15.0",
     "react-native-webview": "13.13.5"
   },
   "devDependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -101,7 +101,7 @@
   "react-native-pager-view": "6.9.1",
   "react-native-worklets": "~0.4.1",
   "react-native-reanimated": "~4.0.2",
-  "react-native-screens": "~4.14.0",
+  "react-native-screens": "~4.15.0",
   "react-native-safe-area-context": "~5.6.0",
   "react-native-svg": "15.12.1",
   "react-native-view-shot": "4.0.3",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -34,7 +34,7 @@
     "react-native-worklets": "~0.4.1",
     "react-native-reanimated": "~4.0.2",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.14.0",
+    "react-native-screens": "~4.15.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "react-native-worklets": "~0.4.1",
     "react-native-reanimated": "~4.0.2",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.14.0",
+    "react-native-screens": "~4.15.0",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13891,10 +13891,10 @@ react-native-screens@4.11.1-nightly-20250611-8b82e081e:
     react-native-is-edge-to-edge "^1.1.7"
     warn-once "^0.1.0"
 
-react-native-screens@4.14.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.14.0.tgz#585c84954f2c0a60b8726deb5940c2c0b20b0f1b"
-  integrity sha512-BMTQ30IozI8ZkqqPw71LbiaEcU+F5wDmfXDFlVn0wupZnxt0l7x7lUh2nljxR7rNHQneNIZoRTlu0ExK0R0xmA==
+react-native-screens@4.15.0:
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.15.0.tgz#8b34056b72a2c92da4de2f77419a116154c88e81"
+  integrity sha512-LPz+9qWDfwY3pPKojrWPcQnb2sAq9cy/qA8ZAS14ksSdzqFkTTUbs1as2WGBo7xBtdx5Ht78bF9nNh8libX1Xw==
   dependencies:
     react-freeze "^1.0.0"
     react-native-is-edge-to-edge "^1.2.1"


### PR DESCRIPTION
# Why

react-native-screens released new version that includes improvements to bottom tabs

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

1. Tested expo-go and bare-expo on both Android and iOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
