### PR TITLE
chore(expo): Enable `react-native-strict-api` TS typings condition by default

### DIFF
--- a/apps/native-component-list/tsconfig.json
+++ b/apps/native-component-list/tsconfig.json
@@ -11,6 +11,7 @@
     },
     "types": ["jest"],
     "typeRoots": ["./ts-declarations", "./node_modules/@types", "../../node_modules/@types"],
+    "customConditions": ["react-native"],
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "strictFunctionTypes": true,

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Enable [React Native Strict TypeScript API typings](https://reactnative.dev/docs/strict-typescript-api) by default. This is not a breaking change unless you've used internal APIs in your TypeScript code. ([#39018](https://github.com/expo/expo/pull/39018) by [@kitten](https://github.com/kitten))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -10,7 +10,7 @@
     "module": "preserve",
     "moduleDetection": "force",
     "moduleResolution": "bundler",
-    "customConditions": ["react-native"],
+    "customConditions": ["react-native-strict-api", "react-native"],
     "noEmit": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,


### PR DESCRIPTION
**Beta Note:** We'd like to test this out in the beta, but reserve ourselves some room to reverse this decision. We'd like to see how many people this affects.

This will alter the typings to disable typings for nested/internal imports into `react-native`, effectively informing people not to use internal React Native APIs any longer. This only affects TypeScript types, and will only affect users that use our TypeScript preset (which is shipped in templates by default)

More information: https://reactnative.dev/docs/strict-typescript-api