### PR TITLE
[video][ios]Fix `sourceLoad` event not being emitted

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `sourceLoad` event not being emitted. ([#39023](https://github.com/expo/expo/pull/39023) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 - [Android] Keep the screen on while playback is running by default. ([#37137](https://github.com/expo/expo/pull/37137) by [@behenate](https://github.com/behenate))

--- a/packages/expo-video/ios/VideoPlayerObserver.swift
+++ b/packages/expo-video/ios/VideoPlayerObserver.swift
@@ -398,7 +398,7 @@ class VideoPlayerObserver: VideoSourceLoaderListener {
       status = .error
     }
 
-    if let player, !loadedCurrentItem && (status == .readyToPlay || status == .error) {
+    if let player, !loadedCurrentItem && (newStatus == .readyToPlay || newStatus == .error) {
       onLoadedPlayerItem(player: player, playerItem: playerItem)
     }
 


### PR DESCRIPTION
# Why

The `sourceLoad` event was not being emitted. This is because we were checking the status of the player, which was still loading, instead of checking the status of the PlayerItem, which was already loaded.

# How

We check the status of the playerItem instead of the player.

# Test Plan

Tested in BareExpo on an iPhone 13
