### PR TITLE
[doctor] Inform users about corrupted `node_modules` folders via autolinking duplicates check

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Inform users of corrupted `node_modules` if autolinking finds duplicates with all identical versions ([#39026](https://github.com/expo/expo/pull/39026) by [@kitten](https://github.com/kitten))
+
 ## 1.16.0 — 2025-08-19
 
 ### 🎉 New features

--- a/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
+++ b/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
@@ -127,7 +127,12 @@ export class AutolinkingDependencyDuplicatesCheck implements DoctorCheck {
         // copies of the same version are installed
         if (dependency.version) {
           const areVersionsIdentical = dependency.duplicates.every((duplicate) => {
-            return duplicate.version && duplicate.version === dependency.version;
+            return (
+              duplicate.version &&
+              duplicate.version === dependency.version &&
+              /* NOTE(@kitten): We shouldn't have to compare here, but this is just in case there are weirder corruptions I can't think of */
+              duplicate.originPath !== dependency.originPath
+            );
           });
           if (areVersionsIdentical) corruptedInstallations.push(dependency);
         }

--- a/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
+++ b/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
@@ -136,8 +136,8 @@ export class AutolinkingDependencyDuplicatesCheck implements DoctorCheck {
     if (issues.length) {
       if (corruptedInstallations.length) {
         advice.push(
-          `Multiple copies of the same version exist for: ${corruptedInstallations.map((x) => x.name).join(', ')}\n` +
-            'Try deleting your node_modules folders and reinstall your dependencies after.'
+          `Multiple copies of the same version exist for: ${corruptedInstallations.map((x) => x.name).join(', ')}.\n` +
+            '- Try deleting your node_modules folders and reinstall your dependencies after.'
         );
       }
       advice.push(

--- a/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
+++ b/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
@@ -125,10 +125,12 @@ export class AutolinkingDependencyDuplicatesCheck implements DoctorCheck {
         // - expo-constants@18.0.2 (at: node_modules/expo-asset/node_modules/expo-constants)
         // Note that in this example, all versions are identical, but multiple
         // copies of the same version are installed
-        const areVersionsIdentical = versions.every((resolution, _idx, versions) => {
-          return resolution.version && versions[0].version === resolution.version;
-        });
-        if (areVersionsIdentical) corruptedInstallations.push(dependency);
+        if (dependency.version) {
+          const areVersionsIdentical = dependency.duplicates.every((duplicate) => {
+            return duplicate.version && duplicate.version === dependency.version;
+          });
+          if (areVersionsIdentical) corruptedInstallations.push(dependency);
+        }
       }
     }
 

--- a/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
+++ b/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
@@ -105,6 +105,7 @@ export class AutolinkingDependencyDuplicatesCheck implements DoctorCheck {
         : `${dependency.name} at: ${relative}`;
     }
 
+    const corruptedInstallations: BaseDependencyResolution[] = [];
     for (const dependency of packagesWithIssues.values()) {
       if (dependency.duplicates?.length) {
         const line = [`Found duplicates for ${dependency.name}:`];
@@ -115,17 +116,39 @@ export class AutolinkingDependencyDuplicatesCheck implements DoctorCheck {
           line.push(`  ${prefix} ${await getHumanReadableDependency(duplicate)}`);
         }
         issues.push(line.join('\n'));
+
+        // If all versions are identical then the node_modules folder is corrupted
+        // This can happen if a package manager fails to clean up after itself when updating
+        // and may look like this:
+        // - expo-constants@18.0.2 (at: node_modules/expo-constants)
+        // - expo-constants@18.0.2 (at: node_modules/expo/node_modules/expo-constants)
+        // - expo-constants@18.0.2 (at: node_modules/expo-asset/node_modules/expo-constants)
+        // Note that in this example, all versions are identical, but multiple
+        // copies of the same version are installed
+        const areVersionsIdentical = versions.every((resolution, _idx, versions) => {
+          return resolution.version && versions[0].version === resolution.version;
+        });
+        if (areVersionsIdentical) corruptedInstallations.push(dependency);
       }
+    }
+
+    const advice: string[] = [];
+    if (issues.length) {
+      if (corruptedInstallations.length) {
+        advice.push(
+          `Multiple copies of the same version exist for: ${corruptedInstallations.map((x) => x.name).join(', ')}\n` +
+            'Try deleting your node_modules folders and reinstall your dependencies after.'
+        );
+      }
+      advice.push(
+        `Resolve your dependency issues and deduplicate your dependencies. ${learnMore('https://expo.fyi/resolving-dependency-issues')}`
+      );
     }
 
     return {
       isSuccessful: issues.length === 0,
       issues,
-      advice: issues.length
-        ? [
-            `Resolve your dependency issues and deduplicate your dependencies. ${learnMore('https://expo.fyi/resolving-dependency-issues')}`,
-          ]
-        : [],
+      advice,
     };
   }
 }

--- a/packages/expo-doctor/src/checks/LockfileCheck.ts
+++ b/packages/expo-doctor/src/checks/LockfileCheck.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 
 export class LockfileCheck implements DoctorCheck {

--- a/packages/expo-doctor/src/utils/checkResolver.ts
+++ b/packages/expo-doctor/src/utils/checkResolver.ts
@@ -15,6 +15,7 @@ import { ExpoConfigSchemaCheck } from '../checks/ExpoConfigSchemaCheck';
 import { GlobalPackageInstalledLocallyCheck } from '../checks/GlobalPackageInstalledLocallyCheck';
 import { IllegalPackageCheck } from '../checks/IllegalPackageCheck';
 import { InstalledDependencyVersionCheck } from '../checks/InstalledDependencyVersionCheck';
+import { LockfileCheck } from '../checks/LockfileCheck';
 import { MetroConfigCheck } from '../checks/MetroConfigCheck';
 import { NativeToolingVersionCheck } from '../checks/NativeToolingVersionCheck';
 import { PackageJsonCheck } from '../checks/PackageJsonCheck';
@@ -25,7 +26,6 @@ import { ReactNativeDirectoryCheck } from '../checks/ReactNativeDirectoryCheck';
 import { StoreCompatibilityCheck } from '../checks/StoreCompatibilityCheck';
 import { SupportPackageVersionCheck } from '../checks/SupportPackageVersionCheck';
 import { DoctorCheck } from '../checks/checks.types';
-import { LockfileCheck } from '../checks/LockfileCheck';
 
 /**
  * Resolves the checks that should be run for a given project.


### PR DESCRIPTION
# Why

Context from Discord: https://discord.com/channels/695411232856997968/1407839724193972244

A user reported that Bun failed to clean up after itself. It kept around old duplicate dependencies (presumably from when prior conflicts existed before `expo install --fix`). When it fails to clean up after itself, duplicates exist in the `node_modules` but not in the lockfile.

This is recognisable by seeing duplicates with identical versions. Packages with identical versions should always be deduplicated.

# How

Check if a resolution has duplicates that are all the same version as the base resolution. If so, the package manager failed to hoist (or rather, most of the time, failed to delete old module folders)

We should tell the user to delete their `node_modules` folder(s) and reinstall in that case.