### PR TITLE
Fix `unexpected ',' separator` issue

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `unexpected ',' separator` issue ([#39027](https://github.com/expo/expo/pull/39027) by [@phil9l](https://github.com/phil9l))
+
 ### 💡 Others
 
 ## 29.0.3 — 2025-08-18

--- a/packages/expo-updates/ios/EXUpdates/Procedures/FetchUpdateProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/FetchUpdateProcedure.swift
@@ -58,7 +58,7 @@ final class FetchUpdateProcedure: StateMachineProcedure {
       procedureContext.processStateEvent(.downloadProgress(progress: progress))
     }
     remoteAppLoader.loadUpdate(
-      fromURL: self.config.updateUrl,
+      fromURL: self.config.updateUrl
     ) { updateResponse in
       if let updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective {
         switch updateDirective {


### PR DESCRIPTION
```
  60 |     remoteAppLoader.loadUpdate(
  61 |       fromURL: self.config.updateUrl,
> 62 |     ) { updateResponse in
     |     ^ unexpected ',' separator
  63 |       if let updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective {
  64 |         switch updateDirective {
  65 |         case is NoUpdateAvailableUpdateDirective:
```

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
