### PR TITLE
chore: mark React Compiler as mostly stable

### DIFF
--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -7,9 +7,7 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **important** React Compiler is experimental. Currently, it is on hold and we'll soon provide more updates on its usage.
-
-The new [React Compiler](https://react.dev/learn/react-compiler) automatically memoizes components and hooks to enable fine-grained reactivity. This can lead to significant performance improvements in your app. The React Compiler is currently experimental and is not enabled by default. You can enable it in your app by following the instructions below.
+The new [React Compiler](https://react.dev/learn/react-compiler) automatically memoizes components and hooks to enable fine-grained reactivity. This can lead to significant performance improvements in your app. You can enable it in your app by following the instructions below.
 
 ## Enabling React Compiler
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -132,7 +132,7 @@ export async function loadMetroConfigAsync(
   const platformBundlers = getPlatformBundlers(projectRoot, exp);
 
   if (exp.experiments?.reactCompiler) {
-    Log.warn(`Experimental React Compiler is enabled.`);
+    Log.log(chalk.gray`React Compiler enabled`);
   }
 
   if (env.EXPO_UNSTABLE_TREE_SHAKING && !env.EXPO_UNSTABLE_METRO_OPTIMIZE_GRAPH) {
@@ -431,6 +431,7 @@ function pruneCustomTransformOptions(
     // Set to the default value.
     transformOptions.customTransformOptions.routerRoot = 'app';
   }
+
   if (
     transformOptions.customTransformOptions?.asyncRoutes &&
     // The async routes settings are also used in `expo-router/_ctx.ios.js` (and other platform variants) via `process.env.EXPO_ROUTER_IMPORT_MODE`


### PR DESCRIPTION
# Why

React Compiler is now in RC and mostly stable.
