### PR TITLE
[docs] Add new images to docs

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -1,5 +1,5 @@
 ---
-modificationDate: July 15th, 2025
+modificationDate: August 22nd, 2025
 title: Build server infrastructure
 sidebar_title: Server infrastructure
 maxHeadingDepth: 4
@@ -20,11 +20,12 @@ Linux runners are hosted in Google Cloud Platform. macOS runners are hosted in o
 
 Images for each platform have one specific version of Node.js, Yarn, CocoaPods, Xcode, Ruby, Fastlane, and so on. You can override some of the versions in [eas.json](/build/eas-json). If there is no dedicated configuration option you are looking for, you can use [npm hooks](/build-reference/npm-hooks) to install or update any system dependencies with `apt-get` or `brew`. Consider that those customizations are applied during the build and will increase your build times.
 
-When selecting an image for the build you can use the full name provided below or one of the aliases: `auto`, `latest`, or for a particular SDK such as `sdk-53`.
+When selecting an image for the build you can use the full name provided below or one of the aliases: `auto`, `latest`, or for a particular SDK such as `sdk-54`.
 
 - The use of a specific name guarantees a consistent environment with only minor updates.
 - When using the `auto` alias, the build image will be selected based on the project configuration, Expo SDK version, and React Native version. You can check what image is used for a build in the **Spin up build environment** build logs section.
 - The `latest` alias will be assigned to the image with the most up-to-date versions of the software.
+- The `sdk-54` alias will be assigned to the image best suited for SDK 54 builds.
 - The `sdk-53` alias will be assigned to the image best suited for SDK 53 builds.
 - The `sdk-52` alias will be assigned to the image best suited for SDK 52 builds.
 - The `sdk-51` alias will be assigned to the image best suited for SDK 51 builds.

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -69,6 +69,23 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 ### Android server images
 
+#### <CopyTextButton>`ubuntu-24.04-jdk-17-ndk-r27b` (`sdk-54`)</CopyTextButton>
+
+<Collapsible summary="Details">
+
+- GCE image: `ubuntu-2404-noble-amd64-v20250805`
+- NDK 27.1.12297006
+- Node.js 20.19.4
+- Bun 1.2.20
+- Yarn 1.22.22
+- pnpm 10.14.0
+- npm 10.9.3
+- Java 17
+- node-gyp 11.3.0
+- Maestro 1.41.0
+
+</Collapsible>
+
 #### <CopyTextButton>`ubuntu-22.04-jdk-17-ndk-r26b` (`latest`, `sdk-53`)</CopyTextButton>
 
 <Collapsible summary="Details">
@@ -309,6 +326,31 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 - Git 2.49.0
 - Git LFS 3.6.1
 - applesimutils 0.9.12
+- idb-companion 1.1.8
+
+</Collapsible>
+
+#### <CopyTextButton>`macos-sequoia-15.6-xcode-16.4` (`sdk-54`)</CopyTextButton>
+
+<Collapsible summary="Details">
+
+- macOS Sequoia 15.6
+- Xcode 16.4 (16F6)
+- Node.js 20.19.4
+- Bun 1.2.20
+- Yarn 1.22.22
+- pnpm 10.14.0
+- npm 10.9.3
+- fastlane 2.228.0
+- CocoaPods 1.16.2
+- Ruby 3.2
+- node-gyp 11.3.0
+- Maestro 1.41.0
+- jq 1.8.0
+- Azul Zulu JDK 17.58.21 (OpenJDK 17.0.15)
+- Git 2.49.0
+- Git LFS 3.6.1
+- applesimutils 0.9.10
 - idb-companion 1.1.8
 
 </Collapsible>


### PR DESCRIPTION
# Why

In preparation for `sdk-54`.

# How

Copied old images descriptions, adjusted text. Used [this Android build](https://expo.dev/accounts/sjchmiela/projects/sdk-54/builds/1432cd85-cff7-41b6-871e-dd84729176fd) and [this iOS build](https://expo.dev/accounts/sjchmiela/projects/sdk-54/builds/72329953-bf4c-49ba-898f-1888f2b69e08) for reference.

# Test Plan

CI should pass.