### PR TITLE
[swiftlint] Catch trailing commas in function calls

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -37,7 +37,6 @@ opt_in_rules:
   - closure_spacing
   - collection_alignment
   - comma_inheritance
-  - conditional_returns_on_newline
   - direct_return
   - discouraged_object_literal
   - empty_collection_literal
@@ -410,3 +409,10 @@ void_return: warning
 
 # The variable should be placed on the left, the constant on the right of a comparison operator.
 yoda_condition: warning
+
+custom_rules:
+  no_trailing_comma_in_function_calls:
+    name: 'No trailing comma in function calls'
+    regex: ',\s*(\n\s*)?\)'
+    message: 'Remove trailing comma before closing parenthesis'
+    severity: error


### PR DESCRIPTION
# Why
Xcode 16.3 and above allows adding trailing commas in parameter lists, array, dictionaries etc. and we have done this in some of our modules. This is a compiler error on earlier versions of xcode so we should disallow it until the min xcode version is above 16.3

# How
Swiftlint doesn't have any rule that catches this so I added a custom one. Should be good enough until we can drop it.
I also removed the rule that disallowed
```swift
guard let self else { return }
```
I see no reason to not allow this

# Test Plan
Running swiftlint on files where I added the violation to verify it is caught. 
