### PR TITLE
[video] Make the CHANGELOG.md entry valid

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -6,12 +6,12 @@
 
 ### 🎉 New features
 
-- [Web] Add `useAudioNodePlayback` property. ([#39039](https://github.com/expo/expo/pull/39039) by [@behenate](https://github.com/behenate))
+- [Web] Add `useAudioNodePlayback` prop. ([#39039](https://github.com/expo/expo/pull/39039) by [@behenate](https://github.com/behenate))
 
 ### 🐛 Bug fixes
 
 - [iOS] Fix `sourceLoad` event not being emitted. ([#39023](https://github.com/expo/expo/pull/39023) by [@behenate](https://github.com/behenate))
-- [Web] Fix Audio not playing due to conflicting CORS and AudioNode settings. ([#39039](https://github.com/expo/expo/pull/39039) by [@behenate](https://github.com/behenate))
+- [Web] Fix audio not playing due to conflicting CORS and AudioNode settings. ([#39039](https://github.com/expo/expo/pull/39039) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

This PR references this commit for the sake of the CHANGELOG.md: https://github.com/expo/expo/commit/4f1dd8482c953e24b8aab269e92f94e549c1c8bf

I accidentally pushed a commit straight to main :shipit: . The code is fine, but the changelog points to a non-existing PR.

# How

Create this PR so that the chanelog points to a real PR.

