### PR TITLE
[modules-core] Fix missing file permissions module

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.kt
@@ -37,12 +37,6 @@ open class ExpoModuleRegistryAdapter(moduleRegistryProvider: ReactModuleRegistry
     // Overriding expo-constants/ConstantsService -- binding provides manifest and other expo-related constants
     moduleRegistry.registerInternalModule(ConstantsBinding(scopedContext, experienceProperties, manifest))
 
-    // Overriding expo-file-system FilePermissionModule
-    moduleRegistry.registerInternalModule(ScopedFilePermissionModule(scopedContext))
-
-    // Overriding expo-permissions ScopedPermissionsService
-    moduleRegistry.registerInternalModule(ScopedPermissionsService(scopedContext, experienceKey))
-
     // Overriding expo-notifications classes
     moduleRegistry.registerInternalModule(ScopedNotificationsChannelsProvider(scopedContext, experienceKey))
     moduleRegistry.registerInternalModule(ScopedNotificationsCategoriesSerializer())
@@ -83,6 +77,14 @@ open class ExpoModuleRegistryAdapter(moduleRegistryProvider: ReactModuleRegistry
           ScopedExpoNotificationPresentationModule(scopedContext, experienceKey),
           ScopedExpoNotificationCategoriesModule(experienceKey)
         )
+      }
+
+      with(appContext.legacyModuleRegistry) {
+        // Overriding expo-file-system FilePermissionModule
+        registerInternalModule(ScopedFilePermissionModule(scopedContext))
+
+        // Overriding expo-permissions ScopedPermissionsService
+        registerInternalModule(ScopedPermissionsService(scopedContext, experienceKey))
       }
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/AppDirectoriesModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/AppDirectoriesModule.kt
@@ -15,12 +15,12 @@ This module is a stopgap solution to provide modules with a way to access Scoped
 // The class needs to be 'open', because it's inherited in expoview
 open class AppDirectoriesModule(private val context: Context) : AppDirectoriesModuleInterface, InternalModule {
 
-    override fun getExportedInterfaces(): List<Class<*>> =
-        listOf(AppDirectoriesModuleInterface::class.java)
+  override fun getExportedInterfaces(): List<Class<*>> =
+    listOf(AppDirectoriesModuleInterface::class.java)
 
-    override val cacheDirectory: File
-        get() = context.cacheDir
+  override val cacheDirectory: File
+    get() = context.cacheDir
 
-    override val persistentFilesDirectory: File
-        get() = context.filesDir
+  override val persistentFilesDirectory: File
+    get() = context.filesDir
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/AppDirectoriesModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/AppDirectoriesModule.kt
@@ -1,0 +1,26 @@
+package expo.modules.kotlin.defaultmodules
+
+import android.content.Context
+import expo.modules.core.interfaces.InternalModule
+import expo.modules.interfaces.filesystem.AppDirectoriesModuleInterface
+import java.io.File
+
+/*
+New Sweet API modules don't have an easy way to access scoped context. We can't initialize them with scoped context as they need a ReactApplicationContext instead.
+We can't make ScopedContext inherit from ReactApplicationContext as that would require moving ScopedContext to versioned and a large refactor.
+
+This module is a stopgap solution to provide modules with a way to access ScopedContext directories using the filesystem module, only for our internal modules.
+ */
+
+// The class needs to be 'open', because it's inherited in expoview
+open class AppDirectoriesModule(private val context: Context) : AppDirectoriesModuleInterface, InternalModule {
+
+    override fun getExportedInterfaces(): List<Class<*>> =
+        listOf(AppDirectoriesModuleInterface::class.java)
+
+    override val cacheDirectory: File
+        get() = context.cacheDir
+
+    override val persistentFilesDirectory: File
+        get() = context.filesDir
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/FilePermissionModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/FilePermissionModule.kt
@@ -10,39 +10,39 @@ import java.util.*
 
 // The class needs to be 'open', because it's inherited in expoview
 open class FilePermissionModule : FilePermissionModuleInterface, InternalModule {
-    override fun getExportedInterfaces(): List<Class<*>> =
-        listOf(FilePermissionModuleInterface::class.java)
+  override fun getExportedInterfaces(): List<Class<*>> =
+    listOf(FilePermissionModuleInterface::class.java)
 
-    override fun getPathPermissions(context: Context, path: String): EnumSet<Permission> =
-        getInternalPathPermissions(path, context) ?: getExternalPathPermissions(path)
+  override fun getPathPermissions(context: Context, path: String): EnumSet<Permission> =
+    getInternalPathPermissions(path, context) ?: getExternalPathPermissions(path)
 
-    private fun getInternalPathPermissions(path: String, context: Context): EnumSet<Permission>? {
-        return try {
-            val canonicalPath = File(path).canonicalPath
-            getInternalPaths(context)
-                .firstOrNull { dir -> canonicalPath.startsWith("$dir/") || dir == canonicalPath }
-                ?.let { EnumSet.of(Permission.READ, Permission.WRITE) }
-        } catch (e: IOException) {
-            EnumSet.noneOf(Permission::class.java)
-        }
+  private fun getInternalPathPermissions(path: String, context: Context): EnumSet<Permission>? {
+    return try {
+      val canonicalPath = File(path).canonicalPath
+      getInternalPaths(context)
+        .firstOrNull { dir -> canonicalPath.startsWith("$dir/") || dir == canonicalPath }
+        ?.let { EnumSet.of(Permission.READ, Permission.WRITE) }
+    } catch (e: IOException) {
+      EnumSet.noneOf(Permission::class.java)
     }
+  }
 
-    protected open fun getExternalPathPermissions(path: String): EnumSet<Permission> {
-        val file = File(path)
-        return EnumSet.noneOf(Permission::class.java).apply {
-            if (file.canRead()) {
-                add(Permission.READ)
-            }
-            if (file.canWrite()) {
-                add(Permission.WRITE)
-            }
-        }
+  protected open fun getExternalPathPermissions(path: String): EnumSet<Permission> {
+    val file = File(path)
+    return EnumSet.noneOf(Permission::class.java).apply {
+      if (file.canRead()) {
+        add(Permission.READ)
+      }
+      if (file.canWrite()) {
+        add(Permission.WRITE)
+      }
     }
+  }
 
-    @Throws(IOException::class)
-    private fun getInternalPaths(context: Context): List<String> =
-        listOf(
-            context.filesDir.canonicalPath,
-            context.cacheDir.canonicalPath
-        )
+  @Throws(IOException::class)
+  private fun getInternalPaths(context: Context): List<String> =
+    listOf(
+      context.filesDir.canonicalPath,
+      context.cacheDir.canonicalPath
+    )
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/FilePermissionModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/defaultmodules/FilePermissionModule.kt
@@ -1,0 +1,48 @@
+package expo.modules.kotlin.defaultmodules
+
+import android.content.Context
+import expo.modules.interfaces.filesystem.FilePermissionModuleInterface
+import expo.modules.core.interfaces.InternalModule
+import expo.modules.interfaces.filesystem.Permission
+import java.io.File
+import java.io.IOException
+import java.util.*
+
+// The class needs to be 'open', because it's inherited in expoview
+open class FilePermissionModule : FilePermissionModuleInterface, InternalModule {
+    override fun getExportedInterfaces(): List<Class<*>> =
+        listOf(FilePermissionModuleInterface::class.java)
+
+    override fun getPathPermissions(context: Context, path: String): EnumSet<Permission> =
+        getInternalPathPermissions(path, context) ?: getExternalPathPermissions(path)
+
+    private fun getInternalPathPermissions(path: String, context: Context): EnumSet<Permission>? {
+        return try {
+            val canonicalPath = File(path).canonicalPath
+            getInternalPaths(context)
+                .firstOrNull { dir -> canonicalPath.startsWith("$dir/") || dir == canonicalPath }
+                ?.let { EnumSet.of(Permission.READ, Permission.WRITE) }
+        } catch (e: IOException) {
+            EnumSet.noneOf(Permission::class.java)
+        }
+    }
+
+    protected open fun getExternalPathPermissions(path: String): EnumSet<Permission> {
+        val file = File(path)
+        return EnumSet.noneOf(Permission::class.java).apply {
+            if (file.canRead()) {
+                add(Permission.READ)
+            }
+            if (file.canWrite()) {
+                add(Permission.WRITE)
+            }
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun getInternalPaths(context: Context): List<String> =
+        listOf(
+            context.filesDir.canonicalPath,
+            context.cacheDir.canonicalPath
+        )
+}


### PR DESCRIPTION
# Why

We dropped dependency on `expo-file-system` from `expo` (though we're thinking of bringing it back), which caused issues on Android since we relied on the permissions and appdirectories being provided to internal modules.

I reverted that PR, but I'd still want to land this one, that copies over the legacy modules (only a small part of expo-file-system) to core to make core no longer depend on file-system.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested sandbox and expo-go. Will also test bare-expo tomorrow.
3 apps since 3 scenarios:
- scoped with filesystem
- nonscoped with filesystem (whichever module is used – they are equivalent)
- nonscoped without filesystem (uses these bundled modules)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
