### PR TITLE
[modules-autolinking] fix typo in AutolinkigCommandBuilder class name

### DIFF
--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/AutolinkigCommandBuilder.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/AutolinkigCommandBuilder.kt
@@ -3,7 +3,7 @@ package expo.modules.plugin
 /**
  * Builder for creating command to run using `expo-modules-autolinking`.
  */
-class AutolinkigCommandBuilder {
+class AutolinkingCommandBuilder {
   /**
    * Command for finding and running `expo-modules-autolinking`.
    */

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/GeneratePackagesListTask.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/GeneratePackagesListTask.kt
@@ -42,7 +42,7 @@ abstract class GeneratePackagesListTask : Exec() {
   override fun exec() {
     val autolinkingOptions = AutolinkingOptions.fromJson(options.get())
     commandLine(
-      AutolinkigCommandBuilder()
+      AutolinkingCommandBuilder()
         .command("generate-package-list")
         .option("namespace", namespace.get())
         .option("target", outputFile.get().asFile.absolutePath)

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsExtension.kt
@@ -14,7 +14,7 @@ open class ExpoAutolinkingSettingsExtension(
   /**
    * Command that should be provided to `react-native` to resolve the configuration.
    */
-  val rnConfigCommand = AutolinkigCommandBuilder()
+  val rnConfigCommand = AutolinkingCommandBuilder()
     .command("react-native-config")
     .useJson()
     .build()

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
@@ -50,7 +50,7 @@ class SettingsManager(
    * Resolved configuration from `expo-modules-autolinking`.
    */
   private val config by lazy {
-    val command = AutolinkigCommandBuilder()
+    val command = AutolinkingCommandBuilder()
       .command("resolve")
       .useJson()
       .useAutolinkingOptions(autolinkingOptions)

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/test/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsPluginTest.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/test/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsPluginTest.kt
@@ -42,7 +42,7 @@ class ExpoAutolinkingSettingsPluginTest {
     val configFromPlugin = ExpoAutolinkingConfig.decodeFromString(configStringFromPlugin!!)
 
     val configStringFromAutolinking = testProjectDir.root.runCommand(
-      *AutolinkigCommandBuilder()
+      *AutolinkingCommandBuilder()
         .command("resolve")
         .useJson()
         .build()


### PR DESCRIPTION
# Why

I noticed this small typo while working on the brownfield integration

# How

Rename `AutolinkigCommandBuilder` Android class to `AutolinkingCommandBuilder`

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
