### PR TITLE
chore: bump @expo/vector-icons to 15.0.0

### DIFF
--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@apollo/client": "^3.4.10",
     "@expo/styleguide-native": "^1.0.1",
-    "@expo/vector-icons": "^14.0.0",
+    "@expo/vector-icons": "^15.0.0",
     "@gorhom/bottom-sheet": "5.1.8",
     "@graphql-codegen/introspection": "^2.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/apps/native-component-list/src/screens/Camera/CameraScreenFull.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreenFull.tsx
@@ -344,9 +344,9 @@ export default function CameraScreen() {
       </TouchableOpacity>
       <TouchableOpacity style={styles.toggleButton} onPress={updatePreviewState}>
         {state.previewPaused ? (
-          <AntDesign name="playcircleo" size={24} color="white" />
+          <AntDesign name="play-circle" size={24} color="white" />
         ) : (
-          <AntDesign name="pausecircleo" size={24} color="white" />
+          <AntDesign name="pause-circle" size={24} color="white" />
         )}
       </TouchableOpacity>
       <TouchableOpacity style={styles.toggleButton} onPress={toggleMoreOptions}>

--- a/apps/native-component-list/src/screens/Video/VideoFlashListScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoFlashListScreen.tsx
@@ -1,4 +1,4 @@
-import AntDesign from '@expo/vector-icons/AntDesign';
+import Entypo from '@expo/vector-icons/Entypo';
 import { FlashList } from '@shopify/flash-list';
 import { VideoView, VideoSource, useVideoPlayer } from 'expo-video';
 import { useEffect, useState } from 'react';
@@ -62,16 +62,16 @@ function RenderItem({ item, index, viewSize, visibleIndex }: RenderItemProps) {
       />
       <View style={styles.overlayContainer}>
         <View style={styles.controlsContainer}>
-          <AntDesign
-            name={heart ? 'heart' : 'hearto'}
+          <Entypo
+            name={heart ? 'heart' : 'heart-outlined'}
             size={50}
             color="white"
             onPress={() => {
               setHeart(!heart);
             }}
           />
-          <AntDesign name="message1" size={50} color="white" />
-          <AntDesign name="cloudupload" size={50} color="white" />
+          <Entypo name="message" size={50} color="white" />
+          <Entypo name="upload-to-cloud" size={50} color="white" />
         </View>
       </View>
     </View>

--- a/apps/native-component-list/src/screens/Video/VideoFlatListScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoFlatListScreen.tsx
@@ -1,4 +1,4 @@
-import AntDesign from '@expo/vector-icons/AntDesign';
+import Entypo from '@expo/vector-icons/Entypo';
 import { VideoView, VideoPlayer, createVideoPlayer, VideoSource } from 'expo-video';
 import { useEffect, useRef, useState } from 'react';
 import { FlatList, StyleSheet, View } from 'react-native';
@@ -56,16 +56,16 @@ function RenderItem({ item, index, playerPool, viewSize }: RenderItemProps) {
       />
       <View style={styles.overlayContainer}>
         <View style={styles.controlsContainer}>
-          <AntDesign
-            name={heart ? 'heart' : 'hearto'}
+          <Entypo
+            name={heart ? 'heart' : 'heart-outlined'}
             size={50}
             color="white"
             onPress={() => {
               setHeart(!heart);
             }}
           />
-          <AntDesign name="message1" size={50} color="white" />
-          <AntDesign name="cloudupload" size={50} color="white" />
+          <Entypo name="message" size={50} color="white" />
+          <Entypo name="upload-to-cloud" size={50} color="white" />
         </View>
       </View>
     </View>

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,7 +1,7 @@
 {
   "@expo/fingerprint": "~0.14.2",
   "@expo/metro-runtime": "~6.1.0",
-  "@expo/vector-icons": "^14.1.0",
+  "@expo/vector-icons": "^15.0.0",
   "@expo/ui": "~0.2.0-alpha.4",
   "@react-native-async-storage/async-storage": "2.2.0",
   "@react-native-community/datetimepicker": "8.4.4",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -82,7 +82,7 @@
     "@expo/fingerprint": "0.14.2",
     "@expo/metro": "~0.1.1",
     "@expo/metro-config": "0.21.4",
-    "@expo/vector-icons": "^14.0.0",
+    "@expo/vector-icons": "^15.0.0",
     "babel-preset-expo": "~14.0.2",
     "expo-asset": "~12.0.2",
     "expo-constants": "~18.0.3",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -12,7 +12,7 @@
     "lint": "expo lint"
   },
   "dependencies": {
-    "@expo/vector-icons": "^14.1.0",
+    "@expo/vector-icons": "^15.0.0",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -11,7 +11,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@expo/vector-icons": "^14.1.0",
+    "@expo/vector-icons": "^15.0.0",
     "@react-navigation/native": "^7.1.8",
     "expo": "~54.0.0-preview.5",
     "expo-constants": "~18.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,6 +1767,11 @@
   resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-14.1.0.tgz#d3dddad8b6ea60502e0fe5485b86751827606ce4"
   integrity sha512-7T09UE9h8QDTsUeMGymB4i+iqvtEeaO5VvUjryFB4tugDTG/bkzViWA74hm5pfjjDEhYMXWaX112mcvhccmIwQ==
 
+"@expo/vector-icons@^15.0.0":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-15.0.0.tgz#3e4e30eb17b44b7b44a559f9c7fabcaf9794bc77"
+  integrity sha512-tWmVdNzmpfoffC0MQzwUs5C/uaZDtgrUk+SMpegBcVaSKmR5B/uN0O7B7KvnZwkzWoODsATYx9U4wUyogTcMyw==
+
 "@expo/ws-tunnel@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@expo/ws-tunnel/-/ws-tunnel-1.0.1.tgz#4649bef07a8c687093aa4ab662f35688d3730864"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1762,11 +1762,6 @@
   resolved "https://registry.yarnpkg.com/@expo/sudo-prompt/-/sudo-prompt-9.3.2.tgz#0fd2813402a42988e49145cab220e25bea74b308"
   integrity sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==
 
-"@expo/vector-icons@^14.0.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-14.1.0.tgz#d3dddad8b6ea60502e0fe5485b86751827606ce4"
-  integrity sha512-7T09UE9h8QDTsUeMGymB4i+iqvtEeaO5VvUjryFB4tugDTG/bkzViWA74hm5pfjjDEhYMXWaX112mcvhccmIwQ==
-
 "@expo/vector-icons@^15.0.0":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-15.0.0.tgz#3e4e30eb17b44b7b44a559f9c7fabcaf9794bc77"


### PR DESCRIPTION
# Why

Upgrade `@expo/vector-icons` from v14 to v15.0.0 across all relevant packages in the repo.

This brings updated icons families and `getImageSource` that can be used with native tabs.

# How

Updated the `@expo/vector-icons` dependency version from `^14.0.0`/`^14.1.0` to `^15.0.0` in:
- apps/expo-go/package.json
- packages/expo/bundledNativeModules.json
- packages/expo/package.json
- templates/expo-template-default/package.json
- templates/expo-template-tabs/package.json


# Test Plan

- tested locally in a fresh expo app

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)