### PR TITLE
fix(expo-go): prevent non-app expo.dev subdomains from opening in Expo Go

### DIFF
--- a/apps/expo-go/README.md
+++ b/apps/expo-go/README.md
@@ -39,7 +39,9 @@ If you need to make native code changes to your Expo project, such as adding cus
 
 ## Building Expo Go
 
-1. Build React Native
+1. Set up React Native
+
+Go to the `react-native-lab/react-native` directory and run `yarn install` to install its dependencies.
 
 You can build the React Native Android dep using `./gradlew :packages:react-native:ReactAndroid:buildCMakeDebug` in `react-native-lab/react-native` directory. This is optional because React Native will be built anyway when you build Expo Go, but can help to narrow down a potential issue surface area.
 
@@ -52,6 +54,7 @@ Metro needs to run prior running the build. Verify it runs on port 80. This is b
 For Android, run `./gradlew app:assembleDebug` in the `apps/expo-go/android` directory.
 
 For iOS:
+- run `pod install` in the `apps/expo-go/ios` directory
 - set `DEV_KERNEL_SOURCE` to `LOCAL` in `EXBuildConstants.plist`
 - open and run `ios/Exponent.xcworkspace` in Xcode.
 

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Api/EXUtil.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Api/EXUtil.m
@@ -38,6 +38,17 @@ EX_EXPORT_SCOPED_MODULE(ExponentUtil, UtilService);
   return [name stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
 }
 
++ (BOOL)isExcludedExpoHost:(NSString *)host
+{
+  NSArray *excludedHosts = @[
+    @"launch.expo.dev",
+    @"docs.expo.dev",
+    @"blog.expo.dev",
+    @"chat.expo.dev",
+    @"snack.expo.dev"
+  ];
+  return [excludedHosts containsObject:host];
+}
 
 + (BOOL)isExpoHostedUrl:(NSURL *)url
 {
@@ -47,6 +58,10 @@ EX_EXPORT_SCOPED_MODULE(ExponentUtil, UtilService);
 + (BOOL)isExpoHostedUrlComponents:(NSURLComponents *)components
 {
   if (components.host) {
+    if ([self isExcludedExpoHost:components.host]) {
+      return NO;
+    }
+    
     return [components.host isEqualToString:@"exp.host"] ||
       [components.host isEqualToString:@"expo.io"] ||
       [components.host isEqualToString:@"exp.direct"] ||


### PR DESCRIPTION
# Why

Excludes subdomains from Expo Go's internal URL handling. These should open in the external browser instead of being treated as Expo projects.

The issue does not occur on Android.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Added a new check in `isExpoHostedUrlComponents` to match the URL host against our known non-app subdomains.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

| Before | After |
|--|--|
| ![RocketSim_Recording_iPhone_16_Pro_6 3_2025-08-21_22 43 38](https://github.com/user-attachments/assets/60a7f8ab-c2ed-4bed-a0a1-73e06766c8ee) | ![RocketSim_Recording_iPhone_16_Pro_6 3_2025-08-21_22 31 50](https://github.com/user-attachments/assets/fa56c015-94e2-425f-ba75-190afa1d0852) | 


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
