### PR TITLE
[doctor] Add workspaces to lock file checks

### DIFF
--- a/packages/expo-doctor/src/checks/__tests__/LockfileCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/LockfileCheck.test.ts
@@ -3,6 +3,8 @@ import { vol } from 'memfs';
 
 import { isFileIgnoredAsync } from '../../utils/files';
 import { LockfileCheck } from '../LockfileCheck';
+import spawnAsync from '@expo/spawn-async';
+import { mockSpawnPromise } from '../../__tests__/spawn-utils';
 
 jest.mock('fs');
 jest.mock('glob');
@@ -36,6 +38,7 @@ describe('runAsync', () => {
   });
 
   it('returns result with isSuccessful = false if no lockfile', async () => {
+    jest.mocked(spawnAsync).mockImplementation(() => mockSpawnPromise(Promise.reject(new Error())));
     vol.fromJSON({});
     const check = new LockfileCheck();
     const result = await check.runAsync({
@@ -47,6 +50,7 @@ describe('runAsync', () => {
 
   // multiple lock files
   it('returns result with isSuccessful = true if just one lock file', async () => {
+    jest.mocked(spawnAsync).mockImplementation(() => mockSpawnPromise(Promise.reject(new Error())));
     vol.fromJSON({
       [projectRoot + '/yarn.lock']: 'test',
     });
@@ -59,6 +63,7 @@ describe('runAsync', () => {
   });
 
   it('returns result with isSuccessful = false if more than one lockfile (yarn + npm)', async () => {
+    jest.mocked(spawnAsync).mockImplementation(() => mockSpawnPromise(Promise.reject(new Error())));
     vol.fromJSON({
       [projectRoot + '/yarn.lock']: 'test',
       [projectRoot + '/package-lock.json']: 'test',
@@ -72,6 +77,7 @@ describe('runAsync', () => {
   });
 
   it('returns result with isSuccessful = false if more than one lockfile (yarn + pnpm)', async () => {
+    jest.mocked(spawnAsync).mockImplementation(() => mockSpawnPromise(Promise.reject(new Error())));
     vol.fromJSON({
       [projectRoot + '/yarn.lock']: 'test',
       [projectRoot + '/pnpm-lock.yaml']: 'test',


### PR DESCRIPTION
# Why

Lockfile check is broken in monorepos/workspaces.

# How

Look up workspace root via `npm root` and `pnpm root -w`.

# Test Plan

Ran tests, updated current tests and added new ones.

Ran it on a test project with a pnpm workspace and got the expected result.

Ran it on a test project with an npm/yarn workspace and got the expected result.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
