### PR TITLE
[docs] update build cache url

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -1,5 +1,5 @@
 ---
-modificationDate: July 15th, 2025
+modificationDate: August 22nd, 2025
 title: Build server infrastructure
 sidebar_title: Server infrastructure
 maxHeadingDepth: 4

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -55,7 +55,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 - Global npm configuration in **~/.npmrc**:
 
   ```ini ~/.npmrc
-  registry=http://10.4.0.19:4873
+  registry=http://npm.production.caches.eas-build.internal
   ```
 
 - Global Yarn configuration in **~/.yarnrc.yml**:
@@ -63,7 +63,7 @@ Android builders run on virtual machines in an isolated environment. Every build
   ```yaml ~/.yarnrc.yml
   unsafeHttpWhitelist:
     - '*'
-  npmRegistryServer: 'http://10.4.0.19:4873'
+  npmRegistryServer: 'http://npm.production.caches.eas-build.internal'
   enableImmutableInstalls: false
   ```
 
@@ -275,7 +275,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 - Global npm configuration in **~/.npmrc**:
 
   ```ini ~/.npmrc
-  registry=http://10.94.183.70:4873
+  registry=http://npm.caches.eas-build.internal
   ```
 
 - Global Yarn configuration in **~/.yarnrc.yml**:
@@ -283,7 +283,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
   ```yaml ~/.yarnrc.yml
   unsafeHttpWhitelist:
     - '*'
-  npmRegistryServer: 'http://10.94.183.70:4873'
+  npmRegistryServer: 'http://npm.caches.eas-build.internal'
   enableImmutableInstalls: false
   ```
 


### PR DESCRIPTION
# Why

We migrated build cache servers and now we use internal urls to reach them.

# How

Update build cache urls.

# Test Plan

Verify locally.
<img width="771" height="579" alt="image" src="https://github.com/user-attachments/assets/3eaf46a9-fe82-44b8-9f63-1c1cef45b38d" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
