### PR TITLE
[ios][expo-router] added dependency on RNScreens in ExpoHead.podspec

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [ios] Added dependency on RNScreens in podspec to support dynamic linking through USE_FRAMEWORKS
+- [ios] Added dependency on RNScreens in podspec to support dynamic linking through USE_FRAMEWORKS ([#39074](https://github.com/expo/expo/pull/39074) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Added dependency on RNScreens in podspec to support dynamic linking through USE_FRAMEWORKS
+
 ### 💡 Others
 
 - extract Screen component in NativeTabsView ([#39011](https://github.com/expo/expo/pull/39011) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/ios/ExpoHead.podspec
+++ b/packages/expo-router/ios/ExpoHead.podspec
@@ -27,6 +27,8 @@ Pod::Spec.new do |s|
 
   s.dependency 'ExpoModulesCore'
 
+  add_dependency(s, "RNScreens")
+
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',


### PR DESCRIPTION
# Why

When building/compiling using USE_FRAMEWORK and dynamic linkage, dependencies are much more delicate and requires dependencies to be explicitly declared.

# How

This PR fixes this in ExpoHead.podspec by adding RNScreens.

# Test Plan

Build test-project with USE_FRAMEWORKS="dynamic"

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
