### PR TITLE
Revert dropping the expo-file-system dependency from expo

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Temporarily bring back dependency on `expo-file-system`. ([#38792](https://github.com/expo/expo/pull/38792) by [@aleqsio](https://github.com/aleqsio))
+
 ### 💡 Others
 
 ## 54.0.0-preview.6 — 2025-08-21
@@ -54,7 +56,6 @@ _This version does not introduce any user-facing changes._
 
 ### 💡 Others
 
-- Drop unused dependency on `expo-file-system`. ([#38792](https://github.com/expo/expo/pull/38792) by [@aleqsio](https://github.com/aleqsio))
 - Use `Networking` module and streaming to suppress warning for async bundles on native. ([#38587](https://github.com/expo/expo/pull/38587) by [@EvanBacon](https://github.com/EvanBacon))
 - Fork `react-native/Libraries/Utilities/PolyfillFunctions` to suppress warning. ([#38495](https://github.com/expo/expo/pull/38495) by [@EvanBacon](https://github.com/EvanBacon))
 - Change how FormData is parsed in expo/fetch. ([#38160](https://github.com/expo/expo/pull/38160) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -56,6 +56,7 @@ _This version does not introduce any user-facing changes._
 
 ### 💡 Others
 
+- Drop unused dependency on `expo-file-system`. ([#38792](https://github.com/expo/expo/pull/38792) by [@aleqsio](https://github.com/aleqsio))
 - Use `Networking` module and streaming to suppress warning for async bundles on native. ([#38587](https://github.com/expo/expo/pull/38587) by [@EvanBacon](https://github.com/EvanBacon))
 - Fork `react-native/Libraries/Utilities/PolyfillFunctions` to suppress warning. ([#38495](https://github.com/expo/expo/pull/38495) by [@EvanBacon](https://github.com/EvanBacon))
 - Change how FormData is parsed in expo/fetch. ([#38160](https://github.com/expo/expo/pull/38160) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -86,6 +86,7 @@
     "babel-preset-expo": "~14.0.2",
     "expo-asset": "~12.0.3",
     "expo-constants": "~18.0.3",
+    "expo-file-system": "~19.0.4",
     "expo-font": "~14.0.2",
     "expo-keep-awake": "~15.0.2",
     "expo-modules-autolinking": "3.0.3",


### PR DESCRIPTION
# Why

Fixes `Call to function 'ExpoAsset.downloadAsync' has been rejected.` issue on Android.

# How

Bring back the dependency on filesystem for now.
A way better solution would be to land https://github.com/expo/expo/pull/39051, but I'd like to get @lukmccall eyes on that, also we need to decide if fs is going to be core API.

# Test Plan

Reverts a change from a PR to previous state – should be safe, but let's also wait for CI to pass (CI fails seem unrelated, but I retested locally).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
