### PR TITLE
[docs] Add callout to use --example

### DIFF
--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -63,6 +63,8 @@ Running `create-expo-app` with a [Node Package Manager](#node-package-managers-s
 
 You can use the `--template` option to select one of the following templates or pass it as an argument to the option. For example, `--template default`.
 
+> **info** Looking for more templates? Check out the [`--example`](#--example) option to initialize your project with one of our example apps that demonstrate specific features and integrations.
+
 | Template                                                                                              | Description                                                                                                                                                                           |
 | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`default`](https://github.com/expo/expo/tree/main/templates/expo-template-default)                   | Default template. Designed to build multi-screen apps. Includes recommended tools such as Expo CLI, Expo Router library and TypeScript configuration enabled. Suitable for most apps. |
@@ -75,7 +77,10 @@ You can use the `--template` option to select one of the following templates or 
 
 Use this option to initialize a project using an example from [expo/examples](https://github.com/expo/examples).
 
-For example, running `npx create-expo-app --example with-router` will set up a project with Expo Router library.
+For example:
+
+- running `npx create-expo-app --example with-router` sets up a project with Expo Router library.
+- running `npx create-expo-app --example with-react-navigation` sets up a project similar to the default template but configured with plain React Navigation only.
 
 ### `--version`
 

--- a/docs/pages/more/create-expo.mdx
+++ b/docs/pages/more/create-expo.mdx
@@ -63,7 +63,7 @@ Running `create-expo-app` with a [Node Package Manager](#node-package-managers-s
 
 You can use the `--template` option to select one of the following templates or pass it as an argument to the option. For example, `--template default`.
 
-> **info** Looking for more templates? Check out the [`--example`](#--example) option to initialize your project with one of our example apps that demonstrate specific features and integrations.
+> **info** Looking for more templates? Check out the [`--example`](#--example) option to initialize your project with one of the example apps that demonstrate specific features and integrations.
 
 | Template                                                                                              | Description                                                                                                                                                                           |
 | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -79,8 +79,8 @@ Use this option to initialize a project using an example from [expo/examples](ht
 
 For example:
 
-- running `npx create-expo-app --example with-router` sets up a project with Expo Router library.
-- running `npx create-expo-app --example with-react-navigation` sets up a project similar to the default template but configured with plain React Navigation only.
+- Running `npx create-expo-app --example with-router` sets up a project with the Expo Router library
+- Running `npx create-expo-app --example with-react-navigation` sets up a project similar to the default template, but configured with plain React Navigation library
 
 ### `--version`
 


### PR DESCRIPTION
# Why

[ENG-17040 Update Aman's PR to include React Navigation template changes](https://linear.app/expo/issue/ENG-17040/update-amans-pr-to-include-react-navigation-template-changes)

# Test Plan

I ran the docs locally and also created a new project running `bun create expo-app --example with-react-navigation` and confirmed it works correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
