### PR TITLE
[docs] Remove yarn-specific note on build limitations doc and update glossary

### DIFF
--- a/docs/pages/build-reference/limitations.mdx
+++ b/docs/pages/build-reference/limitations.mdx
@@ -28,11 +28,11 @@ If your build takes longer than 2 hours to run, it will be canceled. This limit 
 
 If you have more than 50 builds pending for a platform, new builds will be rejected until the number of pending builds drops below the limit.
 
-## Yarn workspaces is recommended for monorepos
+## Package managers with workspaces support may require special setup
 
-> **Note**: Official guidance for package managers other than Yarn is limited.
+> **Note**: Official guidance for package managers other than Bun, npm, pnpm, and Yarn is limited.
 
-While you likely can have success using other monorepo tools like Nx if you are willing to dig in and understand the tooling and get your hands dirty, the Expo team will be unable to provide support and guidance on those tools. We recommend using [Yarn Workspaces](https://yarnpkg.com/en/docs/workspaces) because it is the only monorepo tool that we provide first-class integration with at the moment.
+EAS Build supports monorepos managed with package managers supporting workspaces. However, third-party monorepo or workspaces tooling may not work as expected or require additional setup. Increased complexity is common when setting up and configuring monorepos and workspaces. Check whether your tools and libraries work well within a monorepo before setting one up. See [Work with monorepos](/guides/monorepos/).
 
 ## Get notified about changes
 

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -277,11 +277,11 @@ A native application containing a [JavaScript engine](#javascript-engine), and i
 
 ### Package manager
 
-Automates the process of installing, upgrading, configuring, and removing libraries, also known as dependencies, from your project. See [npm](#npm), [pnpm](#pnpm), and [Yarn](#yarn).
+Automates the process of installing, upgrading, configuring, and removing libraries, also known as dependencies, from your project. See [Bun](#bun), [npm](#npm), [pnpm](#pnpm), and [Yarn](#yarn).
 
 ### Package manager workspaces
 
-The [monorepo](#monorepo) solution we recommend for Expo users. See [Working with Monorepos](/guides/monorepos) for more information on how to configure workspaces with supported package managers.
+The recommended [monorepo](#monorepo) solution for Expo users. See [Working with Monorepos](/guides/monorepos) guide for more information on how to configure workspaces with supported package managers.
 
 ### Platform extensions
 
@@ -385,7 +385,7 @@ The deprecated bundler used by [Expo CLI](#expo-cli) for developing [`react-nati
 
 ### Yarn
 
-[Yarn](https://yarnpkg.com/) is a [package manager for JavaScript](#package-manager), created at Meta. It has two mainline versions [Yarn v1 (Classic)](https://classic.yarnpkg.com/lang/en/) and [Yarn Berry](https://github.com/yarnpkg/berry)
+[Yarn](https://yarnpkg.com/) is a [package manager for JavaScript](#package-manager), created at Meta. It has two mainline versions [Yarn v1 (Classic)](https://classic.yarnpkg.com/lang/en/) and [Yarn Berry](https://github.com/yarnpkg/berry).
 
 ### Yoga
 

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -58,7 +58,7 @@ This is in contrast to using [app config and prebuild](/workflow/prebuild), wher
 
 ### Bun
 
-A JavaScript runtime and a drop-in alternative for Node.js. For more information about usage with Expo and EAS, see [using Bun](/guides/using-bun/) guide.
+A JavaScript runtime and a drop-in alternative for Node.js. Bun can also be used as a [package manager for JavaScript](#package-manager). For more information about usage with Expo and EAS, see [using Bun](/guides/using-bun/) guide.
 
 ### CocoaPods
 
@@ -273,11 +273,15 @@ A native application containing a [JavaScript engine](#javascript-engine), and i
 
 ### npm
 
-[npm](https://www.npmjs.com/) is a package manager for JavaScript and the registry where the packages are stored. An alternative package manager, which we use internally at Expo, is [Yarn](#yarn).
+[npm](https://www.npmjs.com/) is a [package manager for JavaScript](#package-manager) and the registry where the packages are stored.
 
 ### Package manager
 
-Automates the process of installing, upgrading, configuring, and removing libraries, also known as dependencies, from your project. See [npm](#npm) and [Yarn](#yarn).
+Automates the process of installing, upgrading, configuring, and removing libraries, also known as dependencies, from your project. See [npm](#npm), [pnpm](#pnpm), and [Yarn](#yarn).
+
+### Package manager workspaces
+
+The [monorepo](#monorepo) solution we recommend for Expo users. See [Working with Monorepos](/guides/monorepos) for more information on how to configure workspaces with supported package managers.
 
 ### Platform extensions
 
@@ -290,6 +294,10 @@ By default, platform extensions are resolved in `@expo/metro-config` using the f
 - Web: **\*.web.js**, **\*.js**
 
 {/* TODO: Multi-Resolution Asset Extensions */}
+
+### pnpm
+
+[pnpm](https://pnpm.io/) is [package manager for JavaScript](#package-manager), focused on disk space efficiency.
 
 ### Prebuild
 
@@ -377,11 +385,7 @@ The deprecated bundler used by [Expo CLI](#expo-cli) for developing [`react-nati
 
 ### Yarn
 
-A package manager for JavaScript. For more information, see [Yarn](https://yarnpkg.com/) documentation.
-
-### Yarn workspaces
-
-The [monorepo](#monorepo) solution we recommend for Expo users. See [Working with Monorepos](/guides/monorepos) for more information on how to configure Yarn workspaces.
+[Yarn](https://yarnpkg.com/) is a [package manager for JavaScript](#package-manager), created at Meta. It has two mainline versions [Yarn v1 (Classic)](https://classic.yarnpkg.com/lang/en/) and [Yarn Berry](https://github.com/yarnpkg/berry)
 
 ### Yoga
 


### PR DESCRIPTION
- Remove references to Yarn being recommended from "EAS Build Limitations" doc
- Update "EAS Build Limitations" not to recommend a specific package manager
- Update glossary of terms to add pnpm
- Update how package managers are described
- Remove note of us using Yarn from the page / that it's recommended