### PR TITLE
[docs] remove deprecated SafeAreaView imports from examples

### DIFF
--- a/docs/pages/router/basics/common-navigation-patterns.mdx
+++ b/docs/pages/router/basics/common-navigation-patterns.mdx
@@ -235,7 +235,8 @@ Separating your navigation states into distinct routes is meant to serve you and
 Thinking back to authentication, the protected route setup works great if the user should simply not be able to visit certain pages without logging in. But what about when unauthenticated users can browse an app in read-only mode? In that case, you might want to show a login modal over the app, rather than redirecting the user to a login page:
 
 ```tsx app/(logged-in)/_layout.tsx
-import { SafeAreaView, Modal } from 'react-native';
+import { Modal } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Stack } from 'expo-router';
 
 export default function Layout() {

--- a/docs/pages/versions/unversioned/sdk/blur-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/blur-view.mdx
@@ -35,13 +35,13 @@ The blur effect does not update when `BlurView` is rendered before dynamic conte
 <SnackInline label='Basic BlurView usage' dependencies={['expo-blur']}>
 
 ```jsx
-import { Text, StyleSheet, View, SafeAreaView } from 'react-native';
+import { Text, StyleSheet, View } from 'react-native';
 import { BlurView } from 'expo-blur';
 
 export default function App() {
   const text = 'Hello, my container is blurring contents underneath!';
   return (
-    <SafeAreaView style={styles.container}>
+    <View style={styles.container}>
       <View style={styles.background}>
         {[...Array(20).keys()].map(i => (
           <View
@@ -59,7 +59,7 @@ export default function App() {
       <BlurView intensity={90} tint="dark" style={styles.blurContainer}>
         <Text style={[styles.text, { color: '#fff' }]}>{text}</Text>
       </BlurView>
-    </SafeAreaView>
+    </View>
   );
 }
 

--- a/docs/pages/versions/unversioned/sdk/media-library.mdx
+++ b/docs/pages/versions/unversioned/sdk/media-library.mdx
@@ -131,7 +131,7 @@ If you're not using Continuous Native Generation ([CNG](/workflow/continuous-nat
 {/* prettier-ignore */}
 ```jsx
 import { useState, useEffect } from 'react';
-import { Button, Text, SafeAreaView, ScrollView, StyleSheet, Image, View, Platform } from 'react-native';
+import { Button, Text, ScrollView, StyleSheet, Image, View, Platform } from 'react-native';
 import * as MediaLibrary from 'expo-media-library';
 
 export default function App() {
@@ -149,12 +149,12 @@ export default function App() {
   }
 
   return (
-    <SafeAreaView style={styles.container}>
+    <View style={styles.container}>
       <Button onPress={getAlbums} title="Get albums" />
       <ScrollView>
         {albums && albums.map((album) => <AlbumEntry album={album} />)}
       </ScrollView>
-    </SafeAreaView>
+    </View>
   );
 }
 
@@ -189,11 +189,6 @@ const styles = StyleSheet.create({
     flex: 1,
     gap: 8,
     justifyContent: 'center',
-    ...Platform.select({
-      android: {
-        paddingTop: 40,
-      },
-    }),
   },
   albumContainer: {
     paddingHorizontal: 20,

--- a/docs/pages/versions/v54.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/blur-view.mdx
@@ -35,13 +35,13 @@ The blur effect does not update when `BlurView` is rendered before dynamic conte
 <SnackInline label='Basic BlurView usage' dependencies={['expo-blur']}>
 
 ```jsx
-import { Text, StyleSheet, View, SafeAreaView } from 'react-native';
+import { Text, StyleSheet, View } from 'react-native';
 import { BlurView } from 'expo-blur';
 
 export default function App() {
   const text = 'Hello, my container is blurring contents underneath!';
   return (
-    <SafeAreaView style={styles.container}>
+    <View style={styles.container}>
       <View style={styles.background}>
         {[...Array(20).keys()].map(i => (
           <View
@@ -59,7 +59,7 @@ export default function App() {
       <BlurView intensity={90} tint="dark" style={styles.blurContainer}>
         <Text style={[styles.text, { color: '#fff' }]}>{text}</Text>
       </BlurView>
-    </SafeAreaView>
+    </View>
   );
 }
 

--- a/docs/pages/versions/v54.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/media-library.mdx
@@ -131,7 +131,7 @@ If you're not using Continuous Native Generation ([CNG](/workflow/continuous-nat
 {/* prettier-ignore */}
 ```jsx
 import { useState, useEffect } from 'react';
-import { Button, Text, SafeAreaView, ScrollView, StyleSheet, Image, View, Platform } from 'react-native';
+import { Button, Text, ScrollView, StyleSheet, Image, View, Platform } from 'react-native';
 import * as MediaLibrary from 'expo-media-library';
 
 export default function App() {
@@ -149,12 +149,12 @@ export default function App() {
   }
 
   return (
-    <SafeAreaView style={styles.container}>
+    <View style={styles.container}>
       <Button onPress={getAlbums} title="Get albums" />
       <ScrollView>
         {albums && albums.map((album) => <AlbumEntry album={album} />)}
       </ScrollView>
-    </SafeAreaView>
+    </View>
   );
 }
 
@@ -189,11 +189,6 @@ const styles = StyleSheet.create({
     flex: 1,
     gap: 8,
     justifyContent: 'center',
-    ...Platform.select({
-      android: {
-        paddingTop: 40,
-      },
-    }),
   },
   albumContainer: {
     paddingHorizontal: 20,


### PR DESCRIPTION
# Why

The SafeAreaView from RN is [deprecated](https://reactnative.dev/blog/2025/08/12/react-native-0.81#safeareaview-deprecation) in 0.81

# How

For 2 references I removed the usage of SafeAreaView completely, this aligns with other examples within the docs. For the expo-router guide I replaced the usage with an import from `react-native-safe-area-context`.

# Test Plan

Verified locally, also backported to SDK54 docs

# Checklist
- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
