### PR TITLE
[Android][expo-image] Fix Glide crashes on new architecture

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix (glide) crash when rapidly updating images on new architecture. ([#39091](https://github.com/expo/expo/pull/39091) by [@SeanSanker](https://github.com/SeanSanker))
+
 ### 💡 Others
 
 ## 3.0.8 — 2025-09-11


### PR DESCRIPTION
Moved Glide clear and rerender operations to the main handler using post to avoid executing them in a Glide callback context. This change helps prevent potential threading issues and ensures UI updates are performed on the main thread.

# Why

On 
Expo 53.0.19
Expo Image 2.4.0
React Native 0.79.6

After enabling the new architecture, our android users are getting numerous glide crashes:
```
          Caused by java.lang.IllegalStateException: You can't start or clear loads in RequestListener or Target callbacks. If you're trying to start a fallback request when a load fails, use RequestBuilder#error(RequestBuilder). Otherwise consider posting your into() or clear() calls to the main thread using a Handler instead.
       at com.bumptech.glide.request.SingleRequest.assertNotCallingCallbacks(SingleRequest.java:305)
       at com.bumptech.glide.request.SingleRequest.clear(SingleRequest.java:325)
       at com.bumptech.glide.manager.RequestTracker.clearAndRemove(RequestTracker.java:70)
       at com.bumptech.glide.RequestManager.untrack(RequestManager.java:677)
       at com.bumptech.glide.RequestManager.untrackOrDelegate(RequestManager.java:645)
       at com.bumptech.glide.RequestManager.clear(RequestManager.java:641)
       at com.bumptech.glide.RequestBuilder.into(RequestBuilder.java:856)
       at com.bumptech.glide.RequestBuilder.into(RequestBuilder.java:825)
       at com.bumptech.glide.RequestBuilder.into(RequestBuilder.java:817)
       at expo.modules.image.ExpoImageViewWrapper.rerenderIfNeeded$expo_image_release(ExpoImageViewWrapper.kt:567)
       at expo.modules.image.ExpoImageViewWrapper.rerenderIfNeeded$expo_image_release$default(ExpoImageViewWrapper.kt:482)
       at expo.modules.image.ExpoImageViewWrapper.onSizeChanged(ExpoImageViewWrapper.kt:400)
       at android.view.View.sizeChange(View.java:23088)
       at android.view.View.setFrame(View.java:23040)
       at android.view.View.layout(View.java:22897)
       at android.view.ViewGroup.layout(ViewGroup.java:6389)
       at com.facebook.react.fabric.mounting.SurfaceMountingManager.updateLayout(SurfaceMountingManager.java:842)
       at com.facebook.react.fabric.mounting.mountitems.IntBufferBatchMountItem.execute(IntBufferBatchMountItem.java:157)
       at com.facebook.react.fabric.mounting.MountItemDispatcher.executeOrEnqueue(MountItemDispatcher.java:370)
       at com.facebook.react.fabric.mounting.MountItemDispatcher.dispatchMountItems(MountItemDispatcher.java:265)
       at com.facebook.react.fabric.mounting.MountItemDispatcher.tryDispatchMountItems(MountItemDispatcher.java:122)
       at com.facebook.react.fabric.FabricUIManager$3.runGuarded(FabricUIManager.java:823)
       at com.facebook.react.bridge.GuardedRunnable.run(GuardedRunnable.java:29)
       at com.facebook.react.fabric.FabricUIManager.scheduleMountItem(FabricUIManager.java:827)
       at com.swmansion.reanimated.NativeProxy.performOperations(NativeProxy.java)
       at com.swmansion.reanimated.NodesManager.performOperations(NodesManager.java:121)
       at com.swmansion.reanimated.NodesManager.onEventDispatch(NodesManager.java:192)
       at com.facebook.react.uimanager.events.FabricEventDispatcher.dispatchEvent(FabricEventDispatcher.kt:60)
       at expo.modules.kotlin.events.KEventEmitterWrapper.emit(KModuleEventEmitterWrapper.kt:107)
       at expo.modules.kotlin.viewevent.ViewEvent.invoke(ViewEvent.kt:48)
       at expo.modules.image.events.GlideRequestListener.onResourceReady(GlideRequestListener.kt:54)
       at expo.modules.image.events.GlideRequestListener.onResourceReady(GlideRequestListener.kt:19)
       at com.bumptech.glide.request.SingleRequest.onResourceReady(SingleRequest.java:650)
       at com.bumptech.glide.request.SingleRequest.onResourceReady(SingleRequest.java:596)
       at com.bumptech.glide.load.engine.EngineJob.callCallbackOnResourceReady(EngineJob.java:159)
       at com.bumptech.glide.load.engine.EngineJob$CallResourceReady.run(EngineJob.java:428)
       at android.os.Handler.handleCallback(Handler.java:938)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:250)
       at android.app.ActivityThread.main(ActivityThread.java:7868)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:958)
        
```


# How

With the help of AI so it may be wrong. 

- [ ] Add tests to confirm operation
Existing tests should already cover this, right? Nothing was added so, so long as no existing tests break, all should be well?
- [ ] Ideally add tests to try and reproduce the original bug
Regarding the above, how would I do so for this PR? I'm not sure how to reliably reproduce this crash, let alone test it.

# Test Plan

Testing: This change has been in production for my app for nearly the past month. Since implementing this change we've gone from dozens of crashes a day due to this issue to zero.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
I think the above is true, though I'm not exactly sure what that entails?
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
