### PR TITLE
[cli] support `--yes` flag in prebuild command to skip git confirmation

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `--yes/-y` flag to `expo prebuild` to skip git confirmation prompt and continue with uncommitted changes ([#39107](https://github.com/expo/expo/pull/39107) by [@nishan](https://github.com/intergalacticspacehighway))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -344,7 +344,7 @@ itNotWindows('runs `npx expo prebuild --platform ios` after building Android', a
   });
 });
 
-itNotWindows('runs `npx expo prebuild --yes`', async () => {
+itNotWindows('runs `npx expo prebuild --clean --yes`', async () => {
   const projectRoot = await setupTestProjectWithOptionsAsync('prebuild-yes-test', 'with-blank', {
     reuseExisting: false,
   });

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -62,7 +62,7 @@ it('runs `npx expo prebuild --help`', async () => {
         --template <template>                    Project template to clone from. File path pointing to a local tar file, npm package or a github repo
         -p, --platform <all|android|ios>         Platforms to sync: ios, android, all. Default: all
         --skip-dependency-update <dependencies>  Preserves versions of listed packages in package.json (comma separated list)
-        -y, --yes                               Skip git confirmation prompt and continue with uncommitted changes
+        -y, --yes                                Skip git confirmation prompt and continue with uncommitted changes
         -h, --help                               Usage info
     "
   `);

--- a/packages/@expo/cli/src/prebuild/index.ts
+++ b/packages/@expo/cli/src/prebuild/index.ts
@@ -43,7 +43,7 @@ export const expoPrebuild: Command = async (argv) => {
         `--template <template>                    Project template to clone from. File path pointing to a local tar file, npm package or a github repo`,
         chalk`-p, --platform <all|android|ios>         Platforms to sync: ios, android, all. {dim Default: all}`,
         `--skip-dependency-update <dependencies>  Preserves versions of listed packages in package.json (comma separated list)`,
-        `-y, --yes                               Skip git confirmation prompt and continue with uncommitted changes`,
+        `-y, --yes                                Skip git confirmation prompt and continue with uncommitted changes`,
         `-h, --help                               Usage info`,
       ].join('\n')
     );

--- a/packages/@expo/cli/src/prebuild/index.ts
+++ b/packages/@expo/cli/src/prebuild/index.ts
@@ -18,10 +18,12 @@ export const expoPrebuild: Command = async (argv) => {
       '--template': String,
       '--platform': String,
       '--skip-dependency-update': String,
+      '--yes': Boolean,
       // Aliases
       '-h': '--help',
       '-p': '--platform',
       '-t': '--type',
+      '-y': '--yes',
     },
     argv
   );
@@ -41,6 +43,7 @@ export const expoPrebuild: Command = async (argv) => {
         `--template <template>                    Project template to clone from. File path pointing to a local tar file, npm package or a github repo`,
         chalk`-p, --platform <all|android|ios>         Platforms to sync: ios, android, all. {dim Default: all}`,
         `--skip-dependency-update <dependencies>  Preserves versions of listed packages in package.json (comma separated list)`,
+        `-y, --yes                               Skip git confirmation prompt and continue with uncommitted changes`,
         `-h, --help                               Usage info`,
       ].join('\n')
     );
@@ -64,6 +67,7 @@ export const expoPrebuild: Command = async (argv) => {
     return prebuildAsync(getProjectRoot(args), {
       // Parsed options
       clean: args['--clean'],
+      yes: args['--yes'],
 
       packageManager: resolvePackageManagerOptions(args),
       install: !args['--no-install'],

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -60,6 +60,8 @@ export async function prebuildAsync(
     };
     /** List of node modules to skip updating. */
     skipDependencyUpdate?: string[];
+    /** Skip git confirmation prompt and continue with uncommitted changes. */
+    yes?: boolean;
   }
 ): Promise<PrebuildResults | null> {
   setNodeEnv('development');
@@ -81,7 +83,7 @@ export async function prebuildAsync(
   if (options.clean) {
     const { maybeBailOnGitStatusAsync } = await import('../utils/git.js');
     // Clean the project folders...
-    if (await maybeBailOnGitStatusAsync()) {
+    if (await maybeBailOnGitStatusAsync({ yes: options.yes })) {
       return null;
     }
     // Clear the native folders before syncing

--- a/packages/@expo/cli/src/utils/git.ts
+++ b/packages/@expo/cli/src/utils/git.ts
@@ -6,7 +6,7 @@ import { isInteractive } from './interactive';
 import { confirmAsync } from './prompts';
 import * as Log from '../log';
 
-export async function maybeBailOnGitStatusAsync(options: { yes?: boolean } = {}): Promise<boolean> {
+export async function maybeBailOnGitStatusAsync(options?: { yes: boolean }): Promise<boolean> {
   if (env.EXPO_NO_GIT_STATUS) {
     Log.warn(
       'Git status is dirty but the command will continue because EXPO_NO_GIT_STATUS is enabled...'
@@ -15,7 +15,7 @@ export async function maybeBailOnGitStatusAsync(options: { yes?: boolean } = {})
   }
 
   // user passed --yes flag to skip git confirmation prompt
-  if (options.yes) {
+  if (options?.yes) {
     return false;
   }
 

--- a/packages/@expo/cli/src/utils/git.ts
+++ b/packages/@expo/cli/src/utils/git.ts
@@ -6,7 +6,7 @@ import { isInteractive } from './interactive';
 import { confirmAsync } from './prompts';
 import * as Log from '../log';
 
-export async function maybeBailOnGitStatusAsync(options?: { yes: boolean }): Promise<boolean> {
+export async function maybeBailOnGitStatusAsync(options?: { yes?: boolean }): Promise<boolean> {
   if (env.EXPO_NO_GIT_STATUS) {
     Log.warn(
       'Git status is dirty but the command will continue because EXPO_NO_GIT_STATUS is enabled...'

--- a/packages/@expo/cli/src/utils/git.ts
+++ b/packages/@expo/cli/src/utils/git.ts
@@ -6,13 +6,19 @@ import { isInteractive } from './interactive';
 import { confirmAsync } from './prompts';
 import * as Log from '../log';
 
-export async function maybeBailOnGitStatusAsync(): Promise<boolean> {
+export async function maybeBailOnGitStatusAsync(options: { yes?: boolean } = {}): Promise<boolean> {
   if (env.EXPO_NO_GIT_STATUS) {
     Log.warn(
       'Git status is dirty but the command will continue because EXPO_NO_GIT_STATUS is enabled...'
     );
     return false;
   }
+
+  // user passed --yes flag to skip git confirmation prompt
+  if (options.yes) {
+    return false;
+  }
+
   const isGitStatusClean = await validateGitStatusAsync();
 
   // Give people a chance to bail out if git working tree is dirty


### PR DESCRIPTION
# Why

[ENG-17123](https://linear.app/expo/issue/ENG-17123/support-yes-y-flag-in-prebuild)

Allows user to pass `--yes` flag in the prebuild command to skip the git uncommitted file changes confirmation. We have an existing env `EXPO_NO_GIT_STATUS` but passing a flag could be a nice addition (also i was assigned this task 😛). 

Original [feature request](https://expo.canny.io/feature-requests/p/allow-skipping-the-continue-with-uncommited-changes-y-n-check-in-prebuild) was from @mozzius. thanks!

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Updated the cli command, skipped git check if `yes` is true.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Added an e2e for the same, made sure it works in CI/non-CI environment.

Also tested manually by creating a test project. 

<img width="500" height="326" alt="Screenshot 2025-08-25 at 9 26 46 AM" src="https://github.com/user-attachments/assets/7a5a0a32-f042-4e29-b0a3-505fe4671520" />

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
