### PR TITLE
[docs] add Host wrappers to expo-ui

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -211,7 +211,7 @@ exceptions:
   # PascalCase for React component names that end with common component suffixes
   - '^[A-Z][a-zA-Z]*(?:Input|Sheet|Picker|Progress|Menu|View|Button|Switch|Slider|Text|TextInput)(?:\s*\([^)]+\))?$'
   # PascalCase for Expo UI component names
-  - '^[A-Z][a-zA-Z]*(?:TextField)(?:\s*\([^)]+\))?$'
+  - '^(?:TextField)(?:\s*\([^)]+\))?$'
   # Standalone common UI component names
   - '^(?:BottomSheet|CircularProgress|LinearProgress|DateTimePicker|ContextMenu|ColorPicker)(?:\s*\([^)]+\))?$'
   # Component, service and product names that are proper nouns

--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -210,6 +210,8 @@ exceptions:
   - '.*YAML.*'
   # PascalCase for React component names that end with common component suffixes
   - '^[A-Z][a-zA-Z]*(?:Input|Sheet|Picker|Progress|Menu|View|Button|Switch|Slider|Text|TextInput)(?:\s*\([^)]+\))?$'
+  # PascalCase for Expo UI component names
+  - '^[A-Z][a-zA-Z]*(?:TextField)(?:\s*\([^)]+\))?$'
   # Standalone common UI component names
   - '^(?:BottomSheet|CircularProgress|LinearProgress|DateTimePicker|ContextMenu|ColorPicker)(?:\s*\([^)]+\))?$'
   # Component, service and product names that are proper nouns

--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -210,10 +210,8 @@ exceptions:
   - '.*YAML.*'
   # PascalCase for React component names that end with common component suffixes
   - '^[A-Z][a-zA-Z]*(?:Input|Sheet|Picker|Progress|Menu|View|Button|Switch|Slider|Text|TextInput)(?:\s*\([^)]+\))?$'
-  # PascalCase for Expo UI component names
-  - '^(?:TextField)(?:\s*\([^)]+\))?$'
-  # Standalone common UI component names
-  - '^(?:BottomSheet|CircularProgress|LinearProgress|DateTimePicker|ContextMenu|ColorPicker)(?:\s*\([^)]+\))?$'
+  # Standalone Expo UI component names
+  - '^(?:BottomSheet|CircularProgress|LinearProgress|DateTimePicker|ContextMenu|ColorPicker|TextField)(?:\s*\([^)]+\))?$'
   # Component, service and product names that are proper nouns
   - '^(?:TinyBase|LiveStore|LaunchDarkly|OneSignal|CleverTap|LogRocket|Vexo|BugSnag|Meta|Vercel|TabTrigger|TabList|Tabs|Drawer|TextEncoder|TextDecoder|AudioPlayer|VideoPlayer)(?:\s*\([^)]+\))?$'
   # Specific edge cases

--- a/docs/pages/versions/unversioned/sdk/ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui.mdx
@@ -292,7 +292,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 ### Host
 
-A component that allows you to put the other `@expo/ui/swift-ui` components in React Native. It acts like [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg) for DOM, [`<Canvas>`](https://shopify.github.io/react-native-skia/docs/canvas/overview/) for [react-native-skia](https://shopify.github.io/react-native-skia/), which underlying uses [`UIHostingController`](https://developer.apple.com/documentation/swiftui/hostingview) to render the SwiftUI views in UIKit.
+A component that allows you to put the other `@expo/ui/swift-ui` components in React Native. It acts like [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg) for DOM, [`<Canvas>`](https://shopify.github.io/react-native-skia/docs/canvas/overview/) for [`react-native-skia`](https://shopify.github.io/react-native-skia/), which underlying uses [`UIHostingController`](https://developer.apple.com/documentation/swiftui/hostingview) to render the SwiftUI views in UIKit.
 
 Since the `Host` component is a React Native [`View`](https://reactnative.dev/docs/view), you can pass the [`style`](https://reactnative.dev/docs/style) prop to it or `matchContents` prop to make the `Host` component match the contents' size.
 
@@ -572,7 +572,7 @@ function Example() {
 
 ### More
 
-Expo UI is still in active development. We continue to add more functionality and may change the API. Some examples in the docs may not be up to date. If you want to see the latest changes, please check the [examples](https://github.com/expo/expo/tree/main/apps/native-component-list/src/screens/UI).
+Expo UI is still in active development. We continue to add more functionality and may change the API. Some examples in the docs may not be up to date. If you want to see the latest changes, check the [examples](https://github.com/expo/expo/tree/main/apps/native-component-list/src/screens/UI).
 
 ## Jetpack Compose examples
 

--- a/docs/pages/versions/unversioned/sdk/ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui.mdx
@@ -299,30 +299,38 @@ Since the `Host` component is a React Native [`View`](https://reactnative.dev/do
 ```tsx Wrapping Button in Host
 import { Button, Host } from '@expo/ui/swift-ui';
 
-<Host matchContents>
-  <Button
-    onPress={() => {
-      console.log('Pressed');
-    }}>
-    Click
-  </Button>
-</Host>
+function Example() {
+  return (
+    <Host matchContents>
+      <Button
+        onPress={() => {
+          console.log('Pressed');
+        }}>
+        Click
+      </Button>
+    </Host>
+  );
+}
 ```
 
 ```tsx Host with flexbox and VStack
 import { Button, Host, VStack, Text } from '@expo/ui/swift-ui';
 
-<Host style={{ flex: 1 }}>
-  <VStack spacing={8}>
-    <Text>Hello, world!</Text>
-    <Button
-      onPress={() => {
-        console.log('Pressed');
-      }}>
-      Click
-    </Button>
-  </VStack>
-</Host>
+function Example() {
+  return (
+    <Host style={{ flex: 1 }}>
+      <VStack spacing={8}>
+        <Text>Hello, world!</Text>
+        <Button
+          onPress={() => {
+            console.log('Pressed');
+          }}>
+          Click
+        </Button>
+      </VStack>
+    </Host>
+  );
+}
 ```
 
 ### LinearProgress

--- a/docs/pages/versions/unversioned/sdk/ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui.mdx
@@ -37,11 +37,16 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
   <Tab label="Code">
     ```tsx
-    import { BottomSheet } from '@expo/ui/swift-ui';
+    import { BottomSheet, Host, Text } from '@expo/ui/swift-ui';
+    import { useWindowDimensions } from 'react-native';
 
-    <BottomSheet isOpened={isOpened} onIsOpenedChange={e => setIsOpened(e)}>
-      <Text>Hello, world!</Text>
-    </BottomSheet>
+    const { width } = useWindowDimensions();
+
+    <Host style={{ position: 'absolute', width }}>
+      <BottomSheet isOpened={isOpened} onIsOpenedChange={e => setIsOpened(e)}>
+        <Text>Hello, world!</Text>
+      </BottomSheet>
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/view/sheet(ispresented:ondismiss:content:))*
 
@@ -62,16 +67,17 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { Button } from '@expo/ui/swift-ui';
+    import { Button, Host } from '@expo/ui/swift-ui';
 
-    <Button
-      style={{ flex: 1 }}
-      variant="default"
-      onPress={() => {
-        setEditingProfile(true);
-      }}>
-      Edit profile
-    </Button>
+    <Host style={{ flex: 1 }}>
+      <Button
+        variant="default"
+        onPress={() => {
+          setEditingProfile(true);
+        }}>
+        Edit profile
+      </Button>
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/button)*
 
@@ -90,9 +96,11 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { CircularProgress } from '@expo/ui/swift-ui';
+    import { CircularProgress, Host } from '@expo/ui/swift-ui';
 
-    <CircularProgress progress={0.5} style={{ width: 300 }} color="blue" />
+    <Host style={{ width: 300 }}>
+      <CircularProgress progress={0.5} color="blue" />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/progressview)*
 
@@ -115,14 +123,15 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
   <Tab label="Code">
     ```tsx
-    import { ColorPicker } from '@expo/ui/swift-ui';
+    import { ColorPicker, Host } from '@expo/ui/swift-ui';
 
-    <ColorPicker
-      label="Select a color"
-      selection={color}
-      onValueChanged={setColor}
-      style={{ width: 400, height: 200 }}
-    />
+    <Host style={{ width: 400, height: 200 }}>
+      <ColorPicker
+        label="Select a color"
+        selection={color}
+        onValueChanged={setColor}
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/colorpicker)*
 
@@ -143,35 +152,37 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { ContextMenu } from '@expo/ui/swift-ui';
+    import { ContextMenu, Host } from '@expo/ui/swift-ui';
 
-    <ContextMenu style={{ width: 150, height: 50 }}>
-      <ContextMenu.Items>
-        <Button
-          systemImage="person.crop.circle.badge.xmark"
-          onPress={() => console.log('Pressed1')}>
-          Hello
-        </Button>
-        <Button
-          variant="bordered"
-          systemImage="heart"
-          onPress={() => console.log('Pressed2')}>
-          Love it
-        </Button>
-        <Picker
-          label="Doggos"
-          options={['very', 'veery', 'veeery', 'much']}
-          variant="menu"
-          selectedIndex={selectedIndex}
-          onOptionSelected={({ nativeEvent: { index } }) => setSelectedIndex(index)}
-        />
-      </ContextMenu.Items>
-      <ContextMenu.Trigger>
-        <Button variant="bordered" style={{ width: 150, height: 50 }}>
-          Show Menu
-        </Button>
-      </ContextMenu.Trigger>
-    </ContextMenu>
+    <Host style={{ width: 150, height: 50 }}>
+      <ContextMenu>
+        <ContextMenu.Items>
+          <Button
+            systemImage="person.crop.circle.badge.xmark"
+            onPress={() => console.log('Pressed1')}>
+            Hello
+          </Button>
+          <Button
+            variant="bordered"
+            systemImage="heart"
+            onPress={() => console.log('Pressed2')}>
+            Love it
+          </Button>
+          <Picker
+            label="Doggos"
+            options={['very', 'veery', 'veeery', 'much']}
+            variant="menu"
+            selectedIndex={selectedIndex}
+            onOptionSelected={({ nativeEvent: { index } }) => setSelectedIndex(index)}
+          />
+        </ContextMenu.Items>
+        <ContextMenu.Trigger>
+          <Button variant="bordered">
+            Show Menu
+          </Button>
+        </ContextMenu.Trigger>
+      </ContextMenu>
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/view/contextmenu(menuitems:))*
 
@@ -192,16 +203,18 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { DateTimePicker } from '@expo/ui/swift-ui';
+    import { DateTimePicker, Host } from '@expo/ui/swift-ui';
 
-    <DateTimePicker
-      onDateSelected={date => {
-        setSelectedDate(date);
-      }}
-      displayedComponents='date'
-      initialDate={selectedDate.toISOString()}
-      variant='wheel'
-    />
+    <Host matchContents>
+      <DateTimePicker
+        onDateSelected={date => {
+          setSelectedDate(date);
+        }}
+        displayedComponents='date'
+        initialDate={selectedDate.toISOString()}
+        variant='wheel'
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/datepicker)*
 
@@ -222,16 +235,18 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { DateTimePicker } from '@expo/ui/swift-ui';
+    import { DateTimePicker, Host } from '@expo/ui/swift-ui';
 
-    <DateTimePicker
-      onDateSelected={date => {
-        setSelectedDate(date);
-      }}
-      displayedComponents='hourAndMinute'
-      initialDate={selectedDate.toISOString()}
-      variant='wheel'
-    />
+    <Host matchContents>
+      <DateTimePicker
+        onDateSelected={date => {
+          setSelectedDate(date);
+        }}
+        displayedComponents='hourAndMinute'
+        initialDate={selectedDate.toISOString()}
+        variant='wheel'
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/datepicker)*
 
@@ -253,25 +268,62 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
   <Tab label="Code">
     ```tsx
-    import { Gauge } from "@expo/ui/swift-ui";
+    import { Gauge, Host } from "@expo/ui/swift-ui";
 
-    <Gauge
-      max={{ value: 1, label: '1' }}
-      min={{ value: 0, label: '0' }}
-      current={{ value: 0.5 }}
-      color={[
-        PlatformColor('systemRed'),
-        PlatformColor('systemOrange'),
-        PlatformColor('systemYellow'),
-        PlatformColor('systemGreen'),
-      ]}
-      type="circularCapacity"
-    />
+    <Host matchContents>
+      <Gauge
+        max={{ value: 1, label: '1' }}
+        min={{ value: 0, label: '0' }}
+        current={{ value: 0.5 }}
+        color={[
+          PlatformColor('systemRed'),
+          PlatformColor('systemOrange'),
+          PlatformColor('systemYellow'),
+          PlatformColor('systemGreen'),
+        ]}
+        type="circularCapacity"
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/gauge)*
 
   </Tab>
 </Tabs>
+
+### Host
+
+A component that allows you to put the other `@expo/ui/swift-ui` components in React Native. It acts like [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg) for DOM, [`<Canvas>`](https://shopify.github.io/react-native-skia/docs/canvas/overview/) for [react-native-skia](https://shopify.github.io/react-native-skia/), which underlying uses [`UIHostingController`](https://developer.apple.com/documentation/swiftui/hostingview) to render the SwiftUI views in UIKit.
+
+Since the `Host` component is a React Native [`View`](https://reactnative.dev/docs/view), you can pass the [`style`](https://reactnative.dev/docs/style) prop to it or `matchContents` prop to make the `Host` component match the contents' size.
+
+```tsx Wrapping Button in Host
+import { Button, Host } from '@expo/ui/swift-ui';
+
+<Host matchContents>
+  <Button
+    onPress={() => {
+      console.log('Pressed');
+    }}>
+    Click
+  </Button>
+</Host>
+```
+
+```tsx Host with flexbox and VStack
+import { Button, Host, VStack, Text } from '@expo/ui/swift-ui';
+
+<Host style={{ flex: 1 }}>
+  <VStack spacing={8}>
+    <Text>Hello, world!</Text>
+    <Button
+      onPress={() => {
+        console.log('Pressed');
+      }}>
+      Click
+    </Button>
+  </VStack>
+</Host>
+```
 
 ### LinearProgress
 
@@ -285,9 +337,11 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { LinearProgress } from '@expo/ui/swift-ui';
+    import { LinearProgress, Host } from '@expo/ui/swift-ui';
 
-    <LinearProgress progress={0.5} style={{ width: 300 }} color="red" />
+    <Host style={{ width: 300 }}>
+      <LinearProgress progress={0.5} color="red" />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/progressview)*
 
@@ -306,23 +360,24 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { List } from '@expo/ui/swift-ui';
+    import { Host, List } from '@expo/ui/swift-ui';
 
-    <List
-      scrollEnabled={false}
-      editModeEnabled={editModeEnabled}
-      onSelectionChange={(items) => alert(`indexes of selected items: ${items.join(', ')}`)}
-      moveEnabled={moveEnabled}
-      onMoveItem={(from, to) => alert(`moved item at index ${from} to index ${to}`)}
-      onDeleteItem={(item) => alert(`deleted item at index: ${item}`)}
-      style={{ flex: 1 }}
-      listStyle='automatic'
-      deleteEnabled={deleteEnabled}
-      selectEnabled={selectEnabled}>
-      {data.map((item, index) => (
-        <LabelPrimitive key={index} title={item.text} systemImage={item.systemImage} color={color} />
-      ))}
-    </List>
+    <Host style={{ flex: 1 }}>
+      <List
+        scrollEnabled={false}
+        editModeEnabled={editModeEnabled}
+        onSelectionChange={(items) => alert(`indexes of selected items: ${items.join(', ')}`)}
+        moveEnabled={moveEnabled}
+        onMoveItem={(from, to) => alert(`moved item at index ${from} to index ${to}`)}
+        onDeleteItem={(item) => alert(`deleted item at index: ${item}`)}
+        listStyle='automatic'
+        deleteEnabled={deleteEnabled}
+        selectEnabled={selectEnabled}>
+        {data.map((item, index) => (
+          <LabelPrimitive key={index} title={item.text} systemImage={item.systemImage} color={color} />
+        ))}
+      </List>
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/list)*
 
@@ -341,16 +396,18 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { Picker } from '@expo/ui/swift-ui';
+    import { Host, Picker } from '@expo/ui/swift-ui';
 
-    <Picker
-      options={['$', '$$', '$$$', '$$$$']}
-      selectedIndex={selectedIndex}
-      onOptionSelected={({ nativeEvent: { index } }) => {
-        setSelectedIndex(index);
-      }}
-      variant="segmented"
-    />
+    <Host matchContents>
+      <Picker
+        options={['$', '$$', '$$$', '$$$$']}
+        selectedIndex={selectedIndex}
+        onOptionSelected={({ nativeEvent: { index } }) => {
+          setSelectedIndex(index);
+        }}
+        variant="segmented"
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/picker#Styling-pickers)*
 
@@ -371,19 +428,18 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { Picker } from '@expo/ui/swift-ui';
+    import { Host, Picker } from '@expo/ui/swift-ui';
 
-    <Picker
-      options={['$', '$$', '$$$', '$$$$']}
-      selectedIndex={selectedIndex}
-      onOptionSelected={({ nativeEvent: { index } }) => {
-        setSelectedIndex(index);
-      }}
-      variant="wheel"
-      style={{
-        height: 100,
-      }}
-    />
+    <Host style={{ height: 100 }}>
+      <Picker
+        options={['$', '$$', '$$$', '$$$$']}
+        selectedIndex={selectedIndex}
+        onOptionSelected={({ nativeEvent: { index } }) => {
+          setSelectedIndex(index);
+        }}
+        variant="wheel"
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/pickerstyle/wheel)*
 
@@ -404,15 +460,16 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { Slider } from '@expo/ui/swift-ui';
+    import { Host, Slider } from '@expo/ui/swift-ui';
 
-    <Slider
-      style={{ minHeight: 60 }}
-      value={value}
-      onValueChange={(value) => {
-        setValue(value);
-      }}
-    />
+    <Host style={{ minHeight: 60 }}>
+      <Slider
+        value={value}
+        onValueChange={(value) => {
+          setValue(value);
+        }}
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/slider)*
 
@@ -433,17 +490,19 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { Switch } from '@expo/ui/swift-ui';
+    import { Host, Switch } from '@expo/ui/swift-ui';
 
-    <Switch
-      checked={checked}
-      onValueChange={checked => {
-        setChecked(checked);
-      }}
-      color="#ff0000"
-      label="Play music"
-      variant="switch"
-    />
+    <Host matchContents>
+      <Switch
+        checked={checked}
+        onValueChange={checked => {
+          setChecked(checked);
+        }}
+        color="#ff0000"
+        label="Play music"
+        variant="switch"
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/toggle)*
 
@@ -462,16 +521,18 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { Switch } from '@expo/ui/swift-ui';
+    import { Host, Switch } from '@expo/ui/swift-ui';
 
-    <Switch
-      checked={checked}
-      onValueChange={checked => {
-        setChecked(checked);
-      }}
-      label="Play music"
-      variant="checkbox"
-    />
+    <Host matchContents>
+      <Switch
+        checked={checked}
+        onValueChange={checked => {
+          setChecked(checked);
+        }}
+        label="Play music"
+        variant="checkbox"
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/toggle)*
 
@@ -490,14 +551,20 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { TextField } from '@expo/ui/swift-ui';
+    import { Host, TextField } from '@expo/ui/swift-ui';
 
-    <TextField autocorrection={false} defaultValue="A single line text input" onChangeText={setValue} />
+    <Host matchContents>
+      <TextField autocorrection={false} defaultValue="A single line text input" onChangeText={setValue} />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/textfield)*
 
   </Tab>
 </Tabs>
+
+### More
+
+Expo UI is still in active development. We continue to add more functionality and may change the API. Some examples in the docs may not be up to date. If you want to see the latest changes, please check the [examples](https://github.com/expo/expo/tree/main/apps/native-component-list/src/screens/UI).
 
 ## Jetpack Compose examples
 

--- a/docs/pages/versions/v54.0.0/sdk/ui.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/ui.mdx
@@ -37,11 +37,16 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
   <Tab label="Code">
     ```tsx
-    import { BottomSheet } from '@expo/ui/swift-ui';
+    import { BottomSheet, Host, Text } from '@expo/ui/swift-ui';
+    import { useWindowDimensions } from 'react-native';
 
-    <BottomSheet isOpened={isOpened} onIsOpenedChange={e => setIsOpened(e)}>
-      <Text>Hello, world!</Text>
-    </BottomSheet>
+    const { width } = useWindowDimensions();
+
+    <Host style={{ position: 'absolute', width }}>
+      <BottomSheet isOpened={isOpened} onIsOpenedChange={e => setIsOpened(e)}>
+        <Text>Hello, world!</Text>
+      </BottomSheet>
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/view/sheet(ispresented:ondismiss:content:))*
 
@@ -62,16 +67,17 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { Button } from '@expo/ui/swift-ui';
+    import { Button, Host } from '@expo/ui/swift-ui';
 
-    <Button
-      style={{ flex: 1 }}
-      variant="default"
-      onPress={() => {
-        setEditingProfile(true);
-      }}>
-      Edit profile
-    </Button>
+    <Host style={{ flex: 1 }}>
+      <Button
+        variant="default"
+        onPress={() => {
+          setEditingProfile(true);
+        }}>
+        Edit profile
+      </Button>
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/button)*
 
@@ -90,9 +96,11 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { CircularProgress } from '@expo/ui/swift-ui';
+    import { CircularProgress, Host } from '@expo/ui/swift-ui';
 
-    <CircularProgress progress={0.5} style={{ width: 300 }} color="blue" />
+    <Host style={{ width: 300 }}>
+      <CircularProgress progress={0.5} color="blue" />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/progressview)*
 
@@ -115,14 +123,15 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
   <Tab label="Code">
     ```tsx
-    import { ColorPicker } from '@expo/ui/swift-ui';
+    import { ColorPicker, Host } from '@expo/ui/swift-ui';
 
-    <ColorPicker
-      label="Select a color"
-      selection={color}
-      onValueChanged={setColor}
-      style={{ width: 400, height: 200 }}
-    />
+    <Host style={{ width: 400, height: 200 }}>
+      <ColorPicker
+        label="Select a color"
+        selection={color}
+        onValueChanged={setColor}
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/colorpicker)*
 
@@ -143,35 +152,37 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { ContextMenu } from '@expo/ui/swift-ui';
+    import { ContextMenu, Host } from '@expo/ui/swift-ui';
 
-    <ContextMenu style={{ width: 150, height: 50 }}>
-      <ContextMenu.Items>
-        <Button
-          systemImage="person.crop.circle.badge.xmark"
-          onPress={() => console.log('Pressed1')}>
-          Hello
-        </Button>
-        <Button
-          variant="bordered"
-          systemImage="heart"
-          onPress={() => console.log('Pressed2')}>
-          Love it
-        </Button>
-        <Picker
-          label="Doggos"
-          options={['very', 'veery', 'veeery', 'much']}
-          variant="menu"
-          selectedIndex={selectedIndex}
-          onOptionSelected={({ nativeEvent: { index } }) => setSelectedIndex(index)}
-        />
-      </ContextMenu.Items>
-      <ContextMenu.Trigger>
-        <Button variant="bordered" style={{ width: 150, height: 50 }}>
-          Show Menu
-        </Button>
-      </ContextMenu.Trigger>
-    </ContextMenu>
+    <Host style={{ width: 150, height: 50 }}>
+      <ContextMenu>
+        <ContextMenu.Items>
+          <Button
+            systemImage="person.crop.circle.badge.xmark"
+            onPress={() => console.log('Pressed1')}>
+            Hello
+          </Button>
+          <Button
+            variant="bordered"
+            systemImage="heart"
+            onPress={() => console.log('Pressed2')}>
+            Love it
+          </Button>
+          <Picker
+            label="Doggos"
+            options={['very', 'veery', 'veeery', 'much']}
+            variant="menu"
+            selectedIndex={selectedIndex}
+            onOptionSelected={({ nativeEvent: { index } }) => setSelectedIndex(index)}
+          />
+        </ContextMenu.Items>
+        <ContextMenu.Trigger>
+          <Button variant="bordered">
+            Show Menu
+          </Button>
+        </ContextMenu.Trigger>
+      </ContextMenu>
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/view/contextmenu(menuitems:))*
 
@@ -192,16 +203,18 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { DateTimePicker } from '@expo/ui/swift-ui';
+    import { DateTimePicker, Host } from '@expo/ui/swift-ui';
 
-    <DateTimePicker
-      onDateSelected={date => {
-        setSelectedDate(date);
-      }}
-      displayedComponents='date'
-      initialDate={selectedDate.toISOString()}
-      variant='wheel'
-    />
+    <Host matchContents>
+      <DateTimePicker
+        onDateSelected={date => {
+          setSelectedDate(date);
+        }}
+        displayedComponents='date'
+        initialDate={selectedDate.toISOString()}
+        variant='wheel'
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/datepicker)*
 
@@ -222,16 +235,18 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { DateTimePicker } from '@expo/ui/swift-ui';
+    import { DateTimePicker, Host } from '@expo/ui/swift-ui';
 
-    <DateTimePicker
-      onDateSelected={date => {
-        setSelectedDate(date);
-      }}
-      displayedComponents='hourAndMinute'
-      initialDate={selectedDate.toISOString()}
-      variant='wheel'
-    />
+    <Host matchContents>
+      <DateTimePicker
+        onDateSelected={date => {
+          setSelectedDate(date);
+        }}
+        displayedComponents='hourAndMinute'
+        initialDate={selectedDate.toISOString()}
+        variant='wheel'
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/datepicker)*
 
@@ -253,25 +268,62 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
   <Tab label="Code">
     ```tsx
-    import { Gauge } from "@expo/ui/swift-ui";
+    import { Gauge, Host } from "@expo/ui/swift-ui";
 
-    <Gauge
-      max={{ value: 1, label: '1' }}
-      min={{ value: 0, label: '0' }}
-      current={{ value: 0.5 }}
-      color={[
-        PlatformColor('systemRed'),
-        PlatformColor('systemOrange'),
-        PlatformColor('systemYellow'),
-        PlatformColor('systemGreen'),
-      ]}
-      type="circularCapacity"
-    />
+    <Host matchContents>
+      <Gauge
+        max={{ value: 1, label: '1' }}
+        min={{ value: 0, label: '0' }}
+        current={{ value: 0.5 }}
+        color={[
+          PlatformColor('systemRed'),
+          PlatformColor('systemOrange'),
+          PlatformColor('systemYellow'),
+          PlatformColor('systemGreen'),
+        ]}
+        type="circularCapacity"
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/gauge)*
 
   </Tab>
 </Tabs>
+
+### Host
+
+A component that allows you to put the other `@expo/ui/swift-ui` components in React Native. It acts like [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg) for DOM, [`<Canvas>`](https://shopify.github.io/react-native-skia/docs/canvas/overview/) for [react-native-skia](https://shopify.github.io/react-native-skia/), which underlying uses [`UIHostingController`](https://developer.apple.com/documentation/swiftui/hostingview) to render the SwiftUI views in UIKit.
+
+Since the `Host` component is a React Native [`View`](https://reactnative.dev/docs/view), you can pass the [`style`](https://reactnative.dev/docs/style) prop to it or `matchContents` prop to make the `Host` component match the contents' size.
+
+```tsx Wrapping Button in Host
+import { Button, Host } from '@expo/ui/swift-ui';
+
+<Host matchContents>
+  <Button
+    onPress={() => {
+      console.log('Pressed');
+    }}>
+    Click
+  </Button>
+</Host>
+```
+
+```tsx Host with flexbox and VStack
+import { Button, Host, VStack, Text } from '@expo/ui/swift-ui';
+
+<Host style={{ flex: 1 }}>
+  <VStack spacing={8}>
+    <Text>Hello, world!</Text>
+    <Button
+      onPress={() => {
+        console.log('Pressed');
+      }}>
+      Click
+    </Button>
+  </VStack>
+</Host>
+```
 
 ### LinearProgress
 
@@ -285,9 +337,11 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { LinearProgress } from '@expo/ui/swift-ui';
+    import { LinearProgress, Host } from '@expo/ui/swift-ui';
 
-    <LinearProgress progress={0.5} style={{ width: 300 }} color="red" />
+    <Host style={{ width: 300 }}>
+      <LinearProgress progress={0.5} color="red" />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/progressview)*
 
@@ -306,23 +360,24 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { List } from '@expo/ui/swift-ui';
+    import { Host, List } from '@expo/ui/swift-ui';
 
-    <List
-      scrollEnabled={false}
-      editModeEnabled={editModeEnabled}
-      onSelectionChange={(items) => alert(`indexes of selected items: ${items.join(', ')}`)}
-      moveEnabled={moveEnabled}
-      onMoveItem={(from, to) => alert(`moved item at index ${from} to index ${to}`)}
-      onDeleteItem={(item) => alert(`deleted item at index: ${item}`)}
-      style={{ flex: 1 }}
-      listStyle='automatic'
-      deleteEnabled={deleteEnabled}
-      selectEnabled={selectEnabled}>
-      {data.map((item, index) => (
-        <LabelPrimitive key={index} title={item.text} systemImage={item.systemImage} color={color} />
-      ))}
-    </List>
+    <Host style={{ flex: 1 }}>
+      <List
+        scrollEnabled={false}
+        editModeEnabled={editModeEnabled}
+        onSelectionChange={(items) => alert(`indexes of selected items: ${items.join(', ')}`)}
+        moveEnabled={moveEnabled}
+        onMoveItem={(from, to) => alert(`moved item at index ${from} to index ${to}`)}
+        onDeleteItem={(item) => alert(`deleted item at index: ${item}`)}
+        listStyle='automatic'
+        deleteEnabled={deleteEnabled}
+        selectEnabled={selectEnabled}>
+        {data.map((item, index) => (
+          <LabelPrimitive key={index} title={item.text} systemImage={item.systemImage} color={color} />
+        ))}
+      </List>
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/list)*
 
@@ -341,16 +396,18 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { Picker } from '@expo/ui/swift-ui';
+    import { Host, Picker } from '@expo/ui/swift-ui';
 
-    <Picker
-      options={['$', '$$', '$$$', '$$$$']}
-      selectedIndex={selectedIndex}
-      onOptionSelected={({ nativeEvent: { index } }) => {
-        setSelectedIndex(index);
-      }}
-      variant="segmented"
-    />
+    <Host matchContents>
+      <Picker
+        options={['$', '$$', '$$$', '$$$$']}
+        selectedIndex={selectedIndex}
+        onOptionSelected={({ nativeEvent: { index } }) => {
+          setSelectedIndex(index);
+        }}
+        variant="segmented"
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/picker#Styling-pickers)*
 
@@ -371,19 +428,18 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { Picker } from '@expo/ui/swift-ui';
+    import { Host, Picker } from '@expo/ui/swift-ui';
 
-    <Picker
-      options={['$', '$$', '$$$', '$$$$']}
-      selectedIndex={selectedIndex}
-      onOptionSelected={({ nativeEvent: { index } }) => {
-        setSelectedIndex(index);
-      }}
-      variant="wheel"
-      style={{
-        height: 100,
-      }}
-    />
+    <Host style={{ height: 100 }}>
+      <Picker
+        options={['$', '$$', '$$$', '$$$$']}
+        selectedIndex={selectedIndex}
+        onOptionSelected={({ nativeEvent: { index } }) => {
+          setSelectedIndex(index);
+        }}
+        variant="wheel"
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/pickerstyle/wheel)*
 
@@ -404,15 +460,16 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { Slider } from '@expo/ui/swift-ui';
+    import { Host, Slider } from '@expo/ui/swift-ui';
 
-    <Slider
-      style={{ minHeight: 60 }}
-      value={value}
-      onValueChange={(value) => {
-        setValue(value);
-      }}
-    />
+    <Host style={{ minHeight: 60 }}>
+      <Slider
+        value={value}
+        onValueChange={(value) => {
+          setValue(value);
+        }}
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/slider)*
 
@@ -433,17 +490,19 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { Switch } from '@expo/ui/swift-ui';
+    import { Host, Switch } from '@expo/ui/swift-ui';
 
-    <Switch
-      checked={checked}
-      onValueChange={checked => {
-        setChecked(checked);
-      }}
-      color="#ff0000"
-      label="Play music"
-      variant="switch"
-    />
+    <Host matchContents>
+      <Switch
+        checked={checked}
+        onValueChange={checked => {
+          setChecked(checked);
+        }}
+        color="#ff0000"
+        label="Play music"
+        variant="switch"
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/toggle)*
 
@@ -462,42 +521,50 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { Switch } from '@expo/ui/swift-ui';
+    import { Host, Switch } from '@expo/ui/swift-ui';
 
-    <Switch
-      checked={checked}
-      onValueChange={checked => {
-        setChecked(checked);
-      }}
-      label="Play music"
-      variant="checkbox"
-    />
+    <Host matchContents>
+      <Switch
+        checked={checked}
+        onValueChange={checked => {
+          setChecked(checked);
+        }}
+        label="Play music"
+        variant="checkbox"
+      />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/toggle)*
 
   </Tab>
 </Tabs>
 
-### TextInput
+### TextField
 
 <Tabs>
   <Tab label="iOS">
     <ContentSpotlight
-      alt="TextInput component on iOS."
+      alt="TextField component on iOS."
       src="/static/images/expo-ui/textinput/ios.png"
       className="max-w-[320px]"
     />
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { TextInput } from '@expo/ui/swift-ui';
+    import { Host, TextField } from '@expo/ui/swift-ui';
 
-    <TextInput autocorrection={false} defaultValue="A single line text input" onChangeText={setValue} />
+    <Host matchContents>
+      <TextField autocorrection={false} defaultValue="A single line text input" onChangeText={setValue} />
+    </Host>
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/textfield)*
 
   </Tab>
 </Tabs>
+
+### More
+
+Expo UI is still in active development. We continue to add more functionality and may change the API. Some examples in the docs may not be up to date. If you want to see the latest changes, please check the [examples](https://github.com/expo/expo/tree/main/apps/native-component-list/src/screens/UI).
 
 ## Jetpack Compose examples
 

--- a/docs/pages/versions/v54.0.0/sdk/ui.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/ui.mdx
@@ -292,7 +292,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 ### Host
 
-A component that allows you to put the other `@expo/ui/swift-ui` components in React Native. It acts like [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg) for DOM, [`<Canvas>`](https://shopify.github.io/react-native-skia/docs/canvas/overview/) for [react-native-skia](https://shopify.github.io/react-native-skia/), which underlying uses [`UIHostingController`](https://developer.apple.com/documentation/swiftui/hostingview) to render the SwiftUI views in UIKit.
+A component that allows you to put the other `@expo/ui/swift-ui` components in React Native. It acts like [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg) for DOM, [`<Canvas>`](https://shopify.github.io/react-native-skia/docs/canvas/overview/) for [`react-native-skia`](https://shopify.github.io/react-native-skia/), which underlying uses [`UIHostingController`](https://developer.apple.com/documentation/swiftui/hostingview) to render the SwiftUI views in UIKit.
 
 Since the `Host` component is a React Native [`View`](https://reactnative.dev/docs/view), you can pass the [`style`](https://reactnative.dev/docs/style) prop to it or `matchContents` prop to make the `Host` component match the contents' size.
 
@@ -572,7 +572,7 @@ function Example() {
 
 ### More
 
-Expo UI is still in active development. We continue to add more functionality and may change the API. Some examples in the docs may not be up to date. If you want to see the latest changes, please check the [examples](https://github.com/expo/expo/tree/main/apps/native-component-list/src/screens/UI).
+Expo UI is still in active development. We continue to add more functionality and may change the API. Some examples in the docs may not be up to date. If you want to see the latest changes, check the [examples](https://github.com/expo/expo/tree/main/apps/native-component-list/src/screens/UI).
 
 ## Jetpack Compose examples
 

--- a/docs/pages/versions/v54.0.0/sdk/ui.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/ui.mdx
@@ -299,30 +299,38 @@ Since the `Host` component is a React Native [`View`](https://reactnative.dev/do
 ```tsx Wrapping Button in Host
 import { Button, Host } from '@expo/ui/swift-ui';
 
-<Host matchContents>
-  <Button
-    onPress={() => {
-      console.log('Pressed');
-    }}>
-    Click
-  </Button>
-</Host>
+function Example() {
+  return (
+    <Host matchContents>
+      <Button
+        onPress={() => {
+          console.log('Pressed');
+        }}>
+        Click
+      </Button>
+    </Host>
+  );
+}
 ```
 
 ```tsx Host with flexbox and VStack
 import { Button, Host, VStack, Text } from '@expo/ui/swift-ui';
 
-<Host style={{ flex: 1 }}>
-  <VStack spacing={8}>
-    <Text>Hello, world!</Text>
-    <Button
-      onPress={() => {
-        console.log('Pressed');
-      }}>
-      Click
-    </Button>
-  </VStack>
-</Host>
+function Example() {
+  return (
+    <Host style={{ flex: 1 }}>
+      <VStack spacing={8}>
+        <Text>Hello, world!</Text>
+        <Button
+          onPress={() => {
+            console.log('Pressed');
+          }}>
+          Click
+        </Button>
+      </VStack>
+    </Host>
+  );
+}
 ```
 
 ### LinearProgress


### PR DESCRIPTION
# Why

since #38866, every component should add `<Host>` wrapper explicitly. this pr tries to update the doc for it

# How

- add `<Host>` doc
- add `<Host>` to all components
- add more section

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
