### PR TITLE
[docs] SwiftUI rename TextInput to TextField

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui.mdx
@@ -478,21 +478,21 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
   </Tab>
 </Tabs>
 
-### TextInput
+### TextField
 
 <Tabs>
   <Tab label="iOS">
     <ContentSpotlight
-      alt="TextInput component on iOS."
+      alt="TextField component on iOS."
       src="/static/images/expo-ui/textinput/ios.png"
       className="max-w-[320px]"
     />
   </Tab>
   <Tab label="Code">
     ```tsx
-    import { TextInput } from '@expo/ui/swift-ui';
+    import { TextField } from '@expo/ui/swift-ui';
 
-    <TextInput autocorrection={false} defaultValue="A single line text input" onChangeText={setValue} />
+    <TextField autocorrection={false} defaultValue="A single line text input" onChangeText={setValue} />
     ```
     *See also: [official SwiftUI documentation](https://developer.apple.com/documentation/swiftui/textfield)*
 


### PR DESCRIPTION
Expo Swift UI has TextField not TextInput.

- Renamed in https://github.com/expo/expo/pull/37642

https://github.com/expo/expo/blob/7ec2c4a6cbdacf3b48470ef7a52b9ed52941456f/packages/expo-ui/src/swift-ui/TextField/index.tsx

