### PR TITLE
[android][camera] Fix with nav drawer

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix early tear down from `onDetachedFromWindow`.
+
 ### 💡 Others
 
 ## 17.0.2 — 2025-08-16

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix early tear down from `onDetachedFromWindow`.
+- [Android] Fix early tear down from `onDetachedFromWindow`. ([#39119](https://github.com/expo/expo/pull/39119) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -15,10 +15,10 @@ android {
 }
 
 dependencies {
-  def camerax_version = "1.4.1"
+  def camerax_version = "1.5.0-rc01"
 
-  api "androidx.exifinterface:exifinterface:1.3.7"
-  api "androidx.appcompat:appcompat:1.1.0"
+  api "androidx.exifinterface:exifinterface:1.4.1"
+  api "androidx.appcompat:appcompat:1.7.1"
 
   implementation "androidx.camera:camera-core:${camerax_version}"
   implementation "androidx.camera:camera-camera2:${camerax_version}"

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
@@ -382,6 +382,10 @@ class CameraViewModule : Module() {
         }
       }
 
+      OnViewDestroys { view ->
+        view.cleanupCamera()
+      }
+
       AsyncFunction("takePicture") { view: ExpoCameraView, options: PictureOptions, promise: Promise ->
         if (!EmulatorUtilities.isRunningOnEmulator()) {
           view.takePicture(options, promise, cacheDirectory, runtimeContext)

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -10,7 +10,6 @@ import android.graphics.SurfaceTexture
 import android.hardware.camera2.CameraCharacteristics
 import android.media.AudioManager
 import android.media.MediaActionSound
-import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.util.Size
@@ -18,7 +17,6 @@ import android.view.OrientationEventListener
 import android.view.Surface
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowManager
 import androidx.annotation.OptIn
 import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.camera2.interop.Camera2CameraInfo

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -14,7 +14,6 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.util.Size
-import kotlin.math.roundToInt
 import android.view.OrientationEventListener
 import android.view.Surface
 import android.view.View
@@ -86,6 +85,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.lang.Float.max
 import java.lang.Float.min
+import kotlin.math.roundToInt
 import kotlin.properties.Delegates
 
 const val ANIMATION_FAST_MILLIS = 50L
@@ -634,12 +634,6 @@ class ExpoCameraView(
     barcodeFormats = settings?.barcodeTypes ?: emptyList()
   }
 
-  private fun getDeviceOrientation() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-    context.display.rotation
-  } else {
-    (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay.rotation
-  }
-
   private fun transformBarcodeScannerResultToViewCoordinates(barcode: BarCodeScannerResult) {
     val cornerPoints = barcode.cornerPoints
     val previewWidth = previewView.width.toFloat()
@@ -800,7 +794,7 @@ class ExpoCameraView(
     Log.e(CameraViewModule.TAG, "The scope does not have a job in it")
   }
 
-  override fun onDetachedFromWindow() {
+  fun cleanupCamera() {
     super.onDetachedFromWindow()
     orientationEventListener.disable()
     cancelCoroutineScope()

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -793,7 +793,6 @@ class ExpoCameraView(
   }
 
   fun cleanupCamera() {
-    super.onDetachedFromWindow()
     orientationEventListener.disable()
     cancelCoroutineScope()
     cameraProvider?.unbindAll()


### PR DESCRIPTION
# Why
Closes #38142
When using the drawer from react navigation, `onDetachedFromWindow` is called when it opens and closes. Because this is where we do the camera cleanup, when the drawer is opened, the camera is killed and never restarted

# How
Use `OnViewDestroys` for cleanup instead on `onDetachedFromWindow`. The issue mentions a second problem of the preview become distorted. This is supposed to have been fixed in cameraX so I've bumped the version to get those fixes. I could not repro the problem after that.

# Test Plan
Bare-expo ✅

