### PR TITLE
[android][core] Fix error manager not receiving events

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix ErrorManager not receiving error/warning events on the JS side. ([#39126](https://github.com/expo/expo/pull/39126) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 3.0.6 — 2025-08-25

--- a/packages/expo-modules-core/build/sweet/NativeErrorManager.d.ts
+++ b/packages/expo-modules-core/build/sweet/NativeErrorManager.d.ts
@@ -1,3 +1,3 @@
-declare const _default: import("..").ProxyNativeModule;
+declare const _default: any;
 export default _default;
 //# sourceMappingURL=NativeErrorManager.d.ts.map

--- a/packages/expo-modules-core/build/sweet/NativeErrorManager.d.ts.map
+++ b/packages/expo-modules-core/build/sweet/NativeErrorManager.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"NativeErrorManager.d.ts","sourceRoot":"","sources":["../../src/sweet/NativeErrorManager.ts"],"names":[],"mappings":";AACA,wBAA8D"}
+{"version":3,"file":"NativeErrorManager.d.ts","sourceRoot":"","sources":["../../src/sweet/NativeErrorManager.ts"],"names":[],"mappings":";AAEA,wBAA0E"}

--- a/packages/expo-modules-core/src/sweet/NativeErrorManager.ts
+++ b/packages/expo-modules-core/src/sweet/NativeErrorManager.ts
@@ -1,2 +1,3 @@
-import NativeModulesProxy from '../NativeModulesProxy';
-export default NativeModulesProxy.ExpoModulesCoreErrorManager;
+import { requireOptionalNativeModule } from '../requireNativeModule';
+
+export default requireOptionalNativeModule('ExpoModulesCoreErrorManager');


### PR DESCRIPTION
# Why

The Error Manager from `expo-modules-core` is not receiving events with errors and warnings from the native side.

# How

Used `requireOptionalNativeModule` in order to import the module.

# Test Plan

Tested in BareExpo on Android and iOS
