### PR TITLE
[dev-launcher] fix typo in 'RECENTLY OPEND' to 'RECENTLY OPENED'

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/HomeScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/HomeScreen.kt
@@ -348,7 +348,7 @@ fun HomeScreen(
           modifier = Modifier.fillMaxWidth()
         ) {
           NewText(
-            "RECENTLY OPEND",
+            "RECENTLY OPENED",
             style = NewAppTheme.font.sm.merge(
               fontWeight = FontWeight.Medium,
               fontFamily = NewAppTheme.font.mono


### PR DESCRIPTION
# Why

fix typo

# How

fix typo


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
