### PR TITLE
[doctor] Add additional advice for excluding specific packages

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add link to FYI about excluding dependencies from packages validation check. ([#39132](https://github.com/expo/expo/pull/39132) by by [@betomoedano](https://github.com/betomoedano))
+
 ## 1.17.1 — 2025-08-25
 
 ### 🐛 Bug fixes

--- a/packages/expo-doctor/src/checks/InstalledDependencyVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/InstalledDependencyVersionCheck.ts
@@ -2,6 +2,7 @@ import spawnAsync, { SpawnResult } from '@expo/spawn-async';
 import semver from 'semver';
 
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+import { learnMore } from '../utils/TerminalLink';
 import { parseInstallCheckOutput } from '../utils/parseInstallCheckOutput';
 
 function isSpawnResult(result: any): result is SpawnResult {
@@ -15,6 +16,7 @@ export class InstalledDependencyVersionCheck implements DoctorCheck {
 
   async runAsync({ exp, projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
     const issues: string[] = [];
+    const advice: string[] = [];
 
     // Expo CLI introduced support for --json output in SDK 54
     // Command: npx expo install --check --json
@@ -75,12 +77,19 @@ export class InstalledDependencyVersionCheck implements DoctorCheck {
       }
     }
 
+    if (issues.length) {
+      advice.push(`Use 'npx expo install --check' to review and upgrade your dependencies.`);
+      advice.push(
+        `To ignore specific packages, add them to "expo.install.exclude" in package.json. ${learnMore(
+          'https://expo.fyi/dependency-validation'
+        )}`
+      );
+    }
+
     return {
       isSuccessful: issues.length === 0,
       issues,
-      advice: issues.length
-        ? [`Use 'npx expo install --check' to review and upgrade your dependencies.`]
-        : [],
+      advice,
     };
   }
 }


### PR DESCRIPTION
# Why

Closes -> [ENG-11835 Add link to info about excluding dependencies from validation in doctor warning](https://linear.app/expo/issue/ENG-11835/add-link-to-info-about-excluding-dependencies-from-validation-in)

# How

Created new FYI page https://github.com/expo/fyi/blob/main/dependency-validation.md and added link in the dependencies check.

# Test Plan

Ran it locally and confirmed the link works.

<img width="1210" height="274" alt="image" src="https://github.com/user-attachments/assets/bceade2b-fcd8-46a8-b754-d7d6c4a42708" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
