### PR TITLE
[android][print] Fix jobName not using file name

### DIFF
--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Use the last path segment of the `uri` as the job name. ([#39133](https://github.com/expo/expo/pull/39133) by [@ouwargui](https://github.com/ouwargui))
+
 ### 💡 Others
 
 ## 15.0.3 — 2025-08-25

--- a/packages/expo-print/android/src/main/java/expo/modules/print/PrintDocumentAdapter.kt
+++ b/packages/expo-print/android/src/main/java/expo/modules/print/PrintDocumentAdapter.kt
@@ -17,7 +17,9 @@ import kotlin.coroutines.Continuation
 import kotlin.coroutines.resumeWithException
 
 class PrintDocumentAdapter(private val context: WeakReference<Context>, private val continuation: Continuation<Unit>, private val uri: String?) : PrintDocumentAdapter() {
-  private val jobName = "Printing"
+  private val jobName: String = uri?.let {
+    Uri.parse(it).lastPathSegment ?: it
+  } ?: "Printing"
 
   override fun onWrite(pages: Array<PageRange>, destination: ParcelFileDescriptor, cancellationSignal: CancellationSignal, callback: WriteResultCallback) {
     if (uri == null) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Users expect the file name on the URI to be pre-populated when saving the file.

Closes #39068 

# How

<!--
How did you build this feature or fix this bug and why?
-->
By parsing the URI and grabbing the last path segment.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Manually tested through bare-expo using this file URI: `'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf'`
<video src="https://github.com/user-attachments/assets/e514cc8c-ce5d-41e0-8989-b0dc42901382">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
