### PR TITLE
[autolinking][android] Add projectRoot option to gradle plugin

### DIFF
--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/ExpoGradleExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/ExpoGradleExtension.kt
@@ -27,7 +27,8 @@ data class AutolinkingOptions(
  */
 open class ExpoGradleExtension(
   val config: ExpoAutolinkingConfig,
-  val options: AutolinkingOptions = AutolinkingOptions()
+  val options: AutolinkingOptions = AutolinkingOptions(),
+  val projectRoot: java.io.File,
 ) {
   /**
    * MD5 hash of the configuration.

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingPlugin.kt
@@ -11,6 +11,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
+import java.io.File
 import java.nio.file.Paths
 
 const val generatedPackageListNamespace = "expo.modules"
@@ -49,7 +50,7 @@ open class ExpoAutolinkingPlugin : Plugin<Project> {
     project.logger.quiet("")
 
     // Creates a task that generates a list of expo modules.
-    val generatePackagesList = createGeneratePackagesListTask(project, gradleExtension.options, gradleExtension.hash)
+    val generatePackagesList = createGeneratePackagesListTask(project, gradleExtension.options, gradleExtension.hash, gradleExtension.projectRoot)
 
     // Ensures that the task is executed before the build.
     project.tasks
@@ -79,12 +80,12 @@ open class ExpoAutolinkingPlugin : Plugin<Project> {
     return project.layout.buildDirectory.file(packageListRelativePath)
   }
 
-  fun createGeneratePackagesListTask(project: Project, options: AutolinkingOptions, hash: String): TaskProvider<GeneratePackagesListTask> {
+  fun createGeneratePackagesListTask(project: Project, options: AutolinkingOptions, hash: String, projectRoot: File): TaskProvider<GeneratePackagesListTask> {
     return project.tasks.register("generatePackagesList", GeneratePackagesListTask::class.java) {
       it.hash.set(hash)
       it.namespace.set(generatedPackageListNamespace)
       it.outputFile.set(getPackageListFile(project))
-      it.workingDir = project.rootDir
+      it.workingDir = projectRoot
       // Serializes the autolinking options to JSON to pass them to the task.
       // The types supported as a task input are limited to primitives, strings, and files.
       it.options.set(options.toJson())

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/ExpoAutolinkingSettingsExtension.kt
@@ -12,12 +12,27 @@ open class ExpoAutolinkingSettingsExtension(
   @Inject val objects: ObjectFactory
 ) {
   /**
+   * The root directory of the react native project.
+   * Should be used by projects that don't follow the /android folder structure.
+   *
+   * Defaults to `settings.rootDir`.
+   */
+  var projectRoot: File = settings.rootDir
+
+  /**
    * Command that should be provided to `react-native` to resolve the configuration.
    */
-  val rnConfigCommand = AutolinkingCommandBuilder()
-    .command("react-native-config")
-    .useJson()
-    .build()
+  val rnConfigCommand by lazy {
+    val commandBuilder = AutolinkingCommandBuilder()
+      .command("react-native-config")
+      .useJson()
+
+    if (projectRoot != settings.rootDir) {
+      commandBuilder.option("project-root", projectRoot.absolutePath)
+      commandBuilder.option("source-dir", settings.rootDir.absolutePath)
+    }
+    commandBuilder.build()
+  }
 
   /**
    * A list of paths relative to the app's root directory where
@@ -41,7 +56,7 @@ open class ExpoAutolinkingSettingsExtension(
   val reactNativeGradlePlugin: File by lazy {
     File(
       settings.providers.exec { env ->
-        env.workingDir(settings.rootDir)
+        env.workingDir(projectRoot)
         env.commandLine("node", "--print", "require.resolve('@react-native/gradle-plugin/package.json', { paths: [require.resolve('react-native/package.json')] })")
       }.standardOutput.asText.get().trim(),
     ).parentFile
@@ -53,7 +68,7 @@ open class ExpoAutolinkingSettingsExtension(
   val reactNative: File by lazy {
     File(
       settings.providers.exec { env ->
-        env.workingDir(settings.rootDir)
+        env.workingDir(projectRoot)
         env.commandLine("node", "--print", "require.resolve('react-native/package.json')")
       }.standardOutput.asText.get().trim(),
     ).parentFile
@@ -65,6 +80,7 @@ open class ExpoAutolinkingSettingsExtension(
   fun useExpoModules() {
     SettingsManager(
       settings,
+      projectRoot,
       searchPaths,
       ignorePaths,
       exclude

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/SettingsManager.kt
@@ -26,6 +26,7 @@ import java.io.File
 
 class SettingsManager(
   val settings: Settings,
+  val projectRoot: File,
   searchPaths: List<String>? = null,
   ignorePaths: List<String>? = null,
   exclude: List<String>? = null
@@ -57,7 +58,7 @@ class SettingsManager(
       .build()
 
     val result = settings.providers.exec { env ->
-      env.workingDir(settings.rootDir)
+      env.workingDir(projectRoot.absolutePath)
       env.commandLine(command)
     }.standardOutput.asText.get()
 
@@ -155,7 +156,7 @@ class SettingsManager(
         }
     }
 
-    settings.gradle.extensions.create("expoGradle", ExpoGradleExtension::class.java, config, autolinkingOptions)
+    settings.gradle.extensions.create("expoGradle", ExpoGradleExtension::class.java, config, autolinkingOptions, projectRoot)
   }
 
   /**


### PR DESCRIPTION
# Why

Android equivalent of https://github.com/expo/expo/pull/38210 

`useExpoModules` does not work as expected when an Android project is not using the standard `/android` folder structure. This happens because the `workingDir` is not set correctly, causing modules to not be linked.

This change would allow users to configure different react-native projects root with the following changes to `settings.gradle`

```gradle
// settings.gradle
expoAutolinking {
  projectRoot = new File(rootDir, "my-expo-app")
}
```

# How

Add `projectRoot` option to the autoliking gradle plugin

# Test Plan

Manually tested adding a react-native view to https://github.com/gabrieldonadel/AntennaPod

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
