### PR TITLE
upgrade react-native-screens to 4.15.3

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2733,7 +2733,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNScreens (4.15.0):
+  - RNScreens (4.15.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2755,9 +2755,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNScreens/common (= 4.15.0)
+    - RNScreens/common (= 4.15.3)
     - Yoga
-  - RNScreens/common (4.15.0):
+  - RNScreens/common (4.15.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3516,90 +3516,90 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  BenchmarkingModule: 272c02f4a7e9e0d9e9f25d018661094608e2d91f
-  EASClient: bac1ef7c808fa661ae0ff626f6cd2f01fc7faaf7
-  EXApplication: 4c96b50bb284b0fd81f49581230e02cd2c405db3
-  EXAV: 6ece237240c291db8eaee6a7226c89fa4fa85600
-  EXConstants: 312d1b38b4fd6074dcd253c347dc7a5682549a02
-  EXImageLoader: 189e3476581efe3ad4d1d3fb4735b7179eb26f05
+  BenchmarkingModule: 69aa39c6f6d42bf6fc47caeacb070d24de22d54f
+  EASClient: 138582a9575c5a71418f6bdc4fd06bb226a3cc76
+  EXApplication: 538d5490f59dc0baa075b37d1dcd07b9f15799a7
+  EXAV: f0f8557a8681fefe7102e0fa3926df90c9548bcd
+  EXConstants: f7ecf52d3f843309cd3d8ecc0cb104f5ca3a4b31
+  EXImageLoader: e501c001bc40b8326605e82e6e80363c80fe06b5
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: c43ae3f01be93094b271e24bf03ee66410d0e7a4
-  EXNotifications: bd1ec144701477f347d0fa909801ee3a4a62f914
-  Expo: a904e85cb7100e77436518b0b7d94d9be537fd20
-  expo-dev-client: 3d4ece4489c032e7cddb64b5ac2f0e109458f8f0
-  expo-dev-launcher: ca8b53ac621fd16d0f21654486455d32a13da0e9
-  expo-dev-menu: d8e72e768aead7083b33f473a383cea284935cc6
+  EXManifests: c496080fa9cc6896c8c0e44de27f0f5d0ba9c6bc
+  EXNotifications: 6f159317e7185f9ff3ec1fc849bc7047fd71fbc4
+  Expo: 17420777f66c5b914f402ee10f2ff283edc87259
+  expo-dev-client: 915e39174758c482f43ae14919fadd0b6d877096
+  expo-dev-launcher: 24f00812bc5001611c42f0c1a79a165c424b918c
+  expo-dev-menu: dd7906186268e2ad14f4f124954b947092328422
   expo-dev-menu-interface: 600df12ea01efecdd822daaf13cc0ac091775533
-  ExpoAppIntegrity: c0bece4874e3c90a76bad2d567379b98eea6942a
-  ExpoAppleAuthentication: c825848c15975e2ea93b8f11b2087a0ae31c2fe4
-  ExpoAsset: 70bf7922c1c089b6735b92dd251da7da2b374212
-  ExpoAudio: ecfdac9428c889e27b36daf140bf4f3608ffa18b
-  ExpoBackgroundFetch: 569d326601ce0799a09bc13c4d8dbd1330411262
-  ExpoBackgroundTask: 80e0e2febf44b6283427c51800a6bd0eeeaa362c
-  ExpoBattery: 80c257ddf6d6416e22b6a0a93bebcb4a5110fe57
-  ExpoBlob: 419bde7cc7861e32fd3e081f7a263ecd76ffb62f
-  ExpoBlur: 6ccfa1957b79c45f3a72a9f262ca2febf43cdea2
-  ExpoBrightness: 5227538dcbbfb4eb2f858a2d0cfdbf7696d14408
-  ExpoCalendar: d291b65454854328a3e65e1fe427f024bcaa28fc
-  ExpoCamera: 915dd48ead12570bfa76d2bb12eeed44056de6b3
-  ExpoCellular: 6768af6429e6a4bd5f24dc6899ab25d8c87c48a3
-  ExpoClipboard: 92fc7255041f7f897c1438186eac5098708cfb3d
-  ExpoContacts: fac10eaca244d546380c55c7ec228324779f529b
-  ExpoCrypto: 938e75ca0b4160a186f723e51559f746c1bcaaeb
-  ExpoDevice: cc368db84ab8733361833e23dda513cebd522c44
-  ExpoDocumentPicker: bc02bbd2beeefaf2c25873ee1b88b001c2f2d228
-  ExpoDomWebView: cff32ab4f0758233fd219d34fb8ef111ed42b6bc
-  ExpoFileSystem: 6750ab7ff79406c819ce0e5a5dac43171761eaf1
-  ExpoFont: aadbbc0baecff6ca39248443a11ba7e77b8ad1a4
-  ExpoGL: 593d8a47f5634123303227648358f307f59c6c70
-  ExpoHaptics: efe3c06397f4e3c09b60126d819c35c965d2a178
-  ExpoImage: 24e5fccd6786797b4e0fa73a54a2dd986786c15f
-  ExpoImageManipulator: 6b1d01fbe401d67264ea4067280c5ec9859197c1
-  ExpoImagePicker: b417075a63a0b08aecb2660e959c9612d1c779cc
-  ExpoInsights: cb8d6f1267f1477306d8701c470c7730068c0f42
-  ExpoKeepAwake: 44a0f029efacb4df7508f30fe8d68b497bc43716
-  ExpoLinearGradient: 4d5fdba019d61b4947da04f9b338db37472c5fed
-  ExpoLinking: b198472f69cc43efe77722b72ea0504bdd3bf68b
-  ExpoLivePhoto: e5ae842d17077afc566575f3bfbc0e87f7fc076f
-  ExpoLocalAuthentication: b8a56535de746be350355790506947b1c7297412
-  ExpoLocalization: 78e8aaa44a74b905ba2d17bcd8b41939c9ca7ce8
-  ExpoLocation: f2262de20261424355a2a3a07e1aaca8a948501c
-  ExpoMailComposer: f9146258a139507d14dde5f9fe3b8bd35a374d2e
-  ExpoMaps: 84b61c64c66cb4655fe0fd5de3b9d05132f9ffcb
-  ExpoMediaLibrary: 5cc65d19296888e077e71b9977f4a80b8e5c3c14
-  ExpoMeshGradient: b4bc1a42c47492ef90b46431da05dad5be568bf3
-  ExpoModulesCore: 294923d8ba7648bfe589d7915a78a79a15788dd7
-  ExpoModulesTestCore: be5073c51ffe7c2db9f14aedfce7d8cdc141f55a
-  ExpoNetwork: d8309bc1f086732f5dc5dba10b37cdb84e6db610
-  ExpoPrint: 59f2a3bc1604fcfaf490c07b9efe0703d556a7f8
-  ExpoScreenCapture: 97e1eb3189efd61f78384f70220df9b66ca56639
-  ExpoScreenOrientation: 410601a2645c15ba070bf628b20f816f5659b9cd
-  ExpoSecureStore: 6ace75e6d81529f785b1afbb65807be1edcfb8ad
-  ExpoSensors: 98a2f22c06a5d0cb8372a027ba87361b52075f28
-  ExpoSharing: 841a124fbed7c7bed44ca91512357145c8fb6559
-  ExpoSMS: 2bd5694f47eef5b06e268674248254e4daa4aad2
-  ExpoSpeech: abe8b34612f5b792196e2d53adb8627a4421f22a
-  ExpoSplashScreen: 98561b244fba777cb103ac72bd71532010258aea
-  ExpoSQLite: e93b6f327e4cc87066226e86d295f4ff9473e4fb
-  ExpoStoreReview: db538d60883450c57cd909c58d9a99195dabe75b
-  ExpoSymbols: 388eb9e9955b95bd4b39d3b081e99bf1117554f1
-  ExpoSystemUI: 5d2a1cd36e9e961f561af4375b1e93fc99418c07
-  ExpoTrackingTransparency: 9b82518e4f428329b85694c2b8fb2f13a6797637
-  ExpoUI: 5bb036298cf1ef02ee3b47b678b946fa92b3b66e
-  ExpoVideo: b5536c3ed406fd9255e4a1177399aa8d45c606f7
-  ExpoVideoThumbnails: 94214009a7c55e107bca40b358043b790f18da9a
-  ExpoWebBrowser: 8a4f46ca3bef49775e3227ae2eb2bc8bb1dc4417
+  ExpoAppIntegrity: 85482911279959f64d6ee6e0dffe90e3d6827d06
+  ExpoAppleAuthentication: 349c76033258c9212e38f4274ed56ef95c154791
+  ExpoAsset: 035bfce2473fc1b5205705c05a05563985b906f5
+  ExpoAudio: d62506c713c82f058182a947b3314ae83442e4d6
+  ExpoBackgroundFetch: 7443b7469728137ecb94fa15497e9741b084a005
+  ExpoBackgroundTask: d1ea554d5fc7134f42dd69031d11c953f0bb1b5d
+  ExpoBattery: 8bbc584adba655b6971ec995bde0aa62b49c7569
+  ExpoBlob: a7eade6c0ba8ec7318b0db5a482518a9ac24402a
+  ExpoBlur: f855bcba5d536cab048a0df0b1fe54306382af3e
+  ExpoBrightness: 18176c75019628b1adce5a0c62b2e0331906cc40
+  ExpoCalendar: 7b41443b59da2d1e09dccf78343a39f23743a7d4
+  ExpoCamera: 4f4fb3c8d91a1495f680d2c04ebb7445af50193f
+  ExpoCellular: d42b44526b25a2d0d339206c7689d86bee3312c7
+  ExpoClipboard: 194a02dda5826abfe724b17d938ece33a5f30ac7
+  ExpoContacts: d51a68048fbae13520b6d8fda4f7b73cab9e9f75
+  ExpoCrypto: 2e1143beae310d40c281b2be62e675f3b3b14016
+  ExpoDevice: 9ab5852154108f3906c3748965b80bd71e03635a
+  ExpoDocumentPicker: 80fc08dffd882f1e3ec5a2b04fe2b6dac95debdb
+  ExpoDomWebView: 53421ff50138c1a7891b33228b89dba28e95972f
+  ExpoFileSystem: d9811023255eefa51ff4732052785a41f84ec29f
+  ExpoFont: e6b2ade4a6e84bab3e1c1256db47461274cc4a01
+  ExpoGL: 0e71c722e5fdf577301d74c4095ddf28972e675a
+  ExpoHaptics: 2ddbc0e34d8656f14b144831d4872defadf3bbe3
+  ExpoImage: 964a2a9008afcfcf4e1f57d3c625cbaac29bf405
+  ExpoImageManipulator: 8458ffd3e894283d9b59fa054478f84ca5bb686f
+  ExpoImagePicker: 6735518d513a669713c52dec910f6ac9befafd08
+  ExpoInsights: 10a183783d7158a8f48e08094feb12b2ef1540a6
+  ExpoKeepAwake: 9b9af4742c8d69b0cfeb777ed8e909c1a9938c1d
+  ExpoLinearGradient: 3ecbb56043c494b48edfc29534eeec41351452ab
+  ExpoLinking: e76895a69085225cc653805dd5d17e4f80dde89c
+  ExpoLivePhoto: 7b022bf508cbc6ba5f287099da084cae48c10b43
+  ExpoLocalAuthentication: 2b1cc60cda69a0f2d370287785d3ad6049b44ce6
+  ExpoLocalization: 310d6e44a46f57f7c5ca3cce9fa8c9459a5d7fc4
+  ExpoLocation: 3f39d1b684337e9682a31262d7ea0d1b5ea06866
+  ExpoMailComposer: 9badcba98974e44bc64ad7711d226aa777e8ec56
+  ExpoMaps: 7fd65aea1fee291ca84602452975e12a69d67523
+  ExpoMediaLibrary: 4d8fb6f615db7ed4156c75af8c97d8777b3bd76c
+  ExpoMeshGradient: caa5c55ce1600519934435fc601d09295d16b757
+  ExpoModulesCore: 49824089a601239055e428feac4cb3fe8f1cf571
+  ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
+  ExpoNetwork: 84b8c5bc0d0811c8bd5bfd64c469132935207b35
+  ExpoPrint: e42212eb339a7069d4de4f738208b2c4b0c85b16
+  ExpoScreenCapture: 7af30ca0245a44479b9809f8e6e6bb257e2035f6
+  ExpoScreenOrientation: 764fdd3a760b6ff5c3bd3259e284be8b1da04a17
+  ExpoSecureStore: 4aaff1f5ac38728252b5fa134cbf14f6aaf249c3
+  ExpoSensors: 363b806ed7e6b24fca0456ea2af0ea6d2f31f924
+  ExpoSharing: 09c195e34fd04dba4221c31948cba1b6744551ea
+  ExpoSMS: 4e86c8a243509fca39bcd55497f4090dee478cd4
+  ExpoSpeech: 3d4cc33982cba4d9b5d21d50d206d33c888a20a0
+  ExpoSplashScreen: 77003d91ee4e3ca565f80658f7c4fe16c9eb3e45
+  ExpoSQLite: 49f3a7956c6a673748efedc264e72e097db3da12
+  ExpoStoreReview: 134aad04960ed2878f3055caa015dc64296ca9c9
+  ExpoSymbols: d754462efddef0c8b4d2c5a1d76285a31db8b71d
+  ExpoSystemUI: 7e705cea742761788b44e50ad49289724586480f
+  ExpoTrackingTransparency: 006ded03556839c789a0949e9373035029dc5818
+  ExpoUI: 0d446737943c9dce78e73e5fa6fdbb979f151053
+  ExpoVideo: e1b99a7404425eaaa026d85e1555d45f9e5a5541
+  ExpoVideoThumbnails: 498abcb70e19374653f97c690e2a4e2021db36db
+  ExpoWebBrowser: dfb3ce8436e822e54e6ae9981f45d39a3de79939
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
-  EXTaskManager: 6dd12e0ba5b5ab9d2c56754b2d66328a1105f9a7
-  EXUpdates: 34845a06de9938415b8da6ae21653c91864a4e67
-  EXUpdatesInterface: 5adf50cb41e079c861da6d9b4b954c3db9a50734
+  EXTaskManager: b29afc41b8b73c6fbe622e39ccb952471bb20165
+  EXUpdates: b672d03131977cebf9c1bfaa053cbc7373a2a5c4
+  EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   FBLazyVector: ab4b9b95d08c7d60f758a8ec05e83803eea069b4
   hermes-engine: e7491a2038f2618c8cd444ed411a6deb350a3742
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: 3aaf4e04de466d1ac3a0456381d88be02ef9f66d
+  lottie-react-native: 29a3610e350f54856048ff5e408032596c45fb26
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
@@ -3609,83 +3609,83 @@ SPEC CHECKSUMS:
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
   React: 1000c0e96d8fb9fbdaf13f7d31d0b09db3cbb4ac
   React-callinvoker: 26dc5861f10a25d89d2f5f976bf280c6adcf365d
-  React-Core: bfd0c56a31d99c7a3e6cad33ec708115fef84f9d
-  React-Core-prebuilt: bf9b8f4d22972e9a4c1163efd405625ac8b1043e
-  React-CoreModules: e6944eda15b49da4af28081173aaddf28579998e
-  React-cxxreact: 2a19c06995834bcd216a0645a599e288d1e7ea97
+  React-Core: 18b8078ab79d59f93383c43f7cc5a60b760df6e1
+  React-Core-prebuilt: 394df02d0713cd81658370c590f839bcade91aa7
+  React-CoreModules: cb3d31e38c33a55311665ed831247e725f9677ea
+  React-cxxreact: 2be74349264dcd0ed4314ee56d95b3601cd4a387
   React-debug: 87a7f77deb10d7022bee2af6c232ca6903482b1f
-  React-defaultsnativemodule: 5c0c2f6d1a81f88b96c06ddcf8c5e32da56df3af
-  React-domnativemodule: 7b06177914832dea63eb6d2684d31f2e16bd4a57
-  React-Fabric: c313bc7f590c83207a88659414c83adcce778bc9
-  React-FabricComponents: a6b06b4f5079b73cfd68b60c61d07dc0241537bd
-  React-FabricImage: 47edeaa04cdf3c56768b0a1bd08e3a6d0610e021
-  React-featureflags: e52e535c0bef80186634e4ef9bcb0b970f0126b7
-  React-featureflagsnativemodule: 0606081060a33d4b6b1923e486d63469a7156f6b
-  React-graphics: 0bab1a2fb2622f270484e8e8be15e7bcf5de1647
-  React-hermes: dc1ca78ca6bb878d39d27f79dbca4c9c4df2d08e
-  React-idlecallbacksnativemodule: 0114bcd22185525adb0e9a766b8c386f6c500385
-  React-ImageManager: fdd8211f77e8985ec576aa0bb2e9690b01c3a6cd
-  React-jserrorhandler: 1989654508f1a6bafab8d0031752f9ac5329ce89
-  React-jsi: 627f8b3e0ab5d683a6ca6bd1e993601022105a22
-  React-jsiexecutor: 5a0c67638707ed4d612f59b27e786200c71bc0b1
-  React-jsinspector: 48d9234b5e2b10e7f9c40ddbc5f7085ca736519d
-  React-jsinspectorcdp: 5515fa810ee1f492474bb943ba80ac8655e7d8c0
-  React-jsinspectornetwork: dd94df05e52bc0197b271b9018674562609bdd87
-  React-jsinspectortracing: 84e59a5e60b681ff2e8f3bd263595612f1136790
-  React-jsitooling: 519f66f63353425a1e65ec20b08b0497e4642d8f
-  React-jsitracing: b9df20c8401d85e4e966287a20e6ad56c08e343c
-  React-logger: f044501f6f1e2d803ac5768ca2a9198f5fa55df2
-  React-Mapbuffer: 79ba3ee7405add8758e3c6d2df9d8e5deb5546ee
-  React-microtasksnativemodule: d7f49e916033c30e1f64bb6b91e5db6c619df220
-  react-native-keyboard-controller: 2e4bd3c2370327f57e8775873527c992382f8e66
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-pager-view: c8817c1d9f4643417e68f0b846c51214b2252eea
-  react-native-safe-area-context: eb2fb5c796f18a08959ee5400bb1c65e4c1b4833
-  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
-  react-native-skia: e600b0756d17cdcff4b02c2125a5e5ca4acbcf07
-  react-native-slider: 8c562583722c396a3682f451f0b6e68e351ec3b9
-  react-native-view-shot: fb3c0774edb448f42705491802a455beac1502a2
-  react-native-webview: b29007f4723bca10872028067b07abacfa1cb35a
-  React-NativeModulesApple: a93cccc5bd37290cf1e2f40cb32718e74df6e8b5
+  React-defaultsnativemodule: 08d815843c7bd357357c2d0e8f00f0c6c38859bd
+  React-domnativemodule: c96b58c5d38255abd40a84388bfd11278bd7b79c
+  React-Fabric: 9dfca03d83a9581939b32b14589d92231703f0a9
+  React-FabricComponents: be365201a534173fd734e48a8d0f6b177040c77a
+  React-FabricImage: d6b7bd6b5e2482520d97180771be6ec933d471e0
+  React-featureflags: e7dcaeffb7e5a1d2b405899785e32594234d6d55
+  React-featureflagsnativemodule: b0f4a74b87e534cbb4f1a5bd21fe92bafb3c8ae1
+  React-graphics: a1f124116693578677b8b3e0c86cd72b93ee9763
+  React-hermes: 2001be5be0a07191b4ff5e7703449f069e02d99b
+  React-idlecallbacksnativemodule: 44e83816f6334f42d0304f895f2ed285038d01ef
+  React-ImageManager: ee7b7125e2c7bedbfc1978772c61d3a789f58558
+  React-jserrorhandler: 8c1c2ba54607708d75e4c35162b7a44f8bf7d505
+  React-jsi: e7ac0afd12b3550d52c8df2af4607fadbbfd09fe
+  React-jsiexecutor: d6197a853bb9dd0c439c9b23c3dfb6eb9c20526d
+  React-jsinspector: 0eb36d4afbcd88e13d136f88ec87c4baad88538b
+  React-jsinspectorcdp: 927a86a462424ef8781f238323252e52517124c2
+  React-jsinspectornetwork: 9803c4c681a702e9e7b94a01ba4dc7c87e7f64f5
+  React-jsinspectortracing: b2c26dfb55fc17abbcf57ac88b45fe753a8a145c
+  React-jsitooling: 815d0d92bded0b15f6dafdd33375373943976c92
+  React-jsitracing: 0fbcec5d567688a068718de6191cc111b1f0d99b
+  React-logger: 932b4d95b12f7d5704b0d317dbc97b27988b0651
+  React-Mapbuffer: 3414f8e0cc811bb315cd9f5d0c3d4fe251aeb2db
+  React-microtasksnativemodule: 0b75d96506c2f0d67bb838ee9042e9549204f3af
+  react-native-keyboard-controller: de4e20f296892fe26972fc782a6a6b1832172bed
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-pager-view: e37989fc447aa4b5de6d0d2ffb0229e817329246
+  react-native-safe-area-context: d46695b29119ba0871705c55c8ac2868888dcca4
+  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
+  react-native-skia: 640caff08810f3008fb2e00b04bd694d9636251f
+  react-native-slider: b76fa3dd989d25e8c2751c2a546674dfc0c2b6f8
+  react-native-view-shot: 26174e54ec6b4b7c5d70b86964b747919759adc1
+  react-native-webview: a4f0775a31b73cf13cfc3d2d2b119aa94ec76e49
+  React-NativeModulesApple: 44622ec668d3de885fecc51dd13aca7e01c2ceff
   React-oscompat: eef0d02e3175b37e2c0eb99f69df82ea2f85f943
-  React-perflogger: 3e93a5384103e04f176c257ee463ba810254856c
-  React-performancetimeline: f8c5b33573d0f9ef5cbc9c784b174170189daf15
+  React-perflogger: 63c6725749403eaf355c9c2c741b9f0e1c4854cf
+  React-performancetimeline: 50f625b5388a0f23ed5c873415b8c04136830497
   React-RCTActionSheet: cbca1a6da03236d19f77092cff407ba65d36be96
-  React-RCTAnimation: 700ff3628d94f541d2a95bf871d670182a9d6c69
-  React-RCTAppDelegate: b618ea35172483162b8388bbf5d64ad337022295
-  React-RCTBlob: 819acc082d783802093d7148f29833ad8e532266
-  React-RCTFabric: ca7693a96eb777bbb5519c71421fe05c95aa162d
-  React-RCTFBReactNativeSpec: 731b4906b07a3f8e035fe3baa81743b2efc5ffb9
-  React-RCTImage: 11763641b1ccb785350777faf2d61df19b4e257a
-  React-RCTLinking: 51c0c53175be34c7be6bbeddfc7bf1d3e43bfb05
-  React-RCTNetwork: a9ac24e519bd82a9d60ccb5641a9db0a955e18aa
-  React-RCTRuntime: 37dbbe9293259c3b02750f739f7401cb63bc20af
-  React-RCTSettings: 215e19c41441e6098281b8f82a0cc2b0edcbd43b
-  React-RCTText: 0eb667f7fc4c8d6cfef33e23eeebb6c54021db72
-  React-RCTVibration: 0d5c509f53d844b2f507e7072f701874818667a1
+  React-RCTAnimation: 44712f63b43c75bd322b22fe33c30271d53bf14d
+  React-RCTAppDelegate: 6fdd47e8da7aa0212bc116a49656aa5cc9dd9b65
+  React-RCTBlob: 0371807ce6d6db0640bcc3d40ff267c941b801ed
+  React-RCTFabric: 3437e80fa117aaaf5a0de6306eeb4e5fcf4ad6ed
+  React-RCTFBReactNativeSpec: c9a42d99406362c1d51f01cdb2b4147640c1182e
+  React-RCTImage: a8e5b31f14f108ca3f9d62ad9b49caf718db39a5
+  React-RCTLinking: ab353b17913e3e96886681723722e39d77752931
+  React-RCTNetwork: aec9f9acc83d902665b4396708bed9ce31b9d281
+  React-RCTRuntime: 1010168e9db109eb42218cac1b174e2f634ba240
+  React-RCTSettings: f3adadfed946ae294669ad0fc206ffce27f51769
+  React-RCTText: 0946683e17b9cf0ef190a6dfa1f9e1e3da0105df
+  React-RCTVibration: 6133b9b5ad9f48c4bf228673b7735f6e3956f117
   React-rendererconsistency: fa354013731fed7144a19274ffb6bb14c3907060
-  React-renderercss: 3dd8e66cc0f67e1f77a952658b6c5bbf723019b4
-  React-rendererdebug: 30fafc71f740e3dc9193706dd361487d6907662b
-  React-RuntimeApple: 719d11c6a3e59ed9073aa771ff13f0a3a8cb706c
-  React-RuntimeCore: d367af2835d9a087f85be273391658f7ed713a8d
-  React-runtimeexecutor: cf72adc9cc7a913d9bfb332baa4a990d653a4c63
-  React-RuntimeHermes: 73d50ce861d77c3d30822642346ed24388d43fdf
-  React-runtimescheduler: 41d2386c7e793da684553f10acfb2d4082983650
+  React-renderercss: 3f3593086bfe517eb6c3d904cf42fe5695f8121c
+  React-rendererdebug: 44e4591f48943140b64ee50997981ad14f545626
+  React-RuntimeApple: 33ad6a4f35b8407fa4429f7f30b004ef86170b35
+  React-RuntimeCore: 6d8effc350a9f08c8001c1eed3474fe575b021ec
+  React-runtimeexecutor: 930c382468e81e855b1d3246163c0b3b3f9c3dfa
+  React-RuntimeHermes: 85104208671712ca51902c7a5379294692918123
+  React-runtimescheduler: d3e37483fcdab7d318560957e419967dd534574b
   React-timing: 29d2d41aecaf56497a5f902592abae6d4930dbb2
-  React-utils: faaba29dfb0924833853af0a29b068878a71b795
-  ReactAppDependencyProvider: c91900fa724baee992f01c05eeb4c9e01a807f78
-  ReactCodegen: 22756947ce56d9d29cd891b7c1bc4a31b8c457ec
-  ReactCommon: 18f3e0fba262b222b8d3247e38f9ec9b36817b9c
+  React-utils: e792282f12412a85eb43bf74fa7e35cb2273e4c7
+  ReactAppDependencyProvider: 562d731311d0524a577cf8a01faa97874bacbdfe
+  ReactCodegen: b9f16a44bcb36528e65ddde1d9b3f6162092f8b2
+  ReactCommon: c093378a7887a0dadffd49284c10069f971771ee
   ReactNativeDependencies: 4ddce14a45bb6fc7c36f2b50b65a6da87ec6835c
-  RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
-  RNCMaskedView: d2578d41c59b936db122b2798ba37e4722d21035
-  RNCPicker: a7170edbcbf8288de8edb2502e08e7fc757fa755
-  RNDateTimePicker: be0e44bcb9ed0607c7c5f47dbedd88cf091f6791
-  RNGestureHandler: 2914750df066d89bf9d8f48a10ad5f0051108ac3
-  RNReanimated: 32528e8dfd89cc4cdda0a04498a4ef87938a85ac
-  RNScreens: e8dd4855d1ff7b27b4eba5b746f1f5d06292f8cd
-  RNSVG: 31d6639663c249b7d5abc9728dde2041eb2a3c34
-  RNWorklets: 449b13de5dcd2b49690715d30968adabba982f1f
+  RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
+  RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
+  RNCPicker: f97c908b7774248c1093ec3831ca70d338627bf7
+  RNDateTimePicker: 6fdd63f5d1e0f21faf4cc8674957c52958a7efae
+  RNGestureHandler: 6a488ce85c88e82d8610db1108daf04e9b2d5162
+  RNReanimated: 98a3da83c44675f5ac6ee39a8f1c74e7f473cac9
+  RNScreens: 19271d3e5d0e9231fd3bd1971887c222495976fc
+  RNSVG: 2825ee146e0f6a16221e852299943e4cceef4528
+  RNWorklets: 135b6c5652935a876524216e6f83584be1ad8121
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -73,7 +73,7 @@
     "react-native-pager-view": "6.9.1",
     "react-native-reanimated": "4.0.2",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.15.0",
+    "react-native-screens": "4.15.3",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3326,7 +3326,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNScreens (4.15.0):
+  - RNScreens (4.15.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3353,10 +3353,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.15.0)
+    - RNScreens/common (= 4.15.3)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.15.0):
+  - RNScreens/common (4.15.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -4201,73 +4201,73 @@ SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EASClient: bac1ef7c808fa661ae0ff626f6cd2f01fc7faaf7
-  EXApplication: 4c96b50bb284b0fd81f49581230e02cd2c405db3
-  EXAV: 6ece237240c291db8eaee6a7226c89fa4fa85600
-  EXConstants: 312d1b38b4fd6074dcd253c347dc7a5682549a02
-  EXImageLoader: 189e3476581efe3ad4d1d3fb4735b7179eb26f05
+  EASClient: 138582a9575c5a71418f6bdc4fd06bb226a3cc76
+  EXApplication: 538d5490f59dc0baa075b37d1dcd07b9f15799a7
+  EXAV: f0f8557a8681fefe7102e0fa3926df90c9548bcd
+  EXConstants: f7ecf52d3f843309cd3d8ecc0cb104f5ca3a4b31
+  EXImageLoader: e501c001bc40b8326605e82e6e80363c80fe06b5
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: c43ae3f01be93094b271e24bf03ee66410d0e7a4
-  EXNotifications: bd1ec144701477f347d0fa909801ee3a4a62f914
-  Expo: 83fd89016f1614e1086ec662b8b94b708b4d0cf1
-  ExpoAppleAuthentication: c825848c15975e2ea93b8f11b2087a0ae31c2fe4
-  ExpoAsset: 70bf7922c1c089b6735b92dd251da7da2b374212
-  ExpoAudio: ecfdac9428c889e27b36daf140bf4f3608ffa18b
-  ExpoBackgroundFetch: 569d326601ce0799a09bc13c4d8dbd1330411262
-  ExpoBackgroundTask: 80e0e2febf44b6283427c51800a6bd0eeeaa362c
-  ExpoBattery: 80c257ddf6d6416e22b6a0a93bebcb4a5110fe57
-  ExpoBlur: 6ccfa1957b79c45f3a72a9f262ca2febf43cdea2
-  ExpoBrightness: 5227538dcbbfb4eb2f858a2d0cfdbf7696d14408
-  ExpoCalendar: d291b65454854328a3e65e1fe427f024bcaa28fc
-  ExpoCamera: 915dd48ead12570bfa76d2bb12eeed44056de6b3
-  ExpoCellular: 6768af6429e6a4bd5f24dc6899ab25d8c87c48a3
-  ExpoClipboard: 92fc7255041f7f897c1438186eac5098708cfb3d
-  ExpoContacts: fac10eaca244d546380c55c7ec228324779f529b
-  ExpoCrypto: 938e75ca0b4160a186f723e51559f746c1bcaaeb
-  ExpoDevice: cc368db84ab8733361833e23dda513cebd522c44
-  ExpoDocumentPicker: bc02bbd2beeefaf2c25873ee1b88b001c2f2d228
-  ExpoDomWebView: cff32ab4f0758233fd219d34fb8ef111ed42b6bc
-  ExpoFileSystem: 6750ab7ff79406c819ce0e5a5dac43171761eaf1
-  ExpoFont: aadbbc0baecff6ca39248443a11ba7e77b8ad1a4
-  ExpoGL: 593d8a47f5634123303227648358f307f59c6c70
-  ExpoHaptics: efe3c06397f4e3c09b60126d819c35c965d2a178
-  ExpoHead: 4585cb06818f1e3955d80c016fd87c8f1348a623
-  ExpoImage: 24e5fccd6786797b4e0fa73a54a2dd986786c15f
-  ExpoImageManipulator: 6b1d01fbe401d67264ea4067280c5ec9859197c1
-  ExpoImagePicker: b417075a63a0b08aecb2660e959c9612d1c779cc
-  ExpoKeepAwake: 44a0f029efacb4df7508f30fe8d68b497bc43716
-  ExpoLinearGradient: 4d5fdba019d61b4947da04f9b338db37472c5fed
-  ExpoLinking: b198472f69cc43efe77722b72ea0504bdd3bf68b
-  ExpoLivePhoto: e5ae842d17077afc566575f3bfbc0e87f7fc076f
-  ExpoLocalAuthentication: b8a56535de746be350355790506947b1c7297412
-  ExpoLocalization: 78e8aaa44a74b905ba2d17bcd8b41939c9ca7ce8
-  ExpoLocation: f2262de20261424355a2a3a07e1aaca8a948501c
-  ExpoMailComposer: f9146258a139507d14dde5f9fe3b8bd35a374d2e
-  ExpoMediaLibrary: 5cc65d19296888e077e71b9977f4a80b8e5c3c14
-  ExpoMeshGradient: b4bc1a42c47492ef90b46431da05dad5be568bf3
-  ExpoModulesCore: 27cb4ba5c494466da5f1e65726ad5fa66595bff9
-  ExpoModulesTestCore: be5073c51ffe7c2db9f14aedfce7d8cdc141f55a
-  ExpoNetwork: d8309bc1f086732f5dc5dba10b37cdb84e6db610
-  ExpoPrint: 59f2a3bc1604fcfaf490c07b9efe0703d556a7f8
-  ExpoScreenCapture: 97e1eb3189efd61f78384f70220df9b66ca56639
-  ExpoScreenOrientation: 9e7f7940da5b1d3ab9092c26d44e8f6a395dd64f
-  ExpoSecureStore: 6ace75e6d81529f785b1afbb65807be1edcfb8ad
-  ExpoSensors: 98a2f22c06a5d0cb8372a027ba87361b52075f28
-  ExpoSharing: 841a124fbed7c7bed44ca91512357145c8fb6559
-  ExpoSMS: 2bd5694f47eef5b06e268674248254e4daa4aad2
-  ExpoSpeech: abe8b34612f5b792196e2d53adb8627a4421f22a
-  ExpoSQLite: e93b6f327e4cc87066226e86d295f4ff9473e4fb
-  ExpoStoreReview: db538d60883450c57cd909c58d9a99195dabe75b
-  ExpoSymbols: 388eb9e9955b95bd4b39d3b081e99bf1117554f1
-  ExpoSystemUI: 5d2a1cd36e9e961f561af4375b1e93fc99418c07
-  ExpoTrackingTransparency: 9b82518e4f428329b85694c2b8fb2f13a6797637
-  ExpoVideo: b5536c3ed406fd9255e4a1177399aa8d45c606f7
-  ExpoVideoThumbnails: 94214009a7c55e107bca40b358043b790f18da9a
-  ExpoWebBrowser: 8a4f46ca3bef49775e3227ae2eb2bc8bb1dc4417
+  EXManifests: c496080fa9cc6896c8c0e44de27f0f5d0ba9c6bc
+  EXNotifications: 6f159317e7185f9ff3ec1fc849bc7047fd71fbc4
+  Expo: 7051ca87e52dbb91837d5adf3521bff8d45e6d28
+  ExpoAppleAuthentication: 349c76033258c9212e38f4274ed56ef95c154791
+  ExpoAsset: 035bfce2473fc1b5205705c05a05563985b906f5
+  ExpoAudio: d62506c713c82f058182a947b3314ae83442e4d6
+  ExpoBackgroundFetch: 7443b7469728137ecb94fa15497e9741b084a005
+  ExpoBackgroundTask: d1ea554d5fc7134f42dd69031d11c953f0bb1b5d
+  ExpoBattery: 8bbc584adba655b6971ec995bde0aa62b49c7569
+  ExpoBlur: f855bcba5d536cab048a0df0b1fe54306382af3e
+  ExpoBrightness: 18176c75019628b1adce5a0c62b2e0331906cc40
+  ExpoCalendar: 7b41443b59da2d1e09dccf78343a39f23743a7d4
+  ExpoCamera: 4f4fb3c8d91a1495f680d2c04ebb7445af50193f
+  ExpoCellular: d42b44526b25a2d0d339206c7689d86bee3312c7
+  ExpoClipboard: 194a02dda5826abfe724b17d938ece33a5f30ac7
+  ExpoContacts: d51a68048fbae13520b6d8fda4f7b73cab9e9f75
+  ExpoCrypto: 2e1143beae310d40c281b2be62e675f3b3b14016
+  ExpoDevice: 9ab5852154108f3906c3748965b80bd71e03635a
+  ExpoDocumentPicker: 80fc08dffd882f1e3ec5a2b04fe2b6dac95debdb
+  ExpoDomWebView: 53421ff50138c1a7891b33228b89dba28e95972f
+  ExpoFileSystem: d9811023255eefa51ff4732052785a41f84ec29f
+  ExpoFont: e6b2ade4a6e84bab3e1c1256db47461274cc4a01
+  ExpoGL: 0e71c722e5fdf577301d74c4095ddf28972e675a
+  ExpoHaptics: 2ddbc0e34d8656f14b144831d4872defadf3bbe3
+  ExpoHead: e570e019b32f46c8a9c36b991d7ff3b87dec1987
+  ExpoImage: 964a2a9008afcfcf4e1f57d3c625cbaac29bf405
+  ExpoImageManipulator: 8458ffd3e894283d9b59fa054478f84ca5bb686f
+  ExpoImagePicker: 6735518d513a669713c52dec910f6ac9befafd08
+  ExpoKeepAwake: 9b9af4742c8d69b0cfeb777ed8e909c1a9938c1d
+  ExpoLinearGradient: 3ecbb56043c494b48edfc29534eeec41351452ab
+  ExpoLinking: e76895a69085225cc653805dd5d17e4f80dde89c
+  ExpoLivePhoto: 7b022bf508cbc6ba5f287099da084cae48c10b43
+  ExpoLocalAuthentication: 2b1cc60cda69a0f2d370287785d3ad6049b44ce6
+  ExpoLocalization: 310d6e44a46f57f7c5ca3cce9fa8c9459a5d7fc4
+  ExpoLocation: 3f39d1b684337e9682a31262d7ea0d1b5ea06866
+  ExpoMailComposer: 9badcba98974e44bc64ad7711d226aa777e8ec56
+  ExpoMediaLibrary: 4d8fb6f615db7ed4156c75af8c97d8777b3bd76c
+  ExpoMeshGradient: caa5c55ce1600519934435fc601d09295d16b757
+  ExpoModulesCore: 9ff6c2b6a6d6110d8a8aae2561d3fdbc130a2585
+  ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
+  ExpoNetwork: 84b8c5bc0d0811c8bd5bfd64c469132935207b35
+  ExpoPrint: e42212eb339a7069d4de4f738208b2c4b0c85b16
+  ExpoScreenCapture: 7af30ca0245a44479b9809f8e6e6bb257e2035f6
+  ExpoScreenOrientation: b5d12946697a8931c9fcfba515de485382deb364
+  ExpoSecureStore: 4aaff1f5ac38728252b5fa134cbf14f6aaf249c3
+  ExpoSensors: 363b806ed7e6b24fca0456ea2af0ea6d2f31f924
+  ExpoSharing: 09c195e34fd04dba4221c31948cba1b6744551ea
+  ExpoSMS: 4e86c8a243509fca39bcd55497f4090dee478cd4
+  ExpoSpeech: 3d4cc33982cba4d9b5d21d50d206d33c888a20a0
+  ExpoSQLite: 49f3a7956c6a673748efedc264e72e097db3da12
+  ExpoStoreReview: 134aad04960ed2878f3055caa015dc64296ca9c9
+  ExpoSymbols: d754462efddef0c8b4d2c5a1d76285a31db8b71d
+  ExpoSystemUI: 7e705cea742761788b44e50ad49289724586480f
+  ExpoTrackingTransparency: 006ded03556839c789a0949e9373035029dc5818
+  ExpoVideo: e1b99a7404425eaaa026d85e1555d45f9e5a5541
+  ExpoVideoThumbnails: 498abcb70e19374653f97c690e2a4e2021db36db
+  ExpoWebBrowser: dfb3ce8436e822e54e6ae9981f45d39a3de79939
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
-  EXTaskManager: 6dd12e0ba5b5ab9d2c56754b2d66328a1105f9a7
-  EXUpdates: 927e7fb050707221f1169db71de34be5c740e7f5
-  EXUpdatesInterface: 5adf50cb41e079c861da6d9b4b954c3db9a50734
+  EXTaskManager: b29afc41b8b73c6fbe622e39ccb952471bb20165
+  EXUpdates: 6551eaacee569218d5683959492ad2f0a19b4abe
+  EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: a867936a67af0d09c37935a1b900a1a3c795b6d1
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
@@ -4285,109 +4285,109 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 7c4a149dce1f6addc91486870daa4525bc0718ce
+  hermes-engine: 0daecdb7b4fc8ebc214446c7fb781eae69eea549
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: ee739c59b332297996b1a1a73884ee75d95a7562
+  lottie-react-native: 8a08f0554027f07f5370bf9129ca5da0878fe5b3
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: 0735ab4f6b3ec93a7f98187b5da74d7916e2cf4c
   RCTRequired: 8fcc7801bfc433072287b0f24a662e2816e89d0c
   RCTTypeSafety: 2b2be515d6b968bcba7a68c4179d8199bd8c9b58
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
   React: 1000c0e96d8fb9fbdaf13f7d31d0b09db3cbb4ac
   React-callinvoker: 7e52661bfaf5d8881a9cee049792627a00001fbe
-  React-Core: 949b436ddfe76cf47ac96375152de2f3506a8421
-  React-CoreModules: 0f27580d0d82d430fa4f2cf4d970b6ad1120d63a
-  React-cxxreact: 48754f11f47a29ea4800cbdd694c10f874a26b9b
+  React-Core: a9128dd77ec52432727bfbec8c55d17189f6c039
+  React-CoreModules: 4597116bd78ae2b183547e3700be0dc9537918e9
+  React-cxxreact: e3a02f535cc1f1b547ac1baafe6ac25552352362
   React-debug: 7a23d96f709f437c5e08973d6e06d0a54dd180a1
-  React-defaultsnativemodule: 569d9222a701ed3dc60a60b2ce066b5bd88da059
-  React-domnativemodule: 34474bda3973bfd0ca2ea9f1b3db20db5d504cc7
-  React-Fabric: 45c3e9b112075451e592f0e008cabd4b82575355
-  React-FabricComponents: a428f23938c27a073baacc069d484b3478df85f3
-  React-FabricImage: 4375129ba8a26e8a7074af1c2468870fb8aab723
-  React-featureflags: ed973a134993f3be204d0b2d385d386603c9a0af
-  React-featureflagsnativemodule: aa3e1dc86bc185344d4875e7cb40cce0bd28de76
-  React-graphics: b5b8709a8216075bb6a5f9e7bb68881212d924ee
-  React-hermes: c543ffa2866304c582bdcb135c184e0f776f0d0b
-  React-idlecallbacksnativemodule: f19c4060b12fffc3ad33ce5de190338751b462ef
-  React-ImageManager: ecaf317aa5dff5eebba178b0813ef998c62547ea
-  React-jserrorhandler: 92eea1ee4f8c56b466b34e0065def59805e5d3a9
-  React-jsi: 7336786a4a14c473d104e6b37df935620d218fcd
-  React-jsiexecutor: 7c750f5b63fbc071d0f0e56e86f1a1589914f7b1
-  React-jsinspector: da5f336c1aa174a05885d061559a92e1d07b8a80
-  React-jsinspectorcdp: 0e807e4c2dc8ae8a07f0a6bfe50377f442079ba3
-  React-jsinspectornetwork: 3399384f2b6b70b287d8b9675452af4cec21dc65
-  React-jsinspectortracing: 030af0e9dca9a4eaa1d0ba258c7bd859fb90f61d
-  React-jsitooling: f8ed67814b17ebb124c48fccdf587ee1e02f16f4
-  React-jsitracing: 5cf6b84d46a4653895e30956a0ce3a315244c10a
-  React-logger: 04ce9229cb57db2c2a8164eaec1105f89da7fb22
-  React-Mapbuffer: e402e7a0535b2213c50727553621480fe8cd8ade
-  React-microtasksnativemodule: a63ce5595016996a9bac1f10c70a7a7fe6506649
-  react-native-google-maps: c4f5c5b2dda17e7cb2cb2b37a81f140b039b3e7e
-  react-native-keyboard-controller: 2d559e821da2dbcfb2781646f5f443e846e3f05b
-  react-native-maps: 9febd31278b35cd21e4fad2cf6fa708993be5dab
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-pager-view: a0516effb17ca5120ac2113bfd21b91130ad5748
-  react-native-safe-area-context: a72764e0eb5d6b79b7450e5d0ae919eb1a4567b4
-  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
-  react-native-skia: 7db0cf4fc9d6203747af5bae5df0db3ad4e84cda
-  react-native-slider: 663776e5683e257de8df8091abc2d93ff6ec67db
-  react-native-view-shot: 6c008e58f4720de58370848201c5d4a082c6d4ca
-  react-native-webview: 4cbb7f05f2c50671a7dcff4012d3e85faad271e4
-  React-NativeModulesApple: b3766e1f87b08064ebc459b9e1538da2447ca874
+  React-defaultsnativemodule: f01b6e58a23efe4fc8d74db7dadeea112908f5d5
+  React-domnativemodule: 2d9796d40ab675e0f91ae8aae26c796b6e9a7499
+  React-Fabric: f4344b3a882292783de9a5404852023b6c4fdd2d
+  React-FabricComponents: 7c51eb1619473ae3ed92d8bbf5d5dd3be0c5ef9d
+  React-FabricImage: 9e743575e67a9c14242bec3ae0e26663eed641bb
+  React-featureflags: 5188951cc2fc81f4d249dc37e8f96dca7ef50e96
+  React-featureflagsnativemodule: 0fa7473065377ca4e5651c75614796326ef57aa8
+  React-graphics: f65ecd0a8c70f9c7dcdae322851c19b21c83ec27
+  React-hermes: 8418dae38a0513aa66aaa0a1b0904e55c4448644
+  React-idlecallbacksnativemodule: 540d6f743fcb595b26da8b182b28c878a1176a96
+  React-ImageManager: 5f9f1e33611a852d21a63e1de76d211fb04ac935
+  React-jserrorhandler: 9c0a7d69cd07c9ae08fab3a61150d526c0174c83
+  React-jsi: b711b7a11d77357beb95fa2eabd30c1ae34dcf40
+  React-jsiexecutor: 0d1c78e666c5be71ff7c0ff5ea7fb043e5b1f14c
+  React-jsinspector: 5fabd9f0be9390d5b5eb5fc88a8965d97e0c14ac
+  React-jsinspectorcdp: e78c65e25253999c0efd5e23c99e649e02fd0244
+  React-jsinspectornetwork: b02c6f7fe00e12b575a7faea0ed9ec9ddbc1c20f
+  React-jsinspectortracing: c6d8da3c8bcd939b8dcfd5113e247d56af932e1b
+  React-jsitooling: 4ca9b158d65909590daf6bf30a345b663eb71964
+  React-jsitracing: d9e9378d5a3e05febea2164a5d0c5fab06492872
+  React-logger: 839abfd18a3fbdf88132824de584b226d0c5cbce
+  React-Mapbuffer: bd5b1120c9bbaac6203eb288735e239f04e03009
+  React-microtasksnativemodule: 10892b00e612d79436022a11e5bc8bdf468a284f
+  react-native-google-maps: 7cc1184afe41fbd15a3dffd53c924819f6587b69
+  react-native-keyboard-controller: 4d479d44dc22d5beb0622d08c9a9f1e7c29456a6
+  react-native-maps: ee1e65647460c3d41e778071be5eda10e3da6225
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-pager-view: 899989dd025d219d3ac0d386b2bc162f81ae8330
+  react-native-safe-area-context: 2249e17382bd5a97cbccaa89e22af8756188c0fb
+  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
+  react-native-skia: e9dd3d45d9b5d1e4116094cfa716719ae6c067cd
+  react-native-slider: 30cea7008de785564de2f4fd064f2deb38614a4a
+  react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
+  react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
+  React-NativeModulesApple: 3f9e97a4a90eeec1ceade511f973b277632650bb
   React-oscompat: 34f3d3c06cadcbc470bc4509c717fb9b919eaa8b
-  React-perflogger: a1edb025fd5d44f61bf09307e248f7608d7b2dcf
-  React-performancetimeline: 1f86dc9782e3fe78727c5fbb3e2178b9fd1aa6fd
+  React-perflogger: 95dff8cc9901777360716cbdcb2998849f133a4f
+  React-performancetimeline: 2937a27399b52ca8baf46f22c39087f617e626b5
   React-RCTActionSheet: 550c9c6c2e7dcd85a51954dc08e2f3837a148e7c
-  React-RCTAnimation: 19d4bb6d2190983d1354b096b7b65dbd591924da
-  React-RCTAppDelegate: 6c71d16eef920831a312ff363355fc3b99c02a98
-  React-RCTBlob: b81a0cffe1a083bcf9d8aa9f27f4d37864579e90
-  React-RCTFabric: 01005d2fa799bba6e21aae18820498f56fe0be5f
-  React-RCTFBReactNativeSpec: 5adb84a81c4ed7a1f2661835d166e4b2c4320cd4
-  React-RCTImage: 607e5e373fb56d72417464bd82e8046af81ab502
-  React-RCTLinking: 301434c7bf1100458be5a3866326ba33491e3687
-  React-RCTNetwork: a118a47bd123ac96c9877e04f5731a1d6545aba5
-  React-RCTRuntime: 85fdbf469fe8a12c4db6c836731b190efc33d11d
-  React-RCTSettings: 5a5aa2cf9ac40f7a8897cc0f9d945ac803886604
-  React-RCTText: e6e00bee9847a8af1218079b73c8bfed16c75b8d
-  React-RCTVibration: 5a05fa0ef05ee73d074a3314e57586afc969f1ba
+  React-RCTAnimation: 0008bfe273566acd3128da13598073383325ac7a
+  React-RCTAppDelegate: 8b9452baef5548856a22f4710d4135cf68746cf5
+  React-RCTBlob: 60006ab743e5fd807aaf536092f5ce86e87df526
+  React-RCTFabric: 8d5d1006b3812c35fd0f37c117ff7bcf6449e20d
+  React-RCTFBReactNativeSpec: 3cb4265fa9a4e4f8250ae89feb345edc542731da
+  React-RCTImage: f40a2ee0f79c1666e8b81da4ea2d9d1182c94962
+  React-RCTLinking: cfe6995bdd8d08d0bb0df12771f4d28fd5fd54ff
+  React-RCTNetwork: 565c0cd46313f2cad0e4db70a44958b2842c372b
+  React-RCTRuntime: 971a71a42d8979475a380e5179083302e5506cdd
+  React-RCTSettings: afcec6060d916e9c0410004ad8419d45f9dbcd36
+  React-RCTText: 952f2a1b618d3f3872e7e5a82aefc5e5082c59aa
+  React-RCTVibration: 2a7e7497ffefa135c7f0fee8ee10e3505ab5cc61
   React-rendererconsistency: c2cb23365f4a7b511893748fe8cad1830bbae637
-  React-renderercss: 0c1472d6572c05e493aee476598c3ed6234b6c33
-  React-rendererdebug: d6335da9730fa5a151537aa976a16d48de6135e2
-  React-RuntimeApple: 5684c2a5d8768e5728a5817c21e5dba798d54c58
-  React-RuntimeCore: 52428a1b48fb3c50ddf4dd5eee494486e4ecffc6
-  React-runtimeexecutor: 1b4e99e5c27d2cb8bdeca9773ff5f1a8eac7709c
-  React-RuntimeHermes: a688639233a3ea44b4f8e4d448f51943d7e00815
-  React-runtimescheduler: b833f0fc8c788329a497e93f55ce30508f56307a
+  React-renderercss: 621b2b85af14694e93c2bcd63986fb57bcceab2e
+  React-rendererdebug: 4ba0769131e20347b900757fcac3c7919b27080c
+  React-RuntimeApple: c1a211351c14d35805d45a94094cfb3e5649552c
+  React-RuntimeCore: b7c7d8dffa3728a9e9616e0e8b5b6b41037ebcca
+  React-runtimeexecutor: e931e48afc888fe459f6ffb481971e23bb34f7ee
+  React-RuntimeHermes: 5763230801ee57d9f414818f48e44b874f3ce1be
+  React-runtimescheduler: b2e99f9702705fc8c11cf3c51f9911f478ee2210
   React-timing: 25e8229ad1cf6874e9f0711515213cb2bc322215
-  React-utils: 068cec677032ba78ca0700f2dcbe6d08a0939647
-  ReactAppDependencyProvider: c91900fa724baee992f01c05eeb4c9e01a807f78
-  ReactCodegen: 51106a4978f28ea0c77ed55accb0cc8cc19f43e5
-  ReactCommon: 116d6ee71679243698620d8cd9a9042541e44aa6
-  RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
-  RNCMaskedView: 5ef8c95cbab95334a32763b72896a7b7d07e6299
-  RNCPicker: 66c392786945ecee5275242c148e6a4601221d3a
-  RNDateTimePicker: cda4c045beca864cebb3209ef9cc4094f974864c
-  RNGestureHandler: 3a73f098d74712952870e948b3d9cf7b6cae9961
-  RNReanimated: b43b4178f9c5c355badd51bc0df933d1eabddc83
-  RNScreens: 48bbaca97a5f9aedc3e52bd48673efd2b6aac4f6
-  RNSVG: 6f39605a4c4d200b11435c35bd077553c6b5963a
-  RNWorklets: 32ea3225502c57b559c76f684fc2abac865b7728
+  React-utils: 7ea6e4d300c43a763e4e08091413aec962588f93
+  ReactAppDependencyProvider: 562d731311d0524a577cf8a01faa97874bacbdfe
+  ReactCodegen: f58c69d306500d239424c03d7b2d6fa99f27e290
+  ReactCommon: c235ebd26d63fde9a2dfa72cee9f8294b910fee1
+  RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
+  RNCMaskedView: 63268de1986a098b5f4d1fb5b1bc1e97fade0aee
+  RNCPicker: 6da395ee9db8d67a38c6102d4128b5a0b9ec0e21
+  RNDateTimePicker: c4a42c6a77d474f05162d61a4ab4253d13008277
+  RNGestureHandler: 4f7cc97a71d4fe0fcba38c94acdd969f5f17c91c
+  RNReanimated: 3b8ec43aaef0389e702878e7725608128daa2053
+  RNScreens: 204935c8b64867c7a5683e2db0a8640f909beda5
+  RNSVG: 8d87cff016edf1b6ca409ed39804101836d75e90
+  RNWorklets: f0b4bfd581c55f18a8bea9beae9cef26650c8cda
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Stripe: d1824162e4bcb6ead10401a0dc8e8a3d5ffee41f
-  stripe-react-native: f2af1d3769363ae90b2a6c4bb9642232c2c4d2c9
+  stripe-react-native: fd628fd2cd45a6d06700cdf499f23dbcb4d5f8d9
   StripeApplePay: eb64705d3c919492b1b28876652fd0aca2db38cc
   StripeCore: b5bee05167f0c8ccce936244a031a9972fdeade8
   StripeFinancialConnections: fd6c661f86f47b1d26a32f588b3a0b09826aba84

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -80,7 +80,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "4.0.2",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.15.0",
+    "react-native-screens": "4.15.3",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -149,7 +149,7 @@
     "react-native-worklets": "0.4.1",
     "react-native-reanimated": "4.0.2",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.15.0",
+    "react-native-screens": "4.15.3",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-web": "~0.21.0",

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -32,7 +32,7 @@
     "react": "19.1.0",
     "react-native": "0.81.0",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.15.0"
+    "react-native-screens": "4.15.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -47,7 +47,7 @@
     "react": "19.1.0",
     "react-native": "0.81.0",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.15.0",
+    "react-native-screens": "4.15.3",
     "react-native-webview": "13.13.5"
   },
   "devDependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -101,7 +101,7 @@
   "react-native-pager-view": "6.9.1",
   "react-native-worklets": "~0.4.1",
   "react-native-reanimated": "~4.0.2",
-  "react-native-screens": "~4.15.0",
+  "react-native-screens": "~4.15.3",
   "react-native-safe-area-context": "~5.6.0",
   "react-native-svg": "15.12.1",
   "react-native-view-shot": "4.0.3",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -34,7 +34,7 @@
     "react-native-worklets": "~0.4.1",
     "react-native-reanimated": "~4.0.2",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.15.0",
+    "react-native-screens": "~4.15.3",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "react-native-worklets": "~0.4.1",
     "react-native-reanimated": "~4.0.2",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.15.0",
+    "react-native-screens": "~4.15.3",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13891,10 +13891,10 @@ react-native-screens@4.11.1-nightly-20250611-8b82e081e:
     react-native-is-edge-to-edge "^1.1.7"
     warn-once "^0.1.0"
 
-react-native-screens@4.15.0:
-  version "4.15.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.15.0.tgz#8b34056b72a2c92da4de2f77419a116154c88e81"
-  integrity sha512-LPz+9qWDfwY3pPKojrWPcQnb2sAq9cy/qA8ZAS14ksSdzqFkTTUbs1as2WGBo7xBtdx5Ht78bF9nNh8libX1Xw==
+react-native-screens@4.15.3:
+  version "4.15.3"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.15.3.tgz#3efb9c47459b7940446955c2219e85a2e0aea187"
+  integrity sha512-xVQu76cddcIncR2UIX+A7FmWsxmNwGYr5gG8T6B1kMvxqNlXm0zS9U6juBRC9jyVexMvHZ2+cOLjGjkTE2VAjg==
   dependencies:
     react-freeze "^1.0.0"
     react-native-is-edge-to-edge "^1.2.1"


### PR DESCRIPTION
# Why

react-native-screens released new version of screens with a patch for native tabs roles

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

1. Bare expo
2. Expo go
3. Expo router

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
