### PR TITLE
[metro-runtime] Avoid printing compilation errors twice

### DIFF
--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Avoid sending compilation errors back to Metro terminal from the application runtime
+- Avoid sending compilation errors back to Metro terminal from the application runtime ([#39142](https://github.com/expo/expo/pull/39142) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-runtime/CHANGELOG.md
+++ b/packages/@expo/metro-runtime/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Avoid sending compilation errors back to Metro terminal from the application runtime
+
 ### 💡 Others
 
 ## 6.1.0 — 2025-08-19

--- a/packages/@expo/metro-runtime/build/metroServerLogs.native.d.ts.map
+++ b/packages/@expo/metro-runtime/build/metroServerLogs.native.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"metroServerLogs.native.d.ts","sourceRoot":"","sources":["../src/metroServerLogs.native.ts"],"names":[],"mappings":"AASA,wBAAgB,yBAAyB,SAyCxC"}
+{"version":3,"file":"metroServerLogs.native.d.ts","sourceRoot":"","sources":["../src/metroServerLogs.native.ts"],"names":[],"mappings":"AASA,wBAAgB,yBAAyB,SAmDxC"}

--- a/packages/@expo/metro-runtime/src/metroServerLogs.native.ts
+++ b/packages/@expo/metro-runtime/src/metroServerLogs.native.ts
@@ -17,6 +17,16 @@ export function captureStackForServerLogs() {
       return HMRClientLogOriginal.apply(HMRClient, [level, data]);
     }
 
+    const preventSymbolication = data.some(
+      (item) => hasBooleanKey(item, 'preventSymbolication') && item.preventSymbolication
+    );
+    if (preventSymbolication) {
+      // NOTE(krystofwoldrich): Although a generic flag, it's only used for compilation errors for which symbolication will fail.
+      // If the error would be send back to metro it would be printed multiple times, once by Metro and once from here.
+      // https://github.com/facebook/react-native/blob/a8bc74c0099252cb1d11ad3b80f3deac71dcc0d5/packages/react-native/Libraries/Utilities/HMRClient.js#L367
+      return;
+    }
+
     const hasErrorLikeStack = data.some((item) => hasStringKey(item, 'stack'));
     const hasComponentStack = data.some(
       (item) =>
@@ -77,6 +87,15 @@ function hasStringKey(obj: unknown, key: string): obj is { [key: string]: string
     obj !== null &&
     key in obj &&
     typeof (obj as Record<string, unknown>)[key] === 'string'
+  );
+}
+
+function hasBooleanKey(obj: unknown, key: string): obj is { [key: string]: boolean } {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    key in obj &&
+    typeof (obj as Record<string, unknown>)[key] === 'boolean'
   );
 }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Compilation/bundling errors are printed directly by Metro into the terminal. In case of HMR they are send to the application and back causing duplicate prints.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR makes use of the `preventSymbolication` flag which is used only by the compilations errors. 

Ideally these errors are marked by RN as CompilationErrors to make this more resilient. 
https://github.com/krystofwoldrich/react-native/blob/7db31e2fca0f828aa6bf489ae6dc4adef9b7b7c3/packages/react-native/Libraries/Utilities/HMRClient.js#L366

After this change from upstream
- https://github.com/facebook/react-native/pull/53452 (https://github.com/facebook/react-native/pull/53452/commits/7db31e2fca0f828aa6bf489ae6dc4adef9b7b7c3)

The compilation errors won't be send back to Metro at all.

NOTE: For the future it would be idea to run E2E tests with Maestro to assert how and where the errors are printed.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Cause HMR bundling error, for example by added `import 'non-existing'` after the app first loads.

Observe no red log from the application in the Metro console.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
