### PR TITLE
[image][Android] Fixed `The method 'getResourceDrawableUri' was expected to be of type static` exception

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `The method 'getResourceDrawableUri' was expected to be of type static` exception.
+
 ### 💡 Others
 
 ## 3.0.3 — 2025-08-25

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed `The method 'getResourceDrawableUri' was expected to be of type static` exception.
+- [Android] Fixed `The method 'getResourceDrawableUri' was expected to be of type static` exception. ([#39143](https://github.com/expo/expo/pull/39143) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ResourceIdHelper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ResourceIdHelper.kt
@@ -32,7 +32,7 @@ object ResourceIdHelper {
   }
 
   fun getResourceUri(context: Context, name: String): Uri? {
-    val drawableUri = ResourceDrawableIdHelper.instance.getResourceDrawableUri(context, name)
+    val drawableUri = ResourceDrawableIdHelper.getResourceDrawableUri(context, name)
     if (drawableUri != Uri.EMPTY) {
       return drawableUri
     }


### PR DESCRIPTION
# Why

Fixes:
```
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: ❌ Error occurred when invoking 'onViewDidUpdateProps' on 'ExpoImageViewWrapper'
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: expo.modules.kotlin.exception.OnViewDidUpdatePropsException: Error occurred when invoking 'onViewDidUpdateProps' on 'ExpoImageViewWrapper'
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: → Caused by: java.lang.IncompatibleClassChangeError: The method 'android.net.Uri com.facebook.react.views.imagehelper.ResourceDrawableIdHelper.getResourceDrawableUri(android.content.Context, java.lang.String)' was expected to be of type static but instead was found to be of type virtual (declaration of 'expo.modules.image.ResourceIdHelper' appears in /data/app/~~0RNjQ6jBz4hCpDUMlVcAfw==/com.swmansion.photos-Dig4HvZWzY8sCFaNX2qH4g==/base.apk!classes2.dex)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at expo.modules.kotlin.views.ViewManagerWrapperDelegate.onViewDidUpdateProps(ViewManagerWrapperDelegate.kt:31)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at expo.modules.kotlin.views.GroupViewManagerWrapper.onAfterUpdateTransaction(GroupViewManagerWrapper.kt:34)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at expo.modules.kotlin.views.GroupViewManagerWrapper.onAfterUpdateTransaction(GroupViewManagerWrapper.kt:12)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.facebook.react.uimanager.ViewManager.updateProperties(ViewManager.java:102)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at expo.modules.kotlin.views.GroupViewManagerWrapper.updateProperties(GroupViewManagerWrapper.kt:26)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at expo.modules.kotlin.views.GroupViewManagerWrapper.updateProperties(GroupViewManagerWrapper.kt:12)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.facebook.react.uimanager.ViewManager.createViewInstance(ViewManager.java:218)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.facebook.react.uimanager.ViewManager.createView(ViewManager.java:145)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.facebook.react.fabric.mounting.SurfaceMountingManager.createViewUnsafe(SurfaceMountingManager.java:674)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.facebook.react.fabric.mounting.SurfaceMountingManager.preallocateView(SurfaceMountingManager.java:1078)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.facebook.react.fabric.mounting.mountitems.PreAllocateViewMountItem.execute(PreAllocateViewMountItem.kt:38)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.facebook.react.fabric.mounting.MountItemDispatcher.executeOrEnqueue(MountItemDispatcher.java:370)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.facebook.react.fabric.mounting.MountItemDispatcher.dispatchPreMountItemsImpl(MountItemDispatcher.java:349)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.facebook.react.fabric.mounting.MountItemDispatcher.dispatchPreMountItems(MountItemDispatcher.java:322)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.facebook.react.fabric.FabricUIManager$DispatchUIFrameCallback.doFrameGuarded(FabricUIManager.java:1395)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.facebook.react.uimanager.GuardedFrameCallback.doFrame(GuardedFrameCallback.kt:25)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.facebook.react.modules.core.ReactChoreographer.frameCallback$lambda$1(ReactChoreographer.kt:59)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.facebook.react.modules.core.ReactChoreographer.$r8$lambda$nSkFhrr5T7rop_XKwzlLov4NLLw(Unknown Source:0)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.facebook.react.modules.core.ReactChoreographer$$ExternalSyntheticLambda0.doFrame(D8$$SyntheticClass:0)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1337)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1348)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at android.view.Choreographer.doCallbacks(Choreographer.java:952)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at android.view.Choreographer.doFrame(Choreographer.java:878)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1322)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at android.os.Handler.handleCallback(Handler.java:958)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at android.os.Handler.dispatchMessage(Handler.java:99)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at android.os.Looper.loopOnce(Looper.java:205)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at android.os.Looper.loop(Looper.java:294)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at android.app.ActivityThread.main(ActivityThread.java:8177)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at java.lang.reflect.Method.invoke(Native Method)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
08-13 11:03:55.415 11924 11924 E ExpoModulesCore: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
```


# How

- migrated to new API

# Test Plan

- bare-expo ✅ 