### PR TITLE
docs: clarify local expo module file structure

### DIFF
--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -41,6 +41,8 @@ Once you've run the command, you will see a new directory created in your projec
     ['modules/my-module/android/'],
     ['modules/my-module/ios/'],
     ['modules/my-module/src/'],
+    ['modules/my-module/expo-module.config.json'],
+    ['modules/my-module/index.ts'],
   ]}
 />
 

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -7,6 +7,7 @@ description: Learn about getting started with Expo modules API.
 import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
@@ -31,6 +32,18 @@ Navigate to your project directory (the one that contains the **package.json** f
 <Terminal cmd={['$ npx create-expo-module@latest --local']} />
 
 You can provide a meaningful module name in the CLI prompt. For the rest of the prompts, you can also accept the default suggestions.
+
+Once you've run the command, you will see a new directory created in your project called **modules/**.
+The directory structure should look like this:
+
+<FileTree
+  files={[
+    ['modules/my-module', 'The name you chose here'],
+    ['modules/my-module/android/'],
+    ['modules/my-module/ios/'],
+    ['modules/my-module/src/'],
+  ]}
+/>
 
 Then, if your project doesn't have native projects generated (**android** and **ios** directories), run the following command, otherwise skip this command:
 

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -37,7 +37,7 @@ Once you've run the command, you will see a new directory created in your projec
 
 <FileTree
   files={[
-    ['modules/my-module', 'The name you chose here'],
+    ['modules/my-module', 'Name of your module'],
     ['modules/my-module/android/'],
     ['modules/my-module/ios/'],
     ['modules/my-module/src/'],

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -33,8 +33,7 @@ Navigate to your project directory (the one that contains the **package.json** f
 
 You can provide a meaningful module name in the CLI prompt. For the rest of the prompts, you can also accept the default suggestions.
 
-Once you've run the command, you will see a new directory created in your project called **modules/**.
-The directory structure should look like this:
+Once you've run the command, you will see a new directory created in your project called **modules**. The directory structure should look like this:
 
 <FileTree
   files={[

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -37,7 +37,7 @@ Once you've run the command, you will see a new directory created in your projec
 
 <FileTree
   files={[
-    ['modules/my-module', 'Name of your module'],
+    ['modules/my-module'],
     ['modules/my-module/android/'],
     ['modules/my-module/ios/'],
     ['modules/my-module/src/'],

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -93,7 +93,6 @@ function renderStructure(structure: FileObject[], level = 0): ReactNode {
       );
     }
 
-    // this allows for showing just the folder name when the file name is empty
     return null;
   });
 }

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -69,22 +69,32 @@ function generateStructure(files: FileTreeProps['files'] = []): FileObject[] {
 function renderStructure(structure: FileObject[], level = 0): ReactNode {
   return structure.map(({ name, note, files }, index) => {
     const FileIcon = getIconForFile(name);
-    return files.length > 0 ? (
-      <div key={name + '_' + index} className="mt-1 flex flex-col rounded-sm pl-2 pt-1">
-        <div className="flex items-center">
-          {' '.repeat(level)}
-          <FolderIcon className="mr-2 min-w-[20px] text-icon-tertiary opacity-60" />
-          <TextWithNote name={name} note={note} className="text-secondary" />
+
+    if (files.length > 0) {
+      return (
+        <div key={name + '_' + index} className="mt-1 flex flex-col rounded-sm pl-2 pt-1">
+          <div className="flex items-center">
+            {' '.repeat(level)}
+            <FolderIcon className="mr-2 min-w-[20px] text-icon-tertiary opacity-60" />
+            <TextWithNote name={name} note={note} className="text-secondary" />
+          </div>
+          {renderStructure(files, level + 1)}
         </div>
-        {renderStructure(files, level + 1)}
-      </div>
-    ) : (
-      <div key={name + '_' + index} className="mt-1 flex items-center rounded-sm pl-2 pt-1">
-        {' '.repeat(Math.max(level, 0))}
-        <FileIcon className="mr-2 min-w-[20px] text-icon-tertiary" />
-        <TextWithNote name={name} note={note} className="text-default" />
-      </div>
-    );
+      );
+    }
+
+    if (name.length > 0) {
+      return (
+        <div key={name + '_' + index} className="mt-1 flex items-center rounded-sm pl-2 pt-1">
+          {' '.repeat(Math.max(level, 0))}
+          <FileIcon className="mr-2 min-w-[20px] text-icon-tertiary" />
+          <TextWithNote name={name} note={note} className="text-default" />
+        </div>
+      );
+    }
+
+    // this allows for showing just the folder name when the file name is empty
+    return null;
   });
 }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

When reading through these docs it wasn't immediately clear to me what files would be generated, it wasn't until I actually ran it that I understood how it was supposed to work.

This makes it clearer that you will get a modules folder and ios/android folder specific for that module.

# How

<!--
How did you build this feature or fix this bug and why?
-->

I added a small change to the file tree to allow it to show just the folder when there is no file name, this makes it show you can show an overview of the folder structure without needing to specify all the files. I did this because theres a lot of nested folders for android.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Check the docs site and see that file trees render as normal and the new page has this new section

<img width="1183" height="680" alt="image" src="https://github.com/user-attachments/assets/9e453e4b-5220-44cc-8c92-645e48bed164" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
