### PR TITLE
[cli] Add code frame extraction for native bundling error messages

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Parse and print code frames above import stack for native bundling errors
+- Parse and print code frames above import stack for native bundling errors ([#39150](https://github.com/expo/expo/pull/39150) by [@krystofwoldrich](https://github.com/krystofwoldrich))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Parse and print code frames above import stack for native bundling errors
+
 ### 💡 Others
 
 ## 0.26.7 — 2025-09-02


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We are printing code frames for web, but stripe them out for native bundling errors.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds message parsing which returns code frames from the message, which id existing are added before the import stack.

Before this PR:
<img width="629" height="155" alt="Screenshot 2025-08-26 at 0 16 18" src="https://github.com/user-attachments/assets/fad7241c-998d-4871-9d07-2a3e1d077cd9" />

After this PR:
<img width="941" height="286" alt="Screenshot 2025-08-26 at 0 23 08" src="https://github.com/user-attachments/assets/2c240e7b-1737-49b9-a3fa-e671188583e6" />

Web for comparison:
<img width="1512" height="380" alt="Screenshot 2025-08-26 at 13 33 08" src="https://github.com/user-attachments/assets/a49ac8a2-c0b0-4de5-a290-e382b05dbc1c" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
