### PR TITLE
[docs] Add warning for Expo Go to `react-native-maps` page

### DIFF
--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -14,7 +14,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 
-No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploy-app-with-google-maps).
+> **warning** `react-native-maps`'s Google Maps support is partially unavailable in Expo Go from SDK 54. Follow the steps in [Deploy app with Google Maps](#deploy-app-with-google-maps) and create a [development build](/develop/development-builds/introduction/) instead.
 
 ## Installation
 

--- a/docs/pages/versions/v54.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/map-view.mdx
@@ -14,7 +14,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 
-No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploy-app-with-google-maps).
+> **warning** `react-native-maps`'s Google Maps support is partially unavailable in Expo Go from SDK 54. Follow the steps in [Deploy app with Google Maps](#deploy-app-with-google-maps) and create a [development build](/develop/development-builds/introduction/) instead.
 
 ## Installation
 


### PR DESCRIPTION
We're getting some confusion about this, and I forgot myself what we landed on here, but I vaguely remember we didn't want to add a key to Expo Go anymore for Google Maps? Some of this seems unclear and people on Discord have reported they see an "empty view" when testing on Expo Go.

I'm assuming that's expected, but it'd be nice to add a warning, if this is a known restriction. The exact phrasing here is just a draft and may have to change. But, it'd be nice to change it to clarify what works and what doesn't.