### PR TITLE
[docs] Update react-native-reanimated installation instructions

### DIFF
--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -9,9 +9,8 @@ inExpoGo: true
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
-import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { SnackInline } from '~/ui/components/Snippet';
+import { SnackInline, Terminal } from '~/ui/components/Snippet';
 
 [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/) provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
@@ -19,7 +18,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 ## Installation
 
-<APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#platform-specific-setup" />
+<Terminal cmd={['$ npx expo install react-native-reanimated react-native-worklets']} />
 
 <br />
 

--- a/docs/pages/versions/v54.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/reanimated.mdx
@@ -9,9 +9,8 @@ inExpoGo: true
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
-import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { SnackInline } from '~/ui/components/Snippet';
+import { SnackInline, Terminal } from '~/ui/components/Snippet';
 
 [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/) provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
@@ -19,7 +18,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 ## Installation
 
-<APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#platform-specific-setup" />
+<Terminal cmd={['$ npx expo install react-native-reanimated react-native-worklets']} />
 
 <br />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Feedback from @kadikraman that `react-native-reanimated` installation now requires installing `react-native-worklets` as a peer dependency.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the installation instructions of the Reanimated reference. Changes applied to unversioned and SDK 54.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="2708" height="1540" alt="CleanShot 2025-08-26 at 23 11 20@2x" src="https://github.com/user-attachments/assets/a1d294e6-cfa5-4ba2-9f2f-e51b6a4a238e" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
