### PR TITLE
[docs] Fix `NSLocationAlwaysUsageDescription` deprecation message in Expo Location reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -69,7 +69,6 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
     {
       name: 'locationWhenInUsePermission',
       platform: 'ios',
-      deprecated: true,
       description:
         'A string to set the [`NSLocationWhenInUseUsageDescription`](#permission-nslocationwheninuseusagedescription) permission message.',
       default: '"Allow $(PRODUCT_NAME) to use your location"',
@@ -380,4 +379,4 @@ The following usage description keys are used by this library:
   ]}
 />
 
-**NSLocationAlwaysUsageDescription** and **NSLocationWhenInUseUsageDescription** are deprecated in favor of **NSLocationAlwaysAndWhenInUseUsageDescription** from iOS 11.
+`NSLocationAlwaysUsageDescription` is deprecated in favor of `NSLocationAlwaysAndWhenInUseUsageDescription` from iOS 11.

--- a/docs/pages/versions/v51.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v51.0.0/sdk/location.mdx
@@ -60,6 +60,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
     {
       name: 'locationAlwaysPermission',
       platform: 'ios',
+      deprecated: true,
       description:
         'A string to set the [`NSLocationAlwaysUsageDescription`](#permission-nslocationalwaysusagedescription) permission message.',
       default: '"Allow $(PRODUCT_NAME) to use your location"',
@@ -278,3 +279,5 @@ The following usage description keys are used by this library:
     'NSLocationWhenInUseUsageDescription',
   ]}
 />
+
+`NSLocationAlwaysUsageDescription` is deprecated in favor of `NSLocationAlwaysAndWhenInUseUsageDescription` from iOS 11.

--- a/docs/pages/versions/v52.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v52.0.0/sdk/location.mdx
@@ -69,7 +69,6 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
     {
       name: 'locationWhenInUsePermission',
       platform: 'ios',
-      deprecated: true,
       description:
         'A string to set the [`NSLocationWhenInUseUsageDescription`](#permission-nslocationwheninuseusagedescription) permission message.',
       default: '"Allow $(PRODUCT_NAME) to use your location"',
@@ -380,4 +379,4 @@ The following usage description keys are used by this library:
   ]}
 />
 
-**NSLocationAlwaysUsageDescription** and **NSLocationWhenInUseUsageDescription** are deprecated in favor of **NSLocationAlwaysAndWhenInUseUsageDescription** from iOS 11.
+`NSLocationAlwaysUsageDescription` is deprecated in favor of `NSLocationAlwaysAndWhenInUseUsageDescription` from iOS 11.

--- a/docs/pages/versions/v53.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/location.mdx
@@ -69,7 +69,6 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
     {
       name: 'locationWhenInUsePermission',
       platform: 'ios',
-      deprecated: true,
       description:
         'A string to set the [`NSLocationWhenInUseUsageDescription`](#permission-nslocationwheninuseusagedescription) permission message.',
       default: '"Allow $(PRODUCT_NAME) to use your location"',
@@ -380,4 +379,5 @@ The following usage description keys are used by this library:
   ]}
 />
 
-**NSLocationAlwaysUsageDescription** and **NSLocationWhenInUseUsageDescription** are deprecated in favor of **NSLocationAlwaysAndWhenInUseUsageDescription** from iOS 11.
+`NSLocationAlwaysUsageDescription` is deprecated in favor of
+`NSLocationAlwaysAndWhenInUseUsageDescription` from iOS 11.

--- a/docs/pages/versions/v54.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/location.mdx
@@ -69,7 +69,6 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
     {
       name: 'locationWhenInUsePermission',
       platform: 'ios',
-      deprecated: true,
       description:
         'A string to set the [`NSLocationWhenInUseUsageDescription`](#permission-nslocationwheninuseusagedescription) permission message.',
       default: '"Allow $(PRODUCT_NAME) to use your location"',
@@ -380,4 +379,4 @@ The following usage description keys are used by this library:
   ]}
 />
 
-**NSLocationAlwaysUsageDescription** and **NSLocationWhenInUseUsageDescription** are deprecated in favor of **NSLocationAlwaysAndWhenInUseUsageDescription** from iOS 11.
+`NSLocationAlwaysUsageDescription` is deprecated in favor of `NSLocationAlwaysAndWhenInUseUsageDescription` from iOS 11.


### PR DESCRIPTION


# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #39153

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Under the iOS permissions section, mention that only `NSLocationAlwaysUsageDescription` is deprecated.
- Under the Configurable properties section, remove `deprecated` from `locationWhenInUsePermission`.
- Changes applied to `unversioned` and backported to SDK 54, 53, 52, and 51.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="1002" height="817" alt="CleanShot 2025-08-27 at 00 44 17" src="https://github.com/user-attachments/assets/5c4ef8d3-1e32-4b78-b075-91300857533d" />


<img width="1015" height="459" alt="CleanShot 2025-08-27 at 00 40 42" src="https://github.com/user-attachments/assets/4bb8723c-9544-4cb7-9595-7d6ec78bf04e" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
