### PR TITLE
[expo-go] Fix menu animation

### DIFF
--- a/apps/expo-go/src/menu/DevMenuBottomSheet.tsx
+++ b/apps/expo-go/src/menu/DevMenuBottomSheet.tsx
@@ -78,7 +78,7 @@ function DevMenuBottomSheet({ children, uuid }: Props) {
   return (
     <BottomSheet
       key={uuid}
-      enableDynamicSizing
+      snapPoints={['70%']}
       index={0}
       ref={bottomSheetRef}
       backdropComponent={renderBackdrop}


### PR DESCRIPTION
# Why
Closes ENG-17043
There is a hitchy animation when the onboarding view is dismissed and the menu expands to full height (see linear task).

# How
It was caused by the `enableDynamicSizing` prop on the bottom sheet. Switching to `snapPoints` fixes the problem.

# Test Plan
Expo go. The view is dismissed without any weird gaps in the UI

