### PR TITLE
[docs] Update Guides overview to include links to Tutorial section

### DIFF
--- a/docs/pages/guides/overview.mdx
+++ b/docs/pages/guides/overview.mdx
@@ -25,3 +25,5 @@ Learn how to add and use Native modules in your app using [Expo Modules API](/mo
 ### Other content
 
 Apart from the essentials listed above, there are plenty of other features to explore such as [Push notifications](/push-notifications/overview/). We also have a collection of guides in the **Assorted** and third-party **Integrations** sections.
+
+If you're looking for step-by-step tutorials for Expo and EAS, see the [Tutorial section](/tutorial/overview/) which includes comprehensive tutorials for both [building apps with Expo](/tutorial/introduction/) and [using EAS services](/tutorial/eas/introduction/).

--- a/docs/pages/guides/overview.mdx
+++ b/docs/pages/guides/overview.mdx
@@ -5,6 +5,7 @@ hideTOC: true
 ---
 
 import { RouterLogo } from '@expo/styleguide';
+import { GraduationHat02DuotoneIcon } from '@expo/styleguide-icons/duotone/GraduationHat02DuotoneIcon';
 import { CodeSquare01Icon } from '@expo/styleguide-icons/outline/CodeSquare01Icon';
 import { CpuChip01Icon } from '@expo/styleguide-icons/outline/CpuChip01Icon';
 
@@ -22,8 +23,10 @@ Learn about using different navigation functionalities from the [Expo Router](/r
 
 Learn how to add and use Native modules in your app using [Expo Modules API](/modules/overview/).
 
+### <span className="inline-flex items-center gap-2"><GraduationHat02DuotoneIcon />Tutorials</span>
+
+If you're looking for step-by-step tutorials for Expo and EAS, see the [Tutorial section](/tutorial/overview/) which includes comprehensive tutorials for both [building apps with Expo](/tutorial/introduction/) and [using EAS services](/tutorial/eas/introduction/).
+
 ### Other content
 
 Apart from the essentials listed above, there are plenty of other features to explore such as [Push notifications](/push-notifications/overview/). We also have a collection of guides in the **Assorted** and third-party **Integrations** sections.
-
-If you're looking for step-by-step tutorials for Expo and EAS, see the [Tutorial section](/tutorial/overview/) which includes comprehensive tutorials for both [building apps with Expo](/tutorial/introduction/) and [using EAS services](/tutorial/eas/introduction/).


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17174

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update Guides overview to include links to the Tutorial section for Expo and EAS tutorials.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="1163" height="205" alt="CleanShot 2025-08-27 at 16 13 25" src="https://github.com/user-attachments/assets/7febdd07-9e1f-488f-bdb0-5374734f8d9d" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
