### PR TITLE
feat(reset-project): add optional uninstall of unused boilerplate packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Package-specific changes not released in any SDK will be added here just before 
 ### 🛠 Breaking changes
 
 ### 🎉 New features
+- **`expo-template`**
+  - Add optional uninstall of unused boilerplate packages in `reset-project` script.
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ Package-specific changes not released in any SDK will be added here just before 
 ### 🛠 Breaking changes
 
 ### 🎉 New features
-- **`expo-template`**
-  - Add optional uninstall of unused boilerplate packages in `reset-project` script.
 
 ### 🐛 Bug fixes
 

--- a/templates/expo-template-default/CHANGELOG.md
+++ b/templates/expo-template-default/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+This is the log of notable changes to the **Expo default template** that are developer-facing.
+Changes here apply specifically to the `expo-template-default` project.
+
+## Unpublished
+
+### 📚 3rd party library updates
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+- Added optional uninstall of unused boilerplate packages in `reset-project` script. ([#PR_NUMBER](https://github.com/expo/expo/pull/PR_NUMBER) by [@devnajam](https://github.com/devnajam))
+
+### 🐛 Bug fixes

--- a/templates/expo-template-default/CHANGELOG.md
+++ b/templates/expo-template-default/CHANGELOG.md
@@ -11,6 +11,6 @@ Changes here apply specifically to the `expo-template-default` project.
 
 ### 🎉 New features
 
-- Added optional uninstall of unused boilerplate packages in `reset-project` script. ([#PR_NUMBER](https://github.com/expo/expo/pull/PR_NUMBER) by [@devnajam](https://github.com/devnajam))
+- Added optional uninstall of unused boilerplate packages in `reset-project` script. ([#PR_NUMBER](https://github.com/expo/expo/pull/PR_NUMBER) by [@devnajam](https://github.com/devnajam)) ([#39182](https://github.com/expo/expo/pull/39182) by [@devnajam](https://github.com/devnajam))
 
 ### 🐛 Bug fixes

--- a/templates/expo-template-default/CHANGELOG.md
+++ b/templates/expo-template-default/CHANGELOG.md
@@ -11,6 +11,6 @@ Changes here apply specifically to the `expo-template-default` project.
 
 ### 🎉 New features
 
-- Added optional uninstall of unused boilerplate packages in `reset-project` script. ([#PR_NUMBER](https://github.com/expo/expo/pull/PR_NUMBER) by [@devnajam](https://github.com/devnajam)) ([#39182](https://github.com/expo/expo/pull/39182) by [@devnajam](https://github.com/devnajam))
+- Added optional uninstall of unused boilerplate packages in `reset-project` script. ([#39182](https://github.com/expo/expo/pull/39182) by [@devnajam](https://github.com/devnajam))
 
 ### 🐛 Bug fixes


### PR DESCRIPTION
# Why

When resetting a project with the default template, the script removes example code and directories but leaves all of the extra dependencies installed by the boilerplate (navigation, vector icons, blur, etc.).  
This can be confusing for new users and unnecessarily bloats the project with unused packages.

# How

- Added an optional prompt after reset asking whether to uninstall the unused boilerplate packages.
- Implemented package manager detection to run `npm uninstall`, `yarn remove`, or `pnpm remove` depending on the lockfile present.
- Kept the uninstall step optional so users can skip it if they want to retain dependencies.

# Test Plan

- Ran the script with **Y**:
  - Old directories were moved/deleted correctly.
  - Fresh `/app` with `index.tsx` and `_layout.tsx` was generated.
  - Detected `npm` and uninstalled the unused packages successfully.
- Ran the script with **N**:
  - Uninstall step skipped, reset completed normally.
- Verified that the change does not affect `expo prebuild` or EAS Build flows.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
