### PR TITLE
[video][android] Bump media3 to 1.8.0

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [Android] Bump media3 version to 1.8.0.
+- [Android] Bump media3 version to 1.8.0. ([#39184](https://github.com/expo/expo/pull/39184) by [@behenate](https://github.com/behenate))
 
 ## 3.0.5 — 2025-08-25
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [Android] Bump media3 version to 1.8.0.
+
 ## 3.0.5 — 2025-08-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-video/android/build.gradle
+++ b/packages/expo-video/android/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   implementation 'com.facebook.react:react-android'
 
   // Remember to keep this in sync with the version in `expo-audio`
-  def androidxMedia3Version = "1.4.0"
+  def androidxMedia3Version = "1.8.0"
   implementation "androidx.media3:media3-session:${androidxMedia3Version}"
   implementation "androidx.media3:media3-exoplayer:${androidxMedia3Version}"
   implementation "androidx.media3:media3-exoplayer-dash:${androidxMedia3Version}"

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/DefaultLoadControl.java
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/DefaultLoadControl.java
@@ -1,0 +1,552 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * NOTE FROM EXPO (@behenate): 
+ * This is a copy of the DefaultLoadControl from ExoPlayer. The only difference being, that the buffer options such as
+ *   long minBufferUs;
+ *   long maxBufferUs;rSizeThresholds
+ *   long bufferForPlaybackUs;Ms
+ *   long bufferForPlaybackAfterRebufferUs;AfterRebufferMs
+ *   int targetBufferBytesOverwrite;
+ *   and some others
+ *
+ * Are protected, instead of private, so that we can inherit from it and modify those at runtime
+ * also the  PlayerLoadingState is made internal
+ *
+ * STEPS FOR UPDATING TO A NEWER VERSION:
+ * - Copy the implementation for the new version from the media3 repo
+ * - Make the following variables protected in DefaultLoadControl class (not the builder!):
+ *     long minBufferUs;
+ *     long maxBufferUs;
+ *     long bufferForPlaybackUs;
+ *     long bufferForPlaybackAfterRebufferUs;
+ *     int targetBufferBytesOverwrite;
+ *     boolean prioritizeTimeOverSizeThresholds;
+ *     long backBufferDurationUs;
+ *     final HashMap<PlayerId, PlayerLoadingState> loadingStates;
+ * - Make PlayerLoadingState class protected instead of private
+ * - Make the updateAllocator method protected
+ * - Remove non-exported annotations from google
+ * - In our class inheriting from DefaultLoadControl make sure that `applyBufferOptions` still does everything necessary to update the buffer preferences
+ */
+
+package expo.modules.video.player;
+
+import static androidx.media3.common.util.Assertions.checkNotNull;
+import static androidx.media3.common.util.Assertions.checkState;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+import androidx.media3.common.C;
+import androidx.media3.common.Timeline;
+import androidx.media3.common.util.Assertions;
+import androidx.media3.common.util.Log;
+import androidx.media3.common.util.NullableType;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.common.util.Util;
+import androidx.media3.exoplayer.Renderer;
+import androidx.media3.exoplayer.analytics.PlayerId;
+import androidx.media3.exoplayer.source.MediaSource.MediaPeriodId;
+import androidx.media3.exoplayer.source.TrackGroupArray;
+import androidx.media3.exoplayer.trackselection.ExoTrackSelection;
+import androidx.media3.exoplayer.upstream.Allocator;
+import androidx.media3.exoplayer.upstream.DefaultAllocator;
+import androidx.media3.exoplayer.LoadControl;
+import java.util.HashMap;
+
+/** The default {@link LoadControl} implementation. */
+@UnstableApi
+public class DefaultLoadControl implements LoadControl {
+
+  /**
+   * The default minimum duration of media that the player will attempt to ensure is buffered at all
+   * times, in milliseconds.
+   */
+  public static final int DEFAULT_MIN_BUFFER_MS = 50_000;
+
+  /**
+   * The default maximum duration of media that the player will attempt to buffer, in milliseconds.
+   */
+  public static final int DEFAULT_MAX_BUFFER_MS = 50_000;
+
+  /**
+   * The default duration of media that must be buffered for playback to start or resume following a
+   * user action such as a seek, in milliseconds.
+   */
+  public static final int DEFAULT_BUFFER_FOR_PLAYBACK_MS = 1000;
+
+  /**
+   * The default duration of media that must be buffered for playback to resume after a rebuffer, in
+   * milliseconds. A rebuffer is defined to be caused by buffer depletion rather than a user action.
+   */
+  public static final int DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS = 2000;
+
+  /**
+   * The default target buffer size in bytes. The value ({@link C#LENGTH_UNSET}) means that the load
+   * control will calculate the target buffer size based on the selected tracks.
+   */
+  public static final int DEFAULT_TARGET_BUFFER_BYTES = C.LENGTH_UNSET;
+
+  /** The default prioritization of buffer time constraints over size constraints. */
+  public static final boolean DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS = false;
+
+  /** The default back buffer duration in milliseconds. */
+  public static final int DEFAULT_BACK_BUFFER_DURATION_MS = 0;
+
+  /** The default for whether the back buffer is retained from the previous keyframe. */
+  public static final boolean DEFAULT_RETAIN_BACK_BUFFER_FROM_KEYFRAME = false;
+
+  /** A default size in bytes for a video buffer. */
+  public static final int DEFAULT_VIDEO_BUFFER_SIZE = 2000 * C.DEFAULT_BUFFER_SEGMENT_SIZE;
+
+  /** A default size in bytes for an audio buffer. */
+  public static final int DEFAULT_AUDIO_BUFFER_SIZE = 200 * C.DEFAULT_BUFFER_SEGMENT_SIZE;
+
+  /** A default size in bytes for a text buffer. */
+  public static final int DEFAULT_TEXT_BUFFER_SIZE = 2 * C.DEFAULT_BUFFER_SEGMENT_SIZE;
+
+  /** A default size in bytes for a metadata buffer. */
+  public static final int DEFAULT_METADATA_BUFFER_SIZE = 2 * C.DEFAULT_BUFFER_SEGMENT_SIZE;
+
+  /** A default size in bytes for a camera motion buffer. */
+  public static final int DEFAULT_CAMERA_MOTION_BUFFER_SIZE = 2 * C.DEFAULT_BUFFER_SEGMENT_SIZE;
+
+  /** A default size in bytes for an image buffer. */
+  public static final int DEFAULT_IMAGE_BUFFER_SIZE = 400 * C.DEFAULT_BUFFER_SEGMENT_SIZE;
+
+  /** A default size in bytes for a muxed buffer (e.g. containing video, audio and text). */
+  public static final int DEFAULT_MUXED_BUFFER_SIZE =
+    DEFAULT_VIDEO_BUFFER_SIZE + DEFAULT_AUDIO_BUFFER_SIZE + DEFAULT_TEXT_BUFFER_SIZE;
+
+  /**
+   * The buffer size in bytes that will be used as a minimum target buffer in all cases. This is
+   * also the default target buffer before tracks are selected.
+   */
+  public static final int DEFAULT_MIN_BUFFER_SIZE = 200 * C.DEFAULT_BUFFER_SEGMENT_SIZE;
+
+  /** Builder for {@link DefaultLoadControl}. */
+  public static final class Builder {
+
+    @Nullable private DefaultAllocator allocator;
+    private int minBufferMs;
+    private int maxBufferMs;
+    private int bufferForPlaybackMs;
+    private int bufferForPlaybackAfterRebufferMs;
+    private int targetBufferBytes;
+    private boolean prioritizeTimeOverSizeThresholds;
+    private int backBufferDurationMs;
+    private boolean retainBackBufferFromKeyframe;
+    private boolean buildCalled;
+
+    /** Constructs a new instance. */
+    public Builder() {
+      minBufferMs = DEFAULT_MIN_BUFFER_MS;
+      maxBufferMs = DEFAULT_MAX_BUFFER_MS;
+      bufferForPlaybackMs = DEFAULT_BUFFER_FOR_PLAYBACK_MS;
+      bufferForPlaybackAfterRebufferMs = DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS;
+      targetBufferBytes = DEFAULT_TARGET_BUFFER_BYTES;
+      prioritizeTimeOverSizeThresholds = DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS;
+      backBufferDurationMs = DEFAULT_BACK_BUFFER_DURATION_MS;
+      retainBackBufferFromKeyframe = DEFAULT_RETAIN_BACK_BUFFER_FROM_KEYFRAME;
+    }
+
+    /**
+     * Sets the {@link DefaultAllocator} used by the loader.
+     *
+     * @param allocator The {@link DefaultAllocator}.
+     * @return This builder, for convenience.
+     * @throws IllegalStateException If {@link #build()} has already been called.
+     */
+    public Builder setAllocator(DefaultAllocator allocator) {
+      checkState(!buildCalled);
+      this.allocator = allocator;
+      return this;
+    }
+
+    /**
+     * Sets the buffer duration parameters.
+     *
+     * @param minBufferMs The minimum duration of media that the player will attempt to ensure is
+     *     buffered at all times, in milliseconds.
+     * @param maxBufferMs The maximum duration of media that the player will attempt to buffer, in
+     *     milliseconds.
+     * @param bufferForPlaybackMs The duration of media that must be buffered for playback to start
+     *     or resume following a user action such as a seek, in milliseconds.
+     * @param bufferForPlaybackAfterRebufferMs The default duration of media that must be buffered
+     *     for playback to resume after a rebuffer, in milliseconds. A rebuffer is defined to be
+     *     caused by buffer depletion rather than a user action.
+     * @return This builder, for convenience.
+     * @throws IllegalStateException If {@link #build()} has already been called.
+     */
+    public Builder setBufferDurationsMs(
+      int minBufferMs,
+      int maxBufferMs,
+      int bufferForPlaybackMs,
+      int bufferForPlaybackAfterRebufferMs) {
+      checkState(!buildCalled);
+      assertGreaterOrEqual(bufferForPlaybackMs, 0, "bufferForPlaybackMs", "0");
+      assertGreaterOrEqual(
+        bufferForPlaybackAfterRebufferMs, 0, "bufferForPlaybackAfterRebufferMs", "0");
+      assertGreaterOrEqual(minBufferMs, bufferForPlaybackMs, "minBufferMs", "bufferForPlaybackMs");
+      assertGreaterOrEqual(
+        minBufferMs,
+        bufferForPlaybackAfterRebufferMs,
+        "minBufferMs",
+        "bufferForPlaybackAfterRebufferMs");
+      assertGreaterOrEqual(maxBufferMs, minBufferMs, "maxBufferMs", "minBufferMs");
+      this.minBufferMs = minBufferMs;
+      this.maxBufferMs = maxBufferMs;
+      this.bufferForPlaybackMs = bufferForPlaybackMs;
+      this.bufferForPlaybackAfterRebufferMs = bufferForPlaybackAfterRebufferMs;
+      return this;
+    }
+
+    /**
+     * Sets the target buffer size in bytes for each player. The actual overall target buffer size
+     * is this value multiplied by the number of players that use the load control simultaneously.
+     * If set to {@link C#LENGTH_UNSET}, the target buffer size of a player will be calculated based
+     * on the selected tracks of the player.
+     *
+     * @param targetBufferBytes The target buffer size in bytes.
+     * @return This builder, for convenience.
+     * @throws IllegalStateException If {@link #build()} has already been called.
+     */
+    public Builder setTargetBufferBytes(int targetBufferBytes) {
+      checkState(!buildCalled);
+      this.targetBufferBytes = targetBufferBytes;
+      return this;
+    }
+
+    /**
+     * Sets whether the load control prioritizes buffer time constraints over buffer size
+     * constraints.
+     *
+     * @param prioritizeTimeOverSizeThresholds Whether the load control prioritizes buffer time
+     *     constraints over buffer size constraints.
+     * @return This builder, for convenience.
+     * @throws IllegalStateException If {@link #build()} has already been called.
+     */
+    public Builder setPrioritizeTimeOverSizeThresholds(boolean prioritizeTimeOverSizeThresholds) {
+      checkState(!buildCalled);
+      this.prioritizeTimeOverSizeThresholds = prioritizeTimeOverSizeThresholds;
+      return this;
+    }
+
+    /**
+     * Sets the back buffer duration, and whether the back buffer is retained from the previous
+     * keyframe.
+     *
+     * @param backBufferDurationMs The back buffer duration in milliseconds.
+     * @param retainBackBufferFromKeyframe Whether the back buffer is retained from the previous
+     *     keyframe.
+     * @return This builder, for convenience.
+     * @throws IllegalStateException If {@link #build()} has already been called.
+     */
+    public Builder setBackBuffer(int backBufferDurationMs, boolean retainBackBufferFromKeyframe) {
+      checkState(!buildCalled);
+      assertGreaterOrEqual(backBufferDurationMs, 0, "backBufferDurationMs", "0");
+      this.backBufferDurationMs = backBufferDurationMs;
+      this.retainBackBufferFromKeyframe = retainBackBufferFromKeyframe;
+      return this;
+    }
+
+    /** Creates a {@link DefaultLoadControl}. */
+    public DefaultLoadControl build() {
+      checkState(!buildCalled);
+      buildCalled = true;
+      if (allocator == null) {
+        allocator = new DefaultAllocator(/* trimOnReset= */ true, C.DEFAULT_BUFFER_SEGMENT_SIZE);
+      }
+      return new DefaultLoadControl(
+        allocator,
+        minBufferMs,
+        maxBufferMs,
+        bufferForPlaybackMs,
+        bufferForPlaybackAfterRebufferMs,
+        targetBufferBytes,
+        prioritizeTimeOverSizeThresholds,
+        backBufferDurationMs,
+        retainBackBufferFromKeyframe);
+    }
+  }
+
+  private final DefaultAllocator allocator;
+
+  protected long minBufferUs;
+  protected long maxBufferUs;
+  protected long bufferForPlaybackUs;
+  protected long bufferForPlaybackAfterRebufferUs;
+  protected int targetBufferBytesOverwrite;
+  protected boolean prioritizeTimeOverSizeThresholds;
+  protected long backBufferDurationUs;
+  private final boolean retainBackBufferFromKeyframe;
+  protected final HashMap<PlayerId, PlayerLoadingState> loadingStates;
+
+  private long threadId;
+
+  /** Constructs a new instance, using the {@code DEFAULT_*} constants defined in this class. */
+  public DefaultLoadControl() {
+    this(
+      new DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE),
+      DEFAULT_MIN_BUFFER_MS,
+      DEFAULT_MAX_BUFFER_MS,
+      DEFAULT_BUFFER_FOR_PLAYBACK_MS,
+      DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS,
+      DEFAULT_TARGET_BUFFER_BYTES,
+      DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS,
+      DEFAULT_BACK_BUFFER_DURATION_MS,
+      DEFAULT_RETAIN_BACK_BUFFER_FROM_KEYFRAME);
+  }
+
+  protected DefaultLoadControl(
+    DefaultAllocator allocator,
+    int minBufferMs,
+    int maxBufferMs,
+    int bufferForPlaybackMs,
+    int bufferForPlaybackAfterRebufferMs,
+    int targetBufferBytes,
+    boolean prioritizeTimeOverSizeThresholds,
+    int backBufferDurationMs,
+    boolean retainBackBufferFromKeyframe) {
+    assertGreaterOrEqual(bufferForPlaybackMs, 0, "bufferForPlaybackMs", "0");
+    assertGreaterOrEqual(
+      bufferForPlaybackAfterRebufferMs, 0, "bufferForPlaybackAfterRebufferMs", "0");
+    assertGreaterOrEqual(minBufferMs, bufferForPlaybackMs, "minBufferMs", "bufferForPlaybackMs");
+    assertGreaterOrEqual(
+      minBufferMs,
+      bufferForPlaybackAfterRebufferMs,
+      "minBufferMs",
+      "bufferForPlaybackAfterRebufferMs");
+    assertGreaterOrEqual(maxBufferMs, minBufferMs, "maxBufferMs", "minBufferMs");
+    assertGreaterOrEqual(backBufferDurationMs, 0, "backBufferDurationMs", "0");
+
+    this.allocator = allocator;
+    this.minBufferUs = Util.msToUs(minBufferMs);
+    this.maxBufferUs = Util.msToUs(maxBufferMs);
+    this.bufferForPlaybackUs = Util.msToUs(bufferForPlaybackMs);
+    this.bufferForPlaybackAfterRebufferUs = Util.msToUs(bufferForPlaybackAfterRebufferMs);
+    this.targetBufferBytesOverwrite = targetBufferBytes;
+    this.prioritizeTimeOverSizeThresholds = prioritizeTimeOverSizeThresholds;
+    this.backBufferDurationUs = Util.msToUs(backBufferDurationMs);
+    this.retainBackBufferFromKeyframe = retainBackBufferFromKeyframe;
+    loadingStates = new HashMap<>();
+    threadId = C.INDEX_UNSET;
+  }
+
+  @Override
+  public void onPrepared(PlayerId playerId) {
+    long currentThreadId = Thread.currentThread().getId();
+    checkState(
+      threadId == C.INDEX_UNSET || threadId == currentThreadId,
+      "Players that share the same LoadControl must share the same playback thread. See"
+        + " ExoPlayer.Builder.setPlaybackLooper(Looper).");
+    threadId = currentThreadId;
+    if (!loadingStates.containsKey(playerId)) {
+      loadingStates.put(playerId, new PlayerLoadingState());
+    }
+    resetPlayerLoadingState(playerId);
+  }
+
+  @Override
+  public void onTracksSelected(
+    LoadControl.Parameters parameters,
+    TrackGroupArray trackGroups,
+    @NullableType ExoTrackSelection[] trackSelections) {
+    checkNotNull(loadingStates.get(parameters.playerId)).targetBufferBytes =
+      targetBufferBytesOverwrite == C.LENGTH_UNSET
+        ? calculateTargetBufferBytes(trackSelections)
+        : targetBufferBytesOverwrite;
+    updateAllocator();
+  }
+
+  @Override
+  public void onStopped(PlayerId playerId) {
+    removePlayer(playerId);
+  }
+
+  @Override
+  public void onReleased(PlayerId playerId) {
+    removePlayer(playerId);
+    if (loadingStates.isEmpty()) {
+      threadId = C.INDEX_UNSET;
+    }
+  }
+
+  @Override
+  public Allocator getAllocator() {
+    return allocator;
+  }
+
+  @Override
+  public long getBackBufferDurationUs(PlayerId playerId) {
+    return backBufferDurationUs;
+  }
+
+  @Override
+  public boolean retainBackBufferFromKeyframe(PlayerId playerId) {
+    return retainBackBufferFromKeyframe;
+  }
+
+  @Override
+  public boolean shouldContinueLoading(Parameters parameters) {
+    PlayerLoadingState playerLoadingState = checkNotNull(loadingStates.get(parameters.playerId));
+    boolean targetBufferSizeReached =
+      allocator.getTotalBytesAllocated() >= calculateTotalTargetBufferBytes();
+    long minBufferUs = this.minBufferUs;
+    if (parameters.playbackSpeed > 1) {
+      // The playback speed is faster than real time, so scale up the minimum required media
+      // duration to keep enough media buffered for a playout duration of minBufferUs.
+      long mediaDurationMinBufferUs =
+        Util.getMediaDurationForPlayoutDuration(minBufferUs, parameters.playbackSpeed);
+      minBufferUs = min(mediaDurationMinBufferUs, maxBufferUs);
+    }
+    // Prevent playback from getting stuck if minBufferUs is too small.
+    minBufferUs = max(minBufferUs, 500_000);
+    if (parameters.bufferedDurationUs < minBufferUs) {
+      playerLoadingState.isLoading = prioritizeTimeOverSizeThresholds || !targetBufferSizeReached;
+      if (!playerLoadingState.isLoading && parameters.bufferedDurationUs < 500_000) {
+        Log.w(
+          "DefaultLoadControl",
+          "Target buffer size reached with less than 500ms of buffered media data.");
+      }
+    } else if (parameters.bufferedDurationUs >= maxBufferUs || targetBufferSizeReached) {
+      playerLoadingState.isLoading = false;
+    } // Else don't change the loading state.
+    return playerLoadingState.isLoading;
+  }
+
+  @Override
+  public boolean shouldStartPlayback(Parameters parameters) {
+    long bufferedDurationUs =
+      Util.getPlayoutDurationForMediaDuration(
+        parameters.bufferedDurationUs, parameters.playbackSpeed);
+    long minBufferDurationUs =
+      parameters.rebuffering ? bufferForPlaybackAfterRebufferUs : bufferForPlaybackUs;
+    if (parameters.targetLiveOffsetUs != C.TIME_UNSET) {
+      minBufferDurationUs = min(parameters.targetLiveOffsetUs / 2, minBufferDurationUs);
+    }
+    return minBufferDurationUs <= 0
+      || bufferedDurationUs >= minBufferDurationUs
+      || (!prioritizeTimeOverSizeThresholds
+      && allocator.getTotalBytesAllocated() >= calculateTotalTargetBufferBytes());
+  }
+
+  @Override
+  public boolean shouldContinuePreloading(
+    Timeline timeline, MediaPeriodId mediaPeriodId, long bufferedDurationUs) {
+    for (PlayerLoadingState playerLoadingState : loadingStates.values()) {
+      if (playerLoadingState.isLoading) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Calculate target buffer size in bytes based on the selected tracks. The player will try not to
+   * exceed this target buffer. Only used when {@code targetBufferBytes} is {@link C#LENGTH_UNSET}.
+   *
+   * @param trackSelectionArray The selected tracks.
+   * @return The target buffer size in bytes.
+   */
+  protected int calculateTargetBufferBytes(@NullableType ExoTrackSelection[] trackSelectionArray) {
+    int targetBufferSize = 0;
+    for (ExoTrackSelection exoTrackSelection : trackSelectionArray) {
+      if (exoTrackSelection != null) {
+        targetBufferSize += getDefaultBufferSize(exoTrackSelection.getTrackGroup().type);
+      }
+    }
+    return max(DEFAULT_MIN_BUFFER_SIZE, targetBufferSize);
+  }
+
+  /**
+   * @deprecated Use {@link #calculateTargetBufferBytes(ExoTrackSelection[])} instead.
+   */
+  @Deprecated
+  protected final int calculateTargetBufferBytes(
+    Renderer[] renderers, ExoTrackSelection[] trackSelectionArray) {
+    return calculateTargetBufferBytes(trackSelectionArray);
+  }
+
+  @VisibleForTesting
+    /* package */ int calculateTotalTargetBufferBytes() {
+    int totalTargetBufferBytes = 0;
+    for (PlayerLoadingState state : loadingStates.values()) {
+      totalTargetBufferBytes += state.targetBufferBytes;
+    }
+    return totalTargetBufferBytes;
+  }
+
+  private void resetPlayerLoadingState(PlayerId playerId) {
+    PlayerLoadingState playerLoadingState = checkNotNull(loadingStates.get(playerId));
+    playerLoadingState.targetBufferBytes =
+      targetBufferBytesOverwrite == C.LENGTH_UNSET
+        ? DEFAULT_MIN_BUFFER_SIZE
+        : targetBufferBytesOverwrite;
+    playerLoadingState.isLoading = false;
+  }
+
+  private void removePlayer(PlayerId playerId) {
+    if (loadingStates.remove(playerId) != null) {
+      updateAllocator();
+    }
+  }
+
+  protected void updateAllocator() {
+    if (loadingStates.isEmpty()) {
+      allocator.reset();
+    } else {
+      allocator.setTargetBufferSize(calculateTotalTargetBufferBytes());
+    }
+  }
+
+  private static int getDefaultBufferSize(@C.TrackType int trackType) {
+    switch (trackType) {
+      case C.TRACK_TYPE_DEFAULT:
+        return DEFAULT_MUXED_BUFFER_SIZE;
+      case C.TRACK_TYPE_AUDIO:
+        return DEFAULT_AUDIO_BUFFER_SIZE;
+      case C.TRACK_TYPE_VIDEO:
+        return DEFAULT_VIDEO_BUFFER_SIZE;
+      case C.TRACK_TYPE_TEXT:
+        return DEFAULT_TEXT_BUFFER_SIZE;
+      case C.TRACK_TYPE_METADATA:
+        return DEFAULT_METADATA_BUFFER_SIZE;
+      case C.TRACK_TYPE_CAMERA_MOTION:
+        return DEFAULT_CAMERA_MOTION_BUFFER_SIZE;
+      case C.TRACK_TYPE_IMAGE:
+        return DEFAULT_IMAGE_BUFFER_SIZE;
+      case C.TRACK_TYPE_NONE:
+        return 0;
+      case C.TRACK_TYPE_UNKNOWN:
+        return DEFAULT_MIN_BUFFER_SIZE;
+      default:
+        throw new IllegalArgumentException();
+    }
+  }
+
+  private static void assertGreaterOrEqual(int value1, int value2, String name1, String name2) {
+    Assertions.checkArgument(value1 >= value2, name1 + " cannot be less than " + name2);
+  }
+
+  protected static class PlayerLoadingState {
+    public boolean isLoading;
+    public int targetBufferBytes;
+  }
+}

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayer.kt
@@ -52,7 +52,7 @@ class VideoPlayer(val context: Context, appContext: AppContext, source: VideoSou
     .setEnableDecoderFallback(true)
   private var listeners: MutableList<WeakReference<VideoPlayerListener>> = mutableListOf()
   private var currentPlayerView = MutableWeakReference<PlayerView?>(null)
-  val loadControl: VideoPlayerLoadControl = VideoPlayerLoadControl.Builder().build()
+  val loadControl: VideoPlayerLoadControl = VideoPlayerLoadControl()
   val subtitles: VideoPlayerSubtitles = VideoPlayerSubtitles(this)
   val audioTracks: VideoPlayerAudioTracks = VideoPlayerAudioTracks(this)
   val trackSelector = DefaultTrackSelector(context)

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayerLoadControl.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/VideoPlayerLoadControl.kt
@@ -1,280 +1,35 @@
 package expo.modules.video.player
 
 import androidx.media3.common.C
-import androidx.media3.common.Timeline
-import androidx.media3.common.util.Assertions
-import androidx.media3.common.util.Log
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
-import androidx.media3.exoplayer.DefaultLoadControl
-import androidx.media3.exoplayer.LoadControl
-import androidx.media3.exoplayer.Renderer
-import androidx.media3.exoplayer.source.MediaSource
-import androidx.media3.exoplayer.source.TrackGroupArray
-import androidx.media3.exoplayer.trackselection.ExoTrackSelection
-import androidx.media3.exoplayer.upstream.Allocator
-import androidx.media3.exoplayer.upstream.DefaultAllocator
 import expo.modules.video.records.BufferOptions
-import kotlin.math.max
-import kotlin.math.min
 
-/**
- * Default LoadControl implementation copied from ExoPlayer source (auto-converted to Kotlin)
- * Modified to allow changing buffer parameters during playback.
- */
-
-/** The default [LoadControl] implementation.  */
 @UnstableApi
-class VideoPlayerLoadControl
-private constructor(
-  allocator: DefaultAllocator,
-  minBufferMs: Int,
-  maxBufferMs: Int,
-  bufferForPlaybackMs: Int,
-  bufferForPlaybackAfterRebufferMs: Int,
-  targetBufferBytes: Int,
-  prioritizeTimeOverSizeThresholds: Boolean,
-  backBufferDurationMs: Int,
-  retainBackBufferFromKeyframe: Boolean
-) : LoadControl {
-  /** Builder for [DefaultLoadControl].  */
-  class Builder {
-    private var allocator: DefaultAllocator? = null
-    private var minBufferMs: Int
-    private var maxBufferMs: Int
-    private var bufferForPlaybackMs: Int
-    private var bufferForPlaybackAfterRebufferMs: Int
-    private var targetBufferBytes: Int
-    private var prioritizeTimeOverSizeThresholds: Boolean
-    private var backBufferDurationMs: Int
-    private var retainBackBufferFromKeyframe: Boolean
-    private var buildCalled = false
-
-    /** Constructs a new instance.  */
-    init {
-      minBufferMs = DEFAULT_MIN_BUFFER_MS
-      maxBufferMs = DEFAULT_MAX_BUFFER_MS
-      bufferForPlaybackMs = DEFAULT_BUFFER_FOR_PLAYBACK_MS
-      bufferForPlaybackAfterRebufferMs = DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS
-      targetBufferBytes = DEFAULT_TARGET_BUFFER_BYTES
-      prioritizeTimeOverSizeThresholds = DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS
-      backBufferDurationMs = DEFAULT_BACK_BUFFER_DURATION_MS
-      retainBackBufferFromKeyframe = DEFAULT_RETAIN_BACK_BUFFER_FROM_KEYFRAME
-    }
-
-    /**
-     * Sets the [DefaultAllocator] used by the loader.
-     *
-     * @param allocator The [DefaultAllocator].
-     * @return This builder, for convenience.
-     * @throws IllegalStateException If [.build] has already been called.
-     */
-    fun setAllocator(allocator: DefaultAllocator?): Builder {
-      Assertions.checkState(!buildCalled)
-      this.allocator = allocator
-      return this
-    }
-
-    /**
-     * Sets the buffer duration parameters.
-     *
-     * @param minBufferMs The minimum duration of media that the player will attempt to ensure is
-     * buffered at all times, in milliseconds.
-     * @param maxBufferMs The maximum duration of media that the player will attempt to buffer, in
-     * milliseconds.
-     * @param bufferForPlaybackMs The duration of media that must be buffered for playback to start
-     * or resume following a user action such as a seek, in milliseconds.
-     * @param bufferForPlaybackAfterRebufferMs The default duration of media that must be buffered
-     * for playback to resume after a rebuffer, in milliseconds. A rebuffer is defined to be
-     * caused by buffer depletion rather than a user action.
-     * @return This builder, for convenience.
-     * @throws IllegalStateException If [.build] has already been called.
-     */
-    fun setBufferDurationsMs(
-      minBufferMs: Int,
-      maxBufferMs: Int,
-      bufferForPlaybackMs: Int,
-      bufferForPlaybackAfterRebufferMs: Int
-    ): Builder {
-      Assertions.checkState(!buildCalled)
-      assertGreaterOrEqual(bufferForPlaybackMs, 0, "bufferForPlaybackMs", "0")
-      assertGreaterOrEqual(
-        bufferForPlaybackAfterRebufferMs,
-        0,
-        "bufferForPlaybackAfterRebufferMs",
-        "0"
-      )
-      assertGreaterOrEqual(minBufferMs, bufferForPlaybackMs, "minBufferMs", "bufferForPlaybackMs")
-      assertGreaterOrEqual(
-        minBufferMs,
-        bufferForPlaybackAfterRebufferMs,
-        "minBufferMs",
-        "bufferForPlaybackAfterRebufferMs"
-      )
-      assertGreaterOrEqual(maxBufferMs, minBufferMs, "maxBufferMs", "minBufferMs")
-      this.minBufferMs = minBufferMs
-      this.maxBufferMs = maxBufferMs
-      this.bufferForPlaybackMs = bufferForPlaybackMs
-      this.bufferForPlaybackAfterRebufferMs = bufferForPlaybackAfterRebufferMs
-      return this
-    }
-
-    /**
-     * Sets the target buffer size in bytes. If set to [C.LENGTH_UNSET], the target buffer
-     * size will be calculated based on the selected tracks.
-     *
-     * @param targetBufferBytes The target buffer size in bytes.
-     * @return This builder, for convenience.
-     * @throws IllegalStateException If [.build] has already been called.
-     */
-    fun setTargetBufferBytes(targetBufferBytes: Int): Builder {
-      Assertions.checkState(!buildCalled)
-      this.targetBufferBytes = targetBufferBytes
-      return this
-    }
-
-    /**
-     * Sets whether the load control prioritizes buffer time constraints over buffer size
-     * constraints.
-     *
-     * @param prioritizeTimeOverSizeThresholds Whether the load control prioritizes buffer time
-     * constraints over buffer size constraints.
-     * @return This builder, for convenience.
-     * @throws IllegalStateException If [.build] has already been called.
-     */
-    fun setPrioritizeTimeOverSizeThresholds(prioritizeTimeOverSizeThresholds: Boolean): Builder {
-      Assertions.checkState(!buildCalled)
-      this.prioritizeTimeOverSizeThresholds = prioritizeTimeOverSizeThresholds
-      return this
-    }
-
-    /**
-     * Sets the back buffer duration, and whether the back buffer is retained from the previous
-     * keyframe.
-     *
-     * @param backBufferDurationMs The back buffer duration in milliseconds.
-     * @param retainBackBufferFromKeyframe Whether the back buffer is retained from the previous
-     * keyframe.
-     * @return This builder, for convenience.
-     * @throws IllegalStateException If [.build] has already been called.
-     */
-    fun setBackBuffer(backBufferDurationMs: Int, retainBackBufferFromKeyframe: Boolean): Builder {
-      Assertions.checkState(!buildCalled)
-      assertGreaterOrEqual(backBufferDurationMs, 0, "backBufferDurationMs", "0")
-      this.backBufferDurationMs = backBufferDurationMs
-      this.retainBackBufferFromKeyframe = retainBackBufferFromKeyframe
-      return this
-    }
-
-    /** Creates a [DefaultLoadControl].  */
-    fun build(): VideoPlayerLoadControl {
-      Assertions.checkState(!buildCalled)
-      buildCalled = true
-      if (allocator == null) {
-        allocator = DefaultAllocator( /* trimOnReset= */true, C.DEFAULT_BUFFER_SEGMENT_SIZE)
-      }
-      return VideoPlayerLoadControl(
-        allocator!!,
-        minBufferMs,
-        maxBufferMs,
-        bufferForPlaybackMs,
-        bufferForPlaybackAfterRebufferMs,
-        targetBufferBytes,
-        prioritizeTimeOverSizeThresholds,
-        backBufferDurationMs,
-        retainBackBufferFromKeyframe
-      )
-    }
-  }
-
-  private var minBufferUs: Long
-  private var maxBufferUs: Long
-  private var bufferForPlaybackUs: Long
-  private var bufferForPlaybackAfterRebufferUs: Long
-  private var targetBufferBytesOverwrite: Int
-  private var prioritizeTimeOverSizeThresholds: Boolean
-  private val backBufferDurationUs: Long
-  private val retainBackBufferFromKeyframe: Boolean
-
-  private var targetBufferBytes: Int
-  private var isLoading = false
-
-  private var renderers: Array<Renderer>? = null
-  private var trackSelections: Array<ExoTrackSelection>? = null
-
-  private val allocator: DefaultAllocator
-
-  var targetBufferMs: Long = DEFAULT_MAX_BUFFER_MS.toLong()
+class VideoPlayerLoadControl: DefaultLoadControl() {
+  private var targetBufferMs: Long
+    get() = maxBufferUs / 1000
     set(value) {
       minBufferUs = Util.msToUs(value)
       maxBufferUs = Util.msToUs(value)
     }
 
-  var bufferForPlaybackMs: Long = DEFAULT_BUFFER_FOR_PLAYBACK_MS.toLong()
+  private var bufferForPlaybackMs: Long
+    get() = bufferForPlaybackUs / 1000
     set(value) {
       bufferForPlaybackUs = Util.msToUs(value)
     }
 
-  var bufferForPlaybackAfterRebufferMs: Long = DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS.toLong()
+  private var bufferForPlaybackAfterRebufferMs: Long
+    get() = bufferForPlaybackAfterRebufferUs / 1000
     set(value) {
       bufferForPlaybackAfterRebufferUs = Util.msToUs(value)
     }
 
-  /** Constructs a new instance, using the `DEFAULT_*` constants defined in this class.  */
-  constructor() : this(
-    DefaultAllocator(true, C.DEFAULT_BUFFER_SEGMENT_SIZE),
-    DEFAULT_MIN_BUFFER_MS,
-    DEFAULT_MAX_BUFFER_MS,
-    DEFAULT_BUFFER_FOR_PLAYBACK_MS,
-    DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS,
-    DEFAULT_TARGET_BUFFER_BYTES,
-    DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS,
-    DEFAULT_BACK_BUFFER_DURATION_MS,
-    DEFAULT_RETAIN_BACK_BUFFER_FROM_KEYFRAME
-  )
-
-  init {
-    assertGreaterOrEqual(bufferForPlaybackMs, 0, "bufferForPlaybackMs", "0")
-    assertGreaterOrEqual(
-      bufferForPlaybackAfterRebufferMs,
-      0,
-      "bufferForPlaybackAfterRebufferMs",
-      "0"
-    )
-    assertGreaterOrEqual(minBufferMs, bufferForPlaybackMs, "minBufferMs", "bufferForPlaybackMs")
-    assertGreaterOrEqual(
-      minBufferMs,
-      bufferForPlaybackAfterRebufferMs,
-      "minBufferMs",
-      "bufferForPlaybackAfterRebufferMs"
-    )
-    assertGreaterOrEqual(maxBufferMs, minBufferMs, "maxBufferMs", "minBufferMs")
-    assertGreaterOrEqual(backBufferDurationMs, 0, "backBufferDurationMs", "0")
-
-    this.allocator = allocator
-    this.minBufferUs = Util.msToUs(minBufferMs.toLong())
-    this.maxBufferUs = Util.msToUs(maxBufferMs.toLong())
-    this.bufferForPlaybackUs = Util.msToUs(bufferForPlaybackMs.toLong())
-    this.bufferForPlaybackAfterRebufferUs = Util.msToUs(bufferForPlaybackAfterRebufferMs.toLong())
-    this.targetBufferBytesOverwrite = targetBufferBytes
-    this.targetBufferBytes =
-      if (targetBufferBytesOverwrite != C.LENGTH_UNSET
-      ) {
-        targetBufferBytesOverwrite
-      } else {
-        DEFAULT_MIN_BUFFER_SIZE
-      }
-    this.prioritizeTimeOverSizeThresholds = prioritizeTimeOverSizeThresholds
-    this.backBufferDurationUs = Util.msToUs(backBufferDurationMs.toLong())
-    this.retainBackBufferFromKeyframe = retainBackBufferFromKeyframe
-  }
 
   fun applyBufferOptions(bufferOptions: BufferOptions) {
-    bufferOptions.preferredForwardBufferDuration?.let {
-      targetBufferMs = (it * 1000).toLong()
-    } ?: run {
-      targetBufferMs = DEFAULT_MAX_BUFFER_MS.toLong()
-    }
+    targetBufferMs = bufferOptions.preferredForwardBufferDuration?.let { (it * 1000).toLong() }
+      ?: DEFAULT_MAX_BUFFER_MS.toLong()
 
     targetBufferBytesOverwrite = if (bufferOptions.maxBufferBytes == 0L) {
       C.LENGTH_UNSET
@@ -283,243 +38,21 @@ private constructor(
     }
 
     if (targetBufferBytesOverwrite != C.LENGTH_UNSET) {
-      targetBufferBytes = targetBufferBytesOverwrite
+      for (state in loadingStates.values) {
+        state.targetBufferBytes = targetBufferBytesOverwrite
+      }
     }
-
-    applyBufferBytes()
 
     prioritizeTimeOverSizeThresholds = bufferOptions.prioritizeTimeOverSizeThreshold
 
-    val optionsBufferForPlaybackMs = bufferOptions.minBufferForPlayback * 1000
-    val safeBufferForPlayback = if (optionsBufferForPlaybackMs > targetBufferMs) {
+    val safeBufferForPlayback = if (bufferOptions.minBufferForPlayback * 1000 > targetBufferMs) {
       targetBufferMs
     } else {
-      bufferOptions.minBufferForPlayback
+      (bufferOptions.minBufferForPlayback * 1000).toLong()
     }
-    bufferForPlaybackMs = safeBufferForPlayback.toLong()
-    bufferForPlaybackAfterRebufferMs = safeBufferForPlayback.toLong()
-  }
+    bufferForPlaybackMs = safeBufferForPlayback
+    bufferForPlaybackAfterRebufferMs = safeBufferForPlayback
 
-  private fun applyBufferBytes() {
-    val calculatedBufferBytes = this.renderers?.let { renderers ->
-      this.trackSelections?.let { trackSelections ->
-        calculateTargetBufferBytes(renderers, trackSelections)
-      }
-    }
-
-    if (targetBufferBytesOverwrite == C.LENGTH_UNSET && calculatedBufferBytes != null) {
-      allocator.setTargetBufferSize(calculatedBufferBytes)
-      targetBufferBytes = calculatedBufferBytes
-    } else {
-      allocator.setTargetBufferSize(targetBufferBytesOverwrite)
-    }
-  }
-
-  override fun onPrepared() {
-    reset(false)
-  }
-
-  override fun onTracksSelected(
-    timeline: Timeline,
-    mediaPeriodId: MediaSource.MediaPeriodId,
-    renderers: Array<Renderer>,
-    trackGroups: TrackGroupArray,
-    trackSelections: Array<ExoTrackSelection>
-  ) {
-    this.renderers = renderers
-    this.trackSelections = trackSelections
-    applyBufferBytes()
-  }
-
-  override fun onStopped() {
-    reset(true)
-  }
-
-  override fun onReleased() {
-    reset(true)
-  }
-
-  override fun getAllocator(): Allocator {
-    return allocator
-  }
-
-  override fun getBackBufferDurationUs(): Long {
-    return backBufferDurationUs
-  }
-
-  override fun retainBackBufferFromKeyframe(): Boolean {
-    return retainBackBufferFromKeyframe
-  }
-
-  override fun shouldContinueLoading(
-    playbackPositionUs: Long,
-    bufferedDurationUs: Long,
-    playbackSpeed: Float
-  ): Boolean {
-    val targetBufferSizeReached = allocator.totalBytesAllocated >= targetBufferBytes
-    var minBufferUs = this.minBufferUs
-    if (playbackSpeed > 1) {
-      // The playback speed is faster than real time, so scale up the minimum required media
-      // duration to keep enough media buffered for a playout duration of minBufferUs.
-      val mediaDurationMinBufferUs =
-        Util.getMediaDurationForPlayoutDuration(minBufferUs, playbackSpeed)
-      minBufferUs = min(mediaDurationMinBufferUs.toDouble(), maxBufferUs.toDouble()).toLong()
-    }
-    // Prevent playback from getting stuck if minBufferUs is too small.
-    minBufferUs = max(minBufferUs.toDouble(), 500000.0).toLong()
-    if (bufferedDurationUs < minBufferUs) {
-      isLoading = prioritizeTimeOverSizeThresholds || !targetBufferSizeReached
-      if (!isLoading && bufferedDurationUs < 500000) {
-        Log.w(
-          "DefaultLoadControl",
-          "Target buffer size reached with less than 500ms of buffered media data."
-        )
-      }
-    } else if (bufferedDurationUs >= maxBufferUs || targetBufferSizeReached) {
-      isLoading = false
-    } // Else don't change the loading state.
-
-    return isLoading
-  }
-
-  override fun shouldStartPlayback(
-    timeline: Timeline,
-    mediaPeriodId: MediaSource.MediaPeriodId,
-    bufferedDurationUs: Long,
-    playbackSpeed: Float,
-    rebuffering: Boolean,
-    targetLiveOffsetUs: Long
-  ): Boolean {
-    var bufferedDurationUs = bufferedDurationUs
-    bufferedDurationUs = Util.getPlayoutDurationForMediaDuration(bufferedDurationUs, playbackSpeed)
-    var minBufferDurationUs = if (rebuffering) bufferForPlaybackAfterRebufferUs else bufferForPlaybackUs
-    if (targetLiveOffsetUs != C.TIME_UNSET) {
-      minBufferDurationUs = min((targetLiveOffsetUs / 2).toDouble(), minBufferDurationUs.toDouble()).toLong()
-    }
-    return minBufferDurationUs <= 0 || bufferedDurationUs >= minBufferDurationUs || (
-      !prioritizeTimeOverSizeThresholds &&
-        allocator.totalBytesAllocated >= targetBufferBytes
-      )
-  }
-
-  /**
-   * Calculate target buffer size in bytes based on the selected tracks. The player will try not to
-   * exceed this target buffer. Only used when `targetBufferBytes` is [C.LENGTH_UNSET].
-   *
-   * @param renderers The renderers for which the track were selected.
-   * @param trackSelectionArray The selected tracks.
-   * @return The target buffer size in bytes.
-   */
-  protected fun calculateTargetBufferBytes(
-    renderers: Array<Renderer>,
-    trackSelectionArray: Array<ExoTrackSelection>
-  ): Int {
-    var targetBufferSize = 0
-    for (i in renderers.indices) {
-      if (trackSelectionArray[i] != null) {
-        targetBufferSize += getDefaultBufferSize(renderers[i].trackType)
-      }
-    }
-    return max(DEFAULT_MIN_BUFFER_SIZE.toDouble(), targetBufferSize.toDouble()).toInt()
-  }
-
-  private fun reset(resetAllocator: Boolean) {
-    targetBufferBytes =
-      if (targetBufferBytesOverwrite == C.LENGTH_UNSET
-      ) {
-        DEFAULT_MIN_BUFFER_SIZE
-      } else {
-        targetBufferBytesOverwrite
-      }
-    isLoading = false
-    if (resetAllocator) {
-      allocator.reset()
-    }
-  }
-
-  companion object {
-    /**
-     * The default minimum duration of media that the player will attempt to ensure is buffered at all
-     * times, in milliseconds.
-     */
-    const val DEFAULT_MIN_BUFFER_MS: Int = 25000
-
-    /**
-     * The default maximum duration of media that the player will attempt to buffer, in milliseconds.
-     */
-    const val DEFAULT_MAX_BUFFER_MS: Int = 25000
-
-    /**
-     * The default duration of media that must be buffered for playback to start or resume following a
-     * user action such as a seek, in milliseconds.
-     */
-    const val DEFAULT_BUFFER_FOR_PLAYBACK_MS: Int = 2000
-
-    /**
-     * The default duration of media that must be buffered for playback to resume after a rebuffer, in
-     * milliseconds. A rebuffer is defined to be caused by buffer depletion rather than a user action.
-     */
-    const val DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS: Int = 2000
-
-    /**
-     * The default target buffer size in bytes. The value ([C.LENGTH_UNSET]) means that the load
-     * control will calculate the target buffer size based on the selected tracks.
-     */
-    const val DEFAULT_TARGET_BUFFER_BYTES: Int = C.LENGTH_UNSET
-
-    /** The default prioritization of buffer time constraints over size constraints.  */
-    const val DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS: Boolean = false
-
-    /** The default back buffer duration in milliseconds.  */
-    const val DEFAULT_BACK_BUFFER_DURATION_MS: Int = 0
-
-    /** The default for whether the back buffer is retained from the previous keyframe.  */
-    const val DEFAULT_RETAIN_BACK_BUFFER_FROM_KEYFRAME: Boolean = false
-
-    /** A default size in bytes for a video buffer.  */
-    const val DEFAULT_VIDEO_BUFFER_SIZE: Int = 2000 * C.DEFAULT_BUFFER_SEGMENT_SIZE
-
-    /** A default size in bytes for an audio buffer.  */
-    const val DEFAULT_AUDIO_BUFFER_SIZE: Int = 200 * C.DEFAULT_BUFFER_SEGMENT_SIZE
-
-    /** A default size in bytes for a text buffer.  */
-    const val DEFAULT_TEXT_BUFFER_SIZE: Int = 2 * C.DEFAULT_BUFFER_SEGMENT_SIZE
-
-    /** A default size in bytes for a metadata buffer.  */
-    const val DEFAULT_METADATA_BUFFER_SIZE: Int = 2 * C.DEFAULT_BUFFER_SEGMENT_SIZE
-
-    /** A default size in bytes for a camera motion buffer.  */
-    const val DEFAULT_CAMERA_MOTION_BUFFER_SIZE: Int = 2 * C.DEFAULT_BUFFER_SEGMENT_SIZE
-
-    /** A default size in bytes for an image buffer.  */
-    const val DEFAULT_IMAGE_BUFFER_SIZE: Int = 2 * C.DEFAULT_BUFFER_SEGMENT_SIZE
-
-    /** A default size in bytes for a muxed buffer (e.g. containing video, audio and text).  */
-    val DEFAULT_MUXED_BUFFER_SIZE: Int = VideoPlayerLoadControl.DEFAULT_VIDEO_BUFFER_SIZE + VideoPlayerLoadControl.DEFAULT_AUDIO_BUFFER_SIZE + VideoPlayerLoadControl.DEFAULT_TEXT_BUFFER_SIZE
-
-    /**
-     * The buffer size in bytes that will be used as a minimum target buffer in all cases. This is
-     * also the default target buffer before tracks are selected.
-     */
-    const val DEFAULT_MIN_BUFFER_SIZE: Int = 200 * C.DEFAULT_BUFFER_SEGMENT_SIZE
-
-    private fun getDefaultBufferSize(trackType: @C.TrackType Int): Int {
-      return when (trackType) {
-        C.TRACK_TYPE_DEFAULT -> DEFAULT_MUXED_BUFFER_SIZE
-        C.TRACK_TYPE_AUDIO -> DEFAULT_AUDIO_BUFFER_SIZE
-        C.TRACK_TYPE_VIDEO -> DEFAULT_VIDEO_BUFFER_SIZE
-        C.TRACK_TYPE_TEXT -> DEFAULT_TEXT_BUFFER_SIZE
-        C.TRACK_TYPE_METADATA -> DEFAULT_METADATA_BUFFER_SIZE
-        C.TRACK_TYPE_CAMERA_MOTION -> DEFAULT_CAMERA_MOTION_BUFFER_SIZE
-        C.TRACK_TYPE_IMAGE -> DEFAULT_IMAGE_BUFFER_SIZE
-        C.TRACK_TYPE_NONE -> 0
-        C.TRACK_TYPE_UNKNOWN -> throw IllegalArgumentException()
-        else -> throw IllegalArgumentException()
-      }
-    }
-
-    private fun assertGreaterOrEqual(value1: Int, value2: Int, name1: String, name2: String) {
-      Assertions.checkArgument(value1 >= value2, "$name1 cannot be less than $name2")
-    }
+    updateAllocator()
   }
 }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/BufferOptions.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/BufferOptions.kt
@@ -3,13 +3,14 @@ package expo.modules.video.records
 import androidx.media3.common.util.UnstableApi
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.video.player.VideoPlayerLoadControl
+import expo.modules.video.player.DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS
+import expo.modules.video.player.DefaultLoadControl.DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS
 import java.io.Serializable
 
 @UnstableApi
 class BufferOptions(
   @Field var preferredForwardBufferDuration: Double? = null,
   @Field var maxBufferBytes: Long = 0,
-  @Field var prioritizeTimeOverSizeThreshold: Boolean = VideoPlayerLoadControl.DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS,
-  @Field var minBufferForPlayback: Double = VideoPlayerLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS.toDouble() / 1000
+  @Field var prioritizeTimeOverSizeThreshold: Boolean = DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS,
+  @Field var minBufferForPlayback: Double = DEFAULT_BUFFER_FOR_PLAYBACK_MS.toDouble() / 1000
 ) : Record, Serializable


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/39086

We are using an outdated media3 version from 10 months ago. We can bump it from 1.4.0 to 1.8.0.
We are using a modified version of `DefaultLoadController.java` from media3 source, converted to `VideoLoadController.kt` to provide buffering options to our users.  While writing this PR I've found out that the upgrade process with the current arrangement is a bit of a nightmare when changes to `DefaultLoadController` are introduced in media3. That is, because it hard to see what actually changed and needs to be updated between the versions. I've decided to change the approach - see below:

# How

- Bumped media3 to 1.8.0 version. 
- DefaultLoadController is now copied and left in java, the few simple, minimal changes (making stuff non-private) are explained in the note at the top
- `VideoLoadController` inherits from `DefaultLoadController` providing support for `BufferOptions`
This should make the upgrade process in the future easy.

# Test Plan

Tested in BareExpo on Android
