### PR TITLE
[expo-router] fix active font size on web

### DIFF
--- a/apps/router-e2e/__e2e__/native-tabs/app/_layout.tsx
+++ b/apps/router-e2e/__e2e__/native-tabs/app/_layout.tsx
@@ -2,7 +2,7 @@ import MIcons from '@expo/vector-icons/MaterialIcons';
 import { ThemeProvider, DarkTheme } from '@react-navigation/native';
 import { Badge, Icon, Label, NativeTabs, VectorIcon } from 'expo-router/unstable-native-tabs';
 import { useState } from 'react';
-import { Appearance } from 'react-native';
+import { Appearance, Platform } from 'react-native';
 
 import { ActiveTabsContext } from '../utils/active-tabs-context';
 
@@ -82,7 +82,9 @@ export default function Layout() {
             <Badge>1</Badge>
           </NativeTabs.Trigger>
           <NativeTabs.Trigger name="explore">
-            <Icon src={<VectorIcon family={MIcons} name="compass-calibration" />} />
+            {Platform.OS !== 'web' && (
+              <Icon src={<VectorIcon family={MIcons} name="compass-calibration" />} />
+            )}
             <Label>Explore</Label>
           </NativeTabs.Trigger>
           <NativeTabs.Trigger name="dynamic">

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [web] fix active font size on web ([#39190](https://github.com/expo/expo/pull/39190) by [@Ubax](https://github.com/Ubax))
+
 ### 💡 Others
 
 ## 6.0.0-beta.8 — 2025-08-26

--- a/packages/expo-router/assets/native-tabs.module.css
+++ b/packages/expo-router/assets/native-tabs.module.css
@@ -73,7 +73,7 @@
 
 .navigationMenuTrigger[data-state="active"] .tabText {
   color: var(--expo-router-tabs-active-text-color, #ffffff);
-  font-size: var(--expo-router-tabs-active-font-size);
+  font-size: var(--expo-router-tabs-active-font-size, var(--expo-router-tabs-font-size, 15px));
 }
 
 .navigationMenuTrigger:not([data-state="active"]) .tabText:hover {


### PR DESCRIPTION
# Why

Solves: https://linear.app/expo/issue/ENG-17049/the-size-of-the-native-tab-bar-on-web-changes-when-switching-tabs

# How

1. When active font size is not set, use the default font size

# Test Plan

1. Manual testing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
