### PR TITLE
[android][expo-updates] Fixed id and commitTime not regenerating from manifest during build

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [android][expo-updates] Fixed id and commitTime not regenerating from manifest during build ([#39195](https://github.com/expo/expo/pull/39195) by [@RodolfoGS](https://github.com/RodolfoGS))
+- [android][expo-updates] Fixed `id` and `commitTime` not regenerating from manifest during build ([#39195](https://github.com/expo/expo/pull/39195) by [@RodolfoGS](https://github.com/RodolfoGS))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [android][expo-updates] Fixed id and commitTime not regenerating from manifest during build ([#39195](https://github.com/expo/expo/pull/39195) by [@RodolfoGS](https://github.com/RodolfoGS))
+
 ### 💡 Others
 
 ## 29.0.5 — 2025-08-26

--- a/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
+++ b/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
@@ -45,6 +45,9 @@ abstract class ExpoUpdatesPlugin : Plugin<Project> {
         it.nodeExecutableAndArgs.set(reactExtension.nodeExecutableAndArgs.get())
         it.debuggableVariant.set(isDebuggableVariant)
         it.entryFile.set(entryFile.toPath().toString())
+
+        // Force task to run every time to regenerate id and commitTime
+        it.outputs.upToDateWhen { false }
       }
       variant.sources.assets?.addGeneratedSourceDirectory(createUpdatesResourcesTask, CreateUpdatesResourcesTask::assetDir)
     }


### PR DESCRIPTION
# Why

Fix https://github.com/expo/expo/issues/38164

# How

Force to run the task to regenerate the `id` and `commitTime` from the manifest during build.

# Test Plan

### Before the fix:
1. Install `expo-updates`
2. Compile Android APK
3. Unzip the APK and note the `id` and `commitTime` from the manifest (`apk/assets/app.manifest`)
4. Do the step 2 and 3 again.
5. ❌ The `id` and `commitTime` did not change

### After the fix:
1. Install `expo-updates`
2. Compile Android APK
3. Unzip the APK and note the `id` and `commitTime` from the manifest (`apk/assets/app.manifest`)
4. Do the step 2 and 3 again.
5. ✅ The `id` and `commitTime` are different

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
