### PR TITLE
[docs] Document how to save assets for later use with Maestro

### DIFF
--- a/docs/pages/eas/workflows/examples/e2e-tests.mdx
+++ b/docs/pages/eas/workflows/examples/e2e-tests.mdx
@@ -125,14 +125,14 @@ jobs:
     type: maestro
     params:
       build_id: ${{ needs.build_android_for_e2e.outputs.build_id }}
-      flow_path: ['.maestro/home.yml']
+      flow_path: ['.maestro/home.yml', '.maestro/expand_test.yml']
 ```
 
 This workflow builds an **.apk** for Android using the `e2e-test` build profile from the previous step. Then it runs the **.maestro/home.yml** flow on the built APK.
 
 Here's an example of the same test workflow for iOS:
 
-```yaml .eas/workflows/e2e-test.yml
+```yaml .eas/workflows/e2e-test-ios.yml
 name: e2e-test-ios
 
 on:
@@ -151,7 +151,7 @@ jobs:
     type: maestro
     params:
       build_id: ${{ needs.build_ios_for_e2e.outputs.build_id }}
-      flow_path: ['.maestro/home.yml']
+      flow_path: ['.maestro/home.yml', '.maestro/expand_test.yml']
 ```
 
 Learn more about [Syntax for EAS Workflows](/eas/workflows/syntax/).

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -882,9 +882,9 @@ jobs:
 
 </Collapsible>
 
-<Collapsible summary="Saving assets for use in subsequent steps">
+<Collapsible summary="Saving screenshots and recordings">
 
-To save assets created by Maestro commands (such as [takeScreenshot](https://docs.maestro.dev/api-reference/commands/takescreenshot) or [startRecording](https://docs.maestro.dev/api-reference/commands/startrecording)) for use in subsequent workflow steps, use the `MAESTRO_TESTS_DIR` environment variable to specify predictable file locations.
+To save assets created by Maestro commands (such as [`takeScreenshot`](https://docs.maestro.dev/api-reference/commands/takescreenshot) or [`startRecording`](https://docs.maestro.dev/api-reference/commands/startrecording)) to use for debugging later, use the `MAESTRO_TESTS_DIR` environment variable.
 
 In your Maestro flow file, specify the asset locations:
 
@@ -899,7 +899,7 @@ appId: com.myapp
 - stopRecording
 ```
 
-The assets created in one step will be available at the specified paths (e.g., `${MAESTRO_TESTS_DIR}/my_recording` and `${MAESTRO_TESTS_DIR}/my_screenshot`) in subsequent workflow steps.
+The assets will be available within the "Maestro Test Results" artifact in the Artifacts section.
 
 </Collapsible>
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -882,6 +882,27 @@ jobs:
 
 </Collapsible>
 
+<Collapsible summary="Saving assets for use in subsequent steps">
+
+To save assets created by Maestro commands (such as [takeScreenshot](https://docs.maestro.dev/api-reference/commands/takescreenshot) or [startRecording](https://docs.maestro.dev/api-reference/commands/startrecording)) for use in subsequent workflow steps, use the `MAESTRO_TESTS_DIR` environment variable to specify predictable file locations.
+
+In your Maestro flow file, specify the asset locations:
+
+```yaml maestro/flows/test-flow.yaml
+appId: com.myapp
+---
+- launchApp
+- startRecording: ${MAESTRO_TESTS_DIR}/my_recording
+- takeScreenshot: ${MAESTRO_TESTS_DIR}/my_screenshot
+- tapOn: 'Login Button'
+- takeScreenshot: ${MAESTRO_TESTS_DIR}/after_login_screenshot
+- stopRecording
+```
+
+The assets created in one step will be available at the specified paths (e.g., `${MAESTRO_TESTS_DIR}/my_recording` and `${MAESTRO_TESTS_DIR}/my_screenshot`) in subsequent workflow steps.
+
+</Collapsible>
+
 ## Maestro Cloud
 
 Run Maestro tests on Maestro Cloud.


### PR DESCRIPTION
# Why

It came up on Discord and I noticed it was not documented yet.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Add instructions on how to save assets for later use.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

See the last section in the Maestro job docs.

<img width="955" height="490" alt="Screenshot 2025-08-28 at 14 20 41" src="https://github.com/user-attachments/assets/f0cbfbf1-b4f7-428b-aa32-8190b629c136" />


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
