### PR TITLE
[docs] Add example for react-native-edge-to-edge config plugin when explicitly setting userInterfaceStyle property to 'light' or 'dark'

### DIFF
--- a/docs/pages/develop/user-interface/color-themes.mdx
+++ b/docs/pages/develop/user-interface/color-themes.mdx
@@ -92,6 +92,34 @@ The `userInterfaceStyle` property supports the following values:
 - `light`: Restrict the app to support light theme only.
 - `dark`: Restrict the app to support dark theme only.
 
+<Collapsible summary="Using react-native-edge-to-edge?">
+
+#### Android
+
+If `userInterfaceStyle` property is set to `light` or `dark` ensure the `parentTheme` property is set correctly using the `react-native-edge-to-edge` config plugin:
+
+```json app.json
+{
+  "expo": {
+    "android": "light"
+    "plugins": [
+      [
+        "react-native-edge-to-edge",
+        {
+          "android": {
+            "parentTheme": "Light",
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+For a complete overview of all available options, refer to the [react-native-edge-to-edge README](https://github.com/zoontek/react-native-edge-to-edge?tab=readme-ov-file#expo).
+
+</Collapsible>
+
 ## Detect the color scheme
 
 To detect the color scheme in your project, use `Appearance` or `useColorScheme` from `react-native`:

--- a/docs/pages/develop/user-interface/color-themes.mdx
+++ b/docs/pages/develop/user-interface/color-themes.mdx
@@ -101,7 +101,10 @@ If `userInterfaceStyle` property is set to `light` or `dark` ensure the `parentT
 ```json app.json
 {
   "expo": {
-    "android": "light"
+    "userInterfaceStyle": "light",
+    "android": {
+      "edgeToEdgeEnabled": true,
+    },
     "plugins": [
       [
         "react-native-edge-to-edge",


### PR DESCRIPTION
# Why

On Android when userInterfaceStyle property is set to 'light' but react-native-edge-to-edge parentTheme is not set some components like Text don't respect the userInterfaceStyle property when changing device themes.

# How

Added react-native-edge-to-edge config plugin example when explicitly setting userInterfaceStyle property to 'light' or 'dark'.

# Test Plan

N/A

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)