### PR TITLE
[ci][android] Fix `KotlinInteropModuleRegistryTest`

### DIFF
--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -72,7 +72,7 @@ private val provider = object : ModulesProvider {
 class KotlinInteropModuleRegistryTest {
   private val interopModuleRegistry = KotlinInteropModuleRegistry(
     provider,
-    mockk(),
+    mockk(relaxed = true),
     WeakReference(mockk(relaxed = true))
   )
 


### PR DESCRIPTION
# Why
These tests were failing

# How
Add `mockk(relaxed = true)` so that Unit return types are inferred. 

# Test Plan
Tests pass

