### PR TITLE
Upgrade react-native-worklets to 0.4.2

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -77,7 +77,7 @@
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",
-    "react-native-worklets": "0.4.1",
+    "react-native-worklets": "0.4.2",
     "test-suite": "*"
   },
   "devDependencies": {

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -84,7 +84,7 @@
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",
-    "react-native-worklets": "0.4.1",
+    "react-native-worklets": "0.4.2",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",
     "redux": "^4.0.5",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -146,7 +146,7 @@
     "react-native-maps": "1.20.1",
     "react-native-pager-view": "6.9.1",
     "react-native-paper": "^5.12.5",
-    "react-native-worklets": "0.4.1",
+    "react-native-worklets": "0.4.2",
     "react-native-reanimated": "4.0.2",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.15.3",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -99,7 +99,7 @@
   "react-native-keyboard-controller": "1.18.5",
   "react-native-maps": "1.20.1",
   "react-native-pager-view": "6.9.1",
-  "react-native-worklets": "~0.4.1",
+  "react-native-worklets": "~0.4.2",
   "react-native-reanimated": "~4.0.2",
   "react-native-screens": "~4.15.3",
   "react-native-safe-area-context": "~5.6.0",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -31,7 +31,7 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.1",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-worklets": "~0.4.1",
+    "react-native-worklets": "~0.4.2",
     "react-native-reanimated": "~4.0.2",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.15.3",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -24,7 +24,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.1",
-    "react-native-worklets": "~0.4.1",
+    "react-native-worklets": "~0.4.2",
     "react-native-reanimated": "~4.0.2",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.15.3",


### PR DESCRIPTION
# Why

RNWorklets was missing a dependency on React-hermes which caused USE_FRAMEWORKS to fail with precompiled binaries.

This was fixed in RNWorklets here:

https://github.com/software-mansion/react-native-reanimated/pull/8120

# How

Upgraded react-native-worklets from 0.4.1 -> 0.4.2

# Test Plan

Build BareExpo with precompiled on iOS (enabled by default) and USE_FRAMEWORKS enabled. Observe that react-native-worklets no longer fails to compile (but BareExpo will fail, precompiled/USE_FRAMEWORKS not yet ready)

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
