### PR TITLE
[core][ios] AppContext in views environment

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - [Android] Adds support for `ArrayBuffer`. ([#39943](https://github.com/expo/expo/pull/39943) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Introduce ExpoAppDelegateSubscriberManager class ([#40008](https://github.com/expo/expo/pull/40008) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [iOS] Add `AppContext` to views environment it can be accessed if needed. ([#39207](https://github.com/expo/expo/pull/39207) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Add `AppContext` to views environment so it can be accessed if needed. ([#39207](https://github.com/expo/expo/pull/39207) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [Android] Adds support for `ArrayBuffer`. ([#39943](https://github.com/expo/expo/pull/39943) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Introduce ExpoAppDelegateSubscriberManager class ([#40008](https://github.com/expo/expo/pull/40008) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Add `AppContext` to views environment it can be accessed if needed.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - [Android] Adds support for `ArrayBuffer`. ([#39943](https://github.com/expo/expo/pull/39943) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Introduce ExpoAppDelegateSubscriberManager class ([#40008](https://github.com/expo/expo/pull/40008) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [iOS] Add `AppContext` to views environment it can be accessed if needed.
+- [iOS] Add `AppContext` to views environment it can be accessed if needed. ([#39207](https://github.com/expo/expo/pull/39207) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIEnvironment.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIEnvironment.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+extension ExpoSwiftUI {
+  public struct AppContextKey: EnvironmentKey {
+    public static let defaultValue: AppContext? = nil
+  }
+}
+
+extension EnvironmentValues {
+  public var appContext: AppContext? {
+    get { self[ExpoSwiftUI.AppContextKey.self] }
+    set { self[ExpoSwiftUI.AppContextKey.self] = newValue }
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -65,7 +65,11 @@ extension ExpoSwiftUI {
      */
     init(viewType: ContentView.Type, props: Props, appContext: AppContext) {
       self.contentView = ContentView(props: props)
-      let rootView = AnyView(contentView.environmentObject(shadowNodeProxy))
+      let rootView = AnyView(
+        contentView
+          .environmentObject(shadowNodeProxy)
+          .environment(\.appContext, appContext)
+      )
       self.props = props
       let controller = UIHostingController(rootView: rootView)
 


### PR DESCRIPTION
# Why
Sometimes it's useful to have access to the `AppContext` in views. We have this in `ExpoView` so adding a method to access it from swiftUI views.

# How
Add an environment key and attach the `AppContext` when the view is created. There is no observation overhead here as the `AppContext` is treated as effectively read-only. It's the same object passed through the hierarchy with no published properties. 

Usage
```swift
struct MyView: ExpoSwiftUI.View {
  @Environment(\.appContext) private var appContext
}
```

# Test Plan
Bare-expo ✅

