### PR TITLE
upgrade react-native-screens to 4.15.4

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2757,7 +2757,7 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNScreens (4.15.3):
+  - RNScreens (4.15.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2779,9 +2779,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNScreens/common (= 4.15.3)
+    - RNScreens/common (= 4.15.4)
     - Yoga
-  - RNScreens/common (4.15.3):
+  - RNScreens/common (4.15.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2849,7 +2849,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets (0.4.1):
+  - RNWorklets (0.4.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2859,6 +2859,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
     - React-jsi
     - React-NativeModulesApple
@@ -2870,9 +2871,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/worklets (= 0.4.1)
+    - RNWorklets/worklets (= 0.4.2)
     - Yoga
-  - RNWorklets/worklets (0.4.1):
+  - RNWorklets/worklets (0.4.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2882,6 +2883,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
     - React-jsi
     - React-NativeModulesApple
@@ -2893,9 +2895,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/worklets/apple (= 0.4.1)
+    - RNWorklets/worklets/apple (= 0.4.2)
     - Yoga
-  - RNWorklets/worklets/apple (0.4.1):
+  - RNWorklets/worklets/apple (0.4.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2905,6 +2907,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
     - React-jsi
     - React-NativeModulesApple
@@ -3540,90 +3543,90 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  BenchmarkingModule: 272c02f4a7e9e0d9e9f25d018661094608e2d91f
-  EASClient: 2da432b06330907695b6660a8a7990c488f69dd2
-  EXApplication: df3ab389fa135b8d7f68b5a62f06b827dd46b8fd
-  EXAV: 4b6ecbfb0554f537d0b4af4c43d522473ea2a48c
-  EXConstants: 02e2a69e11c641fa20fa262947d167fab3ecb200
-  EXImageLoader: 189e3476581efe3ad4d1d3fb4735b7179eb26f05
+  BenchmarkingModule: 69aa39c6f6d42bf6fc47caeacb070d24de22d54f
+  EASClient: c5cf14bd2cac2ddb823e6e82475f84c35d521e17
+  EXApplication: 194b1a0fd9a9e4ee8326d95a85362df8bb0dfb4a
+  EXAV: 91e715adb687e6657bbd9ed4beafee483d368b3a
+  EXConstants: f6f14a2aece3ab12ed925c9ee29c8bc7d6be61aa
+  EXImageLoader: e501c001bc40b8326605e82e6e80363c80fe06b5
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: ba44a6836e3ec4fa5e947c6db39ab1ec9e871de1
-  EXNotifications: e4995fac6ea317a55f56679342962256d15b1865
-  Expo: 4f020fbc9a6d36f3028917c8269d0354be70d743
-  expo-dev-client: 90ec1d6fb55e9e05866f405bc3311d82ef212da7
-  expo-dev-launcher: 7ea52963531f04a49adac5fd06ef2e4afac7c17f
-  expo-dev-menu: 2ab5bf4c8112d1ee311edf981210ee789c7db84e
+  EXManifests: c110cbe41d9def69d37c101edf84181925a73c7b
+  EXNotifications: eeadd008c17a8651e3c206b72c9f5e6bfa765ca6
+  Expo: 80029cb47305dd33288be98e6de4da0b2f9647ea
+  expo-dev-client: 2deff21aafcf49d10c961b48727813daa9b46ce1
+  expo-dev-launcher: 5ed870b1b72570224c4c44bd37c67e30c23c2dd8
+  expo-dev-menu: 776501cf36a1513136f727bb40029066e62b0b63
   expo-dev-menu-interface: 600df12ea01efecdd822daaf13cc0ac091775533
-  ExpoAppIntegrity: df6d90d7d5056107d15973482a051eda98ccbf22
-  ExpoAppleAuthentication: 00cb9ae1572a39af3d76d829e22c58d096638620
-  ExpoAsset: 88b5636713bc233a3819bc83a2e69130d385fadc
-  ExpoAudio: 8934673769246bf0c31eed3291c063f0d3d36674
-  ExpoBackgroundFetch: b7e562ae0562ef65b8d07e7879adff71a08523c7
-  ExpoBackgroundTask: d354b0de714b32adfafbf1429ef54e003d348f7a
-  ExpoBattery: 8c21f8fc3dc7d844ce52bdcf497415b939cbf92d
-  ExpoBlob: fb262f4e1de3a06c113e73e8923ecafb278f0ca1
-  ExpoBlur: b94d599fc9ac76f9db50c8406613da332d280e4c
-  ExpoBrightness: 685d9eeaf88793cd821e303ae6f83cd5e6a5d7a3
-  ExpoCalendar: f56bdfa447f84798eec45d20469573201cbce6ee
-  ExpoCamera: 58795c3070de5d7f45b1b59283e95b78630337c0
-  ExpoCellular: 9c1754931458316970154af3db3da2402fba86fa
-  ExpoClipboard: b47fa1d4a8b5390f09feca7a092878bd6ef9e4b3
-  ExpoContacts: d07817cc6c091d207bfa771a0d404e245fbedc96
-  ExpoCrypto: fb84db5b00d758ce30d31013cd33e33fed9c7981
-  ExpoDevice: 361879fb8c0ed1abec6c2bf5f32d7ce46744c73b
-  ExpoDocumentPicker: 8eb69d67b237e0e88d072fec9a95b15333d392ec
-  ExpoDomWebView: 4e0559eee7b80d727b46bdab2f9803433a3ebbb6
-  ExpoFileSystem: 95cb3f55bc14c80c464793973e33539c59e8a58a
-  ExpoFont: e533472deff8181f9b4a27ad39d4a00996a79ceb
-  ExpoGL: 5b6ded7547537d06a8a36435f37a01054875b06d
-  ExpoHaptics: f20dc9498e94a4b70c8d0097ac04ac3701ae4a0c
-  ExpoImage: 0cc208541bd217cff611c831dca7d0c3bfb4fd3f
-  ExpoImageManipulator: a761ed203e6cceb550ef6ec38e45cb26f90e7424
-  ExpoImagePicker: 5b8605982bf41611fa1fb9e537971125cf2c3c36
-  ExpoInsights: 0a80f20096ae465ce554aa348031b79c56f54ca1
-  ExpoKeepAwake: cf946c3cb68c4aae9d042a1f245d74984e349b98
-  ExpoLinearGradient: e3651d3cafe53a2a5a1cdccdca2a3e6e9928b0fa
-  ExpoLinking: dc1f27352a9223dbb3b0e78a51add62ccf7f4242
-  ExpoLivePhoto: 6b60f819ca789bf01818cbce6995d96c4b6275ef
-  ExpoLocalAuthentication: c0d2e91f4827126099588a7f8d9964686c36c0a5
-  ExpoLocalization: e1447009a5c398706bf79d9f4b3f5e0ec344db20
-  ExpoLocation: 57d4e26a7727de45638ac6d2d650c7271d768e75
-  ExpoMailComposer: bd7ef338e2080b28a7364feb6aa33dcdd0909267
-  ExpoMaps: 912a760f39c63c50a225613e3e79ba8f0e4fa8a0
-  ExpoMediaLibrary: da23763613cfef9afe6784e071ef2e9f9197a346
-  ExpoMeshGradient: 372ab0f2ad554416c32fd46675dbb5a068115ad3
-  ExpoModulesCore: 29cbf40cfd161d34c2c9dc2c3f409a11f92d24aa
-  ExpoModulesTestCore: be5073c51ffe7c2db9f14aedfce7d8cdc141f55a
-  ExpoNetwork: cb29bcf3ac401fcb0b2f10d18ab3507fcf4efe89
-  ExpoPrint: 262fbd40c537359c5a708d1cac030cf03bb7fbac
-  ExpoScreenCapture: 441dc1fbf881c3e0e11cda654faaedcb9bdc8eae
-  ExpoScreenOrientation: b7ec534b6814f1e58d9cd8376a86bad8df3064b6
-  ExpoSecureStore: 143bf3748dc23f2982e2cc142e5bf05b22fbb417
-  ExpoSensors: 8c6d995da14b1d514e7a6c5600a30d9f61247449
-  ExpoSharing: 59437f9eadde58f040bea51dea456135fbfae725
-  ExpoSMS: 37645689553a9ee90419bf27578511b204aa3b43
-  ExpoSpeech: 17288f5de6e59ac5feeab90faef2849a05578abb
-  ExpoSplashScreen: 407cebbf896e8bfddc341b6bf82c314c8c373df4
-  ExpoSQLite: a73f515e546bed031e5d2b6568edb3702ec579c6
-  ExpoStoreReview: 801dab693aaa4296349b4b1bc16b0bfdd6a0e20c
-  ExpoSymbols: 4c52a4ded26691e398458c7315d955dd1cc5ea61
-  ExpoSystemUI: ffed49d2ad5d1166f2dc5326f2f5a0ed17e154b6
-  ExpoTrackingTransparency: 1e5aa4ae976898b8407864e562afdf7293dc3f6a
-  ExpoUI: bd693019c55b4848d417dc858337f44d25a44bd7
-  ExpoVideo: 1f6c31eb687164ea7907b382cf956d3faa616246
-  ExpoVideoThumbnails: 993af250852f5a5e39da4c23810027e9d0613fa8
-  ExpoWebBrowser: dc155434ba400538014a6a82ff297901e8354737
+  ExpoAppIntegrity: 3d9bdfec7ba1d4313369a3c38e79e16288c1fdf0
+  ExpoAppleAuthentication: 87df5a22f6ce3894e041273b2520c2f68aa34c14
+  ExpoAsset: 9fa8639ed7a3880a471efbbcf48cec5e27aa7898
+  ExpoAudio: fc72e14d770a3435b537d857673c339e8f32bafe
+  ExpoBackgroundFetch: 27f067117f7e7c84af4a0d3ae12e65a1dca353f9
+  ExpoBackgroundTask: 9e50fd3302a0da927c43d8efdf4714dbca6e981b
+  ExpoBattery: b697ffb18b5066bfd723b09afa480bcffafd96a5
+  ExpoBlob: 7a5b6d475a29ee2710a199fb580b7ae6361089d5
+  ExpoBlur: 4d76f2df118e9f0806e07d465f4a8e1df0b86375
+  ExpoBrightness: 700b54cd8bc0143f7551723e47f61d2d9d374395
+  ExpoCalendar: d9b85fade39ac845d9f80fa29e7f282f97678fb7
+  ExpoCamera: 0f72b30786e3dc35d5b5057d96d7c8dbce8781e4
+  ExpoCellular: 6dc38b43ae3f86c309d7ceb535f357e40b0ed50c
+  ExpoClipboard: 7e799877155ebcd1ac8332d53161d2dd0ea2bdde
+  ExpoContacts: 9faae2ac1365e3b79d32b6291b3cd04abec624be
+  ExpoCrypto: d75530b42b972195e9456cc5f2757019d6f1ff5a
+  ExpoDevice: fcf7ba80c6c0b5b6c67306a9ee42f2f5a220bbcb
+  ExpoDocumentPicker: fbf749f4e3cb45f1f63c877a0233afa929ee3165
+  ExpoDomWebView: 596201e00559fc684b417f197dff2fa024156175
+  ExpoFileSystem: fd826d115d4b3d9a7235a830410bbd8ff325ab70
+  ExpoFont: ca1c16e248fd750772b0271b30e45ba1b8b3aea1
+  ExpoGL: 5bf6ad2d06a62a0141f5062e86f52f715bdd737b
+  ExpoHaptics: aa6f23ecadfb91acaa686a5954b5d58982cd33cb
+  ExpoImage: 12ae7ea83b5f8a8c7574577e11252c718ea72175
+  ExpoImageManipulator: 9f0bcf13de8277ef174f290e525fca80130b90f9
+  ExpoImagePicker: b8792e4f497c02fd9e8233e8ed5492d38b552d5d
+  ExpoInsights: 885d20449ee430116bfca6ec0b4f75b3a6d2d1e7
+  ExpoKeepAwake: 35d2828601297db6802ddbe8cc74377c0a1fbf2c
+  ExpoLinearGradient: c73aaffc26051af9a3c40384b762c6854c15ef2f
+  ExpoLinking: e5bf85a6847f9eaeb7af1e7619e72ea3d808e65a
+  ExpoLivePhoto: 12b82e69aeb12d0ea4cefae00c62b04a706a2b6d
+  ExpoLocalAuthentication: 32612305f9eee46a2aec76198b74efc92b52b289
+  ExpoLocalization: 9cd2553b87540c0d9b9922629df5d7a404c6d590
+  ExpoLocation: 528f9e0914cca5c7062d2e6f9a0c89ec67235b01
+  ExpoMailComposer: 59e445195005a26cbb443886806285a8f19c00b6
+  ExpoMaps: 54a2ad0c89b0d3a99166421b2e9ccb692c03f8b6
+  ExpoMediaLibrary: 415afa7c6e091974c27653a6adc4f2a21bfe7c16
+  ExpoMeshGradient: 98075e5b9b36438d79ab32a3cff84ec094891953
+  ExpoModulesCore: f075b9991b3a2da9ffebc18e02184cdba9185b35
+  ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
+  ExpoNetwork: 7e76cda434421251c893c07defccc98f45f97dfa
+  ExpoPrint: ccb2992d47eae236470ce2fc602d12dde08ef2d0
+  ExpoScreenCapture: 0e5f8ee9f561855178b253a1117f04af2cd3f5b0
+  ExpoScreenOrientation: adce80b615a2fc4bcc865d48a3d9a81baa526f2d
+  ExpoSecureStore: 4d1ecaeeb8abe5fc59725892f0865e8944b89e1c
+  ExpoSensors: db657936d25354de87b6beb3800d651af114918b
+  ExpoSharing: 94d7216621331426b9ca81017f79f7e3e4a05dbc
+  ExpoSMS: f4862c49a7906cee644419bd22a6eed04084aa0c
+  ExpoSpeech: 8ee2942a920aadeaf69de4da4754f724be05b02c
+  ExpoSplashScreen: 35c7aaf75997f43cacc70c9c78c1456dd5dfb96e
+  ExpoSQLite: 975767ff80045b5a938d41cb0878cedcc819e789
+  ExpoStoreReview: 15a7ede4124c24694172337decd03e9bbf1293ee
+  ExpoSymbols: f7de5e67ea4d38c8cb4f090b92226dcdd80ecdf1
+  ExpoSystemUI: 3432471e55821d84e73fe1fca320fcae2df22ddc
+  ExpoTrackingTransparency: 8c86a1cce442f4d2ad85e6e5b24d78d6d795be9f
+  ExpoUI: 63858c8a87ea8ee6b21b32af6899b03b33c6393e
+  ExpoVideo: aed7f95acdb804bc6563239b50e8defbdff0fe57
+  ExpoVideoThumbnails: ba8822f3324f81b9f2ffba11d4b1fa317c42d173
+  ExpoWebBrowser: c683a16058262bc81299b5b227aa55be84693cc3
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
-  EXTaskManager: 868c078452bbbe2c67130628faf9cf58ba0b68c5
-  EXUpdates: 8d5421e575447e91d4b2b98f118e0646c71796c8
-  EXUpdatesInterface: 5adf50cb41e079c861da6d9b4b954c3db9a50734
+  EXTaskManager: 7811334c6b56160b6909ffc9f2a4669ba97b271e
+  EXUpdates: 00589f1cd4d5e1d6b9a7cba6f858fba70c2248bf
+  EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   FBLazyVector: 8da1272845e10a35c1e661a4c8ba644526c014fb
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: 3aaf4e04de466d1ac3a0456381d88be02ef9f66d
+  lottie-react-native: 29a3610e350f54856048ff5e408032596c45fb26
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
@@ -3633,83 +3636,83 @@ SPEC CHECKSUMS:
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
   React: f1486d005993b0af01943af1850d3d4f3b597545
   React-callinvoker: 944c9e97ef08e3995b05cc29b40c071a7bd0eaec
-  React-Core: 33c2f29eb1054f2fe4b6c7bb1e595495170f6c15
-  React-Core-prebuilt: 70adad8a28cf9ec5c1f349ced6375354644500ac
-  React-CoreModules: 6d0945fdc20d150789baaeefe2794b0dbc8f6379
-  React-cxxreact: 1d8096423b2b3e7b05c24f40277d117896e8873f
+  React-Core: 82b0d1d786602971d6ada67644599bba504e4f05
+  React-Core-prebuilt: 3f8f6d2c0c922cef26e1d9a385eeedbc91b8a495
+  React-CoreModules: db30069ee05bf3d4f8c26fbd1bcf8b9ce19efe3a
+  React-cxxreact: 0b53ae8c621ca115a390fd2546eae1c066a82d61
   React-debug: 0268bacb2cc38d98790ce15159e962a6b0b1895e
-  React-defaultsnativemodule: 5f2f1cdd3765b7fd7aed963e9b61cc6292343c46
-  React-domnativemodule: 4407d05b3bf87d604be08307e71ca308c7201043
-  React-Fabric: f68b67dd472fc90352fe80e2a6837a8642e7ef23
-  React-FabricComponents: e138111ec8093b42a3d74dc75865091d99bace64
-  React-FabricImage: cedf4cee2a69eb3518753291aa056f65189f09ef
-  React-featureflags: 7a70fce3a3c7c7745560d5c0ade1d46d7460c9c7
-  React-featureflagsnativemodule: 267f61c8648729837851cefe9a5017eb40855473
-  React-graphics: 70d3b71cde945c870d5528a4763abc34456a35d8
-  React-hermes: 66d0e0adcd5d7d8852efcee7129b1d248d9e76fc
-  React-idlecallbacksnativemodule: 987fcd4d77fed9d7f3ed5595d08bc283ac302d28
-  React-ImageManager: ceccf49e14a8c306e144ed192fe16f7704fbe6dd
-  React-jserrorhandler: e58b58bd3135795310b52d18d37d86b339d3753e
-  React-jsi: 1a403eb9781c8ab89d27bbe9a0573d9bb039b6a5
-  React-jsiexecutor: 81ea81bfd3f2ef78858e11d13179b740e2ea46d8
-  React-jsinspector: 5677b6102cc59b5c89ff471c1f461c8af99ed648
-  React-jsinspectorcdp: b4f743cb748c30677faf600f093c6bbd2aa5352b
-  React-jsinspectornetwork: 4c3fe84b72157f483a292e2605af88ace0c20177
-  React-jsinspectortracing: 4313f327e2bf0c6e4e0cfda1949734732e9f5530
-  React-jsitooling: 8a6546ee9c511c5497e013c05abbbc4f2dd1e87c
-  React-jsitracing: 8d11a4f0d444dbc9cf24862728d16afbb0cf67bb
-  React-logger: a1c9c8dfc56711d06a21109b55908e177113e554
-  React-Mapbuffer: bc36232966c55d5b1cbef3b84cb97c4317fa4403
-  React-microtasksnativemodule: cbabfedcf6c2984e59d07f9ab553f3d277599b1b
-  react-native-keyboard-controller: 1ad78688f744e0ebdf3b04007b91089a254b80f9
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-pager-view: c8817c1d9f4643417e68f0b846c51214b2252eea
-  react-native-safe-area-context: eb2fb5c796f18a08959ee5400bb1c65e4c1b4833
-  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
-  react-native-skia: e600b0756d17cdcff4b02c2125a5e5ca4acbcf07
-  react-native-slider: 8c562583722c396a3682f451f0b6e68e351ec3b9
-  react-native-view-shot: fb3c0774edb448f42705491802a455beac1502a2
-  react-native-webview: b29007f4723bca10872028067b07abacfa1cb35a
-  React-NativeModulesApple: 055e2d1417c663e7a26fc0847609f503e626e9e1
+  React-defaultsnativemodule: f14128fd8ae509b5b51ccec568b93b98e1041be5
+  React-domnativemodule: 2ade4dffd56afd15bd93b488c64dd73fb351f3a8
+  React-Fabric: a3d6cb96b6b7ed39ef0d864cbe41c74c7e284b97
+  React-FabricComponents: 7c72646d6045f44efa04c90f79c5a97c121e5de1
+  React-FabricImage: b79cabc0f325b794ba6b8f14ff9a99f53a17d099
+  React-featureflags: a0bfc1ff76a81490a58a0d9e204bb9a33d2c8214
+  React-featureflagsnativemodule: 4672fd8ff443e5bc75d6ab5db99e4d7d08e6f974
+  React-graphics: a60e11059d736649f585255e01926d2b3170575f
+  React-hermes: 64a6b17a933d2e1d8d2be744388a5559afb81970
+  React-idlecallbacksnativemodule: 2b92149958695ceee2d4650ae6a019c2548397b1
+  React-ImageManager: ba24d3464a6e744fd2a4ff3d360c51e682d48161
+  React-jserrorhandler: 97af7bef2872f4d2f5473c259e285b73449c128a
+  React-jsi: 4726ae342196e7c47473a12877aa5cd15ac84938
+  React-jsiexecutor: 41510e615e89031d52349942753a157ca95e98b9
+  React-jsinspector: 56acf32e7fa571aacff9d0b0b63be26a26e046eb
+  React-jsinspectorcdp: 684c504f4b3e9cc7f32a67b0be0a912b7814bb1e
+  React-jsinspectornetwork: 474c1b45712c84cd8e5f2e06d34579fa8d288e1d
+  React-jsinspectortracing: 97f8cad22aa70a3afd1e400c36ca9a025413ff4d
+  React-jsitooling: 65a70b922d21ea0ff62da79702a7e63290b26e18
+  React-jsitracing: c11208843b9704c3529e29be6e66c7553f8a754f
+  React-logger: 57463ca0b4e2821e99de5d3e169c73bb44747fa8
+  React-Mapbuffer: 1c2d763cab246940480c26f7783fea3158328e6e
+  React-microtasksnativemodule: fd8ba0661426ff3b0d75420d9735c06d1267a65e
+  react-native-keyboard-controller: 5587bad7f102125e2020720c4e37e0b58ff5e52e
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-pager-view: e37989fc447aa4b5de6d0d2ffb0229e817329246
+  react-native-safe-area-context: d46695b29119ba0871705c55c8ac2868888dcca4
+  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
+  react-native-skia: 640caff08810f3008fb2e00b04bd694d9636251f
+  react-native-slider: b76fa3dd989d25e8c2751c2a546674dfc0c2b6f8
+  react-native-view-shot: 26174e54ec6b4b7c5d70b86964b747919759adc1
+  react-native-webview: a4f0775a31b73cf13cfc3d2d2b119aa94ec76e49
+  React-NativeModulesApple: 9d84ce1083672774f99e47db67b72a1754a229f4
   React-oscompat: 8f2893713639e12c7558750a9f7de3f08ac255b0
-  React-perflogger: 34b632f94b15e1068f7997e5a68b40a55162ad13
-  React-performancetimeline: 6e067040e1af47a26e306c726e228e53718518ac
+  React-perflogger: 8b2e23af5d2ad2af3564dc5b39e8f645fe6e213e
+  React-performancetimeline: 181ca89f10ecb72ba69a8f18d53d1501f36192d2
   React-RCTActionSheet: 0280ff8cf63ef67a5a74898b18316b204d686c83
-  React-RCTAnimation: a33e999cdfc9ebc8eb17f8f9f262ac765635d3b8
-  React-RCTAppDelegate: 8ca4feb7290edf02f70ee824b0ef735c24d78b0e
-  React-RCTBlob: ab87e8283899ec563c429f55a7a584c8bae78f17
-  React-RCTFabric: 465111d965717cbe4e1fe4a5caffc66723423d68
-  React-RCTFBReactNativeSpec: 7637e1b9e3838c7a43e870a1c519346ec1787e90
-  React-RCTImage: 7e07ef9065bf18dd8566421b550c041455f24bdb
-  React-RCTLinking: 0877fa82d7a04bbdd6167e7d93ebbab2147d4398
-  React-RCTNetwork: f26cc6a43530af00bc6c3c73cfdb0df58e319126
-  React-RCTRuntime: c22ce17d068c7447c7406c00050785776cb376a4
-  React-RCTSettings: 58a19d845f0e05555246c8325b527bd90cdc88e7
-  React-RCTText: 972fe79182d4082d36e988c094c5876f9ddfaab0
-  React-RCTVibration: 56c26c46c7c574a46fb424e9ba9445e686ddf53f
+  React-RCTAnimation: 2e460cb0e6bab212da0d51ae2fa06d4940f57dc7
+  React-RCTAppDelegate: bd20359306c39f4c681b0a8178524f36876dc349
+  React-RCTBlob: 9f7666589118df1b878506ac0cdb4c95909f57d9
+  React-RCTFabric: 2c6476d5f1afe558cae3c95609ff460140bcf30b
+  React-RCTFBReactNativeSpec: 9aa6e59bc8b16bcf0bd08854a0eec2fce69a8b76
+  React-RCTImage: d28b4429d50041b21a94b6a924d68bf2ea657a0c
+  React-RCTLinking: 8c1e982add09a0112d38ff0bd0da54f12d8bfb1a
+  React-RCTNetwork: ba16bcc6dbfbdd1b27597ffbe6ea77477db51b3a
+  React-RCTRuntime: 22c74af836f6dc4f9ffcb288a2765a6674538130
+  React-RCTSettings: e0401d546157fc9ee538edcca289d37c4d1e477e
+  React-RCTText: 794b6c97c1ea30ae9636c46187ff5f4569a54b1e
+  React-RCTVibration: f161f990b05224043b2449ec26fd03c5d355446f
   React-rendererconsistency: 4917405e8864ded5d3b350f04ee7f1712435d8e7
-  React-renderercss: dd4f24445dcb209267e1034df31cc156e336342d
-  React-rendererdebug: c335166d55d20a7c1a7a7ac0ca491d996f4adf5b
-  React-RuntimeApple: 9e7edf7c631cf2446fbb728e68bfbbc859d8aabd
-  React-RuntimeCore: a6a70ca5ab98f08191f6c7dfd3424b4fc86ed24d
-  React-runtimeexecutor: 2d4128882cf41c7824e9d8a72c6b9461897889af
-  React-RuntimeHermes: 4e74b3ea837c4bae9903b6a9210f97329007b7f2
-  React-runtimescheduler: 5ec6bcc02a05de1e87b9830dbfccff4dc1bddcae
-  React-timing: b49069174c0330be78b67c8a24d7127dfca99bba
-  React-utils: de22e0dfdd4494e401dfd0194f552c7175480939
-  ReactAppDependencyProvider: 3eb9096cb139eb433965693bbe541d96eb3d3ec9
-  ReactCodegen: ca588e96c4a81c9bfe4caedbb47f76f709851815
-  ReactCommon: 3579ef7cd884fbb5218bed929f25b7b212299700
+  React-renderercss: 3b00d7534182d59cca0a1f2a5d1606ea6d4c5656
+  React-rendererdebug: 326ee2825f7feb069b0b0edc3fc0703d9f176314
+  React-RuntimeApple: ab3d39b4c94d2238f69d85f1668d7c7b597a769c
+  React-RuntimeCore: 2452c439b756946f71147057b5da445df15077d9
+  React-runtimeexecutor: 54de512bb6e263df659dd47736f78d2dc8b4b46c
+  React-RuntimeHermes: 8d5aa86d1b54fca18895d8e3e8ddede07010cf42
+  React-runtimescheduler: 21e5deedc055fe04605ed8e4078ed281d17e3df0
+  React-timing: 2502b4a021b00d98bca9d0ded432306e19dfe13d
+  React-utils: f5f16cbfd98f4e5b66584e1ddc75c6b58a5b3680
+  ReactAppDependencyProvider: 448b422f8af1dedf81374eacc90a15439a0ed7f5
+  ReactCodegen: c0084f0db390ba7400dbcaabfb178028e5bf6591
+  ReactCommon: b5d0aa700194902664f749d300e7f9478f5759c6
   ReactNativeDependencies: 9444683ddc7eaa98d2289224ce730a7632b705ff
-  RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
-  RNCMaskedView: d2578d41c59b936db122b2798ba37e4722d21035
-  RNCPicker: a7170edbcbf8288de8edb2502e08e7fc757fa755
-  RNDateTimePicker: be0e44bcb9ed0607c7c5f47dbedd88cf091f6791
-  RNGestureHandler: 2914750df066d89bf9d8f48a10ad5f0051108ac3
-  RNReanimated: 32528e8dfd89cc4cdda0a04498a4ef87938a85ac
-  RNScreens: 4f42834f22634a54306f43a216ef189f5404d164
-  RNSVG: 31d6639663c249b7d5abc9728dde2041eb2a3c34
-  RNWorklets: 449b13de5dcd2b49690715d30968adabba982f1f
+  RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
+  RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
+  RNCPicker: f97c908b7774248c1093ec3831ca70d338627bf7
+  RNDateTimePicker: 6fdd63f5d1e0f21faf4cc8674957c52958a7efae
+  RNGestureHandler: 6a488ce85c88e82d8610db1108daf04e9b2d5162
+  RNReanimated: 98a3da83c44675f5ac6ee39a8f1c74e7f473cac9
+  RNScreens: 4c50c00f02d33bb8def35965c690b33e74208b7d
+  RNSVG: 2825ee146e0f6a16221e852299943e4cceef4528
+  RNWorklets: df67c4f059c0d1c9168fb48e57f16d14d5443deb
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -73,7 +73,7 @@
     "react-native-pager-view": "6.9.1",
     "react-native-reanimated": "4.0.2",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.15.3",
+    "react-native-screens": "4.15.4",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3356,7 +3356,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNScreens (4.15.3):
+  - RNScreens (4.15.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3383,10 +3383,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.15.3)
+    - RNScreens/common (= 4.15.4)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.15.3):
+  - RNScreens/common (4.15.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3472,7 +3472,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNWorklets (0.4.1):
+  - RNWorklets (0.4.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3488,6 +3488,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
     - React-jsi
     - React-NativeModulesApple
@@ -3498,10 +3499,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets (= 0.4.1)
+    - RNWorklets/worklets (= 0.4.2)
     - SocketRocket
     - Yoga
-  - RNWorklets/worklets (0.4.1):
+  - RNWorklets/worklets (0.4.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3517,6 +3518,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
     - React-jsi
     - React-NativeModulesApple
@@ -3527,10 +3529,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets/apple (= 0.4.1)
+    - RNWorklets/worklets/apple (= 0.4.2)
     - SocketRocket
     - Yoga
-  - RNWorklets/worklets/apple (0.4.1):
+  - RNWorklets/worklets/apple (0.4.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3546,6 +3548,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
     - React-jsi
     - React-NativeModulesApple
@@ -4231,73 +4234,73 @@ SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EASClient: 2da432b06330907695b6660a8a7990c488f69dd2
-  EXApplication: df3ab389fa135b8d7f68b5a62f06b827dd46b8fd
-  EXAV: 4b6ecbfb0554f537d0b4af4c43d522473ea2a48c
-  EXConstants: 02e2a69e11c641fa20fa262947d167fab3ecb200
-  EXImageLoader: 189e3476581efe3ad4d1d3fb4735b7179eb26f05
+  EASClient: c5cf14bd2cac2ddb823e6e82475f84c35d521e17
+  EXApplication: 194b1a0fd9a9e4ee8326d95a85362df8bb0dfb4a
+  EXAV: 91e715adb687e6657bbd9ed4beafee483d368b3a
+  EXConstants: f6f14a2aece3ab12ed925c9ee29c8bc7d6be61aa
+  EXImageLoader: e501c001bc40b8326605e82e6e80363c80fe06b5
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: ba44a6836e3ec4fa5e947c6db39ab1ec9e871de1
-  EXNotifications: e4995fac6ea317a55f56679342962256d15b1865
-  Expo: 3455e7ccf2cd80cf9d093e2186c9e28166b948b6
-  ExpoAppleAuthentication: 00cb9ae1572a39af3d76d829e22c58d096638620
-  ExpoAsset: 88b5636713bc233a3819bc83a2e69130d385fadc
-  ExpoAudio: 8934673769246bf0c31eed3291c063f0d3d36674
-  ExpoBackgroundFetch: b7e562ae0562ef65b8d07e7879adff71a08523c7
-  ExpoBackgroundTask: d354b0de714b32adfafbf1429ef54e003d348f7a
-  ExpoBattery: 8c21f8fc3dc7d844ce52bdcf497415b939cbf92d
-  ExpoBlur: b94d599fc9ac76f9db50c8406613da332d280e4c
-  ExpoBrightness: 685d9eeaf88793cd821e303ae6f83cd5e6a5d7a3
-  ExpoCalendar: f56bdfa447f84798eec45d20469573201cbce6ee
-  ExpoCamera: 58795c3070de5d7f45b1b59283e95b78630337c0
-  ExpoCellular: 9c1754931458316970154af3db3da2402fba86fa
-  ExpoClipboard: b47fa1d4a8b5390f09feca7a092878bd6ef9e4b3
-  ExpoContacts: d07817cc6c091d207bfa771a0d404e245fbedc96
-  ExpoCrypto: fb84db5b00d758ce30d31013cd33e33fed9c7981
-  ExpoDevice: 361879fb8c0ed1abec6c2bf5f32d7ce46744c73b
-  ExpoDocumentPicker: 8eb69d67b237e0e88d072fec9a95b15333d392ec
-  ExpoDomWebView: 4e0559eee7b80d727b46bdab2f9803433a3ebbb6
-  ExpoFileSystem: 95cb3f55bc14c80c464793973e33539c59e8a58a
-  ExpoFont: e533472deff8181f9b4a27ad39d4a00996a79ceb
-  ExpoGL: 5b6ded7547537d06a8a36435f37a01054875b06d
-  ExpoHaptics: f20dc9498e94a4b70c8d0097ac04ac3701ae4a0c
-  ExpoHead: bbb16e9eac2187ab7ee32aea2b3edf97f88d31aa
-  ExpoImage: 0cc208541bd217cff611c831dca7d0c3bfb4fd3f
-  ExpoImageManipulator: a761ed203e6cceb550ef6ec38e45cb26f90e7424
-  ExpoImagePicker: 5b8605982bf41611fa1fb9e537971125cf2c3c36
-  ExpoKeepAwake: cf946c3cb68c4aae9d042a1f245d74984e349b98
-  ExpoLinearGradient: e3651d3cafe53a2a5a1cdccdca2a3e6e9928b0fa
-  ExpoLinking: dc1f27352a9223dbb3b0e78a51add62ccf7f4242
-  ExpoLivePhoto: 6b60f819ca789bf01818cbce6995d96c4b6275ef
-  ExpoLocalAuthentication: c0d2e91f4827126099588a7f8d9964686c36c0a5
-  ExpoLocalization: e1447009a5c398706bf79d9f4b3f5e0ec344db20
-  ExpoLocation: 57d4e26a7727de45638ac6d2d650c7271d768e75
-  ExpoMailComposer: bd7ef338e2080b28a7364feb6aa33dcdd0909267
-  ExpoMediaLibrary: da23763613cfef9afe6784e071ef2e9f9197a346
-  ExpoMeshGradient: 372ab0f2ad554416c32fd46675dbb5a068115ad3
-  ExpoModulesCore: 25662cce3e02abd48a6483a24cd0a55965f95094
-  ExpoModulesTestCore: be5073c51ffe7c2db9f14aedfce7d8cdc141f55a
-  ExpoNetwork: cb29bcf3ac401fcb0b2f10d18ab3507fcf4efe89
-  ExpoPrint: 262fbd40c537359c5a708d1cac030cf03bb7fbac
-  ExpoScreenCapture: 441dc1fbf881c3e0e11cda654faaedcb9bdc8eae
-  ExpoScreenOrientation: 866cee47b9a2c61dee5220cab17df7aa8746e431
-  ExpoSecureStore: 143bf3748dc23f2982e2cc142e5bf05b22fbb417
-  ExpoSensors: 8c6d995da14b1d514e7a6c5600a30d9f61247449
-  ExpoSharing: 59437f9eadde58f040bea51dea456135fbfae725
-  ExpoSMS: 37645689553a9ee90419bf27578511b204aa3b43
-  ExpoSpeech: 17288f5de6e59ac5feeab90faef2849a05578abb
-  ExpoSQLite: a73f515e546bed031e5d2b6568edb3702ec579c6
-  ExpoStoreReview: 801dab693aaa4296349b4b1bc16b0bfdd6a0e20c
-  ExpoSymbols: 4c52a4ded26691e398458c7315d955dd1cc5ea61
-  ExpoSystemUI: ffed49d2ad5d1166f2dc5326f2f5a0ed17e154b6
-  ExpoTrackingTransparency: 1e5aa4ae976898b8407864e562afdf7293dc3f6a
-  ExpoVideo: 1f6c31eb687164ea7907b382cf956d3faa616246
-  ExpoVideoThumbnails: 993af250852f5a5e39da4c23810027e9d0613fa8
-  ExpoWebBrowser: dc155434ba400538014a6a82ff297901e8354737
+  EXManifests: c110cbe41d9def69d37c101edf84181925a73c7b
+  EXNotifications: eeadd008c17a8651e3c206b72c9f5e6bfa765ca6
+  Expo: 346c94c5bb2188a5856b5c0a68a20341695b841c
+  ExpoAppleAuthentication: 87df5a22f6ce3894e041273b2520c2f68aa34c14
+  ExpoAsset: 9fa8639ed7a3880a471efbbcf48cec5e27aa7898
+  ExpoAudio: fc72e14d770a3435b537d857673c339e8f32bafe
+  ExpoBackgroundFetch: 27f067117f7e7c84af4a0d3ae12e65a1dca353f9
+  ExpoBackgroundTask: 9e50fd3302a0da927c43d8efdf4714dbca6e981b
+  ExpoBattery: b697ffb18b5066bfd723b09afa480bcffafd96a5
+  ExpoBlur: 4d76f2df118e9f0806e07d465f4a8e1df0b86375
+  ExpoBrightness: 700b54cd8bc0143f7551723e47f61d2d9d374395
+  ExpoCalendar: d9b85fade39ac845d9f80fa29e7f282f97678fb7
+  ExpoCamera: 0f72b30786e3dc35d5b5057d96d7c8dbce8781e4
+  ExpoCellular: 6dc38b43ae3f86c309d7ceb535f357e40b0ed50c
+  ExpoClipboard: 7e799877155ebcd1ac8332d53161d2dd0ea2bdde
+  ExpoContacts: 9faae2ac1365e3b79d32b6291b3cd04abec624be
+  ExpoCrypto: d75530b42b972195e9456cc5f2757019d6f1ff5a
+  ExpoDevice: fcf7ba80c6c0b5b6c67306a9ee42f2f5a220bbcb
+  ExpoDocumentPicker: fbf749f4e3cb45f1f63c877a0233afa929ee3165
+  ExpoDomWebView: 596201e00559fc684b417f197dff2fa024156175
+  ExpoFileSystem: fd826d115d4b3d9a7235a830410bbd8ff325ab70
+  ExpoFont: ca1c16e248fd750772b0271b30e45ba1b8b3aea1
+  ExpoGL: 5bf6ad2d06a62a0141f5062e86f52f715bdd737b
+  ExpoHaptics: aa6f23ecadfb91acaa686a5954b5d58982cd33cb
+  ExpoHead: e72a438d8a0c5d942ce649903f5d3071a32779ed
+  ExpoImage: 12ae7ea83b5f8a8c7574577e11252c718ea72175
+  ExpoImageManipulator: 9f0bcf13de8277ef174f290e525fca80130b90f9
+  ExpoImagePicker: b8792e4f497c02fd9e8233e8ed5492d38b552d5d
+  ExpoKeepAwake: 35d2828601297db6802ddbe8cc74377c0a1fbf2c
+  ExpoLinearGradient: c73aaffc26051af9a3c40384b762c6854c15ef2f
+  ExpoLinking: e5bf85a6847f9eaeb7af1e7619e72ea3d808e65a
+  ExpoLivePhoto: 12b82e69aeb12d0ea4cefae00c62b04a706a2b6d
+  ExpoLocalAuthentication: 32612305f9eee46a2aec76198b74efc92b52b289
+  ExpoLocalization: 9cd2553b87540c0d9b9922629df5d7a404c6d590
+  ExpoLocation: 528f9e0914cca5c7062d2e6f9a0c89ec67235b01
+  ExpoMailComposer: 59e445195005a26cbb443886806285a8f19c00b6
+  ExpoMediaLibrary: 415afa7c6e091974c27653a6adc4f2a21bfe7c16
+  ExpoMeshGradient: 98075e5b9b36438d79ab32a3cff84ec094891953
+  ExpoModulesCore: 0d77f8048a077ae0a3616f10c71cc5f5c185e16b
+  ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
+  ExpoNetwork: 7e76cda434421251c893c07defccc98f45f97dfa
+  ExpoPrint: ccb2992d47eae236470ce2fc602d12dde08ef2d0
+  ExpoScreenCapture: 0e5f8ee9f561855178b253a1117f04af2cd3f5b0
+  ExpoScreenOrientation: 868c2b5e1816d77e341b2ef2a22e4138c04b0510
+  ExpoSecureStore: 4d1ecaeeb8abe5fc59725892f0865e8944b89e1c
+  ExpoSensors: db657936d25354de87b6beb3800d651af114918b
+  ExpoSharing: 94d7216621331426b9ca81017f79f7e3e4a05dbc
+  ExpoSMS: f4862c49a7906cee644419bd22a6eed04084aa0c
+  ExpoSpeech: 8ee2942a920aadeaf69de4da4754f724be05b02c
+  ExpoSQLite: 975767ff80045b5a938d41cb0878cedcc819e789
+  ExpoStoreReview: 15a7ede4124c24694172337decd03e9bbf1293ee
+  ExpoSymbols: f7de5e67ea4d38c8cb4f090b92226dcdd80ecdf1
+  ExpoSystemUI: 3432471e55821d84e73fe1fca320fcae2df22ddc
+  ExpoTrackingTransparency: 8c86a1cce442f4d2ad85e6e5b24d78d6d795be9f
+  ExpoVideo: aed7f95acdb804bc6563239b50e8defbdff0fe57
+  ExpoVideoThumbnails: ba8822f3324f81b9f2ffba11d4b1fa317c42d173
+  ExpoWebBrowser: c683a16058262bc81299b5b227aa55be84693cc3
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
-  EXTaskManager: 868c078452bbbe2c67130628faf9cf58ba0b68c5
-  EXUpdates: 0f0dbe5d1aaffc268954a62120020cb50bd7e3b0
-  EXUpdatesInterface: 5adf50cb41e079c861da6d9b4b954c3db9a50734
+  EXTaskManager: 7811334c6b56160b6909ffc9f2a4669ba97b271e
+  EXUpdates: 09c7f4c3ea0ae837c5f4cb900f6bbbadbbe6d00d
+  EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: b8f1312d48447cca7b4abc21ed155db14742bd03
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
@@ -4315,109 +4318,109 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 58c28ef03bc3ad3ddfef92f25c7e49dedc8baa36
+  hermes-engine: c61ca2af39fb819b79c0d70193aaf833bc93e727
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: ee739c59b332297996b1a1a73884ee75d95a7562
+  lottie-react-native: 8a08f0554027f07f5370bf9129ca5da0878fe5b3
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a
   RCTTypeSafety: 720403058b7c1380c6a3ae5706981d6362962c89
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
   React: f1486d005993b0af01943af1850d3d4f3b597545
   React-callinvoker: 133f69368c8559e744efa345223625d412f5dfbe
-  React-Core: 559823921b4f294c2840fa8238ca958a29ddc211
-  React-CoreModules: c41e7bbfabbc420783bb926f45837a0d5e53341e
-  React-cxxreact: 9cb9fa738274a1b36b97ede09c8a6717dec1a20b
+  React-Core: d6d8c1fd33697cec596d33b820456505ee305686
+  React-CoreModules: 81ab751a7668ba161440f9623b994e1a6a3019fe
+  React-cxxreact: 16f2a2751d0dce8b569f23c1914edc90f655b01b
   React-debug: e01581e1589f329e61c95b332bf7f4969b10564b
-  React-defaultsnativemodule: bbb39447caa6b6cf9405fa0099f828c083640faa
-  React-domnativemodule: 03744d12b6d56d098531a933730bf1d4cb79bdfb
-  React-Fabric: 530b3993a12a96e8a7cdb9f0ef48e605277b572e
-  React-FabricComponents: 271ec2a9b2c00ac66fd6d1fd24e9e964d907751d
-  React-FabricImage: d0af66e976dbab7f8b81e36dd369fc70727d2695
-  React-featureflags: 269704c8eff86e0485c9d384e286350fcda6eb70
-  React-featureflagsnativemodule: db1e5d88a912fb08a5ece33fcf64e1b732da8467
-  React-graphics: b19d03a01b0722b4dc82f47acb56dc3ed41937e7
-  React-hermes: 811606c0aca5a3f9c6fa8e4994e02ca8f677e68e
-  React-idlecallbacksnativemodule: 3a3df629cd50046c7e4354f9025aefe8f2c84601
-  React-ImageManager: 0d53866c63132791e37bb2373f93044fdef14aa3
-  React-jserrorhandler: d5700d6ab7162fd575287502a3c5d601d98e7f09
-  React-jsi: ece95417fedbed0e7153a855cb8342b7c72ab75e
-  React-jsiexecutor: 2b0bb644b533df2f5c0cd6ade9a4560d0bf1dd84
-  React-jsinspector: 0c160f8510a8852bdf2dac12f0b1949efc18200b
-  React-jsinspectorcdp: f4b84409f453f61ddd8614ad45139bc594ec6bb5
-  React-jsinspectornetwork: 8f2f0ca8c871ca19b571f426002c0012e7fb2aee
-  React-jsinspectortracing: 33f6b977eb8a4bc1e3d1a4b948809aca083143f9
-  React-jsitooling: 2c61529b589e17229a9f0a4a4fc35aa7ad495850
-  React-jsitracing: 838a7b0c013c4aff7d382d7fdc78cf442013ba1d
-  React-logger: 7aef4d74123e5e3d267e5af1fbf5135b5a0d8381
-  React-Mapbuffer: 91e0eab42a6ae7f3e34091a126d70fc53bd3823e
-  React-microtasksnativemodule: 1ead4fe154df3b1ba34b5a9e35ef3c4bdfa72ccb
-  react-native-google-maps: c4f5c5b2dda17e7cb2cb2b37a81f140b039b3e7e
-  react-native-keyboard-controller: 8bd5f5572b6d5d402a2f77987a17492f869e5d62
-  react-native-maps: 9febd31278b35cd21e4fad2cf6fa708993be5dab
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-pager-view: a0516effb17ca5120ac2113bfd21b91130ad5748
-  react-native-safe-area-context: a72764e0eb5d6b79b7450e5d0ae919eb1a4567b4
-  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
-  react-native-skia: 7db0cf4fc9d6203747af5bae5df0db3ad4e84cda
-  react-native-slider: 663776e5683e257de8df8091abc2d93ff6ec67db
-  react-native-view-shot: 6c008e58f4720de58370848201c5d4a082c6d4ca
-  react-native-webview: 4cbb7f05f2c50671a7dcff4012d3e85faad271e4
-  React-NativeModulesApple: eff2eba56030eb0d107b1642b8f853bc36a833ac
+  React-defaultsnativemodule: e956b1d8fe15cc79d23061db229bf88170565f2f
+  React-domnativemodule: a18b0f7a31b9c75f12fa369baece5542d1265b36
+  React-Fabric: c0237a32c3c0dbea2d2b294c8e95605e1dfe2f57
+  React-FabricComponents: 65b03884bd5d9f24c79a631d7d26f0fa079bc4aa
+  React-FabricImage: de1ea2f2a0b32ad02e5cbb64827d1eec0439cf0d
+  React-featureflags: 02de9c35256cc624269b01d670d99e1fd706ea8d
+  React-featureflagsnativemodule: 8b84e67edbaa7b9318390c5bd3ae19790a74f356
+  React-graphics: 004b40c1b236ea3bb8de6693439bef9797922ba9
+  React-hermes: 2179a018b2f86652f6f33ef23efd9e5ac284b247
+  React-idlecallbacksnativemodule: f54ea68f984b12e42feed1e7110623b2c38df4d1
+  React-ImageManager: 9dd04b7b62bc5397f876ca5fb1b712e700ce390c
+  React-jserrorhandler: 2f90bf50fffea1d012e7f3d717c6adf748b1813d
+  React-jsi: b27208f8866e53238534f65f304903e4eff25e05
+  React-jsiexecutor: 1d3e827797f592c393860dea91aaa6d53c7715e7
+  React-jsinspector: bda319277ae779bc476b736fe3a497c6aed304cd
+  React-jsinspectorcdp: 69e1736edfd5420037680b7b4557fa748c3c8216
+  React-jsinspectornetwork: 7aa707b057c6129b4af59e0c9160436bbab25022
+  React-jsinspectortracing: b4a8a328ad2697f9638daa4b7cc054e0303fa47f
+  React-jsitooling: a6c7e2829437b28665e97a398b3374d443125e24
+  React-jsitracing: d87ae17dd0eef7844e605945da926c5433fe2b51
+  React-logger: d27dd2000f520bf891d24f6e141cde34df41f0ee
+  React-Mapbuffer: 0746ffab5ac0f49b7c9347338e3d0c1d9dd634c8
+  React-microtasksnativemodule: b0fb3f97372df39bda3e657536039f1af227cc29
+  react-native-google-maps: 7cc1184afe41fbd15a3dffd53c924819f6587b69
+  react-native-keyboard-controller: 5e209d13d4c5355ddf8c36be3d41b8dfc879cd91
+  react-native-maps: ee1e65647460c3d41e778071be5eda10e3da6225
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-pager-view: 899989dd025d219d3ac0d386b2bc162f81ae8330
+  react-native-safe-area-context: 2249e17382bd5a97cbccaa89e22af8756188c0fb
+  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
+  react-native-skia: e9dd3d45d9b5d1e4116094cfa716719ae6c067cd
+  react-native-slider: 30cea7008de785564de2f4fd064f2deb38614a4a
+  react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
+  react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
+  React-NativeModulesApple: 9ec9240159974c94886ebbe4caec18e3395f6aef
   React-oscompat: b12c633e9c00f1f99467b1e0e0b8038895dae436
-  React-perflogger: 58d12c4e5df1403030c97b9c621375c312cca454
-  React-performancetimeline: 0ee0a3236c77a4ee6d8a6189089e41e4003d292e
+  React-perflogger: ccf4fd2664b00818645e588623c7531a8b32d114
+  React-performancetimeline: a866ba759d8e06e9ba174b4421677edcae487baf
   React-RCTActionSheet: 3f741a3712653611a6bfc5abceb8260af9d0b218
-  React-RCTAnimation: 408ad69ea136e99a463dd33eadecc29e586b3d72
-  React-RCTAppDelegate: f03b46e80b8a3dbfa84b35abfe123e02f3ceef83
-  React-RCTBlob: bd42e92a00ad22eaab92ffe5c137e7a2f725887a
-  React-RCTFabric: b99ab638c73cf2d57b886eafdbfb2e4909b0eb9a
-  React-RCTFBReactNativeSpec: 7ad9aba0e0655e3f29be0a1c3fd4a888fab04dcf
-  React-RCTImage: 0f1c74f7cd20027f8c34976a211b35d4263a0add
-  React-RCTLinking: 6d7dfc3a74110df56c3a73cc7626bf4415656542
-  React-RCTNetwork: 6a25d8645a80d5b86098675ca39bf8fcf1afa08b
-  React-RCTRuntime: 38bfe9766565ae3293ca230bc51c9c020a8bc98a
-  React-RCTSettings: 651d9ae2cdd32f547ad0d225a2c13886d6ad2358
-  React-RCTText: 9bc66cd288478e23195e01f5cb45eba79986b2b4
-  React-RCTVibration: 371226f5667a00c76d792dcdb5c2e0fcbcde0c3b
+  React-RCTAnimation: 2edeebfba175cc2e937e2752209ab605d3c48f21
+  React-RCTAppDelegate: e292321e83ee966897244a032216a70930b758d6
+  React-RCTBlob: 8dfb24b6dd4a5af45e1e59e2fd925b2df1e44d08
+  React-RCTFabric: b25b02a2016f5cb15926a60c77a8d75865aa3558
+  React-RCTFBReactNativeSpec: 20338571a1ed853d01da6c68576aa6e8e107b6f6
+  React-RCTImage: c7fe8c2f2ae8bad98ab4d944d5d50a889da4b652
+  React-RCTLinking: 9ac21ce9f1af914bb01c06af3752db2ec840d0ee
+  React-RCTNetwork: 09a5de71d757dbad4b3fe3615839290200b932aa
+  React-RCTRuntime: da3f1e0ce088c20350044cdf1efcd7f8d9b9b40c
+  React-RCTSettings: fee112652ac7569ea9abe910206e1685f5f9adba
+  React-RCTText: 7ee9d0bc16b3a8149f8df6d70c48e724d0db1d89
+  React-RCTVibration: 619d613abaeb05f6fbc2b2e5e33f724f05df8eb8
   React-rendererconsistency: a05f6c37f9389c53213d1e28798e441fa6fbdbcd
-  React-renderercss: 6e4febfa014b0f53bc171a62b0f713ddbdbb9860
-  React-rendererdebug: e94bf27b9d55ef2795caa8e43aa92abc4a373b8b
-  React-RuntimeApple: 723be5159519eba1cd92449acb29436d21571b82
-  React-RuntimeCore: f58eb0f01065c9d27d91de10b2e4ab4c76d83b0e
-  React-runtimeexecutor: f615ec8742d0b5820170f7c8b4d2c7cb75d93ac9
-  React-RuntimeHermes: fddb258e03d330d1132bb19e78fe51ac2f3f41ac
-  React-runtimescheduler: e92a31460e654ced8587debeec37553315e1b6a5
-  React-timing: 97ada2c47b4c5932e7f773c7d239c52b90d6ca68
-  React-utils: f0949d247a46b4c09f03e5a3cb1167602d0b729a
-  ReactAppDependencyProvider: 3eb9096cb139eb433965693bbe541d96eb3d3ec9
-  ReactCodegen: da219247e01e4c60850c38eee67eba211248fecf
-  ReactCommon: ce5d4226dfaf9d5dacbef57b4528819e39d3a120
-  RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
-  RNCMaskedView: 5ef8c95cbab95334a32763b72896a7b7d07e6299
-  RNCPicker: 66c392786945ecee5275242c148e6a4601221d3a
-  RNDateTimePicker: cda4c045beca864cebb3209ef9cc4094f974864c
-  RNGestureHandler: 3a73f098d74712952870e948b3d9cf7b6cae9961
-  RNReanimated: b43b4178f9c5c355badd51bc0df933d1eabddc83
-  RNScreens: 83be436fa9efeb1ea225e11243d4c4d0655d7e00
-  RNSVG: 6f39605a4c4d200b11435c35bd077553c6b5963a
-  RNWorklets: 32ea3225502c57b559c76f684fc2abac865b7728
+  React-renderercss: 3decb27a81648fcdee837c59994b51fff5be5a67
+  React-rendererdebug: 3b9a92d36932af52e1b473f2a89ea4b05dbdecdf
+  React-RuntimeApple: 4e35fb74be4b721c2e1fd6d54ec66456fa7043e9
+  React-RuntimeCore: 0fd7ac6e3e9dd20cb47e87c6b9f35832dd445d5e
+  React-runtimeexecutor: 7680156c9f3a5a49c688bc33f9ec5ea1b00527f5
+  React-RuntimeHermes: 435b7104a3c749af6251353dcb7317a8e53cbd73
+  React-runtimescheduler: 8056b916168e446ea44531883928034e62e76a81
+  React-timing: 36da85e32e53008ce73f87528818191e7f2508ba
+  React-utils: 71e53d55ce778c6e7c7c9db4b1b9d63ef8f55289
+  ReactAppDependencyProvider: 448b422f8af1dedf81374eacc90a15439a0ed7f5
+  ReactCodegen: 647efd11d3dd86a88119fabfb2d86a0ba9b0cdd6
+  ReactCommon: e897f9a1b4afab370cfefaaf5fb3c80371bc3937
+  RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
+  RNCMaskedView: 63268de1986a098b5f4d1fb5b1bc1e97fade0aee
+  RNCPicker: 6da395ee9db8d67a38c6102d4128b5a0b9ec0e21
+  RNDateTimePicker: c4a42c6a77d474f05162d61a4ab4253d13008277
+  RNGestureHandler: 4f7cc97a71d4fe0fcba38c94acdd969f5f17c91c
+  RNReanimated: 3b8ec43aaef0389e702878e7725608128daa2053
+  RNScreens: 5c7f22b19ee2e900e5de2c578471aeb153d1e502
+  RNSVG: 8d87cff016edf1b6ca409ed39804101836d75e90
+  RNWorklets: 751f5e1c24503305ac031a00ce5ef1261b8c5e4c
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Stripe: d1824162e4bcb6ead10401a0dc8e8a3d5ffee41f
-  stripe-react-native: f2af1d3769363ae90b2a6c4bb9642232c2c4d2c9
+  stripe-react-native: fd628fd2cd45a6d06700cdf499f23dbcb4d5f8d9
   StripeApplePay: eb64705d3c919492b1b28876652fd0aca2db38cc
   StripeCore: b5bee05167f0c8ccce936244a031a9972fdeade8
   StripeFinancialConnections: fd6c661f86f47b1d26a32f588b3a0b09826aba84

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -80,7 +80,7 @@
     "react-native-paper": "^5.12.5",
     "react-native-reanimated": "4.0.2",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.15.3",
+    "react-native-screens": "4.15.4",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -149,7 +149,7 @@
     "react-native-worklets": "0.4.2",
     "react-native-reanimated": "4.0.2",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.15.3",
+    "react-native-screens": "4.15.4",
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-web": "~0.21.0",

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -33,7 +33,7 @@
     "react": "19.1.0",
     "react-native": "0.81.1",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.15.3"
+    "react-native-screens": "4.15.4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -47,7 +47,7 @@
     "react": "19.1.0",
     "react-native": "0.81.1",
     "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "4.15.3",
+    "react-native-screens": "4.15.4",
     "react-native-webview": "13.13.5"
   },
   "devDependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -101,7 +101,7 @@
   "react-native-pager-view": "6.9.1",
   "react-native-worklets": "~0.4.2",
   "react-native-reanimated": "~4.0.2",
-  "react-native-screens": "~4.15.3",
+  "react-native-screens": "~4.15.4",
   "react-native-safe-area-context": "~5.6.0",
   "react-native-svg": "15.12.1",
   "react-native-view-shot": "4.0.3",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -34,7 +34,7 @@
     "react-native-worklets": "~0.4.2",
     "react-native-reanimated": "~4.0.2",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.15.3",
+    "react-native-screens": "~4.15.4",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -27,7 +27,7 @@
     "react-native-worklets": "~0.4.2",
     "react-native-reanimated": "~4.0.2",
     "react-native-safe-area-context": "~5.6.0",
-    "react-native-screens": "~4.15.3",
+    "react-native-screens": "~4.15.4",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13871,10 +13871,10 @@ react-native-screens@4.11.1-nightly-20250611-8b82e081e:
     react-native-is-edge-to-edge "^1.1.7"
     warn-once "^0.1.0"
 
-react-native-screens@4.15.3:
-  version "4.15.3"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.15.3.tgz#3efb9c47459b7940446955c2219e85a2e0aea187"
-  integrity sha512-xVQu76cddcIncR2UIX+A7FmWsxmNwGYr5gG8T6B1kMvxqNlXm0zS9U6juBRC9jyVexMvHZ2+cOLjGjkTE2VAjg==
+react-native-screens@4.15.4:
+  version "4.15.4"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.15.4.tgz#834541023fd26589d2c81fcbe35576553caee840"
+  integrity sha512-aKHPDScUbpQiZEG9eZssHdG5jEQs4yiJ8eMx6g81Ex/xU7DZkv3911enzdCb+v4eJE79X8waizY0ZhauZJQmrw==
   dependencies:
     react-freeze "^1.0.0"
     react-native-is-edge-to-edge "^1.2.1"
@@ -13931,10 +13931,10 @@ react-native-webview@13.15.0:
     escape-string-regexp "^4.0.0"
     invariant "2.2.4"
 
-react-native-worklets@0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/react-native-worklets/-/react-native-worklets-0.4.1.tgz#563d39160195101d9cf236b54b383d6950508263"
-  integrity sha512-QXAMZ8jz0sLEoNrc3ej050z6Sd+UJ/Gef4SACeMuoLRinwHIy4uel7XtMPJZMqKhFerkwXZ7Ips5vIjnNyPDBA==
+react-native-worklets@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/react-native-worklets/-/react-native-worklets-0.4.2.tgz#7b571a64a0d340ffab156f74bc2efc66bda75e57"
+  integrity sha512-02IMmU2rOL6vrF7uA6cLAeN4haXOMTBh7opmVYQbjYG8mNAb0cnhmkvkdQupmpFjBpWZRJnBGYJJa471a/9IPg==
   dependencies:
     "@babel/plugin-transform-arrow-functions" "^7.0.0-0"
     "@babel/plugin-transform-class-properties" "^7.0.0-0"


### PR DESCRIPTION
# Why

New version of react-native-screens was released with a native tabs patch

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

1. Tested expo go and bare expo 
2. Tested native tabs in expo-router

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
