### PR TITLE
[bare-minimum] Improve setting `DefaultNewArchitectureEntryPoint.releaseLevel`

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/templates/expo-template-bare-minimum/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -40,10 +40,10 @@ class MainApplication : Application(), ReactApplication {
 
   override fun onCreate() {
     super.onCreate()
-    try {
-      DefaultNewArchitectureEntryPoint.releaseLevel = ReleaseLevel.valueOf(BuildConfig.REACT_NATIVE_RELEASE_LEVEL.uppercase())
+    DefaultNewArchitectureEntryPoint.releaseLevel = try {
+      ReleaseLevel.valueOf(BuildConfig.REACT_NATIVE_RELEASE_LEVEL.uppercase())
     } catch (e: IllegalArgumentException) {
-      DefaultNewArchitectureEntryPoint.releaseLevel = ReleaseLevel.STABLE
+      ReleaseLevel.STABLE
     }
     loadReactNative(this)
     ApplicationLifecycleDispatcher.onApplicationCreate(this)


### PR DESCRIPTION
# Why

Improves how we set the `DefaultNewArchitectureEntryPoint.releaseLevel` 

# Test Plan

- tested in the bare-expo ✅ 