### PR TITLE
[docs] Update the Existing React Native apps section for SDK 54

### DIFF
--- a/docs/pages/bare/install-dev-builds-in-bare.mdx
+++ b/docs/pages/bare/install-dev-builds-in-bare.mdx
@@ -68,22 +68,6 @@ For more information, see the [`uri-scheme` library](https://www.npmjs.com/packa
 
 <Step label="3">
 
-## Add additional optional configuration
-
-For certain types of errors, you can obtain more helpful error messages when using `expo-dev-client`. To turn this on, import `expo-dev-client` in the project's **index** file. Make sure that the import statement is executed early, before your application's JS code is imported (place the import above `import App from './App'`).
-
-```js
-import 'expo-dev-client';
-/* @hide ... */ /* @end */
-import App from './App';
-```
-
-For more information, see [Error handling](/develop/development-builds/use-development-builds/#add-error-handling).
-
-</Step>
-
-<Step label="4">
-
 ## Build and install the app
 
 Create a debug build of your app using the tools of your choice. For example, you can do this [locally with Expo CLI](/guides/local-app-development/) or [in the cloud with EAS Build](/develop/development-builds/create-a-build/).

--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -38,7 +38,7 @@ To install and use Expo modules, the easiest way to get up and running is with t
 
 ## Manual installation
 
-The following instructions apply to installing the latest version of Expo modules in React Native 0.79. For previous versions, check the [native upgrade helper](/bare/upgrade) to see how these files are customized.
+The following instructions apply to installing the latest version of Expo modules in React Native 0.81. For previous versions, check the [native upgrade helper](/bare/upgrade) to see how these files are customized.
 
 <InstallSection packageName="expo" cmd={['$ npm install expo']} hideBareInstructions />
 
@@ -52,7 +52,7 @@ Once installation is complete, apply the changes from the following diffs to con
 
 <DiffBlock source="/static/diffs/expo-ios.diff" />
 
-Optionally, you can also add additional delegate methods to your **AppDelegate.swift**. Some libraries may require them, so unless you have a good reason to leave them out, it is recommended to add them. [See delegate methods in AppDelegate.swift](https://github.com/expo/expo/blob/sdk-53/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift#L24-L42).
+Optionally, you can also add additional delegate methods to your **AppDelegate.swift**. Some libraries may require them, so unless you have a good reason to leave them out, it is recommended to add them. [See delegate methods in AppDelegate.swift](https://github.com/expo/expo/blob/sdk-54/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift#L24-L42).
 
 Save all of your changes and update your iOS Deployment Target in Xcode to `iOS 15.1`:
 

--- a/docs/public/static/diffs/expo-android.diff
+++ b/docs/public/static/diffs/expo-android.diff
@@ -16,7 +16,7 @@ index 1789e54..b6ac31d 100644
 +      ReactActivityDelegateWrapper(this, BuildConfig.IS_NEW_ARCHITECTURE_ENABLED, DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled))
  }
 diff --git a/android/app/src/main/java/com/myapp/MainApplication.kt b/android/app/src/main/java/com/myapp/MainApplication.kt
-index 6f58c28..24e3a00 100644
+index 46c8f72..6edfde8 100644
 --- a/android/app/src/main/java/com/myapp/MainApplication.kt
 +++ b/android/app/src/main/java/com/myapp/MainApplication.kt
 @@ -1,4 +1,7 @@
@@ -27,7 +27,7 @@ index 6f58c28..24e3a00 100644
 
  import android.app.Application
  import com.facebook.react.PackageList
-@@ -15,7 +18,7 @@ import com.facebook.soloader.SoLoader
+@@ -13,7 +16,7 @@ import com.facebook.react.defaults.DefaultReactNativeHost
  class MainApplication : Application(), ReactApplication {
 
    override val reactNativeHost: ReactNativeHost =
@@ -36,7 +36,7 @@ index 6f58c28..24e3a00 100644
          override fun getPackages(): List<ReactPackage> =
              PackageList(this).packages.apply {
                // Packages that cannot be autolinked yet can be added manually here, for example:
-@@ -28,10 +31,10 @@ class MainApplication : Application(), ReactApplication {
+@@ -26,13 +29,19 @@ class MainApplication : Application(), ReactApplication {
 
          override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
          override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
@@ -49,10 +49,7 @@ index 6f58c28..24e3a00 100644
 
    override fun onCreate() {
      super.onCreate()
-@@ -40,5 +43,11 @@ class MainApplication : Application(), ReactApplication {
-       // If you opted-in for the New Architecture, we load the native entry point for this app.
-       load()
-     }
+     loadReactNative(this)
 +    ApplicationLifecycleDispatcher.onApplicationCreate(this)
 +  }
 +
@@ -62,39 +59,13 @@ index 6f58c28..24e3a00 100644
    }
  }
 diff --git a/android/settings.gradle b/android/settings.gradle
-index 8762b63..1e69c41 100644
+index 8762b63..12bcbde 100644
 --- a/android/settings.gradle
 +++ b/android/settings.gradle
-@@ -1,6 +1,20 @@
--pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
--plugins { id("com.facebook.react.settings") }
--extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
-+pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin")
-+  def expoPluginsPath = new File(
-+    providers.exec {
-+      workingDir(rootDir)
-+      commandLine("node", "--print", "require.resolve('expo-modules-autolinking/package.json', { paths: [require.resolve('expo/package.json')] })")
-+    }.standardOutput.asText.get().trim(),
-+    "../android/expo-gradle-plugin"
-+  ).absolutePath
-+  includeBuild(expoPluginsPath)
-+}
-+plugins { id("com.facebook.react.settings")
-+id("expo-autolinking-settings")
-+}
-+extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand(expoAutolinking.rnConfigCommand) }
+@@ -4,3 +4,6 @@ extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autoli
  rootProject.name = 'myapp'
  include ':app'
  includeBuild('../node_modules/@react-native/gradle-plugin')
-+expoAutolinking.useExpoModules()
-+expoAutolinking.useExpoVersionCatalog()
-+includeBuild(expoAutolinking.reactNativeGradlePlugin)
-diff --git a/android/build.gradle b/android/build.gradle
-index 9766946..6ee6b73 100644
---- a/android/build.gradle
-+++ b/android/build.gradle
-@@ -19,3 +19,4 @@ buildscript {
- }
-
- apply plugin: "com.facebook.react.rootproject"
-+apply plugin: "expo-root-project"
++
++apply from: new File(["node", "--print", "require.resolve('expo/package.json')"].execute(null, rootDir).text.trim(), "../scripts/autolinking.gradle")
++useExpoModules()

--- a/docs/public/static/diffs/expo-cli-android.diff
+++ b/docs/public/static/diffs/expo-cli-android.diff
@@ -1,16 +1,14 @@
 diff --git a/android/app/build.gradle b/android/app/build.gradle
-index 01841f5..e1740a6 100644
+index 804b381..475de6a 100644
 --- a/android/app/build.gradle
 +++ b/android/app/build.gradle
-@@ -50,6 +50,11 @@ react {
-     //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
-     // hermesFlags = ["-O", "-output-source-map"]
+@@ -52,6 +52,11 @@ react {
 
-+    // Bundle with Expo CLI
+     /* Autolinking */
+     autolinkLibrariesWithApp()
++    //
++    // Added by install-expo-modules
 +    entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", rootDir.getAbsoluteFile().getParentFile().getAbsolutePath(), "android", "absolute"].execute(null, rootDir).text.trim())
 +    cliFile = new File(["node", "--print", "require.resolve('@expo/cli')"].execute(null, rootDir).text.trim())
 +    bundleCommand = "export:embed"
-+
-     /* Autolinking */
-     autolinkLibrariesWithApp()
  }

--- a/docs/public/static/diffs/expo-ios.diff
+++ b/docs/public/static/diffs/expo-ios.diff
@@ -1,15 +1,3 @@
-diff --git a/ios/myapp/AppDelegate.swift b/ios/myapp/AppDelegate.swift
-index d06a6a8..061307a 100644
---- a/ios/myapp/AppDelegate.swift
-+++ b/ios/myapp/AppDelegate.swift
-@@ -29,6 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
-       launchOptions: launchOptions
-     )
-
-+    super.application(application, didFinishLaunchingWithOptions: launchOptions)
-     return true
-   }
- }
 diff --git a/ios/Podfile b/ios/Podfile
 index f7583bb..56bb898 100644
 --- a/ios/Podfile

--- a/docs/public/static/diffs/expo-ios.diff
+++ b/docs/public/static/diffs/expo-ios.diff
@@ -1,57 +1,17 @@
 diff --git a/ios/myapp/AppDelegate.swift b/ios/myapp/AppDelegate.swift
-index d06a6a8..15a0034 100644
+index d06a6a8..061307a 100644
 --- a/ios/myapp/AppDelegate.swift
 +++ b/ios/myapp/AppDelegate.swift
-@@ -1,25 +1,27 @@
- import UIKit
-+import Expo
- import React
- import React_RCTAppDelegate
- import ReactAppDependencyProvider
-
- @main
--class AppDelegate: UIResponder, UIApplicationDelegate {
-+class AppDelegate: ExpoAppDelegate {
-   var window: UIWindow?
-
-   var reactNativeDelegate: ReactNativeDelegate?
-   var reactNativeFactory: RCTReactNativeFactory?
-
--  func application(
-+  override func application(
-     _ application: UIApplication,
-     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
-   ) -> Bool {
-     let delegate = ReactNativeDelegate()
--    let factory = RCTReactNativeFactory(delegate: delegate)
-+    let factory = ExpoReactNativeFactory(delegate: delegate)
-     delegate.dependencyProvider = RCTAppDependencyProvider()
-
-     reactNativeDelegate = delegate
-     reactNativeFactory = factory
-+    bindReactNativeFactory(factory)
-
-     window = UIWindow(frame: UIScreen.main.bounds)
-
-@@ -29,18 +31,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
+@@ -29,6 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
        launchOptions: launchOptions
      )
 
--    return true
-+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
++    super.application(application, didFinishLaunchingWithOptions: launchOptions)
+     return true
    }
  }
-
--class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
-+class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
-   override func sourceURL(for bridge: RCTBridge) -> URL? {
--    self.bundleURL()
-+    // needed to return the correct URL for expo-dev-client.
-+    bridge.bundleURL ?? bundleURL()
-   }
-
 diff --git a/ios/Podfile b/ios/Podfile
-index f7583bb..626c42d 100644
+index f7583bb..56bb898 100644
 --- a/ios/Podfile
 +++ b/ios/Podfile
 @@ -1,3 +1,4 @@
@@ -59,29 +19,31 @@ index f7583bb..626c42d 100644
  # Resolve react_native_pods.rb with node to allow for hoisting
  require Pod::Executable.execute_command('node', ['-p',
    'require.resolve(
-@@ -15,7 +16,24 @@ if linkage != nil
+@@ -15,6 +16,14 @@ if linkage != nil
  end
 
  target 'myapp' do
--  config = use_native_modules!
 +  use_expo_modules!
-+
-+  if ENV['EXPO_USE_COMMUNITY_AUTOLINKING'] == '1'
-+    config_command = ['node', '-e', "process.argv=['', '', 'config'];require('@react-native-community/cli').run()"];
-+  else
-+    config_command = [
-+      'node',
-+      '--no-warnings',
-+      '--eval',
-+      'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
-+      'react-native-config',
-+      '--json',
-+      '--platform',
-+      'ios'
-+    ]
++  post_integrate do |installer|
++    begin
++      expo_patch_react_imports!(installer)
++    rescue => e
++      Pod::UI.warn e
++    end
 +  end
-+
-+  config = use_native_modules!(config_command)
+   config = use_native_modules!
 
    use_react_native!(
-     :path => config[:reactNativePath],
+diff --git a/ios/myapp/Info.plist b/ios/myapp/Info.plist
+index b97aa30..20171fc 100644
+--- a/ios/myapp/Info.plist
++++ b/ios/myapp/Info.plist
+@@ -34,7 +34,7 @@
+ 	<key>NSLocationWhenInUseUsageDescription</key>
+ 	<string></string>
+ 	<key>RCTNewArchEnabled</key>
+-	<false/>
++	<true/>
+ 	<key>UILaunchStoryboardName</key>
+ 	<string>LaunchScreen</string>
+ 	<key>UIRequiredDeviceCapabilities</key>

--- a/docs/ui/components/Snippet/DiffBlock.test.tsx
+++ b/docs/ui/components/Snippet/DiffBlock.test.tsx
@@ -12,10 +12,7 @@ const DIFF_PATH = '/static/diffs/expo-ios.diff';
 const DIFF_CONTENT = fs.readFileSync(path.join(dirname, '../../../public', DIFF_PATH)).toString();
 
 const validateDiffContent = (screen: Screen) => {
-  expect(screen.getByText('ios/myapp/AppDelegate.swift')).toBeInTheDocument();
   expect(screen.getByText('ios/Podfile')).toBeInTheDocument();
-  expect(screen.getByText('import UIKit')).toBeInTheDocument();
-  expect(screen.getByText('import Expo')).toBeInTheDocument();
 };
 
 describe(DiffBlock, () => {
@@ -28,7 +25,7 @@ describe(DiffBlock, () => {
 
     render(<DiffBlock source={DIFF_PATH} />);
 
-    await screen.findByText('ios/myapp/AppDelegate.swift');
+    await screen.findByText('ios/Podfile');
 
     validateDiffContent(screen);
   });


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16938

# How

<!--
How did you build this feature or fix this bug and why?
-->

- [Update "Manual instructions" for Android and iOS](https://docs.expo.dev/bare/installing-expo-modules/) in Install Expo modules in an existing React Native project
- Remove "Add additional optional configuration" section  in Install expo-dev-client in an existing React Native project since it doesn't do anything and is not required anymore. Follow up #39168

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs app locally and visit: http://localhost:3002/bare/installing-expo-modules/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
