### PR TITLE
bump expo/vector-icons to 15.0.1

### DIFF
--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@apollo/client": "^3.4.10",
     "@expo/styleguide-native": "^1.0.1",
-    "@expo/vector-icons": "^15.0.0",
+    "@expo/vector-icons": "^15.0.1",
     "@gorhom/bottom-sheet": "5.1.8",
     "@graphql-codegen/introspection": "^2.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@expo/dom-webview": "0.2.4",
-    "@expo/vector-icons": "^15.0.0",
+    "@expo/vector-icons": "~15.0.1",
     "expo": "~54.0.0-preview.10",
     "expo-haptics": "~15.0.4",
     "expo-linking": "~8.0.4",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,7 +1,7 @@
 {
   "@expo/fingerprint": "~0.14.4",
   "@expo/metro-runtime": "~6.1.1",
-  "@expo/vector-icons": "^15.0.0",
+  "@expo/vector-icons": "^15.0.1",
   "@expo/ui": "~0.2.0-alpha.6",
   "@react-native-async-storage/async-storage": "2.2.0",
   "@react-native-community/datetimepicker": "8.4.4",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -82,7 +82,7 @@
     "@expo/fingerprint": "0.14.4",
     "@expo/metro": "~0.1.1",
     "@expo/metro-config": "0.21.6",
-    "@expo/vector-icons": "^15.0.0",
+    "@expo/vector-icons": "^15.0.1",
     "@ungap/structured-clone": "^1.3.0",
     "babel-preset-expo": "~14.0.4",
     "expo-asset": "~12.0.5",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -12,7 +12,7 @@
     "lint": "expo lint"
   },
   "dependencies": {
-    "@expo/vector-icons": "^15.0.0",
+    "@expo/vector-icons": "^15.0.1",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -11,7 +11,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@expo/vector-icons": "^15.0.0",
+    "@expo/vector-icons": "^15.0.1",
     "@react-navigation/native": "^7.1.8",
     "expo": "~54.0.0-preview.10",
     "expo-constants": "~18.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1762,10 +1762,10 @@
   resolved "https://registry.yarnpkg.com/@expo/sudo-prompt/-/sudo-prompt-9.3.2.tgz#0fd2813402a42988e49145cab220e25bea74b308"
   integrity sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==
 
-"@expo/vector-icons@^15.0.0":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-15.0.0.tgz#3e4e30eb17b44b7b44a559f9c7fabcaf9794bc77"
-  integrity sha512-tWmVdNzmpfoffC0MQzwUs5C/uaZDtgrUk+SMpegBcVaSKmR5B/uN0O7B7KvnZwkzWoODsATYx9U4wUyogTcMyw==
+"@expo/vector-icons@^15.0.1", "@expo/vector-icons@~15.0.1":
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-15.0.1.tgz#20f23762a27e565467957b16ab64da73e00fb9bf"
+  integrity sha512-59ej0hbW1G5f1v+UcuIaAqVHriPYHk2HeG3GVnflmBNMJ/R3lY82B4yoXz8KS6yTt3uD7WU5hl1y1Ze0GXsHfg==
 
 "@expo/ws-tunnel@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
# Why

@expo/vector-icons was released to align with latest expo-font release. Bump the dependencies to 15.0.1 to make sure vector icons work properly.  

# How

1. Bump vector icons

# Test Plan

1. Test bare-expo
2. Test native tabs in expo-router

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
