### PR TITLE
[iOS][expo-contacts] Fix undefined labels for emails in contacts

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -19,6 +19,7 @@ _This version does not introduce any user-facing changes._
 ### 🐛 Bug fixes
 
 - fix `CNContactViewController` presentation ([#39004](https://github.com/expo/expo/pull/39004) by [@vonovak](https://github.com/vonovak))
+- [iOS] Fixed undefined labels for emails in contacts. ([#39222](https://github.com/expo/expo/pull/39222) by [@NorseGaud](https://github.com/hryhoriiK97)
 
 ## 15.0.2 — 2025-08-16
 

--- a/packages/expo-contacts/ios/Serialization.swift
+++ b/packages/expo-contacts/ios/Serialization.swift
@@ -423,16 +423,20 @@ private func emailsFor(contact person: CNContact) -> [[String: Any]]? {
 
   for container in person.emailAddresses {
     let emailAddress = container.value as String
+    let emailLabel: String
     if let label = container.label {
-      let emailLabel = CNLabeledValue<NSString>.localizedString(forLabel: label)
-      results.append(["email": emailAddress, "label": emailLabel, "id": container.identifier])
+      emailLabel = CNLabeledValue<NSString>.localizedString(forLabel: label)
     } else {
-      results.append(["email": emailAddress, "id": container.identifier])
+      // Use localized "other" label to match iOS's standard.
+      // This ensures iCloud contacts (which could have no label) still have a consistent label.
+      emailLabel = CNLabeledValue<NSString>.localizedString(forLabel: CNLabelOther)
     }
+    results.append(["email": emailAddress, "label": emailLabel, "id": container.identifier])
   }
 
   return results.isEmpty ? nil : results
 }
+
 
 private func phoneNumbersFor(contact person: CNContact) -> [[String: Any]]? {
   var results = [[String: Any]]()

--- a/packages/expo-contacts/ios/Serialization.swift
+++ b/packages/expo-contacts/ios/Serialization.swift
@@ -437,7 +437,6 @@ private func emailsFor(contact person: CNContact) -> [[String: Any]]? {
   return results.isEmpty ? nil : results
 }
 
-
 private func phoneNumbersFor(contact person: CNContact) -> [[String: Any]]? {
   var results = [[String: Any]]()
 


### PR DESCRIPTION
# Why
When an email from iCloud has no label, we now use iOS's "other" label instead of leaving it undefined. This matches how iOS handles unlabeled emails and ensures the label appears in the user's language correctly.

# How
We check if an email has a label (container.label). If it doesn't, instead of returning no label, we use CNLabeledValue<NSString>.localizedString(forLabel: CNLabelOther) to get iOS's standard "other" label in the user's language.

# Test Plan
This issue was identified with private contacts from iCloud. It would be difficult to reproduce now since Apple provides a default label when creating new contacts. This fix mainly handles backward compatibility for older contacts that may have undefined labels.

<img width="461" height="40" alt="Screenshot 2025-08-28 at 14 45 50" src="https://github.com/user-attachments/assets/5ed7320b-d286-454a-baad-b666a5f4978b" />

<img width="461" height="30" alt="Screenshot 2025-08-28 at 14 47 07" src="https://github.com/user-attachments/assets/8b475299-1e8f-4a8d-939f-cf1368cb121c" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
