### PR TITLE
bump @expo/vector-icons to 15.0.2

### DIFF
--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@apollo/client": "^3.4.10",
     "@expo/styleguide-native": "^1.0.1",
-    "@expo/vector-icons": "^15.0.0",
+    "@expo/vector-icons": "^15.0.2",
     "@gorhom/bottom-sheet": "5.1.8",
     "@graphql-codegen/introspection": "^2.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/apps/native-component-list/src/screens/FontScreen.tsx
+++ b/apps/native-component-list/src/screens/FontScreen.tsx
@@ -1,17 +1,33 @@
+import FontAwesome from '@expo/vector-icons/FontAwesome';
 import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
+import FoundationIcons from '@expo/vector-icons/Foundation';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import * as Font from 'expo-font';
-import { useState } from 'react';
-import { Button, Image, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { RenderToImageResult } from 'expo-font';
+import { Image } from 'expo-image';
+import { useState, useEffect, Fragment } from 'react';
+import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { Page, Section } from '../components/Page';
 
+const round = (num: number) => Math.round(num * 100) / 100;
+
 export default function FontScreen() {
-  const [preview, setPreview] = useState<string | null>(null);
-  const toImageAsync = async (glyphs: string, options: any) => {
-    const imageURL = await Font.renderToImageAsync(glyphs, options);
-    setPreview(imageURL.uri);
-  };
+  const renderedFontAwesomeImage = useLoadIcon(() =>
+    Font.renderToImageAsync(String.fromCodePoint(62491), {
+      fontFamily: 'FontAwesome5Free-Brand',
+      color: '#61dafb',
+      size: 172,
+    })
+  );
+
+  const renderedFontAsImage = useLoadIcon(() =>
+    Font.renderToImageAsync('ÅBÇD', {
+      fontFamily: 'Inter-BoldItalic',
+      size: 100,
+    })
+  );
 
   return (
     <ScrollView style={{ flex: 1 }}>
@@ -128,28 +144,42 @@ export default function FontScreen() {
             </View>
           </View>
         </Section>
-        <Section title="renderToImageAsync">
-          <Button
-            title="ABCD Inter-ThinItalic"
-            onPress={() =>
-              toImageAsync('ABCD', {
-                fontFamily: 'Inter-BoldItalic',
-                size: 172,
-              })
-            }
-          />
-          <Button
-            title="React from FontAwesome5"
-            onPress={() =>
-              toImageAsync(String.fromCodePoint(62491), {
-                fontFamily: 'FontAwesome5Free-Brand',
-                color: '#61dafb',
-                size: 172,
-              })
-            }
-          />
-          {preview && (
-            <Image source={{ uri: preview }} style={{ height: 64 }} resizeMode="contain" />
+        <VectorIconSection />
+
+        <Section title="renderToImageAsync" gap={5}>
+          {renderedFontAwesomeImage && (
+            <>
+              <Text>
+                FontAwesome5Free rendered to image
+                {round(renderedFontAwesomeImage.width)}x{round(renderedFontAwesomeImage.height)}
+              </Text>
+              <Image
+                source={{ uri: renderedFontAwesomeImage.uri }}
+                style={{
+                  height: renderedFontAwesomeImage.height,
+                  width: renderedFontAwesomeImage.width,
+                  backgroundColor: 'grey',
+                }}
+                resizeMode="contain"
+              />
+            </>
+          )}
+          {renderedFontAsImage && (
+            <>
+              <Text>
+                Inter-BoldItalic rendered to image
+                {round(renderedFontAsImage.width)}x{round(renderedFontAsImage.height)}
+              </Text>
+              <Image
+                source={{ uri: renderedFontAsImage.uri }}
+                style={{
+                  height: renderedFontAsImage.height,
+                  width: renderedFontAsImage.width,
+                  backgroundColor: 'grey',
+                }}
+                resizeMode="contain"
+              />
+            </>
           )}
         </Section>
       </Page>
@@ -183,3 +213,54 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
 });
+
+const size = 100;
+
+function useLoadIcon(getImage: () => Promise<RenderToImageResult | null>) {
+  const [icon, setIcon] = useState<RenderToImageResult | null>(null);
+  useEffect(() => {
+    const loadIcon = async () => {
+      const icon = await getImage();
+      if (icon) {
+        setIcon(icon);
+      } else {
+        console.error('Failed to load icon');
+      }
+    };
+    loadIcon();
+  }, []);
+  return icon;
+}
+
+function VectorIconSection() {
+  const icons = [
+    useLoadIcon(() => MaterialIcons.getImageSource('camera', size, 'yellow')),
+    useLoadIcon(() => FontAwesome.getImageSource('book', size, 'yellow')),
+    useLoadIcon(() => Ionicons.getImageSource('camera', size, 'yellow')),
+    useLoadIcon(() => FoundationIcons.getImageSource('book', size, 'yellow')),
+  ];
+
+  return (
+    <Section title="vector icon to image" gap={5}>
+      {icons.map((icon) => {
+        return (
+          !!icon && (
+            <Fragment key={icon.uri}>
+              <Text>
+                Icon rendered to image {round(icon.width)}x{round(icon.height)}
+              </Text>
+              <Image
+                source={icon}
+                style={{
+                  height: icon.height,
+                  width: icon.width,
+                  backgroundColor: 'lightgrey',
+                }}
+              />
+            </Fragment>
+          )
+        );
+      })}
+    </Section>
+  );
+}

--- a/apps/native-component-list/src/screens/FontScreen.tsx
+++ b/apps/native-component-list/src/screens/FontScreen.tsx
@@ -160,7 +160,7 @@ export default function FontScreen() {
                   width: renderedFontAwesomeImage.width,
                   backgroundColor: 'grey',
                 }}
-                resizeMode="contain"
+                contentFit="cover"
               />
             </>
           )}
@@ -177,7 +177,7 @@ export default function FontScreen() {
                   width: renderedFontAsImage.width,
                   backgroundColor: 'grey',
                 }}
-                resizeMode="contain"
+                contentFit="cover"
               />
             </>
           )}

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@expo/dom-webview": "0.2.4",
-    "@expo/vector-icons": "^15.0.0",
+    "@expo/vector-icons": "^15.0.2",
     "expo": "~54.0.0-preview.10",
     "expo-haptics": "~15.0.4",
     "expo-linking": "~8.0.4",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,7 +1,7 @@
 {
   "@expo/fingerprint": "~0.14.4",
   "@expo/metro-runtime": "~6.1.1",
-  "@expo/vector-icons": "^15.0.0",
+  "@expo/vector-icons": "^15.0.2",
   "@expo/ui": "~0.2.0-alpha.6",
   "@react-native-async-storage/async-storage": "2.2.0",
   "@react-native-community/datetimepicker": "8.4.4",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -82,7 +82,7 @@
     "@expo/fingerprint": "0.14.4",
     "@expo/metro": "~0.1.1",
     "@expo/metro-config": "0.21.6",
-    "@expo/vector-icons": "^15.0.0",
+    "@expo/vector-icons": "^15.0.2",
     "@ungap/structured-clone": "^1.3.0",
     "babel-preset-expo": "~14.0.4",
     "expo-asset": "~12.0.5",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -12,7 +12,7 @@
     "lint": "expo lint"
   },
   "dependencies": {
-    "@expo/vector-icons": "^15.0.0",
+    "@expo/vector-icons": "^15.0.2",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -11,7 +11,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@expo/vector-icons": "^15.0.0",
+    "@expo/vector-icons": "^15.0.2",
     "@react-navigation/native": "^7.1.8",
     "expo": "~54.0.0-preview.10",
     "expo-constants": "~18.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1762,10 +1762,10 @@
   resolved "https://registry.yarnpkg.com/@expo/sudo-prompt/-/sudo-prompt-9.3.2.tgz#0fd2813402a42988e49145cab220e25bea74b308"
   integrity sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw==
 
-"@expo/vector-icons@^15.0.0":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-15.0.0.tgz#3e4e30eb17b44b7b44a559f9c7fabcaf9794bc77"
-  integrity sha512-tWmVdNzmpfoffC0MQzwUs5C/uaZDtgrUk+SMpegBcVaSKmR5B/uN0O7B7KvnZwkzWoODsATYx9U4wUyogTcMyw==
+"@expo/vector-icons@^15.0.2":
+  version "15.0.2"
+  resolved "https://registry.yarnpkg.com/@expo/vector-icons/-/vector-icons-15.0.2.tgz#64d380f04cf2bdeb1dac502c3a0d880b6c2a9e37"
+  integrity sha512-IiBjg7ZikueuHNf40wSGCf0zS73a3guJLdZzKnDUxsauB8VWPLMeWnRIupc+7cFhLUkqyvyo0jLNlcxG5xPOuQ==
 
 "@expo/ws-tunnel@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
# Why

@expo/vector-icons was released to align with latest expo-font release. Bump the dependencies to 15.0.2 to make sure vector icons work properly (`getImageSource` to be specific)

# How

- bump the dep

# Test Plan

- the updated examples at `apps/native-component-list/src/screens/FontScreen.tsx`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
