### PR TITLE
[core][Android] Add StaticFunction and StaticAsyncFunction to Class in modules API

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [iOS] Add explicit CallInvoker and CallbackWrapper imports to EXJSIUtils ([#39818](https://github.com/expo/expo/pull/39818) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Refactor getDelayLoadAppHandler to use ReactHost ([#40084](https://github.com/expo/expo/pull/40084) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Use module name from `expo-module.config.json`. ([#39985](https://github.com/expo/expo/pull/39985), [#40241](https://github.com/expo/expo/pull/40241) by [@jakex7](https://github.com/jakex7))
+- [Android] Add StaticFunction and StaticAsyncFunction to Class in modules API.
 
 ## 3.0.19 - 2025-10-01
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [Android] Add experimental formatters API. ([#38946](https://github.com/expo/expo/pull/38946) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Add `convertResult` to `Convertible`. ([#40302](https://github.com/expo/expo/pull/40302) by [@jakex7](https://github.com/jakex7))
 - [iOS] Adopted Swift 6 ([#40369](https://github.com/expo/expo/pull/40369) by [@tsapeta](https://github.com/tsapeta))
+- [Android] Add StaticFunction and StaticAsyncFunction to Class in modules API. ([#39228](https://github.com/expo/expo/pull/39228) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 
@@ -30,7 +31,6 @@
 - [iOS] Add explicit CallInvoker and CallbackWrapper imports to EXJSIUtils ([#39818](https://github.com/expo/expo/pull/39818) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Refactor getDelayLoadAppHandler to use ReactHost ([#40084](https://github.com/expo/expo/pull/40084) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Use module name from `expo-module.config.json`. ([#39985](https://github.com/expo/expo/pull/39985), [#40241](https://github.com/expo/expo/pull/40241) by [@jakex7](https://github.com/jakex7))
-- [Android] Add StaticFunction and StaticAsyncFunction to Class in modules API.
 
 ## 3.0.19 - 2025-10-01
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -163,6 +163,17 @@ class SingleTestContext(
     return jsiInterop.evaluateScript("(new $moduleRef.$className()).$functionName($args)")
   }
 
+  fun callClassStatic(className: String, functionName: String, args: String = "") = jsiInterop.evaluateScript(
+    "$moduleRef.$className.$functionName($args)"
+  )
+
+  fun callClassStaticAsync(className: String, functionName: String, args: String = "", shouldBeResolved: Boolean = true) =
+    jsiInterop.waitForAsyncFunction(
+      methodQueue,
+      "$moduleRef.$className.$functionName($args)",
+      shouldBeResolved
+    )
+
   fun classProperty(className: String, propertyName: String) =
     jsiInterop.evaluateScript("(new $moduleRef.$className()).$propertyName")
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
@@ -119,6 +119,32 @@ class JavaScriptClassTest {
   }
 
   @Test
+  fun shared_object_should_call_static_functions() {
+    class MySharedObject : SharedObject()
+
+    var wasCalled = false
+    var wasAsyncCalled = false
+    withSingleModule({
+      Class(MySharedObject::class) {
+        Constructor {
+          return@Constructor MySharedObject()
+        }
+        StaticFunction<Unit>("staticSyncFunction") {
+          wasCalled = true
+        }
+        StaticAsyncFunction<Unit>("staticAsyncFunction") {
+          wasAsyncCalled = true
+        }
+      }
+    }) {
+      callClassStatic("MySharedObject", "staticSyncFunction")
+      Truth.assertThat(wasCalled).isTrue()
+      callClassStaticAsync("MySharedObject", "staticAsyncFunction")
+      Truth.assertThat(wasAsyncCalled).isTrue()
+    }
+  }
+
+  @Test
   fun shared_object_should_be_passed_as_this_in_async_function() {
     class MySharedObject : SharedObject()
 

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.h
@@ -22,6 +22,7 @@ public:
   void registerClass(
     jni::alias_ref<jstring> name,
     jni::alias_ref<jni::HybridClass<JSDecoratorsBridgingObject>::javaobject> prototypeDecorator,
+    jni::alias_ref<jni::HybridClass<JSDecoratorsBridgingObject>::javaobject> constructorDecorator,
     jboolean takesOwner,
     jni::alias_ref<jclass> ownerClass,
     jboolean isSharedRef,
@@ -37,6 +38,7 @@ public:
 private:
   struct ClassEntry {
     std::vector<std::unique_ptr<JSDecorator>> prototypeDecorators;
+    std::vector<std::unique_ptr<JSDecorator>> constructorDecorators;
     std::shared_ptr<MethodMetadata> constructor;
     jni::global_ref<jclass> ownerClass;
     bool isSharedRef;

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.cpp
@@ -116,6 +116,7 @@ void JSDecoratorsBridgingObject::registerObject(
 void JSDecoratorsBridgingObject::registerClass(
   jni::alias_ref<jstring> name,
   jni::alias_ref<JSDecoratorsBridgingObject::javaobject> jsDecoratorsBridgingObject,
+  jni::alias_ref<JSDecoratorsBridgingObject::javaobject> jsDecoratorsConstructor,
   jboolean takesOwner,
   jni::alias_ref<jclass> ownerClass,
   jboolean isSharedRef,
@@ -129,6 +130,7 @@ void JSDecoratorsBridgingObject::registerClass(
   classDecorator->registerClass(
     name,
     jsDecoratorsBridgingObject,
+    jsDecoratorsConstructor,
     takesOwner,
     ownerClass,
     isSharedRef,

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
@@ -72,6 +72,7 @@ public:
   void registerClass(
     jni::alias_ref<jstring> name,
     jni::alias_ref<JSDecoratorsBridgingObject::javaobject> jsDecoratorsBridgingObject,
+    jni::alias_ref<JSDecoratorsBridgingObject::javaobject> jsDecoratorsConstructor,
     jboolean takesOwner,
     jni::alias_ref<jclass> ownerClass,
     jboolean isSharedRef,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -3,10 +3,16 @@
 package expo.modules.kotlin.classcomponent
 
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.Promise
 import expo.modules.kotlin.component6
 import expo.modules.kotlin.component7
 import expo.modules.kotlin.component8
+import expo.modules.kotlin.functions.AsyncFunctionBuilder
+import expo.modules.kotlin.functions.AsyncFunctionComponent
+import expo.modules.kotlin.functions.AsyncFunctionWithPromiseComponent
+import expo.modules.kotlin.functions.FunctionBuilder
 import expo.modules.kotlin.functions.SyncFunctionComponent
+import expo.modules.kotlin.functions.createAsyncFunctionComponent
 import expo.modules.kotlin.objects.ObjectDefinitionBuilder
 import expo.modules.kotlin.objects.PropertyComponentBuilderWithThis
 import expo.modules.kotlin.sharedobjects.SharedObject
@@ -30,6 +36,17 @@ class ClassComponentBuilder<SharedObjectType : Any>(
 ) : ObjectDefinitionBuilder(converters) {
   var constructor: SyncFunctionComponent? = null
   val traits = mutableListOf<Trait<in SharedObjectType>>()
+
+  @PublishedApi
+  internal var staticSyncFunctions = mutableMapOf<String, SyncFunctionComponent>()
+
+  @PublishedApi
+  internal var staticSyncFunctionBuilder = mutableMapOf<String, FunctionBuilder>()
+
+  @PublishedApi
+  internal var staticAsyncFunctions = mutableMapOf<String, AsyncFunctionComponent>()
+
+  private var staticAsyncFunctionBuilders = mutableMapOf<String, AsyncFunctionBuilder>()
 
   fun buildClass(): ClassDefinitionData {
     val hasOwnerType = ownerClass != Unit::class
@@ -72,6 +89,8 @@ class ClassComponentBuilder<SharedObjectType : Any>(
     return ClassDefinitionData(
       name,
       constructor,
+      staticSyncFunctions + staticSyncFunctionBuilder.mapValues { (_, value) -> value.build() },
+      staticAsyncFunctions + staticAsyncFunctionBuilders.mapValues { (_, value) -> value.build() },
       objectData,
       isSharedRef
     )
@@ -191,6 +210,339 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   override fun Property(name: String): PropertyComponentBuilderWithThis<SharedObjectType> {
     return PropertyComponentBuilderWithThis<SharedObjectType>(ownerType.kType, name).also {
       properties[name] = it
+    }
+  }
+
+  fun StaticFunction(
+    name: String
+  ) = FunctionBuilder(name).also { staticSyncFunctionBuilder[name] = it }
+
+  @JvmName("StaticFunctionWithoutArgs")
+  inline fun StaticFunction(
+    name: String,
+    crossinline body: () -> Any?
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, emptyArray(), toReturnType<Any?>()) { body() }.also {
+      staticSyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R> StaticFunction(
+    name: String,
+    crossinline body: () -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, emptyArray(), toReturnType<R>()) { body() }.also {
+      staticSyncFunctions[name] = it
+    }
+  }
+  inline fun <reified R, reified P0> StaticFunction(
+    name: String,
+    crossinline body: (p0: P0) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, toArgsArray<P0>(converterProvider = converters), toReturnType<R>()) { (p0) ->
+      enforceType<P0>(p0)
+      body(p0)
+    }.also {
+      staticSyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1> StaticFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1>(converterProvider = converters), toReturnType<R>()) { (p0, p1) ->
+      enforceType<P0, P1>(p0, p1)
+      body(p0, p1)
+    }.also {
+      staticSyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2> StaticFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2>(converterProvider = converters), toReturnType<R>()) { (p0, p1, p2) ->
+      enforceType<P0, P1, P2>(p0, p1, p2)
+      body(p0, p1, p2)
+    }.also {
+      staticSyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> StaticFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>(converterProvider = converters), toReturnType<R>()) { (p0, p1, p2, p3) ->
+      enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
+      body(p0, p1, p2, p3)
+    }.also {
+      staticSyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> StaticFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>(converterProvider = converters), toReturnType<R>()) { (p0, p1, p2, p3, p4) ->
+      enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
+      body(p0, p1, p2, p3, p4)
+    }.also {
+      staticSyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> StaticFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>(converterProvider = converters), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5) ->
+      enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
+      body(p0, p1, p2, p3, p4, p5)
+    }.also {
+      staticSyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> StaticFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>(converterProvider = converters), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5, p6) ->
+      enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
+      body(p0, p1, p2, p3, p4, p5, p6)
+    }.also {
+      staticSyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> StaticFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>(converterProvider = converters), toReturnType<R>()) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+      enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
+      body(p0, p1, p2, p3, p4, p5, p6, p7)
+    }.also {
+      staticSyncFunctions[name] = it
+    }
+  }
+
+  fun StaticAsyncFunction(
+    name: String
+  ) = AsyncFunctionBuilder(name, converters).also { staticAsyncFunctionBuilders[name] = it }
+
+  @JvmName("StaticAsyncFunctionWithoutArgs")
+  inline fun StaticAsyncFunction(
+    name: String,
+    crossinline body: () -> Any?
+  ): AsyncFunctionComponent {
+    return createAsyncFunctionComponent(name, emptyArray()) { body() }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R> StaticAsyncFunction(
+    name: String,
+    crossinline body: () -> R
+  ): AsyncFunctionComponent {
+    return createAsyncFunctionComponent(name, emptyArray()) { body() }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0) -> R
+  ): AsyncFunctionComponent {
+    // We can't split that function, because that introduces a ambiguity when creating DSL component without parameters.
+    return if (P0::class.java == Promise::class.java) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf()) { _, promise -> body(promise as P0) }
+    } else {
+      createAsyncFunctionComponent(name, toArgsArray<P0>(converterProvider = converters)) { (p0) ->
+        enforceType<P0>(p0)
+        body(p0)
+      }
+    }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1) -> R
+  ): AsyncFunctionComponent {
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1>(converterProvider = converters)) { (p0, p1) ->
+      enforceType<P0, P1>(p0, p1)
+      body(p0, p1)
+    }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("StaticAsyncFunctionWithPromise")
+  inline fun <reified R, reified P0> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: Promise) -> R
+  ): AsyncFunctionComponent {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0>(converterProvider = converters)) { (p0), promise ->
+      enforceType<P0>(p0)
+      body(p0, promise)
+    }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2) -> R
+  ): AsyncFunctionComponent {
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2>(converterProvider = converters)) { (p0, p1, p2) ->
+      enforceType<P0, P1, P2>(p0, p1, p2)
+      body(p0, p1, p2)
+    }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("StaticAsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: Promise) -> R
+  ): AsyncFunctionComponent {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1>(converterProvider = converters)) { (p0, p1), promise ->
+      enforceType<P0, P1>(p0, p1)
+      body(p0, p1, promise)
+    }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
+  ): AsyncFunctionComponent {
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3>(converterProvider = converters)) { (p0, p1, p2, p3) ->
+      enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
+      body(p0, p1, p2, p3)
+    }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("StaticAsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: Promise) -> R
+  ): AsyncFunctionComponent {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2>(converterProvider = converters)) { (p0, p1, p2), promise ->
+      enforceType<P0, P1, P2>(p0, p1, p2)
+      body(p0, p1, p2, promise)
+    }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
+  ): AsyncFunctionComponent {
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4>(converterProvider = converters)) { (p0, p1, p2, p3, p4) ->
+      enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
+      body(p0, p1, p2, p3, p4)
+    }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("StaticAsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: Promise) -> R
+  ): AsyncFunctionComponent {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3>(converterProvider = converters)) { (p0, p1, p2, p3), promise ->
+      enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
+      body(p0, p1, p2, p3, promise)
+    }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
+  ): AsyncFunctionComponent {
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5) ->
+      enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
+      body(p0, p1, p2, p3, p4, p5)
+    }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("StaticAsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: Promise) -> R
+  ): AsyncFunctionComponent {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4>(converterProvider = converters)) { (p0, p1, p2, p3, p4), promise ->
+      enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
+      body(p0, p1, p2, p3, p4, promise)
+    }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
+  ): AsyncFunctionComponent {
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5, p6) ->
+      enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
+      body(p0, p1, p2, p3, p4, p5, p6)
+    }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("StaticAsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: Promise) -> R
+  ): AsyncFunctionComponent {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5), promise ->
+      enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
+      body(p0, p1, p2, p3, p4, p5, promise)
+    }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
+  ): AsyncFunctionComponent {
+    return createAsyncFunctionComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6, P7>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5, p6, p7) ->
+      enforceType<P0, P1, P2, P3, P4, P5, P6, P7>(p0, p1, p2, p3, p4, p5, p6, p7)
+      body(p0, p1, p2, p3, p4, p5, p6, p7)
+    }.also {
+      staticAsyncFunctions[name] = it
+    }
+  }
+
+  @JvmName("StaticAsyncFunctionWithPromise")
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> StaticAsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: Promise) -> R
+  ): AsyncFunctionComponent {
+    return AsyncFunctionWithPromiseComponent(name, toArgsArray<P0, P1, P2, P3, P4, P5, P6>(converterProvider = converters)) { (p0, p1, p2, p3, p4, p5, p6), promise ->
+      enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
+      body(p0, p1, p2, p3, p4, p5, p6, promise)
+    }.also {
+      staticAsyncFunctions[name] = it
     }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassDefinitionData.kt
@@ -1,11 +1,18 @@
 package expo.modules.kotlin.classcomponent
 
+import expo.modules.kotlin.ConcatIterator
+import expo.modules.kotlin.functions.BaseAsyncFunctionComponent
 import expo.modules.kotlin.functions.SyncFunctionComponent
 import expo.modules.kotlin.objects.ObjectDefinitionData
 
 class ClassDefinitionData(
   val name: String,
   val constructor: SyncFunctionComponent,
+  val staticSyncFunctions: Map<String, SyncFunctionComponent>,
+  val staticAsyncFunctions: Map<String, BaseAsyncFunctionComponent>,
   val objectDefinition: ObjectDefinitionData,
   val isSharedRef: Boolean
-)
+) {
+  val staticFunctions
+    get() = ConcatIterator(staticSyncFunctions.values.iterator(), staticAsyncFunctions.values.iterator())
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
@@ -78,6 +78,7 @@ class JSDecoratorsBridgingObject(jniDeallocator: JNIDeallocator) : Destructible 
   external fun registerClass(
     name: String,
     prototypeDecorator: JSDecoratorsBridgingObject,
+    constructorDecorator: JSDecoratorsBridgingObject,
     takesOwner: Boolean,
     ownerClass: Class<*>?,
     isSharedRef: Boolean,


### PR DESCRIPTION
# Why

Follow-up for https://github.com/expo/expo/pull/38754

It should be possible to create a static functions on SharedObjects

# How

Add `StaticFunction` and `StaticAsyncFunction` in DSL and decorate the class constructor with them. 

# Test Plan

* Tests should pass
* Add static functions to shared object

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
