### PR TITLE
chore(templates): add `android/` and `ios/` folders to `.gitignore` in the default template

### DIFF
--- a/templates/expo-template-default/gitignore
+++ b/templates/expo-template-default/gitignore
@@ -37,3 +37,7 @@ yarn-error.*
 *.tsbuildinfo
 
 app-example
+
+# platform projects
+android/
+ios/


### PR DESCRIPTION
# Why

Expo's CNG support has been stable for some time now, so we should update our default template to reflect that.

# How

Added `android/` and `ios/` to the default template's `.gitignore`.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
