### PR TITLE
[image-picker][ios] fix: wrong dimensions for portrait images

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix wrong dimensions reported for portrait images ([#39230](https://github.com/expo/expo/pull/39230) by [@hirbod](https://github.com/hirbod))
+
 ### 💡 Others
 
 ## 17.0.4 — 2025-08-27

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -97,7 +97,7 @@ internal struct MediaHandler {
           imageData: imageData, orImageFileUrl: targetUrl, tryReadingFile: fileWasCopied) : nil
 
       let exif = options.exif ? await ImageUtils.readExifFrom(mediaInfo: mediaInfo) : nil
-      let size = ImageUtils.readSizeFrom(url: targetUrl) ?? .zero
+      let size = CGSize(width: image.size.width, height: image.size.height)
 
       return AssetInfo(
         assetId: asset?.localIdentifier,
@@ -144,7 +144,7 @@ internal struct MediaHandler {
         let cachedUrl = targetUrl
         let fileExtension = "." + cachedUrl.pathExtension
 
-        let size = ImageUtils.readSizeFrom(url: cachedUrl) ?? .zero
+        let size = ImageUtils.readVisualSizeFrom(url: cachedUrl) ?? .zero
         let fileSize = getFileSize(from: cachedUrl)
         let mimeType = getMimeType(from: cachedUrl.pathExtension)
         let fileName = itemProvider.suggestedName.map { $0 + fileExtension }
@@ -197,7 +197,7 @@ internal struct MediaHandler {
     let exif = options.exif ? ImageUtils.readExifFrom(data: rawData) : nil
     let base64 = options.base64 ? imageData?.base64EncodedString() : nil
 
-    let size = ImageUtils.readSizeFrom(url: targetUrl) ?? .zero
+    let size = CGSize(width: image.size.width, height: image.size.height)
 
     return AssetInfo(
       assetId: selectedImage.assetIdentifier,


### PR DESCRIPTION
# Why

Portrait image dimensions were reported as landscape (width > height) due to a mismatch between processed images and metadata reading.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- UIImagePicker & PHPicker processed paths: Read dimensions directly from processed UIImage object instead of file metadata
- PHPicker fast path: Created readVisualSizeFrom() that accounts for EXIF orientation when reading raw file metadata
- Performance bonus: Eliminated redundant file I/O in 2/3 code paths

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
