### PR TITLE
[core][ui] use convertible for modifiers

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 💡 Others
 
 - Fix JavaScriptRuntimeSpec tests ([#39281](https://github.com/expo/expo/pull/39281) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Added `appContext` to `ExpoSwiftUI.ViewProps`. ([#39231](https://github.com/expo/expo/pull/39231) by [@kudo](https://github.com/kudo))
 
 ## 3.0.10 — 2025-08-31
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -65,6 +65,10 @@ public extension ExpoSwiftUIView {
   static func getDynamicType() -> AnyDynamicType {
     return DynamicSwiftUIViewType(innerType: Self.self)
   }
+
+  var appContext: AppContext? {
+    return props.appContext
+  }
 }
 
 extension ExpoSwiftUI {
@@ -88,6 +92,7 @@ extension ExpoSwiftUI {
     public override func createView(appContext: AppContext) -> AppleView? {
 #if RCT_NEW_ARCH_ENABLED
       let props = Props()
+      props.appContext = appContext
 
       if ViewType.self is WithHostingView.Type {
         let view = HostingView(viewType: ViewType.self, props: props, appContext: appContext)

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewProps.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewProps.swift
@@ -17,6 +17,8 @@ extension ExpoSwiftUI {
      */
     @Field public var children: [any AnyChild]?
 
+    public internal(set) weak var appContext: AppContext?
+
     /**
      A global event dispatcher that allows views to call `view.dispatchEvent(_:payload)` directly
      */

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Used convertibles to process modifiers' parameters. ([#39231](https://github.com/expo/expo/pull/39231) by [@kudo](https://github.com/kudo))
+
 ## 0.2.0-alpha.7 — 2025-08-31
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-ui/ios/Convertibles/AlignmentOptions.swift
+++ b/packages/expo-ui/ios/Convertibles/AlignmentOptions.swift
@@ -1,0 +1,58 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+import SwiftUI
+
+internal enum AlignmentOptions: String, Enumerable {
+  case center
+  case leading
+  case trailing
+  case top
+  case bottom
+  case topLeading
+  case topTrailing
+  case bottomLeading
+  case bottomTrailing
+
+  case centerFirstTextBaseline
+  case centerLastTextBaseline
+  case leadingFirstTextBaseline
+  case leadingLastTextBaseline
+  case trailingFirstTextBaseline
+  case trailingLastTextBaseline
+
+  func toAlignment() -> SwiftUI.Alignment {
+    switch self {
+    case .center:
+      return .center
+    case .leading:
+      return .leading
+    case .trailing:
+      return .trailing
+    case .top:
+      return .top
+    case .bottom:
+      return .bottom
+    case .topLeading:
+      return .topLeading
+    case .topTrailing:
+      return .topTrailing
+    case .bottomLeading:
+      return .bottomLeading
+    case .bottomTrailing:
+      return .bottomTrailing
+    case .centerFirstTextBaseline:
+      return .centerFirstTextBaseline
+    case .centerLastTextBaseline:
+      return .centerLastTextBaseline
+    case .leadingFirstTextBaseline:
+      return .leadingFirstTextBaseline
+    case .leadingLastTextBaseline:
+      return .leadingLastTextBaseline
+    case .trailingFirstTextBaseline:
+      return .trailingFirstTextBaseline
+    case .trailingLastTextBaseline:
+      return .trailingLastTextBaseline
+    }
+  }
+}

--- a/packages/expo-ui/ios/Modifiers/CommonViewModifiers.swift
+++ b/packages/expo-ui/ios/Modifiers/CommonViewModifiers.swift
@@ -9,6 +9,8 @@ internal protocol CommonViewModifierProps: ObservableObject {
   var padding: PaddingOptions? { get }
   var testID: String? { get }
   var modifiers: ModifierArray? { get }
+
+  var appContext: AppContext? { get }
   var globalEventDispatcher: EventDispatcher { get }
 }
 
@@ -22,6 +24,6 @@ internal struct CommonViewModifiers<Props: CommonViewModifierProps>: ViewModifie
       .applyFrame(props.frame, defaultAlignment: defaultFrameAlignment)
       .applyPadding(props.padding)
       .applyAccessibilityIdentifier(props.testID)
-      .applyModifiers(props.modifiers, globalEventDispatcher: props.globalEventDispatcher)
+      .applyModifiers(props.modifiers, appContext: props.appContext, globalEventDispatcher: props.globalEventDispatcher)
   }
 }

--- a/packages/expo-ui/ios/Modifiers/View+FrameModifiers.swift
+++ b/packages/expo-ui/ios/Modifiers/View+FrameModifiers.swift
@@ -3,41 +3,6 @@
 import ExpoModulesCore
 import SwiftUI
 
-internal enum AlignmentOptions: String, Enumerable {
-  case center
-  case leading
-  case trailing
-  case top
-  case bottom
-  case topLeading
-  case topTrailing
-  case bottomLeading
-  case bottomTrailing
-
-  func toAlignment() -> Alignment {
-    switch self {
-    case .center:
-      return .center
-    case .leading:
-      return .leading
-    case .trailing:
-      return .trailing
-    case .top:
-      return .top
-    case .bottom:
-      return .bottom
-    case .topLeading:
-      return .topLeading
-    case .topTrailing:
-      return .topTrailing
-    case .bottomLeading:
-      return .bottomLeading
-    case .bottomTrailing:
-      return .bottomTrailing
-    }
-  }
-}
-
 internal struct FrameOptions: Record {
   @Field var width: Double?
   @Field var height: Double?

--- a/packages/expo-ui/ios/Modifiers/View+ModifierArray.swift
+++ b/packages/expo-ui/ios/Modifiers/View+ModifierArray.swift
@@ -11,14 +11,20 @@ internal extension View {
    * Applies an array of modifiers to a view using the ViewModifierRegistry.
    */
   @ViewBuilder
-  func applyModifiers(_ modifiers: ModifierArray?, globalEventDispatcher: EventDispatcher) -> some View {
-    if let modifiers = modifiers {
+  func applyModifiers(_ modifiers: ModifierArray?, appContext: AppContext?, globalEventDispatcher: EventDispatcher) -> some View {
+    if let modifiers, let appContext {
       modifiers.reduce(AnyView(self)) { currentView, modifierConfig in
         guard let type = modifierConfig["$type"] as? String else {
           return currentView
         }
 
-        return ViewModifierRegistry.shared.applyModifier(type, to: currentView, globalEventDispatcher: globalEventDispatcher, params: modifierConfig)
+        return ViewModifierRegistry.shared.applyModifier(
+          type,
+          to: currentView,
+          appContext: appContext,
+          globalEventDispatcher: globalEventDispatcher,
+          params: modifierConfig
+        )
       }
     } else {
       self

--- a/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
+++ b/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
@@ -5,8 +5,8 @@ import SwiftUI
 
 // MARK: - Individual ViewModifier Structs
 
-internal struct BackgroundModifier: ViewModifier {
-  let color: Color?
+internal struct BackgroundModifier: ViewModifier, Record {
+  @Field var color: Color?
 
   func body(content: Content) -> some View {
     if let color = color {
@@ -17,94 +17,113 @@ internal struct BackgroundModifier: ViewModifier {
   }
 }
 
-internal struct CornerRadiusModifier: ViewModifier {
-  let radius: CGFloat
+internal struct CornerRadiusModifier: ViewModifier, Record {
+  @Field var radius: CGFloat = 0
 
   func body(content: Content) -> some View {
     content.cornerRadius(radius)
   }
 }
 
-internal struct ShadowModifier: ViewModifier {
-  let color: Color
-  let radius: CGFloat
-  let x: CGFloat
-  let y: CGFloat
+internal struct ShadowModifier: ViewModifier, Record {
+  @Field var color: Color = .white
+  @Field var radius: CGFloat = 0
+  @Field var x: CGFloat = 0
+  @Field var y: CGFloat = 0
 
   func body(content: Content) -> some View {
     content.shadow(color: color, radius: radius, x: x, y: y)
   }
 }
 
-internal struct FrameModifier: ViewModifier {
-  let width: CGFloat?
-  let height: CGFloat?
-  let minWidth: CGFloat?
-  let maxWidth: CGFloat?
-  let minHeight: CGFloat?
-  let maxHeight: CGFloat?
-  let idealWidth: CGFloat?
-  let idealHeight: CGFloat?
-  let alignment: Alignment
+internal struct FrameModifier: ViewModifier, Record {
+  @Field var width: CGFloat?
+  @Field var height: CGFloat?
+  @Field var minWidth: CGFloat?
+  @Field var maxWidth: CGFloat?
+  @Field var minHeight: CGFloat?
+  @Field var maxHeight: CGFloat?
+  @Field var idealWidth: CGFloat?
+  @Field var idealHeight: CGFloat?
+  @Field var alignment: AlignmentOptions = .center
 
   func body(content: Content) -> some View {
-    content
-      .frame(
+    if width != nil || height != nil {
+      content.frame(width: width, height: height, alignment: alignment.toAlignment())
+    } else {
+      content.frame(
         minWidth: minWidth,
         idealWidth: idealWidth,
         maxWidth: maxWidth,
         minHeight: minHeight,
         idealHeight: idealHeight,
         maxHeight: maxHeight,
-        alignment: alignment
+        alignment: alignment.toAlignment()
       )
-      .frame(width: width, height: height, alignment: alignment)
+    }
   }
 }
 
-internal struct PaddingModifier: ViewModifier {
-  let edgeInsets: EdgeInsets
+internal struct PaddingModifier: ViewModifier, Record {
+  @Field var all: CGFloat?
+  @Field var horizontal: CGFloat?
+  @Field var vertical: CGFloat?
+
+  @Field var top: CGFloat?
+  @Field var leading: CGFloat?
+  @Field var bottom: CGFloat?
+  @Field var trailing: CGFloat?
 
   func body(content: Content) -> some View {
-    content.padding(edgeInsets)
+    if let all {
+      content.padding(all)
+    } else if let horizontal, let vertical {
+      content.padding(EdgeInsets(top: vertical, leading: horizontal, bottom: vertical, trailing: horizontal))
+    } else if let horizontal {
+      content.padding(EdgeInsets(top: 0, leading: horizontal, bottom: 0, trailing: horizontal))
+    } else if let vertical {
+      content.padding(EdgeInsets(top: vertical, leading: 0, bottom: vertical, trailing: 0))
+    } else {
+      content.padding(EdgeInsets(top: top ?? 0, leading: leading ?? 0, bottom: bottom ?? 0, trailing: trailing ?? 0))
+    }
   }
 }
 
-internal struct OpacityModifier: ViewModifier {
-  let value: Double
+internal struct OpacityModifier: ViewModifier, Record {
+  @Field var value: Double = 1.0
 
   func body(content: Content) -> some View {
     content.opacity(value)
   }
 }
 
-internal struct ScaleEffectModifier: ViewModifier {
-  let scale: CGFloat
+internal struct ScaleEffectModifier: ViewModifier, Record {
+  @Field var scale: CGFloat = 1.0
 
   func body(content: Content) -> some View {
     content.scaleEffect(scale)
   }
 }
 
-internal struct RotationEffectModifier: ViewModifier {
-  let angle: Double
+internal struct RotationEffectModifier: ViewModifier, Record {
+  @Field var angle: Double = 0
 
   func body(content: Content) -> some View {
     content.rotationEffect(.degrees(angle))
   }
 }
 
-internal struct OffsetModifier: ViewModifier {
-  let x: CGFloat
-  let y: CGFloat
+internal struct OffsetModifier: ViewModifier, Record {
+  @Field var x: CGFloat = 0
+  @Field var y: CGFloat = 0
 
   func body(content: Content) -> some View {
     content.offset(x: x, y: y)
   }
 }
 
-internal struct ForegroundColorModifier: ViewModifier {
-  let color: Color?
+internal struct ForegroundColorModifier: ViewModifier, Record {
+  @Field var color: Color?
 
   func body(content: Content) -> some View {
     if let color = color {
@@ -115,8 +134,8 @@ internal struct ForegroundColorModifier: ViewModifier {
   }
 }
 
-internal struct TintModifier: ViewModifier {
-  let color: Color?
+internal struct TintModifier: ViewModifier, Record {
+  @Field var color: Color?
 
   func body(content: Content) -> some View {
     if let color = color {
@@ -127,8 +146,8 @@ internal struct TintModifier: ViewModifier {
   }
 }
 
-internal struct HiddenModifier: ViewModifier {
-  let hidden: Bool
+internal struct HiddenModifier: ViewModifier, Record {
+  @Field var hidden: Bool = true
 
   func body(content: Content) -> some View {
     if hidden {
@@ -139,48 +158,48 @@ internal struct HiddenModifier: ViewModifier {
   }
 }
 
-internal struct ZIndexModifier: ViewModifier {
-  let index: Double
+internal struct ZIndexModifier: ViewModifier, Record {
+  @Field var index: Double = 0
 
   func body(content: Content) -> some View {
     content.zIndex(index)
   }
 }
 
-internal struct BlurModifier: ViewModifier {
-  let radius: CGFloat
+internal struct BlurModifier: ViewModifier, Record {
+  @Field var radius: CGFloat = 0
 
   func body(content: Content) -> some View {
     content.blur(radius: radius)
   }
 }
 
-internal struct BrightnessModifier: ViewModifier {
-  let amount: Double
+internal struct BrightnessModifier: ViewModifier, Record {
+  @Field var amount: Double = 0
 
   func body(content: Content) -> some View {
     content.brightness(amount)
   }
 }
 
-internal struct ContrastModifier: ViewModifier {
-  let amount: Double
+internal struct ContrastModifier: ViewModifier, Record {
+  @Field var amount: Double = 1
 
   func body(content: Content) -> some View {
     content.contrast(amount)
   }
 }
 
-internal struct SaturationModifier: ViewModifier {
-  let amount: Double
+internal struct SaturationModifier: ViewModifier, Record {
+  @Field var amount: Double = 1
 
   func body(content: Content) -> some View {
     content.saturation(amount)
   }
 }
 
-internal struct ColorInvertModifier: ViewModifier {
-  let inverted: Bool
+internal struct ColorInvertModifier: ViewModifier, Record {
+  @Field var inverted: Bool = true
 
   func body(content: Content) -> some View {
     if inverted {
@@ -191,26 +210,26 @@ internal struct ColorInvertModifier: ViewModifier {
   }
 }
 
-internal struct GrayscaleModifier: ViewModifier {
-  let amount: Double
+internal struct GrayscaleModifier: ViewModifier, Record {
+  @Field var amount: Double = 0
 
   func body(content: Content) -> some View {
     content.grayscale(amount)
   }
 }
 
-internal struct BorderModifier: ViewModifier {
-  let color: Color
-  let width: CGFloat
+internal struct BorderModifier: ViewModifier, Record {
+  @Field var color: Color = .white
+  @Field var width: CGFloat = 1.0
 
   func body(content: Content) -> some View {
     content.border(color, width: width)
   }
 }
 
-internal struct ClipShapeModifier: ViewModifier {
-  let shape: String
-  let cornerRadius: CGFloat
+internal struct ClipShapeModifier: ViewModifier, Record {
+  @Field var shape: String = "rectangle"
+  @Field var cornerRadius: CGFloat = 8
 
   @ViewBuilder
   func body(content: Content) -> some View {
@@ -225,39 +244,53 @@ internal struct ClipShapeModifier: ViewModifier {
   }
 }
 
-internal struct OnTapGestureModifier: ViewModifier {
-  let eventDispatcher: EventDispatcher
+internal struct OnTapGestureModifier: ViewModifier, Record {
+  var eventDispatcher: EventDispatcher?
+
+  init() {}
+
+  init(from params: Dict, appContext: AppContext, eventDispatcher: EventDispatcher) throws {
+    try self = .init(from: params, appContext: appContext)
+    self.eventDispatcher = eventDispatcher
+  }
 
   func body(content: Content) -> some View {
     if #available(iOS 15.0, tvOS 16.0, *) {
       content.onTapGesture {
-        eventDispatcher(["onTapGesture": [:]])
+        eventDispatcher?(["onTapGesture": [:]])
       }
     }
   }
 }
 
-internal struct OnLongPressGestureModifier: ViewModifier {
-  let minimumDuration: Double
-  let eventDispatcher: EventDispatcher
+internal struct OnLongPressGestureModifier: ViewModifier, Record {
+  @Field var minimumDuration: Double = 0.5
+  var eventDispatcher: EventDispatcher?
+
+  init() {}
+
+  init(from params: Dict, appContext: AppContext, eventDispatcher: EventDispatcher) throws {
+    try self = .init(from: params, appContext: appContext)
+    self.eventDispatcher = eventDispatcher
+  }
 
   func body(content: Content) -> some View {
     content.onLongPressGesture(minimumDuration: minimumDuration) {
-      eventDispatcher(["onLongPressGesture": [:]])
+      eventDispatcher?(["onLongPressGesture": [:]])
     }
   }
 }
 
-internal struct HueRotationModifier: ViewModifier {
-  let angle: Double
+internal struct HueRotationModifier: ViewModifier, Record {
+  @Field var angle: Double = 0
 
   func body(content: Content) -> some View {
     content.hueRotation(.degrees(angle))
   }
 }
 
-internal struct AccessibilityLabelModifier: ViewModifier {
-  let label: String?
+internal struct AccessibilityLabelModifier: ViewModifier, Record {
+  @Field var label: String?
 
   func body(content: Content) -> some View {
     if let label = label {
@@ -268,8 +301,8 @@ internal struct AccessibilityLabelModifier: ViewModifier {
   }
 }
 
-internal struct AccessibilityHintModifier: ViewModifier {
-  let hint: String?
+internal struct AccessibilityHintModifier: ViewModifier, Record {
+  @Field var hint: String?
 
   func body(content: Content) -> some View {
     if let hint = hint {
@@ -280,8 +313,8 @@ internal struct AccessibilityHintModifier: ViewModifier {
   }
 }
 
-internal struct AccessibilityValueModifier: ViewModifier {
-  let value: String?
+internal struct AccessibilityValueModifier: ViewModifier, Record {
+  @Field var value: String?
 
   func body(content: Content) -> some View {
     if let value = value {
@@ -292,25 +325,25 @@ internal struct AccessibilityValueModifier: ViewModifier {
   }
 }
 
-internal struct LayoutPriorityModifier: ViewModifier {
-  let priority: Double
+internal struct LayoutPriorityModifier: ViewModifier, Record {
+  @Field var priority: Double = 0
 
   func body(content: Content) -> some View {
     content.layoutPriority(priority)
   }
 }
 
-internal struct AspectRatioModifier: ViewModifier {
-  let ratio: Double
-  let contentMode: ContentMode
+internal struct AspectRatioModifier: ViewModifier, Record {
+  @Field var ratio: Double = 1.0
+  @Field var contentMode: String = "fit"
 
   func body(content: Content) -> some View {
-    content.aspectRatio(ratio, contentMode: contentMode)
+    content.aspectRatio(ratio, contentMode: contentMode == "fill" ? .fill : .fit)
   }
 }
 
-internal struct ClippedModifier: ViewModifier {
-  let clipped: Bool
+internal struct ClippedModifier: ViewModifier, Record {
+  @Field var clipped: Bool = true
 
   func body(content: Content) -> some View {
     if clipped {
@@ -321,9 +354,9 @@ internal struct ClippedModifier: ViewModifier {
   }
 }
 
-internal struct MaskModifier: ViewModifier {
-  let shape: String
-  let cornerRadius: CGFloat
+internal struct MaskModifier: ViewModifier, Record {
+  @Field var shape: String = "rectangle"
+  @Field var cornerRadius: CGFloat = 8
 
   @ViewBuilder
   func body(content: Content) -> some View {
@@ -338,26 +371,25 @@ internal struct MaskModifier: ViewModifier {
   }
 }
 
-internal struct OverlayModifier: ViewModifier {
-  let color: Color?
-  let alignment: Alignment
-
+internal struct OverlayModifier: ViewModifier, Record {
+  @Field var color: Color?
+  @Field var alignment: AlignmentOptions = .center
   func body(content: Content) -> some View {
     if let color = color {
-      content.overlay(color, alignment: alignment)
+      content.overlay(color, alignment: alignment.toAlignment())
     } else {
       content
     }
   }
 }
 
-internal struct BackgroundOverlayModifier: ViewModifier {
-  let color: Color?
-  let alignment: Alignment
+internal struct BackgroundOverlayModifier: ViewModifier, Record {
+  @Field var color: Color?
+  @Field var alignment: AlignmentOptions = .center
 
   func body(content: Content) -> some View {
     if let color = color {
-      content.background(color, alignment: alignment)
+      content.background(color, alignment: alignment.toAlignment())
     } else {
       content
     }
@@ -381,17 +413,23 @@ internal struct AnyViewModifier: ViewModifier {
   }
 }
 
-internal struct GlassEffectModifier: ViewModifier {
-  let glassVariant: String
-  let interactive: Bool
-  let tint: Color?
-  let shape: String
+internal struct GlassEffectOptions: Record {
+  @Field var variant: String?
+  @Field var interactive: Bool?
+  @Field var tint: Color?
+}
+
+internal struct GlassEffectModifier: ViewModifier, Record {
+  @Field var glass: GlassEffectOptions?
+  @Field var shape: String = "capsule"
 
   @ViewBuilder
   func body(content: Content) -> some View {
     if #available(iOS 26.0, *) {
       #if compiler(>=6.2) // Xcode 26
-      let glass = parseGlassVariant(glassVariant)
+      let interactive = glass?.interactive ?? false
+      let tint = glass?.tint
+      let glass = parseGlassVariant(glass?.variant ?? "regular")
       switch shape {
       case "capsule":
         content.glassEffect(glass.interactive(interactive).tint(tint), in: Capsule())
@@ -533,7 +571,7 @@ internal struct AnimationModifier: ViewModifier {
 internal class ViewModifierRegistry {
   static let shared = ViewModifierRegistry()
 
-  internal typealias ModiferFactory = ([String: Any], EventDispatcher) -> any ViewModifier
+  internal typealias ModiferFactory = ([String: Any], AppContext, EventDispatcher) throws -> any ViewModifier
   private(set) internal var modifierFactories: [String: ModiferFactory] = [:]
 
   private init() {
@@ -556,8 +594,14 @@ internal class ViewModifierRegistry {
    * Returns the original view if the modifier type is not found.
    * This method handles the type erasure properly for extensibility.
    */
-  func applyModifier(_ type: String, to view: AnyView, globalEventDispatcher: EventDispatcher, params: [String: Any]) -> AnyView {
-    guard let viewModifier = modifierFactories[type]?(params, globalEventDispatcher) else {
+  func applyModifier(
+    _ type: String,
+    to view: AnyView,
+    appContext: AppContext,
+    globalEventDispatcher: EventDispatcher,
+    params: [String: Any]
+  ) -> AnyView {
+    guard let viewModifier = try? modifierFactories[type]?(params, appContext, globalEventDispatcher) else {
       return view
     }
     return AnyView(view.modifier(AnyViewModifier(viewModifier)))
@@ -583,305 +627,147 @@ internal class ViewModifierRegistry {
 // swiftlint:disable:next no_grouping_extension
 extension ViewModifierRegistry {
   private func registerBuiltInModifiers() {
-    register("background") { params, _ in
-      let color = (params["color"] as? String).map { Color(hex: $0) }
-      return BackgroundModifier(color: color)
+    register("background") { params, appContext, _ in
+      return try BackgroundModifier(from: params, appContext: appContext)
     }
 
-    register("cornerRadius") { params, _ in
-      let radius = params["radius"] as? Double ?? 0
-      return CornerRadiusModifier(radius: CGFloat(radius))
+    register("cornerRadius") { params, appContext, _ in
+      return try CornerRadiusModifier(from: params, appContext: appContext)
     }
 
-    register("shadow") { params, _ in
-      let radius = params["radius"] as? Double ?? 0
-      let x = params["x"] as? Double ?? 0
-      let y = params["y"] as? Double ?? 0
-      let colorString = params["color"] as? String ?? "#000000"
-      let color = Color(hex: colorString)
-
-      return ShadowModifier(
-        color: color,
-        radius: CGFloat(radius),
-        x: CGFloat(x),
-        y: CGFloat(y)
-      )
+    register("shadow") { params, appContext, _ in
+      return try ShadowModifier(from: params, appContext: appContext)
     }
 
-    register("frame") { params, _ in
-      let width = (params["width"] as? Double).map { CGFloat($0) }
-      let height = (params["height"] as? Double).map { CGFloat($0) }
-      let minWidth = (params["minWidth"] as? Double).map { CGFloat($0) }
-      let maxWidth = (params["maxWidth"] as? Double).map { CGFloat($0) }
-      let minHeight = (params["minHeight"] as? Double).map { CGFloat($0) }
-      let maxHeight = (params["maxHeight"] as? Double).map { CGFloat($0) }
-      let idealWidth = (params["idealWidth"] as? Double).map { CGFloat($0) }
-      let idealHeight = (params["idealHeight"] as? Double).map { CGFloat($0) }
-      let alignmentString = params["alignment"] as? String ?? "center"
-      let alignment = parseAlignment(alignmentString)
-
-      return FrameModifier(
-        width: width,
-        height: height,
-        minWidth: minWidth,
-        maxWidth: maxWidth,
-        minHeight: minHeight,
-        maxHeight: maxHeight,
-        idealWidth: idealWidth,
-        idealHeight: idealHeight,
-        alignment: alignment
-      )
+    register("frame") { params, appContext, _ in
+      return try FrameModifier(from: params, appContext: appContext)
     }
 
-    register("padding") { params, _ in
-      var edgeInsets = EdgeInsets()
-
-      if let all = params["all"] as? Double {
-        edgeInsets = EdgeInsets(top: CGFloat(all), leading: CGFloat(all), bottom: CGFloat(all), trailing: CGFloat(all))
-      } else if let horizontal = params["horizontal"] as? Double, let vertical = params["vertical"] as? Double {
-        edgeInsets = EdgeInsets(top: CGFloat(vertical), leading: CGFloat(horizontal), bottom: CGFloat(vertical), trailing: CGFloat(horizontal))
-      } else if let horizontal = params["horizontal"] as? Double {
-        edgeInsets = EdgeInsets(top: 0, leading: CGFloat(horizontal), bottom: 0, trailing: CGFloat(horizontal))
-      } else if let vertical = params["vertical"] as? Double {
-        edgeInsets = EdgeInsets(top: CGFloat(vertical), leading: 0, bottom: CGFloat(vertical), trailing: 0)
-      } else {
-        edgeInsets = EdgeInsets(
-          top: CGFloat(params["top"] as? Double ?? 0),
-          leading: CGFloat(params["leading"] as? Double ?? 0),
-          bottom: CGFloat(params["bottom"] as? Double ?? 0),
-          trailing: CGFloat(params["trailing"] as? Double ?? 0)
-        )
-      }
-
-      return PaddingModifier(edgeInsets: edgeInsets)
+    register("padding") { params, appContext, _ in
+      return try PaddingModifier(from: params, appContext: appContext)
     }
 
-    register("opacity") { params, _ in
-      let value = params["value"] as? Double ?? 1.0
-      return OpacityModifier(value: value)
+    register("opacity") { params, appContext, _ in
+      return try OpacityModifier(from: params, appContext: appContext)
     }
 
-    register("scaleEffect") { params, _ in
-      let scale = params["scale"] as? Double ?? 1.0
-      return ScaleEffectModifier(scale: CGFloat(scale))
+    register("scaleEffect") { params, appContext, _ in
+      return try ScaleEffectModifier(from: params, appContext: appContext)
     }
 
-    register("rotationEffect") { params, _ in
-      let angle = params["angle"] as? Double ?? 0.0
-      return RotationEffectModifier(angle: angle)
+    register("rotationEffect") { params, appContext, _ in
+      return try RotationEffectModifier(from: params, appContext: appContext)
     }
 
-    register("offset") { params, _ in
-      let x = params["x"] as? Double ?? 0
-      let y = params["y"] as? Double ?? 0
-      return OffsetModifier(x: CGFloat(x), y: CGFloat(y))
+    register("offset") { params, appContext, _ in
+      return try OffsetModifier(from: params, appContext: appContext)
     }
 
-    register("foregroundColor") { params, _ in
-      let color = (params["color"] as? String).map { Color(hex: $0) }
-      return ForegroundColorModifier(color: color)
+    register("foregroundColor") { params, appContext, _ in
+      return try ForegroundColorModifier(from: params, appContext: appContext)
     }
 
-    register("tint") { params, _ in
-      let color = (params["color"] as? String).map { Color(hex: $0) }
-      return TintModifier(color: color)
+    register("tint") { params, appContext, _ in
+      return try TintModifier(from: params, appContext: appContext)
     }
 
-    register("hidden") { params, _ in
-      let hidden = params["hidden"] as? Bool ?? true
-      return HiddenModifier(hidden: hidden)
+    register("hidden") { params, appContext, _ in
+      return try HiddenModifier(from: params, appContext: appContext)
     }
 
-    register("zIndex") { params, _ in
-      let index = params["index"] as? Double ?? 0
-      return ZIndexModifier(index: index)
+    register("zIndex") { params, appContext, _ in
+      return try ZIndexModifier(from: params, appContext: appContext)
     }
 
-    register("blur") { params, _ in
-      let radius = params["radius"] as? Double ?? 0
-      return BlurModifier(radius: CGFloat(radius))
+    register("blur") { params, appContext, _ in
+      return try BlurModifier(from: params, appContext: appContext)
     }
 
-    register("brightness") { params, _ in
-      let amount = params["amount"] as? Double ?? 0
-      return BrightnessModifier(amount: amount)
+    register("brightness") { params, appContext, _ in
+      return try BrightnessModifier(from: params, appContext: appContext)
     }
 
-    register("contrast") { params, _ in
-      let amount = params["amount"] as? Double ?? 1
-      return ContrastModifier(amount: amount)
+    register("contrast") { params, appContext, _ in
+      return try ContrastModifier(from: params, appContext: appContext)
     }
 
-    register("saturation") { params, _ in
-      let amount = params["amount"] as? Double ?? 1
-      return SaturationModifier(amount: amount)
+    register("saturation") { params, appContext, _ in
+      return try SaturationModifier(from: params, appContext: appContext)
     }
 
-    register("colorInvert") { params, _ in
-      let inverted = params["inverted"] as? Bool ?? true
-      return ColorInvertModifier(inverted: inverted)
+    register("colorInvert") { params, appContext, _ in
+      return try ColorInvertModifier(from: params, appContext: appContext)
     }
 
-    register("grayscale") { params, _ in
-      let amount = params["amount"] as? Double ?? 0
-      return GrayscaleModifier(amount: amount)
+    register("grayscale") { params, appContext, _ in
+      return try GrayscaleModifier(from: params, appContext: appContext)
     }
 
-    register("border") { params, _ in
-      let colorString = params["color"] as? String ?? "#000000"
-      let width = params["width"] as? Double ?? 1.0
-      let color = Color(hex: colorString)
-
-      return BorderModifier(color: color, width: CGFloat(width))
+    register("border") { params, appContext, _ in
+      return try BorderModifier(from: params, appContext: appContext)
     }
 
-    register("clipShape") { params, _ in
-      let shape = params["shape"] as? String ?? "rectangle"
-      let cornerRadius = params["cornerRadius"] as? Double ?? 8
-
-      return ClipShapeModifier(shape: shape, cornerRadius: CGFloat(cornerRadius))
+    register("clipShape") { params, appContext, _ in
+      return try ClipShapeModifier(from: params, appContext: appContext)
     }
 
-    register("onTapGesture") { _, eventDispatcher in
-      return OnTapGestureModifier(eventDispatcher: eventDispatcher)
+    register("onTapGesture") { params, appContext, eventDispatcher in
+      return try OnTapGestureModifier(from: params, appContext: appContext, eventDispatcher: eventDispatcher)
     }
 
-    register("onLongPressGesture") { params, eventDispatcher in
-      let minimumDuration = params["minimumDuration"] as? Double ?? 0.5
-      return OnLongPressGestureModifier(minimumDuration: minimumDuration, eventDispatcher: eventDispatcher)
+    register("onLongPressGesture") { params, appContext, eventDispatcher in
+      return try OnLongPressGestureModifier(from: params, appContext: appContext, eventDispatcher: eventDispatcher)
     }
 
-    register("hueRotation") { params, _ in
-      let angle = params["angle"] as? Double ?? 0
-      return HueRotationModifier(angle: angle)
+    register("hueRotation") { params, appContext, _ in
+      return try HueRotationModifier(from: params, appContext: appContext)
     }
 
-    register("accessibilityLabel") { params, _ in
-      let label = params["label"] as? String
-      return AccessibilityLabelModifier(label: label)
+    register("accessibilityLabel") { params, appContext, _ in
+      return try AccessibilityLabelModifier(from: params, appContext: appContext)
     }
 
-    register("accessibilityHint") { params, _ in
-      let hint = params["hint"] as? String
-      return AccessibilityHintModifier(hint: hint)
+    register("accessibilityHint") { params, appContext, _ in
+      return try AccessibilityHintModifier(from: params, appContext: appContext)
     }
 
-    register("accessibilityValue") { params, _ in
-      let value = params["value"] as? String
-      return AccessibilityValueModifier(value: value)
+    register("accessibilityValue") { params, appContext, _ in
+      return try AccessibilityValueModifier(from: params, appContext: appContext)
     }
 
-    register("layoutPriority") { params, _ in
-      let priority = params["priority"] as? Double ?? 0
-      return LayoutPriorityModifier(priority: priority)
+    register("layoutPriority") { params, appContext, _ in
+      return try LayoutPriorityModifier(from: params, appContext: appContext)
     }
 
-    register("aspectRatio") { params, _ in
-      let ratio = params["ratio"] as? Double ?? 1.0
-      let contentMode = params["contentMode"] as? String ?? "fit"
-      let mode: ContentMode = contentMode == "fill" ? .fill : .fit
-      return AspectRatioModifier(ratio: ratio, contentMode: mode)
+    register("aspectRatio") { params, appContext, _ in
+      return try AspectRatioModifier(from: params, appContext: appContext)
     }
 
-    register("clipped") { params, _ in
-      let clipped = params["clipped"] as? Bool ?? true
-      return ClippedModifier(clipped: clipped)
+    register("clipped") { params, appContext, _ in
+      return try ClippedModifier(from: params, appContext: appContext)
     }
 
-    register("mask") { params, _ in
-      let shape = params["shape"] as? String ?? "rectangle"
-      let cornerRadius = params["cornerRadius"] as? Double ?? 8
-      return MaskModifier(shape: shape, cornerRadius: CGFloat(cornerRadius))
+    register("mask") { params, appContext, _ in
+      return try MaskModifier(from: params, appContext: appContext)
     }
 
-    register("overlay") { params, _ in
-      let color = (params["color"] as? String).map { Color(hex: $0) }
-      let alignmentString = params["alignment"] as? String ?? "center"
-      let alignment = parseAlignment(alignmentString)
-      return OverlayModifier(color: color, alignment: alignment)
+    register("overlay") { params, appContext, _ in
+      return try OverlayModifier(from: params, appContext: appContext)
     }
 
-    register("backgroundOverlay") { params, _ in
-      let color = (params["color"] as? String).map { Color(hex: $0) }
-      let alignmentString = params["alignment"] as? String ?? "center"
-      let alignment = parseAlignment(alignmentString)
-      return BackgroundOverlayModifier(color: color, alignment: alignment)
+    register("backgroundOverlay") { params, appContext, _ in
+      return try BackgroundOverlayModifier(from: params, appContext: appContext)
     }
 
-    register("glassEffect") { params, _ in
-      let glassDict = params["glass"] as? [String: Any]
-      let glassVariant = glassDict?["variant"] as? String ?? "regular"
-      let interactive = glassDict?["interactive"] as? Bool ?? false
-      let tintColor = (glassDict?["tint"] as? String).map { Color(hex: $0) }
-      let shape = params["shape"] as? String ?? "capsule"
-
-      return GlassEffectModifier(
-        glassVariant: glassVariant,
-        interactive: interactive,
-        tint: tintColor,
-        shape: shape
-      )
+    register("glassEffect") { params, appContext, _ in
+      return try GlassEffectModifier(from: params, appContext: appContext)
     }
 
-    register("animation") { params, _ in
+    register("animation") { params, _, _ in
       let animationConfig = params["animation"] as? [String: Any] ?? ["type": "default"]
       let animatedValue = params["animatedValue"] as? AnyHashable
 
       return AnimationModifier(animationConfig: animationConfig, animatedValue: animatedValue)
     }
-  }
-}
-
-// MARK: - Utility Functions
-
-private func parseAlignment(_ alignmentString: String) -> Alignment {
-  switch alignmentString {
-  case "leading":
-    return .leading
-  case "trailing":
-    return .trailing
-  case "top":
-    return .top
-  case "bottom":
-    return .bottom
-  case "topLeading":
-    return .topLeading
-  case "topTrailing":
-    return .topTrailing
-  case "bottomLeading":
-    return .bottomLeading
-  case "bottomTrailing":
-    return .bottomTrailing
-  default:
-    return .center
-  }
-}
-
-// MARK: - Color Extension
-
-internal extension Color {
-  init(hex: String) {
-    let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-    var int: UInt64 = 0
-    Scanner(string: hex).scanHexInt64(&int)
-    let a, r, g, b: UInt64
-    switch hex.count {
-    case 3: // RGB (12-bit)
-      (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
-    case 6: // RGB (24-bit)
-      (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
-    case 8: // ARGB (32-bit)
-      (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
-    default:
-      (a, r, g, b) = (1, 1, 1, 0)
-    }
-
-    self.init(
-      .sRGB,
-      red: Double(r) / 255,
-      green: Double(g) / 255,
-      blue: Double(b) / 255,
-      opacity: Double(a) / 255
-    )
   }
 }


### PR DESCRIPTION
# Why

use convertibles to handle parameters for modifiers

# How

- [core] pass `appContext` to `props.appContext` and allow `view.appContext` as shortcut. that aligns to ExpoView usage.
- [ui] use convertibles to handle all modifiers and support context-dependent color
  - AnimationModifier is not migrated yet. will try to do that in a separate pr

# Test Plan

NCL modifiers example

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
