### PR TITLE
[test-suite] boot simulator early in the workflow

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -105,6 +105,9 @@ jobs:
           submodules: true
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: 📱 Boot iOS Simulator (in background)
+        run: ./scripts/boot-ios-simulator.js &
+        working-directory: apps/bare-expo
       - name: 🌠 Download builds
         uses: actions/download-artifact@v4
         with:

--- a/apps/bare-expo/scripts/boot-ios-simulator.js
+++ b/apps/bare-expo/scripts/boot-ios-simulator.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// @ts-check
+
+const spawnAsync = require('@expo/spawn-async');
+
+const TARGET_DEVICE = 'iPhone 16 Pro';
+const TARGET_DEVICE_IOS_VERSION = 18;
+
+async function bootSimulatorAsync(deviceId, deviceName = TARGET_DEVICE) {
+  console.log(`📱 Booting Device - name[${deviceName}] udid[${deviceId}]`);
+  await spawnAsync('xcrun', ['simctl', 'bootstatus', deviceId, '-b'], { stdio: 'inherit' });
+
+  // Only open Simulator app if not in CI environment
+  if (!process.env.CI) {
+    await spawnAsync('open', ['-a', 'Simulator', '--args', '-CurrentDeviceUDID', deviceId], {
+      stdio: 'inherit',
+    });
+  }
+}
+
+// Run as standalone script if called directly
+if (require.main === module) {
+  (async () => {
+    try {
+      const device = await queryDeviceIdAsync(TARGET_DEVICE_IOS_VERSION, TARGET_DEVICE);
+      if (!device) {
+        throw new Error(`Device not found: ${TARGET_DEVICE}`);
+      }
+
+      await bootSimulatorAsync(device.udid, TARGET_DEVICE);
+      console.log(`✅ Device ready: ${device.udid} ${device.name}`);
+    } catch (e) {
+      console.error('Error booting simulator:', e);
+      process.exit(1);
+    }
+  })();
+}
+
+/**
+ * Query simulator UDID
+ * @param {number?} iosVersion
+ * @param {string?} device
+ * @returns {Promise<{ udid: string, name: string } | null>}
+ */
+async function queryDeviceIdAsync(iosVersion = TARGET_DEVICE_IOS_VERSION, device = TARGET_DEVICE) {
+  const { stdout } = await spawnAsync('xcrun', [
+    'simctl',
+    'list',
+    'devices',
+    'iPhone',
+    'available',
+    '--json',
+  ]);
+  const { devices: deviceWithRuntimes } = JSON.parse(stdout);
+
+  // Try to find the target device first
+  for (const [runtime, devices] of Object.entries(deviceWithRuntimes)) {
+    if (runtime.startsWith(`com.apple.CoreSimulator.SimRuntime.iOS-${iosVersion}-`)) {
+      for (const { name, udid } of devices) {
+        if (name === device) {
+          return {
+            udid,
+            name,
+          };
+        }
+      }
+    }
+  }
+
+  // Fallback to the first available device
+  const firstEntry = Object.entries(deviceWithRuntimes).find(
+    ([runtime, devices]) => devices.length > 0
+  );
+  const maybeUdid = firstEntry?.[1][0]?.udid;
+  return maybeUdid
+    ? {
+        udid: maybeUdid,
+        name: firstEntry?.[1][0]?.name,
+      }
+    : null;
+}
+
+module.exports = {
+  bootSimulatorAsync,
+  queryDeviceIdAsync,
+};

--- a/apps/bare-expo/scripts/start-ios-e2e-test.js
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.js
@@ -6,6 +6,7 @@ const spawnAsync = require('@expo/spawn-async');
 const fs = require('fs/promises');
 const path = require('path');
 
+const { bootSimulatorAsync, queryDeviceIdAsync } = require('./boot-ios-simulator.js');
 const {
   createMaestroFlowAsync,
   ensureDirAsync,
@@ -14,8 +15,6 @@ const {
   getMaestroFlowFilePath,
 } = require('./lib/e2e-common.js');
 
-const TARGET_DEVICE = 'iPhone 16 Pro';
-const TARGET_DEVICE_IOS_VERSION = 18;
 const APP_ID = 'dev.expo.Payments';
 const OUTPUT_APP_PATH = 'ios/build/BareExpo.app';
 const MAESTRO_DRIVER_STARTUP_TIMEOUT = '120000'; // Wait 2 minutes for Maestro driver to start
@@ -26,14 +25,14 @@ const NUM_OF_RETRIES = 6; // Number of retries for the suite
     const startMode = getStartMode(__filename);
 
     const projectRoot = path.resolve(__dirname, '..');
-    const deviceId = await queryDeviceIdAsync(TARGET_DEVICE_IOS_VERSION, TARGET_DEVICE);
-    if (!deviceId) {
-      throw new Error(`Device not found: ${TARGET_DEVICE}`);
+    const device = await queryDeviceIdAsync();
+    if (!device) {
+      throw new Error(`No iOS device found`);
     }
 
     const appBinaryPath = path.join(projectRoot, OUTPUT_APP_PATH);
     if (startMode === 'BUILD' || startMode === 'BUILD_AND_TEST') {
-      const binaryPath = await buildAsync(projectRoot, deviceId);
+      const binaryPath = await buildAsync(projectRoot, device);
       await ensureDirAsync(path.dirname(appBinaryPath));
       await fs.cp(binaryPath, appBinaryPath, { recursive: true });
     }
@@ -47,7 +46,7 @@ const NUM_OF_RETRIES = 6; // Number of retries for the suite
 
       await retryAsync((retryNumber) => {
         console.log(`Test suite attempt ${retryNumber + 1} of ${NUM_OF_RETRIES}`);
-        return testAsync(maestroFlowFilePath, deviceId, appBinaryPath);
+        return testAsync(maestroFlowFilePath, device.udid, appBinaryPath);
       }, NUM_OF_RETRIES);
     }
   } catch (e) {
@@ -58,10 +57,10 @@ const NUM_OF_RETRIES = 6; // Number of retries for the suite
 
 /**
  * @param {string} projectRoot
- * @param {string} deviceId
+ * @param {{ udid: string, name: string }} device
  * @returns {Promise<string>}
  */
-async function buildAsync(projectRoot, deviceId) {
+async function buildAsync(projectRoot, device) {
   console.log('\n💿 Building App');
   const buildOutput = await XcodeBuild.buildAsync({
     projectRoot,
@@ -71,8 +70,8 @@ async function buildAsync(projectRoot, deviceId) {
       isWorkspace: true,
     },
     device: {
-      name: TARGET_DEVICE,
-      udid: deviceId,
+      name: device.name,
+      udid: device.udid,
     },
     configuration: 'Release',
     shouldSkipInitialBundling: false,
@@ -94,11 +93,7 @@ async function buildAsync(projectRoot, deviceId) {
  */
 async function testAsync(maestroFlowFilePath, deviceId, appBinaryPath) {
   try {
-    console.log(`\n📱 Starting Device - name[${TARGET_DEVICE}] udid[${deviceId}]`);
-    await spawnAsync('xcrun', ['simctl', 'bootstatus', deviceId, '-b'], { stdio: 'inherit' });
-    await spawnAsync('open', ['-a', 'Simulator', '--args', '-CurrentDeviceUDID', deviceId], {
-      stdio: 'inherit',
-    });
+    await bootSimulatorAsync(deviceId);
 
     console.log(`\n🔌 Installing App - appBinaryPath[${appBinaryPath}]`);
     await spawnAsync('xcrun', ['simctl', 'install', deviceId, appBinaryPath], { stdio: 'inherit' });
@@ -114,39 +109,4 @@ async function testAsync(maestroFlowFilePath, deviceId, appBinaryPath) {
   } finally {
     await spawnAsync('xcrun', ['simctl', 'shutdown', deviceId], { stdio: 'inherit' });
   }
-}
-
-/**
- * Query simulator UDID
- * @param {number} iosVersion
- * @param {string} device
- * @returns {Promise<string | null>}
- */
-async function queryDeviceIdAsync(iosVersion, device) {
-  const { stdout } = await spawnAsync('xcrun', [
-    'simctl',
-    'list',
-    'devices',
-    'iPhone',
-    'available',
-    '--json',
-  ]);
-  const { devices: deviceWithRuntimes } = JSON.parse(stdout);
-
-  // Try to find the target device first
-  for (const [runtime, devices] of Object.entries(deviceWithRuntimes)) {
-    if (runtime.startsWith(`com.apple.CoreSimulator.SimRuntime.iOS-${iosVersion}-`)) {
-      for (const { name, udid } of devices) {
-        if (name === device) {
-          return udid;
-        }
-      }
-    }
-  }
-
-  // Fallback to the first available device
-  const firstEntry = Object.entries(deviceWithRuntimes).find(
-    ([runtime, devices]) => devices.length > 0
-  );
-  return firstEntry?.[1][0]?.udid ?? null;
 }


### PR DESCRIPTION
# Why

to not wait for device to boot up.

However, a delay is still caused [here](https://github.com/expo/expo/blob/deeaccf50bbc5b904c0b67c120efcf7e0accfd0b/apps/bare-expo/scripts/start-ios-e2e-test.js#L109), maybe can be removed?

# How

start simulator before caches and node_modules as downloaded and installed

### before

```
Run ./scripts/start-ios-e2e-test.js --test
  ./scripts/start-ios-e2e-test.js --test
  shell: /bin/bash -e {0}
Test suite attempt 1 of 6
📱 Booting Device - name[iPhone 16 Pro] udid[C707DF3C-D29E-4CA9-B02F-06CBF9E434B2]
Monitoring boot status for iPhone 16 Pro (C707DF3C-D29E-4CA9-B02F-06CBF9E434B2).
Booting device...
[2025-08-29 08:31:39 +0000] Status=0, isTerminal=NO, Elapsed=00:00.
	Booting

[2025-08-29 08:31:46 +0000] Status=2, isTerminal=NO, Elapsed=00:06.
	Waiting on Data Migration
		Reason:(null)
		Migration Elapsed:00:00 seconds
...

[2025-08-29 08:32:36 +0000] Status=4294967295, isTerminal=YES, Elapsed=00:57.
	Finished

🔌 Installing App - appBinaryPath[/Users/runner/work/expo/expo/apps/bare-expo/ios/build/BareExpo.app]
```

### after:

```
Run ./scripts/start-ios-e2e-test.js --test
  ./scripts/start-ios-e2e-test.js --test
  shell: /bin/bash -e {0}
Test suite attempt 1 of 6
📱 Booting Device - name[iPhone 16 Pro] udid[C707DF3C-D29E-4CA9-B02F-06CBF9E434B2]
Monitoring boot status for iPhone 16 Pro (C707DF3C-D29E-4CA9-B02F-06CBF9E434B2).
Device already booted, nothing to do.
🔌 Installing App - appBinaryPath[/Users/runner/work/expo/expo/apps/bare-expo/ios/build/BareExpo.app]
```

# Test Plan

- green CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
