### PR TITLE
[expo-modules-core] remove ForceFlattenView trait, when collapsable is false

### DIFF
--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewShadowNode.cpp
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewShadowNode.cpp
@@ -31,6 +31,12 @@ void ExpoViewShadowNode::initialize() noexcept {
   } else {
     traits_.unset(react::ShadowNodeTraits::Trait::ChildrenFormStackingContext);
   }
+  // This is needed for display: contents, so that native view is still rendered
+  // https://github.com/facebook/react-native/blob/b02251e7f5c147296fab93c1ae613d27400cec92/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp#L399
+  // Without it the native view is flattened and not added to native hierarchy
+  if (viewProps.collapsable == false) {
+    traits_.unset(react::ShadowNodeTraits::Trait::ForceFlattenView);
+  }
 }
 
 } // namespace expo


### PR DESCRIPTION
# Why

When `display: contents` is used, a trait is added to shadow node forcing it to flatten - https://github.com/facebook/react-native/blob/b02251e7f5c147296fab93c1ae613d27400cec92/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp#L399

This effectively removes native view, making it impossible to render native view without layout.

This PR, based on @intergalacticspacehighway proposition - https://github.com/facebook/react-native/commit/bb82e16a278693f27d26769e75d294881e176c5a, removes the trait.

The change should not affect other modules, because when one would like to flatten the view, they would not add `collapsable={false}`. 

# How

1. When collapsable is `false` then remove `react::ShadowNodeTraits::Trait::ForceFlattenView` trait

# Test Plan

1. Manual testing of `bare-expo` on iOS and Android

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
