### PR TITLE
[iOS][contacts] Added handling for optional labels

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed issue with missing `instantMessageAddresses` on iOS ([#38985](https://github.com/expo/expo/pull/38985) by [@hryhoriiK97](https://github.com/hryhoriiK97)
-- [iOS] Added handling for optional labels. ([#38985](https://github.com/expo/expo/pull/39247) by [@hryhoriiK97](https://github.com/hryhoriiK97)
+- [iOS] Fixed issue with missing `instantMessageAddresses` on iOS ([#38985](https://github.com/expo/expo/pull/38985) by [@hryhoriiK97](https://github.com/hryhoriiK97))
+- [iOS] Added handling for optional labels. ([#38985](https://github.com/expo/expo/pull/39247) by [@hryhoriiK97](https://github.com/hryhoriiK97))
 
 ### 💡 Others
 

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed issue with missing `instantMessageAddresses` on iOS ([#38985](https://github.com/expo/expo/pull/38985) by [@hryhoriiK97](https://github.com/hryhoriiK97)
+- [iOS] Added handling for optional labels. ([#38985](https://github.com/expo/expo/pull/39247) by [@hryhoriiK97](https://github.com/hryhoriiK97)
 
 ### 💡 Others
 

--- a/packages/expo-contacts/ios/Serialization.swift
+++ b/packages/expo-contacts/ios/Serialization.swift
@@ -371,9 +371,7 @@ private func relationsFor(contact person: CNContact) -> [[String: Any]]? {
     var relation = [String: Any]()
     relation["name"] = val.name
     relation["id"] = container.identifier
-    if let label = container.label {
-      relation["label"] = CNLabeledValue<NSString>.localizedString(forLabel: label)
-    }
+    relation["label"] = getLocalizedLabel(from: container.label)
     results.append(relation)
   }
 
@@ -390,7 +388,7 @@ private func instantMessageAddressesFor(contact person: CNContact) -> [[String: 
     address["localizedService"] = CNInstantMessageAddress.localizedString(forKey: val.service)
     address["username"] = val.username
     address["id"] = container.identifier
-    address["label"] = container.label
+    address["label"] = getLocalizedLabel(from: container.label)
     results.append(address)
   }
 
@@ -409,9 +407,7 @@ private func socialProfilesFor(contact person: CNContact) -> [[String: Any]]? {
     profile["username"] = val.username
     profile["userId"] = val.userIdentifier
     profile["id"] = container.identifier
-    if let label = container.label {
-      profile["label"] = CNLabeledValue<NSString>.localizedString(forLabel: label)
-    }
+    profile["label"] = getLocalizedLabel(from: container.label)
     results.append(profile)
   }
 
@@ -423,15 +419,7 @@ private func emailsFor(contact person: CNContact) -> [[String: Any]]? {
 
   for container in person.emailAddresses {
     let emailAddress = container.value as String
-    let emailLabel: String
-    if let label = container.label {
-      emailLabel = CNLabeledValue<NSString>.localizedString(forLabel: label)
-    } else {
-      // Use localized "other" label to match iOS's standard.
-      // This ensures iCloud contacts (which could have no label) still have a consistent label.
-      emailLabel = CNLabeledValue<NSString>.localizedString(forLabel: CNLabelOther)
-    }
-    results.append(["email": emailAddress, "label": emailLabel, "id": container.identifier])
+    results.append(["email": emailAddress, "label": getLocalizedLabel(from: container.label), "id": container.identifier])
   }
 
   return results.isEmpty ? nil : results
@@ -447,9 +435,7 @@ private func phoneNumbersFor(contact person: CNContact) -> [[String: Any]]? {
     phoneNumber["countryCode"] = val.value(forKey: "countryCode")
     phoneNumber["digits"] = val.value(forKey: "digits")
     phoneNumber["id"] = container.identifier
-    if let label = container.label {
-      phoneNumber["label"] = CNLabeledValue<NSString>.localizedString(forLabel: label)
-    }
+    phoneNumber["label"] = getLocalizedLabel(from: container.label)
     results.append(phoneNumber)
   }
 
@@ -470,11 +456,7 @@ private func addressesFor(contact person: CNContact) -> [[String: Any]]? {
     address["country"] = val.country
     address["isoCountryCode"] = val.isoCountryCode
     address["id"] = container.identifier
-
-    if let label = container.label {
-      address["label"] = CNLabeledValue<NSString>.localizedString(forLabel: label)
-    }
-
+    address["label"] = getLocalizedLabel(from: container.label)
     results.append(address)
   }
 
@@ -508,12 +490,7 @@ private func urlsFor(contact person: CNContact) -> [[String: Any]]? {
 
   for container in person.urlAddresses {
     let urlAddress = container.value
-    if let label = container.label {
-      let urlLabel = CNLabeledValue<NSString>.localizedString(forLabel: label)
-      results.append(["url": urlAddress, "label": urlLabel, "id": container.identifier])
-    } else {
-      results.append(["url": urlAddress, "id": container.identifier])
-    }
+    results.append(["url": urlAddress, "label": getLocalizedLabel(from: container.label), "id": container.identifier])
   }
 
   return results.isEmpty ? nil : results
@@ -521,7 +498,6 @@ private func urlsFor(contact person: CNContact) -> [[String: Any]]? {
 
 private func datesFor(contact person: CNContact) -> [[String: Any]]? {
   var results = [[String: Any]]()
-
   for container in person.dates {
     let val = container.value
     var date = [String: Any]()
@@ -532,9 +508,7 @@ private func datesFor(contact person: CNContact) -> [[String: Any]]? {
     if let calendar = val.calendar {
       date["format"] = calendarFormatToString(calendar.identifier)
     }
-    if let label = container.label {
-      date["label"] = CNLabeledValue<NSString>.localizedString(forLabel: label)
-    }
+    date["label"] = getLocalizedLabel(from: container.label)
     results.append(date)
   }
 
@@ -543,6 +517,15 @@ private func datesFor(contact person: CNContact) -> [[String: Any]]? {
 
 private func fieldHasValue(field: String) -> Bool {
   return !field.isEmpty
+}
+
+private func getLocalizedLabel(from label: String?) -> String {
+  if let label = label {
+    return CNLabeledValue<NSString>.localizedString(forLabel: label)
+  }
+  // Use localized "other" label to match iOS's standard.
+  // Since label is optional (String?), we provide a default value to ensure consistent label handling.
+  return CNLabeledValue<NSString>.localizedString(forLabel: CNLabelOther)
 }
 
 private func calendarFormatToString(_ identifier: Calendar.Identifier) -> String {


### PR DESCRIPTION
# Why
This is a follow-up PR to https://github.com/expo/expo/pull/39222. After carefully checking the code and the actual type of label (which is String? optional), it would be safer to provide a default value for all cases.

<img width="257" height="233" alt="Screenshot 2025-08-29 at 14 59 45" src="https://github.com/user-attachments/assets/7a5d04f7-d82d-4990-84e9-bc569300778a" />

In Android, all labels which could be null fallback to "unknown" string.

# How
A utility function getLocalizedLabel was created to handle contact labels consistently. It converts optional labels to localized text or defaults to "other" when missing. All contact types were updated to use this single function, making the code simpler and ensuring every field has a readable label.

# Test Plan
Originally this issue was identified with private contacts from iCloud. It would be difficult to reproduce now since Apple provides a default label when creating new contacts. This fix mainly handles backward compatibility for older contacts that may have undefined labels.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
