### PR TITLE
[ios][dev-launcher] Updates tab UI

### DIFF
--- a/packages/expo-dev-launcher/ios/SwiftUI/GraphQL/APIClient.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/GraphQL/APIClient.swift
@@ -6,11 +6,7 @@ class APIClient {
   static let shared = APIClient()
 
   private var useStaging: Bool {
-#if DEBUG
-    return true
-#else
     return false
-#endif
   }
 
   private var session: URLSession {

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdateRow.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdateRow.swift
@@ -22,7 +22,9 @@ struct UpdateRow: View {
         openButton
       }
     }
-    .padding(.vertical, 4)
+    .padding()
+    .background(Color.expoSecondarySystemBackground)
+    .cornerRadius(12)
   }
 
   private var openButton: some View {

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
@@ -12,21 +12,21 @@ struct UpdatesListView: View {
   @State private var errorMessage: String?
 
   var body: some View {
-    List {
-      Section {
-        HStack {
-          Toggle("Compatible only", isOn: $filterByCompatibility)
-          Spacer()
-          Button(sortByRecency ? "Newest first" : "Oldest first") {
-            sortByRecency.toggle()
-            applyFilters()
-          }
-          .font(.caption)
-          .foregroundColor(.blue)
+    VStack(spacing: 20) {
+      HStack {
+        Toggle("Compatible only", isOn: $filterByCompatibility)
+        Spacer()
+        Button(sortByRecency ? "Newest first" : "Oldest first") {
+          sortByRecency.toggle()
+          applyFilters()
         }
-        .padding(.vertical, 4)
+        .font(.caption)
+        .foregroundColor(.blue)
       }
-
+      .padding()
+      .background(Color.expoSecondarySystemBackground)
+      .cornerRadius(12)
+      
       if isLoading {
         loading
       } else if let message = errorMessage {
@@ -34,14 +34,17 @@ struct UpdatesListView: View {
       } else if filteredUpdates.isEmpty {
         emptyUpdates
       } else {
-        Section("Updates (\(filteredUpdates.count))") {
+        LazyVStack(alignment: .leading) {
+          Text("Updates (\(filteredUpdates.count))".uppercased())
+            .font(.caption)
+            .foregroundColor(.primary.opacity(0.6))
           ForEach(filteredUpdates, id: \.update.id) { tuple in
             UpdateRow(update: tuple.update, branchName: tuple.branchName, isCompatible: viewModel.isCompatibleRuntime(tuple.update.runtimeVersion))
           }
         }
       }
     }
-    .background(Color.expoSystemGroupedBackground)
+    .padding()
     .onChange(of: filterByCompatibility) { _ in
       applyFilters()
     }
@@ -136,40 +139,36 @@ struct UpdatesListView: View {
   }
 
   private var loading: some View {
-    Section {
-      HStack {
-        Spacer()
-        ProgressView()
-          .scaleEffect(1.2)
-        Spacer()
-      }
-      .padding()
+    HStack {
+      Spacer()
+      ProgressView()
+        .scaleEffect(1.2)
+      Spacer()
     }
+    .padding()
   }
 
   @ViewBuilder
   func createError(message: String) -> some View {
-    Section {
-      VStack(spacing: 12) {
-        Image(systemName: "exclamationmark.triangle")
-          .foregroundColor(.red)
-          .font(.title2)
-
-        Text("Error loading updates")
-          .font(.headline)
-
-        Text(message)
-          .font(.caption)
-          .foregroundStyle(.secondary)
-          .multilineTextAlignment(.center)
-
-        Button("Retry") {
-          loadBranches()
-        }
-        .buttonStyle(.borderedProminent)
+    VStack(spacing: 12) {
+      Image(systemName: "exclamationmark.triangle")
+        .foregroundColor(.red)
+        .font(.title2)
+      
+      Text("Error loading updates")
+        .font(.headline)
+      
+      Text(message)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+      
+      Button("Retry") {
+        loadBranches()
       }
-      .padding()
+      .buttonStyle(.borderedProminent)
     }
+    .padding()
   }
 
   private var emptyUpdates: some View {

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
@@ -26,7 +26,7 @@ struct UpdatesListView: View {
       .padding()
       .background(Color.expoSecondarySystemBackground)
       .cornerRadius(12)
-      
+
       if isLoading {
         loading
       } else if let message = errorMessage {
@@ -154,15 +154,15 @@ struct UpdatesListView: View {
       Image(systemName: "exclamationmark.triangle")
         .foregroundColor(.red)
         .font(.title2)
-      
+
       Text("Error loading updates")
         .font(.headline)
-      
+
       Text(message)
         .font(.caption)
         .foregroundStyle(.secondary)
         .multilineTextAlignment(.center)
-      
+
       Button("Retry") {
         loadBranches()
       }

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesTabView.swift
@@ -9,13 +9,15 @@ struct UpdatesTabView: View {
     VStack(spacing: 0) {
       DevLauncherNavigationHeader()
 
-      if !viewModel.isLoggedIn {
-        NotSignedInView()
-          .padding()
-      } else if !viewModel.structuredBuildInfo.usesEASUpdates {
-        NotUsingUpdatesView()
-      } else {
-        UpdatesListView()
+      ScrollView {
+        if !viewModel.isLoggedIn {
+          NotSignedInView()
+            .padding()
+        } else if !viewModel.structuredBuildInfo.usesEASUpdates {
+          NotUsingUpdatesView()
+        } else {
+          UpdatesListView()
+        }
       }
     }
   }


### PR DESCRIPTION
# Why
Updates the `UpdatesTab` to align with the rest of the UI.

# Test Plan
<img width="350" height="759" alt="Simulator Screenshot - iPhone 16 - 2025-08-29 at 15 52 52" src="https://github.com/user-attachments/assets/4d6b22e8-3a4f-4d0f-bf29-e09c82938d96" />

<img width="350" height="759" alt="Simulator Screenshot - iPhone 16 - 2025-08-29 at 15 51 47" src="https://github.com/user-attachments/assets/ff7d7a1b-324a-4649-8564-7b1941aed703" />

