### PR TITLE
[docs] Share content to your app doc guide

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -174,6 +174,7 @@ export const general = [
         makePage('linking/into-your-app.mdx'),
         makePage('linking/android-app-links.mdx'),
         makePage('linking/ios-universal-links.mdx'),
+        makePage('linking/share-content-into-your-app.mdx'),
       ],
       {
         expanded: false,

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -18,7 +18,7 @@ On Android, the system delivers shared data to an `Activity`. An `Activity` is a
 
 - Apps register intent filters (`ACTION_SEND`/`ACTION_SEND_MULTIPLE`) for specific MIME types (for example, text/plain, image/\*) in **AndroidManifest.xml**.
 - When selected from the share sheet, your launch `Activity` receives an Intent containing the data payload.
-- Your Activity must handle the incoming Intent in Java or Kotlin by calling getIntent() and reading extras like EXTRA_TEXT or EXTRA_STREAM.
+- Your `Activity` must handle the incoming Intent in Java or Kotlin by calling `getIntent()` and reading extras like `EXTRA_TEXT` or `EXTRA_STREAM`.
 
 **iOS**
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -8,7 +8,7 @@ import { FileTree } from '~/ui/components/FileTree';
 
 You may want to let other apps share content into your app &mdash; like articles, images, or files &mdash; using the native system share sheet. This guide explains how that works under the hood and gives an overview of the tools available to help you implement it.
 
-With [`expo-sharing`](/versions/latest/sdk/sharing), you can already share content _from_ your app into other apps. Receiving content works the other way around: your app needs to become a share target, which on iOS means handling a Share Extension and on Android means responding to Intents.
+With [`expo-sharing`](/versions/latest/sdk/sharing), you can already share content _from_ your app into other apps. Receiving content works the other way around: your app needs to become a share target, which on Android means responding to Intents and on iOS means handling a Share Extension.
 
 ## OS foundations
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -36,7 +36,7 @@ For more in-depth details, see the official platform documentation:
 
 ## Available libraries
 
-Expo does not currently provide its own official library for receiving shared content. Instead, you'll need to rely on community-maintained packages or build a custom solution. Here are some options that Expo developers commonly use:
+Expo does not currently provide its own official library for receiving shared content. Instead, you'll need to rely on community-maintained libraries or build a custom solution. Here are some options that Expo developers commonly use:
 
 **Expo Share Intent**
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -17,7 +17,7 @@ With [`expo-sharing`](/versions/latest/sdk/sharing), you can already share conte
 On Android, the system delivers shared data to an `Activity`. An `Activity` is a single, focused screen in your app, and it can also act as an entry point that the system launches directly when the user selects your app in the share sheet.
 
 - Apps register intent filters (`ACTION_SEND`/`ACTION_SEND_MULTIPLE`) for specific MIME types (for example, text/plain, image/\*) in **AndroidManifest.xml**.
-- When selected from the share sheet, your launch Activity receives an Intent containing the data payload.
+- When selected from the share sheet, your launch `Activity` receives an Intent containing the data payload.
 - Your Activity must handle the incoming Intent in Java or Kotlin by calling getIntent() and reading extras like EXTRA_TEXT or EXTRA_STREAM.
 
 **iOS**

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -25,8 +25,8 @@ On Android, the system delivers shared data to an `Activity`. An `Activity` is a
 On iOS, receiving shared data is handled by a Share Extension that runs separately from your main app.
 
 - A Share Extension lets users send content into your app.
-- The system launches your extension with an NSExtensionContext containing NSExtensionItem attachments.
-- The extension processes those items (e.g., reads text/URLs/files). To make them available to the main app, a common approach is to write data to a shared App Group container and then open the app (via a custom URL or universal link).
+- The system launches your extension with an `NSExtensionContext` containing `NSExtensionItem` attachments.
+- The extension processes those items (for example, reads text/URLs/files). To make them available to the main app, a common approach is to write data to a shared App Group container and then open the app (via a custom URL or universal link).
 - A Share Extension is implemented as its own target. It runs as a separate process from your main app and is written in Swift or Objective-C, since it needs to use iOS system APIs to receive shared content.
 
 For more in-depth details, see the official platform documentation:

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -76,7 +76,7 @@ The `useShareIntent` hook tells you whether your app was opened from the share s
 
 ### Handling deep links with Expo Router
 
-If you're using Expo Router, you can intercept deep links coming from the share extension with a special file called +native-intent.ts:
+If you're using Expo Router, you can intercept deep links coming from the share extension with a special file called [**+native-intent.ts**](/router/advanced/native-intent/):
 
 ```
 // app/+native-intent.ts

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -12,7 +12,7 @@ With [`expo-sharing`](/versions/latest/sdk/sharing), you can already share conte
 
 ## OS foundations
 
-**Android**
+#### Android
 
 On Android, the system delivers shared data to an Activity. An Activity is a single, focused screen in your app, and it can also act as an entry point that the system launches directly when the user selects your app in the share sheet.
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -72,7 +72,7 @@ export default function ShareIntentScreen() {
 }
 ```
 
-The useShareIntent hook tells you whether your app was opened from the share sheet and gives you the payload (text, URLs, files, etc.).
+The `useShareIntent` hook tells you whether your app was opened from the share sheet and gives you the payload (text, URLs, files, and so on).
 
 ### Handling deep links with Expo Router
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -44,7 +44,7 @@ Expo does not currently provide its own official library for receiving shared co
 - Adds intent support on Android and a Share Extension on iOS.
 - Works in Expo with a [development build](/develop/development-builds/introduction/) and exposes a simple JS hook.
 
-**Expo Apple Targets**
+### Expo Apple Targets
 
 - Enables additional iOS targets such as Share Extensions, widgets, and Siri intents.
 - More powerful and flexible if you're focused on advanced iOS functionality.

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -49,7 +49,7 @@ Expo does not currently provide its own official library for receiving shared co
 - Enables additional iOS targets such as Share Extensions, widgets, and Siri intents.
 - More powerful and flexible if you're focused on advanced iOS functionality.
 
-**Example app**
+### Example app
 
 The open-source Bluesky app implements [share intent functionality](https://github.com/bluesky-social/social-app/tree/main/plugins/shareExtension) — useful as a production reference.
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -55,8 +55,7 @@ The open source Bluesky app implements [share intent functionality](https://gith
 
 ## Receiving shared data in your app
 
-The exact setup steps vary depending on which library you choose, and since these are not maintained by Expo, the best place to find installation instructions is always the library's own README. Using Expo Share Intent
-as an example, a minimal implementation in code could look like this:
+The exact setup steps vary depending on which library you choose, and since these are not maintained by Expo, the best place to find installation instructions is always the library's own README. Using `expo-share-intent` as an example, a minimal implementation in your code could look like this:
 
 ### Handling shared data in JavaScript
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -16,7 +16,7 @@ With [`expo-sharing`](/versions/latest/sdk/sharing), you can already share conte
 
 On Android, the system delivers shared data to an Activity. An Activity is a single, focused screen in your app, and it can also act as an entry point that the system launches directly when the user selects your app in the share sheet.
 
-- Apps register intent filters (ACTION_SEND / ACTION_SEND_MULTIPLE) for specific MIME types (e.g., text/plain, image/\*) in AndroidManifest.xml.
+- Apps register intent filters (`ACTION_SEND`/`ACTION_SEND_MULTIPLE`) for specific MIME types (for example, text/plain, image/\*) in **AndroidManifest.xml**.
 - When selected from the share sheet, your launch Activity receives an Intent containing the data payload.
 - Your Activity must handle the incoming Intent in Java or Kotlin by calling getIntent() and reading extras like EXTRA_TEXT or EXTRA_STREAM.
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -38,10 +38,10 @@ For more in-depth details, see the official platform documentation:
 
 Expo does not currently provide its own official library for receiving shared content. Instead, you'll need to rely on community-maintained libraries or build a custom solution. Here are some options that Expo developers commonly use:
 
-**Expo Share Intent**
+### `expo-share-intent`
 
 - Cross-platform support (Android and iOS) for receiving shared data.
-- Adds a Share Extension on iOS and intent support on Android.
+- Adds intent support on Android and a Share Extension on iOS.
 - Works in Expo with a development build and exposes a simple JS hook.
 
 **Expo Apple Targets**

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -1,6 +1,6 @@
 ---
 title: Receiving content to your app
-sidebar_title: Receiving content to your app
+sidebar_title: Receiving content
 description: Learn how to receive content to your app from another app.
 ---
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -5,6 +5,9 @@ description: Learn how to receive content to your Expo app from another app.
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+import { BoxLink } from '/ui/components/BoxLink';
 
 You may want to let other apps share content into your app &mdash; like articles, images, or files &mdash; using the native system share sheet. This guide explains how that works under the hood and gives an overview of the tools available to help you implement it.
 
@@ -44,10 +47,23 @@ Expo does not currently provide its own official library for receiving shared co
 - Adds intent support on Android and a Share Extension on iOS.
 - Works in Expo with a [development build](/develop/development-builds/introduction/) and exposes a simple JS hook.
 
-### Expo Apple Targets
+<BoxLink
+  title="Expo Share Intent"
+  href="https://github.com/achorein/expo-share-intent"
+  Icon={BookOpen02Icon}
+/>
+
+### `expo-apple-targets`
 
 - Enables additional iOS targets such as Share Extensions, widgets, and Siri intents.
 - More powerful and flexible if you're focused on advanced iOS functionality.
+
+<BoxLink
+  title="Expo Apple Targets"
+  href="https://github.com/EvanBacon/expo-apple-targets"
+
+Icon={BookOpen02Icon}
+/>
 
 ### Example app
 
@@ -60,8 +76,8 @@ The exact setup steps vary depending on which library you choose, and since thes
 ### Handling shared data in JavaScript
 
 ```tsx app/shared-content-receiver.tsx
-import { Text } from "react-native";
-import { useShareIntent } from "expo-share-intent";
+import { Text } from 'react-native';
+import { useShareIntent } from 'expo-share-intent';
 
 export default function ShareIntentScreen() {
   const { hasShareIntent, shareIntent } = useShareIntent();
@@ -79,11 +95,11 @@ The `useShareIntent` hook tells you whether your app was opened from the share s
 If you're using Expo Router, you can intercept deep links coming from the share extension with a special file called [**+native-intent.ts**](/router/advanced/native-intent/):
 
 ```ts app/+native-intent.ts
-import { getShareExtensionKey } from "expo-share-intent";
+import { getShareExtensionKey } from 'expo-share-intent';
 
 export function redirectSystemPath({ path }: { path: string }) {
   if (path.includes(`dataUrl=${getShareExtensionKey()}`)) {
-    return "/shared-content-receiver"; // redirect to the screen that handles shared data
+    return '/shared-content-receiver'; // redirect to the screen that handles shared data
   }
   return path;
 }

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -42,7 +42,7 @@ Expo does not currently provide its own official library for receiving shared co
 
 - Cross-platform support (Android and iOS) for receiving shared data.
 - Adds intent support on Android and a Share Extension on iOS.
-- Works in Expo with a development build and exposes a simple JS hook.
+- Works in Expo with a [development build](/develop/development-builds/introduction/) and exposes a simple JS hook.
 
 **Expo Apple Targets**
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -78,8 +78,7 @@ The `useShareIntent` hook tells you whether your app was opened from the share s
 
 If you're using Expo Router, you can intercept deep links coming from the share extension with a special file called [**+native-intent.ts**](/router/advanced/native-intent/):
 
-```
-// app/+native-intent.ts
+```ts app/+native-intent.ts
 import { getShareExtensionKey } from "expo-share-intent";
 
 export function redirectSystemPath({ path }: { path: string }) {

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -1,0 +1,123 @@
+---
+title: Receiving content to your app
+sidebar_title: Receiving content to your app
+description: Learn how to receive content to your app from another app.
+---
+
+import { Collapsible } from '~/ui/components/Collapsible';
+import { FileTree } from '~/ui/components/FileTree';
+
+You may want to let other apps share content into your app &mdash; like articles, images, or files &mdash; using the native system share sheet. This guide explains how that works under the hood and gives an overview of the tools available to help you implement it.
+
+With [`expo-sharing`](/versions/latest/sdk/sharing), you can already share content _from_ your app into other apps. Receiving content works the other way around: your app needs to become a share target, which on iOS means handling a Share Extension and on Android means responding to Intents.
+
+## OS foundations
+
+**Android**
+
+On Android, the system delivers shared data to an Activity. An Activity is a single, focused screen in your app, and it can also act as an entry point that the system launches directly when the user selects your app in the share sheet.
+
+- Apps register intent filters (ACTION_SEND / ACTION_SEND_MULTIPLE) for specific MIME types (e.g., text/plain, image/\*) in AndroidManifest.xml.
+- When selected from the share sheet, your launch Activity receives an Intent containing the data payload.
+- Your Activity must handle the incoming Intent in Java or Kotlin by calling getIntent() and reading extras like EXTRA_TEXT or EXTRA_STREAM.
+
+**iOS**
+
+On iOS, receiving shared data is handled by a Share Extension that runs separately from your main app.
+
+- A Share Extension lets users send content into your app.
+- The system launches your extension with an NSExtensionContext containing NSExtensionItem attachments.
+- The extension processes those items (e.g., reads text/URLs/files). To make them available to the main app, a common approach is to write data to a shared App Group container and then open the app (via a custom URL or universal link).
+- A Share Extension is implemented as its own target. It runs as a separate process from your main app and is written in Swift or Objective-C, since it needs to use iOS system APIs to receive shared content.
+
+For more in-depth details, see the official platform documentation:
+
+- Android: [Receiving simple data from other apps](https://developer.android.com/training/sharing/receive)
+- iOS: [App Extension Programming Guide – Share](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/Share.html)
+
+## Available libraries
+
+Expo does not currently provide its own official library for receiving shared content. Instead, you'll need to rely on community-maintained packages or build a custom solution. Here are some options that Expo developers commonly use:
+
+**Expo Share Intent**
+
+- Cross-platform support (Android and iOS) for receiving shared data.
+- Adds a Share Extension on iOS and intent support on Android.
+- Works in Expo with a development build and exposes a simple JS hook.
+
+**Expo Apple Targets**
+
+- Enables additional iOS targets such as Share Extensions, widgets, and Siri intents.
+- More powerful and flexible if you're focused on advanced iOS functionality.
+
+**Example app**
+
+The open-source Bluesky app implements [share intent functionality](https://github.com/bluesky-social/social-app/tree/main/plugins/shareExtension) — useful as a production reference.
+
+## Receiving shared data in your app
+
+The exact setup steps vary depending on which library you choose, and since these are not maintained by Expo, the best place to find installation instructions is always the library's own README. Using Expo Share Intent
+as an example, a minimal implementation in code could look like this:
+
+### Handling shared data in JavaScript
+
+```
+// app/shared-content-receiver.tsx
+import { Text } from "react-native";
+import { useShareIntent } from "expo-share-intent";
+
+export default function ShareIntentScreen() {
+  const { hasShareIntent, shareIntent } = useShareIntent();
+
+  if (!hasShareIntent) return <Text>No shared data</Text>;
+
+  return <Text>Incoming: {JSON.stringify(shareIntent)}</Text>;
+}
+```
+
+The useShareIntent hook tells you whether your app was opened from the share sheet and gives you the payload (text, URLs, files, etc.).
+
+### Handling deep links with Expo Router
+
+If you're using Expo Router, you can intercept deep links coming from the share extension with a special file called +native-intent.ts:
+
+```
+// app/+native-intent.ts
+import { getShareExtensionKey } from "expo-share-intent";
+
+export function redirectSystemPath({ path }: { path: string }) {
+  if (path.includes(`dataUrl=${getShareExtensionKey()}`)) {
+    return "/shared-content-receiver"; // redirect to the screen that handles shared data
+  }
+  return path;
+}
+```
+
+This file runs whenever your app is opened with a deep link that doesn't match a normal route. By checking for the share extension key, you can make sure the user is redirected into your ShareIntent screen where the data is handled.
+
+An example project structure might look like this:
+
+<FileTree
+  files={[
+    ['app/_layout.tsx'],
+    ['app/index.tsx'],
+    ['app/+native-intent.tsx'],
+    ['app/share-intent.tsx'],
+  ]}
+/>
+
+### Building custom solutions with Expo Modules
+
+Sometimes existing libraries won't cover all your needs. In those cases, you can use the Expo Modules to implement custom native functionality for receiving shared content.
+
+On **Android**, it means declaring &lt;intent-filter&gt; entries in your manifest, handling incoming Intents, and surfacing the content to your app via an Expo Module.
+
+On **iOS**, this means creating a Share Extension target, handling the NSExtensionContext to access shared items, and then exposing that data through your Expo Module.
+
+The Expo Modules is the recommended approach for building these kinds of extensions because it lets you:
+
+- Write native code in Swift and Kotlin that feels natural to each platform.
+- Expose the parts you need directly to JavaScript in a clean, typed interface.
+- Integrate smoothly with your Expo app.
+
+If community packages are a good fit, they're probably the quickest way to get started. But when you need more control or custom behavior, Expo Modules give you the foundation to build exactly what your app requires.

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -59,8 +59,7 @@ The exact setup steps vary depending on which library you choose, and since thes
 
 ### Handling shared data in JavaScript
 
-```
-// app/shared-content-receiver.tsx
+```tsx app/shared-content-receiver.tsx
 import { Text } from "react-native";
 import { useShareIntent } from "expo-share-intent";
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -108,7 +108,7 @@ Sometimes existing libraries won't cover all your needs. In those cases, you can
 
 On **Android**, it means declaring `<intent-filter>` entries in your project's **AndroidManifest.xml**, handling incoming Intents, and surfacing the content to your app via an Expo Module.
 
-On **iOS**, this means creating a Share Extension target, handling the NSExtensionContext to access shared items, and then exposing that data through your Expo Module.
+On **iOS**, this means creating a Share Extension target, handling the `NSExtensionContext` to access shared items, and then exposing that data through your Expo Module.
 
 The Expo Modules is the recommended approach for building these kinds of extensions because it lets you:
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -116,4 +116,4 @@ Expo Modules API is the recommended approach for building these kinds of extensi
 - Expose the parts you need directly to JavaScript in a clean, typed interface.
 - Integrate smoothly with your Expo app.
 
-If community packages are a good fit, they're probably the quickest way to get started. But when you need more control or custom behavior, Expo Modules give you the foundation to build exactly what your app requires.
+If community libraries are a good fit, they're probably the quickest way to get started. However, when you need more control or custom behavior, Expo Modules API gives you the foundation to build exactly what your app requires.

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -4,7 +4,6 @@ sidebar_title: Receiving content to your app
 description: Learn how to receive content to your app from another app.
 ---
 
-import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
 
 You may want to let other apps share content into your app &mdash; like articles, images, or files &mdash; using the native system share sheet. This guide explains how that works under the hood and gives an overview of the tools available to help you implement it.

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -89,7 +89,7 @@ export function redirectSystemPath({ path }: { path: string }) {
 }
 ```
 
-This file runs whenever your app is opened with a deep link that doesn't match a normal route. By checking for the share extension key, you can make sure the user is redirected into your ShareIntent screen where the data is handled.
+This file runs whenever your app is opened with a deep link that doesn't match a normal route. By checking for the share extension key, you can make sure the user is redirected to your `ShareIntent` screen, where the data is handled.
 
 An example project structure might look like this:
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -107,7 +107,7 @@ An example project structure might look like this:
 
 ### Building custom solutions with Expo Modules
 
-Sometimes existing libraries won't cover all your needs. In those cases, you can use the Expo Modules to implement custom native functionality for receiving shared content.
+Sometimes existing libraries won't cover all your needs. In those cases, you can use the [Expo Modules API](/modules/overview/) to implement custom native functionality for receiving shared content.
 
 On **Android**, it means declaring &lt;intent-filter&gt; entries in your manifest, handling incoming Intents, and surfacing the content to your app via an Expo Module.
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -110,7 +110,7 @@ On **Android**, it means declaring `<intent-filter>` entries in your project's *
 
 On **iOS**, this means creating a Share Extension target, handling the `NSExtensionContext` to access shared items, and then exposing that data through your Expo Module.
 
-The Expo Modules is the recommended approach for building these kinds of extensions because it lets you:
+Expo Modules API is the recommended approach for building these kinds of extensions because it lets you:
 
 - Write native code in Swift and Kotlin that feels natural to each platform.
 - Expose the parts you need directly to JavaScript in a clean, typed interface.

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -102,7 +102,7 @@ An example project structure might look like this:
   ]}
 />
 
-### Building custom solutions with Expo Modules
+### Building custom solutions with Expo Modules API
 
 Sometimes existing libraries won't cover all your needs. In those cases, you can use the [Expo Modules API](/modules/overview/) to implement custom native functionality for receiving shared content.
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -109,7 +109,7 @@ An example project structure might look like this:
 
 Sometimes existing libraries won't cover all your needs. In those cases, you can use the [Expo Modules API](/modules/overview/) to implement custom native functionality for receiving shared content.
 
-On **Android**, it means declaring &lt;intent-filter&gt; entries in your manifest, handling incoming Intents, and surfacing the content to your app via an Expo Module.
+On **Android**, it means declaring `<intent-filter>` entries in your project's **AndroidManifest.xml**, handling incoming Intents, and surfacing the content to your app via an Expo Module.
 
 On **iOS**, this means creating a Share Extension target, handling the NSExtensionContext to access shared items, and then exposing that data through your Expo Module.
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -1,7 +1,7 @@
 ---
 title: Receiving content to your app
 sidebar_title: Receiving content
-description: Learn how to receive content to your app from another app.
+description: Learn how to receive content to your Expo app from another app.
 ---
 
 import { FileTree } from '~/ui/components/FileTree';

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -32,7 +32,7 @@ On iOS, receiving shared data is handled by a Share Extension that runs separate
 For more in-depth details, see the official platform documentation:
 
 - Android: [Receiving simple data from other apps](https://developer.android.com/training/sharing/receive)
-- iOS: [App Extension Programming Guide – Share](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/Share.html)
+- iOS: [App Extension Programming Guide &mdash; Share](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/Share.html)
 
 ## Available libraries
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -51,7 +51,7 @@ Expo does not currently provide its own official library for receiving shared co
 
 ### Example app
 
-The open-source Bluesky app implements [share intent functionality](https://github.com/bluesky-social/social-app/tree/main/plugins/shareExtension) — useful as a production reference.
+The open source Bluesky app implements [share intent functionality](https://github.com/bluesky-social/social-app/tree/main/plugins/shareExtension) &mdash; useful as a production reference.
 
 ## Receiving shared data in your app
 

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -65,10 +65,6 @@ Expo does not currently provide its own official library for receiving shared co
 Icon={BookOpen02Icon}
 />
 
-### Example app
-
-The open source Bluesky app implements [share intent functionality](https://github.com/bluesky-social/social-app/tree/main/plugins/shareExtension) &mdash; useful as a production reference.
-
 ## Receiving shared data in your app
 
 The exact setup steps vary depending on which library you choose, and since these are not maintained by Expo, the best place to find installation instructions is always the library's own README. Using `expo-share-intent` as an example, a minimal implementation in your code could look like this:

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -14,7 +14,7 @@ With [`expo-sharing`](/versions/latest/sdk/sharing), you can already share conte
 
 #### Android
 
-On Android, the system delivers shared data to an Activity. An Activity is a single, focused screen in your app, and it can also act as an entry point that the system launches directly when the user selects your app in the share sheet.
+On Android, the system delivers shared data to an `Activity`. An `Activity` is a single, focused screen in your app, and it can also act as an entry point that the system launches directly when the user selects your app in the share sheet.
 
 - Apps register intent filters (`ACTION_SEND`/`ACTION_SEND_MULTIPLE`) for specific MIME types (for example, text/plain, image/\*) in **AndroidManifest.xml**.
 - When selected from the share sheet, your launch Activity receives an Intent containing the data payload.

--- a/docs/pages/linking/share-content-into-your-app.mdx
+++ b/docs/pages/linking/share-content-into-your-app.mdx
@@ -20,7 +20,7 @@ On Android, the system delivers shared data to an `Activity`. An `Activity` is a
 - When selected from the share sheet, your launch `Activity` receives an Intent containing the data payload.
 - Your `Activity` must handle the incoming Intent in Java or Kotlin by calling `getIntent()` and reading extras like `EXTRA_TEXT` or `EXTRA_STREAM`.
 
-**iOS**
+#### iOS
 
 On iOS, receiving shared data is handled by a Share Extension that runs separately from your main app.
 


### PR DESCRIPTION
# Why

Resolves ENG-16963

# How

This PR adds a new docs guide that explains how apps can receive content into the app from another app.

So far this is what I've been trying to cover very briefly.
- OS foundations
- Community libraries
- Example code for handling shared data in JavaScript and with Expo Router and Expo Share Intent
- Custom solutions with Expo Modules

This is a first draft and still a work in progress - feedback on scope, accuracy, or missing details is very welcome :)

Right now I've added it under the Linking section - there's probably a better place to put it.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
