### PR TITLE
[docs] Add video tutorial link for in-app purchases guide

### DIFF
--- a/docs/pages/guides/in-app-purchases.mdx
+++ b/docs/pages/guides/in-app-purchases.mdx
@@ -2,6 +2,7 @@
 title: Using in-app purchases
 description: Learn about how to use in-app purchases in your Expo app.
 hideTOC: true
+hasVideoLink: true
 ---
 
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
@@ -9,12 +10,17 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { CODE } from '~/ui/components/Text';
+import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 In-app purchases (IAP) are transactions within a mobile or desktop application where users can buy digital goods or additional features. This guide provides a list of popular libraries and tutorials for implementing IAP in your Expo app.
 
 > In-app purchase libraries require configuring custom native code. Native code is not configurable when using Expo Go. Instead, create a [development build](/develop/development-builds/introduction/), which allows using a native library in your project.
 
 ## Tutorial
+
+<VideoBoxLink videoId="R3fLKC-2Qh0" title="Watch: How to Implement In-App Purchases in Expo" />
+
+<br />
 
 <BoxLink
   title="Expo In-App Purchase Tutorial"


### PR DESCRIPTION
# Why

[ENG-17171 Consider adding RevenueCat tutorial video to documentation page](https://linear.app/expo/issue/ENG-17171/consider-adding-revenuecat-tutorial-video-to-documentation-page)

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
