### PR TITLE
[docs] Update `macos-sequoia-15.5-xcode-26.0` info

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -312,7 +312,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 <Collapsible summary="Details">
 
 - macOS Sequoia 15.5
-- Xcode 26.0 Beta 4 (17A5285i)
+- Xcode 26.0 Beta 6 (17A5305f)
 - Node.js 20.19.2
 - Bun 1.2.19
 - Yarn 1.22.22
@@ -328,6 +328,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 - Git LFS 3.6.1
 - applesimutils 0.9.12
 - idb-companion 1.1.8
+- Maestro 2.0.0
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

We updated the image today.

# How

Updated information about Xcode version and added Maestro version.

# Test Plan

Confirmed it's correct at https://staging.expo.dev/accounts/sjchmiela/projects/staging-app/workflows/0198f53c-da50-7168-9e33-3d833ca8572b.