### PR TITLE
[docs] Fix example syntax for supportedLocales option

### DIFF
--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -40,6 +40,8 @@ You can either provide an array of supported locales directly, or use the `suppo
 
 ```json app.json
 {
+  "expo": {
+    "plugins": [
       [
         "expo-localization",
         {
@@ -49,6 +51,7 @@ You can either provide an array of supported locales directly, or use the `suppo
           }
         }
       ]
+    ]
   }
 }
 ```


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
The previous snippet contained a bracket mismatch, which could make the configuration unclear. Wrapping the plugin block under "expo" → "plugins" both resolves this and makes it easier to understand where the setting belongs within app.json.

# How

<!--
How did you build this feature or fix this bug and why?
-->
Fixed bracket mismatch and clarified plugin placement in app.json.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
This change only updates documentation.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
