### PR TITLE
[docs] Fix typo in Google authentication guide

### DIFF
--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -5,7 +5,7 @@ description: A guide on using @react-native-google-signin/google-signin library 
 
 import { BoxLink } from '~/ui/components/BoxLink';
 
-The [`@react-native-google-signin/google-signin`](https://github.com/react-native-google-signin/google-signin) library provides a way integrate Google authentication in your Expo app. It also provides native sign-in buttons and supports authenticating the user as well as obtaining their authorization to use Google APIs. You can use the library in your project by adding the [config plugin](/config-plugins/introduction/) in the [app config](/versions/latest/config/app/).
+The [`@react-native-google-signin/google-signin`](https://github.com/react-native-google-signin/google-signin) library provides a way to integrate Google authentication in your Expo app. It also provides native sign-in buttons and supports authenticating the user as well as obtaining their authorization to use Google APIs. You can use the library in your project by adding the [config plugin](/config-plugins/introduction/) in the [app config](/versions/latest/config/app/).
 
 This guide provides information on how to configure the library for your project.
 


### PR DESCRIPTION
# Why

The Google authentication guide contained a small typo that could cause confusion for readers following the documentation. This PR corrects that typo to improve clarity.  

# How

I reviewed the guide, identified the typo, and updated the text to ensure the instructions are accurate and consistent.  

# Test Plan

No functional code changes were made. I verified the fix by reviewing the updated documentation to confirm the typo is resolved.  

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)  
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).  
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)  