### PR TITLE
Fix SDK 54 support for macOS

### DIFF
--- a/apps/bare-expo/macos/BareExpo-macOS.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/macos/BareExpo-macOS.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		29363141DC7A80DB22FA5171 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA3B41EA56BB5B268268C8D /* ExpoModulesProvider.swift */; };
 		41623B8AA3C3B314A17BE04C /* libPods-BareExpo-macOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D34AEDD54AEC68400CFA542E /* libPods-BareExpo-macOS.a */; };
 		514201552437B4B40078DB4F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 514201532437B4B40078DB4F /* Main.storyboard */; };
-		514201582437B4B40078DB4F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 514201572437B4B40078DB4F /* main.m */; };
 		A2022C6326D9C49C1CC23D41 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 6E6919923BB3CB3F3071FB08 /* PrivacyInfo.xcprivacy */; };
 		C07765852D65E82B007CC5C3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07765842D65E82B007CC5C3 /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
@@ -22,7 +21,6 @@
 		514201492437B4B30078DB4F /* BareExpo-macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "BareExpo-macOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		514201542437B4B40078DB4F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		514201562437B4B40078DB4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		514201572437B4B40078DB4F /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		514201592437B4B40078DB4F /* BareExpo-macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "BareExpo-macOS.entitlements"; sourceTree = "<group>"; };
 		6E6919923BB3CB3F3071FB08 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = ../PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		C07765842D65E82B007CC5C3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -92,7 +90,6 @@
 				C07765842D65E82B007CC5C3 /* AppDelegate.swift */,
 				514201532437B4B40078DB4F /* Main.storyboard */,
 				514201562437B4B40078DB4F /* Info.plist */,
-				514201572437B4B40078DB4F /* main.m */,
 				514201592437B4B40078DB4F /* BareExpo-macOS.entitlements */,
 				6E6919923BB3CB3F3071FB08 /* PrivacyInfo.xcprivacy */,
 				C02466F72E09DA4C00F9B72D /* Supporting */,
@@ -316,7 +313,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				C07765852D65E82B007CC5C3 /* AppDelegate.swift in Sources */,
-				514201582437B4B40078DB4F /* main.m in Sources */,
 				29363141DC7A80DB22FA5171 /* ExpoModulesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
+++ b/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
@@ -2,6 +2,7 @@ import Expo
 import React
 import ReactAppDependencyProvider
 
+@main
 public class AppDelegate: ExpoAppDelegate {
   var window: UIWindow?
 
@@ -17,13 +18,17 @@ public class AppDelegate: ExpoAppDelegate {
     reactNativeFactory = factory
     bindReactNativeFactory(factory)
 
-#if os(iOS) || os(tvOS)
-    window = UIWindow(frame: UIScreen.main.bounds)
+    let launchOptions = notification.userInfo
+    window = UIWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 1280, height: 720),
+      styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+      backing: .buffered,
+      defer: false
+    )
     factory.startReactNative(
       withModuleName: "main",
       in: window,
       launchOptions: launchOptions)
-#endif
 
     return super.applicationDidFinishLaunching(notification)
   }

--- a/apps/bare-expo/macos/BareExpo-macOS/main.m
+++ b/apps/bare-expo/macos/BareExpo-macOS/main.m
@@ -1,5 +1,0 @@
-#import <Cocoa/Cocoa.h>
-
-int main(int argc, const char *argv[]) {
-  return NSApplicationMain(argc, argv);
-}

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix Color extension on macOS. ([#39280](https://github.com/expo/expo/pull/39280) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 3.0.10 — 2025-08-31

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/ExpoSystemColors.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/ExpoSystemColors.swift
@@ -5,7 +5,7 @@ import SwiftUI
 // Wrap system colors to hide platform differences
 
 public extension Color {
-  #if os(tvOS)
+  #if os(tvOS) || os(macOS)
   private static let _systemGray6: Color = Color(.systemGray.withAlphaComponent(0.5))
   private static let _systemGray5: Color = Color(.systemGray.withAlphaComponent(0.6))
   private static let _systemGray4: Color = Color(.systemGray.withAlphaComponent(0.7))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add support for React Native Factory when extending ExpoAppDelegate on macOS. ([#35061](https://github.com/expo/expo/pull/35061) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -16,34 +16,6 @@ open class ExpoAppDelegate: NSObject, @preconcurrency ReactNativeFactoryProvider
   private let defaultModuleName = "main"
   private let defaultInitialProps = [AnyHashable: Any]()
 
-  func loadMacOSWindow(launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
-#if os(macOS)
-    if let rootView = factory?.rootViewFactory.view(
-      withModuleName: defaultModuleName,
-      initialProperties: defaultInitialProps,
-      launchOptions: launchOptions
-    ) {
-      let frame = NSRect(x: 0, y: 0, width: 1280, height: 720)
-      let window = NSWindow(
-        contentRect: NSRect.zero,
-        styleMask: [.titled, .resizable, .closable, .miniaturizable],
-        backing: .buffered,
-        defer: false)
-
-      window.title = defaultModuleName
-      window.autorecalculatesKeyViewLoop = true
-
-      let rootViewController = NSViewController()
-      rootViewController.view = rootView
-      rootView.frame = frame
-
-      window.contentViewController = rootViewController
-      window.makeKeyAndOrderFront(self)
-      window.center()
-    }
-#endif
-  }
-
   public func bindReactNativeFactory(_ factory: RCTReactNativeFactory) {
     self.factory = factory
   }
@@ -141,9 +113,6 @@ open class ExpoAppDelegate: NSObject, @preconcurrency ReactNativeFactoryProvider
   }
 
   open func applicationDidFinishLaunching(_ notification: Notification) {
-    let launchOptions = notification.userInfo as? [String: Any]
-    loadMacOSWindow(launchOptions: launchOptions)
-
     ExpoAppDelegateSubscriberRepository
       .subscribers
       .forEach { subscriber in

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -5,6 +5,8 @@ import React
 @MainActor public class ExpoReactNativeFactory: RCTReactNativeFactory {
   private let reactDelegate = ExpoReactDelegate(handlers: ExpoAppDelegateSubscriberRepository.reactDelegateHandlers)
 
+  // TODO: Remove check when react-native-macos 0.81 is released
+  #if !os(macOS)
   @objc public override init(delegate: any RCTReactNativeFactoryDelegate) {
     let releaseLevel = (Bundle.main.object(forInfoDictionaryKey: "ReactNativeReleaseLevel") as? String)
       .flatMap { [
@@ -17,6 +19,7 @@ import React
 
     super.init(delegate: delegate, releaseLevel: releaseLevel)
   }
+  #endif
 
   @objc func createRCTRootViewFactory() -> RCTRootViewFactory {
     // Alan: This is temporary. We need to cast to ExpoReactNativeFactoryDelegate here because currently, if you extend RCTReactNativeFactory

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -42,10 +42,7 @@ import React
       return weakDelegate.createRootView(with: bridge, moduleName: moduleName, initProps: initProps)
     }
 
-    // TODO: Remove this check when react-native-macos releases v0.79
-    if configuration.responds(to: Selector(("setJsRuntimeConfiguratorDelegate:"))) {
-      configuration.setValue(delegate, forKey: "jsRuntimeConfiguratorDelegate")
-    }
+    configuration.jsRuntimeConfiguratorDelegate = delegate
 
     configuration.createBridgeWithDelegate = { delegate, launchOptions in
       weakDelegate.createBridge(with: delegate, launchOptions: launchOptions)


### PR DESCRIPTION
# Why

Expo modules core is failing to compile on macOS because of the extension Color, which needs to `withAlphaComponent` syntax, and given that React native macOS 0.79 is out, we can also take advantage of the react native factory to simplify our code. 

# How

- Fix expo modules core Color extension for macOS
- Remove `loadMacOSWindow` function from ExpoAppDelegate, now users must create their own root view instances (e.g. `factory.startReactNative()`)
- Update BareExpo macOS to use react native factory and removed `main.m`

# Test Plan

Run BareExpo locally 

<img width="1392" height="832" alt="image" src="https://github.com/user-attachments/assets/4fe9485e-3bb3-4514-aba2-8ef595ab67e8" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
