### PR TITLE
[modules-core] Fix JavaScriptRuntimeSpec tests

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Fix JavaScriptRuntimeSpec tests ([#39281](https://github.com/expo/expo/pull/39281) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 3.0.10 — 2025-08-31
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-modules-core/ios/Tests/JavaScriptRuntimeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/JavaScriptRuntimeSpec.swift
@@ -86,11 +86,11 @@ class JavaScriptRuntimeSpec: ExpoSpec {
       it("throws evaluation exception") {
         expect({ try runtime.eval("foo") }).to(throwError { error in
           expect(error).to(beAKindOf(JavaScriptEvalException.self))
-          #if canImport(reacthermes)
-          expect((error as! JavaScriptEvalException).reason).to(contain("Property 'foo' doesn't exist"))
-          #else
-          expect((error as! JavaScriptEvalException).reason).to(contain("Can't find variable: foo"))
-          #endif
+          if runtime.global().hasProperty("HermesInternal") {
+            expect((error as! JavaScriptEvalException).reason).to(contain("Property 'foo' doesn't exist"))
+          } else {
+            expect((error as! JavaScriptEvalException).reason).to(contain("Can't find variable: foo"))
+          }
         })
       }
     }


### PR DESCRIPTION
# Why

When using React native prebuilds the `#if canImport(reacthermes)` condition fails, even when using hermes

# How

Update the test to check if it is using hermes by checking the HermesInternal property 

# Test Plan

CI should be green 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
