### PR TITLE
[cli] Promote buildCacheProvider to stable

### DIFF
--- a/docs/pages/guides/cache-builds-remotely.mdx
+++ b/docs/pages/guides/cache-builds-remotely.mdx
@@ -7,7 +7,7 @@ description: Accelerate local development by caching and reusing builds from a p
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-Build caching is an experimental feature that speeds up `npx expo run:[android|ios]` by caching builds remotely, based on the project [fingerprint](/versions/latest/sdk/fingerprint/).
+Build caching is a feature that speeds up `npx expo run:[android|ios]` by caching builds remotely, based on the project [fingerprint](/versions/latest/sdk/fingerprint/).
 When you run `npx expo run:[android|ios]`, it checks if a build with a matching fingerprint exists, then downloads and launches it rather than compiling it again. Otherwise, the project is compiled as usual and then the resulting binary is uploaded to the remote cache for future runs.
 
 ## Using EAS as a build provider
@@ -16,15 +16,13 @@ To use the EAS Build provider plugin, start by installing the `eas-build-cache-p
 
 <Terminal cmd={['$ npx expo install eas-build-cache-provider']} />
 
-Then, update your **app.json** to include the `buildCacheProvider` property and its provider under `experiments`:
+Then, update your **app.json** to include the `buildCacheProvider` property and its provider:
 
 ```json app.json
 {
   "expo": {
     ...
-    "experiments": {
-      "buildCacheProvider": "eas"
-    }
+    "buildCacheProvider": "eas"
   }
 }
 ```
@@ -141,10 +139,8 @@ At the root of your project, run `npm run build provider` to start the TypeScrip
 {
   "expo": {
     ...
-    "experiments": {
-      "buildCacheProvider": {
-        "plugin": "./provider.plugin.js"
-      }
+    "buildCacheProvider": {
+      "plugin": "./provider.plugin.js"
     }
   }
 }
@@ -170,12 +166,10 @@ To inject custom options to your plugin you can use the `options` field and it w
 {
   "expo": {
     ...
-    "experiments": {
-      "buildCacheProvider": {
-        "plugin": "./provider.plugin.js",
-        "options": {
-          "myCustomKey": "XXX-XXX-XXX"
-        }
+    "buildCacheProvider": {
+      "plugin": "./provider.plugin.js",
+      "options": {
+        "myCustomKey": "XXX-XXX-XXX"
       }
     }
   }

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Promote buildCacheProvider to stable ([#39297](https://github.com/expo/expo/pull/39297) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 0.26.6 — 2025-08-31
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/cli/src/run/android/resolveOptions.ts
+++ b/packages/@expo/cli/src/run/android/resolveOptions.ts
@@ -40,8 +40,7 @@ export async function resolveOptionsAsync(
 
   const projectConfig = getConfig(projectRoot);
   const buildCacheProvider = await resolveBuildCacheProvider(
-    projectConfig.exp.experiments?.buildCacheProvider ??
-      projectConfig.exp.experiments?.remoteBuildCache?.provider,
+    projectConfig.exp?.buildCacheProvider ?? projectConfig.exp.experiments?.buildCacheProvider,
     projectRoot
   );
 

--- a/packages/@expo/cli/src/run/ios/options/resolveOptions.ts
+++ b/packages/@expo/cli/src/run/ios/options/resolveOptions.ts
@@ -43,8 +43,7 @@ export async function resolveOptionsAsync(
 
   const projectConfig = getConfig(projectRoot);
   const buildCacheProvider = await resolveBuildCacheProvider(
-    projectConfig.exp.experiments?.buildCacheProvider ??
-      projectConfig.exp.experiments?.remoteBuildCache?.provider,
+    projectConfig.exp?.buildCacheProvider ?? projectConfig.exp.experiments?.buildCacheProvider,
     projectRoot
   );
 

--- a/packages/@expo/cli/src/utils/build-cache-providers/index.ts
+++ b/packages/@expo/cli/src/utils/build-cache-providers/index.ts
@@ -11,7 +11,7 @@ import { CommandError } from '../errors';
 const debug = require('debug')('expo:run:build-cache-provider') as typeof console.log;
 
 export const resolveBuildCacheProvider = async (
-  provider: Required<Required<ExpoConfig>['experiments']>['buildCacheProvider'] | undefined,
+  provider: Required<ExpoConfig>['buildCacheProvider'] | undefined,
   projectRoot: string
 ): Promise<BuildCacheProvider | undefined> => {
   if (!provider) {

--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -246,6 +246,15 @@ export interface ExpoConfig {
      * A Boolean value that indicates whether the app should use the new architecture. Defaults to true.
      */
     newArchEnabled?: boolean;
+    /**
+     * Enable downloading cached builds from remote.
+     */
+    buildCacheProvider?: 'eas' | {
+        plugin: string;
+        options?: {
+            [k: string]: any;
+        };
+    };
     ios?: IOS;
     android?: Android;
     web?: Web;
@@ -261,6 +270,15 @@ export interface ExpoConfig {
          * Export a website relative to a subpath of a domain. The path will be prepended as-is to links to all bundled resources. Prefix the path with a `/` (recommended) to load all resources relative to the server root. If the path **does not** start with a `/` then resources will be loaded relative to the code that requests them, this could lead to unexpected behavior. Example '/subpath'. Defaults to '' (empty string).
          */
         baseUrl?: string;
+        /**
+         * @deprecated This field is not longer marked as experimental and will be removed in a future release, use the `buildCacheProvider` field instead.
+         */
+        buildCacheProvider?: 'eas' | {
+            plugin: string;
+            options?: {
+                [k: string]: any;
+            };
+        };
         /**
          * If true, indicates that this project does not support tablets or handsets, and only supports Apple TV and Android TV
          */
@@ -293,29 +311,6 @@ export interface ExpoConfig {
          * Experimentally enable React Server Functions support in Expo CLI and Expo Router.
          */
         reactServerFunctions?: boolean;
-        /**
-         * Experimentally enable downloading cached builds from a provider.
-         */
-        buildCacheProvider?: 'eas' | {
-            plugin: string;
-            options?: {
-                [k: string]: any;
-            };
-        };
-        /**
-         * @deprecated This field will be removed in a future release, use the `buildCacheProvider` field instead.
-         */
-        remoteBuildCache?: {
-            /**
-             * Service provider for remote builds.
-             */
-            provider?: 'eas' | {
-                plugin: string;
-                options?: {
-                    [k: string]: any;
-                };
-            };
-        };
     };
     /**
      * Internal properties for developer tools

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -250,6 +250,17 @@ export interface ExpoConfig {
    * A Boolean value that indicates whether the app should use the new architecture. Defaults to true.
    */
   newArchEnabled?: boolean;
+  /**
+   * Enable downloading cached builds from remote.
+   */
+  buildCacheProvider?:
+    | 'eas'
+    | {
+        plugin: string;
+        options?: {
+          [k: string]: any;
+        };
+      };
   ios?: IOS;
   android?: Android;
   web?: Web;
@@ -265,6 +276,17 @@ export interface ExpoConfig {
      * Export a website relative to a subpath of a domain. The path will be prepended as-is to links to all bundled resources. Prefix the path with a `/` (recommended) to load all resources relative to the server root. If the path **does not** start with a `/` then resources will be loaded relative to the code that requests them, this could lead to unexpected behavior. Example '/subpath'. Defaults to '' (empty string).
      */
     baseUrl?: string;
+    /**
+     * @deprecated This field is not longer marked as experimental and will be removed in a future release, use the `buildCacheProvider` field instead.
+     */
+    buildCacheProvider?:
+      | 'eas'
+      | {
+          plugin: string;
+          options?: {
+            [k: string]: any;
+          };
+        };
     /**
      * If true, indicates that this project does not support tablets or handsets, and only supports Apple TV and Android TV
      */
@@ -297,33 +319,6 @@ export interface ExpoConfig {
      * Experimentally enable React Server Functions support in Expo CLI and Expo Router.
      */
     reactServerFunctions?: boolean;
-    /**
-     * Experimentally enable downloading cached builds from a provider.
-     */
-    buildCacheProvider?:
-      | 'eas'
-      | {
-          plugin: string;
-          options?: {
-            [k: string]: any;
-          };
-        };
-    /**
-     * @deprecated This field will be removed in a future release, use the `buildCacheProvider` field instead.
-     */
-    remoteBuildCache?: {
-      /**
-       * Service provider for remote builds.
-       */
-      provider?:
-        | 'eas'
-        | {
-            plugin: string;
-            options?: {
-              [k: string]: any;
-            };
-          };
-    };
   };
   /**
    * Internal properties for developer tools


### PR DESCRIPTION
# Why

SDK 54 is getting out in the next couple of days, and we want to promote buildCacheProvider to stable

Universe PR: https://github.com/expo/universe/pull/21763

# How

- Add `expo.buildCacheProvider` key, deprecate `expo.experiments.buildCacheProvider` and removed `expo.experiments.remoteBuildCache` in config types
- Update docs to no longer use the term "experimental"


# Test Plan

`nexpo run:ios`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
