### PR TITLE
[cli] Fix unnecessary version warning when prebuilding prerelease versions

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix unnecessary version warning when running prebuild for prerelease versions. ([#39298](https://github.com/expo/expo/pull/39298) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 0.26.6 — 2025-08-31

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -168,7 +168,8 @@ export function updatePkgDependencies(
       // Warn users for outdated dependencies when prebuilding
       const hasRecommendedVersion = versionRangesIntersect(
         pkg.dependencies[dependencyKey],
-        String(defaultDependencies[dependencyKey])
+        String(defaultDependencies[dependencyKey]),
+        true
       );
       if (!hasRecommendedVersion) {
         nonRecommendedPackages.push([
@@ -293,9 +294,13 @@ export function createFileHash(contents: string): string {
  * Determine if two semver ranges are overlapping or intersecting.
  * This is a safe version of `semver.intersects` that does not throw.
  */
-function versionRangesIntersect(rangeA: string | SemverRange, rangeB: string | SemverRange) {
+function versionRangesIntersect(
+  rangeA: string | SemverRange,
+  rangeB: string | SemverRange,
+  includePrerelease: boolean = false
+) {
   try {
-    return semverIntersects(rangeA, rangeB);
+    return semverIntersects(rangeA, rangeB, { includePrerelease });
   } catch {
     return false;
   }


### PR DESCRIPTION
# Why

ENG-17186

We show an unnecessary warning when the prerelease version of expo is explicitly specified: 
in package.json e.g. :
```
"expo": "54.0.0-preview.10",
```
when the recommended version is `~54.0.0-preview.10`, will result in the following warning: 
`› Using expo@54.0.0-preview.10 instead of recommended expo@~54.0.0-preview.10.`


# How

After some research, turns out that semver has a `includePrerelease` that makes it work the same as the npm versioning.
See more [here](https://github.com/Masterminds/semver?tab=readme-ov-file#working-with-prerelease-versions)

# Test Plan

Ran `npx expo prebuild` in a project.
