### PR TITLE
test(metro-config): Add tests for past import-export-plugin changes

### DIFF
--- a/packages/@expo/metro-config/src/transform-plugins/__tests__/suite/regressions.test.ts
+++ b/packages/@expo/metro-config/src/transform-plugins/__tests__/suite/regressions.test.ts
@@ -1,0 +1,111 @@
+import { makeEval } from './utils';
+
+const exec = makeEval();
+
+// See: https://github.com/expo/expo/issues/39277
+it('side-effect import order (#39277)', () => {
+  expect(
+    exec({
+      sideEffect: 'export {}',
+      default: 'export default "default";',
+      exports: 'export const foo = "foo";',
+      entry: `
+        import "sideEffect";
+        export { default } from "default";
+        export * from "exports";
+      `,
+    })
+  ).toEqual({
+    exports: {
+      foo: 'foo',
+      default: 'default',
+    },
+    requests: ['sideEffect', 'default', 'exports'],
+  });
+});
+
+// See: https://github.com/expo/expo/pull/39276
+it('double import-default shadowed by export specifier (#39276)', () => {
+  expect(
+    exec({
+      react: 'export default "react";',
+      entry: `
+        import A from "react";
+        import B from "react";
+        A;
+        B;
+        var x = "x";
+        export { x as A };
+      `,
+    })
+  ).toEqual({
+    exports: {
+      A: 'x',
+    },
+    requests: ['react'],
+  });
+});
+
+// See: https://github.com/expo/expo/pull/38976
+it('live-bound re-export default (#38976)', () => {
+  const mod = exec({
+    default: `
+      let test = 0;
+      export { test as default };
+      export function inc() {
+        test++;
+      }
+    `,
+    entry: `
+      export { default, inc } from './default';
+    `,
+  });
+  expect(mod).toEqual({
+    exports: { default: 0, inc: expect.any(Function) },
+    requests: ['default'],
+  });
+  mod.exports.inc();
+  expect(mod.exports.default).toBe(1);
+});
+
+// See: https://github.com/expo/expo/pull/38951
+it('prevents default and namespace conflicts (#38951)', () => {
+  expect(
+    exec({
+      a: `
+      export const a = "a";
+      export default "A";
+    `,
+      entry: `
+      import A from "a";
+      import * as a from "a";
+      export { A, a };
+    `,
+    })
+  ).toEqual({
+    exports: { A: 'A', a: { a: 'a', default: 'A' } },
+    requests: ['a'],
+  });
+});
+
+// See: https://github.com/expo/expo/pull/38111
+it('supports cicular deps initialization (#38111)', () => {
+  expect(
+    exec({
+      a: `
+      export const a = "a";
+    `,
+      b: `
+      import { a } from "entry";
+      export const b = "b" + a;
+    `,
+      entry: `
+      export { a } from "a";
+      export { b } from "b";
+    `,
+    })
+  ).toEqual({
+    exports: { a: 'a', b: 'ba' },
+    requests: ['a', 'b'],
+  });
+});

--- a/packages/@expo/metro-config/src/transform-plugins/__tests__/suite/utils.ts
+++ b/packages/@expo/metro-config/src/transform-plugins/__tests__/suite/utils.ts
@@ -48,6 +48,7 @@ export const makeEval = ({
           path: request,
         });
       if (!mod.loaded) {
+        mod.loaded = true;
         const code = transform(input[request]);
         // eslint-disable-next-line no-new-func
         const wrapper = new Function(
@@ -59,8 +60,12 @@ export const makeEval = ({
           code
         );
         const { exports, require, path: dirname } = mod;
-        Reflect.apply(wrapper, exports, [exports, require, mod, request, dirname]);
-        mod.loaded = true;
+        try {
+          Reflect.apply(wrapper, exports, [exports, require, mod, request, dirname]);
+        } catch (error) {
+          error.message += ` (eval: ${dirname})`;
+          throw error;
+        }
       }
       return mod.exports;
     }


### PR DESCRIPTION
Merging into #39282 

Adds initial tests for prior failing behaviour based on current/past issues and changes/PRs.