### PR TITLE
[notifications] fix race condition in setNotificationCategoryAsync

### DIFF
--- a/apps/notification-tester/src/app/index.tsx
+++ b/apps/notification-tester/src/app/index.tsx
@@ -9,7 +9,8 @@ export default function IndexPage() {
   return (
     <ScrollView contentContainerStyle={{ rowGap: 10, padding: 10 }}>
       <Button title="Run on-device tests" onPress={() => router.push('/run')} />
-      <Button title="Go to notification playground" onPress={() => router.push('/utilities')} />
+      <Button title="Go to NCL NotificationScreen" onPress={() => router.push('/utilities')} />
+      <Button title="Go to playground" onPress={() => router.push('/playground')} />
       <Button title="Go to test scenarios" onPress={() => router.push('/scenarios')} />
       <Notifier />
     </ScrollView>

--- a/apps/notification-tester/src/app/playground.tsx
+++ b/apps/notification-tester/src/app/playground.tsx
@@ -1,0 +1,126 @@
+import * as ExpoNotifications from 'expo-notifications';
+import HeadingText from 'native-component-list/src/components/HeadingText';
+import React, { useCallback } from 'react';
+import { Text } from 'react-native';
+
+import { ScrollView } from '../misc/Themed';
+
+export default function PlaygroundPage() {
+  const foo = useCallback(() => {
+    const categories = {
+      cat1: [
+        {
+          identifier: 'id1.1',
+          buttonTitle: 'id 1',
+          options: {
+            isDestructive: false,
+            opensAppToForeground: true,
+          },
+        },
+        {
+          identifier: 'id1.2',
+          buttonTitle: 'id 2',
+          options: {
+            isDestructive: false,
+            opensAppToForeground: true,
+          },
+        },
+      ],
+      cat2: [
+        {
+          identifier: 'id2.1',
+          buttonTitle: 'id 1',
+          options: {
+            isDestructive: false,
+            opensAppToForeground: true,
+          },
+        },
+        {
+          identifier: 'id2.2',
+          buttonTitle: 'id 2',
+          options: {
+            isDestructive: false,
+            opensAppToForeground: true,
+          },
+        },
+      ],
+      cat3: [
+        {
+          identifier: 'id3.1',
+          buttonTitle: 'id 1',
+          options: {
+            isDestructive: false,
+            opensAppToForeground: true,
+          },
+        },
+        {
+          identifier: 'id3.2',
+          buttonTitle: 'id 2',
+          options: {
+            isDestructive: false,
+            opensAppToForeground: true,
+          },
+        },
+      ],
+      cat4: [
+        {
+          identifier: 'id4.1',
+          buttonTitle: 'id 1',
+          options: {
+            isDestructive: false,
+            opensAppToForeground: true,
+          },
+        },
+        {
+          identifier: 'id4.2',
+          buttonTitle: 'id 2',
+          options: {
+            isDestructive: false,
+            opensAppToForeground: true,
+          },
+        },
+      ],
+    };
+    Promise.all(
+      Object.entries(categories).map(([id, acts]) => {
+        console.log(`Registering category ${id}`);
+        return ExpoNotifications.setNotificationCategoryAsync(id, acts);
+      })
+    )
+      .then((v) => {
+        console.log('"Successful" register: ' + JSON.stringify(v.map((x) => !!x)));
+        return ExpoNotifications.getNotificationCategoriesAsync();
+      })
+      .then((categories) => {
+        console.log(
+          'Registered categories: ' +
+            JSON.stringify(
+              categories.map((it) => it.identifier),
+              null,
+              2
+            )
+        );
+        // NOT all categories are always returned, but at least one is.
+      });
+  }, []);
+
+  return (
+    <ScrollView contentContainerStyle={{ rowGap: 10, padding: 10 }}>
+      <HeadingText>
+        Playground for bug repros. Keep in mind this is not completely isolated (other notifications
+        code runs at startup)
+      </HeadingText>
+      <Text onPress={foo}>Press me</Text>
+      <Text
+        onPress={async () => {
+          for (const cat of ['cat1', 'cat2', 'cat3', 'cat4']) {
+            await ExpoNotifications.deleteNotificationCategoryAsync(cat);
+          }
+          const cats = await ExpoNotifications.getNotificationCategoriesAsync();
+          console.log(`left: ${cats.map((c) => c.identifier).join(', ') || '<none>'}`);
+        }}>
+        delete all four
+      </Text>
+    </ScrollView>
+  );
+}

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [android] do not send faulty duplicate `TextInputNotificationResponse` events ([#39356](https://github.com/expo/expo/pull/39356) by [@vonovak](https://github.com/vonovak))
 - fix text response not present on some Android versions ([#39350](https://github.com/expo/expo/pull/39350) by [@vonovak](https://github.com/vonovak))
+- [ios] fix race condition in `setNotificationCategoryAsync` ([#39306](https://github.com/expo/expo/pull/39306) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/SharedPreferencesNotificationCategoriesStore.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/SharedPreferencesNotificationCategoriesStore.kt
@@ -86,14 +86,15 @@ class SharedPreferencesNotificationCategoriesStore(context: Context) {
    * @return Return true if category was deleted, false if not.
    */
   fun removeNotificationCategory(identifier: String): Boolean {
+    val id = preferencesNotificationCategoryKey(identifier)
     sharedPreferences.getString(
-      preferencesNotificationCategoryKey(identifier),
+      id,
       null
-    ).let { if (it == null) return false }
+    ) ?: return false
 
     return sharedPreferences
       .edit()
-      .remove(preferencesNotificationCategoryKey(identifier))
+      .remove(id)
       .commit()
   }
 

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/CategoriesModule.swift
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/Categories/CategoriesModule.swift
@@ -2,9 +2,50 @@
 
 import ExpoModulesCore
 import UIKit
-import MachO
+
+actor CategoryManager {
+  private var categories: Set<UNNotificationCategory>?
+
+  func setCategory(identifier: String, actions: [CategoryActionRecord], options: CategoryOptionsRecord?) async -> CategoryRecord {
+    let categoryRecord = CategoryRecord(identifier, actions: actions, options: options)
+    let newCategory = categoryRecord.toUNNotificationCategory()
+
+    let current = await loadCategories()
+    let updated = current.filter { $0.identifier != identifier }.union([newCategory])
+
+    await updateCategories(updated)
+    return CategoryRecord(newCategory)
+  }
+
+  func deleteCategory(identifier: String) async -> Bool {
+    let current = await loadCategories()
+    let exists = current.contains { $0.identifier == identifier }
+
+    if exists {
+      let updated = current.filter { $0.identifier != identifier }
+      await updateCategories(updated)
+    }
+    return exists
+  }
+
+  private func loadCategories() async -> Set<UNNotificationCategory> {
+    if let cached = categories {
+      return cached
+    }
+    let fresh = await UNUserNotificationCenter.current().notificationCategories()
+    categories = fresh
+    return fresh
+  }
+
+  private func updateCategories(_ newCategories: Set<UNNotificationCategory>) async {
+    categories = newCategories
+    UNUserNotificationCenter.current().setNotificationCategories(newCategories)
+  }
+}
 
 open class CategoriesModule: Module {
+  private let categoryManager = CategoryManager()
+
   public func definition() -> ModuleDefinition {
     Name("ExpoNotificationCategoriesModule")
 
@@ -27,29 +68,10 @@ open class CategoriesModule: Module {
   }
 
   open func setNotificationCategoryAsync(identifier: String, actions: [CategoryActionRecord], options: CategoryOptionsRecord?) async -> CategoryRecord {
-    let categoryRecord = CategoryRecord(identifier, actions: actions, options: options)
-    let newNotificationCategory = categoryRecord.toUNNotificationCategory()
-    let oldCategories = await UNUserNotificationCenter.current().notificationCategories()
-    let newCategories = oldCategories
-        .filter { oldCategory in
-          return oldCategory.identifier != newNotificationCategory.identifier
-        }
-        .union([newNotificationCategory])
-    UNUserNotificationCenter.current().setNotificationCategories(newCategories)
-    return CategoryRecord(newNotificationCategory)
+    return await categoryManager.setCategory(identifier: identifier, actions: actions, options: options)
   }
 
   open func deleteNotificationCategoryAsync(identifier: String) async -> Bool {
-    let oldCategories = await UNUserNotificationCenter.current().notificationCategories()
-    let didDelete = oldCategories.contains { oldCategory in
-      return oldCategory.identifier == identifier
-    }
-    if didDelete {
-      let newCategories = oldCategories.filter { oldCategory in
-        return oldCategory.identifier != identifier
-      }
-      UNUserNotificationCenter.current().setNotificationCategories(newCategories)
-    }
-    return didDelete
+    return await categoryManager.deleteCategory(identifier: identifier)
   }
 }


### PR DESCRIPTION
# Why

This PR addresses a bug in notification categories management where not all categories are consistently returned when registering multiple categories at once.

closes #37268

The issue is that the call to `UNUserNotificationCenter.current().setNotificationCategories(newCategories)` isn't synchronous

This is a somewhat dirty fix and the real issue is that our api surface for categories is kind of weird. Refactor of that will come in another PR.

# How

- Added a new playground page in notification tester
- Implemented an actor-based `CategoryManager` in iOS to serialize calls that modify categories. Added a `private var categories: Set<UNNotificationCategory>?` field that acts as a cache for the categories before they are _actually_ stored by iOS
- cosmetic changes to the Android implementation of `removeNotificationCategory` 

# Test Plan

- playground screen

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)