### PR TITLE
[expo-router] adjust native tabs app for light and dark mode

### DIFF
--- a/apps/router-e2e/__e2e__/native-tabs/app/_layout.tsx
+++ b/apps/router-e2e/__e2e__/native-tabs/app/_layout.tsx
@@ -1,19 +1,20 @@
 import MIcons from '@expo/vector-icons/MaterialIcons';
-import { ThemeProvider, DarkTheme } from '@react-navigation/native';
+import { ThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';
 import { Badge, Icon, Label, NativeTabs, VectorIcon } from 'expo-router/unstable-native-tabs';
 import { useState } from 'react';
-import { Appearance, Platform } from 'react-native';
+import { Appearance, Platform, useColorScheme } from 'react-native';
 
 import { ActiveTabsContext } from '../utils/active-tabs-context';
 
 if (process.env.EXPO_OS !== 'web') {
-  Appearance.setColorScheme('dark');
+  Appearance.setColorScheme(null);
 }
 
 export default function Layout() {
   const [activeTabs, setActiveTabs] = useState<string[]>([]);
+  const scheme = useColorScheme();
   return (
-    <ThemeProvider value={DarkTheme}>
+    <ThemeProvider value={scheme === 'dark' ? DarkTheme : DefaultTheme}>
       <ActiveTabsContext.Provider value={{ activeTabs, setActiveTabs }}>
         <NativeTabs
         // Both platforms
@@ -29,7 +30,7 @@ export default function Layout() {
         // tintColor="orange"
         // iconColor={Platform.OS === 'android' ? '#888' : undefined}
         // iOS only
-        // blurEffect="systemDefault"
+        // blurEffect="systemChromeMaterial"
         // minimizeBehavior="onScrollDown"
         // disableTransparentOnScrollEdge
         // Android only

--- a/apps/router-e2e/__e2e__/native-tabs/app/explore/_layout.tsx
+++ b/apps/router-e2e/__e2e__/native-tabs/app/explore/_layout.tsx
@@ -6,14 +6,15 @@ export default function Layout() {
       <Stack.Screen name="index" options={{ title: 'News' }} />
       <Stack.Screen
         name="news/[title]"
-        options={{
+        options={({ route }) => ({
           headerShown: true,
           headerLargeTitle: true,
           headerLargeStyle: { backgroundColor: 'transparent' },
           headerStyle: { backgroundColor: 'transparent' },
           headerTransparent: true,
           headerBlurEffect: 'systemChromeMaterial',
-        }}
+          title: String(route.params?.title),
+        })}
       />
     </Stack>
   );

--- a/apps/router-e2e/__e2e__/native-tabs/app/explore/index.tsx
+++ b/apps/router-e2e/__e2e__/native-tabs/app/explore/index.tsx
@@ -1,11 +1,14 @@
+import { useTheme } from '@react-navigation/native';
 import { ScrollView } from 'react-native';
+
 import { Post } from '../../components/Post';
 
 export default function Index() {
+  const { colors } = useTheme();
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
-      style={{ flex: 1, backgroundColor: '#000' }}
+      style={{ flex: 1, backgroundColor: colors.background }}
       contentContainerStyle={{
         padding: 32,
         gap: 16,

--- a/apps/router-e2e/__e2e__/native-tabs/app/explore/news/[title].tsx
+++ b/apps/router-e2e/__e2e__/native-tabs/app/explore/news/[title].tsx
@@ -1,20 +1,20 @@
-import { Stack } from 'expo-router';
+import { useTheme } from '@react-navigation/native';
 import { useLocalSearchParams } from 'expo-router/build/hooks';
 import { ScrollView, Text } from 'react-native';
 
 export default function Index() {
   const { title } = useLocalSearchParams();
+  const { colors } = useTheme();
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
-      style={{ flex: 1, backgroundColor: '#000' }}
+      style={{ flex: 1, backgroundColor: colors.background }}
       contentContainerStyle={{
         padding: 32,
         gap: 16,
         width: '100%',
       }}>
-      <Stack.Screen options={{ title }} />
-      <Text style={{ color: '#fff', fontSize: 24, fontWeight: 'bold' }}>
+      <Text style={{ color: colors.text, fontSize: 24, fontWeight: 'bold' }}>
         This is single news page for {title}
       </Text>
     </ScrollView>

--- a/apps/router-e2e/__e2e__/native-tabs/app/faces/index.tsx
+++ b/apps/router-e2e/__e2e__/native-tabs/app/faces/index.tsx
@@ -1,12 +1,14 @@
+import { useTheme } from '@react-navigation/native';
 import { ScrollView } from 'react-native';
 
 import { Faces } from '../../components/faces';
 
 export default function Index() {
+  const { colors } = useTheme();
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
-      style={{ flex: 1, backgroundColor: '#000' }}
+      style={{ flex: 1, backgroundColor: colors.background }}
       contentContainerStyle={{
         alignItems: 'center',
         padding: 32,

--- a/apps/router-e2e/__e2e__/native-tabs/app/index.tsx
+++ b/apps/router-e2e/__e2e__/native-tabs/app/index.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from '@react-navigation/native';
 import { Link } from 'expo-router';
 import { use } from 'react';
 import { Pressable, ScrollView, Switch, Text, View } from 'react-native';
@@ -9,43 +10,44 @@ import { ActiveTabsContext } from '../utils/active-tabs-context';
 const availableTabs = ['tab-1', 'tab-2', 'tab-3', 'tab-4', 'tab-5', 'tab-6'];
 
 export default function Index() {
+  const { colors } = useTheme();
   const { activeTabs, setActiveTabs } = use(ActiveTabsContext);
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
-      style={{ flex: 1, backgroundColor: '#000' }}
+      style={{ flex: 1, backgroundColor: colors.background }}
       contentContainerStyle={{
         justifyContent: 'center',
         // alignItems: 'center',
         padding: 32,
         gap: 16,
       }}>
-      <Text style={{ color: '#fff', fontSize: 32, fontWeight: 'bold', textAlign: 'center' }}>
+      <Text style={{ color: colors.text, fontSize: 32, fontWeight: 'bold', textAlign: 'center' }}>
         Good Afternoon
       </Text>
-      <Text style={{ color: '#ddd', fontSize: 24, marginBottom: 16, textAlign: 'center' }}>
+      <Text style={{ color: colors.text, fontSize: 24, marginBottom: 16, textAlign: 'center' }}>
         If you have a watch, this is an app for you!
       </Text>
-      <Text style={{ color: '#fff', fontSize: 24, fontWeight: 'bold' }}>Best faces</Text>
+      <Text style={{ color: colors.text, fontSize: 24, fontWeight: 'bold' }}>Best faces</Text>
       <Faces numberOfFaces={3} />
-      <Link href="/faces" style={{ color: '#fff', fontSize: 18 }}>
+      <Link href="/faces" style={{ color: colors.text, fontSize: 18 }}>
         <Link.Trigger>See all faces</Link.Trigger>
         <Link.Preview />
       </Link>
 
-      <Text style={{ color: '#fff', fontSize: 24, fontWeight: 'bold' }}>Latest news</Text>
+      <Text style={{ color: colors.text, fontSize: 24, fontWeight: 'bold' }}>Latest news</Text>
       <Post title="New watches in August" href="/explore/news/new-watches-august" />
-      <Link href="/explore" style={{ color: '#fff', fontSize: 18 }}>
+      <Link href="/explore" style={{ color: colors.text, fontSize: 18 }}>
         <Link.Trigger>See all news</Link.Trigger>
         <Link.Preview />
       </Link>
 
-      <Text style={{ color: '#fff', fontSize: 24, fontWeight: 'bold' }}>History</Text>
+      <Text style={{ color: colors.text, fontSize: 24, fontWeight: 'bold' }}>History</Text>
       <Link href="/explore/news/new-watches-august" asChild>
         <Link.Trigger>
           <Pressable>
             <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
-              <Text style={{ color: '#fff', fontSize: 48, fontWeight: 600 }}>08</Text>
+              <Text style={{ color: colors.text, fontSize: 48, fontWeight: 600 }}>08</Text>
               <Link href="/explore/news/new-watches-august" asChild>
                 <Link.Trigger>
                   <Pressable style={{ flex: 1 }}>
@@ -67,33 +69,33 @@ export default function Index() {
         <Link.Preview />
       </Link>
 
-      <Link href="/explore" style={{ color: '#fff', fontSize: 18 }}>
+      <Link href="/explore" style={{ color: colors.text, fontSize: 18 }}>
         <Link.Trigger>See all</Link.Trigger>
         <Link.Preview />
       </Link>
 
-      <Text style={{ color: '#fff', fontSize: 24, fontWeight: 'bold' }}>Additional links</Text>
-      <Link href="/dynamic" style={{ color: '#fff', fontSize: 18 }}>
+      <Text style={{ color: colors.text, fontSize: 24, fontWeight: 'bold' }}>Additional links</Text>
+      <Link href="/dynamic" style={{ color: colors.text, fontSize: 18 }}>
         <Link.Trigger>Dynamic</Link.Trigger>
         <Link.Preview />
       </Link>
-      <Link href="/404" style={{ color: '#fff', fontSize: 18 }}>
+      <Link href="/404" style={{ color: colors.text, fontSize: 18 }}>
         Try and go to 404
       </Link>
-      <Link href="/tab-1" style={{ color: '#fff', fontSize: 18 }}>
+      <Link href="/tab-1" style={{ color: colors.text, fontSize: 18 }}>
         Try and go to Tab 1
       </Link>
-      <Link href="/tab-2" style={{ color: '#fff', fontSize: 18 }}>
+      <Link href="/tab-2" style={{ color: colors.text, fontSize: 18 }}>
         Try and go to Tab 2
       </Link>
-      <Link href="/faces" style={{ color: '#fff', fontSize: 18 }}>
+      <Link href="/faces" style={{ color: colors.text, fontSize: 18 }}>
         Try and go to Faces
       </Link>
-      <Link href="/_sitemap" style={{ color: '#fff', fontSize: 18 }}>
+      <Link href="/_sitemap" style={{ color: colors.text, fontSize: 18 }}>
         Sitemap is here
       </Link>
       <View style={{ marginTop: 16 }}>
-        <Text style={{ color: '#fff', fontSize: 18 }}>Additional Tabs:</Text>
+        <Text style={{ color: colors.text, fontSize: 18 }}>Additional Tabs:</Text>
         {availableTabs.map((tab) => (
           <View
             key={tab}
@@ -104,7 +106,7 @@ export default function Index() {
                 setActiveTabs((prev) => (value ? [...prev, tab] : prev.filter((t) => t !== tab)));
               }}
             />
-            <Text style={{ color: '#fff' }}>{tab}</Text>
+            <Text style={{ color: colors.text }}>{tab}</Text>
           </View>
         ))}
       </View>

--- a/apps/router-e2e/__e2e__/native-tabs/components/Post.tsx
+++ b/apps/router-e2e/__e2e__/native-tabs/components/Post.tsx
@@ -1,7 +1,9 @@
+import { useTheme } from '@react-navigation/native';
 import { Link, type Href } from 'expo-router';
 import { Pressable, Text, View } from 'react-native';
 
 export function Post(props: { title: string; href: Href }) {
+  const { colors } = useTheme();
   return (
     <Link href={props.href} asChild>
       <Link.Trigger>
@@ -10,9 +12,9 @@ export function Post(props: { title: string; href: Href }) {
             flex: 1,
             width: '100%',
             gap: 8,
-            backgroundColor: '#000',
+            backgroundColor: colors.background,
           }}>
-          <Text style={{ color: '#fff', fontSize: 18 }}>{props.title}</Text>
+          <Text style={{ color: colors.text, fontSize: 18 }}>{props.title}</Text>
           <View
             style={{ width: '100%', aspectRatio: 1, backgroundColor: '#9ca3af', borderRadius: 8 }}
           />


### PR DESCRIPTION
# Why

The native tabs router-e2e app forced the dark mode. This made it hard to test native tabs in light mode.

# How

1. Remove explicit setColorScheme
2. Remove explicit colors and use `useTheme`

# Test Plan

1. Manual testing 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
