### PR TITLE
[docs] Remove and update info that referenced SDK 51

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -270,7 +270,7 @@ et generate-docs-api-data --packageName expo-constants
 
 #### NOTE ####
 # To update a specific SDK reference, run the command by mentioning the SDK version
-et gdad -p expo-constants --sdk 51
+et gdad -p expo-constants --sdk 54
 
 # For more information about et command, run: et gdad --help
 ```

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -28,7 +28,6 @@ When selecting an image for the build you can use the full name provided below o
 - The `sdk-54` alias will be assigned to the image best suited for SDK 54 builds.
 - The `sdk-53` alias will be assigned to the image best suited for SDK 53 builds.
 - The `sdk-52` alias will be assigned to the image best suited for SDK 52 builds.
-- The `sdk-51` alias will be assigned to the image best suited for SDK 51 builds.
 - SDK aliases will be updated with every new SDK release.
 - The `latest` alias will be updated with every new image release.
 

--- a/docs/pages/develop/user-interface/assets.mdx
+++ b/docs/pages/develop/user-interface/assets.mdx
@@ -30,8 +30,6 @@ Locally stored assets are served over HTTP in development. They are automaticall
 
 ### Load an asset at build time with `expo-asset` config plugin
 
-> **Note:** The `expo-asset` config plugin is only available for SDK 51 and above. If you are using an older SDK, you can load a [using the `useAssets` hook](#load-an-asset-at-runtime-with-useassets-hook).
-
 To load an asset at build time, you can use the [config plugin](/versions/latest/sdk/asset/#example-appjson-with-config-plugin) from the `expo-asset` library. This plugin will embed the asset file in your native project.
 
 <Step label="1">

--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -141,7 +141,7 @@ If your app does not use [Expo Prebuild](/workflow/prebuild) (formerly the _mana
 
 <Collapsible summary="Troubleshooting: New splash screen not appearing on iOS">
 
-For SDK 51 and below, in iOS development builds, launch screens can sometimes remain cached between builds, making it harder to test new images. Apple recommends clearing the _derived data_ directory before rebuilding, this can be done with Expo CLI by running:
+For SDK versions below 52, in iOS development builds, launch screens can sometimes remain cached between builds, making it harder to test new images. Apple recommends clearing the _derived data_ directory before rebuilding, this can be done with Expo CLI by running:
 
 <Terminal cmd={['$ npx expo run:ios --no-build-cache']} />
 

--- a/docs/pages/eas-update/asset-selection.mdx
+++ b/docs/pages/eas-update/asset-selection.mdx
@@ -15,7 +15,7 @@ SDK 52 launched this feature to general availability.
 
 ## Using asset selection
 
-To use asset selection in SDK 51 and below, include the property `extra.updates.assetPatternsToBeBundled` in your app config. It should define one or more file-matching patterns (regular expressions). For example, an **app.json** file has the patterns defined in the following way:
+To use asset selection in SDK versions below 52, include the property `extra.updates.assetPatternsToBeBundled` in your app config. It should define one or more file-matching patterns (regular expressions). For example, an **app.json** file has the patterns defined in the following way:
 
 ```json app.json
   "expo": {

--- a/docs/pages/guides/analyzing-bundles.mdx
+++ b/docs/pages/guides/analyzing-bundles.mdx
@@ -13,9 +13,7 @@ Bundle performance varies for different platforms. For example, web browsers don
 
 <ContentSpotlight alt="Expo Atlas overview page." src="/static/images/atlas/atlas-overview.avif" />
 
-> Available only for **SDK 51 and above**.
-
-The libraries used in a project influence the size of the production JavaScript bundle. Starting from **Expo SDK 51**, you can use [Expo Atlas](https://github.com/expo/expo-atlas#readme) to visualize the production bundle and identify which libraries contribute to the bundle size.
+The libraries used in a project influence the size of the production JavaScript bundle. You can use [Expo Atlas](https://github.com/expo/expo-atlas#readme) to visualize the production bundle and identify which libraries contribute to the bundle size.
 
 ### Using Atlas with `npx expo start`
 

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -55,7 +55,7 @@ The fastest way to generate a new project is described in the [TV example](https
 
 <Terminal cmd={['$ npx create-expo-app MyTVProject -e with-tv']} />
 
-For SDK 51 and later, you can start with the [TV Router example](https://github.com/expo/examples/tree/master/with-router-tv):
+You can start with the [TV Router example](https://github.com/expo/examples/tree/master/with-router-tv):
 
 <Terminal cmd={['$ npx create-expo-app MyTVProject -e with-router-tv']} />
 
@@ -112,7 +112,6 @@ TV also works with [React Navigation](https://reactnavigation.org/), [React Nati
 - The [Expo DevClient](/versions/latest/sdk/dev-client/) library is only supported in SDK 54 and later:
   - **Android TV**: All operations are supported, similar to an Android phone.
   - **Apple TV**: Basic operations with a local or tunneled packager are supported. Authentication to EAS and listing of EAS builds and updates is not yet supported.
-- The [Expo Router](/router/introduction/) library is only supported in SDK 51 and later.
 
 </Collapsible>
 

--- a/docs/pages/guides/tree-shaking.mdx
+++ b/docs/pages/guides/tree-shaking.mdx
@@ -40,7 +40,7 @@ console.log('Hello on iOS');
 
 This optimization is production only and runs on a per-file basis. If you re-export `Platform.OS` from a different module, it will not be removed from the production bundle.
 
-Starting in SDK 51, `process.env.EXPO_OS` can be used to detect the platform that the JavaScript was bundled for (cannot change at runtime). This value does not support platform shaking imports due to how Metro minifies code after dependency resolution.
+The `process.env.EXPO_OS` can be used to detect the platform that the JavaScript was bundled for (cannot change at runtime). This value does not support platform shaking imports due to how Metro minifies code after dependency resolution.
 
 ## Remove development-only code
 
@@ -134,8 +134,6 @@ The above code snippet is then minified, which removes the unused conditional:
 - Library authors should not use `EXPO_PUBLIC_` environment variables as they only run in application code for security reasons.
 
 ## Removing server code
-
-> SDK 51 and greater
 
 It's common to use `typeof window === 'undefined'` to conditionally enable or disable code for server and client environments.
 

--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -161,7 +161,7 @@ the Expo config needs to be modified in one of two ways:
 
 If you are not using CNG, then you should [add the push notification entitlement in Xcode](https://developer.apple.com/documentation/usernotifications/registering-your-app-with-apns).
 
-> **Note**: If you are upgrading an Expo app from a version before SDK 51, you should refer to [this FYI document](https://expo.fyi/apns-entitlement-sdk-51).
+> **Note**: If you are upgrading an Expo app from a version from SDK 51 and below, you should refer to [this FYI document](https://expo.fyi/apns-entitlement-sdk-51).
 
 ### Authorization
 

--- a/docs/pages/router/reference/sitemap.mdx
+++ b/docs/pages/router/reference/sitemap.mdx
@@ -27,7 +27,7 @@ You can also search for links directly in a browser like Safari or Chrome to tes
 
 Expo Router currently injects a **/\_sitemap** automatically that provides a list of all routes in the app. This is useful for debugging.
 
-In SDK 52 and above, the sitemap can be removed by adding `sitemap: false` to the `expo-router` config plugin in the app config:
+The sitemap can be removed by adding `sitemap: false` to the `expo-router` config plugin in the app config:
 
 ```json app.json
 {
@@ -41,13 +41,5 @@ In SDK 52 and above, the sitemap can be removed by adding `sitemap: false` to th
       }
     ]
   ]
-}
-```
-
-In SDK 51 and below, the sitemap can be removed by creating an empty **\_sitemap** file inside the **app** directory:
-
-```tsx app/_sitemap.tsx
-export default function Sitemap() {
-  return null;
 }
 ```


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #39304

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove and update info that referenced SDK 51 from multiple pages. Any feature released in SDK 51 is now available in SDK 52 and above.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
