### PR TITLE
[docs] Update code examples to reference SDK 54

### DIFF
--- a/docs/pages/config-plugins/development-and-debugging.mdx
+++ b/docs/pages/config-plugins/development-and-debugging.mdx
@@ -21,10 +21,10 @@ Use the following dependencies in a library that provides a config plugin:
 {
   "dependencies": {},
   "devDependencies": {
-    "expo": "^53.0.0"
+    "expo": "^54.0.0"
   },
   "peerDependencies": {
-    "expo": ">=53.0.0"
+    "expo": ">=54.0.0"
   },
   "peerDependenciesMeta": {
     "expo": {

--- a/docs/pages/config-plugins/development-for-libraries.mdx
+++ b/docs/pages/config-plugins/development-for-libraries.mdx
@@ -81,10 +81,10 @@ When using `expo-module-scripts`, it requires the following **package.json** con
     "prepublishOnly": "expo-module prepublishOnly"
   },
   "devDependencies": {
-    "expo": "^53.0.0"
+    "expo": "^54.0.0"
   },
   "peerDependencies": {
-    "expo": ">=53.0.0"
+    "expo": ">=54.0.0"
   },
   "peerDependenciesMeta": {
     "expo": {

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -200,10 +200,10 @@ Like standard packages, we need to add our **cool-package** as a dependency to o
   },
   "dependencies": {
     "cool-package": "*",
-    "expo": "~53.0.0",
-    "expo-status-bar": "~2.2.3",
-    "react": "19.0.0",
-    "react-native": "0.79.4"
+    "expo": "~54.0.0",
+    "expo-status-bar": "~3.0.6",
+    "react": "19.1.0",
+    "react-native": "0.81.1"
   }
 }
 ```


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up #39304

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the code examples that previously referenced Expo 53 and related dependency versions. These examples are now up to date with SDK 54 versions.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
