### PR TITLE
[doctor] deep dependency check for expo-modules-core

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Add deep dependency version check for expo-modules-core against recommended range. ([#39316](https://github.com/expo/expo/pull/39316) by by [@entiendonull](https://github.com/entiendonull))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-doctor/src/checks/DeepNativeModuleVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/DeepNativeModuleVersionCheck.ts
@@ -1,0 +1,47 @@
+import { getVersionedNativeModulesAsync } from '@expo/cli/src/start/doctor/dependencies/bundledNativeModules';
+
+import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+import { getDeepDependenciesWarningWithPackageNameAsync } from '../utils/explainDependencies';
+
+export class DeepNativeModuleVersionCheck implements DoctorCheck {
+  description =
+    'Check that deep dependencies versions for key modules against recommended versions';
+
+  sdkVersionRange = '>=45.0.0';
+
+  async runAsync({ exp, projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    let issues: string[] = [];
+
+    // Specify which packages to validate
+    const packagesToCheck = ['expo-modules-core'];
+
+    // Fetch expected version ranges for native modules for the current SDK
+    const nativeModuleVersions = await getVersionedNativeModulesAsync(projectRoot, exp.sdkVersion!);
+
+    const packagesToValidate = packagesToCheck
+      .filter((packageName) => nativeModuleVersions[packageName])
+      .map((packageName) => ({ packageName, version: nativeModuleVersions[packageName] }));
+
+    // check that a specific semver is installed for each package
+    const warnings = (
+      await Promise.all(
+        packagesToValidate.map((p) =>
+          getDeepDependenciesWarningWithPackageNameAsync(p.packageName, p.version, projectRoot)
+        )
+      )
+    ).flatMap((r) => (r ? [r] : []));
+
+    issues = warnings.map((r) => r.message);
+
+    return {
+      isSuccessful: issues.length === 0,
+      issues,
+      advice: issues.length
+        ? [
+            'Update packages so the resolved version matches the recommended range.',
+            'If version ranges already allow a compatible version, regenerate the lockfile and reinstall dependencies to refresh the resolution.',
+          ]
+        : [],
+    };
+  }
+}

--- a/packages/expo-doctor/src/checks/SupportPackageVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/SupportPackageVersionCheck.ts
@@ -1,22 +1,7 @@
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
-import { getDeepDependenciesWarningAsync } from '../utils/explainDependencies';
+import { getDeepDependenciesWarningWithPackageNameAsync } from '../utils/explainDependencies';
 import { getRemoteVersionsForSdkAsync } from '../utils/getRemoteVersionsForSdkAsync';
 import { joinWithCommasAnd } from '../utils/strings';
-
-async function getDeepDependenciesWarningWithPackageNameAsync(
-  packageName: string,
-  version: string,
-  projectRoot: string
-): Promise<{ packageName: string; message: string } | null> {
-  const maybeWarning = await getDeepDependenciesWarningAsync(
-    { name: packageName, version },
-    projectRoot
-  );
-  if (maybeWarning) {
-    return { packageName, message: maybeWarning };
-  }
-  return null;
-}
 
 export class SupportPackageVersionCheck implements DoctorCheck {
   description =

--- a/packages/expo-doctor/src/checks/__tests__/DeepNativeModuleVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/DeepNativeModuleVersionCheck.test.ts
@@ -1,0 +1,93 @@
+import { getVersionedNativeModulesAsync } from '@expo/cli/src/start/doctor/dependencies/bundledNativeModules';
+
+import { getDeepDependenciesWarningWithPackageNameAsync } from '../../utils/explainDependencies';
+import { DeepNativeModuleVersionCheck } from '../DeepNativeModuleVersionCheck';
+
+jest.mock('../../utils/explainDependencies');
+
+jest.mock('@expo/cli/src/start/doctor/dependencies/bundledNativeModules');
+
+// required by runAsync
+const additionalProjectProps = {
+  exp: {
+    name: 'name',
+    slug: 'slug',
+    sdkVersion: '50.0.0',
+  },
+  pkg: {
+    resolutions: {
+      metro: '0.9.0',
+    },
+  },
+  hasUnusedStaticConfig: false,
+  staticConfigPath: null,
+  dynamicConfigPath: null,
+};
+
+const mockGetRemoteVersionsForSdkAsyncResult = {
+  'expo-modules-core': '~2.5.0',
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('runAsync', () => {
+  it('returns result with isSuccessful = true if check passes', async () => {
+    jest
+      .mocked(getVersionedNativeModulesAsync)
+      .mockResolvedValueOnce(mockGetRemoteVersionsForSdkAsyncResult);
+    jest.mocked(getDeepDependenciesWarningWithPackageNameAsync).mockResolvedValue(null);
+
+    const check = new DeepNativeModuleVersionCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+    });
+
+    expect(result.isSuccessful).toBeTruthy();
+    expect(result.advice).toEqual([]);
+  });
+
+  it('returns result with isSuccessful = false if check fails', async () => {
+    jest
+      .mocked(getVersionedNativeModulesAsync)
+      .mockResolvedValueOnce(mockGetRemoteVersionsForSdkAsyncResult);
+    jest
+      .mocked(getDeepDependenciesWarningWithPackageNameAsync)
+      .mockResolvedValueOnce({ packageName: 'expo-modules-core', message: 'warning' });
+
+    const check = new DeepNativeModuleVersionCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+    });
+
+    expect(result.isSuccessful).toBeFalsy();
+  });
+
+  it('returns the default advice when there is a warning', async () => {
+    jest
+      .mocked(getVersionedNativeModulesAsync)
+      .mockResolvedValueOnce(mockGetRemoteVersionsForSdkAsyncResult);
+    jest
+      .mocked(getDeepDependenciesWarningWithPackageNameAsync)
+      .mockImplementation(async (pkg) =>
+        pkg === 'expo-modules-core'
+          ? { packageName: 'expo-modules-core', message: 'warning' }
+          : null
+      );
+
+    const check = new DeepNativeModuleVersionCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+    });
+
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.advice).toEqual([
+      'Update packages so the resolved version matches the recommended range.',
+      'If version ranges already allow a compatible version, regenerate the lockfile and reinstall dependencies to refresh the resolution.',
+    ]);
+  });
+});

--- a/packages/expo-doctor/src/checks/__tests__/SupportPackageVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/SupportPackageVersionCheck.test.ts
@@ -1,4 +1,4 @@
-import { getDeepDependenciesWarningAsync } from '../../utils/explainDependencies';
+import { getDeepDependenciesWarningWithPackageNameAsync } from '../../utils/explainDependencies';
 import { getRemoteVersionsForSdkAsync } from '../../utils/getRemoteVersionsForSdkAsync';
 import { SupportPackageVersionCheck } from '../SupportPackageVersionCheck';
 
@@ -35,7 +35,7 @@ describe('runAsync', () => {
     jest
       .mocked(getRemoteVersionsForSdkAsync)
       .mockResolvedValueOnce(mockGetRemoteVersionsForSdkAsyncResult);
-    jest.mocked(getDeepDependenciesWarningAsync).mockResolvedValue(null);
+    jest.mocked(getDeepDependenciesWarningWithPackageNameAsync).mockResolvedValue(null);
     const check = new SupportPackageVersionCheck();
     const result = await check.runAsync({
       projectRoot: '/path/to/project',
@@ -48,7 +48,9 @@ describe('runAsync', () => {
     jest
       .mocked(getRemoteVersionsForSdkAsync)
       .mockResolvedValueOnce(mockGetRemoteVersionsForSdkAsyncResult);
-    jest.mocked(getDeepDependenciesWarningAsync).mockResolvedValueOnce('warning');
+    jest
+      .mocked(getDeepDependenciesWarningWithPackageNameAsync)
+      .mockResolvedValueOnce({ packageName: 'expo-modules-autolinking', message: 'warning' });
     const check = new SupportPackageVersionCheck();
     const result = await check.runAsync({
       projectRoot: '/path/to/project',
@@ -61,12 +63,14 @@ describe('runAsync', () => {
     jest
       .mocked(getRemoteVersionsForSdkAsync)
       .mockResolvedValueOnce(mockGetRemoteVersionsForSdkAsyncResult);
-    jest.mocked(getDeepDependenciesWarningAsync).mockImplementation(async (pkg, projectRoot) => {
-      if (pkg.name === 'metro') {
-        return 'warning';
-      }
-      return null;
-    });
+    jest
+      .mocked(getDeepDependenciesWarningWithPackageNameAsync)
+      .mockImplementation(async (pkg, projectRoot) => {
+        if (pkg === 'metro') {
+          return { packageName: 'metro', message: 'warning' };
+        }
+        return null;
+      });
     const check = new SupportPackageVersionCheck();
     const result = await check.runAsync({
       projectRoot: '/path/to/project',
@@ -82,12 +86,14 @@ describe('runAsync', () => {
     jest
       .mocked(getRemoteVersionsForSdkAsync)
       .mockResolvedValueOnce(mockGetRemoteVersionsForSdkAsyncResult);
-    jest.mocked(getDeepDependenciesWarningAsync).mockImplementation(async (pkg, projectRoot) => {
-      if (pkg.name === 'metro-config') {
-        return 'warning';
-      }
-      return null;
-    });
+    jest
+      .mocked(getDeepDependenciesWarningWithPackageNameAsync)
+      .mockImplementation(async (pkg, projectRoot) => {
+        if (pkg === 'metro-config') {
+          return { packageName: 'metro-config', message: 'warning' };
+        }
+        return null;
+      });
     const check = new SupportPackageVersionCheck();
     const result = await check.runAsync({
       projectRoot: '/path/to/project',
@@ -103,12 +109,14 @@ describe('runAsync', () => {
     jest
       .mocked(getRemoteVersionsForSdkAsync)
       .mockResolvedValueOnce(mockGetRemoteVersionsForSdkAsyncResult);
-    jest.mocked(getDeepDependenciesWarningAsync).mockImplementation(async (pkg, projectRoot) => {
-      if (pkg.name === 'metro') {
-        return 'warning';
-      }
-      return null;
-    });
+    jest
+      .mocked(getDeepDependenciesWarningWithPackageNameAsync)
+      .mockImplementation(async (pkg, projectRoot) => {
+        if (pkg === 'metro') {
+          return { packageName: 'metro', message: 'warning' };
+        }
+        return null;
+      });
     const check = new SupportPackageVersionCheck();
     const result = await check.runAsync({
       projectRoot: '/path/to/project',

--- a/packages/expo-doctor/src/utils/checkResolver.ts
+++ b/packages/expo-doctor/src/utils/checkResolver.ts
@@ -26,6 +26,7 @@ import { ReactNativeDirectoryCheck } from '../checks/ReactNativeDirectoryCheck';
 import { StoreCompatibilityCheck } from '../checks/StoreCompatibilityCheck';
 import { SupportPackageVersionCheck } from '../checks/SupportPackageVersionCheck';
 import { DoctorCheck } from '../checks/checks.types';
+import { DeepNativeModuleVersionCheck } from '../checks/DeepNativeModuleVersionCheck';
 
 /**
  * Resolves the checks that should be run for a given project.
@@ -55,6 +56,7 @@ export function resolveChecksInScope(exp: ExpoConfig, pkg: PackageJSONConfig): D
     // Version Checks
     new SupportPackageVersionCheck(),
     new NativeToolingVersionCheck(),
+    new DeepNativeModuleVersionCheck(),
 
     // Compatibility Checks
     new StoreCompatibilityCheck(),

--- a/packages/expo-doctor/src/utils/explainDependencies.ts
+++ b/packages/expo-doctor/src/utils/explainDependencies.ts
@@ -138,3 +138,18 @@ export async function getDeepDependenciesWarningAsync(
 
   return getExplanationsAsync(pkg, explanations);
 }
+
+export async function getDeepDependenciesWarningWithPackageNameAsync(
+  packageName: string,
+  version: string,
+  projectRoot: string
+): Promise<{ packageName: string; message: string } | null> {
+  const maybeWarning = await getDeepDependenciesWarningAsync(
+    { name: packageName, version },
+    projectRoot
+  );
+  if (maybeWarning) {
+    return { packageName, message: maybeWarning };
+  }
+  return null;
+}


### PR DESCRIPTION
# Why

Resolves ENG-12459

# How

- Implemented `DeepNativeModuleVersionCheck` (based on `SupportPackageVersionCheck`) to validate the deep dependency version of `expo-modules-core` against the recommended range.  
- Extracted a shared helper in `utils/explainDependencies` to reduce duplication.  
- Added/adjusted tests

The check ensures that when a consuming package depends on `expo-modules-core`, its version aligns with the expected range for the current SDK.  

The screenshot below shows an example where an installed dependency uses a non-compatible version of `expo-modules-core` (`2.4.2`) instead of the SDK-recommended version (`~2.5.0`), which causes a warning during dependency resolution: 

<img width="924" height="106" alt="image" src="https://github.com/user-attachments/assets/ee74cc7f-2439-422b-b4c7-f01c222b1164" />


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested locally by creating an expo-module which I consumed in a test project.

1. No direct install:
```
18/18 checks passed. No issues detected!
```

2. Installed a non-compatible version of expo-modules-core as a direct dependency
```
17/18 checks passed. 1 checks failed. Possible issues detected:
Use the --verbose flag to see more details about passed checks.

✖ Check that deep dependencies versions for key modules against recommended versions
Expected package expo-modules-core@~2.5.0
Found invalid:
  expo-modules-core@2.4.2
  (for more info, run: npm why expo-modules-core)
Advice:
Update packages so the resolved version matches the recommended range.
If version ranges already allow a compatible version, regenerate the lockfile and reinstall dependencies to refresh the resolution.

1 check failed, indicating possible issues with the project.
```

3. Set an override in the expo module to use a non-compatible version
```
17/18 checks passed. 1 checks failed. Possible issues detected:
Use the --verbose flag to see more details about passed checks.

✖ Check that deep dependencies versions for key modules against recommended versions
Expected package expo-modules-core@~2.5.0
Found invalid:
  expo-modules-core@2.4.2
  (for more info, run: npm why expo-modules-core)
Advice:
Update packages so the resolved version matches the recommended range.
If version ranges already allow a compatible version, regenerate the lockfile and reinstall dependencies to refresh the resolution.

1 check failed, indicating possible issues with the project.
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
