### PR TITLE
[ios][image] Fix images in the top tabs navigator

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix images not displaying in Material Top Tabs navigator.
+- [iOS] Fix images not displaying in Material Top Tabs navigator. ([#39323](https://github.com/expo/expo/pull/39323) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix images not displaying in Material Top Tabs navigator.
+
 ### 💡 Others
 
 ## 3.0.5 — 2025-08-31

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -116,15 +116,10 @@ public final class ImageView: ExpoView {
 
     addSubview(sdImageView)
   }
-
-  public override func didMoveToWindow() {
-    if window == nil {
-      // Cancel pending requests when the view is unmounted.
-      cancelPendingOperation()
-      return
-    }
-
-    loadPlaceholderIfNecessary()
+  
+  deinit {
+    // Cancel pending requests when the view is deallocated.
+    cancelPendingOperation()
   }
 
   public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -116,7 +116,7 @@ public final class ImageView: ExpoView {
 
     addSubview(sdImageView)
   }
-  
+
   deinit {
     // Cancel pending requests when the view is deallocated.
     cancelPendingOperation()


### PR DESCRIPTION
# Why

Fixes images not displaying in the Material Top Tabs navigator.
Fixes https://github.com/expo/expo/issues/38783.

# How

It turns out that in `didMoveToWindow`, the window can be null if, according to the [documentation](https://developer.apple.com/documentation/uikit/uiview/didmovetowindow()), "the receiver has just been added to a superview that is not attached to a window". Our logic that canceled the pending operation on unmount wasn't correct. Additionally, we don't need to call `loadPlaceholderIfNecessary`, as it will be handled by the reload function when the view bounds change. 

# Test Plan

- NCL ✅ 
- https://snack.expo.dev/@victorpe/bug-expo-image-and-material-top-tabs ✅ 