### PR TITLE
[ui] migrate AnimationModifier to convertibles

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 💡 Others
 
 - Used convertibles to process modifiers' parameters. ([#39231](https://github.com/expo/expo/pull/39231) by [@kudo](https://github.com/kudo))
+- Migrated `AnimationModifier` to convertibles. ([#39326](https://github.com/expo/expo/pull/39326) by [@kudo](https://github.com/kudo))
 
 ## 0.2.0-alpha.7 — 2025-08-31
 


### PR DESCRIPTION
# Why

following up #39231

# How

migrate the remaining AnimationModifier to convertibles

# Test Plan

test ncl animation modifier example

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
