### PR TITLE
[notifications] change exception message for better debuggability

### DIFF
--- a/apps/notification-tester/src/registerForNotifications.ts
+++ b/apps/notification-tester/src/registerForNotifications.ts
@@ -35,6 +35,5 @@ export async function registerForPushNotificationsAsync() {
       projectId,
     })
   ).data;
-  console.log(token);
   return token;
 }

--- a/apps/notification-tester/src/usePushToken.ts
+++ b/apps/notification-tester/src/usePushToken.ts
@@ -11,6 +11,7 @@ export function usePushToken() {
   useEffect(() => {
     registerForPushNotificationsAsync()
       .then((token) => {
+        console.log(token);
         setExpoPushToken(token);
       })
       .catch(console.error);
@@ -18,6 +19,7 @@ export function usePushToken() {
     getDevicePushTokenAsync()
       .then((token) => {
         const tokenString = JSON.stringify(token);
+        console.log(tokenString);
         setDevicePushToken(tokenString);
       })
       .catch(console.error);

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -481,7 +481,7 @@ open class NotificationsService : BroadcastReceiver() {
       val notification = extras?.getParcelable<Notification>(NOTIFICATION_KEY)
       val action = extras?.getParcelable<NotificationAction>(NOTIFICATION_ACTION_KEY)
       if (notification == null || action == null) {
-        throw IllegalArgumentException("notification and action should not be null")
+        throw IllegalArgumentException("notification ($notification) and action ($action) should not be null")
       }
       val backgroundAction = NotificationAction(action.identifier, action.title, false)
       val intent = Intent(


### PR DESCRIPTION
# Why

#38908 - I wasn't able to repro the issue but wonder what the values are

# How

Enhanced the error message in `NotificationsService.kt` to include the actual values of notification and action when they're null.

# Test Plan


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)