### PR TITLE
add ExpoLiquidGlassConstants to expoModules mocks

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add `ExpoLiquidGlassConstants` to expoModules mocks ([#39333](https://github.com/expo/expo/pull/39333) by [@Ubax](https://github.com/Ubax))
+
 ## 54.0.6 — 2025-08-31
 
 _This version does not introduce any user-facing changes._

--- a/packages/jest-expo/src/preset/moduleMocks/expoModules.js
+++ b/packages/jest-expo/src/preset/moduleMocks/expoModules.js
@@ -295,6 +295,7 @@ module.exports = {
           { name: 'isActivated', argumentsCount: 0, key: 'isActivated' },
         ],
         ExpoLinearGradient: [],
+        ExpoLiquidGlassConstants: [],
         ExpoLivePhoto: [],
         ExpoLocalAuthentication: [
           { name: 'authenticateAsync', argumentsCount: 1, key: 'authenticateAsync' },
@@ -981,6 +982,9 @@ module.exports = {
         ExpoLinearGradient: {
           addListener: { type: 'function' },
           removeListeners: { type: 'function' },
+        },
+        ExpoLiquidGlassConstants: {
+          isLiquidGlassAvailable: { type: 'string' },
         },
         ExpoLivePhoto: { addListener: { type: 'function' }, removeListeners: { type: 'function' } },
         ExpoLocalAuthentication: {


### PR DESCRIPTION
# Why

The `ExpoLiquidGlassConstants` was not added to `packages/jest-expo/src/preset/moduleMocks/expoModules.js`

# How

Add the module

# Test Plan

1. CI
2. Unit tests


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
