### PR TITLE
[docs] Fix example "upload files as blobs directly with fetch"

### DIFF
--- a/docs/pages/versions/v54.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/filesystem.mdx
@@ -126,11 +126,11 @@ You can upload files as blobs directly with `fetch` built into the Expo package:
 
 ```ts example.ts
 import { fetch } from 'expo/fetch';
-import { File } from 'expo-file-system';
+import { File, Paths } from 'expo-file-system';
 
-const src = new File(testDirectory, 'file.txt');
+const file = new File(Paths.cache, 'file.txt');
 file.write('Hello, world!');
-const blob = src.blob();
+const blob = file.blob();
 
 const response = await fetch('https://example.com', {
   method: 'POST',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The current code example is broken, referencing non declared variables

# How

<!--
How did you build this feature or fix this bug and why?
-->

Replace the unknown "testDirectory" with "Paths.cache" and naming the file variable "file" accordingly to the call in the next line.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Paste the code snippet in a project and verify it now works.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
