### PR TITLE
[create-expo-nightly] Fix createRequire import with @vercel/ncc 0.38.3

### DIFF
--- a/packages/create-expo-nightly/src/ExpoRepo.ts
+++ b/packages/create-expo-nightly/src/ExpoRepo.ts
@@ -1,12 +1,13 @@
 import fs from 'fs';
-import { createRequire } from 'node:module';
+import * as Module from 'node:module';
 import path from 'node:path';
 
 import { REACT_NATIVE_TRANSITIVE_DEPENDENCIES } from './Packages.js';
 import { runAsync } from './Processes.js';
 
-const require = createRequire(import.meta.url);
-const { default: JsonFile } = require('@expo/json-file') as typeof import('@expo/json-file');
+const { default: JsonFile } = Module.createRequire(import.meta.url)(
+  '@expo/json-file'
+) as typeof import('@expo/json-file');
 
 /**
  * Clone the expo/expo repository and install dependencies.

--- a/packages/create-expo-nightly/src/Packages.ts
+++ b/packages/create-expo-nightly/src/Packages.ts
@@ -1,12 +1,13 @@
 import { glob } from 'glob';
 import fs from 'node:fs/promises';
-import { createRequire } from 'node:module';
+import * as Module from 'node:module';
 import path from 'node:path';
 
 import { runAsync } from './Processes.js';
 
-const require = createRequire(import.meta.url);
-const { default: JsonFile } = require('@expo/json-file') as typeof import('@expo/json-file');
+const { default: JsonFile } = Module.createRequire(import.meta.url)(
+  '@expo/json-file'
+) as typeof import('@expo/json-file');
 
 let cachedPackages: Package[] | null = null;
 

--- a/packages/create-expo-nightly/src/Processes.ts
+++ b/packages/create-expo-nightly/src/Processes.ts
@@ -1,7 +1,6 @@
-import { createRequire } from 'node:module';
+import * as Module from 'node:module';
 
-const require = createRequire(import.meta.url);
-const { $, cd } = require('zx') as typeof import('zx');
+const { $, cd } = Module.createRequire(import.meta.url)('zx') as typeof import('zx');
 
 let defaultVerbose = false;
 

--- a/packages/create-expo-nightly/src/Project.ts
+++ b/packages/create-expo-nightly/src/Project.ts
@@ -1,15 +1,16 @@
 import type { JSONArray, JSONObject, JSONValue } from '@expo/json-file';
 import fs from 'fs';
 import assert from 'node:assert';
-import { createRequire } from 'node:module';
+import * as Module from 'node:module';
 import path from 'node:path';
 
 import { setupExpoRepoAsync } from './ExpoRepo.js';
 import { REACT_NATIVE_TRANSITIVE_DEPENDENCIES } from './Packages.js';
 import { runAsync } from './Processes.js';
 
-const require = createRequire(import.meta.url);
-const { default: JsonFile } = require('@expo/json-file') as typeof import('@expo/json-file');
+const { default: JsonFile } = Module.createRequire(import.meta.url)(
+  '@expo/json-file'
+) as typeof import('@expo/json-file');
 
 export interface ProjectProperties {
   /** The Android applicationId and iOS bundleIdentifier. */

--- a/packages/create-expo-nightly/src/SanityChecks.ts
+++ b/packages/create-expo-nightly/src/SanityChecks.ts
@@ -1,7 +1,6 @@
-import { createRequire } from 'node:module';
+import * as Module from 'node:module';
 
-const require = createRequire(import.meta.url);
-const { which } = require('zx') as typeof import('zx');
+const { which } = Module.createRequire(import.meta.url)('zx') as typeof import('zx');
 
 /**
  * Check whether the current environment has the required tools available.


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/38801

<img width="865" height="217" alt="image" src="https://github.com/user-attachments/assets/0f233ebb-4824-4c12-bc68-180e856bff9b" />


After bumping `ncc` to 0.38.3, `create-expo-nightly` builds broke because ncc tightened how it transforms direct `createRequire` usage in ESM bundles, rewriting local require aliases to `const X_require = /* createRequire() */ undefined;`

https://github.com/expo/expo/actions/runs/17392273604

# How

 Use `Module.createRequire` to avoid NCC stubbing direct createRequire calls in ESM output

# Test Plan

`bun build/index.js --expo-repo ../../  --no-install ~/Workspace/expo/issues/test`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
