### PR TITLE
[file-system][ios] Fix tvOS compile errors

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix tvOS compile error. ([#39345](https://github.com/expo/expo/pull/39345) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 ## 19.0.8 — 2025-09-02

--- a/packages/expo-file-system/ios/FilePickingHandler.swift
+++ b/packages/expo-file-system/ios/FilePickingHandler.swift
@@ -1,6 +1,7 @@
 // UIKit is unavailable on macOS, so platform checks are necessary.
 // For macOS support, we should consider using NSOpenPanel: https://developer.apple.com/documentation/appkit/nsopenpanel
-#if os(iOS) || os(tvOS)
+// UIDocumentPickerViewController is unavailable on tvOS
+#if os(iOS)
 import ExpoModulesCore
 import UIKit
 

--- a/packages/expo-file-system/ios/FilePickingUtils.swift
+++ b/packages/expo-file-system/ios/FilePickingUtils.swift
@@ -1,4 +1,5 @@
-#if os(iOS) || os(tvOS)
+// UIDocumentPickerViewController is unavailable on tvOS
+#if os(iOS)
 import ExpoModulesCore
 import MobileCoreServices
 import UIKit

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -4,7 +4,7 @@ import ExpoModulesCore
 
 @available(iOS 14, tvOS 14, *)
 public final class FileSystemModule: Module {
-  #if os(iOS) || os(tvOS)
+  #if os(iOS)
   private lazy var filePickingHandler = FilePickingHandler(module: self)
   #endif
 
@@ -107,7 +107,7 @@ public final class FileSystemModule: Module {
     }
 
     AsyncFunction("pickFileAsync") { (initialUri: URL?, mimeType: String?, promise: Promise) in
-      #if os(iOS) || os(tvOS)
+      #if os(iOS)
       filePickingHandler.presentDocumentPicker(
         picker: createFilePicker(initialUri: initialUri, mimeType: mimeType),
         isDirectory: false,


### PR DESCRIPTION
# Why

The new file picker on Apple platforms uses an API that is not available on tvOS.

# How

Modify the existing platform checks to suppress the picker on tvOS.

# Test Plan

TV compile test should pass in CI.

# Checklist


- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
