### PR TITLE
[home][iOS] Add backgroundColor for native bottom tabs

### DIFF
--- a/apps/expo-go/src/navigation/NativeBottomTabsNavigator.tsx
+++ b/apps/expo-go/src/navigation/NativeBottomTabsNavigator.tsx
@@ -62,7 +62,9 @@ function NativeBottomTabsNavigator({
               tabKey={route.key}
               title={descriptor.options.tabBarLabel ?? route.name}
               isFocused={isFocused}
-              icon={descriptor.options.tabBarIcon()}>
+              icon={descriptor.options.tabBarIcon()}
+              standardAppearance={{ tabBarBackgroundColor: rest.tabBarStyle?.backgroundColor }}
+              scrollEdgeAppearance={{ tabBarBackgroundColor: rest.tabBarStyle?.backgroundColor }}>
               {descriptor.render()}
             </BottomTabsScreen>
           );


### PR DESCRIPTION
# Why

Follow up for https://github.com/expo/expo/pull/39006

> @alanjhughes 
> We should have the tabs background match the headers.

# Test Plan

![Uploading simulator_screenshot_4651C418-5AEF-4020-A2C9-BD736D40DB36.png…]()