### PR TITLE
[expo][iOS] load isLiquidGlassAvailable lazily

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] load isLiquidGlassAvailable lazily ([#39349](https://github.com/expo/expo/pull/39349) by [@Ubax](https://github.com/Ubax))
+
 ## 54.0.0-preview.13 — 2025-09-02
 
 ### 🎉 New features

--- a/packages/expo/build/environment/isLiquidGlassAvailable.ios.d.ts.map
+++ b/packages/expo/build/environment/isLiquidGlassAvailable.ios.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"isLiquidGlassAvailable.ios.d.ts","sourceRoot":"","sources":["../../src/environment/isLiquidGlassAvailable.ios.ts"],"names":[],"mappings":"AAMA;;;;;;;;;;GAUG;AACH,wBAAgB,sBAAsB,IAAI,OAAO,CAEhD"}
+{"version":3,"file":"isLiquidGlassAvailable.ios.d.ts","sourceRoot":"","sources":["../../src/environment/isLiquidGlassAvailable.ios.ts"],"names":[],"mappings":"AAIA;;;;;;;;;;GAUG;AACH,wBAAgB,sBAAsB,IAAI,OAAO,CAOhD"}

--- a/packages/expo/src/environment/isLiquidGlassAvailable.ios.ts
+++ b/packages/expo/src/environment/isLiquidGlassAvailable.ios.ts
@@ -1,8 +1,6 @@
 import { requireNativeModule } from 'expo-modules-core';
 
-const IS_LIQUID_GLASS_AVAILABLE = requireNativeModule(
-  'ExpoLiquidGlassConstants'
-).isLiquidGlassAvailable;
+let IS_LIQUID_GLASS_AVAILABLE: boolean | undefined;
 
 /**
  * Indicates whether the app is using the Liquid Glass design. The value will be `true` when the
@@ -16,5 +14,10 @@ const IS_LIQUID_GLASS_AVAILABLE = requireNativeModule(
  * @platform ios
  */
 export function isLiquidGlassAvailable(): boolean {
-  return IS_LIQUID_GLASS_AVAILABLE;
+  if (IS_LIQUID_GLASS_AVAILABLE === undefined) {
+    IS_LIQUID_GLASS_AVAILABLE = requireNativeModule(
+      'ExpoLiquidGlassConstants'
+    ).isLiquidGlassAvailable;
+  }
+  return !!IS_LIQUID_GLASS_AVAILABLE;
 }


### PR DESCRIPTION
# Why

If there is no check for `isLiquidGlassAvailable`, then there is no need to load its native module. 

# How

1. Require native module on the first check

# Test Plan

1. Manual testing of the module

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
