### PR TITLE
[notifications] fix text response not present on some Android versions

### DIFF
--- a/apps/native-component-list/src/screens/NotificationScreen.tsx
+++ b/apps/native-component-list/src/screens/NotificationScreen.tsx
@@ -14,6 +14,8 @@ const BACKGROUND_TEST_INFO = `[notification-tester app only]: To test background
 
 const remotePushSupported = Device.isDevice;
 
+const welcomeCategoryId = 'welcome';
+
 export default class NotificationScreen extends React.Component<
   void,
   {
@@ -37,7 +39,7 @@ export default class NotificationScreen extends React.Component<
       return;
     }
     // Using the same category as in `registerForPushNotificationsAsync`
-    Notifications.setNotificationCategoryAsync('welcome', [
+    Notifications.setNotificationCategoryAsync(welcomeCategoryId, [
       {
         buttonTitle: `Don't open app`,
         identifier: 'first-button',
@@ -107,7 +109,7 @@ export default class NotificationScreen extends React.Component<
             });
             await Notifications.scheduleNotificationAsync({
               content: {
-                categoryIdentifier: 'welcome',
+                categoryIdentifier: welcomeCategoryId,
                 title: 'Here is a notification!',
                 body: 'This one has buttons!',
                 autoDismiss: true,

--- a/apps/notification-tester/src/app/run.tsx
+++ b/apps/notification-tester/src/app/run.tsx
@@ -1,4 +1,3 @@
-// @ts-expect-error
 import TestScreen from 'test-suite/screens/TestScreen';
 
 const NotificationTestScreen = require('test-suite/tests/Notifications');
@@ -10,9 +9,7 @@ const NotificationTestScreen = require('test-suite/tests/Notifications');
 export default class NotificationTesterScreen extends TestScreen {
   componentDidMount() {
     const selectedModules = [NotificationTestScreen];
-    // @ts-expect-error
     this._runTests(selectedModules);
-    // @ts-expect-error
     this._isMounted = true;
   }
 }

--- a/apps/notification-tester/src/registerTaskAsync.ts
+++ b/apps/notification-tester/src/registerTaskAsync.ts
@@ -80,6 +80,11 @@ export const registerTask = () => {
           source: 'BACKGROUND_TASK_RESPONSE_RECEIVED',
           data: taskPayload,
         });
+        Notifications.dismissNotificationAsync(taskPayload.notification.request.identifier).catch(
+          (err) => {
+            console.error('Error dismissing notification:', err);
+          }
+        );
       } else {
         const categoryIdentifier = taskPayload.data.categoryId;
         const expoData = taskPayload.data.dataString && JSON.parse(taskPayload.data.dataString);

--- a/apps/test-suite/screens/TestScreen.js
+++ b/apps/test-suite/screens/TestScreen.js
@@ -270,7 +270,7 @@ export default class TestScreen extends React.Component {
       return (
         <RunnerError>
           No tests were selected. Please provide a correct query to select tests to run.
-          SelectionQuery: "{this.props.route.params?.tests}"
+          SelectionQuery: "{this.props.route?.params?.tests}"
         </RunnerError>
       );
     }

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- fix text response not present on some Android versions ([#39350](https://github.com/expo/expo/pull/39350) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 ## 0.32.8 — 2025-09-02

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -15,8 +15,8 @@ class NotificationForwarderActivity : Activity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     val broadcastIntent =
-      NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent.extras)
-    val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(broadcastIntent)
+      NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent)
+    val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(intent)
     ExpoHandlingDelegate.openAppToForeground(this, notificationResponse)
     sendBroadcast(broadcastIntent)
     finish()

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -459,8 +459,7 @@ open class NotificationsService : BroadcastReceiver() {
       // are not allowed. If the notification wants to open foreground app,
       // we should use the dedicated Activity pendingIntent.
       if (action.opensAppToForeground() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        val notificationResponse = getNotificationResponseFromBroadcastIntent(intent)
-        return ExpoHandlingDelegate.createPendingIntentForOpeningApp(context, intent, notificationResponse)
+        return ExpoHandlingDelegate.createPendingIntentForOpeningApp(context, intent)
       }
 
       // We're defaulting to the behaviour prior API 31 (mutable) even though Android recommends immutability
@@ -474,17 +473,24 @@ open class NotificationsService : BroadcastReceiver() {
     }
 
     /**
-     * Recreate an Intent from [createNotificationResponseIntent] extras
+     * Recreate an Intent from [createNotificationResponseIntent] intent
      * for [NotificationForwarderActivity] to send broadcasts
      */
-    fun createNotificationResponseBroadcastIntent(context: Context, extras: Bundle?): Intent {
+    fun createNotificationResponseBroadcastIntent(context: Context, intent: Intent?): Intent {
+      val extras = intent?.extras
       val notification = extras?.getParcelable<Notification>(NOTIFICATION_KEY)
       val action = extras?.getParcelable<NotificationAction>(NOTIFICATION_ACTION_KEY)
       if (notification == null || action == null) {
         throw IllegalArgumentException("notification ($notification) and action ($action) should not be null")
       }
-      val backgroundAction = NotificationAction(action.identifier, action.title, false)
-      val intent = Intent(
+      val textResponse = RemoteInput.getResultsFromIntent(intent)?.getString(USER_TEXT_RESPONSE_KEY)
+      val isTextInputResponse = textResponse != null && action is TextInputNotificationAction
+      val backgroundAction = if (isTextInputResponse) {
+        TextInputNotificationAction(action.identifier, action.title, false, action.placeholder)
+      } else {
+        NotificationAction(action.identifier, action.title, false)
+      }
+      val broadcastIntent = Intent(
         NOTIFICATION_EVENT_ACTION,
         getUriBuilder()
           .appendPath(notification.notificationRequest.identifier)
@@ -498,8 +504,17 @@ open class NotificationsService : BroadcastReceiver() {
         intent.putExtra(EVENT_TYPE_KEY, RECEIVE_RESPONSE_TYPE)
         intent.putExtra(NOTIFICATION_KEY, notification)
         intent.putExtra(NOTIFICATION_ACTION_KEY, backgroundAction as Parcelable)
+
+        // Include the text response in the new intent
+        if (isTextInputResponse) {
+          val remoteInput = RemoteInput.Builder(USER_TEXT_RESPONSE_KEY).build()
+          val remoteInputResults = Bundle().apply {
+            putString(USER_TEXT_RESPONSE_KEY, textResponse)
+          }
+          RemoteInput.addResultsToIntent(arrayOf(remoteInput), intent, remoteInputResults)
+        }
       }
-      return intent
+      return broadcastIntent
     }
 
     fun getNotificationResponseFromBroadcastIntent(intent: Intent): NotificationResponse {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -62,7 +62,7 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
      *   - the foreground main Activity
      *   - the background [NotificationForwarderActivity] Activity that send notification clicked events through broadcast
      */
-    fun createPendingIntentForOpeningApp(context: Context, broadcastIntent: Intent, notificationResponse: NotificationResponse): PendingIntent {
+    fun createPendingIntentForOpeningApp(context: Context, broadcastIntent: Intent): PendingIntent {
       var intentFlags = PendingIntent.FLAG_UPDATE_CURRENT
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         // The intent may include `RemoteInput` from `TextInputNotificationAction`.


### PR DESCRIPTION
# Why

This PR fixes an issue with textinput notification handling in Android, when the text part of the response (in `addNotificationResponseReceivedListener`) would not be present in the response event on newer Android versions.

On old Android versions, the response would go directly to `NotificationsService.onReceiveNotificationResponse -> NotificationEmitter.onNotificationResponseReceived`

but on new Android versions, the process starts at `NotificationForwarderActivity` which fabricates a new intent using `getNotificationResponseFromBroadcastIntent` and the forwards _that_ to the `NotificationsService`.

# How

- fixed text input response handling by properly transferring text responses between intents

# Test Plan

- notification tester app

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)