### PR TITLE
[notifications] do not send faulty duplicate TextInputNotificationResponse events

### DIFF
--- a/apps/native-component-list/src/screens/NotificationScreen.tsx
+++ b/apps/native-component-list/src/screens/NotificationScreen.tsx
@@ -52,6 +52,9 @@ export default class NotificationScreen extends React.Component<
           submitButtonTitle: 'Submit button',
           placeholder: 'Placeholder text',
         },
+        options: {
+          opensAppToForeground: false,
+        },
       },
       {
         buttonTitle: 'Open app',
@@ -229,7 +232,7 @@ export default class NotificationScreen extends React.Component<
   _handleNotificationResponseReceived = (
     notificationResponse: Notifications.NotificationResponse
   ) => {
-    console.log({ notificationResponse });
+    console.log('NCL', { notificationResponse });
 
     // Calling alert(message) immediately fails to show the alert on Android
     // if after backgrounding the app and then clicking on a notification

--- a/apps/notification-tester/README.md
+++ b/apps/notification-tester/README.md
@@ -7,3 +7,10 @@ It does require a bit of setup for push notifications to work - see https://docs
 Otherwise, it's a standard Expo + Expo router app that uses prebuild.
 
 The goal is to be able to develop the package in the `expo` monorepo and easily test the changes through this app.
+
+
+### Android
+
+For debugging background behavior, you can use:
+
+`adb shell am set-debug-app -w --persistent "com.brents.microfoam"`

--- a/apps/notification-tester/src/Notifier.tsx
+++ b/apps/notification-tester/src/Notifier.tsx
@@ -79,7 +79,9 @@ export const Notifier = () => {
 
     const responseListener = addNotificationResponseReceivedListener((response) => {
       setResponse(response);
-      console.log(`${Platform.OS} saw response for ${JSON.stringify(response, null, 2)}`);
+      console.log(
+        `Notifier useEffect: ${Platform.OS} saw response for ${JSON.stringify(response, null, 2)}`
+      );
     });
 
     console.log(`${Platform.OS} added listeners`);
@@ -103,7 +105,7 @@ export const Notifier = () => {
       <Text>Your expo push token:</Text>
       <Text selectable>{expoPushToken}</Text>
 
-      <Text>Your device push token</Text>
+      <Text>Your device push token:</Text>
       <Text selectable>{devicePushToken}</Text>
       <Text>{`Channels: ${JSON.stringify(
         channels.map((c: { id: string }) => c.id),

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsPackage.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/NotificationsPackage.java
@@ -40,7 +40,7 @@ public class NotificationsPackage extends BasePackage {
 
   @Override
   public List<ReactActivityLifecycleListener> createReactActivityLifecycleListeners(Context activityContext) {
-    return Collections.singletonList(new ExpoNotificationLifecycleListener(activityContext, mNotificationManager));
+    return Collections.singletonList(new ExpoNotificationLifecycleListener(mNotificationManager));
   }
 }
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationManager.java
@@ -138,7 +138,7 @@ public class NotificationManager implements SingletonModule {
     // OR a background state (ExpoNotificationLifecycleListener::onNewIntent)
 
     // If we've just come from a background state, we'll have listeners set up
-    // pass on the notification to them
+    // - pass on the notification to them
     if (!mListenerReferenceMap.isEmpty()) {
       for (WeakReference<NotificationListener> listenerReference : mListenerReferenceMap.values()) {
         NotificationListener listener = listenerReference.get();

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoHandlingDelegate.kt
@@ -47,12 +47,10 @@ class ExpoHandlingDelegate(protected val context: Context) : HandlingDelegate {
       }
 
       sListenersReferences[listener] = WeakReference(listener)
-      if (sPendingNotificationResponses.isNotEmpty()) {
-        val responseIterator = sPendingNotificationResponses.iterator()
-        while (responseIterator.hasNext()) {
-          listener.onNotificationResponseReceived(responseIterator.next())
-          responseIterator.remove()
-        }
+      val responseIterator = sPendingNotificationResponses.iterator()
+      while (responseIterator.hasNext()) {
+        listener.onNotificationResponseReceived(responseIterator.next())
+        responseIterator.remove()
       }
     }
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/ExpoNotificationLifecycleListener.java
@@ -1,7 +1,9 @@
 package expo.modules.notifications.service.delegates;
 
+import static expo.modules.notifications.service.NotificationsService.NOTIFICATION_RESPONSE_KEY;
+import static expo.modules.notifications.service.NotificationsService.TEXT_INPUT_NOTIFICATION_RESPONSE_KEY;
+
 import android.app.Activity;
-import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
@@ -10,11 +12,12 @@ import expo.modules.core.interfaces.ReactActivityLifecycleListener;
 import expo.modules.notifications.notifications.NotificationManager;
 import expo.modules.notifications.notifications.debug.DebugLogging;
 
+// TODO vonovak consider removing this class entirely for SDK 55, its purpose is unclear
 public class ExpoNotificationLifecycleListener implements ReactActivityLifecycleListener {
 
     private NotificationManager mNotificationManager;
 
-    public ExpoNotificationLifecycleListener(Context context, NotificationManager notificationManager) {
+    public ExpoNotificationLifecycleListener(NotificationManager notificationManager) {
       mNotificationManager = notificationManager;
     }
 
@@ -33,8 +36,9 @@ public class ExpoNotificationLifecycleListener implements ReactActivityLifecycle
         if (intent != null) {
             Bundle extras = intent.getExtras();
             if (extras != null) {
-                if (extras.containsKey("notificationResponse")) {
-                    Log.d("ReactNativeJS", "[native] ExpoNotificationLifecycleListener contains an unmarshaled notification response. Skipping.");
+                // only actions that have opensAppToForeground: true are handled here
+                if (extras.containsKey(NOTIFICATION_RESPONSE_KEY) || extras.containsKey(TEXT_INPUT_NOTIFICATION_RESPONSE_KEY)) {
+                    Log.d("ReactNativeJS", "[native] ExpoNotificationLifecycleListener contains an unmarshalled notification response. Skipping.");
                     return;
                 }
                 DebugLogging.logBundle("ExpoNotificationLifeCycleListener.onCreate:", extras);
@@ -46,7 +50,7 @@ public class ExpoNotificationLifecycleListener implements ReactActivityLifecycle
     /**
      * This will be triggered if the app is running and in the background,
      * and the user clicks on a notification to open the app.
-     * <p>
+     * <p> no-text response: NotificationsService -> NotificationManager.onNotificationReceived
      * Notification data will be in intent.extras
      *
      * @param intent
@@ -56,9 +60,11 @@ public class ExpoNotificationLifecycleListener implements ReactActivityLifecycle
     public boolean onNewIntent(Intent intent) {
         Bundle extras = intent.getExtras();
         if (extras != null) {
-            if (extras.containsKey("notificationResponse")) {
-                Log.d("ReactNativeJS", "[native] ExpoNotificationLifecycleListener contains an unmarshaled notification response. Skipping.");
-                intent.removeExtra("notificationResponse");
+            if (extras.containsKey(NOTIFICATION_RESPONSE_KEY) || extras.containsKey(TEXT_INPUT_NOTIFICATION_RESPONSE_KEY)) {
+                intent.removeExtra(NOTIFICATION_RESPONSE_KEY);
+                intent.removeExtra(TEXT_INPUT_NOTIFICATION_RESPONSE_KEY);
+                // response events are already handled by
+                // NotificationForwarderActivity -> NotificationsService.onReceiveNotificationResponse -> NotificationEmitter.onNotificationResponseReceived
                 return ReactActivityLifecycleListener.super.onNewIntent(intent);
             }
             DebugLogging.logBundle("ExpoNotificationLifeCycleListener.onNewIntent:", extras);


### PR DESCRIPTION

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
