### PR TITLE
[templates][reset-project] Align app/index.tsx with tutorial example

### DIFF
--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -133,14 +133,13 @@ Styles applied to these components use JavaScript objects rather than CSS, which
 
 Let's modify **app/index.tsx** screen:
 
-1. Import `StyleSheet` from `react-native` and create a `styles` object to define our custom styles.
-2. Add a `styles.container.backgroundColor` property to `<View>` with the value of `#25292e`. This changes the background color.
-3. Replace the default value of `<Text>` with "Home screen".
-4. Add a `styles.text.color` property to `<Text>` with the value of `#fff` (white) to change the text color.
+1. Add a `styles.container.backgroundColor` property to `<View>` with the value of `#25292e`. This changes the background color.
+2. Replace the default value of `<Text>` with "Home screen".
+3. Add a `styles.text.color` property to `<Text>` with the value of `#fff` (white) to change the text color.
 
 {/* prettier-ignore */}
 ```tsx app/index.tsx|collapseHeight=340
-import { Text, View, /* @tutinfo Import <CODE>StyleSheet</CODE> to define styles. */ StyleSheet/* @end */ } from 'react-native';
+import { Text, View, StyleSheet } from 'react-native';
 
 export default function Index() {
   return (
@@ -161,9 +160,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  /* @tutinfo Create a <CODE>text</CODE> style with a <CODE>color</CODE> property of <CODE>'#fff'</CODE>. */
   text: {
     color: '#fff',
   },
+  /* @end */
 });
 ```
 

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -133,13 +133,14 @@ Styles applied to these components use JavaScript objects rather than CSS, which
 
 Let's modify **app/index.tsx** screen:
 
-1. Add a `styles.container.backgroundColor` property to `<View>` with the value of `#25292e`. This changes the background color.
-2. Replace the default value of `<Text>` with "Home screen".
-3. Add a `styles.text.color` property to `<Text>` with the value of `#fff` (white) to change the text color.
+1. Import `StyleSheet` from `react-native` and create a `styles` object to define our custom styles.
+2. Add a `styles.container.backgroundColor` property to `<View>` with the value of `#25292e`. This changes the background color.
+3. Replace the default value of `<Text>` with "Home screen".
+4. Add a `styles.text.color` property to `<Text>` with the value of `#fff` (white) to change the text color.
 
 {/* prettier-ignore */}
 ```tsx app/index.tsx|collapseHeight=340
-import { Text, View, StyleSheet } from 'react-native';
+import { Text, View, /* @tutinfo Import <CODE>StyleSheet</CODE> to define styles. */ StyleSheet/* @end */ } from 'react-native';
 
 export default function Index() {
   return (
@@ -160,11 +161,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  /* @tutinfo Create a <CODE>text</CODE> style with a <CODE>color</CODE> property of <CODE>'#fff'</CODE>. */
   text: {
     color: '#fff',
   },
-  /* @end */
 });
 ```
 

--- a/templates/expo-template-default/scripts/reset-project.js
+++ b/templates/expo-template-default/scripts/reset-project.js
@@ -29,8 +29,8 @@ export default function Index() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: "center",
     alignItems: "center",
+    justifyContent: "center",
   },
 });
 `;

--- a/templates/expo-template-default/scripts/reset-project.js
+++ b/templates/expo-template-default/scripts/reset-project.js
@@ -16,21 +16,23 @@ const exampleDir = "app-example";
 const newAppDir = "app";
 const exampleDirPath = path.join(root, exampleDir);
 
-const indexContent = `import { Text, View } from "react-native";
+const indexContent = `import { Text, View, StyleSheet } from "react-native";
 
 export default function Index() {
   return (
-    <View
-      style={{
-        flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
-      }}
-    >
+    <View style={styles.container}>
       <Text>Edit app/index.tsx to edit this screen.</Text>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+});
 `;
 
 const layoutContent = `import { Stack } from "expo-router";


### PR DESCRIPTION
# Why
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
The reset-project script generated an `app/index.tsx` file that did not match the code shown in the [tutorial documentation](https://docs.expo.dev/tutorial/create-your-first-app/#edit-the-index-screen).
This could cause confusion for new users following the tutorial.

# How
<!--
How did you build this feature or fix this bug and why?
-->
Updated the `reset-project` script so that the generated `app/index.tsx` matches the tutorial code sample and instructions:

- Replaced inline styles with **StyleSheet.create**
- ~~Removed the redundant "import StyleSheet" step and its associated code highlighting from the tutorial~~
- ~~Fixed missing syntax highlighting for `text: { color: '#fff' }` in the tutorial code block~~

**Note (Update after review):**  
The documentation/tutorial changes have been **reverted** from this PR based on reviewer feedback.  
They will be submitted in a **separate follow-up PR** after this template update is published.


# Test Plan
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
- Ran the `reset-project` script locally
- Confirmed that the generated `app/index.tsx` uses **StyleSheet.create** instead of inline styles
- Verified that the generated code matches the updated tutorial documentation
- Opened the tutorial page locally and checked that:
  - ~~The redundant "import StyleSheet" step and its associated code highlighting were removed~~
  - ~~Syntax highlighting for `text: { color: '#fff' }` is rendered correctly~~
- Launched the generated app in Expo Go and confirmed it displays as expected

## Screenshots

### reset-project
| File      | Before | After |
|-----------|--------|-------|
| index.tsx | <img width="733" height="468" alt="before-reset-project" src="https://github.com/user-attachments/assets/aa676b2a-c033-4ca1-881b-05f4ed7fae05" /> | <img width="733" height="524" alt="after-reset-project" src="https://github.com/user-attachments/assets/a8a4130b-632b-4754-bb41-403c6000543c" /> |

### tutorial
| Theme | Before | After |
|-------|--------|-------|
| Light | <img width="1110" height="947" alt="screenshots_before_light" src="https://github.com/user-attachments/assets/eb671e6c-084c-4773-9be5-1726b6ab8767" /> | <img width="1110" height="913" alt="screenshots_after_light" src="https://github.com/user-attachments/assets/55aa8f25-6a00-4f25-8f74-4df65cea506a" />
| Dark  | <img width="1110" height="947" alt="screenshots_before_dark" src="https://github.com/user-attachments/assets/ab65cdd9-a651-4320-abc2-0ff6bd3390e7" /> | <img width="1110" height="913" alt="screenshots_after_dark" src="https://github.com/user-attachments/assets/4d06ccc7-742b-4cf8-b3e6-20597f1717a4" /> |

# Checklist
<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
