### PR TITLE
[android][expo/fetch] allow sending POST requests without body

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [android] allow sending a POST, PATCH or PUT request without a body ([#39363](https://github.com/expo/expo/pull/39363))
+- [Android] allow `expo/fetch` sending a `POST`, `PATCH` or `PUT` request without a body. ([#39363](https://github.com/expo/expo/pull/39363) by [@julian-dueck](https://github.com/julian-dueck))
 
 ### 💡 Others
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [android] allow sending a POST, PATCH or PUT request without a body ([#39363](https://github.com/expo/expo/pull/39363))
+
 ### 💡 Others
 
 - load isLiquidGlassAvailable lazily ([#39361](https://github.com/expo/expo/pull/39361) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo/android/src/main/java/expo/modules/fetch/NativeRequest.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/NativeRequest.kt
@@ -34,14 +34,14 @@ internal class NativeRequest(appContext: AppContext, internal val response: Nati
     val newClient = clientBuilder.build()
     response.redirectMode = requestInit.redirect
 
-    var reqBody = requestBody?.toRequestBody(mediaType);
+    val headers = requestInit.headers.toHeaders()
+    val mediaType = headers["Content-Type"]?.toMediaTypeOrNull()
+    var reqBody = requestBody?.toRequestBody(mediaType)
     // OkHttp requires a non-null body for POST, PATCH and PUT requests. (also for PROPPATCH and REPORT)
     // https://github.com/expo/expo/issues/35950#issuecomment-3245173248
     if (reqBody == null && requestInit.method in ALLOWED_METHODS_FOR_BODY) {
-      reqBody = byteArrayOf(0)
+      reqBody = byteArrayOf(0).toRequestBody(mediaType)
     }
-    val headers = requestInit.headers.toHeaders()
-    val mediaType = headers["Content-Type"]?.toMediaTypeOrNull()
     val request = Request.Builder()
       .headers(headers)
       .method(requestInit.method, reqBody)

--- a/packages/expo/android/src/main/java/expo/modules/fetch/NativeRequest.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/NativeRequest.kt
@@ -36,11 +36,16 @@ internal class NativeRequest(appContext: AppContext, internal val response: Nati
 
     val headers = requestInit.headers.toHeaders()
     val mediaType = headers["Content-Type"]?.toMediaTypeOrNull()
-    var reqBody = requestBody?.toRequestBody(mediaType)
-    // OkHttp requires a non-null body for POST, PATCH and PUT requests. (also for PROPPATCH and REPORT)
-    // https://github.com/expo/expo/issues/35950#issuecomment-3245173248
-    if (reqBody == null && requestInit.method in ALLOWED_METHODS_FOR_BODY) {
-      reqBody = byteArrayOf(0).toRequestBody(mediaType)
+    val reqBody = requestBody?.toRequestBody(mediaType) ?: run {
+      // OkHttp requires a non-null body for POST, PATCH, and PUT requests.
+      // WinterTC fetch, however, does not have this limitation.
+      // Provide an empty body to make OkHttp behave like WinterTC fetch.
+      // Ref: https://github.com/expo/expo/issues/35950#issuecomment-3245173248
+      if (requestInit.method in METHODS_REQUIRING_BODY) {
+        byteArrayOf(0).toRequestBody(mediaType)
+      } else {
+        null
+      }
     }
     val request = Request.Builder()
       .headers(headers)

--- a/packages/expo/android/src/main/java/expo/modules/fetch/NativeRequest.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/NativeRequest.kt
@@ -14,7 +14,7 @@ import java.net.URL
 
 private data class RequestHolder(var request: Request?)
 
-internal val ALLOWED_METHODS_FOR_BODY = arrayOf("POST", "PUT", "PATCH")
+internal val METHODS_REQUIRING_BODY = arrayOf("POST", "PUT", "PATCH")
 
 internal class NativeRequest(appContext: AppContext, internal val response: NativeResponse) :
   SharedObject(appContext) {


### PR DESCRIPTION
# Why

Android implementation doesn't allow sending no body if the request method is POST, PATCH or PUT. This is a limitation of the underlying okhttp library, so this is a workaround
Closes #35950

# How

If the method of the request is POST, PATCH or PUT and the body is null, set the body to a byte array of 0.

# Test Plan

Didn't test, can't get gradle to build in android studio following the instructions for contributions...

# Checklist


- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
