### PR TITLE
fix(cli): Fix missing URI encoding in Metro middleware project path header

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix UTF-8 characters in project path causing `setHeader` error in Metro middleware ([#39285](https://github.com/expo/expo/pull/39285) by [@HMYang33](https://github.com/HMYang33))
+
 ### 💡 Others
 
 ## 0.26.8 — 2025-09-03

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -68,7 +68,7 @@ function createMetroStatusMiddleware(
   metroConfig: Pick<MetroConfig, 'projectRoot'>
 ): connect.NextHandleFunction {
   return (_req, res) => {
-    res.setHeader('X-React-Native-Project-Root', metroConfig.projectRoot!);
+    res.setHeader('X-React-Native-Project-Root', encodeURI(metroConfig.projectRoot!));
     res.end('packager-status:running');
   };
 }


### PR DESCRIPTION
> reproduction

1. Make a folder contains any Chinese characters like `我的项目`
2. Open powershell or cmd.
3. Create a project inside this folder by `npx create-expo`
4. Scan QR code with ExpoGo app after `npm start`
5. Error occurred.

```
TypeError: Invalid character in header content ["X-React-Native-Project-Root"]
    at ServerResponse.setHeader (node:_http_outgoing:706:3)
    at C:\Users\admin\Desktop\我的项目\others\demo-app-for-expo-issue\node_modules\@expo\cli\src\start\server\metro\dev-server\createMetroMiddleware.ts:71:9
    at call (C:\Users\admin\Desktop\我的项目\others\demo-app-for-expo-issue\node_modules\connect\index.js:239:7)
    at next (C:\Users\admin\Desktop\我的项目\others\demo-app-for-expo-issue\node_modules\connect\index.js:183:5)
    at next (C:\Users\admin\Desktop\我的项目\others\demo-app-for-expo-issue\node_modules\connect\index.js:161:14)
    at next (C:\Users\admin\Desktop\我的项目\others\demo-app-for-expo-issue\node_modules\connect\index.js:161:14)
    at next (C:\Users\admin\Desktop\我的项目\others\demo-app-for-expo-issue\node_modules\connect\index.js:161:14)
    at compression (C:\Users\admin\Desktop\我的项目\others\demo-app-for-expo-issue\node_modules\compression\index.js:243:5)
    at call (C:\Users\admin\Desktop\我的项目\others\demo-app-for-expo-issue\node_modules\connect\index.js:239:7)
    at next (C:\Users\admin\Desktop\我的项目\others\demo-app-for-expo-issue\node_modules\connect\index.js:183:5)

```

So I locate this error and wrap `metroConfig.projectRoot` with `encodeURI` and it works now.
BTW , I only have Windows laptop and a Android phone.

I also tried on Android emulator, occurres too.

It's just because you can only write ascii characters in the HTTP header content. But project path usually contains others.(especially with non-English users)