### PR TITLE
fix(expo-dev-client): fix LICENSE.md conflict

### DIFF
--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- fix LICENSE.md conflict ([#39373](https://github.com/expo/expo/pull/39373) by [@iameli](https://github.com/iameli))
+
 ### 💡 Others
 
 ## 6.0.9 — 2025-09-03

--- a/packages/expo-dev-client/android/build.gradle
+++ b/packages/expo-dev-client/android/build.gradle
@@ -28,6 +28,12 @@ android {
     buildConfig true
     viewBinding true
   }
+
+  packaging {
+    resources {
+      merges.add("/META-INF/LICENSE*")
+    }
+  }
 }
 
 dependencies {


### PR DESCRIPTION
fixes #34799

This manifests like this upon a `./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release` command (but probably will happen with any other test too)

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':expo-dev-client:mergeDebugAndroidTestJavaResource'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeJavaResWorkAction
   > 6 files found with path 'META-INF/LICENSE.md' from inputs:
      - org.junit.jupiter:junit-jupiter-params:5.8.2/junit-jupiter-params-5.8.2.jar
      - org.junit.jupiter:junit-jupiter-engine:5.8.2/junit-jupiter-engine-5.8.2.jar
      - org.junit.jupiter:junit-jupiter-api:5.8.2/junit-jupiter-api-5.8.2.jar
      - org.junit.platform:junit-platform-engine:1.8.2/junit-platform-engine-1.8.2.jar
      - org.junit.platform:junit-platform-commons:1.8.2/junit-platform-commons-1.8.2.jar
      - org.junit.jupiter:junit-jupiter:5.8.2/junit-jupiter-5.8.2.jar
     Adding a packaging block may help, please refer to
     https://developer.android.com/reference/tools/gradle-api/com/android/build/api/dsl/Packaging
     for more information
```

It looks like all the junit test files are attempting to write their LICENSE.md files to the same location, so we need to merge them into one big LICENSE.md file.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
