### PR TITLE
test(babel-preset-expo): update snapshots

### DIFF
--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/index.test.ts.snap
@@ -264,7 +264,7 @@ exports[`metro supports reanimated worklets 1`] = `
 function someWorklet_workletJs1Factory(_ref){var _worklet_14307677064221_init_data=_ref._worklet_14307677064221_init_data;var _e=[new global.Error(),1,-27];var someWorklet=function someWorklet(greeting){
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="0.4.1";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data:_worklet_14307677064221_init_data});"
+};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="0.5.0";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data:_worklet_14307677064221_init_data});"
 `;
 
 exports[`metro transpiles non-standard exports 1`] = `
@@ -296,7 +296,7 @@ exports[`metro+hermes supports reanimated worklets 1`] = `
 function someWorklet_workletJs1Factory(_ref){var _worklet_14307677064221_init_data=_ref._worklet_14307677064221_init_data;var _e=[new global.Error(),1,-27];var someWorklet=function(greeting){
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="0.4.1";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data});"
+};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="0.5.0";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data});"
 `;
 
 exports[`metro+hermes transpiles non-standard exports 1`] = `
@@ -328,7 +328,7 @@ exports[`webpack supports reanimated worklets 1`] = `
 function someWorklet_workletJs1Factory({_worklet_14307677064221_init_data}){const _e=[new global.Error(),1,-27];const someWorklet=function(greeting){
 
 console.log("Hey I'm running on the UI thread");
-};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="0.4.1";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data});"
+};someWorklet.__closure={};someWorklet.__workletHash=14307677064221;someWorklet.__pluginVersion="0.5.0";someWorklet.__initData=_worklet_14307677064221_init_data;someWorklet.__stackDetails=_e;return someWorklet;}({_worklet_14307677064221_init_data});"
 `;
 
 exports[`webpack transpiles non-standard exports 1`] = `


### PR DESCRIPTION
# Why

It seems as though this breakage has happened before and was resolved in #38549. Digging a little further, it seems to happen whenever `react-native-reanimated` (or `react-native-worklets`) is updated in `bare-expo`, `expo-go` or `native-component-list`, which recently happened in #39252. Our SDK CI workflow uses incremental checks, and so it flew under the radar until I made an unrelated change.

Since this will be a recurring issue every time we upgrade `react-native-reanimated`, we could add it to `devDependencies` (so its not missed when manually grepping while upgrading), or replace the snapshot tests entirely.

# How

Updated snapshots for `babel-preset-expo` which test `react-native-worklets`.

# Test Plan

CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
