### PR TITLE
[bare-expo] Fix `node_modules` were indexed

### DIFF
--- a/apps/bare-expo/android/.idea/modules/app/BareExpo.app.main.iml
+++ b/apps/bare-expo/android/.idea/modules/app/BareExpo.app.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../../../../../node_modules" dumb="true">
+      <excludeFolder url="file://$MODULE_DIR$/../../../../../../node_modules" />
+    </content>
+  </component>
+</module>


### PR DESCRIPTION
# Why

Fixes that node_modules were being indexed by Android Studio. This indexing makes Android Studio unusable, and manually excluding it after each sync is very tedious. This PR aims to exclude root-level node_modules by default. This doesn't mean that files like those in third-party libraries aren't indexed; they will still be indexed because they're added directly by CMake or Gradle.  

So, why does Android Studio index node_modules in the first place? The answer is a bit tricky. For some reason, when the root project imports CMakeList.txt from React Native (to integrate with codegen), it allows node_modules to become indexable. I tried to address this by moving the integration part to the app code; however, including CMake files generated by codegen from a third-party library causes the same issue. The proposed solution is a workaround to make our lives easier.
 
From my tests, it makes Android Studio consume about 20-30% less memory. I don't have any metrics on CPU usage, but it feels better (still not perfect, but at least usable). 

# Test Plan

- bare-expo
<img width="230" height="166" alt="image" src="https://github.com/user-attachments/assets/c323d7a7-fbdc-4f4d-85e8-4ff6b4ff8ef9" />

