### PR TITLE
[core][Android] Remove usage of `kotlin.reflect.full.*`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [Android] Remove some usage of `kotlin.reflect.full.*`.
+- [Android] Remove some usage of `kotlin.reflect.full.*`. ([#39385](https://github.com/expo/expo/pull/39385) by [@lukmccall](https://github.com/lukmccall))
 
 ## 3.0.12 — 2025-09-03
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [Android] Remove some usage of `kotlin.reflect.full.*`.
+
 ## 3.0.12 — 2025-09-03
 
 ### 💡 Others

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/EnumExtensions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/EnumExtensions.kt
@@ -1,13 +1,12 @@
-package expo.modules.kotlin.modules
+package expo.modules.kotlin
 
 import expo.modules.kotlin.types.Enumerable
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.declaredMemberProperties
-import kotlin.reflect.full.primaryConstructor
 
-internal fun <T> convertEnumToString(enumValue: T): String where T : Enumerable, T : Enum<T> {
-  val enumClass = enumValue::class
-  val primaryConstructor = enumClass.primaryConstructor
+fun <T> T.convertToString(): String where T : Enum<T>, T : Enumerable {
+  val enumClass = this::class
+  val primaryConstructor = enumClass.fastPrimaryConstructor
   if (primaryConstructor?.parameters?.size == 1) {
     val parameterName = primaryConstructor.parameters.first().name
     val parameterProperty = enumClass
@@ -18,8 +17,8 @@ internal fun <T> convertEnumToString(enumValue: T): String where T : Enumerable,
     require(parameterProperty.returnType.classifier == String::class) { "The enum parameter has to be a string." }
 
     @Suppress("UNCHECKED_CAST")
-    return (parameterProperty as KProperty1<T, String>).get(enumValue)
+    return (parameterProperty as KProperty1<T, String>).get(this)
   }
 
-  return enumValue.name
+  return this.name
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KClassExtensions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KClassExtensions.kt
@@ -1,0 +1,10 @@
+package expo.modules.kotlin
+
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.primaryConstructor
+
+val <T : Any> KClass<T>.fastPrimaryConstructor: KFunction<T>?
+  // If class only has one constructor, use it as a primary constructor.
+  // Otherwise, try to find the primary constructor using kotlin reflection.
+  get() = constructors.singleOrNull() ?: primaryConstructor

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReadableTypeExtensions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReadableTypeExtensions.kt
@@ -3,16 +3,15 @@ package expo.modules.kotlin
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
-import kotlin.reflect.KType
-import kotlin.reflect.full.createType
+import kotlin.reflect.KClass
 
-fun ReadableType.toKType(): KType {
+fun ReadableType.toKClass(): KClass<*> {
   return when (this) {
-    ReadableType.Null -> Any::class.createType(nullable = true)
-    ReadableType.Boolean -> Boolean::class.createType()
-    ReadableType.Number -> Number::class.createType()
-    ReadableType.String -> String::class.createType()
-    ReadableType.Map -> ReadableMap::class.createType()
-    ReadableType.Array -> ReadableArray::class.createType()
+    ReadableType.Null -> Any::class
+    ReadableType.Boolean -> Boolean::class
+    ReadableType.Number -> Number::class
+    ReadableType.String -> String::class
+    ReadableType.Map -> ReadableMap::class
+    ReadableType.Array -> ReadableArray::class
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -71,8 +71,8 @@ inline fun <reified T : CodedException> errorCodeOf(): String =
   CodedException.inferCode(T::class.java)
 
 internal class IncompatibleArgTypeException(
-  argumentType: KType,
-  desiredType: KType,
+  argumentType: KClass<*>,
+  desiredType: KClass<*>,
   cause: Throwable? = null
 ) : CodedException(
   message = "Argument type '$argumentType' is not compatible with expected type '$desiredType'.",

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin.modules
 import android.os.Bundle
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.RuntimeContext
+import expo.modules.kotlin.convertToString
 import expo.modules.kotlin.providers.AppContextProvider
 import expo.modules.kotlin.tracing.trace
 import expo.modules.kotlin.types.Enumerable
@@ -44,11 +45,11 @@ abstract class Module : AppContextProvider {
   }
 
   fun <T> sendEvent(enum: T, body: Bundle? = Bundle.EMPTY) where T : Enumerable, T : Enum<T> {
-    moduleEventEmitter?.emit(convertEnumToString(enum), body)
+    moduleEventEmitter?.emit(enum.convertToString(), body)
   }
 
   fun <T> sendEvent(enum: T, body: Map<String, Any?>? = null) where T : Enumerable, T : Enum<T> {
-    moduleEventEmitter?.emit(convertEnumToString(enum), body)
+    moduleEventEmitter?.emit(enum.convertToString(), body)
   }
 
   open fun converters(): TypeConverterProvider? = null

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -7,7 +7,9 @@ import expo.modules.kotlin.Promise
 import expo.modules.kotlin.component6
 import expo.modules.kotlin.component7
 import expo.modules.kotlin.component8
+import expo.modules.kotlin.convertToString
 import expo.modules.kotlin.events.EventsDefinition
+import expo.modules.kotlin.fastPrimaryConstructor
 import expo.modules.kotlin.functions.AsyncFunctionComponent
 import expo.modules.kotlin.functions.AsyncFunctionBuilder
 import expo.modules.kotlin.functions.AsyncFunctionWithPromiseComponent
@@ -18,14 +20,12 @@ import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinitionBuilder
-import expo.modules.kotlin.modules.convertEnumToString
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.types.TypeConverterProvider
 import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.types.toArgsArray
 import expo.modules.kotlin.types.toReturnType
 import kotlin.reflect.full.declaredMemberProperties
-import kotlin.reflect.full.primaryConstructor
 
 /**
  * Base class for other definitions representing an object, such as `ModuleDefinition`.
@@ -449,7 +449,7 @@ open class ObjectDefinitionBuilder(
   }
 
   inline fun <reified T> Events() where T : Enumerable, T : Enum<T> {
-    val primaryConstructor = T::class.primaryConstructor
+    val primaryConstructor = T::class.fastPrimaryConstructor
     val events = if (primaryConstructor?.parameters?.size == 1) {
       val parameterName = primaryConstructor.parameters.first().name
 
@@ -487,7 +487,7 @@ open class ObjectDefinitionBuilder(
    * Creates module's lifecycle listener that is called right after the first event listener is added for given event.
    */
   fun <T> OnStartObserving(enum: T, body: () -> Unit) where T : Enumerable, T : Enum<T> {
-    OnStartObserving(convertEnumToString(enum), body)
+    OnStartObserving(enum.convertToString(), body)
   }
 
   /**
@@ -520,7 +520,7 @@ open class ObjectDefinitionBuilder(
    * Creates module's lifecycle listener that is called right after all event listeners are removed for given event.
    */
   fun <T> OnStopObserving(enum: T, body: () -> Unit) where T : Enumerable, T : Enum<T> {
-    OnStopObserving(convertEnumToString(enum), body)
+    OnStopObserving(enum.convertToString(), body)
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
@@ -10,7 +10,6 @@ import expo.modules.kotlin.types.NonNullableTypeConverter
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
-import kotlin.reflect.full.isSuperclassOf
 
 class SharedObjectTypeConverter<T : SharedObject>(
   val type: KType
@@ -74,7 +73,7 @@ class SharedRefTypeConverter<T : SharedRef<*>>(
     val ref = sharedRef.ref ?: return sharedRef
     val sharedRefClass = sharedRefType?.classifier as? KClass<*>
       ?: return sharedRef
-    if (sharedRefClass.isSuperclassOf(ref.javaClass.kotlin)) {
+    if (ref::class.java.isAssignableFrom(sharedRefClass.javaObjectType) || ref::class.java.isAssignableFrom(sharedRefClass.java)) {
       return sharedRef
     }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
@@ -5,12 +5,11 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.EnumNoSuchValueException
 import expo.modules.kotlin.exception.IncompatibleArgTypeException
+import expo.modules.kotlin.fastPrimaryConstructor
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.logger
-import expo.modules.kotlin.toKType
+import expo.modules.kotlin.toKClass
 import kotlin.reflect.KClass
-import kotlin.reflect.full.createType
-import kotlin.reflect.full.primaryConstructor
 
 class EnumTypeConverter(
   private val enumClass: KClass<Enum<*>>
@@ -23,7 +22,9 @@ class EnumTypeConverter(
     }
   }
 
-  private val primaryConstructor = requireNotNull(enumClass.primaryConstructor) {
+  private val primaryConstructor = requireNotNull(
+    enumClass.fastPrimaryConstructor
+  ) {
     "Cannot convert js value to enum without the primary constructor"
   }
 
@@ -48,7 +49,7 @@ class EnumTypeConverter(
       )
     }
 
-    throw IncompatibleArgTypeException(value.type.toKType(), enumClass.createType())
+    throw IncompatibleArgTypeException(value.type.toKClass(), enumClass)
   }
 
   override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Enum<*> {
@@ -62,7 +63,7 @@ class EnumTypeConverter(
       )
     }
 
-    throw IncompatibleArgTypeException(value::class.createType(), enumClass.createType())
+    throw IncompatibleArgTypeException(value::class, enumClass)
   }
 
   /**


### PR DESCRIPTION
# Why

Removes some usage of `kotlin.reflect.full.*` if possible. 

# How

When we can code the same functionality using Java reflection, we should do so. It's much faster.

# Test Plan

- unit tests ✅ 