### PR TITLE
[docs] Add Better Auth example link to authentication documentation

### DIFF
--- a/docs/pages/develop/authentication.mdx
+++ b/docs/pages/develop/authentication.mdx
@@ -5,6 +5,7 @@ sidebar_title: Authentication
 hasVideoLink: true
 ---
 
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
@@ -65,6 +66,13 @@ If you're building this flow yourself, be sure to review the [Authentication Che
 > **info** Adding email and password authentication is usually enough to pass App Store and Play Store review. You can submit your app with this method first. If you include "Sign in with Google," Apple may reject your app unless you also support "Sign in with Apple." The same rule applies in reverse on Google Play.
 
 </Collapsible>
+
+<BoxLink
+  title="Better Auth Example"
+  description="Example demonstrating email and password authentication with Better Auth"
+  href="https://github.com/expo/examples/tree/master/with-better-auth"
+  Icon={GithubIcon}
+/>
 
 ## Passwordless login
 

--- a/docs/pages/develop/authentication.mdx
+++ b/docs/pages/develop/authentication.mdx
@@ -69,7 +69,7 @@ If you're building this flow yourself, be sure to review the [Authentication Che
 
 <BoxLink
   title="Better Auth Example"
-  description="Example demonstrating email and password authentication with Better Auth"
+  description="An example demonstrating email and password authentication with Better Auth."
   href="https://github.com/expo/examples/tree/master/with-better-auth"
   Icon={GithubIcon}
 />


### PR DESCRIPTION
# Why

[ENG-17242 [docs] Update auth doc to include better auth example](https://linear.app/expo/issue/ENG-17242/docs-update-auth-doc-to-include-better-auth-example)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
