### PR TITLE
[cli] add dynamic import to ESM modules

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Allowing import to ESM modules. ([#39390](https://github.com/expo/expo/pull/39390) by [@kudo](https://github.com/kudo))
+
 ## 0.26.8 — 2025-09-03
 
 ### 🎉 New features

--- a/packages/@expo/cli/e2e/__tests__/config-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/config-test.ts
@@ -22,6 +22,7 @@ it('loads expected modules by default', async () => {
     '@expo/cli/build/src/config/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/asyncImportInterop.js',
   ]);
 });
 

--- a/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
@@ -33,6 +33,7 @@ it('loads expected modules by default', async () => {
     '@expo/cli/build/src/export/embed/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/asyncImportInterop.js',
   ]);
 });
 

--- a/packages/@expo/cli/e2e/__tests__/export-web-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-web-test.ts
@@ -34,6 +34,7 @@ it('loads expected modules by default', async () => {
     '@expo/cli/build/src/export/web/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/asyncImportInterop.js',
     '@expo/cli/build/src/utils/errors.js',
   ]);
 });

--- a/packages/@expo/cli/e2e/__tests__/export.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export.test.ts
@@ -40,6 +40,7 @@ it('loads expected modules by default', async () => {
     '@expo/cli/build/src/export/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/asyncImportInterop.js',
     '@expo/cli/build/src/utils/errors.js',
   ]);
 });

--- a/packages/@expo/cli/e2e/__tests__/login-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/login-test.ts
@@ -22,6 +22,7 @@ it('loads expected modules by default', async () => {
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/login/index.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/asyncImportInterop.js',
     '@expo/cli/build/src/utils/errors.js',
   ]);
 });

--- a/packages/@expo/cli/e2e/__tests__/logout-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/logout-test.ts
@@ -20,6 +20,7 @@ it('loads expected modules by default', async () => {
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/logout/index.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/asyncImportInterop.js',
     '@expo/cli/build/src/utils/errors.js',
   ]);
 });

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -37,6 +37,7 @@ it('loads expected modules by default', async () => {
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/prebuild/index.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/asyncImportInterop.js',
   ]);
 });
 

--- a/packages/@expo/cli/e2e/__tests__/register-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/register-test.ts
@@ -22,6 +22,7 @@ it('loads expected modules by default', async () => {
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/register/index.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/asyncImportInterop.js',
     '@expo/cli/build/src/utils/errors.js',
   ]);
 });

--- a/packages/@expo/cli/e2e/__tests__/run-android-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/run-android-test.ts
@@ -26,6 +26,7 @@ it('loads expected modules by default', async () => {
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/run/android/index.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/asyncImportInterop.js',
     '@expo/cli/build/src/utils/errors.js',
   ]);
 });

--- a/packages/@expo/cli/e2e/__tests__/run-ios-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/run-ios-test.ts
@@ -24,6 +24,7 @@ it('loads expected modules by default', async () => {
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/run/ios/index.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/asyncImportInterop.js',
     '@expo/cli/build/src/utils/errors.js',
   ]);
 });

--- a/packages/@expo/cli/e2e/__tests__/run-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/run-test.ts
@@ -25,6 +25,7 @@ it('loads expected modules by default', async () => {
     '@expo/cli/build/src/run/hints.js',
     '@expo/cli/build/src/run/index.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/asyncImportInterop.js',
     '@expo/cli/build/src/utils/env.js',
     '@expo/cli/build/src/utils/errors.js',
     '@expo/cli/build/src/utils/interactive.js',

--- a/packages/@expo/cli/e2e/__tests__/start-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/start-test.ts
@@ -30,6 +30,7 @@ it('loads expected modules by default', async () => {
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/start/index.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/asyncImportInterop.js',
     '@expo/cli/build/src/utils/errors.js',
   ]);
 });

--- a/packages/@expo/cli/e2e/__tests__/whoami-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/whoami-test.ts
@@ -19,6 +19,7 @@ it('loads expected modules by default', async () => {
   expect(modules).toStrictEqual([
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/asyncImportInterop.js',
     '@expo/cli/build/src/utils/errors.js',
     '@expo/cli/build/src/whoami/index.js',
   ]);

--- a/packages/@expo/cli/src/config/configAsync.ts
+++ b/packages/@expo/cli/src/config/configAsync.ts
@@ -3,6 +3,7 @@ import assert from 'assert';
 import util from 'util';
 
 import * as Log from '../log';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 import { CommandError } from '../utils/errors';
 import { setNodeEnv } from '../utils/nodeEnv';
 import { profile } from '../utils/profile';
@@ -54,14 +55,16 @@ export async function configAsync(projectRoot: string, options: Options) {
   let config: ProjectConfig;
 
   if (options.type === 'prebuild') {
-    const { getPrebuildConfigAsync } = await import('@expo/prebuild-config');
+    const { getPrebuildConfigAsync } = asyncImportInterop(await import('@expo/prebuild-config'));
 
     config = await profile(getPrebuildConfigAsync)(projectRoot, {
       platforms: ['ios', 'android'],
     });
   } else if (options.type === 'introspect') {
-    const { getPrebuildConfigAsync } = await import('@expo/prebuild-config');
-    const { compileModsAsync } = await import('@expo/config-plugins/build/plugins/mod-compiler.js');
+    const { getPrebuildConfigAsync } = asyncImportInterop(await import('@expo/prebuild-config'));
+    const { compileModsAsync } = asyncImportInterop(
+      await import('@expo/config-plugins/build/plugins/mod-compiler.js')
+    );
 
     config = await profile(getPrebuildConfigAsync)(projectRoot, {
       platforms: ['ios', 'android'],

--- a/packages/@expo/cli/src/config/index.ts
+++ b/packages/@expo/cli/src/config/index.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 
 import { Command } from '../../bin/cli';
 import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 
 export const expoConfig: Command = async (argv) => {
   const args = assertArgs(
@@ -39,7 +40,9 @@ export const expoConfig: Command = async (argv) => {
     { configAsync },
     // ../utils/errors
     { logCmdError },
-  ] = await Promise.all([import('./configAsync.js'), import('../utils/errors.js')]);
+  ] = (await Promise.all([import('./configAsync.js'), import('../utils/errors.js')])).flatMap(
+    asyncImportInterop
+  );
 
   return configAsync(getProjectRoot(args), {
     // Parsed options

--- a/packages/@expo/cli/src/customize/typescript.ts
+++ b/packages/@expo/cli/src/customize/typescript.ts
@@ -1,13 +1,18 @@
 import { getConfig } from '@expo/config';
 
 import { Log } from '../log';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 
 export async function typescript(projectRoot: string) {
-  const { TypeScriptProjectPrerequisite } = await import(
-    '../start/doctor/typescript/TypeScriptProjectPrerequisite.js'
+  const { TypeScriptProjectPrerequisite } = asyncImportInterop(
+    await import('../start/doctor/typescript/TypeScriptProjectPrerequisite.js')
   );
-  const { MetroBundlerDevServer } = await import('../start/server/metro/MetroBundlerDevServer.js');
-  const { getPlatformBundlers } = await import('../start/server/platformBundlers.js');
+  const { MetroBundlerDevServer } = asyncImportInterop(
+    await import('../start/server/metro/MetroBundlerDevServer.js')
+  );
+  const { getPlatformBundlers } = asyncImportInterop(
+    await import('../start/server/platformBundlers.js')
+  );
 
   try {
     await new TypeScriptProjectPrerequisite(projectRoot).bootstrapAsync();

--- a/packages/@expo/cli/src/export/embed/index.ts
+++ b/packages/@expo/cli/src/export/embed/index.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 import { Command } from '../../../bin/cli';
 import { assertWithOptionsArgs, printHelp } from '../../utils/args';
+import { asyncImportInterop } from '../../utils/asyncImportInterop';
 
 export const expoExportEmbed: Command = async (argv) => {
   const rawArgsMap: arg.Spec = {
@@ -84,12 +85,14 @@ export const expoExportEmbed: Command = async (argv) => {
     { resolveOptions },
     { logCmdError },
     { resolveCustomBooleanArgsAsync },
-  ] = await Promise.all([
-    import('./exportEmbedAsync.js'),
-    import('./resolveOptions.js'),
-    import('../../utils/errors.js'),
-    import('../../utils/resolveArgs.js'),
-  ]);
+  ] = (
+    await Promise.all([
+      import('./exportEmbedAsync.js'),
+      import('./resolveOptions.js'),
+      import('../../utils/errors.js'),
+      import('../../utils/resolveArgs.js'),
+    ])
+  ).flatMap(asyncImportInterop);
 
   return (async () => {
     const parsed = await resolveCustomBooleanArgsAsync(argv ?? [], rawArgsMap, {

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 
 import { Command } from '../../bin/cli';
 import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 import { logCmdError } from '../utils/errors';
 
 export const expoExport: Command = async (argv) => {
@@ -64,9 +65,9 @@ export const expoExport: Command = async (argv) => {
   }
 
   const projectRoot = getProjectRoot(args);
-  const { resolveOptionsAsync } = await import('./resolveOptions.js');
+  const { resolveOptionsAsync } = asyncImportInterop(await import('./resolveOptions.js'));
   const options = await resolveOptionsAsync(projectRoot, args).catch(logCmdError);
 
-  const { exportAsync } = await import('./exportAsync.js');
+  const { exportAsync } = asyncImportInterop(await import('./exportAsync.js'));
   return exportAsync(projectRoot, options).catch(logCmdError);
 };

--- a/packages/@expo/cli/src/export/web/index.ts
+++ b/packages/@expo/cli/src/export/web/index.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 
 import { Command } from '../../../bin/cli';
 import { assertArgs, getProjectRoot, printHelp } from '../../utils/args';
+import { asyncImportInterop } from '../../utils/asyncImportInterop';
 import { logCmdError } from '../../utils/errors';
 
 export const expoExportWeb: Command = async (argv) => {
@@ -33,9 +34,9 @@ export const expoExportWeb: Command = async (argv) => {
   }
 
   const projectRoot = getProjectRoot(args);
-  const { resolveOptionsAsync } = await import('./resolveOptions.js');
+  const { resolveOptionsAsync } = asyncImportInterop(await import('./resolveOptions.js'));
   const options = await resolveOptionsAsync(args).catch(logCmdError);
 
-  const { exportWebAsync } = await import('./exportWebAsync.js');
+  const { exportWebAsync } = asyncImportInterop(await import('./exportWebAsync.js'));
   return exportWebAsync(projectRoot, options).catch(logCmdError);
 };

--- a/packages/@expo/cli/src/install/applyPlugins.ts
+++ b/packages/@expo/cli/src/install/applyPlugins.ts
@@ -1,13 +1,16 @@
 import { getConfig } from '@expo/config';
 
 import * as Log from '../log';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 
 /**
  * A convenience feature for automatically applying Expo Config Plugins to the `app.json` after installing them.
  * This should be dropped in favor of autolinking in the future.
  */
 export async function applyPluginsAsync(projectRoot: string, packages: string[]) {
-  const { autoAddConfigPluginsAsync } = await import('./utils/autoAddConfigPlugins.js');
+  const { autoAddConfigPluginsAsync } = asyncImportInterop(
+    await import('./utils/autoAddConfigPlugins.js')
+  );
 
   try {
     const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });

--- a/packages/@expo/cli/src/install/checkPackages.ts
+++ b/packages/@expo/cli/src/install/checkPackages.ts
@@ -10,6 +10,7 @@ import {
   getVersionedDependenciesAsync,
   logIncorrectDependencies,
 } from '../start/doctor/dependencies/validateDependenciesVersions';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 import { isInteractive } from '../utils/interactive';
 import { learnMore } from '../utils/link';
 import { confirmAsync } from '../utils/prompts';
@@ -76,7 +77,7 @@ export async function checkPackagesAsync(
   if (pkg.dependencies?.['expo-router']) {
     // TODO(@kitten): This should be removed. None of the checks apply anymore
     try {
-      const { doctor: routerDoctor } = await import('expo-router/doctor.js');
+      const { doctor: routerDoctor } = asyncImportInterop(await import('expo-router/doctor.js'));
       dependencies.push(
         ...routerDoctor(pkg, resolveFrom.silent(projectRoot, '@react-navigation/native'), {
           bold: chalk.bold,

--- a/packages/@expo/cli/src/lint/lintAsync.ts
+++ b/packages/@expo/cli/src/lint/lintAsync.ts
@@ -5,6 +5,7 @@ import semver from 'semver';
 
 import { ESLintProjectPrerequisite } from './ESlintPrerequisite';
 import type { Options } from './resolveOptions';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 import { CommandError } from '../utils/errors';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
 import { setNodeEnv } from '../utils/nodeEnv';
@@ -35,7 +36,7 @@ export const lintAsync = async (
   // However, it'd be safer to replace this with resolve-from, or another way of requiring via the project root
   const { loadESLint } = require('eslint');
 
-  const mod = await import('eslint');
+  const mod = asyncImportInterop(await import('eslint'));
 
   let ESLint: typeof import('eslint').ESLint;
   // loadESLint is >= 8.57.0 (https://github.com/eslint/eslint/releases/tag/v8.57.0) https://github.com/eslint/eslint/pull/18098

--- a/packages/@expo/cli/src/login/index.ts
+++ b/packages/@expo/cli/src/login/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from '../../bin/cli';
 import { assertArgs, printHelp } from '../utils/args';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 import { logCmdError } from '../utils/errors';
 
 export const expoLogin: Command = async (argv) => {
@@ -35,7 +36,7 @@ export const expoLogin: Command = async (argv) => {
     );
   }
 
-  const { showLoginPromptAsync } = await import('../api/user/actions.js');
+  const { showLoginPromptAsync } = asyncImportInterop(await import('../api/user/actions.js'));
   return showLoginPromptAsync({
     // Parsed options
     username: args['--username'],

--- a/packages/@expo/cli/src/logout/index.ts
+++ b/packages/@expo/cli/src/logout/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from '../../bin/cli';
 import { assertArgs, printHelp } from '../utils/args';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 import { logCmdError } from '../utils/errors';
 
 export const expoLogout: Command = async (argv) => {
@@ -24,6 +25,6 @@ export const expoLogout: Command = async (argv) => {
     );
   }
 
-  const { logoutAsync } = await import('../api/user/user.js');
+  const { logoutAsync } = asyncImportInterop(await import('../api/user/user.js'));
   return logoutAsync().catch(logCmdError);
 };

--- a/packages/@expo/cli/src/prebuild/index.ts
+++ b/packages/@expo/cli/src/prebuild/index.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 
 import { Command } from '../../bin/cli';
 import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 
 export const expoPrebuild: Command = async (argv) => {
   const args = assertArgs(
@@ -54,11 +55,13 @@ export const expoPrebuild: Command = async (argv) => {
     { resolvePlatformOption, resolvePackageManagerOptions, resolveSkipDependencyUpdate },
     // ../utils/errors
     { logCmdError },
-  ] = await Promise.all([
-    import('./prebuildAsync.js'),
-    import('./resolveOptions.js'),
-    import('../utils/errors.js'),
-  ]);
+  ] = (
+    await Promise.all([
+      import('./prebuildAsync.js'),
+      import('./resolveOptions.js'),
+      import('../utils/errors.js'),
+    ])
+  ).flatMap(asyncImportInterop);
 
   return (() => {
     return prebuildAsync(getProjectRoot(args), {

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -9,6 +9,7 @@ import { assertPlatforms, ensureValidPlatforms, resolveTemplateOption } from './
 import { updateFromTemplateAsync } from './updateFromTemplate';
 import { installAsync } from '../install/installAsync';
 import { Log } from '../log';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 import { env } from '../utils/env';
 import { setNodeEnv } from '../utils/nodeEnv';
 import { clearNodeModulesAsync } from '../utils/nodeModules';
@@ -79,7 +80,7 @@ export async function prebuildAsync(
     }
   }
   if (options.clean) {
-    const { maybeBailOnGitStatusAsync } = await import('../utils/git.js');
+    const { maybeBailOnGitStatusAsync } = asyncImportInterop(await import('../utils/git.js'));
     // Clean the project folders...
     if (await maybeBailOnGitStatusAsync()) {
       return null;
@@ -167,7 +168,7 @@ export async function prebuildAsync(
   let podsInstalled: boolean = false;
   // err towards running pod install less because it's slow and users can easily run npx pod-install afterwards.
   if (options.platforms.includes('ios') && options.install && needsPodInstall) {
-    const { installCocoaPodsAsync } = await import('../utils/cocoapods.js');
+    const { installCocoaPodsAsync } = asyncImportInterop(await import('../utils/cocoapods.js'));
 
     podsInstalled = await installCocoaPodsAsync(projectRoot);
   } else {

--- a/packages/@expo/cli/src/register/index.ts
+++ b/packages/@expo/cli/src/register/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from '../../bin/cli';
 import { assertArgs, printHelp } from '../utils/args';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 import { logCmdError } from '../utils/errors';
 
 export const expoRegister: Command = async (argv) => {
@@ -23,6 +24,6 @@ export const expoRegister: Command = async (argv) => {
     );
   }
 
-  const { registerAsync } = await import('./registerAsync.js');
+  const { registerAsync } = asyncImportInterop(await import('./registerAsync.js'));
   return registerAsync().catch(logCmdError);
 };

--- a/packages/@expo/cli/src/run/android/index.ts
+++ b/packages/@expo/cli/src/run/android/index.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { Command } from '../../../bin/cli';
 import * as Log from '../../log';
 import { assertWithOptionsArgs } from '../../utils/args';
+import { asyncImportInterop } from '../../utils/asyncImportInterop';
 import { logCmdError } from '../../utils/errors';
 
 export const expoRunAndroid: Command = async (argv) => {
@@ -60,13 +61,15 @@ export const expoRunAndroid: Command = async (argv) => {
     );
   }
 
-  const { resolveStringOrBooleanArgsAsync } = await import('../../utils/resolveArgs.js');
+  const { resolveStringOrBooleanArgsAsync } = asyncImportInterop(
+    await import('../../utils/resolveArgs.js')
+  );
   const parsed = await resolveStringOrBooleanArgsAsync(argv ?? [], rawArgsMap, {
     '--device': Boolean,
     '-d': '--device',
   }).catch(logCmdError);
 
-  const { runAndroidAsync } = await import('./runAndroidAsync.js');
+  const { runAndroidAsync } = asyncImportInterop(await import('./runAndroidAsync.js'));
 
   return runAndroidAsync(path.resolve(parsed.projectRoot), {
     // Parsed options

--- a/packages/@expo/cli/src/run/index.ts
+++ b/packages/@expo/cli/src/run/index.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import { logPlatformRunCommand } from './hints';
 import { Command } from '../../bin/cli';
 import { assertWithOptionsArgs, printHelp } from '../utils/args';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 import { CommandError, logCmdError } from '../utils/errors';
 
 export const expoRun: Command = async (argv) => {
@@ -42,7 +43,7 @@ export const expoRun: Command = async (argv) => {
     }
 
     if (!platform) {
-      const { selectAsync } = await import('../utils/prompts.js');
+      const { selectAsync } = asyncImportInterop(await import('../utils/prompts.js'));
       platform = await selectAsync('Select the platform to run', [
         { title: 'Android', value: 'android' },
         { title: 'iOS', value: 'ios' },
@@ -53,12 +54,12 @@ export const expoRun: Command = async (argv) => {
 
     switch (platform) {
       case 'android': {
-        const { expoRunAndroid } = await import('./android/index.js');
+        const { expoRunAndroid } = asyncImportInterop(await import('./android/index.js'));
         return expoRunAndroid(argsWithoutPlatform);
       }
 
       case 'ios': {
-        const { expoRunIos } = await import('./ios/index.js');
+        const { expoRunIos } = asyncImportInterop(await import('./ios/index.js'));
         return expoRunIos(argsWithoutPlatform);
       }
 

--- a/packages/@expo/cli/src/run/ios/index.ts
+++ b/packages/@expo/cli/src/run/ios/index.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { XcodeConfiguration } from './XcodeBuild.types';
 import { Command } from '../../../bin/cli';
 import { assertWithOptionsArgs, printHelp } from '../../utils/args';
+import { asyncImportInterop } from '../../utils/asyncImportInterop';
 import { logCmdError } from '../../utils/errors';
 
 export const expoRunIos: Command = async (argv) => {
@@ -61,14 +62,16 @@ export const expoRunIos: Command = async (argv) => {
     );
   }
 
-  const { resolveStringOrBooleanArgsAsync } = await import('../../utils/resolveArgs.js');
+  const { resolveStringOrBooleanArgsAsync } = asyncImportInterop(
+    await import('../../utils/resolveArgs.js')
+  );
   const parsed = await resolveStringOrBooleanArgsAsync(argv ?? [], rawArgsMap, {
     '--scheme': Boolean,
     '--device': Boolean,
     '-d': '--device',
   }).catch(logCmdError);
 
-  const { runIosAsync } = await import('./runIosAsync.js');
+  const { runIosAsync } = asyncImportInterop(await import('./runIosAsync.js'));
   return runIosAsync(path.resolve(parsed.projectRoot), {
     // Parsed options
     buildCache: !args['--no-build-cache'],

--- a/packages/@expo/cli/src/serve/index.ts
+++ b/packages/@expo/cli/src/serve/index.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 
 import { Command } from '../../bin/cli';
 import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 
 export const expoServe: Command = async (argv) => {
   const args = assertArgs(
@@ -35,7 +36,9 @@ export const expoServe: Command = async (argv) => {
     { serveAsync },
     // ../utils/errors
     { logCmdError },
-  ] = await Promise.all([import('./serveAsync.js'), import('../utils/errors.js')]);
+  ] = (await Promise.all([import('./serveAsync.js'), import('../utils/errors.js')])).flatMap(
+    asyncImportInterop
+  );
 
   return serveAsync(getProjectRoot(args), {
     isDefaultDirectory: !args._[0],

--- a/packages/@expo/cli/src/start/index.ts
+++ b/packages/@expo/cli/src/start/index.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 
 import { Command } from '../../bin/cli';
 import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 import { logCmdError } from '../utils/errors';
 
 export const expoStart: Command = async (argv) => {
@@ -84,18 +85,18 @@ export const expoStart: Command = async (argv) => {
   const projectRoot = getProjectRoot(args);
 
   // NOTE(cedric): `./resolveOptions` loads the expo config when using dev clients, this needs to be initialized before that
-  const { setNodeEnv, loadEnvFiles } = await import('../utils/nodeEnv.js');
+  const { setNodeEnv, loadEnvFiles } = asyncImportInterop(await import('../utils/nodeEnv.js'));
   setNodeEnv(!args['--no-dev'] ? 'development' : 'production');
   loadEnvFiles(projectRoot);
 
-  const { resolveOptionsAsync } = await import('./resolveOptions.js');
+  const { resolveOptionsAsync } = asyncImportInterop(await import('./resolveOptions.js'));
   const options = await resolveOptionsAsync(projectRoot, args).catch(logCmdError);
 
   if (options.offline) {
-    const { disableNetwork } = await import('../api/settings.js');
+    const { disableNetwork } = asyncImportInterop(await import('../api/settings.js'));
     disableNetwork();
   }
 
-  const { startAsync } = await import('./startAsync.js');
+  const { startAsync } = asyncImportInterop(await import('./startAsync.js'));
   return startAsync(projectRoot, options, { webOnly: false }).catch(logCmdError);
 };

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -61,6 +61,7 @@ import {
   ExportAssetMap,
 } from '../../../export/saveAssets';
 import { Log } from '../../../log';
+import { asyncImportInterop } from '../../../utils/asyncImportInterop';
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { toPosixPath } from '../../../utils/filePath';
@@ -1364,8 +1365,8 @@ export class MetroBundlerDevServer extends BundlerDevServer {
         callback: async () => {
           // Run once, this prevents the TypeScript project prerequisite from running on every file change.
           off();
-          const { TypeScriptProjectPrerequisite } = await import(
-            '../../doctor/typescript/TypeScriptProjectPrerequisite.js'
+          const { TypeScriptProjectPrerequisite } = asyncImportInterop(
+            await import('../../doctor/typescript/TypeScriptProjectPrerequisite.js')
           );
 
           try {

--- a/packages/@expo/cli/src/utils/asyncImportInterop.ts
+++ b/packages/@expo/cli/src/utils/asyncImportInterop.ts
@@ -1,0 +1,48 @@
+interface ESModuleType {
+  __esModule?: boolean;
+  default: any;
+}
+
+/**
+ * Interop helper for async imports.
+ *
+ * Because CLI files are built with CJS, we need the interop helper for async imports.
+ * @example
+ * ```ts
+ * const { setNodeEnv, loadEnvFiles } = asyncImportInterop(await import('../utils/nodeEnv.js'));
+ * ```
+ *
+ * FWIW, these are the differences
+ * ```
+ * > // Import CJS module
+ * > await import('./packages/@expo/cli/build/src/utils/nodeEnv.js')
+ * [Module: null prototype] {
+ *   __esModule: true,
+ *   default: { loadEnvFiles: [Getter], setNodeEnv: [Getter] }
+ * }
+ * >
+ * > // Require a CJS module
+ * > require('./packages/@expo/cli/build/src/utils/nodeEnv.js')
+ * { loadEnvFiles: [Getter], setNodeEnv: [Getter] }
+ * >
+ * > // Import an ESM module
+ * > await import('expo-mcp')
+ * [Module: null prototype] {
+ *   addMcpCapabilities: [Function: addMcpCapabilities]
+ * }
+ * ```
+ */
+export function asyncImportInterop(obj: ESModuleType): ESModuleType['default'] {
+  if (
+    obj &&
+    typeof obj === 'object' &&
+    '__esModule' in obj &&
+    obj.__esModule &&
+    'default' in obj &&
+    obj.default
+  ) {
+    return obj.default;
+  }
+
+  return obj;
+}

--- a/packages/@expo/cli/src/utils/build-cache-providers/index.ts
+++ b/packages/@expo/cli/src/utils/build-cache-providers/index.ts
@@ -35,7 +35,7 @@ export const resolveBuildCacheProvider = async (
       });
 
       // We need to manually load dependencies installed on the fly
-      const plugin = await manuallyLoadDependency(projectRoot, 'eas-build-cache-provider');
+      const plugin = manuallyLoadDependency(projectRoot, 'eas-build-cache-provider');
 
       return {
         plugin: plugin.default ?? plugin,
@@ -243,7 +243,7 @@ export function resolvePluginFunction(
   }
 }
 
-async function manuallyLoadDependency(projectRoot: string, packageName: string) {
+function manuallyLoadDependency(projectRoot: string, packageName: string) {
   const possiblePaths = [
     path.join(projectRoot, 'node_modules'),
     ...(require.resolve.paths(packageName) ?? []),
@@ -256,6 +256,6 @@ async function manuallyLoadDependency(projectRoot: string, packageName: string) 
     throw new Error(`Package ${packageName} not found in ${possiblePaths}`);
   }
 
-  const { main } = await import(path.join(nodeModulesFolder, packageName, 'package.json'));
-  return import(path.join(nodeModulesFolder, packageName, main));
+  const { main } = require(path.join(nodeModulesFolder, packageName, 'package.json'));
+  return require(path.join(nodeModulesFolder, packageName, main));
 }

--- a/packages/@expo/cli/src/whoami/index.ts
+++ b/packages/@expo/cli/src/whoami/index.ts
@@ -22,6 +22,6 @@ export const expoWhoami: Command = async (argv) => {
     );
   }
 
-  const { whoamiAsync } = await import('./whoamiAsync.js');
+  const { whoamiAsync } = asyncImportInterop(await import('./whoamiAsync.js'));
   return whoamiAsync().catch(logCmdError);
 };

--- a/packages/@expo/cli/src/whoami/index.ts
+++ b/packages/@expo/cli/src/whoami/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from '../../bin/cli';
 import { assertArgs, printHelp } from '../utils/args';
+import { asyncImportInterop } from '../utils/asyncImportInterop';
 import { logCmdError } from '../utils/errors';
 
 export const expoWhoami: Command = async (argv) => {

--- a/packages/@expo/cli/taskfile-swc.js
+++ b/packages/@expo/cli/taskfile-swc.js
@@ -1,9 +1,8 @@
 // Based on Next.js swc taskr file.
 // https://github.com/vercel/next.js/blob/9d1ae19af360367e53c0f5a570e261e94cc8e59b/packages/next/taskfile-swc.js
 
-const path = require('path');
 const assert = require('assert');
-
+const path = require('path');
 const transform = require('@swc/core').transform;
 
 module.exports = function (task) {
@@ -45,6 +44,7 @@ module.exports = function (task) {
         module: {
           type: 'commonjs',
           lazy: true,
+          ignoreDynamic: true,
         },
         env: {
           targets: {


### PR DESCRIPTION
# Why

to support importing for ESM modules like `expo-mcp`

# How

- add `ignoreDynamic: true` to swc
- since all cli files are still built as cjs, `await import()` will break because swc at the same time wrapping an interop code. i added an `asyncImportInterop()` similar to babel interop wrapper to keep it working
- for `eas-build-cache-provider/package.json`​ which we cannot use `await import(‘eas-build-cache-provider/package.json’)`​, i changed it to require. 

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md`entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild`& EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)