### PR TITLE
[cli] Fix Expo Go docs link in `ExpoGoInstaller`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix Expo Go docs link in ExpoGoInstaller ([#39394](https://github.com/expo/expo/pull/39394) by [@amandeepmittal](https://github.com/amandeepmittal))
+
 - Fix UTF-8 characters in project path causing `setHeader` error in Metro middleware ([#39285](https://github.com/expo/expo/pull/39285) by [@HMYang33](https://github.com/HMYang33))
 
 ### 💡 Others

--- a/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
+++ b/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
@@ -85,7 +85,7 @@ export class ExpoGoInstaller<IDevice> {
         message: `Expo Go ${expectedExpoGoVersion} is recommended for SDK ${this.sdkVersion} (${
           deviceManager.name
         } is using ${installedExpoGoVersion}). ${learnMore(
-          'https://docs.expo.dev/get-started/expo-go/#sdk-versions'
+          'https://docs.expo.dev/develop/tools/#expo-go'
         )}. Install the recommended Expo Go version?`,
       });
 


### PR DESCRIPTION
<!-- disable:changelog-checks -->

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17150

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update Expo Go link to https://docs.expo.dev/develop/tools/#expo-go.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Create a new project locally with an older SDK version: `bunx create-expo-app --template default@51`
- Run `nexpo start`
- Once the metro bundler is running, press `i` or `a` to open the app in Expo Go on iOS Simulator or Android Emualtor
- You will see the Expo Go recommended version message. Click the link in "Learn more" and it should open https://docs.expo.dev/develop/tools/#expo-go.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
