### PR TITLE
[cli] add MCP integration

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -59,7 +59,6 @@
     "expo-dev-client": "~6.0.12",
     "expo-image": "~3.0.8",
     "expo-insights": "~0.10.7",
-    "expo-mcp": "~0.1.5",
     "expo-network-addons": "~0.10.7",
     "expo-notifications": "~0.32.11",
     "expo-splash-screen": "~31.0.10",

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -59,6 +59,7 @@
     "expo-dev-client": "~6.0.12",
     "expo-image": "~3.0.8",
     "expo-insights": "~0.10.7",
+    "expo-mcp": "~0.1.5",
     "expo-network-addons": "~0.10.7",
     "expo-notifications": "~0.32.11",
     "expo-splash-screen": "~31.0.10",

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Added MCP tunnel integration. ([#39392](https://github.com/expo/expo/pull/39392) by [@kudo](https://github.com/kudo))
+
 ## 54.0.5 — 2025-09-13
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/add-module.js
+++ b/packages/@expo/cli/add-module.js
@@ -1,0 +1,5 @@
+// A wrapper that allows to import an ESM module from a CJS module.
+// This works because the `import` in this wrapper is not transpiled by SWC.
+module.exports = function (name) {
+  return import(name);
+};

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -7,6 +7,7 @@
     "expo-internal": "build/bin/cli"
   },
   "files": [
+    "add-module.js",
     "internal",
     "static",
     "build"
@@ -48,6 +49,7 @@
     "@expo/env": "~2.0.7",
     "@expo/image-utils": "^0.8.7",
     "@expo/json-file": "^10.0.7",
+    "@expo/mcp-tunnel": "~0.0.7",
     "@expo/metro": "~0.1.1",
     "@expo/metro-config": "~54.0.3",
     "@expo/osascript": "^2.3.7",

--- a/packages/@expo/cli/src/start/server/MCP.ts
+++ b/packages/@expo/cli/src/start/server/MCP.ts
@@ -1,0 +1,85 @@
+import type {
+  McpServerProxy,
+  TunnelMcpServerProxy as TunnelMcpServerProxyType,
+} from '@expo/mcp-tunnel' with { 'resolution-mode': 'import' };
+import resolveFrom from 'resolve-from';
+
+import { getAccessToken, getSession } from '../../api/user/UserSettings';
+import { Log } from '../../log';
+import { env } from '../../utils/env';
+
+const importESM = require('@expo/cli/add-module') as <T>(moduleName: string) => Promise<T>;
+
+const debug = require('debug')('expo:start:server:mcp') as typeof console.log;
+
+/**
+ * Create the MCP server
+ */
+export async function maybeCreateMCPServerAsync(
+  projectRoot: string
+): Promise<McpServerProxy | null> {
+  const mcpServer = env.EXPO_UNSTABLE_MCP_SERVER;
+  if (!mcpServer) {
+    return null;
+  }
+  const mcpPackagePath = resolveFrom.silent(projectRoot, 'expo-mcp');
+  if (!mcpPackagePath) {
+    Log.error(
+      'Missing the `expo-mcp` package in the project. To enable the MCP integration, add the `expo-mcp` package to your project.'
+    );
+    return null;
+  }
+
+  const normalizedServer = /^([a-zA-Z][a-zA-Z\d+\-.]*):\/\//.test(mcpServer)
+    ? mcpServer
+    : `wss://${mcpServer}`;
+  const mcpServerUrlObject = new URL(normalizedServer);
+  const scheme = mcpServerUrlObject.protocol ?? 'wss:';
+  const mcpServerUrl = `${scheme}//${mcpServerUrlObject.host}`;
+  debug(`Creating MCP tunnel - server URL: ${mcpServerUrl}`);
+
+  try {
+    const { addMcpCapabilities } = await importESM<{
+      addMcpCapabilities: (server: McpServerProxy, projectRoot: string) => void;
+    }>(mcpPackagePath);
+    const { TunnelMcpServerProxy } = await importESM<{
+      TunnelMcpServerProxy: typeof TunnelMcpServerProxyType;
+    }>('@expo/mcp-tunnel');
+
+    const logger = {
+      ...Log,
+      debug(...message: any[]): void {
+        debug(...message);
+      },
+      info(...message: any[]): void {
+        Log.log(...message);
+      },
+    };
+    const server: McpServerProxy = new TunnelMcpServerProxy(mcpServerUrl, {
+      logger,
+      wsHeaders: createAuthHeaders(),
+    });
+    addMcpCapabilities(server, projectRoot);
+
+    return server;
+  } catch (error: unknown) {
+    debug(`Error creating MCP tunnel: ${error}`);
+  }
+  return null;
+}
+
+function createAuthHeaders(): Record<string, string> {
+  const token = getAccessToken();
+  if (token) {
+    return {
+      authorization: `Bearer ${token}`,
+    };
+  }
+  const sessionSecret = getSession()?.sessionSecret;
+  if (sessionSecret) {
+    return {
+      'expo-session': sessionSecret,
+    };
+  }
+  return {};
+}

--- a/packages/@expo/cli/src/start/server/__tests__/MCP-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/MCP-test.ts
@@ -1,0 +1,88 @@
+// @ts-expect-error
+import resolveFrom from 'resolve-from';
+
+import { Log } from '../../../log';
+import { maybeCreateMCPServerAsync } from '../MCP';
+
+jest.mock('@expo/mcp-tunnel', () => ({
+  __esModule: true,
+  default: {},
+}));
+jest.mock('@expo/cli/add-module', () =>
+  jest.fn().mockReturnValue({
+    TunnelMcpServerProxy: jest.fn().mockImplementation((mcpServerUrl: string) => ({
+      // Adding a mock property that allows checking the server URL
+      mockServerUrl: mcpServerUrl,
+    })),
+    addMcpCapabilities: jest.fn(),
+  })
+);
+jest.mock('resolve-from');
+jest.mock('../../../log');
+
+describe(maybeCreateMCPServerAsync, () => {
+  const mockResolveFromSilent = resolveFrom.silent as jest.MockedFunction<
+    typeof resolveFrom.silent
+  >;
+
+  const originalEnv = process.env;
+  beforeEach(() => {
+    delete process.env.EXPO_STAGING;
+    delete process.env.EXPO_UNSTABLE_MCP_SERVER;
+  });
+
+  afterEach(() => {
+    mockResolveFromSilent.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should return null if the MCP server is not enabled', async () => {
+    const server = await maybeCreateMCPServerAsync('/app');
+    expect(server).toBeNull();
+  });
+
+  it('should return non-null value if the MCP server is enabled', async () => {
+    process.env.EXPO_UNSTABLE_MCP_SERVER = '1';
+    mockResolveFromSilent.mockReturnValue('/app/node_modules/expo-mcp');
+    const server = await maybeCreateMCPServerAsync('/app');
+    expect(server).not.toBeNull();
+  });
+
+  it('should return null and log an error if the MCP server is enabled but the expo-mcp package is not installed', async () => {
+    process.env.EXPO_UNSTABLE_MCP_SERVER = '1';
+    const spyLogError = jest.spyOn(Log, 'error');
+    const server = await maybeCreateMCPServerAsync('/app');
+    expect(spyLogError).toHaveBeenCalledWith(
+      'Missing the `expo-mcp` package in the project. To enable the MCP integration, add the `expo-mcp` package to your project.'
+    );
+    expect(server).toBeNull();
+  });
+
+  it('should use production MCP server by default', async () => {
+    process.env.EXPO_UNSTABLE_MCP_SERVER = '1';
+    mockResolveFromSilent.mockReturnValue('/app/node_modules/expo-mcp');
+    const server = await maybeCreateMCPServerAsync('/app');
+    // @ts-expect-error
+    expect(server?.mockServerUrl).toBe('wss://mcp.expo.dev');
+  });
+
+  it('should use staging MCP server if the EXPO_STAGING environment variable is set', async () => {
+    process.env.EXPO_UNSTABLE_MCP_SERVER = '1';
+    process.env.EXPO_STAGING = '1';
+    mockResolveFromSilent.mockReturnValue('/app/node_modules/expo-mcp');
+    const server = await maybeCreateMCPServerAsync('/app');
+    // @ts-expect-error
+    expect(server?.mockServerUrl).toBe('wss://staging-mcp.expo.dev');
+  });
+
+  it('should allow specifying custom MCP server URL', async () => {
+    process.env.EXPO_UNSTABLE_MCP_SERVER = 'ws://localhost:8787';
+    mockResolveFromSilent.mockReturnValue('/app/node_modules/expo-mcp');
+    const server = await maybeCreateMCPServerAsync('/app');
+    // @ts-expect-error
+    expect(server?.mockServerUrl).toBe('ws://localhost:8787');
+  });
+});

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -15,6 +15,7 @@ import { getPlatformBundlers, PlatformBundlers } from './server/platformBundlers
 import { env } from '../utils/env';
 import { isInteractive } from '../utils/interactive';
 import { profile } from '../utils/profile';
+import { maybeCreateMCPServerAsync } from './server/MCP';
 
 async function getMultiBundlerStartOptions(
   projectRoot: string,
@@ -114,9 +115,13 @@ export async function startAsync(
 
   // Present the Terminal UI.
   if (isInteractive()) {
+    const mcpServer = await profile(maybeCreateMCPServerAsync)(projectRoot);
+
     await profile(startInterfaceAsync)(devServerManager, {
       platforms: exp.platforms ?? ['ios', 'android', 'web'],
     });
+
+    mcpServer?.start();
   } else {
     // Display the server location in CI...
     const url = devServerManager.getDefaultDevServer()?.getDevServerUrl();

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -275,6 +275,17 @@ class Env {
   get EXPO_UNSTABLE_LIVE_BINDINGS(): boolean {
     return boolish('EXPO_UNSTABLE_LIVE_BINDINGS', true);
   }
+
+  /**
+   * Enable the experimental MCP integration or further specify the MCP server URL.
+   */
+  get EXPO_UNSTABLE_MCP_SERVER(): string {
+    const value = string('EXPO_UNSTABLE_MCP_SERVER', '');
+    if (value === '1' || value.toLowerCase() === 'true') {
+      return this.EXPO_STAGING ? 'staging-mcp.expo.dev' : 'mcp.expo.dev';
+    }
+    return value;
+  }
 }
 
 export const env = new Env();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1570,6 +1570,15 @@
     debug "^3.1.0"
     glob "^10.4.2"
 
+"@expo/mcp-tunnel@~0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@expo/mcp-tunnel/-/mcp-tunnel-0.0.7.tgz#16850d5e7b5b3961bf06be0111ae4689de959aeb"
+  integrity sha512-ht8Q1nKtiHobZqkUqt/7awwjW2D59ardP6XDVmGceGjQtoZELVaJDHyMIX+aVG9SZ9aj8+uGlhQYeBi57SZPMA==
+  dependencies:
+    ws "^8.18.3"
+    zod "^3.25.76"
+    zod-to-json-schema "^3.24.6"
+
 "@expo/metro@~0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@expo/metro/-/metro-0.1.1.tgz#234099226509f88d3a431f386e83c21a64a01630"
@@ -3123,6 +3132,24 @@
   dependencies:
     lottie-web "^5.12.2"
 
+"@modelcontextprotocol/sdk@^1.17.5":
+  version "1.17.5"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.17.5.tgz#7eab1c9249532b16b7e181d9af0aec5f696c1a55"
+  integrity sha512-QakrKIGniGuRVfWBdMsDea/dx1PNE739QJ7gCM41s9q+qaCYTHCdsIBXQVVXry3mfWAiaM9kT22Hyz53Uw8mfg==
+  dependencies:
+    ajv "^6.12.6"
+    content-type "^1.0.5"
+    cors "^2.8.5"
+    cross-spawn "^7.0.5"
+    eventsource "^3.0.2"
+    eventsource-parser "^3.0.0"
+    express "^5.0.1"
+    express-rate-limit "^7.5.0"
+    pkce-challenge "^5.0.0"
+    raw-body "^3.0.0"
+    zod "^3.23.8"
+    zod-to-json-schema "^3.24.1"
+
 "@netlify/functions@^1.4.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@netlify/functions/-/functions-1.6.0.tgz#c373423e6fef0e6f7422ac0345e8bbf2cb692366"
@@ -4259,14 +4286,6 @@
   resolved "https://registry.yarnpkg.com/@types/fontfaceobserver/-/fontfaceobserver-2.1.3.tgz#2c735284b71dde89afab441bff05ebad4a636e04"
   integrity sha512-AewfFg9iUfoUZ4EfKxhBaEuzY2TUS+Hm0vXWMPcJRY7C4wC9XtW20lPVYHTcWVZYq1uthCEa5APl7RAX7jr2Xg==
 
-"@types/fs-extra@>=11":
-  version "11.0.4"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-11.0.4.tgz#e16a863bb8843fba8c5004362b5a73e17becca45"
-  integrity sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==
-  dependencies:
-    "@types/jsonfile" "*"
-    "@types/node" "*"
-
 "@types/geojson@^7946.0.13":
   version "7946.0.14"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.14.tgz#319b63ad6df705ee2a65a73ef042c8271e696613"
@@ -4384,13 +4403,6 @@
   dependencies:
     json5 "*"
 
-"@types/jsonfile@*":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@types/jsonfile/-/jsonfile-6.1.4.tgz#614afec1a1164e7d670b4a7ad64df3e7beb7b702"
-  integrity sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/keyv@*":
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.4.tgz#3ccdb1c6751b0c7e52300bcdacd5bcbf8faa75b6"
@@ -4459,7 +4471,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@>=20", "@types/node@^22.14.0":
+"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^22.14.0":
   version "22.14.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.14.0.tgz#d3bfa3936fef0dbacd79ea3eb17d521c628bb47e"
   integrity sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==
@@ -6686,6 +6698,14 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cosmiconfig-typescript-loader@^4.3.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.4.0.tgz#f3feae459ea090f131df5474ce4b1222912319f9"
@@ -8162,6 +8182,18 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+eventsource-parser@^3.0.0, eventsource-parser@^3.0.1:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.6.tgz#292e165e34cacbc936c3c92719ef326d4aeb4e90"
+  integrity sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==
+
+eventsource@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-3.0.7.tgz#1157622e2f5377bb6aef2114372728ba0c156989"
+  integrity sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==
+  dependencies:
+    eventsource-parser "^3.0.1"
+
 exec-async@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/exec-async/-/exec-async-2.2.0.tgz#c7c5ad2eef3478d38390c6dd3acfe8af0efc8301"
@@ -8285,6 +8317,17 @@ expo-atlas@^0.4.1:
     serve-static "^1.15.0"
     stream-json "^1.8.0"
 
+expo-mcp@~0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/expo-mcp/-/expo-mcp-0.1.5.tgz#366162d84ee2395c0acaa1c39158d809b2e1f68f"
+  integrity sha512-86To3z4PXdY/GloyIwCJv8jkJpmA6NIKcE6+Bpw0+CuNv41hKXMUwnbKyl/DmVvO9ycT/wmsstmtEKGC4Jk8ww==
+  dependencies:
+    "@expo/mcp-tunnel" "~0.0.7"
+    "@modelcontextprotocol/sdk" "^1.17.5"
+    glob "^11.0.3"
+    zod "^3.25.76"
+    zx "^8.8.1"
+
 expo-progress@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/expo-progress/-/expo-progress-0.0.2.tgz#0d42470f8f1f019d3ae0f1da377c9bca891f3dd8"
@@ -8302,6 +8345,11 @@ exponential-backoff@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
   integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
+
+express-rate-limit@^7.5.0:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-7.5.1.tgz#8c3a42f69209a3a1c969890070ece9e20a879dec"
+  integrity sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==
 
 express@^4.19.2:
   version "4.21.1"
@@ -8340,7 +8388,7 @@ express@^4.19.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-express@^5.1.0:
+express@^5.0.1, express@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/express/-/express-5.1.0.tgz#d31beaf715a0016f0d53f47d3b4d7acf28c75cc9"
   integrity sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==
@@ -9090,7 +9138,7 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@11.0.x, glob@^11.0.0:
+glob@11.0.x, glob@^11.0.0, glob@^11.0.3:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-11.0.3.tgz#9d8087e6d72ddb3c4707b1d2778f80ea3eaefcd6"
   integrity sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==
@@ -12546,7 +12594,7 @@ ob1@0.83.1:
   dependencies:
     flow-enums-runtime "^0.0.6"
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -13132,6 +13180,11 @@ pixi.js@^4.6.1:
     pixi-gl-core "^1.1.4"
     remove-array-items "^1.0.0"
     resource-loader "^2.2.3"
+
+pkce-challenge@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pkce-challenge/-/pkce-challenge-5.0.0.tgz#c3a405cb49e272094a38e890a2b51da0228c4d97"
+  integrity sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==
 
 pkg-dir@^4.2.0:
   version "4.2.0"
@@ -16485,7 +16538,7 @@ value-or-promise@1.0.12, value-or-promise@^1.0.11, value-or-promise@^1.0.12:
   resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.12.tgz#0e5abfeec70148c78460a849f6b003ea7986f15c"
   integrity sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==
 
-vary@^1.1.2, vary@~1.1.2:
+vary@^1, vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
@@ -17123,10 +17176,10 @@ ws@8.12.1:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"
   integrity sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==
 
-ws@>=7.4.6, ws@^8.11.0, ws@^8.12.0, ws@^8.12.1, ws@^8.18.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+ws@>=7.4.6, ws@^8.11.0, ws@^8.12.0, ws@^8.12.1, ws@^8.18.0, ws@^8.18.3:
+  version "8.18.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
+  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
 ws@^6.2.3:
   version "6.2.3"
@@ -17351,10 +17404,17 @@ zen-observable@0.8.15:
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
-zx@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/zx/-/zx-8.2.0.tgz#46e8594bf2fe8c6bc15d6e571108e525da3c22b1"
-  integrity sha512-ec7Z1Ki9h4CsKqbMjZ8H7G1PbbZYErscxT314LF66Ljx1YRENisqa5m9IN2VjbYgOKxdv5t0MbVd3Hf+II3e7w==
-  optionalDependencies:
-    "@types/fs-extra" ">=11"
-    "@types/node" ">=20"
+zod-to-json-schema@^3.24.1, zod-to-json-schema@^3.24.6:
+  version "3.24.6"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz#5920f020c4d2647edfbb954fa036082b92c9e12d"
+  integrity sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==
+
+zod@^3.23.8, zod@^3.25.76:
+  version "3.25.76"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
+  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
+
+zx@^8.2.0, zx@^8.8.1:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/zx/-/zx-8.8.1.tgz#5c30645d3383d961771d911c63defa6a6e58014c"
+  integrity sha512-qvsKBnvWHstHKCluKPlEgI/D3+mdiQyMoSSeFR8IX/aXzWIas5A297KxKgPJhuPXdrR6ma0Jzx43+GQ/8sqbrw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3132,24 +3132,6 @@
   dependencies:
     lottie-web "^5.12.2"
 
-"@modelcontextprotocol/sdk@^1.17.5":
-  version "1.17.5"
-  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.17.5.tgz#7eab1c9249532b16b7e181d9af0aec5f696c1a55"
-  integrity sha512-QakrKIGniGuRVfWBdMsDea/dx1PNE739QJ7gCM41s9q+qaCYTHCdsIBXQVVXry3mfWAiaM9kT22Hyz53Uw8mfg==
-  dependencies:
-    ajv "^6.12.6"
-    content-type "^1.0.5"
-    cors "^2.8.5"
-    cross-spawn "^7.0.5"
-    eventsource "^3.0.2"
-    eventsource-parser "^3.0.0"
-    express "^5.0.1"
-    express-rate-limit "^7.5.0"
-    pkce-challenge "^5.0.0"
-    raw-body "^3.0.0"
-    zod "^3.23.8"
-    zod-to-json-schema "^3.24.1"
-
 "@netlify/functions@^1.4.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@netlify/functions/-/functions-1.6.0.tgz#c373423e6fef0e6f7422ac0345e8bbf2cb692366"
@@ -6698,14 +6680,6 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cors@^2.8.5:
-  version "2.8.5"
-  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
-  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
-  dependencies:
-    object-assign "^4"
-    vary "^1"
-
 cosmiconfig-typescript-loader@^4.3.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.4.0.tgz#f3feae459ea090f131df5474ce4b1222912319f9"
@@ -8182,18 +8156,6 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-eventsource-parser@^3.0.0, eventsource-parser@^3.0.1:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.6.tgz#292e165e34cacbc936c3c92719ef326d4aeb4e90"
-  integrity sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==
-
-eventsource@^3.0.2:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-3.0.7.tgz#1157622e2f5377bb6aef2114372728ba0c156989"
-  integrity sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==
-  dependencies:
-    eventsource-parser "^3.0.1"
-
 exec-async@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/exec-async/-/exec-async-2.2.0.tgz#c7c5ad2eef3478d38390c6dd3acfe8af0efc8301"
@@ -8317,17 +8279,6 @@ expo-atlas@^0.4.1:
     serve-static "^1.15.0"
     stream-json "^1.8.0"
 
-expo-mcp@~0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/expo-mcp/-/expo-mcp-0.1.5.tgz#366162d84ee2395c0acaa1c39158d809b2e1f68f"
-  integrity sha512-86To3z4PXdY/GloyIwCJv8jkJpmA6NIKcE6+Bpw0+CuNv41hKXMUwnbKyl/DmVvO9ycT/wmsstmtEKGC4Jk8ww==
-  dependencies:
-    "@expo/mcp-tunnel" "~0.0.7"
-    "@modelcontextprotocol/sdk" "^1.17.5"
-    glob "^11.0.3"
-    zod "^3.25.76"
-    zx "^8.8.1"
-
 expo-progress@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/expo-progress/-/expo-progress-0.0.2.tgz#0d42470f8f1f019d3ae0f1da377c9bca891f3dd8"
@@ -8345,11 +8296,6 @@ exponential-backoff@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
   integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
-
-express-rate-limit@^7.5.0:
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-7.5.1.tgz#8c3a42f69209a3a1c969890070ece9e20a879dec"
-  integrity sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==
 
 express@^4.19.2:
   version "4.21.1"
@@ -8388,7 +8334,7 @@ express@^4.19.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-express@^5.0.1, express@^5.1.0:
+express@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/express/-/express-5.1.0.tgz#d31beaf715a0016f0d53f47d3b4d7acf28c75cc9"
   integrity sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==
@@ -9138,7 +9084,7 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@11.0.x, glob@^11.0.0, glob@^11.0.3:
+glob@11.0.x, glob@^11.0.0:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-11.0.3.tgz#9d8087e6d72ddb3c4707b1d2778f80ea3eaefcd6"
   integrity sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==
@@ -12594,7 +12540,7 @@ ob1@0.83.1:
   dependencies:
     flow-enums-runtime "^0.0.6"
 
-object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -13180,11 +13126,6 @@ pixi.js@^4.6.1:
     pixi-gl-core "^1.1.4"
     remove-array-items "^1.0.0"
     resource-loader "^2.2.3"
-
-pkce-challenge@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/pkce-challenge/-/pkce-challenge-5.0.0.tgz#c3a405cb49e272094a38e890a2b51da0228c4d97"
-  integrity sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==
 
 pkg-dir@^4.2.0:
   version "4.2.0"
@@ -16538,7 +16479,7 @@ value-or-promise@1.0.12, value-or-promise@^1.0.11, value-or-promise@^1.0.12:
   resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.12.tgz#0e5abfeec70148c78460a849f6b003ea7986f15c"
   integrity sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==
 
-vary@^1, vary@^1.1.2, vary@~1.1.2:
+vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
@@ -17404,17 +17345,17 @@ zen-observable@0.8.15:
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
-zod-to-json-schema@^3.24.1, zod-to-json-schema@^3.24.6:
+zod-to-json-schema@^3.24.6:
   version "3.24.6"
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz#5920f020c4d2647edfbb954fa036082b92c9e12d"
   integrity sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==
 
-zod@^3.23.8, zod@^3.25.76:
+zod@^3.25.76:
   version "3.25.76"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
-zx@^8.2.0, zx@^8.8.1:
+zx@^8.2.0:
   version "8.8.1"
   resolved "https://registry.yarnpkg.com/zx/-/zx-8.8.1.tgz#5c30645d3383d961771d911c63defa6a6e58014c"
   integrity sha512-qvsKBnvWHstHKCluKPlEgI/D3+mdiQyMoSSeFR8IX/aXzWIas5A297KxKgPJhuPXdrR6ma0Jzx43+GQ/8sqbrw==


### PR DESCRIPTION
# Why

add remote mcp integration to expo cli

# How

- add a feature flag `EXPO_UNSTABLE_MCP_SERVER` to enable mcp integration
- if `EXPO_UNSTABLE_MCP_SERVER` is specified and `expo-mcp` is installed, we will start the mcp tunnel

# Test Plan

tested locally with my mcp server (binding to staging env):
```sh
cd apps/bare-expo
yarn add -D expo-mcp
EXPO_STAGING=1 EXPO_UNSTABLE_MCP_SERVER=1 npx expo start
```
also added the mcp server `https://staging-mcp.expo.dev/mcp` using vscode

# Checklist

- [x] I added a `changelog.md`entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild`& EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)