### PR TITLE
[expo-image-picker][ios] add .tiff file support

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [ios] Avoid transcoding for .tiff like it works for .heic. This keeps the asset in its original container/codec (e.g. TIFF instead of JPEG) and is required for the new fast-path. Apps that relied on .automatic re-encoded output can pass preferredAssetRepresentationMode: '.automatic' to restore the old behaviour.([#39398](https://github.com/expo/expo/pull/39398) by [@chocky335](https://github.com/chocky335))
+- [ios] Avoid transcoding for .avif and .tiff like it works for .heic. This keeps the asset in its original container/codec (e.g. TIFF instead of JPEG) and is required for the new fast-path. Apps that relied on .automatic re-encoded output can pass preferredAssetRepresentationMode: '.automatic' to restore the old behaviour.([#39398](https://github.com/expo/expo/pull/39398) by [@chocky335](https://github.com/chocky335))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Avoid transcoding for .tiff like it works for .heic. This keeps the asset in its original container/codec (e.g. TIFF instead of JPEG) and is required for the new fast-path. Apps that relied on .automatic re-encoded output can pass preferredAssetRepresentationMode: '.automatic' to restore the old behaviour.([#39398](https://github.com/expo/expo/pull/39398) by [@chocky335](https://github.com/chocky335))
+
 ### 💡 Others
 
 ## 17.0.6 — 2025-09-02

--- a/packages/expo-image-picker/ios/ImageUtils.swift
+++ b/packages/expo-image-picker/ios/ImageUtils.swift
@@ -6,6 +6,12 @@ import ImageIO
 import Photos
 import UniformTypeIdentifiers
 
+extension UTType {
+  static var avif: UTType {
+    UTType(importedAs: "public.avif")
+  }
+}
+
 internal struct ImageUtils {
   static func readImageFrom(mediaInfo: MediaInfo, shouldReadCroppedImage: Bool) -> UIImage? {
     // ---------------------------------------------------------------------------
@@ -140,6 +146,8 @@ internal struct ImageUtils {
       return (rawData, ".heic")
     case UTType.tiff.identifier:
       return (rawData, ".tiff")
+    case UTType.avif.identifier:
+      return (rawData, ".avif")
     default:
       if options.quality >= 1.0 {
         return (rawData, ".jpg")

--- a/packages/expo-image-picker/ios/ImageUtils.swift
+++ b/packages/expo-image-picker/ios/ImageUtils.swift
@@ -138,6 +138,8 @@ internal struct ImageUtils {
       return (gifData, ".gif")
     case UTType.heic.identifier:
       return (rawData, ".heic")
+    case UTType.tiff.identifier:
+      return (rawData, ".tiff")
     default:
       if options.quality >= 1.0 {
         return (rawData, ".jpg")


### PR DESCRIPTION
# Why

Pick `.tiff` image from medial library with `launchImageLibraryAsync` returns file with `image/jpeg` & `.jpeg` file format. This file throws processing errors in the further use.

# How

Just re-use the same approach as for .heic format

# Test Plan

```
await launchImageLibraryAsync({
      mediaTypes: ['images', 'videos', 'livePhotos'],
      allowsMultipleSelection: true,
      exif: true,
      preferredAssetRepresentationMode: UIImagePickerPreferredAssetRepresentationMode.Current
    })
```
pick `.tiff` image

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
