### PR TITLE
[docs] Add a tile for Launch to docs home page

### DIFF
--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -4,6 +4,7 @@ import { EASHostingShoutoutBanner } from '~/ui/components/EASHostingShoutoutBann
 import { DevicesImageMasks } from '~/ui/components/Home/resources';
 import {
   QuickStart,
+  CommandLineTools,
   DiscoverMore,
   ExploreAPIs,
   Talks,
@@ -23,6 +24,7 @@ function Home() {
       <AppJSBanner />
       <EASHostingShoutoutBanner />
       <QuickStart />
+      <CommandLineTools />
       <DiscoverMore />
       <ExploreAPIs />
       <ExploreExamples />

--- a/docs/ui/components/Home/sections/CommandLineTools.tsx
+++ b/docs/ui/components/Home/sections/CommandLineTools.tsx
@@ -1,0 +1,58 @@
+import { mergeClasses } from '@expo/styleguide';
+import { AppleAppStoreIcon } from '@expo/styleguide-icons/custom/AppleAppStoreIcon';
+import { Cloud01DuotoneIcon } from '@expo/styleguide-icons/duotone/Cloud01DuotoneIcon';
+
+import { GridContainer, GridCell, Header } from '~/ui/components/Home/components';
+import { Terminal } from '~/ui/components/Snippet';
+import { CALLOUT, A } from '~/ui/components/Text';
+
+export function CommandLineTools() {
+  return (
+    <>
+      <Header
+        title="Deploy from the command line"
+        description="Deploy your apps using command-line tools for iOS and web platforms."
+      />
+      <GridContainer>
+        <GridCell
+          className={mergeClasses(
+            'min-h-[192px] bg-subtle bg-gradient-to-br from-subtle from-15% to-palette-purple3',
+            'selection:bg-palette-purple5'
+          )}>
+          <AppleAppStoreIcon className="absolute -bottom-16 -right-10 size-72 text-palette-purple10 opacity-10" />
+          <div className="relative z-10 flex flex-col gap-4">
+            <h2 className="flex items-center gap-2 !font-bold !text-palette-purple10 heading-lg">
+              <AppleAppStoreIcon className="icon-lg text-palette-purple10" /> Deploy to TestFlight
+            </h2>
+            <div>
+              <Terminal cmd={['$ npx testflight']} className="asset-shadow rounded-md" />
+              <CALLOUT theme="secondary">
+                This is an iOS-only command that will upload your app to TestFlight.
+              </CALLOUT>
+            </div>
+          </div>
+        </GridCell>
+        <GridCell
+          className={mergeClasses(
+            'min-h-[192px] bg-subtle bg-gradient-to-br from-subtle from-15% to-palette-green3',
+            'selection:bg-palette-green4'
+          )}>
+          <Cloud01DuotoneIcon className="absolute -bottom-20 -right-8 size-80 text-[#1e8a5f] opacity-10 dark:text-[#4eca8c]" />
+          <div className="relative z-10 flex flex-col gap-4">
+            <h2 className="flex items-center gap-2 !font-bold !text-[#1e8a5f] heading-lg dark:!text-[#4eca8c]">
+              <Cloud01DuotoneIcon className="icon-lg text-[#1e8a5f] dark:text-[#4eca8c]" /> Deploy
+              your web app
+            </h2>
+            <div>
+              <Terminal cmd={['$ npx eas-cli deploy']} className="asset-shadow rounded-md" />
+              <CALLOUT theme="secondary">
+                For prerequisites and complete instructions, see{' '}
+                <A href="/deploy/web/#export-your-web-project/">our guide</A>.
+              </CALLOUT>
+            </div>
+          </div>
+        </GridCell>
+      </GridContainer>
+    </>
+  );
+}

--- a/docs/ui/components/Home/sections/CommandLineTools.tsx
+++ b/docs/ui/components/Home/sections/CommandLineTools.tsx
@@ -10,7 +10,7 @@ export function CommandLineTools() {
   return (
     <>
       <Header
-        title="Deploy from the command line"
+        title="Deploy from CLI"
         description="Deploy your apps using command-line tools for iOS and web platforms."
       />
       <GridContainer>

--- a/docs/ui/components/Home/sections/DiscoverMore.tsx
+++ b/docs/ui/components/Home/sections/DiscoverMore.tsx
@@ -78,7 +78,7 @@ export function DiscoverMore() {
           <SnackImage />
           <RawH3 className="!font-bold !text-palette-orange11">Try Expo in your browser</RawH3>
           <P className="max-w-[24ch] !text-xs !text-palette-orange11">
-            Expo’s Snack lets you try Expo with zero local setup.
+            Expo's Snack lets you try Expo with zero local setup.
           </P>
           <HomeButton
             className={mergeClasses(

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -1,7 +1,7 @@
 import { mergeClasses } from '@expo/styleguide';
-import { AppleAppStoreIcon } from '@expo/styleguide-icons/custom/AppleAppStoreIcon';
-import { Cloud01DuotoneIcon } from '@expo/styleguide-icons/duotone/Cloud01DuotoneIcon';
 import { ArrowRightIcon } from '@expo/styleguide-icons/outline/ArrowRightIcon';
+import { ArrowUpRightIcon } from '@expo/styleguide-icons/outline/ArrowUpRightIcon';
+import { Rocket02Icon } from '@expo/styleguide-icons/outline/Rocket02Icon';
 
 import { GridContainer, GridCell, HomeButton } from '~/ui/components/Home/components';
 import { QuickStartIcon, DevicesImage } from '~/ui/components/Home/resources';
@@ -68,39 +68,26 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'min-h-[192px] bg-subtle bg-gradient-to-br from-subtle from-15% to-palette-purple3',
-            'selection:bg-palette-purple5'
+            'min-h-[192px] bg-gradient-to-br from-palette-black to-[#1a1a1a]',
+            'border border-palette-gray6 selection:bg-palette-gray8 dark:border-palette-gray7'
           )}>
-          <AppleAppStoreIcon className="absolute -bottom-16 -right-10 size-72 text-palette-purple10 opacity-10" />
+          <Rocket02Icon className="absolute -bottom-16 -right-10 size-72 text-palette-white opacity-5" />
           <div className="relative z-10 flex flex-col gap-4">
-            <h2 className="flex items-center gap-2 !font-bold !text-palette-purple10 heading-lg">
-              <AppleAppStoreIcon className="icon-lg text-palette-purple10" /> Deploy to TestFlight
+            <h2 className="flex items-center gap-2 !font-bold !text-palette-white heading-lg">
+              <Rocket02Icon className="icon-lg text-palette-white" /> Launch to App Store
             </h2>
             <div>
-              <Terminal cmd={['$ npx testflight']} className="asset-shadow rounded-md" />
-              <CALLOUT theme="secondary">
-                This is an iOS-only command that will upload your app to TestFlight.
-              </CALLOUT>
-            </div>
-          </div>
-        </GridCell>
-        <GridCell
-          className={mergeClasses(
-            'min-h-[192px] bg-subtle bg-gradient-to-br from-subtle from-15% to-palette-green3',
-            'selection:bg-palette-green4'
-          )}>
-          <Cloud01DuotoneIcon className="absolute -bottom-20 -right-8 size-80 text-[#1e8a5f] opacity-10 dark:text-[#4eca8c]" />
-          <div className="relative z-10 flex flex-col gap-4">
-            <h2 className="flex items-center gap-2 !font-bold !text-[#1e8a5f] heading-lg dark:!text-[#4eca8c]">
-              <Cloud01DuotoneIcon className="icon-lg text-[#1e8a5f] dark:text-[#4eca8c]" /> Deploy
-              your web app
-            </h2>
-            <div>
-              <Terminal cmd={['$ npx eas-cli deploy']} className="asset-shadow rounded-md" />
-              <CALLOUT theme="secondary">
-                For prerequisites and complete instructions, see{' '}
-                <A href="/deploy/web/#export-your-web-project/">our guide</A>.
-              </CALLOUT>
+              <P className="mb-3 !text-xs leading-relaxed !text-palette-gray7 dark:!text-palette-gray11">
+                Ship apps with zero config or no prior experience. Launch easily guides you through
+                the technical stuff, directly from GitHub.
+              </P>
+              <HomeButton
+                className="!relative !bottom-auto border-2 border-palette-white bg-palette-white font-semibold text-palette-black shadow-md hocus:border-palette-gray1 hocus:bg-palette-gray1 hocus:text-palette-black"
+                href="https://launch.expo.dev/"
+                target="_blank"
+                rightSlot={<ArrowUpRightIcon className="icon-md text-palette-black" />}>
+                Try Launch
+              </HomeButton>
             </div>
           </div>
         </GridCell>

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -68,8 +68,8 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'col-span-2 min-h-[192px] overflow-hidden bg-gradient-to-br from-[#faf7ff] via-[#f6f5ff] to-[#f0f2ff]',
-            'border border-[#faf9ff] selection:bg-palette-blue8',
+            'col-span-2 min-h-[192px] overflow-hidden bg-gradient-to-br from-[#F3E5F5] via-[#E3F2FD] to-[#E3F2FD]',
+            'border border-palette-gray7 selection:bg-palette-blue8',
             'dark:border-[#2d3748] dark:from-[#0a0a0a] dark:via-[#1a1a2e] dark:to-[#16213e]',
             'max-xl-gutters:col-span-1',
             'max-lg-gutters:col-span-2',

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -68,9 +68,12 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'min-h-[192px] bg-gradient-to-br from-palette-gray10 from-15% to-[#1a1a1a]',
+            'col-span-2 min-h-[192px] bg-gradient-to-br from-palette-gray10 from-15% to-[#1a1a1a]',
             'border border-palette-gray11 selection:bg-palette-gray8',
-            'dark:border-palette-gray7 dark:from-palette-gray3 dark:to-[#0a0a0a]'
+            'dark:border-palette-gray7 dark:from-palette-gray3 dark:to-[#0a0a0a]',
+            'max-xl-gutters:col-span-1',
+            'max-lg-gutters:col-span-2',
+            'max-md-gutters:col-span-1'
           )}>
           <div
             className={mergeClasses(

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -88,7 +88,7 @@ export function QuickStart() {
                 the technical stuff, directly from GitHub.
               </P>
               <HomeButton
-                className="!relative !bottom-auto border-2 border-palette-white bg-palette-white font-semibold text-palette-black shadow-md hocus:border-palette-gray1 hocus:bg-palette-gray1 hocus:text-palette-black"
+                className="!relative !bottom-auto border-2 border-palette-white bg-palette-white font-semibold text-palette-black shadow-md hocus:border-palette-gray1 hocus:bg-palette-gray1 hocus:text-palette-black dark:hocus:border-palette-gray11 dark:hocus:bg-palette-gray11 dark:hocus:text-palette-black"
                 href="https://launch.expo.dev/"
                 target="_blank"
                 rightSlot={<ArrowUpRightIcon className="icon-md text-palette-black" />}>

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -68,7 +68,7 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'min-h-[192px] bg-gradient-to-br from-palette-black to-[#1a1a1a]',
+            'min-h-[192px] bg-gradient-to-br from-palette-gray11 from-15% to-[#1a1a1a]',
             'border border-palette-gray6 selection:bg-palette-gray8 dark:border-palette-gray7'
           )}>
           <Rocket02Icon className="absolute -bottom-16 -right-10 size-72 text-palette-white opacity-5" />

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -68,8 +68,8 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'col-span-2 min-h-[192px] overflow-hidden bg-gradient-to-br from-[#0a0a0a] via-[#1a1a2e] to-[#16213e]',
-            'border border-[#2d3748] selection:bg-palette-blue8',
+            'col-span-2 min-h-[192px] overflow-hidden bg-gradient-to-br from-[#faf7ff] via-[#f6f5ff] to-[#f0f2ff]',
+            'border border-[#faf9ff] selection:bg-palette-blue8',
             'dark:border-[#2d3748] dark:from-[#0a0a0a] dark:via-[#1a1a2e] dark:to-[#16213e]',
             'max-xl-gutters:col-span-1',
             'max-lg-gutters:col-span-2',
@@ -77,29 +77,28 @@ export function QuickStart() {
           )}>
           <div
             className={mergeClasses(
-              'absolute inset-0 size-full rounded-lg bg-gradient-to-br from-palette-blue3 via-palette-purple3 to-palette-blue3 opacity-20'
+              'absolute inset-0 size-full rounded-lg bg-gradient-to-br from-palette-blue3 via-palette-purple3 to-palette-blue3 opacity-5',
+              'dark:from-palette-blue3 dark:via-palette-purple3 dark:to-palette-blue3 dark:opacity-20'
             )}
           />
           <div className="absolute inset-0 opacity-30">
-            <div className="absolute left-12 top-8 size-1 animate-pulse rounded-full bg-palette-white" />
-            <div className="absolute right-20 top-16 size-0.5 animate-pulse rounded-full bg-palette-blue8 delay-1000" />
-            <div className="absolute bottom-12 left-24 size-0.5 animate-pulse rounded-full bg-palette-white delay-500" />
-            <div className="absolute right-8 top-24 size-1 animate-pulse rounded-full bg-palette-blue7 delay-75" />
-            <div className="absolute bottom-8 right-32 size-0.5 animate-pulse rounded-full bg-palette-white delay-300" />
+            <div className="absolute left-12 top-8 size-1 animate-pulse rounded-full bg-palette-blue9 dark:bg-palette-white" />
+            <div className="absolute right-20 top-16 size-0.5 animate-pulse rounded-full bg-palette-purple8 delay-1000 dark:bg-palette-blue8" />
+            <div className="absolute bottom-12 left-24 size-0.5 animate-pulse rounded-full bg-palette-blue9 delay-500 dark:bg-palette-white" />
+            <div className="absolute right-8 top-24 size-1 animate-pulse rounded-full bg-palette-purple7 delay-75 dark:bg-palette-blue7" />
+            <div className="absolute bottom-8 right-32 size-0.5 animate-pulse rounded-full bg-palette-blue9 delay-300 dark:bg-palette-white" />
           </div>
-          <Rocket02Icon className="absolute -bottom-20 -right-12 size-80 rotate-12 text-palette-blue9 opacity-[0.03]" />
-          <div className="absolute -bottom-16 -right-16 size-64 rounded-full border border-palette-blue9 opacity-10" />
-          <div className="absolute -bottom-12 -right-12 size-56 rounded-full border border-palette-purple9 opacity-5" />
+          <Rocket02Icon className="absolute -bottom-20 -right-12 size-80 rotate-12 text-palette-blue9 opacity-[0.08] dark:opacity-[0.03]" />
 
           <div className="relative z-10 flex flex-col gap-4">
-            <h2 className="flex items-center gap-3 !font-bold !text-palette-white heading-lg">
+            <h2 className="flex items-center gap-3 !font-bold !text-palette-gray12 heading-lg dark:!text-palette-white">
               <div className="rounded-lg bg-gradient-to-br from-palette-blue9 to-palette-purple9 p-2 shadow-lg">
                 <Rocket02Icon className="icon-lg text-palette-white" />
               </div>
               Launch to app stores
             </h2>
             <div>
-              <P className="mb-4 max-w-[80ch] !text-sm leading-relaxed !text-palette-gray3 dark:!text-palette-blue11">
+              <P className="mb-4 max-w-[80ch] !text-sm leading-relaxed !text-palette-gray11 dark:!text-palette-blue11">
                 Ship apps with zero config or no prior experience. Launch easily guides you through
                 the technical stuff, directly from GitHub. No config or prior knowledge needed.
               </P>

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -68,10 +68,15 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'min-h-[192px] bg-gradient-to-br from-palette-gray11 from-15% to-[#1a1a1a]',
-            'border border-palette-gray6 selection:bg-palette-gray8',
+            'min-h-[192px] bg-gradient-to-br from-palette-gray10 from-15% to-[#1a1a1a]',
+            'border border-palette-gray11 selection:bg-palette-gray8',
             'dark:border-palette-gray7 dark:from-palette-gray3 dark:to-[#0a0a0a]'
           )}>
+          <div
+            className={mergeClasses(
+              'absolute inset-0 size-full rounded-lg bg-gradient-to-br from-transparent to-transparent'
+            )}
+          />
           <Rocket02Icon className="absolute -bottom-16 -right-10 size-72 text-palette-white opacity-5" />
           <div className="relative z-10 flex flex-col gap-4">
             <h2 className="flex items-center gap-2 !font-bold !text-palette-white heading-lg">

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -68,27 +68,40 @@ export function QuickStart() {
         </GridCell>
         <GridCell
           className={mergeClasses(
-            'col-span-2 min-h-[192px] bg-gradient-to-br from-palette-gray10 from-15% to-[#1a1a1a]',
-            'border border-palette-gray11 selection:bg-palette-gray8',
-            'dark:border-palette-gray7 dark:from-palette-gray3 dark:to-[#0a0a0a]',
+            'col-span-2 min-h-[192px] overflow-hidden bg-gradient-to-br from-[#0a0a0a] via-[#1a1a2e] to-[#16213e]',
+            'border border-[#2d3748] selection:bg-palette-blue8',
+            'dark:border-[#2d3748] dark:from-[#0a0a0a] dark:via-[#1a1a2e] dark:to-[#16213e]',
             'max-xl-gutters:col-span-1',
             'max-lg-gutters:col-span-2',
             'max-md-gutters:col-span-1'
           )}>
           <div
             className={mergeClasses(
-              'absolute inset-0 size-full rounded-lg bg-gradient-to-br from-transparent to-transparent'
+              'absolute inset-0 size-full rounded-lg bg-gradient-to-br from-palette-blue3 via-palette-purple3 to-palette-blue3 opacity-20'
             )}
           />
-          <Rocket02Icon className="absolute -bottom-16 -right-10 size-72 text-palette-white opacity-5" />
+          <div className="absolute inset-0 opacity-30">
+            <div className="absolute left-12 top-8 size-1 animate-pulse rounded-full bg-palette-white" />
+            <div className="absolute right-20 top-16 size-0.5 animate-pulse rounded-full bg-palette-blue8 delay-1000" />
+            <div className="absolute bottom-12 left-24 size-0.5 animate-pulse rounded-full bg-palette-white delay-500" />
+            <div className="absolute right-8 top-24 size-1 animate-pulse rounded-full bg-palette-blue7 delay-75" />
+            <div className="absolute bottom-8 right-32 size-0.5 animate-pulse rounded-full bg-palette-white delay-300" />
+          </div>
+          <Rocket02Icon className="absolute -bottom-20 -right-12 size-80 rotate-12 text-palette-blue9 opacity-[0.03]" />
+          <div className="absolute -bottom-16 -right-16 size-64 rounded-full border border-palette-blue9 opacity-10" />
+          <div className="absolute -bottom-12 -right-12 size-56 rounded-full border border-palette-purple9 opacity-5" />
+
           <div className="relative z-10 flex flex-col gap-4">
-            <h2 className="flex items-center gap-2 !font-bold !text-palette-white heading-lg">
-              <Rocket02Icon className="icon-lg text-palette-white" /> Launch to App Store
+            <h2 className="flex items-center gap-3 !font-bold !text-palette-white heading-lg">
+              <div className="rounded-lg bg-gradient-to-br from-palette-blue9 to-palette-purple9 p-2 shadow-lg">
+                <Rocket02Icon className="icon-lg text-palette-white" />
+              </div>
+              Launch to app stores
             </h2>
             <div>
-              <P className="mb-3 !text-xs leading-relaxed !text-palette-gray7 dark:!text-palette-gray11">
+              <P className="mb-4 max-w-[80ch] !text-sm leading-relaxed !text-palette-gray3 dark:!text-palette-blue11">
                 Ship apps with zero config or no prior experience. Launch easily guides you through
-                the technical stuff, directly from GitHub.
+                the technical stuff, directly from GitHub. No config or prior knowledge needed.
               </P>
               <HomeButton
                 className="!relative !bottom-auto border-2 border-palette-white bg-palette-white font-semibold text-palette-black shadow-md hocus:border-palette-gray1 hocus:bg-palette-gray1 hocus:text-palette-black dark:hocus:border-palette-gray11 dark:hocus:bg-palette-gray11 dark:hocus:text-palette-black"

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -69,7 +69,8 @@ export function QuickStart() {
         <GridCell
           className={mergeClasses(
             'min-h-[192px] bg-gradient-to-br from-palette-gray11 from-15% to-[#1a1a1a]',
-            'border border-palette-gray6 selection:bg-palette-gray8 dark:border-palette-gray7'
+            'border border-palette-gray6 selection:bg-palette-gray8',
+            'dark:border-palette-gray7 dark:from-palette-gray3 dark:to-[#0a0a0a]'
           )}>
           <Rocket02Icon className="absolute -bottom-16 -right-10 size-72 text-palette-white opacity-5" />
           <div className="relative z-10 flex flex-col gap-4">

--- a/docs/ui/components/Home/sections/index.ts
+++ b/docs/ui/components/Home/sections/index.ts
@@ -1,4 +1,5 @@
 export * from './QuickStart';
+export * from './CommandLineTools';
 export * from './DiscoverMore';
 export * from './ExploreAPIs';
 export * from './Talks';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17106

# How

<!--
How did you build this feature or fix this bug and why?
-->

* The "Quick Start" section now adds the Expo Launch, with a call-to-action button linking to the Launch site. 
* A new "Command Line Tools" section has been added, highlighting CLI-based deployment for iOS (TestFlight) and web platforms.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview.

## Preview

<img width="2368" height="476" alt="CleanShot 2025-09-11 at 20 28 47@2x" src="https://github.com/user-attachments/assets/ff18355e-6e06-4115-a2ab-8b3f7d083c64" />

<img width="2286" height="470" alt="CleanShot 2025-09-11 at 20 28 53@2x" src="https://github.com/user-attachments/assets/d13e96fa-a95a-45bf-b46a-31662fd11b5c" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
