### PR TITLE
[file-system] Add minimal web stub to fix broken import on web

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Add minimal web stub to fix broken imports on web
+- Add minimal web stub to fix broken imports on web ([#39400](https://github.com/expo/expo/pull/39400) by [@LeonDvlpmnt](https://github.com/LeonDvlpmnt))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add minimal web stub to fix broken imports on web
+
 ### 💡 Others
 
 ## 19.0.9 — 2025-09-03

--- a/packages/expo-file-system/build/ExpoFileSystem.web.d.ts
+++ b/packages/expo-file-system/build/ExpoFileSystem.web.d.ts
@@ -1,18 +1,20 @@
 declare class FileSystemFile {
+    constructor();
 }
 declare class FileSystemDirectory {
+    constructor();
 }
 declare const _default: {
     FileSystemDirectory: typeof FileSystemDirectory;
     FileSystemFile: typeof FileSystemFile;
-    downloadFileAsync: () => Promise<void>;
-    pickDirectoryAsync: () => Promise<void>;
-    pickFileAsync: () => Promise<void>;
-    totalDiskSpace: number;
-    availableDiskSpace: number;
-    documentDirectory: string;
-    cacheDirectory: string;
-    bundleDirectory: string;
+    downloadFileAsync: () => Promise<never>;
+    pickDirectoryAsync: () => Promise<never>;
+    pickFileAsync: () => Promise<never>;
+    readonly totalDiskSpace: number;
+    readonly availableDiskSpace: number;
+    readonly documentDirectory: string;
+    readonly cacheDirectory: string;
+    readonly bundleDirectory: string;
 };
 export default _default;
 //# sourceMappingURL=ExpoFileSystem.web.d.ts.map

--- a/packages/expo-file-system/build/ExpoFileSystem.web.d.ts
+++ b/packages/expo-file-system/build/ExpoFileSystem.web.d.ts
@@ -7,9 +7,9 @@ declare class FileSystemDirectory {
 declare const _default: {
     FileSystemDirectory: typeof FileSystemDirectory;
     FileSystemFile: typeof FileSystemFile;
-    downloadFileAsync: () => Promise<never>;
-    pickDirectoryAsync: () => Promise<never>;
-    pickFileAsync: () => Promise<never>;
+    downloadFileAsync: () => Promise<void>;
+    pickDirectoryAsync: () => Promise<void>;
+    pickFileAsync: () => Promise<void>;
     readonly totalDiskSpace: number;
     readonly availableDiskSpace: number;
     readonly documentDirectory: string;

--- a/packages/expo-file-system/build/ExpoFileSystem.web.d.ts
+++ b/packages/expo-file-system/build/ExpoFileSystem.web.d.ts
@@ -1,0 +1,18 @@
+declare class FileSystemFile {
+}
+declare class FileSystemDirectory {
+}
+declare const _default: {
+    FileSystemDirectory: typeof FileSystemDirectory;
+    FileSystemFile: typeof FileSystemFile;
+    downloadFileAsync: () => Promise<void>;
+    pickDirectoryAsync: () => Promise<void>;
+    pickFileAsync: () => Promise<void>;
+    totalDiskSpace: number;
+    availableDiskSpace: number;
+    documentDirectory: string;
+    cacheDirectory: string;
+    bundleDirectory: string;
+};
+export default _default;
+//# sourceMappingURL=ExpoFileSystem.web.d.ts.map

--- a/packages/expo-file-system/build/ExpoFileSystem.web.d.ts.map
+++ b/packages/expo-file-system/build/ExpoFileSystem.web.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"ExpoFileSystem.web.d.ts","sourceRoot":"","sources":["../src/ExpoFileSystem.web.ts"],"names":[],"mappings":"AAAA,cAAM,cAAc;CAAG;AAEvB,cAAM,mBAAmB;CAAG;;;;;;;;;;;;;AAE5B,wBAWE"}

--- a/packages/expo-file-system/build/ExpoFileSystem.web.d.ts.map
+++ b/packages/expo-file-system/build/ExpoFileSystem.web.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ExpoFileSystem.web.d.ts","sourceRoot":"","sources":["../src/ExpoFileSystem.web.ts"],"names":[],"mappings":"AAAA,cAAM,cAAc;CAAG;AAEvB,cAAM,mBAAmB;CAAG;;;;;;;;;;;;;AAE5B,wBAWE"}
+{"version":3,"file":"ExpoFileSystem.web.d.ts","sourceRoot":"","sources":["../src/ExpoFileSystem.web.ts"],"names":[],"mappings":"AAAA,cAAM,cAAc;;CAInB;AAED,cAAM,mBAAmB;;CAIxB;;;;;;;6BAQuB,MAAM;iCAGF,MAAM;gCAGP,MAAM;6BAGT,MAAM;8BAGL,MAAM;;AAlB/B,wBAqBE"}

--- a/packages/expo-file-system/build/ExpoFileSystem.web.d.ts.map
+++ b/packages/expo-file-system/build/ExpoFileSystem.web.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ExpoFileSystem.web.d.ts","sourceRoot":"","sources":["../src/ExpoFileSystem.web.ts"],"names":[],"mappings":"AAAA,cAAM,cAAc;;CAInB;AAED,cAAM,mBAAmB;;CAIxB;;;;;;;6BAQuB,MAAM;iCAGF,MAAM;gCAGP,MAAM;6BAGT,MAAM;8BAGL,MAAM;;AAlB/B,wBAqBE"}
+{"version":3,"file":"ExpoFileSystem.web.d.ts","sourceRoot":"","sources":["../src/ExpoFileSystem.web.ts"],"names":[],"mappings":"AAAA,cAAM,cAAc;;CAInB;AAED,cAAM,mBAAmB;;CAIxB;;;;;;;6BAiBuB,MAAM;iCAIF,MAAM;gCAIP,MAAM;6BAIT,MAAM;8BAIL,MAAM;;AA/B/B,wBAmCE"}

--- a/packages/expo-file-system/src/ExpoFileSystem.web.ts
+++ b/packages/expo-file-system/src/ExpoFileSystem.web.ts
@@ -1,34 +1,48 @@
 class FileSystemFile {
   constructor() {
-    throw new Error('FileSystem is not supported on web');
+    console.warn('expo-file-system is not supported on web');
   }
 }
 
 class FileSystemDirectory {
   constructor() {
-    throw new Error('FileSystem is not supported on web');
+    console.warn('expo-file-system is not supported on web');
   }
 }
 
 export default {
   FileSystemDirectory,
   FileSystemFile,
-  downloadFileAsync: () => Promise.reject(new Error('FileSystem is not supported on web')),
-  pickDirectoryAsync: () => Promise.reject(new Error('FileSystem is not supported on web')),
-  pickFileAsync: () => Promise.reject(new Error('FileSystem is not supported on web')),
+  downloadFileAsync: () => {
+    console.warn('expo-file-system is not supported on web');
+    return Promise.resolve();
+  },
+  pickDirectoryAsync: () => {
+    console.warn('expo-file-system is not supported on web');
+    return Promise.resolve();
+  },
+  pickFileAsync: () => {
+    console.warn('expo-file-system is not supported on web');
+    return Promise.resolve();
+  },
   get totalDiskSpace(): number {
-    throw new Error('FileSystem is not supported on web');
+    console.warn('expo-file-system is not supported on web');
+    return 0;
   },
   get availableDiskSpace(): number {
-    throw new Error('FileSystem is not supported on web');
+    console.warn('expo-file-system is not supported on web');
+    return 0;
   },
   get documentDirectory(): string {
-    throw new Error('FileSystem is not supported on web');
+    console.warn('expo-file-system is not supported on web');
+    return '';
   },
   get cacheDirectory(): string {
-    throw new Error('FileSystem is not supported on web');
+    console.warn('expo-file-system is not supported on web');
+    return '';
   },
   get bundleDirectory(): string {
-    throw new Error('FileSystem is not supported on web');
+    console.warn('expo-file-system is not supported on web');
+    return '';
   },
 };

--- a/packages/expo-file-system/src/ExpoFileSystem.web.ts
+++ b/packages/expo-file-system/src/ExpoFileSystem.web.ts
@@ -1,0 +1,16 @@
+class FileSystemFile {}
+
+class FileSystemDirectory {}
+
+export default {
+  FileSystemDirectory,
+  FileSystemFile,
+  downloadFileAsync: () => Promise.resolve(),
+  pickDirectoryAsync: () => Promise.resolve(),
+  pickFileAsync: () => Promise.resolve(),
+  totalDiskSpace: 0,
+  availableDiskSpace: 0,
+  documentDirectory: '',
+  cacheDirectory: '',
+  bundleDirectory: '',
+};

--- a/packages/expo-file-system/src/ExpoFileSystem.web.ts
+++ b/packages/expo-file-system/src/ExpoFileSystem.web.ts
@@ -1,16 +1,34 @@
-class FileSystemFile {}
+class FileSystemFile {
+  constructor() {
+    throw new Error('FileSystem is not supported on web');
+  }
+}
 
-class FileSystemDirectory {}
+class FileSystemDirectory {
+  constructor() {
+    throw new Error('FileSystem is not supported on web');
+  }
+}
 
 export default {
   FileSystemDirectory,
   FileSystemFile,
-  downloadFileAsync: () => Promise.resolve(),
-  pickDirectoryAsync: () => Promise.resolve(),
-  pickFileAsync: () => Promise.resolve(),
-  totalDiskSpace: 0,
-  availableDiskSpace: 0,
-  documentDirectory: '',
-  cacheDirectory: '',
-  bundleDirectory: '',
+  downloadFileAsync: () => Promise.reject(new Error('FileSystem is not supported on web')),
+  pickDirectoryAsync: () => Promise.reject(new Error('FileSystem is not supported on web')),
+  pickFileAsync: () => Promise.reject(new Error('FileSystem is not supported on web')),
+  get totalDiskSpace(): number {
+    throw new Error('FileSystem is not supported on web');
+  },
+  get availableDiskSpace(): number {
+    throw new Error('FileSystem is not supported on web');
+  },
+  get documentDirectory(): string {
+    throw new Error('FileSystem is not supported on web');
+  },
+  get cacheDirectory(): string {
+    throw new Error('FileSystem is not supported on web');
+  },
+  get bundleDirectory(): string {
+    throw new Error('FileSystem is not supported on web');
+  },
 };


### PR DESCRIPTION
# Why

When importing the filesystem classes on web it would throw the following error: `Class extends value undefined is not a constructor or null`. This is because the `File` and `Directory` classes are extending classes that are only available on the native side.

This was issue was reported on [discord](https://discord.com/channels/695411232856997968/1412790000659202048). 

# How

Added a very minimal web stub. For now it doesn't even throw any errors that web isn't supported.

# Test Plan

Tested locally in the sandbox app

# Checklist
- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
