### PR TITLE
[doctor] Remove internal packages from RN Directory check output

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Remove `expo-dev-launcher`, `expo-dev-menu`, `expo-dev-menu-interface`, `expo-updates-interface`, and `expo-eas-client` to ignore RN Directory packages ([#39409](https://github.com/expo/expo/pull/39409) by [@kitten](https://github.com/kitten))
+
 ## 1.17.5 — 2025-09-04
 
 ### 💡 Others

--- a/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts
+++ b/packages/expo-doctor/src/checks/ReactNativeDirectoryCheck.ts
@@ -26,6 +26,11 @@ export const DEFAULT_PACKAGES_TO_IGNORE = [
   /^@expo\/.*$/,
   /^@expo-google-fonts\/.*$/,
   /^@types\/.*$/,
+  'expo-dev-launcher',
+  'expo-dev-menu',
+  'expo-dev-menu-interface',
+  'expo-updates-interface',
+  'expo-eas-client',
 ];
 
 export function filterPackages(packages: string[], ignoredPackages: (RegExp | string)[]) {


### PR DESCRIPTION
# Why

Some internal packages aren't on the `@expo/*` scope (maybe they should be moved?). They're still included in the React Native directory check however.

# How

Add internal packages to the ignore list for RN Directory.

# Test Plan

- Run `expo-doctor` in `bluesky-social/social-app`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
