### PR TITLE
Add missing double quote

### DIFF
--- a/docs/pages/versions/unversioned/sdk/background-task.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-task.mdx
@@ -208,7 +208,9 @@ function App() {
 
 To troubleshoot or debug issues with background tasks on Android, use the `adb` tool included with the Android SDK to inspect scheduled tasks:
 
-<Terminal cmd={['$ adb shell dumpsys jobscheduler | grep -A 40 -m 1 -E "JOB #.* <package-name>"']} />
+<Terminal
+  cmd={['$ adb shell dumpsys jobscheduler | grep -A 40 -m 1 -E "JOB #.* <package-name>"']}
+/>
 
 The output from this command will show you the scheduled tasks for your app, including their status, constraints, and other information. Look for the `JOB` line to find the ID of the job and other details in the output:
 

--- a/docs/pages/versions/unversioned/sdk/background-task.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-task.mdx
@@ -208,7 +208,7 @@ function App() {
 
 To troubleshoot or debug issues with background tasks on Android, use the `adb` tool included with the Android SDK to inspect scheduled tasks:
 
-<Terminal cmd={['$ adb shell dumpsys jobscheduler | grep -A 40 -m 1 -E "JOB #.* <package-name>']} />
+<Terminal cmd={['$ adb shell dumpsys jobscheduler | grep -A 40 -m 1 -E "JOB #.* <package-name>"']} />
 
 The output from this command will show you the scheduled tasks for your app, including their status, constraints, and other information. Look for the `JOB` line to find the ID of the job and other details in the output:
 


### PR DESCRIPTION
# Why

<!-- -->
The command here https://docs.expo.dev/versions/latest/sdk/background-task/#inspecting-background-tasks is missing the double quote at the end. And when run this command as it, result like below. Runs fine when added missing double quote

adb shell dumpsys jobscheduler | grep -A 40 -m 1 -E "JOB #.* app.debug  
pipe dquote>


# How

<!-- -->
The command in the website should be 
adb shell dumpsys jobscheduler | grep -A 40 -m 1 -E "JOB #.* app.debug"


# Test Plan

<!-- -->
Can simply check the website here https://docs.expo.dev/versions/latest/sdk/background-task/#inspecting-background-tasks for the missing double quote


# Checklist

<!-- -->
Please check the appropriate items below if they apply to your diff.


- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
