### PR TITLE
[bare-expo] migrate js stack navigators to native stack

### DIFF
--- a/apps/bare-expo/MainNavigator.tsx
+++ b/apps/bare-expo/MainNavigator.tsx
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { LinkingOptions, NavigationContainer } from '@react-navigation/native';
-import { createStackNavigator } from '@react-navigation/stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTheme } from 'ThemeProvider';
 import * as Linking from 'expo-linking';
 import { StatusBar } from 'expo-status-bar';
@@ -59,7 +59,7 @@ if (NativeComponentList) {
 }
 
 const Tab = createBottomTabNavigator();
-const Switch = createStackNavigator();
+const Switch = createNativeStackNavigator();
 
 const linking: LinkingOptions<object> = {
   prefixes: [

--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -1,5 +1,5 @@
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
-import { createStackNavigator } from '@react-navigation/stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTheme } from 'ThemeProvider';
 import * as React from 'react';
 
@@ -15,7 +15,7 @@ import ExpoApis from '../screens/ExpoApisScreen';
 import { ModulesCoreScreens } from '../screens/ModulesCore/ModulesCoreScreen';
 import { type ScreenApiItem, type ScreenConfig } from '../types/ScreenConfig';
 
-const Stack = createStackNavigator();
+const Stack = createNativeStackNavigator();
 
 export const ScreensList: ScreenConfig[] = [
   {

--- a/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoComponentsStackNavigator.tsx
@@ -1,5 +1,5 @@
 import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
-import { createStackNavigator } from '@react-navigation/stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTheme } from 'ThemeProvider';
 import * as React from 'react';
 
@@ -18,7 +18,7 @@ import { UIScreens } from '../screens/UI/UIScreen';
 import { VideoScreens } from '../screens/Video/VideoScreen';
 import { type ScreenApiItem, type ScreenConfig } from '../types/ScreenConfig';
 
-const Stack = createStackNavigator();
+const Stack = createNativeStackNavigator();
 
 const ScreensList: ScreenConfig[] = [
   {

--- a/apps/native-component-list/src/navigation/RootNavigation.tsx
+++ b/apps/native-component-list/src/navigation/RootNavigation.tsx
@@ -1,5 +1,5 @@
 import { LinkingOptions, NavigationContainer } from '@react-navigation/native';
-import { createStackNavigator } from '@react-navigation/stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as Linking from 'expo-linking';
 import * as React from 'react';
 import { Text } from 'react-native';
@@ -10,7 +10,7 @@ import MainTabNavigator from './MainTabNavigator';
 import RedirectScreen from '../screens/RedirectScreen';
 import SearchScreen from '../screens/SearchScreen';
 
-const Switch = createStackNavigator();
+const Switch = createNativeStackNavigator();
 
 export const linking: LinkingOptions<object> = {
   prefixes: [Linking.createURL('/')],
@@ -39,11 +39,7 @@ export default function RootNavigation() {
         <Switch.Navigator screenOptions={{ presentation: 'modal', headerShown: false }}>
           <Switch.Screen name="main" component={MainTabNavigator} />
           <Switch.Screen name="redirect" component={RedirectScreen} />
-          <Switch.Screen
-            name="searchNavigator"
-            component={SearchScreen}
-            options={{ cardStyle: { backgroundColor: 'transparent' } }}
-          />
+          <Switch.Screen name="searchNavigator" component={SearchScreen} />
         </Switch.Navigator>
       </NavigationContainer>
     </GestureHandlerRootView>

--- a/apps/native-component-list/src/navigation/StackConfig.tsx
+++ b/apps/native-component-list/src/navigation/StackConfig.tsx
@@ -51,9 +51,10 @@ const HeaderRightComponent = ({
       style={{
         flexDirection: 'row',
         alignItems: 'center',
-        marginRight: 16,
+        marginHorizontal: 10,
         marginBottom: 4,
-        gap: 14,
+        marginTop: 4,
+        gap: 20,
       }}>
       <TouchableOpacity
         onPress={() => {

--- a/apps/native-component-list/src/screens/Screens/index.tsx
+++ b/apps/native-component-list/src/screens/Screens/index.tsx
@@ -1,4 +1,7 @@
-import { createStackNavigator, StackNavigationProp } from '@react-navigation/stack';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from '@react-navigation/native-stack';
 import React from 'react';
 import { FlatList, StyleSheet, Text, TouchableHighlight, View } from 'react-native';
 
@@ -14,7 +17,7 @@ const SCREENS: Record<string, { component: any; options: { title: string } }> = 
 
 type Links = { Container: undefined; NativeStack: undefined; Navigation: undefined };
 
-type Props = { navigation: StackNavigationProp<Links> };
+type Props = { navigation: NativeStackNavigationProp<Links> };
 
 class MainScreen extends React.Component<Props> {
   static navigationOptions = {
@@ -59,8 +62,8 @@ class MainScreenItem extends React.Component<{
   }
 }
 
-const Stack = createStackNavigator();
-const SwitchStack = createStackNavigator();
+const Stack = createNativeStackNavigator();
+const SwitchStack = createNativeStackNavigator();
 
 const ExampleApp = () => (
   <SwitchStack.Navigator initialRouteName="Main" screenOptions={{ headerShown: false }}>

--- a/apps/native-component-list/src/screens/Screens/navigation/index.tsx
+++ b/apps/native-component-list/src/screens/Screens/navigation/index.tsx
@@ -1,8 +1,6 @@
-import { createStackNavigator, StackScreenProps } from '@react-navigation/stack';
+import { createNativeStackNavigator, NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as React from 'react';
 import { Animated, Button, Image, StyleSheet, TextInput, View } from 'react-native';
-
-export { default as LifecycleAwareView } from './LifecycleAwareView';
 
 const IMGS = [
   require('./img/dawid-zawila-628275-unsplash.jpg'),
@@ -26,7 +24,7 @@ const Background: React.FunctionComponent<{ index: number }> = ({ index }) => (
 
 type Links = { Details: undefined | { index?: number } };
 
-type Props = StackScreenProps<Links, 'Details'>;
+type Props = NativeStackScreenProps<Links, 'Details'>;
 
 class DetailsScreen extends React.Component<Props, { count: number; text: string }> {
   animvalue = new Animated.Value(0);
@@ -83,7 +81,7 @@ class DetailsScreen extends React.Component<Props, { count: number; text: string
   }
 }
 
-const Stack = createStackNavigator();
+const Stack = createNativeStackNavigator();
 
 const App = () => (
   <Stack.Navigator>

--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -1,5 +1,5 @@
 import { HeaderBackButton } from '@react-navigation/elements';
-import { createStackNavigator, StackScreenProps } from '@react-navigation/stack';
+import { createNativeStackNavigator, NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useTheme } from 'ThemeProvider';
 import Fuse from 'fuse.js';
 import React from 'react';
@@ -57,7 +57,7 @@ function Header({
   );
 }
 
-function SearchScreen({ route }: StackScreenProps<SearchStack, 'search'>) {
+function SearchScreen({ route }: NativeStackScreenProps<SearchStack, 'search'>) {
   const query = route?.params?.q ?? '';
 
   const apis = React.useMemo(() => fuse.search(query).map(({ item }) => item), [query]);
@@ -76,7 +76,7 @@ type SearchStack = {
   search: { q?: string };
 };
 
-const Stack = createStackNavigator<SearchStack>();
+const Stack = createNativeStackNavigator<SearchStack>();
 
 export default function SearchScreenStack() {
   const { theme } = useTheme();

--- a/apps/native-component-list/src/screens/TextToSpeechScreen.tsx
+++ b/apps/native-component-list/src/screens/TextToSpeechScreen.tsx
@@ -1,4 +1,4 @@
-import { Picker as ExPicker } from '@expo/ui/swift-ui';
+import { Picker as ExPicker, Host } from '@expo/ui/swift-ui';
 import { Picker } from '@react-native-picker/picker';
 import * as Speech from 'expo-speech';
 import * as React from 'react';
@@ -148,19 +148,21 @@ export default class TextToSpeechScreen extends React.Component<object, State> {
           <>
             <Text>useApplicationAudioSession</Text>
             <View style={styles.controlRow}>
-              <ExPicker
-                variant="segmented"
-                options={audioSessionOptions.map((option) => option.label)}
-                selectedIndex={audioSessionOptions.findIndex(
-                  (option) => option.value === this.state.useApplicationAudioSession
-                )}
-                onOptionSelected={({ nativeEvent: { index } }) => {
-                  const useApplicationAudioSession = audioSessionOptions[index].value;
-                  this.setState({
-                    useApplicationAudioSession,
-                  });
-                }}
-              />
+              <Host>
+                <ExPicker
+                  variant="segmented"
+                  options={audioSessionOptions.map((option) => option.label)}
+                  selectedIndex={audioSessionOptions.findIndex(
+                    (option) => option.value === this.state.useApplicationAudioSession
+                  )}
+                  onOptionSelected={({ nativeEvent: { index } }) => {
+                    const useApplicationAudioSession = audioSessionOptions[index].value;
+                    this.setState({
+                      useApplicationAudioSession,
+                    });
+                  }}
+                />
+              </Host>
             </View>
           </>
         )}

--- a/apps/test-suite/AppNavigator.js
+++ b/apps/test-suite/AppNavigator.js
@@ -1,5 +1,5 @@
 import MaterialCommunityIcons from '@expo/vector-icons/build/MaterialCommunityIcons';
-import { createStackNavigator } from '@react-navigation/stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 
@@ -11,7 +11,7 @@ import ThemeToggler from '../common/ThemeToggler';
 // @tsapeta: This navigator is also being used by `bare-expo` app,
 // so make sure it still works there once you change something here.
 
-const Stack = createStackNavigator();
+const Stack = createNativeStackNavigator();
 
 const spec = {
   animation: 'timing',
@@ -56,9 +56,8 @@ export default function AppNavigator(props) {
               style={{
                 flexDirection: 'row',
                 alignItems: 'center',
-                marginRight: 16,
-                marginBottom: 4,
-                gap: 12,
+                justifyContent: 'center',
+                marginHorizontal: 10,
               }}>
               <ThemeToggler />
             </View>


### PR DESCRIPTION
# Why

Migrated all stacks in bare expo to use native stack, as it's the preferred way to do define navigation stacks. We should be using & testing these instead of the JS implementation. 

Maybe we could also use native tabs.

I'll do the same for expo go.

# How

change `createStackNavigator` for `createNativeStackNavigator`

# Test Plan

- tested locally
- green e2e tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
