### PR TITLE
[docs] Add --max-warnings flag to ESLint tool for docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
     "export": "yarn generate-static-resources production && yarn versions-schema-sync && yarn append-last-modified-dates && yarn run build",
     "export-preview": "yarn generate-static-resources preview && yarn versions-schema-sync && yarn append-last-modified-dates && yarn run build",
     "export-server": "http-server out -p 8000",
-    "lint": "tsc --noEmit && node scripts/lint.js",
+    "lint": "tsc --noEmit && node scripts/lint.js --max-warnings 0",
     "lint-links": "remark -u validate-links ./pages",
     "lint-prose": "yarn vale .",
     "watch": "tsc --noEmit -w",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-16945

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update `lint` script in `package.json` file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn lint` and there should be no warnings.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
