### PR TITLE
[expo][iOS] Remove bindReactNativeFactory

### DIFF
--- a/apps/bare-expo/ios/AppDelegate.swift
+++ b/apps/bare-expo/ios/AppDelegate.swift
@@ -23,7 +23,6 @@ public class AppDelegate: ExpoAppDelegate {
 
     reactNativeDelegate = delegate
     reactNativeFactory = factory
-    bindReactNativeFactory(factory)
 
 #if os(iOS) || os(tvOS)
     window = UIWindow(frame: UIScreen.main.bounds)

--- a/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
+++ b/apps/bare-expo/macos/BareExpo-macOS/AppDelegate.swift
@@ -16,7 +16,6 @@ public class AppDelegate: ExpoAppDelegate {
 
     reactNativeDelegate = delegate
     reactNativeFactory = factory
-    bindReactNativeFactory(factory)
 
     let launchOptions = notification.userInfo
     window = UIWindow(

--- a/apps/expo-go/ios/Client/AppDelegate.swift
+++ b/apps/expo-go/ios/Client/AppDelegate.swift
@@ -21,7 +21,6 @@ class AppDelegate: ExpoAppDelegate {
 
     reactNativeDelegate = delegate
     reactNativeFactory = factory
-    bindReactNativeFactory(factory)
 
     FirebaseApp.configure()
 

--- a/apps/paper-tester/ios/AppDelegate.swift
+++ b/apps/paper-tester/ios/AppDelegate.swift
@@ -19,7 +19,6 @@ public class AppDelegate: ExpoAppDelegate {
 
     reactNativeDelegate = delegate
     reactNativeFactory = factory
-    bindReactNativeFactory(factory)
 
 #if os(iOS) || os(tvOS)
     window = UIWindow(frame: UIScreen.main.bounds)

--- a/packages/expo-updates/e2e/fixtures/custom_init/AppDelegate.swift
+++ b/packages/expo-updates/e2e/fixtures/custom_init/AppDelegate.swift
@@ -56,7 +56,6 @@ class AppDelegate: ExpoAppDelegate {
 
     reactNativeDelegate = delegate
     reactNativeFactory = factory
-    bindReactNativeFactory(factory)
 
     // AppController instance must always be created first.
     // expo-updates creates a different type of controller

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Remove `ExpoAppDelegate` inheritance requirement in ExpoReactNativeFactory ([#39417](https://github.com/expo/expo/pull/39417) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Remove bindReactNativeFactory function ([#39418](https://github.com/expo/expo/pull/39418) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -51,7 +51,7 @@
 }
 #else
 - (void)applicationDidFinishLaunching:(NSNotification *)notification
-{ 
+{
   return [_expoAppDelegate applicationDidFinishLaunching:notification];
 }
 
@@ -60,16 +60,6 @@
   return [_expoAppDelegate applicationDidBecomeActive:notification];
 }
 #endif
-
-- (UIViewController *)createRootViewController
-{
-  return [_expoAppDelegate.factory.delegate createRootViewController];
-}
-
-- (void)customizeRootView:(UIView *)rootView
-{
-  [_expoAppDelegate.factory.delegate customizeRootView:rootView];
-}
 
 #pragma mark - RCTComponentViewFactoryComponentProvider
 
@@ -91,16 +81,6 @@
                    isFatal:(BOOL)isFatal
 {
 }
-
-- (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
-{
-  return [_expoAppDelegate.factory.delegate getModuleInstanceFromClass:moduleClass];
-}
-
-- (Class)getModuleClassFromName:(const char *)name {
-  return [_expoAppDelegate.factory.delegate getModuleClassFromName:name];
-}
-
 
 #pragma mark - Helpers
 

--- a/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppDelegate.swift
@@ -12,12 +12,6 @@ import ReactAppDependencyProvider
  */
 @objc(EXExpoAppDelegate)
 open class ExpoAppDelegate: NSObject, UIApplicationDelegate {
-  @objc public var factory: RCTReactNativeFactory?
-
-  public func bindReactNativeFactory(_ factory: RCTReactNativeFactory) {
-    self.factory = factory
-  }
-
   // MARK: - Initializing the App
 #if os(iOS) || os(tvOS)
 

--- a/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn079-updated.swift
+++ b/packages/install-expo-modules/src/plugins/ios/__tests__/fixtures/AppDelegate-rn079-updated.swift
@@ -21,7 +21,6 @@ class AppDelegate: ExpoAppDelegate {
 
     reactNativeDelegate = delegate
     reactNativeFactory = factory
-    bindReactNativeFactory(factory)
 
     window = UIWindow(frame: UIScreen.main.bounds)
 

--- a/packages/install-expo-modules/src/plugins/ios/withIosModulesAppDelegate.ts
+++ b/packages/install-expo-modules/src/plugins/ios/withIosModulesAppDelegate.ts
@@ -158,14 +158,6 @@ export function updateModulesAppDelegateSwift(
     /\b(func application\([\s\S]+?didFinishLaunchingWithOptions launchOptions[\s\S]+?\{[\s\S]+?)(return true)([\s\S]+?\})/m,
     'override $1return super.application(application, didFinishLaunchingWithOptions: launchOptions)$3'
   );
-  // Add `bindReactNativeFactory`
-  if (!contents.match(/\bbindReactNativeFactory\(/)) {
-    contents = contents.replace(
-      /(\breactNativeFactory\s+?=\s+?factory$)/m,
-      `$1
-    bindReactNativeFactory(factory)`
-    );
-  }
 
   // Use Expo classes
   contents = contents.replace(/\b(RCTReactNativeFactory)(\()/, 'ExpoReactNativeFactory$2');

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift
@@ -19,7 +19,6 @@ public class AppDelegate: ExpoAppDelegate {
 
     reactNativeDelegate = delegate
     reactNativeFactory = factory
-    bindReactNativeFactory(factory)
 
 #if os(iOS) || os(tvOS)
     window = UIWindow(frame: UIScreen.main.bounds)


### PR DESCRIPTION
# Why

With the `recreateRootView` function now inside ExpoReactNativeFactory, we no longer need to access reactNativeFactory inside from ExpoAppDelegate.swift, allowing us to remove the bindReactNativeFactory function, further aligning our template with RNCore.

# How

Remove `bindReactNativeFactory` function

# Test Plan

Run BareExpo locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
