### PR TITLE
[ios][location] remove geofencing background location requirement

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Remove UIBackgroundMode location requirement for geofencing. [#39419](https://github.com/expo/expo/pull/39419)
+
 ### 💡 Others
 
 ## 19.0.6 — 2025-09-02

--- a/packages/expo-location/ios/LocationModule.swift
+++ b/packages/expo-location/ios/LocationModule.swift
@@ -201,9 +201,6 @@ public final class LocationModule: Module {
       guard CLLocationManager.isMonitoringAvailable(for: CLCircularRegion.self) else {
         throw Exceptions.GeofencingUnavailable()
       }
-      guard try taskManager.hasBackgroundModeEnabled("location") else {
-        throw Exceptions.LocationUpdatesUnavailable()
-      }
 
       try taskManager.registerTask(withName: taskName, consumer: EXGeofencingTaskConsumer.self, options: options)
     }

--- a/packages/expo-location/ios/TaskConsumers/EXGeofencingTaskConsumer.m
+++ b/packages/expo-location/ios/TaskConsumers/EXGeofencingTaskConsumer.m
@@ -71,7 +71,6 @@
     self->_regionStates = regionStates;
 
     locationManager.delegate = self;
-    locationManager.allowsBackgroundLocationUpdates = YES;
     locationManager.pausesLocationUpdatesAutomatically = NO;
 
     for (NSDictionary *regionDict in regions) {


### PR DESCRIPTION
       this permission is extraneuous to geofencing, and can cause an
       app to be rejectd from the app store if it's enabled and you're
       only using the geofencing api

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

An app I've been working on was rejected because of the background location mode while it was using geofencing. Removing the background mode didn't work, because it was required by expo-location to start the geofencing code.  Here is an excerpt from the rejection message:

## Guideline 2.5.4 - Performance - Software Requirements

The app declares support for location in the UIBackgroundModes key in your Info.plist file but we are unable to locate any features that require persistent location. Apps that declare support for location in the UIBackgroundModes key in your Info.plist file must have features that require persistent location.

### Next Steps

If the app has a feature that requires persistent location, reply to this message and let us know how to locate this feature. 

If the app does not require persistent real-time location updates, please remove the "location" setting from the UIBackgroundModes key. You may wish to use the significant-change location service or the region monitoring location service if persistent real-time location updates are not required for the app features.


Here is a [stack overflow answer](https://stackoverflow.com/a/26944037) confirming the same thing. It's 10 years old, so I also combed through apples documentation and didn't find anything saying you need this UIBackground mode.

# How

<!--
How did you build this feature or fix this bug and why?
-->
I removed the the background location mode error and updated the location manager to not set  background location as true.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I tested this by making a [branch](https://github.com/Eric-Tyrrell22/expo/tree/expo-location-branch) only for the expo-location and using that in my package.json. I then rebuilt the app and updated info.plist to not include the UIBackgroundMode: ['location']. When I resubmitted my app with these changes they were accepted. The app functionality is identical and has been working for a few weeks.



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
