### PR TITLE
[bare][Android] Add new line after `(` and `)`

### DIFF
--- a/apps/bare-expo/android/.idea/codeStyles/Project.xml
+++ b/apps/bare-expo/android/.idea/codeStyles/Project.xml
@@ -11,6 +11,7 @@
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
+          <package name="" withSubpackages="true" static="false" module="true" />
           <package name="android" withSubpackages="true" static="false" />
           <emptyLine />
           <package name="com" withSubpackages="true" static="false" />
@@ -192,8 +193,6 @@
       <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="false" />
       <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="false" />
       <option name="METHOD_PARAMETERS_WRAP" value="0" />
-      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="false" />
-      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="false" />
       <option name="EXTENDS_LIST_WRAP" value="0" />
       <option name="METHOD_CALL_CHAIN_WRAP" value="0" />
       <option name="ASSIGNMENT_WRAP" value="0" />


### PR DESCRIPTION
# Why

Adds a new line after `(` and `)` in function declaration to the style guides.
<img width="312" height="129" alt="image" src="https://github.com/user-attachments/assets/5871fb32-eb3e-4985-bf06-6f287675b5a0" />

Before:
```kotlin
function(code: String, 
         message: String?, 
         cause: Throwable?)
```

After:
function(
  code: String, 
  message: String?, 
  cause: Throwable?
)
```

# Test Plan

- bare-expo ✅ 