### PR TITLE
[expo-go] fix tab bar hiding screen content

### DIFF
--- a/apps/expo-go/src/screens/HomeScreen/HomeScreenView.tsx
+++ b/apps/expo-go/src/screens/HomeScreen/HomeScreenView.tsx
@@ -116,7 +116,8 @@ export class HomeScreenView extends React.Component<Props, State> {
             bounces
             key={Platform.OS === 'ios' ? this.props.allHistory.count() : 'scroll-view'}
             style={styles.container}
-            contentContainerStyle={[styles.contentContainer]}>
+            contentInsetAdjustmentBehavior="automatic"
+            contentContainerStyle={styles.contentContainer}>
             <UpgradeWarning />
             <UserReviewSection apps={data?.apps} snacks={data?.snacks} />
             <DevelopmentServersHeader onHelpPress={this._handlePressHelpProjects} />

--- a/apps/expo-go/src/screens/SettingsScreen/index.tsx
+++ b/apps/expo-go/src/screens/SettingsScreen/index.tsx
@@ -19,7 +19,9 @@ export function SettingsScreen() {
     <KeyboardAwareScrollView
       style={styles.container}
       keyboardShouldPersistTaps="always"
-      keyboardDismissMode="on-drag">
+      keyboardDismissMode="on-drag"
+      showsVerticalScrollIndicator={false}
+      contentInsetAdjustmentBehavior="automatic">
       <CappedWidthContainerView style={padding.padding.medium}>
         <ThemeSection />
         <Spacer.Vertical size="medium" />


### PR DESCRIPTION
# Why

on iOS, the home and settings screen are not fully scrollable. Tab bar is hiding some of the content.

# How

- Added `contentInsetAdjustmentBehavior="automatic"` to make content visible
- Added `showsVerticalScrollIndicator={false}` to hide the scroll indicator on settings screen - it's a little off it seems on both screens. Didn't investigate this further at the moment. On settings screen, it looks better this way anyway imo.

# Test Plan

<details>
<summary>screenshots</summary>

before

![before](https://github.com/user-attachments/assets/cb94c69f-f49c-475d-af32-a639c02dc198)

![after](https://github.com/user-attachments/assets/16fe7cee-6d25-4c17-8887-8f40e8efe09c)


</details>

1. Open the Expo Go app and navigate to the Home & Settings screen
2. Verify that setting screen content is fully visible when scrolling down

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)