### PR TITLE
React-Compiler Docs: Install as dev dependency and fix flat config issues

### DIFF
--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -69,7 +69,7 @@ Additionally, you should use the ESLint plugin to continuously enforce the rules
 
 Run [`npx expo lint`](/guides/using-eslint/#eslint) to ensure ESLint is setup in your app, then install the ESLint plugin for React Compiler:
 
-<Terminal cmd={['$ npx expo install eslint-plugin-react-compiler']} />
+<Terminal cmd={['$ npx expo install eslint-plugin-react-compiler -D']} />
 
 </Step>
 
@@ -81,15 +81,13 @@ Update your [ESLint configuration](/guides/using-eslint/) to include the plugin:
 // https://docs.expo.dev/guides/using-eslint/
 const { defineConfig } = require('eslint/config');
 const expoConfig = require('eslint-config-expo/flat');
+const reactCompiler = require("eslint-plugin-react-compiler");
 
 module.exports = defineConfig([
   expoConfig,
+  reactCompiler.configs.recommended,
   {
     ignores: ['dist/*'],
-    plugins: ['react-compiler'],
-    rules: {
-      'react-compiler/react-compiler': 'error',
-    },
   },
 ]);
 ```


### PR DESCRIPTION
# Why

The given config changes did not work for me and installing it not as a dev dependency caused issues for me. The config changes align with the [eslint-plugin-react-compiler README](https://www.npmjs.com/package/eslint-plugin-react-compiler?activeTab=readme)

# How

n/a

# Test Plan

n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

I don't think any apply.

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
