### PR TITLE
Update fcm-credentials.mdx to decrease amiguity about using EAS Build…

### DIFF
--- a/docs/pages/push-notifications/fcm-credentials.mdx
+++ b/docs/pages/push-notifications/fcm-credentials.mdx
@@ -117,6 +117,8 @@ In **app.json**, add [`expo.android.googleServicesFile`](/versions/latest/config
 }
 ```
 
+If using EAS Build, make sure you are using [Dynamic App Config](https://docs.expo.dev/workflow/configuration/#dynamic-configuration) and use `process.env.GOOGLE_SERVICES_JSON` as the value of `googleServicesFile` to expose the file to the build process. Run `eas env:create --scope project --name GOOGLE_SERVICES_JSON --type file --value ./path/to/google-services.json` in your project directory and ensure that you choose the `Secret` option, as this file contains sensitive data.
+
 </Step>
 
 <Step label="6">


### PR DESCRIPTION
… with google-services.json

# Why

I personally ran into an issue due to the incomplete instructions on this page.

# How

Provided clearer instructions

# Test Plan

N/A

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [N/A ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ √] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
