### PR TITLE
[docs] add `github-comment` workflow job type

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -1,6 +1,6 @@
 extends: capitalization
 message: "'%s' should be in sentence case"
-link: 'https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#headings'
+link: "https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#headings"
 level: warning
 scope:
   - heading.h2
@@ -9,205 +9,205 @@ scope:
   - heading.h5
 match: $sentence
 exceptions:
-  - '.*2FA.*'
+  - ".*2FA.*"
   - '.*app\.config\.js.*'
   - '.*app\.json.*'
   - '.*app\.plugin\.js.*'
-  - '.*app directory.*'
-  - '.*assets.*'
-  - '.*create-expo-app.*'
-  - '.*create-react-native-app.*'
-  - '.*^iOS(.*)'
-  - '.*web.*'
-  - '.*AASA.*'
-  - '.*API.*'
-  - '.*APIs.*'
-  - '.*^Android(.*)'
-  - '.*AndroidManifest.*'
-  - '.*Android.*Bundle.*'
-  - '.*Android.*Package.*'
-  - '.*Android Studio.*'
-  - '.*APNs.*'
-  - '.*App Links.*'
-  - '.*AppDelegate.*'
-  - '.*App Store.*'
-  - '.*App Store Connect.*'
-  - '.*Apple.*'
-  - '.*Apple App Store.*'
-  - '.*Apple Developer.*'
-  - '.*Apple Developer Account.*'
-  - '.*Apple Developer Console.*'
-  - '.*Apple Developer Portal.*'
-  - '.*Apple ID.*'
-  - '.*Apple Pay.*'
-  - '.*Asset Links.*'
-  - '.*Async Storage.*'
-  - '.*Autolinking.*'
-  - '.*AuthSession.*'
-  - '.*AWS Amplify Console.*'
-  - '.*AWS.*'
-  - '.*Babel.*'
+  - ".*app directory.*"
+  - ".*assets.*"
+  - ".*create-expo-app.*"
+  - ".*create-react-native-app.*"
+  - ".*^iOS(.*)"
+  - ".*web.*"
+  - ".*AASA.*"
+  - ".*API.*"
+  - ".*APIs.*"
+  - ".*^Android(.*)"
+  - ".*AndroidManifest.*"
+  - ".*Android.*Bundle.*"
+  - ".*Android.*Package.*"
+  - ".*Android Studio.*"
+  - ".*APNs.*"
+  - ".*App Links.*"
+  - ".*AppDelegate.*"
+  - ".*App Store.*"
+  - ".*App Store Connect.*"
+  - ".*Apple.*"
+  - ".*Apple App Store.*"
+  - ".*Apple Developer.*"
+  - ".*Apple Developer Account.*"
+  - ".*Apple Developer Console.*"
+  - ".*Apple Developer Portal.*"
+  - ".*Apple ID.*"
+  - ".*Apple Pay.*"
+  - ".*Asset Links.*"
+  - ".*Async Storage.*"
+  - ".*Autolinking.*"
+  - ".*AuthSession.*"
+  - ".*AWS Amplify Console.*"
+  - ".*AWS.*"
+  - ".*Babel.*"
   - '.*babel\.config\.js.*'
-  - '.*Bundler.*'
-  - '.*Cache-Control.*'
-  - '.*Can I pay.*'
-  - '.*CSS.*'
-  - '.*CDN.*'
-  - '.*Chrome.*'
-  - '.*CLI.*'
-  - '.*Classic Updates.*'
-  - '.*CNG.*'
-  - '.*CocoaPods.*'
-  - '.*CodePush.*'
-  - '.*Command Line Tools.*'
-  - '.*Config Plugin.*'
-  - '.*CORS.*'
-  - '.*CRUD.*'
+  - ".*Bundler.*"
+  - ".*Cache-Control.*"
+  - ".*Can I pay.*"
+  - ".*CSS.*"
+  - ".*CDN.*"
+  - ".*Chrome.*"
+  - ".*CLI.*"
+  - ".*Classic Updates.*"
+  - ".*CNG.*"
+  - ".*CocoaPods.*"
+  - ".*CodePush.*"
+  - ".*Command Line Tools.*"
+  - ".*Config Plugin.*"
+  - ".*CORS.*"
+  - ".*CRUD.*"
   - '.*credentials\.json.*'
-  - '.*DevTools.*'
-  - '.*Developer Console.*'
-  - '.*Developer Mode.*'
-  - '.*detach.*'
-  - '.*develop.*apps.*Windows.*'
-  - '.*DNS.*'
-  - '.*E2E.*'
-  - '.*EAS.*'
-  - '.*EAS Build.*'
-  - '.*EAS Submit.*'
-  - '.*EAS Metadata.*'
-  - '.*EAS Update.*'
-  - '.*EAS Insights.*'
-  - '.*Element Inspector.*'
-  - '.*Environment Variables.*'
-  - '.*ESLint.*'
-  - '.*Expo.*'
-  - '.*ExpoKit.*'
-  - '.*Expo Application Services.*'
-  - '.*eject.*'
-  - '.*esbuild.*'
-  - '.*ESM.*'
-  - '.*expo.*'
-  - '.*Fastlane.*'
-  - '.*Firebase.*'
-  - '.*FileSystem.*'
-  - '.*Flipper.*'
-  - '.*Frequently Asked Questions.*'
-  - '.*Frame Content-Security Policy.*'
-  - '.*FAQ.*'
-  - '.*FCM.*'
-  - '.*FYI.*'
-  - '.*fingerprintignore.*'
-  - '.*fingerprint.config.js.*'
-  - '.*Generate.*Android.*'
-  - '.*GitHub.*'
-  - '.*GitHub Pages.*'
-  - '.*Google.*'
-  - '.*Google Developer.*'
-  - '.*Google Font.*'
-  - '.*Google Service Account.*'
-  - '.*Google Pay.*'
+  - ".*DevTools.*"
+  - ".*Developer Console.*"
+  - ".*Developer Mode.*"
+  - ".*detach.*"
+  - ".*develop.*apps.*Windows.*"
+  - ".*DNS.*"
+  - ".*E2E.*"
+  - ".*EAS.*"
+  - ".*EAS Build.*"
+  - ".*EAS Submit.*"
+  - ".*EAS Metadata.*"
+  - ".*EAS Update.*"
+  - ".*EAS Insights.*"
+  - ".*Element Inspector.*"
+  - ".*Environment Variables.*"
+  - ".*ESLint.*"
+  - ".*Expo.*"
+  - ".*ExpoKit.*"
+  - ".*Expo Application Services.*"
+  - ".*eject.*"
+  - ".*esbuild.*"
+  - ".*ESM.*"
+  - ".*expo.*"
+  - ".*Fastlane.*"
+  - ".*Firebase.*"
+  - ".*FileSystem.*"
+  - ".*Flipper.*"
+  - ".*Frequently Asked Questions.*"
+  - ".*Frame Content-Security Policy.*"
+  - ".*FAQ.*"
+  - ".*FCM.*"
+  - ".*FYI.*"
+  - ".*fingerprintignore.*"
+  - ".*fingerprint.config.js.*"
+  - ".*Generate.*Android.*"
+  - ".*GitHub.*"
+  - ".*GitHub Pages.*"
+  - ".*Google.*"
+  - ".*Google Developer.*"
+  - ".*Google Font.*"
+  - ".*Google Service Account.*"
+  - ".*Google Pay.*"
   - ".*Giphy's.*"
-  - '.*GLView.*'
-  - '.*gitignore.*'
-  - '.*Play Store.*'
-  - '.*Gradle.*'
-  - '.*Gymfile.*'
-  - '.*Headless.*Background.*'
-  - '.*Help.*published.*'
-  - '.*Hermes.*'
-  - '.*HTML.*'
-  - '.*HTTP.*'
-  - '.*HTTPS.*'
+  - ".*GLView.*"
+  - ".*gitignore.*"
+  - ".*Play Store.*"
+  - ".*Gradle.*"
+  - ".*Gymfile.*"
+  - ".*Headless.*Background.*"
+  - ".*Help.*published.*"
+  - ".*Hermes.*"
+  - ".*HTML.*"
+  - ".*HTTP.*"
+  - ".*HTTPS.*"
   - '.*Info\.plist.*'
-  - '.*iOS.*Simulator.*'
-  - '.*JSON.*'
-  - '.*JavaScript.*'
-  - '.*JavaScriptCore.*'
-  - '.*Java Development Kit.*'
-  - '.*Jest.*'
-  - '.*Keychain.*'
-  - '.*Kotlin.*'
-  - '.*layout.*'
-  - '.*Legend-State.*'
-  - '.*Link component.*'
-  - '.*Linking.*'
-  - '.*macOS.*'
+  - ".*iOS.*Simulator.*"
+  - ".*JSON.*"
+  - ".*JavaScript.*"
+  - ".*JavaScriptCore.*"
+  - ".*Java Development Kit.*"
+  - ".*Jest.*"
+  - ".*Keychain.*"
+  - ".*Kotlin.*"
+  - ".*layout.*"
+  - ".*Legend-State.*"
+  - ".*Link component.*"
+  - ".*Linking.*"
+  - ".*macOS.*"
   - '.*manifest\.json.*'
   - '.*metro\.config\.js.*'
-  - '.*Netlify.*'
+  - ".*Netlify.*"
   - '.*Node\.js.*'
-  - '.*Node Package Managers.*'
-  - '.*NavigationContainer.*'
+  - ".*Node Package Managers.*"
+  - ".*NavigationContainer.*"
   - '.*Next\.js.*'
-  - '.*New Architecture.*'
-  - '.*Notification Message.*'
-  - '.*npm.*'
-  - '.*OAuth.*'
-  - '.*OTA.*'
-  - '.*OTF.*'
-  - '.*PostCSS.*'
-  - '.*PRAGMA.*'
-  - '.*Prebuild.*'
-  - '.*Privacy Shield.*'
-  - '.*Push Notification.*'
-  - '.*PWA.*'
+  - ".*New Architecture.*"
+  - ".*Notification Message.*"
+  - ".*npm.*"
+  - ".*OAuth.*"
+  - ".*OTA.*"
+  - ".*OTF.*"
+  - ".*PostCSS.*"
+  - ".*PRAGMA.*"
+  - ".*Prebuild.*"
+  - ".*Privacy Shield.*"
+  - ".*Push Notification.*"
+  - ".*PWA.*"
   - '.*package\.json.*'
-  - '.*props.*'
-  - '.*QR.*'
-  - '.*RTL.*'
-  - '.*React.*'
-  - '.*React Native.*'
-  - '.*React Navigation.*'
-  - '.*Reanimated.*'
-  - '.*Remote Debugging.*'
-  - '.*REST API.*'
-  - '.*Remote JS.*'
-  - '.*Router.*'
+  - ".*props.*"
+  - ".*QR.*"
+  - ".*RTL.*"
+  - ".*React.*"
+  - ".*React Native.*"
+  - ".*React Navigation.*"
+  - ".*Reanimated.*"
+  - ".*Remote Debugging.*"
+  - ".*REST API.*"
+  - ".*Remote JS.*"
+  - ".*Router.*"
   - ".*Router's.*"
-  - '.*SAF.*'
-  - '.*SASS.*'
-  - '.*SDK.*'
-  - '.*SecureStore.*'
-  - '.*Sentry.*'
-  - '.*Server-side.*'
-  - '.*Sierra.*'
-  - '.*SLAs.*'
-  - '.*Smart Banner.*'
-  - '.*Smart App Banners.*'
-  - '.*SMS.*'
-  - '.*Software Mansion.*'
-  - '.*SQLite.*'
-  - '.*SQLCipher.*'
-  - '.*Statically-typed.*'
-  - '.*Storage Access Framework.*'
-  - '.*Strict-Transport-Security.*'
-  - '.*SSO.*'
-  - '.*Swift.*'
-  - '.*Terser.*'
-  - '.*TestFlight.*'
-  - '.*TLS.*'
-  - '.*Transporter.*'
-  - '.*TTF.*'
-  - '.*Turtle.*'
-  - '.*TV.*'
-  - '.*TypeScript.*'
-  - '.*TypeScript module.*'
-  - '.*Watchman.*'
-  - '.*UI.*'
-  - '.*USB.*'
-  - '.*URI.*'
-  - '.*URL.*'
-  - '.*URLs.*'
-  - '.*V8.*'
-  - '.*VS Code.*'
-  - '.*WebGL.*'
-  - '.*WebView.*'
-  - '.*Wix.*'
-  - '.*webpack.*'
-  - '.*Xcode.*'
-  - '.*XDE.*'
-  - '.*Yarn.*'
-  - '.*YAML.*'
+  - ".*SAF.*"
+  - ".*SASS.*"
+  - ".*SDK.*"
+  - ".*SecureStore.*"
+  - ".*Sentry.*"
+  - ".*Server-side.*"
+  - ".*Sierra.*"
+  - ".*SLAs.*"
+  - ".*Smart Banner.*"
+  - ".*Smart App Banners.*"
+  - ".*SMS.*"
+  - ".*Software Mansion.*"
+  - ".*SQLite.*"
+  - ".*SQLCipher.*"
+  - ".*Statically-typed.*"
+  - ".*Storage Access Framework.*"
+  - ".*Strict-Transport-Security.*"
+  - ".*SSO.*"
+  - ".*Swift.*"
+  - ".*Terser.*"
+  - ".*TestFlight.*"
+  - ".*TLS.*"
+  - ".*Transporter.*"
+  - ".*TTF.*"
+  - ".*Turtle.*"
+  - ".*TV.*"
+  - ".*TypeScript.*"
+  - ".*TypeScript module.*"
+  - ".*Watchman.*"
+  - ".*UI.*"
+  - ".*USB.*"
+  - ".*URI.*"
+  - ".*URL.*"
+  - ".*URLs.*"
+  - ".*V8.*"
+  - ".*VS Code.*"
+  - ".*WebGL.*"
+  - ".*WebView.*"
+  - ".*Wix.*"
+  - ".*webpack.*"
+  - ".*Xcode.*"
+  - ".*XDE.*"
+  - ".*Yarn.*"
+  - ".*YAML.*"
   # PascalCase for React component names that end with common component suffixes
   - '^[A-Z][a-zA-Z]*(?:Input|Sheet|Picker|Progress|Menu|View|Button|Switch|Slider|Text|TextInput)(?:\s*\([^)]+\))?$'
   # Standalone Expo UI component names
@@ -279,3 +279,5 @@ exceptions:
   - Secure Context in DOM
   - Enterprise Support
   - Use Stacks
+  - Mode 1: Auto-with-overrides mode
+  - Mode 2: Payload mode

--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -1,6 +1,6 @@
 extends: capitalization
 message: "'%s' should be in sentence case"
-link: "https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#headings"
+link: 'https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#headings'
 level: warning
 scope:
   - heading.h2
@@ -9,205 +9,205 @@ scope:
   - heading.h5
 match: $sentence
 exceptions:
-  - ".*2FA.*"
+  - '.*2FA.*'
   - '.*app\.config\.js.*'
   - '.*app\.json.*'
   - '.*app\.plugin\.js.*'
-  - ".*app directory.*"
-  - ".*assets.*"
-  - ".*create-expo-app.*"
-  - ".*create-react-native-app.*"
-  - ".*^iOS(.*)"
-  - ".*web.*"
-  - ".*AASA.*"
-  - ".*API.*"
-  - ".*APIs.*"
-  - ".*^Android(.*)"
-  - ".*AndroidManifest.*"
-  - ".*Android.*Bundle.*"
-  - ".*Android.*Package.*"
-  - ".*Android Studio.*"
-  - ".*APNs.*"
-  - ".*App Links.*"
-  - ".*AppDelegate.*"
-  - ".*App Store.*"
-  - ".*App Store Connect.*"
-  - ".*Apple.*"
-  - ".*Apple App Store.*"
-  - ".*Apple Developer.*"
-  - ".*Apple Developer Account.*"
-  - ".*Apple Developer Console.*"
-  - ".*Apple Developer Portal.*"
-  - ".*Apple ID.*"
-  - ".*Apple Pay.*"
-  - ".*Asset Links.*"
-  - ".*Async Storage.*"
-  - ".*Autolinking.*"
-  - ".*AuthSession.*"
-  - ".*AWS Amplify Console.*"
-  - ".*AWS.*"
-  - ".*Babel.*"
+  - '.*app directory.*'
+  - '.*assets.*'
+  - '.*create-expo-app.*'
+  - '.*create-react-native-app.*'
+  - '.*^iOS(.*)'
+  - '.*web.*'
+  - '.*AASA.*'
+  - '.*API.*'
+  - '.*APIs.*'
+  - '.*^Android(.*)'
+  - '.*AndroidManifest.*'
+  - '.*Android.*Bundle.*'
+  - '.*Android.*Package.*'
+  - '.*Android Studio.*'
+  - '.*APNs.*'
+  - '.*App Links.*'
+  - '.*AppDelegate.*'
+  - '.*App Store.*'
+  - '.*App Store Connect.*'
+  - '.*Apple.*'
+  - '.*Apple App Store.*'
+  - '.*Apple Developer.*'
+  - '.*Apple Developer Account.*'
+  - '.*Apple Developer Console.*'
+  - '.*Apple Developer Portal.*'
+  - '.*Apple ID.*'
+  - '.*Apple Pay.*'
+  - '.*Asset Links.*'
+  - '.*Async Storage.*'
+  - '.*Autolinking.*'
+  - '.*AuthSession.*'
+  - '.*AWS Amplify Console.*'
+  - '.*AWS.*'
+  - '.*Babel.*'
   - '.*babel\.config\.js.*'
-  - ".*Bundler.*"
-  - ".*Cache-Control.*"
-  - ".*Can I pay.*"
-  - ".*CSS.*"
-  - ".*CDN.*"
-  - ".*Chrome.*"
-  - ".*CLI.*"
-  - ".*Classic Updates.*"
-  - ".*CNG.*"
-  - ".*CocoaPods.*"
-  - ".*CodePush.*"
-  - ".*Command Line Tools.*"
-  - ".*Config Plugin.*"
-  - ".*CORS.*"
-  - ".*CRUD.*"
+  - '.*Bundler.*'
+  - '.*Cache-Control.*'
+  - '.*Can I pay.*'
+  - '.*CSS.*'
+  - '.*CDN.*'
+  - '.*Chrome.*'
+  - '.*CLI.*'
+  - '.*Classic Updates.*'
+  - '.*CNG.*'
+  - '.*CocoaPods.*'
+  - '.*CodePush.*'
+  - '.*Command Line Tools.*'
+  - '.*Config Plugin.*'
+  - '.*CORS.*'
+  - '.*CRUD.*'
   - '.*credentials\.json.*'
-  - ".*DevTools.*"
-  - ".*Developer Console.*"
-  - ".*Developer Mode.*"
-  - ".*detach.*"
-  - ".*develop.*apps.*Windows.*"
-  - ".*DNS.*"
-  - ".*E2E.*"
-  - ".*EAS.*"
-  - ".*EAS Build.*"
-  - ".*EAS Submit.*"
-  - ".*EAS Metadata.*"
-  - ".*EAS Update.*"
-  - ".*EAS Insights.*"
-  - ".*Element Inspector.*"
-  - ".*Environment Variables.*"
-  - ".*ESLint.*"
-  - ".*Expo.*"
-  - ".*ExpoKit.*"
-  - ".*Expo Application Services.*"
-  - ".*eject.*"
-  - ".*esbuild.*"
-  - ".*ESM.*"
-  - ".*expo.*"
-  - ".*Fastlane.*"
-  - ".*Firebase.*"
-  - ".*FileSystem.*"
-  - ".*Flipper.*"
-  - ".*Frequently Asked Questions.*"
-  - ".*Frame Content-Security Policy.*"
-  - ".*FAQ.*"
-  - ".*FCM.*"
-  - ".*FYI.*"
-  - ".*fingerprintignore.*"
-  - ".*fingerprint.config.js.*"
-  - ".*Generate.*Android.*"
-  - ".*GitHub.*"
-  - ".*GitHub Pages.*"
-  - ".*Google.*"
-  - ".*Google Developer.*"
-  - ".*Google Font.*"
-  - ".*Google Service Account.*"
-  - ".*Google Pay.*"
+  - '.*DevTools.*'
+  - '.*Developer Console.*'
+  - '.*Developer Mode.*'
+  - '.*detach.*'
+  - '.*develop.*apps.*Windows.*'
+  - '.*DNS.*'
+  - '.*E2E.*'
+  - '.*EAS.*'
+  - '.*EAS Build.*'
+  - '.*EAS Submit.*'
+  - '.*EAS Metadata.*'
+  - '.*EAS Update.*'
+  - '.*EAS Insights.*'
+  - '.*Element Inspector.*'
+  - '.*Environment Variables.*'
+  - '.*ESLint.*'
+  - '.*Expo.*'
+  - '.*ExpoKit.*'
+  - '.*Expo Application Services.*'
+  - '.*eject.*'
+  - '.*esbuild.*'
+  - '.*ESM.*'
+  - '.*expo.*'
+  - '.*Fastlane.*'
+  - '.*Firebase.*'
+  - '.*FileSystem.*'
+  - '.*Flipper.*'
+  - '.*Frequently Asked Questions.*'
+  - '.*Frame Content-Security Policy.*'
+  - '.*FAQ.*'
+  - '.*FCM.*'
+  - '.*FYI.*'
+  - '.*fingerprintignore.*'
+  - '.*fingerprint.config.js.*'
+  - '.*Generate.*Android.*'
+  - '.*GitHub.*'
+  - '.*GitHub Pages.*'
+  - '.*Google.*'
+  - '.*Google Developer.*'
+  - '.*Google Font.*'
+  - '.*Google Service Account.*'
+  - '.*Google Pay.*'
   - ".*Giphy's.*"
-  - ".*GLView.*"
-  - ".*gitignore.*"
-  - ".*Play Store.*"
-  - ".*Gradle.*"
-  - ".*Gymfile.*"
-  - ".*Headless.*Background.*"
-  - ".*Help.*published.*"
-  - ".*Hermes.*"
-  - ".*HTML.*"
-  - ".*HTTP.*"
-  - ".*HTTPS.*"
+  - '.*GLView.*'
+  - '.*gitignore.*'
+  - '.*Play Store.*'
+  - '.*Gradle.*'
+  - '.*Gymfile.*'
+  - '.*Headless.*Background.*'
+  - '.*Help.*published.*'
+  - '.*Hermes.*'
+  - '.*HTML.*'
+  - '.*HTTP.*'
+  - '.*HTTPS.*'
   - '.*Info\.plist.*'
-  - ".*iOS.*Simulator.*"
-  - ".*JSON.*"
-  - ".*JavaScript.*"
-  - ".*JavaScriptCore.*"
-  - ".*Java Development Kit.*"
-  - ".*Jest.*"
-  - ".*Keychain.*"
-  - ".*Kotlin.*"
-  - ".*layout.*"
-  - ".*Legend-State.*"
-  - ".*Link component.*"
-  - ".*Linking.*"
-  - ".*macOS.*"
+  - '.*iOS.*Simulator.*'
+  - '.*JSON.*'
+  - '.*JavaScript.*'
+  - '.*JavaScriptCore.*'
+  - '.*Java Development Kit.*'
+  - '.*Jest.*'
+  - '.*Keychain.*'
+  - '.*Kotlin.*'
+  - '.*layout.*'
+  - '.*Legend-State.*'
+  - '.*Link component.*'
+  - '.*Linking.*'
+  - '.*macOS.*'
   - '.*manifest\.json.*'
   - '.*metro\.config\.js.*'
-  - ".*Netlify.*"
+  - '.*Netlify.*'
   - '.*Node\.js.*'
-  - ".*Node Package Managers.*"
-  - ".*NavigationContainer.*"
+  - '.*Node Package Managers.*'
+  - '.*NavigationContainer.*'
   - '.*Next\.js.*'
-  - ".*New Architecture.*"
-  - ".*Notification Message.*"
-  - ".*npm.*"
-  - ".*OAuth.*"
-  - ".*OTA.*"
-  - ".*OTF.*"
-  - ".*PostCSS.*"
-  - ".*PRAGMA.*"
-  - ".*Prebuild.*"
-  - ".*Privacy Shield.*"
-  - ".*Push Notification.*"
-  - ".*PWA.*"
+  - '.*New Architecture.*'
+  - '.*Notification Message.*'
+  - '.*npm.*'
+  - '.*OAuth.*'
+  - '.*OTA.*'
+  - '.*OTF.*'
+  - '.*PostCSS.*'
+  - '.*PRAGMA.*'
+  - '.*Prebuild.*'
+  - '.*Privacy Shield.*'
+  - '.*Push Notification.*'
+  - '.*PWA.*'
   - '.*package\.json.*'
-  - ".*props.*"
-  - ".*QR.*"
-  - ".*RTL.*"
-  - ".*React.*"
-  - ".*React Native.*"
-  - ".*React Navigation.*"
-  - ".*Reanimated.*"
-  - ".*Remote Debugging.*"
-  - ".*REST API.*"
-  - ".*Remote JS.*"
-  - ".*Router.*"
+  - '.*props.*'
+  - '.*QR.*'
+  - '.*RTL.*'
+  - '.*React.*'
+  - '.*React Native.*'
+  - '.*React Navigation.*'
+  - '.*Reanimated.*'
+  - '.*Remote Debugging.*'
+  - '.*REST API.*'
+  - '.*Remote JS.*'
+  - '.*Router.*'
   - ".*Router's.*"
-  - ".*SAF.*"
-  - ".*SASS.*"
-  - ".*SDK.*"
-  - ".*SecureStore.*"
-  - ".*Sentry.*"
-  - ".*Server-side.*"
-  - ".*Sierra.*"
-  - ".*SLAs.*"
-  - ".*Smart Banner.*"
-  - ".*Smart App Banners.*"
-  - ".*SMS.*"
-  - ".*Software Mansion.*"
-  - ".*SQLite.*"
-  - ".*SQLCipher.*"
-  - ".*Statically-typed.*"
-  - ".*Storage Access Framework.*"
-  - ".*Strict-Transport-Security.*"
-  - ".*SSO.*"
-  - ".*Swift.*"
-  - ".*Terser.*"
-  - ".*TestFlight.*"
-  - ".*TLS.*"
-  - ".*Transporter.*"
-  - ".*TTF.*"
-  - ".*Turtle.*"
-  - ".*TV.*"
-  - ".*TypeScript.*"
-  - ".*TypeScript module.*"
-  - ".*Watchman.*"
-  - ".*UI.*"
-  - ".*USB.*"
-  - ".*URI.*"
-  - ".*URL.*"
-  - ".*URLs.*"
-  - ".*V8.*"
-  - ".*VS Code.*"
-  - ".*WebGL.*"
-  - ".*WebView.*"
-  - ".*Wix.*"
-  - ".*webpack.*"
-  - ".*Xcode.*"
-  - ".*XDE.*"
-  - ".*Yarn.*"
-  - ".*YAML.*"
+  - '.*SAF.*'
+  - '.*SASS.*'
+  - '.*SDK.*'
+  - '.*SecureStore.*'
+  - '.*Sentry.*'
+  - '.*Server-side.*'
+  - '.*Sierra.*'
+  - '.*SLAs.*'
+  - '.*Smart Banner.*'
+  - '.*Smart App Banners.*'
+  - '.*SMS.*'
+  - '.*Software Mansion.*'
+  - '.*SQLite.*'
+  - '.*SQLCipher.*'
+  - '.*Statically-typed.*'
+  - '.*Storage Access Framework.*'
+  - '.*Strict-Transport-Security.*'
+  - '.*SSO.*'
+  - '.*Swift.*'
+  - '.*Terser.*'
+  - '.*TestFlight.*'
+  - '.*TLS.*'
+  - '.*Transporter.*'
+  - '.*TTF.*'
+  - '.*Turtle.*'
+  - '.*TV.*'
+  - '.*TypeScript.*'
+  - '.*TypeScript module.*'
+  - '.*Watchman.*'
+  - '.*UI.*'
+  - '.*USB.*'
+  - '.*URI.*'
+  - '.*URL.*'
+  - '.*URLs.*'
+  - '.*V8.*'
+  - '.*VS Code.*'
+  - '.*WebGL.*'
+  - '.*WebView.*'
+  - '.*Wix.*'
+  - '.*webpack.*'
+  - '.*Xcode.*'
+  - '.*XDE.*'
+  - '.*Yarn.*'
+  - '.*YAML.*'
   # PascalCase for React component names that end with common component suffixes
   - '^[A-Z][a-zA-Z]*(?:Input|Sheet|Picker|Progress|Menu|View|Button|Switch|Slider|Text|TextInput)(?:\s*\([^)]+\))?$'
   # Standalone Expo UI component names
@@ -279,5 +279,5 @@ exceptions:
   - Secure Context in DOM
   - Enterprise Support
   - Use Stacks
-  - "Mode 1: Auto-with-overrides mode"
-  - "Mode 2: Payload mode"
+  - 'Mode 1: Auto-with-overrides mode'
+  - 'Mode 2: Payload mode'

--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -279,5 +279,5 @@ exceptions:
   - Secure Context in DOM
   - Enterprise Support
   - Use Stacks
-  - Mode 1: Auto-with-overrides mode
-  - Mode 2: Payload mode
+  - "Mode 1: Auto-with-overrides mode"
+  - "Mode 2: Payload mode"

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1111,7 +1111,7 @@ jobs:
 
 ## GitHub Comment
 
-Automatically post comprehensive reports of your workflow's completed builds and updates to GitHub pull requests. This job operates in two mutually exclusive modes: **auto-with-overrides mode** for automated reports with optional customization, or **payload mode** for fully custom content. It's particularly useful for providing instant feedback on PR builds, sharing test builds with QR codes for easy device testing, and automating deployment notifications.
+Automatically post reports of your workflow's completed builds and updates to GitHub pull requests. It's particularly useful for providing instant feedback on PR builds, sharing test builds with QR codes for easy device testing, and automating deployment notifications. If you want, you can override the comment contents by providing `payload` parameter.
 
 ### Prerequisites
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1232,7 +1232,7 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  ...
+  # ...
 
   comment_update:
     name: Post Update to PR

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1111,11 +1111,11 @@ jobs:
 
 ## GitHub Comment
 
-Automatically post comprehensive reports of your workflow's completed builds and updates to GitHub pull requests. This job can generate an auto-report of all builds and updates from your workflow, display specific builds and updates with customized messages, or use a payload to fully customize the entire comment content to display anything you need. It's particularly useful for providing instant feedback on PR builds, sharing test builds with QR codes for easy device testing, and automating deployment notifications.
+Automatically post comprehensive reports of your workflow's completed builds and updates to GitHub pull requests. This job operates in two mutually exclusive modes: **auto-with-overrides mode** for automated reports with optional customization, or **payload mode** for fully custom content. It's particularly useful for providing instant feedback on PR builds, sharing test builds with QR codes for easy device testing, and automating deployment notifications.
 
 ### Prerequisites
 
-To use the GitHub Comment job, your project must have a GitHub repository connected. Learn how to [connect your GitHub repository](/eas/build/github) to get started.
+To use the GitHub Comment job, your project must have a GitHub repository connected. Learn how to [connect your GitHub repository](/build/building-from-github) to get started.
 
 ### Syntax
 
@@ -1124,51 +1124,81 @@ jobs:
   github_comment:
     type: github-comment
     params:
-      payload: string # optional - raw markdown content (Takes precedence over all other parameters.)
-      message: string # optional - custom message (used when payload is not provided)
-      build_ids: string[] # optional - array of build IDs to include
-      update_group_ids: string[] # optional - array of update group IDs to include
+      # Mode 1: Auto-with-overrides mode
+      message: string # optional - custom message to include in the report
+      build_ids: string[] # optional - specific build IDs to include
+      update_group_ids: string[] # optional - specific update group IDs to include
+      # Mode 2: Payload mode (mutually exclusive with other parameters)
+      payload: string # optional - raw markdown/HTML content for fully custom comment
 ```
 
 #### Parameters
 
-You can pass the following parameters into the `params` list:
+The job operates in two mutually exclusive modes:
 
-| Parameter        | Type     | Description                                                                                                       |
-| ---------------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
-| payload          | string   | Optional. Raw markdown content to post as the comment. Takes precedence over all other parameters.                |
-| message          | string   | Optional. Custom message to include at the top of the comment. If not provided, a default message will be used.   |
-| build_ids        | string[] | Optional. Array of build IDs to include in the comment. Build information will be displayed in a formatted table. |
-| update_group_ids | string[] | Optional. Array of update group IDs to include. Updates will be displayed with QR codes for easy device testing.  |
+##### Mode 1: Auto-with-Overrides Mode
 
-> **Note**: The job operates in three modes:
->
-> - **Payload Mode**: When `payload` is provided, posts the exact content as the comment (highest priority)
-> - **Explicit Mode**: When `build_ids` or `update_group_ids` are specified, displays only the specified builds and updates. Custom message can be set via the `message` parameter
-> - **Auto Mode**: When no `build_ids` or `update_group_ids` are specified, automatically discovers and displays all completed/failed/canceled builds and successful updates from the current workflow. Custom message can be set via the `message` parameter
+When not using payload, you can optionally specify any combination of these parameters:
+
+| Parameter        | Type     | Description                                                                                                                                                      |
+| ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| message          | string   | Optional. Custom message to include at the top of the comment. Defaults to "Your builds and updates are ready for testing!"                                      |
+| build_ids        | string[] | Optional. Array of specific build IDs to include. If not specified, auto-discovers all completed/failed/canceled builds. Use empty array `[]` to exclude builds. |
+| update_group_ids | string[] | Optional. Array of specific update group IDs to include. If not specified, auto-discovers all successful updates. Use empty array `[]` to exclude updates.       |
+
+> **Auto-discovery behavior**: When `build_ids` or `update_group_ids` are not specified (undefined), the job automatically discovers all relevant builds and updates from the current workflow. To explicitly exclude builds or updates, pass an empty array `[]`.
+
+##### Mode 2: Payload Mode
+
+When using payload mode, you cannot specify any other parameters.
+
+| Parameter | Type   | Description                                                                                    |
+| --------- | ------ | ---------------------------------------------------------------------------------------------- |
+| payload   | string | Raw markdown or HTML content to post as the comment. Supports workflow variable interpolation. |
 
 #### Outputs
 
 You can reference the following outputs in subsequent jobs:
 
-| Output                | Type   | Description                                                                           |
-| --------------------- | ------ | ------------------------------------------------------------------------------------- |
-| github_comment_posted | string | Whether a comment was posted ('true' or 'false')                                      |
-| pr_number             | string | The PR number if the workflow was triggered by a pull request                         |
-| comment_url           | string | URL of the posted GitHub comment (only available when comment is successfully posted) |
-| comment_content       | string | Full content of the comment (useful for non-PR workflows to display in UI)            |
-| note                  | string | Additional information about the job result (e.g., why a comment wasn't posted)       |
+| Output      | Type   | Description                                                                           |
+| ----------- | ------ | ------------------------------------------------------------------------------------- |
+| comment_url | string | URL of the posted GitHub comment (only available when comment is successfully posted) |
 
 ### Examples
 
-Here are some practical examples of using the GitHub Comment job:
+Here are practical examples demonstrating both modes of the GitHub Comment job:
 
-<Collapsible summary="Post build results to PR">
+#### Auto-with-Overrides Mode Examples
 
-This workflow automatically posts build results to the pull request after the build and update jobs have completed.
+<Collapsible summary="Auto-discover all builds and updates">
 
-```yaml .eas/workflows/pr-build-comment.yml
-name: PR Build Comment
+This is the simplest usage - automatically discovers and posts all builds and updates from the workflow.
+
+```yaml .eas/workflows/pr-auto-comment.yml
+name: PR Auto Comment
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  ...
+
+  comment_on_pr:
+    name: Post Results to PR
+    after: [build_ios, build_android, publish_update]
+    type: github-comment
+    # No params needed - auto-discovers all builds and updates
+```
+
+</Collapsible>
+
+<Collapsible summary="Custom message with auto-discovery">
+
+Adds a custom message while still auto-discovering all builds and updates.
+
+```yaml .eas/workflows/pr-custom-message.yml
+name: PR Custom Message
 
 on:
   pull_request:
@@ -1181,19 +1211,19 @@ jobs:
     name: Post Build to PR
     after: [build_ios, build_android, publish_update]
     type: github-comment
-    #params:
-      #message: "You can override the message in the report template here (optiional)"
-
+    params:
+      message: "🎉 Preview builds are ready! Please test these changes before approving the PR."
+      # build_ids and update_group_ids are undefined, so auto-discovery is enabled
 ```
 
 </Collapsible>
 
-<Collapsible summary="Post update with specified build and update">
+<Collapsible summary="Specify exact builds and updates">
 
-This workflow publishes an update and posts it to the PR with a QR code for easy device testing.
+Explicitly specify which builds and updates to include in the comment.
 
-```yaml .eas/workflows/pr-update-comment.yml
-name: PR Update Comment
+```yaml .eas/workflows/pr-specific-builds.yml
+name: PR Specific Builds
 
 on:
   pull_request:
@@ -1207,7 +1237,7 @@ jobs:
     after: [build_ios, build_android, publish_update]
     type: github-comment
     params:
-      #message: "You can override the message in the report template here (optiional)"
+      message: "Testing builds ready for QA review"
       build_ids:
         - ${{ after.build_ios.outputs.build_id }}
         - ${{ after.build_android.outputs.build_id }}
@@ -1217,9 +1247,37 @@ jobs:
 
 </Collapsible>
 
-<Collapsible summary="Custom comment with payload">
+<Collapsible summary="Exclude builds or updates">
 
-This workflow uses a custom payload to create a rich comment with build status and custom formatting.
+Use empty arrays to exclude specific content types.
+
+```yaml .eas/workflows/pr-updates-only.yml
+name: PR Updates Only
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  ...
+
+  comment_updates_only:
+    name: Post Updates Only
+    after: [publish_update]
+    type: github-comment
+    params:
+      message: "New update available for testing!"
+      build_ids: [] # Empty array excludes all builds
+      # update_group_ids undefined = auto-discover updates
+```
+
+</Collapsible>
+
+#### Payload Mode Examples
+
+<Collapsible summary="Fully custom comment with payload">
+
+Payload mode gives you complete control over the comment content. Note that when using payload, you cannot specify any other parameters.
 
 ```yaml .eas/workflows/custom-pr-comment.yml
 name: Custom PR Comment
@@ -1236,6 +1294,8 @@ jobs:
     needs: [build_ios]
     type: github-comment
     params:
+      # Payload mode: complete control over content
+      # Cannot use message, build_ids, or update_group_ids with payload
       payload: |
         ## 🚀 Build Status Update
 
@@ -1297,6 +1357,16 @@ jobs:
 ```
 
 </Collapsible>
+
+### Important Notes
+
+- **Mode Mutual Exclusivity**: The `payload` parameter cannot be used together with `message`, `build_ids`, or `update_group_ids`. If you specify `payload`, the job will use payload mode and ignore all other parameters.
+- **Auto-discovery vs Exclusion**: There's an important difference between not specifying a parameter (undefined) and providing an empty array:
+  - `build_ids` undefined → auto-discovers all builds
+  - `build_ids: []` → excludes all builds from the comment
+  - Same applies to `update_group_ids`
+- **GitHub Repository Required**: This job only works when the workflow is triggered from a GitHub repository with proper permissions configured.
+- **Pull Request Context**: The job automatically detects if it's running in a pull request context. If not, it will still generate the comment content but won't post to GitHub.
 
 ## Require Approval
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1163,8 +1163,8 @@ When using payload mode, you cannot specify any other parameters.
 
 You can reference the following outputs in subsequent jobs:
 
-| Output      | Type   | Description                                                                           |
-| ----------- | ------ | ------------------------------------------------------------------------------------- |
+| Output      | Type   | Description                                                                                |
+| ----------- | ------ | ------------------------------------------------------------------------------------------ |
 | comment_url | string | URL of the posted GitHub comment (only available when the comment is successfully posted). |
 
 ### Examples
@@ -1203,8 +1203,7 @@ Adds a custom message while still auto-discovering all builds and updates.
 name: PR Custom Message
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  pull_request: {}
 
 jobs:
   # ...
@@ -1214,7 +1213,7 @@ jobs:
     after: [build_ios, build_android, publish_update]
     type: github-comment
     params:
-      message: "🎉 Preview builds are ready! Please test these changes before approving the PR."
+      message: '🎉 Preview builds are ready! Please test these changes before approving the PR.'
       # build_ids and update_group_ids are undefined, so auto-discovery is enabled
 ```
 
@@ -1228,8 +1227,7 @@ Explicitly specify which builds and updates to include in the comment.
 name: PR Specific Builds
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  pull_request: {}
 
 jobs:
   # ...
@@ -1239,7 +1237,7 @@ jobs:
     after: [build_ios, build_android, publish_update]
     type: github-comment
     params:
-      message: "Testing builds ready for QA review"
+      message: 'Testing builds ready for QA review'
       build_ids:
         - ${{ after.build_ios.outputs.build_id }}
         - ${{ after.build_android.outputs.build_id }}
@@ -1257,8 +1255,7 @@ Use empty arrays to exclude specific content types.
 name: PR Updates Only
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  pull_request: {}
 
 jobs:
   # ...
@@ -1268,7 +1265,7 @@ jobs:
     after: [publish_update]
     type: github-comment
     params:
-      message: "New update available for testing!"
+      message: 'New update available for testing!'
       build_ids: [] # Empty array excludes all builds
       # update_group_ids undefined = auto-discover updates
 ```
@@ -1285,8 +1282,7 @@ Payload mode gives you complete control over the comment content. Note that when
 name: Custom PR Comment
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  pull_request: {}
 
 jobs:
   # ...
@@ -1325,8 +1321,7 @@ This workflow posts different comments based on whether the build succeeded or f
 name: Conditional PR Comment
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  pull_request: {}
 
 jobs:
   build_android:

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1109,6 +1109,194 @@ jobs:
 
 </Collapsible>
 
+## GitHub Comment
+
+Automatically post comprehensive reports of your workflow's completed builds and updates to GitHub pull requests. This job can generate an auto-report of all builds and updates from your workflow, display specific builds and updates with customized messages, or use a payload to fully customize the entire comment content to display anything you need. It's particularly useful for providing instant feedback on PR builds, sharing test builds with QR codes for easy device testing, and automating deployment notifications.
+
+### Prerequisites
+
+To use the GitHub Comment job, your project must have a GitHub repository connected. Learn how to [connect your GitHub repository](/eas/build/github) to get started.
+
+### Syntax
+
+```yaml
+jobs:
+  github_comment:
+    type: github-comment
+    params:
+      payload: string # optional - raw markdown content (Takes precedence over all other parameters.)
+      message: string # optional - custom message (used when payload is not provided)
+      build_ids: string[] # optional - array of build IDs to include
+      update_group_ids: string[] # optional - array of update group IDs to include
+```
+
+#### Parameters
+
+You can pass the following parameters into the `params` list:
+
+| Parameter        | Type       | Description                                                                                                              |
+| ---------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| payload          | string     | Optional. Raw markdown content to post as the comment. Takes precedence over all other parameters.                      |
+| message          | string     | Optional. Custom message to include at the top of the comment. If not provided, a default message will be used.         |
+| build_ids        | string[]   | Optional. Array of build IDs to include in the comment. Build information will be displayed in a formatted table.       |
+| update_group_ids | string[]   | Optional. Array of update group IDs to include. Updates will be displayed with QR codes for easy device testing.        |
+
+> **Note**: The job operates in three modes:
+> - **Payload Mode**: When `payload` is provided, posts the exact content as the comment (highest priority)
+> - **Explicit Mode**: When `build_ids` or `update_group_ids` are specified, displays only the specified builds and updates. Custom message can be set via the `message` parameter
+> - **Auto Mode**: When no `build_ids` or `update_group_ids` are specified, automatically discovers and displays all completed/failed/canceled builds and successful updates from the current workflow. Custom message can be set via the `message` parameter
+
+#### Outputs
+
+You can reference the following outputs in subsequent jobs:
+
+| Output                 | Type   | Description                                                                                      |
+| ---------------------- | ------ | ------------------------------------------------------------------------------------------------ |
+| github_comment_posted  | string | Whether a comment was posted ('true' or 'false')                                                |
+| pr_number              | string | The PR number if the workflow was triggered by a pull request                                   |
+| comment_url            | string | URL of the posted GitHub comment (only available when comment is successfully posted)           |
+| comment_content        | string | Full content of the comment (useful for non-PR workflows to display in UI)                     |
+| note                   | string | Additional information about the job result (e.g., why a comment wasn't posted)                 |
+
+### Examples
+
+Here are some practical examples of using the GitHub Comment job:
+
+<Collapsible summary="Post build results to PR">
+
+This workflow automatically posts build results to the pull request after the build and update jobs have completed.
+
+```yaml .eas/workflows/pr-build-comment.yml
+name: PR Build Comment
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  ...
+
+  comment_on_pr:
+    name: Post Build to PR
+    after: [build_ios, build_android, publish_update]
+    type: github-comment
+    #params:
+      #message: "You can override the message in the report template here (optiional)"
+
+```
+
+</Collapsible>
+
+<Collapsible summary="Post update with specified build and update">
+
+This workflow publishes an update and posts it to the PR with a QR code for easy device testing.
+
+```yaml .eas/workflows/pr-update-comment.yml
+name: PR Update Comment
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  ...
+
+  comment_update:
+    name: Post Update to PR
+    after: [build_ios, build_android, publish_update]
+    type: github-comment
+    params:
+      #message: "You can override the message in the report template here (optiional)"
+      build_ids:
+        - ${{ after.build_ios.outputs.build_id }}
+        - ${{ after.build_android.outputs.build_id }}
+      update_group_ids:
+        - ${{ after.publish_update.outputs.first_update_group_id }}
+```
+
+</Collapsible>
+
+<Collapsible summary="Custom comment with payload">
+
+This workflow uses a custom payload to create a rich comment with build status and custom formatting.
+
+```yaml .eas/workflows/custom-pr-comment.yml
+name: Custom PR Comment
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  ...
+
+  custom_comment:
+    name: Post Custom Comment
+    needs: [build_ios]
+    type: github-comment
+    params:
+      payload: |
+        ## 🚀 Build Status Update
+        
+        ### iOS Build Completed
+        - **Build ID**: `${{ needs.build_ios.outputs.build_id }}`
+        - **Version**: ${{ needs.build_ios.outputs.app_version }}
+        - **Build Number**: ${{ needs.build_ios.outputs.app_build_version }}
+        
+        ### Next Steps
+        1. Download the build from [EAS Dashboard](https://expo.dev/accounts/[account]/projects/[project]/builds/${{ needs.build_ios.outputs.build_id }})
+        2. Test on physical device
+        3. Approve for TestFlight distribution
+        
+        ---
+        *This comment was automatically generated by EAS Workflows*
+```
+
+</Collapsible>
+
+<Collapsible summary="Conditional comment based on build status">
+
+This workflow posts different comments based on whether the build succeeded or failed.
+
+```yaml .eas/workflows/conditional-comment.yml
+name: Conditional PR Comment
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build_android:
+    name: Build Android
+    type: build
+    params:
+      platform: android
+      profile: preview
+
+  comment_success:
+    name: Post Success Comment
+    needs: [build_android]
+    if: ${{ needs.build_android.status == 'success' }}
+    type: github-comment
+    params:
+      message: "✅ Android build succeeded! Ready for testing."
+      build_ids:
+        - ${{ needs.build_android.outputs.build_id }}
+
+  comment_failure:
+    name: Post Failure Comment
+    after: [build_android]
+    if: ${{ after.build_android.status == 'failure' }}
+    type: github-comment
+    params:
+      payload: |
+        ❌ **Android build failed**
+        
+        Please check the [workflow logs](https://expo.dev/accounts/[account]/projects/[project]/workflows) for details.
+```
+
+</Collapsible>
+
 ## Require Approval
 
 Require approval from a user before continuing with the workflow. A user can approve or reject which translates to success or failure of the job.

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1261,7 +1261,7 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  ...
+  # ...
 
   comment_updates_only:
     name: Post Updates Only

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1367,7 +1367,7 @@ jobs:
   - `build_ids: []` → excludes all builds from the comment
   - Same applies to `update_group_ids`
 - **GitHub Repository Required**: This job only works when the workflow is triggered from a GitHub repository with proper permissions configured.
-- **Pull Request Context**: The job automatically detects if it's running in a pull request context. If not, it will still generate the comment content but won't post to GitHub.
+- **non-pull request behavior**: The job is marked as successful if it's not running from a pull request.
 
 ## Require Approval
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1184,7 +1184,7 @@ on:
   pull_request: {}
 
 jobs:
-  ...
+  # ...
 
   comment_on_pr:
     name: Post Results to PR

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1289,7 +1289,7 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  ...
+  # ...
 
   custom_comment:
     name: Post Custom Comment

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1207,7 +1207,7 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  ...
+  # ...
 
   comment_on_pr:
     name: Post Build to PR

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1111,7 +1111,7 @@ jobs:
 
 ## GitHub Comment
 
-Automatically post reports of your workflow's completed builds and updates to GitHub pull requests. It's particularly useful for providing instant feedback on PR builds, sharing test builds with QR codes for easy device testing, and automating deployment notifications. If you want, you can override the comment contents by providing `payload` parameter.
+Automatically post reports of your workflow's completed builds and updates to GitHub pull requests. It's particularly useful for providing instant feedback on PR builds, sharing test builds with QR codes for easy device testing, and automating deployment notifications. You can also override the comment contents by providing the `payload` parameter.
 
 ### Prerequisites
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1165,7 +1165,7 @@ You can reference the following outputs in subsequent jobs:
 
 | Output      | Type   | Description                                                                           |
 | ----------- | ------ | ------------------------------------------------------------------------------------- |
-| comment_url | string | URL of the posted GitHub comment (only available when comment is successfully posted) |
+| comment_url | string | URL of the posted GitHub comment (only available when the comment is successfully posted). |
 
 ### Examples
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1124,13 +1124,15 @@ jobs:
   github_comment:
     type: github-comment
     params:
-      # Mode 1: Auto-with-overrides mode
       message: string # optional - custom message to include in the report
-      build_ids: string[] # optional - specific build IDs to include
-      update_group_ids: string[] # optional - specific update group IDs to include
-      # Mode 2: Payload mode (mutually exclusive with other parameters)
+      build_ids: string[] # optional - specific build IDs to include, defaults to all related to the running workflow
+      update_group_ids: string[] # optional - specific update group IDs to include, defaults to all related to the workfow
+
+  # instead of using message and the builds and updates table, you can also override the comment contents with `payload`
+  custom_github_comment:
+    type: github-comment
+    params:
       payload: string # optional - raw markdown/HTML content for fully custom comment
-```
 
 #### Parameters
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1342,7 +1342,7 @@ jobs:
     type: github-comment
     params:
       message: '✅ Android build succeeded! Ready for testing.'
-      build_ids:
+      build_ids: # provided only for instructional purposes, you could as well omit this here
         - ${{ needs.build_android.outputs.build_id }}
 
   comment_failure:

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1134,14 +1134,15 @@ jobs:
 
 You can pass the following parameters into the `params` list:
 
-| Parameter        | Type       | Description                                                                                                              |
-| ---------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
-| payload          | string     | Optional. Raw markdown content to post as the comment. Takes precedence over all other parameters.                      |
-| message          | string     | Optional. Custom message to include at the top of the comment. If not provided, a default message will be used.         |
-| build_ids        | string[]   | Optional. Array of build IDs to include in the comment. Build information will be displayed in a formatted table.       |
-| update_group_ids | string[]   | Optional. Array of update group IDs to include. Updates will be displayed with QR codes for easy device testing.        |
+| Parameter        | Type     | Description                                                                                                       |
+| ---------------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| payload          | string   | Optional. Raw markdown content to post as the comment. Takes precedence over all other parameters.                |
+| message          | string   | Optional. Custom message to include at the top of the comment. If not provided, a default message will be used.   |
+| build_ids        | string[] | Optional. Array of build IDs to include in the comment. Build information will be displayed in a formatted table. |
+| update_group_ids | string[] | Optional. Array of update group IDs to include. Updates will be displayed with QR codes for easy device testing.  |
 
 > **Note**: The job operates in three modes:
+>
 > - **Payload Mode**: When `payload` is provided, posts the exact content as the comment (highest priority)
 > - **Explicit Mode**: When `build_ids` or `update_group_ids` are specified, displays only the specified builds and updates. Custom message can be set via the `message` parameter
 > - **Auto Mode**: When no `build_ids` or `update_group_ids` are specified, automatically discovers and displays all completed/failed/canceled builds and successful updates from the current workflow. Custom message can be set via the `message` parameter
@@ -1150,13 +1151,13 @@ You can pass the following parameters into the `params` list:
 
 You can reference the following outputs in subsequent jobs:
 
-| Output                 | Type   | Description                                                                                      |
-| ---------------------- | ------ | ------------------------------------------------------------------------------------------------ |
-| github_comment_posted  | string | Whether a comment was posted ('true' or 'false')                                                |
-| pr_number              | string | The PR number if the workflow was triggered by a pull request                                   |
-| comment_url            | string | URL of the posted GitHub comment (only available when comment is successfully posted)           |
-| comment_content        | string | Full content of the comment (useful for non-PR workflows to display in UI)                     |
-| note                   | string | Additional information about the job result (e.g., why a comment wasn't posted)                 |
+| Output                | Type   | Description                                                                           |
+| --------------------- | ------ | ------------------------------------------------------------------------------------- |
+| github_comment_posted | string | Whether a comment was posted ('true' or 'false')                                      |
+| pr_number             | string | The PR number if the workflow was triggered by a pull request                         |
+| comment_url           | string | URL of the posted GitHub comment (only available when comment is successfully posted) |
+| comment_content       | string | Full content of the comment (useful for non-PR workflows to display in UI)            |
+| note                  | string | Additional information about the job result (e.g., why a comment wasn't posted)       |
 
 ### Examples
 
@@ -1237,17 +1238,17 @@ jobs:
     params:
       payload: |
         ## 🚀 Build Status Update
-        
+
         ### iOS Build Completed
         - **Build ID**: `${{ needs.build_ios.outputs.build_id }}`
         - **Version**: ${{ needs.build_ios.outputs.app_version }}
         - **Build Number**: ${{ needs.build_ios.outputs.app_build_version }}
-        
+
         ### Next Steps
         1. Download the build from [EAS Dashboard](https://expo.dev/accounts/[account]/projects/[project]/builds/${{ needs.build_ios.outputs.build_id }})
         2. Test on physical device
         3. Approve for TestFlight distribution
-        
+
         ---
         *This comment was automatically generated by EAS Workflows*
 ```
@@ -1279,7 +1280,7 @@ jobs:
     if: ${{ needs.build_android.status == 'success' }}
     type: github-comment
     params:
-      message: "✅ Android build succeeded! Ready for testing."
+      message: '✅ Android build succeeded! Ready for testing.'
       build_ids:
         - ${{ needs.build_android.outputs.build_id }}
 
@@ -1291,7 +1292,7 @@ jobs:
     params:
       payload: |
         ❌ **Android build failed**
-        
+
         Please check the [workflow logs](https://expo.dev/accounts/[account]/projects/[project]/workflows) for details.
 ```
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1136,7 +1136,7 @@ jobs:
 
 The job operates in two mutually exclusive modes:
 
-##### Mode 1: Auto-with-Overrides Mode
+##### Mode 1: Auto-with-overrides mode
 
 When not using payload, you can optionally specify any combination of these parameters:
 
@@ -1148,7 +1148,7 @@ When not using payload, you can optionally specify any combination of these para
 
 > **Auto-discovery behavior**: When `build_ids` or `update_group_ids` are not specified (undefined), the job automatically discovers all relevant builds and updates from the current workflow. To explicitly exclude builds or updates, pass an empty array `[]`.
 
-##### Mode 2: Payload Mode
+##### Mode 2: Payload mode
 
 When using payload mode, you cannot specify any other parameters.
 
@@ -1168,7 +1168,7 @@ You can reference the following outputs in subsequent jobs:
 
 Here are practical examples demonstrating both modes of the GitHub Comment job:
 
-#### Auto-with-Overrides Mode Examples
+#### Auto-with-overrides mode examples
 
 <Collapsible summary="Auto-discover all builds and updates">
 
@@ -1273,7 +1273,7 @@ jobs:
 
 </Collapsible>
 
-#### Payload Mode Examples
+#### Payload mode examples
 
 <Collapsible summary="Fully custom comment with payload">
 
@@ -1358,7 +1358,7 @@ jobs:
 
 </Collapsible>
 
-### Important Notes
+### Important notes
 
 - **Mode Mutual Exclusivity**: The `payload` parameter cannot be used together with `message`, `build_ids`, or `update_group_ids`. If you specify `payload`, the job will use payload mode and ignore all other parameters.
 - **Auto-discovery vs Exclusion**: There's an important difference between not specifying a parameter (undefined) and providing an empty array:

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1180,8 +1180,7 @@ This is the simplest usage - automatically discovers and posts all builds and up
 name: PR Auto Comment
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  pull_request: {}
 
 jobs:
   ...

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1141,7 +1141,7 @@ The job operates in two mutually exclusive modes:
 
 ##### Mode 1: Auto-with-overrides mode
 
-Default behavior is auto discovery builds & updates, you can specify any of these parameters if you want to:
+Default behavior is auto discovery builds and updates, you can specify any of these parameters if you want to:
 
 | Parameter        | Type     | Description                                                                                                                                                      |
 | ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1133,6 +1133,7 @@ jobs:
     type: github-comment
     params:
       payload: string # optional - raw markdown/HTML content for fully custom comment
+```
 
 #### Parameters
 
@@ -1140,7 +1141,7 @@ The job operates in two mutually exclusive modes:
 
 ##### Mode 1: Auto-with-overrides mode
 
-When not using payload, you can optionally specify any combination of these parameters:
+Default behavior is auto discovery builds & updates, you can specify any of these parameters if you want to:
 
 | Parameter        | Type     | Description                                                                                                                                                      |
 | ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -1358,16 +1359,6 @@ jobs:
 ```
 
 </Collapsible>
-
-### Important notes
-
-- **Mode Mutual Exclusivity**: The `payload` parameter cannot be used together with `message`, `build_ids`, or `update_group_ids`. If you specify `payload`, the job will use payload mode and ignore all other parameters.
-- **Auto-discovery vs Exclusion**: There's an important difference between not specifying a parameter (undefined) and providing an empty array:
-  - `build_ids` undefined → auto-discovers all builds
-  - `build_ids: []` → excludes all builds from the comment
-  - Same applies to `update_group_ids`
-- **GitHub Repository Required**: This job only works when the workflow is triggered from a GitHub repository with proper permissions configured.
-- **non-pull request behavior**: The job is marked as successful if it's not running from a pull request.
 
 ## Require Approval
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -855,6 +855,35 @@ jobs:
       payload: object # required if message is not provided
 ```
 
+#### `github-comment`
+
+Automatically posts comprehensive reports of your workflow's completed builds and updates to GitHub pull requests. Can generate auto-reports, display specific builds/updates with custom messages, or use payload for fully customized content. See [GitHub Comment job documentation](/eas/workflows/pre-packaged-jobs#github-comment) for detailed information and examples.
+
+```yaml
+jobs:
+  my_job:
+    # @info #
+    type: github-comment
+    # @end #
+    params:
+      payload: string # optional - raw markdown content (Takes precedence over all other parameters.)
+      message: string # optional - custom message
+      build_ids: string[] # optional - array of build IDs
+      update_group_ids: string[] # optional - array of update group IDs
+```
+
+This job outputs the following properties:
+
+```json
+{
+  "github_comment_posted": "true" | "false",
+  "pr_number": string | null,
+  "comment_url": string | null,
+  "comment_content": string | null,
+  "note": string | null
+}
+```
+
 #### `require-approval`
 
 Requires approval from a user before continuing with the workflow. A user can approve or reject which translates to success or failure of the job. See [Require Approval job documentation](/eas/workflows/pre-packaged-jobs#require-approval) for detailed information and examples.

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -857,7 +857,7 @@ jobs:
 
 #### `github-comment`
 
-Automatically posts comprehensive reports of your workflow's completed builds and updates to GitHub pull requests. Can generate auto-reports, display specific builds/updates with custom messages, or use payload for fully customized content. See [GitHub Comment job documentation](/eas/workflows/pre-packaged-jobs#github-comment) for detailed information and examples.
+Automatically posts comprehensive reports of your workflow's completed builds and updates to GitHub pull requests. The job operates in two mutually exclusive modes: payload mode for fully custom content, or auto-with-overrides mode for automated reports with optional customization. See [GitHub Comment job documentation](/eas/workflows/pre-packaged-jobs#github-comment) for detailed information and examples.
 
 ```yaml
 jobs:
@@ -866,21 +866,19 @@ jobs:
     type: github-comment
     # @end #
     params:
-      payload: string # optional - raw markdown content (Takes precedence over all other parameters.)
-      message: string # optional - custom message
-      build_ids: string[] # optional - array of build IDs
-      update_group_ids: string[] # optional - array of update group IDs
+      # Mode 1: Auto-with-overrides mode
+      message: string # optional - custom message to include in the report
+      build_ids: string[] # optional - specific build IDs to include (auto-discovers if not specified, use [] to exclude)
+      update_group_ids: string[] # optional - specific update group IDs to include (auto-discovers if not specified, use [] to exclude)
+      # Mode 2: Payload mode (mutually exclusive with other parameters)
+      payload: string # optional - raw markdown/HTML content for fully custom comment
 ```
 
 This job outputs the following properties:
 
 ```json
 {
-  "github_comment_posted": "true" | "false",
-  "pr_number": string | null,
-  "comment_url": string | null,
-  "comment_content": string | null,
-  "note": string | null
+  "comment_url": string | null  // URL of the posted GitHub comment
 }
 ```
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -878,7 +878,7 @@ This job outputs the following properties:
 
 ```json
 {
-  "comment_url": string | null  // URL of the posted GitHub comment
+  "comment_url": string | undefined  // URL of the posted GitHub comment
 }
 ```
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -857,7 +857,7 @@ jobs:
 
 #### `github-comment`
 
-Automatically posts comprehensive reports of your workflow's completed builds and updates to GitHub pull requests. The job operates in two mutually exclusive modes: payload mode for fully custom content, or auto-with-overrides mode for automated reports with optional customization. See [GitHub Comment job documentation](/eas/workflows/pre-packaged-jobs#github-comment) for detailed information and examples.
+Automatically posts comprehensive reports of your workflow's completed builds and updates to GitHub pull requests or content provided by you. See [GitHub Comment job documentation](/eas/workflows/pre-packaged-jobs#github-comment) for detailed information and examples.
 
 ```yaml
 jobs:

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -866,11 +866,14 @@ jobs:
     type: github-comment
     # @end #
     params:
-      # Mode 1: Auto-with-overrides mode
       message: string # optional - custom message to include in the report
-      build_ids: string[] # optional - specific build IDs to include (auto-discovers if not specified, use [] to exclude)
-      update_group_ids: string[] # optional - specific update group IDs to include (auto-discovers if not specified, use [] to exclude)
-      # Mode 2: Payload mode (mutually exclusive with other parameters)
+      build_ids: string[] # optional - specific build IDs to include, defaults to all related to the running workflow
+      update_group_ids: string[] # optional - specific update group IDs to include, defaults to all related to the workfow
+
+  # instead of using message and the builds and updates table, you can also override the comment contents with `payload`
+  custom_github_comment:
+    type: github-comment
+    params:
       payload: string # optional - raw markdown/HTML content for fully custom comment
 ```
 


### PR DESCRIPTION
# Why

We recently added a new `github-comment` workflow job type to EAS Workflows that enables teams to automatically post build and update reports to GitHub PRs. This documentation ensures developers can discover and use this new feature effectively.

# How

  - Added `github-comment` job documentation to `/pages/eas/workflows/pre-packaged-jobs.mdx` with complete syntax, parameters, outputs, and practical examples
  - Added `github-comment` job type reference to `/pages/eas/workflows/syntax.mdx` with output properties

# Test Plan

Tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
