### PR TITLE
[android][camera] Fix scanning error on unsupported devices

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix errors on devices that do not have Google Play Services installed.
+
 ### 💡 Others
 
 ## 17.0.6 — 2025-09-02

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix errors on devices that do not have Google Play Services installed.
+- [Android] Fix errors on devices that do not have Google Play Services installed. ([#39455](https://github.com/expo/expo/pull/39455) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -28,6 +28,6 @@ dependencies {
 
   implementation "androidx.camera:camera-view:${camerax_version}"
   implementation "androidx.camera:camera-extensions:${camerax_version}"
-  implementation "com.google.mlkit:barcode-scanning:17.3.0"
+  compileOnly "com.google.mlkit:barcode-scanning:17.3.0"
   implementation "androidx.camera:camera-mlkit-vision:${camerax_version}"
 }

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -28,6 +28,6 @@ dependencies {
 
   implementation "androidx.camera:camera-view:${camerax_version}"
   implementation "androidx.camera:camera-extensions:${camerax_version}"
-  compileOnly "com.google.mlkit:barcode-scanning:17.3.0"
+  implementation "com.google.mlkit:barcode-scanning:17.3.0"
   implementation "androidx.camera:camera-mlkit-vision:${camerax_version}"
 }

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraExceptions.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraExceptions.kt
@@ -16,5 +16,11 @@ class CameraExceptions {
   class BarcodeScanningFailedException :
     CodedException("Barcode scanning failed")
 
+  class MLKitUnavailableException :
+    CodedException("MLKit is not available on this device. Barcode scanning requires Google Play Services.")
+
+  class GooglePlayServicesUnavailableException :
+    CodedException("Google Play Services is not available on this device. This feature requires Google Play Services.")
+
   class WriteImageException(cause: String?) : CodedException("Writing image has failed: $cause")
 }

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -493,12 +493,16 @@ class ExpoCameraView(
       .build()
       .also { analyzer ->
         if (shouldScanBarcodes && CameraUtils.isMLKitAvailable(context)) {
-          analyzer.setAnalyzer(
-            ContextCompat.getMainExecutor(context),
-            BarcodeAnalyzer(lensFacing, barcodeFormats) {
-              onBarcodeScanned(it)
-            }
-          )
+          try {
+            analyzer.setAnalyzer(
+              ContextCompat.getMainExecutor(context),
+              BarcodeAnalyzer(lensFacing, barcodeFormats) {
+                onBarcodeScanned(it)
+              }
+            )
+          } catch (e: Exception) {
+            Log.e(CameraViewModule.TAG, "Failed to initialize BarcodeAnalyzer: ${e.message}")
+          }
         }
       }
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -65,6 +65,7 @@ import expo.modules.camera.records.VideoQuality
 import expo.modules.camera.tasks.ResolveTakenPicture
 import expo.modules.camera.utils.BarCodeScannerResult
 import expo.modules.camera.utils.BarCodeScannerResult.BoundingBox
+import expo.modules.camera.utils.CameraUtils
 import expo.modules.camera.utils.FileSystemUtils
 import expo.modules.camera.utils.mapX
 import expo.modules.camera.utils.mapY
@@ -491,7 +492,7 @@ class ExpoCameraView(
       .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
       .build()
       .also { analyzer ->
-        if (shouldScanBarcodes) {
+        if (shouldScanBarcodes && CameraUtils.isMLKitAvailable(context)) {
           analyzer.setAnalyzer(
             ContextCompat.getMainExecutor(context),
             BarcodeAnalyzer(lensFacing, barcodeFormats) {
@@ -788,7 +789,7 @@ class ExpoCameraView(
 
   private fun cancelCoroutineScope() = try {
     scope.cancel(ModuleDestroyedException())
-  } catch (e: Exception) {
+  } catch (_: Exception) {
     Log.e(CameraViewModule.TAG, "The scope does not have a job in it")
   }
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/utils/CameraUtils.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/utils/CameraUtils.kt
@@ -1,0 +1,34 @@
+package expo.modules.camera.utils
+
+import android.content.Context
+import android.content.pm.PackageManager
+
+object CameraUtils {
+  private const val GOOGLE_PLAY_STORE_PACKAGE = "com.android.vending"
+
+  fun hasGooglePlayServices(context: Context?): Boolean {
+    if (context == null) {
+      return false
+    }
+    return try {
+      context.packageManager
+        .getPackageInfo(GOOGLE_PLAY_STORE_PACKAGE, 0)
+      true
+    } catch (_: PackageManager.NameNotFoundException) {
+      false
+    }
+  }
+
+  fun isMLKitAvailable(context: Context?): Boolean {
+    if (!hasGooglePlayServices(context)) {
+      return false
+    }
+
+    return try {
+      Class.forName("com.google.mlkit.vision.barcode.BarcodeScanning")
+      true
+    } catch (_: ClassNotFoundException) {
+      false
+    }
+  }
+}


### PR DESCRIPTION
# Why
Closes #39449
Play services and MLKit are not available on all devices. We need to add checks for this to prevent hard crashes on unsupported devices. 

# How
Add a utils object that checks for mlkit and play services availability. Google provide a utility for checking play services is available through the `GooglePlayServicesUtil` class but I'm not sure of it's availability on some of these devices. It just checks for the presence of the `com.android.vending` package so it might be safer to just do that. 

# Test Plan
Bare-expo. I don't have a problematic device but this does not affect normal functionality.

