### PR TITLE
[go/dev-menu][android] Add widescreen support

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/DevMenuManager.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/DevMenuManager.kt
@@ -22,6 +22,7 @@ import host.exp.exponent.experience.ReactNativeActivity
 import host.exp.exponent.modules.ExponentKernelModule
 import host.exp.exponent.storage.ExponentSharedPreferences
 import host.exp.exponent.utils.ShakeDetector
+import host.exp.exponent.utils.currentDeviceIsAPhone
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -88,7 +89,9 @@ class DevMenuManager {
         // We need to force the device to use portrait orientation as the dev menu doesn't support landscape.
         // However, when removing it, we should set it back to the orientation from before showing the dev menu.
         orientationBeforeShowingDevMenu = activity.requestedOrientation
-        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        if (currentDeviceIsAPhone(activity)) {
+          activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        }
 
         devMenuView.view?.let {
           activity.addReactViewToContentContainer(it)

--- a/apps/expo-go/src/menu/DevMenuBottomSheet.tsx
+++ b/apps/expo-go/src/menu/DevMenuBottomSheet.tsx
@@ -1,4 +1,7 @@
-import BottomSheet, { BottomSheetView, useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
+import BottomSheet, {
+  BottomSheetScrollView,
+  useBottomSheetSpringConfigs,
+} from '@gorhom/bottom-sheet';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { StyleSheet, View, TouchableWithoutFeedback } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
@@ -103,10 +106,10 @@ function DevMenuBottomSheet({ children, uuid }: Props) {
         enablePanDownToClose
         onChange={onChange}>
         <DevMenuBottomSheetContext.Provider value={{ collapse: onCollapse, expand: onExpand }}>
-          <BottomSheetView style={styles.contentContainerStyle}>{children}</BottomSheetView>
+          <BottomSheetScrollView style={styles.contentContainerStyle}>
+            {children}
+          </BottomSheetScrollView>
         </DevMenuBottomSheetContext.Provider>
-        {/* Adds bottom offset so that no empty space is shown on overdrag */}
-        <View style={{ height: 100 }} />
       </BottomSheet>
     </View>
   );

--- a/apps/expo-go/src/menu/DevMenuOnboarding.tsx
+++ b/apps/expo-go/src/menu/DevMenuOnboarding.tsx
@@ -1,8 +1,18 @@
-import { View, Text, Button, Spacer, scale } from 'expo-dev-client-components';
+import {
+  View,
+  Text,
+  Button,
+  Spacer,
+  scale,
+  useExpoTheme,
+  padding,
+} from 'expo-dev-client-components';
 import { isDevice } from 'expo-device';
 import React from 'react';
 import { Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { CappedWidthContainerView } from '../components/Views';
 
 type Props = {
   onClose: () => void;
@@ -45,14 +55,19 @@ const simulatorMessage = Platform.select({
 
 export function DevMenuOnboarding({ onClose }: Props) {
   const { bottom } = useSafeAreaInsets();
-
+  const theme = useExpoTheme();
   return (
-    <View
-      flex="1"
-      bg="default"
-      pt="medium"
-      px="large"
-      style={{ paddingBottom: bottom + scale.medium }}>
+    <CappedWidthContainerView
+      style={{
+        flex: 1,
+        backgroundColor: theme.background.default,
+        paddingBottom: bottom + scale.medium,
+        ...padding.pt.medium,
+        ...padding.px.large,
+      }}
+      wrapperStyle={{
+        backgroundColor: theme.background.default,
+      }}>
       <View>
         <Text size="medium" maxFontSizeMultiplier={1.2}>
           This is the developer menu. It gives you access to useful tools in Expo Go.
@@ -72,6 +87,6 @@ export function DevMenuOnboarding({ onClose }: Props) {
           </Button.Text>
         </View>
       </Button.FadeOnPressContainer>
-    </View>
+    </CappedWidthContainerView>
   );
 }

--- a/apps/expo-go/src/menu/DevMenuServerInfo.tsx
+++ b/apps/expo-go/src/menu/DevMenuServerInfo.tsx
@@ -1,10 +1,11 @@
 import Constants from 'expo-constants';
-import { Row, View, Text, Spacer } from 'expo-dev-client-components';
+import { Row, Text, Spacer, useExpoTheme, padding } from 'expo-dev-client-components';
 import React from 'react';
 import { StyleSheet, TouchableOpacity, Clipboard } from 'react-native';
 
 import { ClipboardIcon } from './ClipboardIcon';
 import DevIndicator from '../components/DevIndicator';
+import { CappedWidthContainerView } from '../components/Views';
 import FriendlyUrls from '../legacy/FriendlyUrls';
 
 type Props = {
@@ -27,9 +28,17 @@ export function DevMenuServerInfo({ task }: Props) {
     Clipboard.setString(manifestUrl);
     alert(`Copied "${manifestUrl}" to the clipboard.`);
   }
+  const theme = useExpoTheme();
 
   return (
-    <View bg="default" padding="medium">
+    <CappedWidthContainerView
+      style={{
+        backgroundColor: theme.background.default,
+        ...padding.padding.medium,
+      }}
+      wrapperStyle={{
+        backgroundColor: theme.background.default,
+      }}>
       {devServerName ? (
         <>
           <Text size="small" type="InterRegular">
@@ -51,7 +60,7 @@ export function DevMenuServerInfo({ task }: Props) {
           <ClipboardIcon />
         </Row>
       </TouchableOpacity>
-    </View>
+    </CappedWidthContainerView>
   );
 }
 

--- a/apps/expo-go/src/menu/DevMenuTaskInfo.tsx
+++ b/apps/expo-go/src/menu/DevMenuTaskInfo.tsx
@@ -4,6 +4,8 @@ import { Row, View, Text, useExpoTheme } from 'expo-dev-client-components';
 import React from 'react';
 import { Image, Linking, StyleSheet, TouchableOpacity } from 'react-native';
 
+import { CappedWidthContainerView } from '../components/Views';
+
 type Props = {
   task: { manifestUrl: string; manifestString: string };
 };
@@ -56,7 +58,10 @@ export function DevMenuTaskInfo({ task }: Props) {
   const manifestInfo = manifest ? getInfoFromManifest(manifest) : null;
 
   return (
-    <View>
+    <CappedWidthContainerView
+      wrapperStyle={{
+        backgroundColor: theme.background.default,
+      }}>
       <Row bg="default" padding="medium">
         {manifestInfo?.iconUrl ? (
           <Image source={{ uri: manifestInfo.iconUrl }} style={styles.taskIcon} />
@@ -118,7 +123,7 @@ export function DevMenuTaskInfo({ task }: Props) {
           )}
         </View>
       </Row>
-    </View>
+    </CappedWidthContainerView>
   );
 }
 

--- a/apps/expo-go/src/menu/DevMenuView.tsx
+++ b/apps/expo-go/src/menu/DevMenuView.tsx
@@ -1,6 +1,6 @@
 import { HomeFilledIcon, iconSize, RefreshIcon } from '@expo/styleguide-native';
 import MaterialCommunityIcons from '@expo/vector-icons/build/MaterialCommunityIcons';
-import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
+import { Divider, rounded, useExpoTheme, View } from 'expo-dev-client-components';
 import * as Font from 'expo-font';
 import React, { Fragment, useContext, useEffect, useRef } from 'react';
 import { Image } from 'react-native';
@@ -14,6 +14,7 @@ import * as DevMenu from './DevMenuModule';
 import { DevMenuOnboarding } from './DevMenuOnboarding';
 import { DevMenuServerInfo } from './DevMenuServerInfo';
 import { DevMenuTaskInfo } from './DevMenuTaskInfo';
+import { CappedWidthContainerView } from '../components/Views';
 type Props = {
   task: { manifestUrl: string; manifestString: string };
   uuid: string;
@@ -163,7 +164,10 @@ export function DevMenuView({ uuid, task }: Props) {
 
   return (
     <View bg="secondary" flex="1" roundedTop="large" overflow="hidden" style={{ direction: 'ltr' }}>
-      <DevMenuTaskInfo task={task} />
+      <CappedWidthContainerView wrapperStyle={{ backgroundColor: theme.background.default }}>
+        <DevMenuTaskInfo task={task} />
+        <DevMenuCloseButton onPress={collapseAndCloseDevMenuAsync} />
+      </CappedWidthContainerView>
       <Divider />
       <View>
         {!isOnboardingFinished ? (
@@ -172,54 +176,54 @@ export function DevMenuView({ uuid, task }: Props) {
           <View style={{ paddingBottom: insets.bottom }}>
             <DevMenuServerInfo task={task} />
             <Divider />
-            <View padding="medium" style={{ paddingBottom: 0 }}>
-              <UpgradeWarning collapsible />
-            </View>
-            <Divider />
-            <View padding="medium" style={{ paddingTop: 0 }}>
-              <View bg="default" rounded="large">
-                <DevMenuItem
-                  buttonKey="reload"
-                  label="Reload"
-                  onPress={onAppReload}
-                  icon={<RefreshIcon size={iconSize.small} color={theme.icon.default} />}
-                />
-                <Divider />
-                <DevMenuItem
-                  buttonKey="home"
-                  label="Go Home"
-                  onPress={onGoToHome}
-                  icon={<HomeFilledIcon size={iconSize.small} color={theme.icon.default} />}
-                />
+            <CappedWidthContainerView>
+              <View padding="medium" style={{ paddingBottom: 0 }}>
+                <UpgradeWarning collapsible />
               </View>
-            </View>
-            {enableDevMenuTools && devMenuItems && (
               <View padding="medium" style={{ paddingTop: 0 }}>
                 <View bg="default" rounded="large">
-                  {sortedDevMenuItems.map((key, i) => {
-                    const item = devMenuItems[key];
-
-                    const { label, isEnabled } = item;
-                    return (
-                      <Fragment key={key}>
-                        <DevMenuItem
-                          buttonKey={key}
-                          label={label}
-                          onPress={onPressDevMenuButton}
-                          icon={MENU_ITEMS_ICON_MAPPINGS[key]}
-                          isEnabled={isEnabled}
-                        />
-                        {i < sortedDevMenuItems.length - 1 && <Divider />}
-                      </Fragment>
-                    );
-                  })}
+                  <DevMenuItem
+                    buttonKey="reload"
+                    label="Reload"
+                    onPress={onAppReload}
+                    icon={<RefreshIcon size={iconSize.small} color={theme.icon.default} />}
+                  />
+                  <Divider />
+                  <DevMenuItem
+                    buttonKey="home"
+                    label="Go Home"
+                    onPress={onGoToHome}
+                    icon={<HomeFilledIcon size={iconSize.small} color={theme.icon.default} />}
+                  />
                 </View>
               </View>
-            )}
+              {enableDevMenuTools && devMenuItems && (
+                <View padding="medium" style={{ paddingTop: 0 }}>
+                  <View bg="default" rounded="large">
+                    {sortedDevMenuItems.map((key, i) => {
+                      const item = devMenuItems[key];
+
+                      const { label, isEnabled } = item;
+                      return (
+                        <Fragment key={key}>
+                          <DevMenuItem
+                            buttonKey={key}
+                            label={label}
+                            onPress={onPressDevMenuButton}
+                            icon={MENU_ITEMS_ICON_MAPPINGS[key]}
+                            isEnabled={isEnabled}
+                          />
+                          {i < sortedDevMenuItems.length - 1 && <Divider />}
+                        </Fragment>
+                      );
+                    })}
+                  </View>
+                </View>
+              )}
+            </CappedWidthContainerView>
           </View>
         )}
       </View>
-      <DevMenuCloseButton onPress={collapseAndCloseDevMenuAsync} />
     </View>
   );
 }

--- a/apps/expo-go/src/menu/DevMenuView.tsx
+++ b/apps/expo-go/src/menu/DevMenuView.tsx
@@ -1,6 +1,6 @@
 import { HomeFilledIcon, iconSize, RefreshIcon } from '@expo/styleguide-native';
 import MaterialCommunityIcons from '@expo/vector-icons/build/MaterialCommunityIcons';
-import { Divider, rounded, useExpoTheme, View } from 'expo-dev-client-components';
+import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
 import * as Font from 'expo-font';
 import React, { Fragment, useContext, useEffect, useRef } from 'react';
 import { Image } from 'react-native';


### PR DESCRIPTION
# Why

This PR is a part of an effort to make expo-go better on the Quest. Dev-menu on Android currently doesn't support widescreen.

# How

Used the same method as for home in order to add widescreen support to dev-menu.

- Conditionally request ActivityInfo.SCREEN_ORIENTATION_PORTRAIT - only on phones
- Use `CappedWidthContainerView` to make UI components less wide in landscape mode.

# Test Plan

Tested in Expo Go on an Android Tablet emulator and Meta Quest 3

| Old (Notice the black bars appearing when dev-menu is visible) | New |
| ------------- | ------------- |
| <img width="600"  alt="image" src="https://github.com/user-attachments/assets/20a65b5d-1abb-4b1b-ab76-7e8941988d22" /> | <img width="600" alt="image" src="https://github.com/user-attachments/assets/488e23d7-5932-406f-abbb-d1c3f6096387" /> |






