### PR TITLE
fix: Class 'android.media.MediaMetadataRetriever' does not implement interface 'java.lang.AutoCloseable' on android < 29

### DIFF
--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- fix crash on android API < 29. ([#39460](https://github.com/expo/expo/pull/39460) by [@ACHP](https://github.com/ACHP))
+
 ### 💡 Others
 
 ## 9.1.3 — 2025-04-30


### PR DESCRIPTION
# Why

on Android < 29 the module crash because of the MediaMetaDataRetriever.

`Class 'android.media.MediaMetadataRetriever' does not implement interface 'java.lang.AutoCloseable'`

On API levels below 29, MediaMetadataRetriever does not implement AutoCloseable. Using use { } in such cases can lead to a ClassCastException or unexpected behavior at runtime

# How

it’s best to manually handle the lifecycle of MediaMetadataRetriever

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
