### PR TITLE
[documentation] Safe area - Fix external links

### DIFF
--- a/docs/pages/develop/user-interface/safe-areas.mdx
+++ b/docs/pages/develop/user-interface/safe-areas.mdx
@@ -37,7 +37,7 @@ You can skip installing `react-native-safe-area-context` if you have created a p
 
 ### Usage
 
-You can directly use [`SafeAreaView`](https://github.com/th3rdwave/react-native-safe-area-context#safeareaview) to wrap the content of your screen's component. It is a regular `<View>` with the safe area insets applied as extra padding or margin.
+You can directly use [`SafeAreaView`](https://appandflow.github.io/react-native-safe-area-context/api/safe-area-view) to wrap the content of your screen's component. It is a regular `<View>` with the safe area insets applied as extra padding or margin.
 
 ```tsx app/index.tsx
 import { Text } from 'react-native';
@@ -54,7 +54,7 @@ export default function HomeScreen() {
 
 <Collapsible summary="Using a different Expo template and don't have Expo Router installed?">
 
-Import and add [`SafeAreaProvider`](https://github.com/th3rdwave/react-native-safe-area-context#safeareaprovider) to the root component file (such as **App.tsx**) before using `SafeAreaView` in your screen component.
+Import and add [`SafeAreaProvider`](https://appandflow.github.io/react-native-safe-area-context/api/safe-area-provider) to the root component file (such as **App.tsx**) before using `SafeAreaView` in your screen component.
 
 ```tsx App.tsx
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -70,7 +70,7 @@ export default function App() {
 
 ## Alternate: `useSafeAreaInsets` hook
 
-Alternate to `SafeAreaView`, you can use [`useSafeAreaInsets`](https://github.com/th3rdwave/react-native-safe-area-context#usesafeareainsets) hook in your screen component. It provides direct access to the safe area insets, allowing you to apply padding for each edge of the `<View>` using an inset from this hook.
+Alternate to `SafeAreaView`, you can use [`useSafeAreaInsets`](https://appandflow.github.io/react-native-safe-area-context/api/use-safe-area-insets) hook in your screen component. It provides direct access to the safe area insets, allowing you to apply padding for each edge of the `<View>` using an inset from this hook.
 
 The example below uses the `useSafeAreaInsets` hook. It applies top padding to a `<View>` using `insets.top`.
 
@@ -138,4 +138,4 @@ By default, React Navigation supports safe areas and uses `react-native-safe-are
 
 ### Usage with web
 
-If you are targeting the web, set up `SafeAreaProvider` as described in the [usage section](#usage). If you are doing server-side rendering (SSR), see the [Web SSR section](https://github.com/th3rdwave/react-native-safe-area-context#web-ssr) in the library's documentation.
+If you are targeting the web, set up `SafeAreaProvider` as described in the [usage section](#usage). If you are doing server-side rendering (SSR), see the [Web SSR section](https://appandflow.github.io/react-native-safe-area-context/optimizations#web-ssr) in the library's documentation.

--- a/docs/pages/develop/user-interface/safe-areas.mdx
+++ b/docs/pages/develop/user-interface/safe-areas.mdx
@@ -19,7 +19,7 @@ Here's an example of an app screen's content getting concealed by the status bar
 
 ## Use `react-native-safe-area-context` library
 
-[`react-native-safe-area-context`](https://github.com/th3rdwave/react-native-safe-area-context) provides a flexible API for handling Android and iOS device's safe area insets. It also provides a `SafeAreaView` component that you can use instead of a [`<View>`](https://reactnative.dev/docs/view) to account for safe areas automatically in your screen components.
+[`react-native-safe-area-context`](https://github.com/AppAndFlow/react-native-safe-area-context) provides a flexible API for handling Android and iOS device's safe area insets. It also provides a `SafeAreaView` component that you can use instead of a [`<View>`](https://reactnative.dev/docs/view) to account for safe areas automatically in your screen components.
 
 Using the library, the result of the previous example changes as it displays the content inside a safe area, as shown below:
 


### PR DESCRIPTION
# Why

Links to https://github.com/th3rdwave/react-native-safe-area-context no longer work, because the repo was migrated to https://github.com/AppAndFlow/react-native-safe-area-context.

# How

Replaced the links with links to the new documentation hosted under https://appandflow.github.io/react-native-safe-area-context/

# Test Plan

Markdown works in the GitHub preview.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
