### PR TITLE
Update building-for-tv.mdx

### DIFF
--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -83,7 +83,7 @@ At this time, TV applications work with the following libraries and APIs listed 
 - [FlashList](/versions/latest/sdk/flash-list/)
 - [Font](/versions/latest/sdk/font/)
 - [Image](/versions/latest/sdk/image)
-- [ImageManipulator](/versions/latest/sdk/imagemanipulator/)]
+- [ImageManipulator](/versions/latest/sdk/imagemanipulator/)
 - [KeepAwake](/versions/latest/sdk/keep-awake/)
 - [LinearGradient](/versions/latest/sdk/linear-gradient/)
 - [Localization](/versions/latest/sdk/localization/)


### PR DESCRIPTION
# Why

<img width="848" height="138" alt="image" src="https://github.com/user-attachments/assets/02cea791-7fc8-4568-a87b-bb39664281fb" />

<!--
The Doc mdx format extra one "]". So we can remove that
-->

# How

<!--
Just remove this"]" from the MDX file
-->
