### PR TITLE
fix(cli): Apply upstream 0.82 Metro changes to metro-require fork

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Apply upstream changes to optional require runtime fork ([#39473](https://github.com/expo/expo/pull/39473) by [@kitten](https://github.com/kitten))
+
 ## 0.26.9 — 2025-09-08
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/metro-require/require.ts
+++ b/packages/@expo/cli/metro-require/require.ts
@@ -113,8 +113,9 @@ const CYCLE_DETECTED = {};
 const { hasOwnProperty } = {};
 
 if (__DEV__) {
-  global.$RefreshReg$ = () => {};
-  global.$RefreshSig$ = () => (type) => type;
+  // UPSTREAM: https://github.com/facebook/metro/commit/15fef8ebcf5ae0a13e7f0925a22d4211dde95e02
+  global.$RefreshReg$ = global.$RefreshReg$ ?? (() => {});
+  global.$RefreshSig$ = global.$RefreshSig$ ?? (() => type => type);
 }
 
 function clear(): ModuleList {
@@ -185,7 +186,7 @@ function define(factory: FactoryFn, moduleId: ModuleID, dependencyMap?: Dependen
 }
 
 function metroRequire(
-  moduleId: ModuleID | VerboseModuleNameForDev,
+  moduleId: ModuleID | VerboseModuleNameForDev | null,
   moduleIdHint?: string
 ): Exports {
   // if (__DEV__ && typeof moduleId === 'string') {
@@ -196,6 +197,15 @@ function metroRequire(
   //       'debugging purposes and will BREAK IN PRODUCTION!'
   //   );
   // }
+
+  // UPSTREAM: https://github.com/facebook/metro/commit/5f8548c2210ac824c1989b347aa1b52438449a8d#diff-d1563cf313be4f94a026f469dbd47f0822593ccdbf1eb43ef9f651b6f60fb9ec
+  // Unresolved optional dependencies are nulls in dependency maps
+  if (moduleId === null) {
+    if (__DEV__ && typeof moduleIdHint === 'string') {
+      throw new Error("Cannot find module '" + moduleIdHint + "'");
+    }
+    throw new Error('Cannot find module');
+  }
 
   if (__DEV__) {
     const initializingIndex = initializingModuleIds.indexOf(moduleId);
@@ -472,7 +482,10 @@ function loadModuleImplementation(
       if (Refresh != null) {
         const RefreshRuntime = Refresh;
         global.$RefreshReg$ = (type, id) => {
-          RefreshRuntime.register(type, moduleId + ' ' + id);
+          // UPSTREAM: https://github.com/facebook/metro/commit/c8de6512c63c3c0f6556446f8aec924380ac2014
+          // prefix the id with global prefix to enable multiple HMR clients
+          const prefixedModuleId = __METRO_GLOBAL_PREFIX__ + ' ' + moduleId + ' ' + id;
+          RefreshRuntime.register(type, prefixedModuleId);
         };
         global.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
       }
@@ -503,7 +516,13 @@ function loadModuleImplementation(
       Systrace.endEvent();
 
       if (Refresh != null) {
-        registerExportsForReactRefresh(Refresh, moduleObject.exports, moduleId);
+        // UPSTREAM: https://github.com/facebook/metro/commit/c8de6512c63c3c0f6556446f8aec924380ac2014
+        const prefixedModuleId = __METRO_GLOBAL_PREFIX__ + ' ' + moduleId;
+        registerExportsForReactRefresh(
+          Refresh,
+          moduleObject.exports,
+          prefixedModuleId,
+        );
       }
     }
 
@@ -966,7 +985,7 @@ if (__DEV__) {
   var registerExportsForReactRefresh = (
     Refresh: any,
     moduleExports: Exports,
-    moduleID: ModuleID
+    moduleID: string
   ) => {
     Refresh.register(moduleExports, moduleID + ' %exports%');
     if (moduleExports == null || typeof moduleExports !== 'object') {
@@ -1000,8 +1019,18 @@ if (__DEV__) {
     return global[__METRO_GLOBAL_PREFIX__ + '__SYSTRACE'] || metroRequire.Systrace;
   };
 
+  // UPSTREAM: https://github.com/facebook/metro/commit/c8de6512c63c3c0f6556446f8aec924380ac2014
   var requireRefresh = function requireRefresh() {
-    // @ts-expect-error
-    return global[__METRO_GLOBAL_PREFIX__ + '__ReactRefresh'] || metroRequire.Refresh;
+    // __METRO_GLOBAL_PREFIX__ and global.__METRO_GLOBAL_PREFIX__ differ from
+    // each other when multiple module systems are used - e.g, in the context
+    // of Module Federation, the first one would refer to the local prefix
+    // defined at the top of the bundle, while the other always refers to the
+    // one coming from the Host
+    return (
+      global[__METRO_GLOBAL_PREFIX__ + '__ReactRefresh'] ||
+      global[global.__METRO_GLOBAL_PREFIX__ + '__ReactRefresh'] ||
+      // @ts-expect-error: missing prop
+      metroRequire.Refresh
+    );
   };
 }


### PR DESCRIPTION
# Why

This fork isn't always active, but we should match upstream changes due to optional deps and runtime forking to it.

# How

Apply relevant upstream changes

<img width="1388" height="343" alt="image" src="https://github.com/user-attachments/assets/a03332fb-5fec-44fd-9c54-40cb88b3518d" />

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
