### PR TITLE
[ios][expo-go] Fix menu flicker

### DIFF
--- a/apps/expo-go/src/menu/DevMenuBottomSheet.tsx
+++ b/apps/expo-go/src/menu/DevMenuBottomSheet.tsx
@@ -44,7 +44,7 @@ function DevMenuBottomSheet({ children, uuid }: Props) {
         setTimeout(() => {
           resolve();
           DevMenu.closeAsync();
-        }, 400);
+        }, 300);
       }),
     []
   );
@@ -55,7 +55,7 @@ function DevMenuBottomSheet({ children, uuid }: Props) {
         bottomSheetRef.current?.expand();
         setTimeout(() => {
           resolve();
-        }, 400);
+        }, 300);
       }),
     []
   );

--- a/apps/expo-go/src/menu/DevMenuBottomSheet.tsx
+++ b/apps/expo-go/src/menu/DevMenuBottomSheet.tsx
@@ -1,11 +1,7 @@
-import BottomSheet, {
-  BottomSheetBackdrop,
-  BottomSheetBackdropProps,
-  BottomSheetView,
-  useBottomSheetSpringConfigs,
-} from '@gorhom/bottom-sheet';
+import BottomSheet, { BottomSheetView, useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
 import React, { useCallback, useEffect, useRef } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, View, TouchableWithoutFeedback } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
 import DevMenuBottomSheetContext from './DevMenuBottomSheetContext';
 import * as DevMenu from './DevMenuModule';
@@ -15,6 +11,28 @@ type Props = {
   children?: React.ReactNode;
 };
 
+function Backdrop({ onPress }: { onPress: () => void }) {
+  const opacity = useSharedValue(0);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      opacity.value = withTiming(0.5, { duration: 350 });
+    }, 50);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+
+  return (
+    <TouchableWithoutFeedback onPress={onPress}>
+      <Animated.View style={[styles.backdrop, animatedStyle]} />
+    </TouchableWithoutFeedback>
+  );
+}
+
 function DevMenuBottomSheet({ children, uuid }: Props) {
   const bottomSheetRef = useRef<BottomSheet | null>(null);
 
@@ -23,11 +41,10 @@ function DevMenuBottomSheet({ children, uuid }: Props) {
       new Promise<void>((resolve) => {
         bottomSheetRef.current?.close();
 
-        // still no way to wait for animation to end before the callback, so we wait for 300ms
         setTimeout(() => {
           resolve();
           DevMenu.closeAsync();
-        }, 300);
+        }, 400);
       }),
     []
   );
@@ -38,7 +55,7 @@ function DevMenuBottomSheet({ children, uuid }: Props) {
         bottomSheetRef.current?.expand();
         setTimeout(() => {
           resolve();
-        }, 300);
+        }, 400);
       }),
     []
   );
@@ -61,12 +78,9 @@ function DevMenuBottomSheet({ children, uuid }: Props) {
     };
   }, []);
 
-  const renderBackdrop = useCallback(
-    (props: BottomSheetBackdropProps) => (
-      <BottomSheetBackdrop {...props} opacity={0.5} appearsOnIndex={0} disappearsOnIndex={-1} />
-    ),
-    []
-  );
+  const onBackdropPress = useCallback(() => {
+    bottomSheetRef.current?.close();
+  }, []);
 
   const animationConfigs = useBottomSheetSpringConfigs({
     duration: 350,
@@ -76,27 +90,33 @@ function DevMenuBottomSheet({ children, uuid }: Props) {
   });
 
   return (
-    <BottomSheet
-      key={uuid}
-      snapPoints={['70%']}
-      index={0}
-      ref={bottomSheetRef}
-      backdropComponent={renderBackdrop}
-      handleComponent={null}
-      animationConfigs={animationConfigs}
-      backgroundStyle={styles.bottomSheetBackground}
-      enablePanDownToClose
-      onChange={onChange}>
-      <DevMenuBottomSheetContext.Provider value={{ collapse: onCollapse, expand: onExpand }}>
-        <BottomSheetView style={styles.contentContainerStyle}>{children}</BottomSheetView>
-      </DevMenuBottomSheetContext.Provider>
-      {/* Adds bottom offset so that no empty space is shown on overdrag */}
-      <View style={{ height: 100 }} />
-    </BottomSheet>
+    <View style={styles.bottomSheetContainer}>
+      <Backdrop onPress={onBackdropPress} />
+      <BottomSheet
+        key={uuid}
+        snapPoints={['70%']}
+        index={0}
+        ref={bottomSheetRef}
+        handleComponent={null}
+        animationConfigs={animationConfigs}
+        backgroundStyle={styles.bottomSheetBackground}
+        enablePanDownToClose
+        onChange={onChange}>
+        <DevMenuBottomSheetContext.Provider value={{ collapse: onCollapse, expand: onExpand }}>
+          <BottomSheetView style={styles.contentContainerStyle}>{children}</BottomSheetView>
+        </DevMenuBottomSheetContext.Provider>
+        {/* Adds bottom offset so that no empty space is shown on overdrag */}
+        <View style={{ height: 100 }} />
+      </BottomSheet>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'black',
+  },
   bottomSheetContainer: {
     flex: 1,
   },


### PR DESCRIPTION
# Why
Fixes another janky animation, this time on ios. It is caused by using the `backdropComponent` prop provided by bottom sheet. No matter what options I tried, nothing fixed it.

# How
Implemented our own backdrop component and dropped the prop entirely. It's hard to see in the recording but the issue is very pronounced. The changes fix it completely.

# Test Plan

Before 
https://github.com/user-attachments/assets/a93c9b03-1ed2-450d-815d-157454ea0557

After
https://github.com/user-attachments/assets/37a94374-b491-4590-9018-f4b5168bf788

