### PR TITLE
[sdk-54] updated @shopify/react-native-skia to latest (2.2.12)

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -2112,7 +2112,7 @@ PODS:
     - Yoga
   - react-native-segmented-control (2.5.7):
     - React-Core
-  - react-native-skia (2.2.3):
+  - react-native-skia (2.2.12):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3676,7 +3676,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: c8817c1d9f4643417e68f0b846c51214b2252eea
   react-native-safe-area-context: eb2fb5c796f18a08959ee5400bb1c65e4c1b4833
   react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
-  react-native-skia: e600b0756d17cdcff4b02c2125a5e5ca4acbcf07
+  react-native-skia: 05327e7acee05e7c27b68a5da0bc80d65f5d790c
   react-native-slider: 8c562583722c396a3682f451f0b6e68e351ec3b9
   react-native-view-shot: fb3c0774edb448f42705491802a455beac1502a2
   react-native-webview: b29007f4723bca10872028067b07abacfa1cb35a

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -52,7 +52,7 @@
     "@react-native-picker/picker": "2.11.1",
     "@react-native-segmented-control/segmented-control": "2.5.7",
     "@shopify/flash-list": "2.0.2",
-    "@shopify/react-native-skia": "2.2.3",
+    "@shopify/react-native-skia": "2.2.12",
     "expo": "~54.0.0-preview.16",
     "expo-build-properties": "~1.0.7",
     "expo-camera": "~17.0.6",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -2478,7 +2478,7 @@ PODS:
     - Yoga
   - react-native-segmented-control (2.5.7):
     - React-Core
-  - react-native-skia (2.2.3):
+  - react-native-skia (2.2.12):
     - boost
     - DoubleConversion
     - fast_float
@@ -4377,7 +4377,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: a0516effb17ca5120ac2113bfd21b91130ad5748
   react-native-safe-area-context: a72764e0eb5d6b79b7450e5d0ae919eb1a4567b4
   react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
-  react-native-skia: 7db0cf4fc9d6203747af5bae5df0db3ad4e84cda
+  react-native-skia: 665cd52db7ad3d41e2a59c84e9c097343745c088
   react-native-slider: 663776e5683e257de8df8091abc2d93ff6ec67db
   react-native-view-shot: 6c008e58f4720de58370848201c5d4a082c6d4ca
   react-native-webview: 4cbb7f05f2c50671a7dcff4012d3e85faad271e4

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -38,7 +38,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "@react-navigation/stack": "^7.4.7",
-    "@shopify/react-native-skia": "2.2.3",
+    "@shopify/react-native-skia": "2.2.12",
     "@stripe/stripe-react-native": "0.50.3",
     "date-fns": "^2.28.0",
     "dedent": "^0.7.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -52,7 +52,7 @@
     "@react-navigation/native": "^7.1.8",
     "@react-navigation/stack": "^7.4.7",
     "@shopify/flash-list": "2.0.2",
-    "@shopify/react-native-skia": "2.2.3",
+    "@shopify/react-native-skia": "2.2.12",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.9",
     "expo": "~54.0.0-preview.16",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -109,7 +109,7 @@
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~6.0.6",
   "unimodules-image-loader-interface": "~6.1.0",
-  "@shopify/react-native-skia": "2.2.3",
+  "@shopify/react-native-skia": "2.2.12",
   "@shopify/flash-list": "2.0.2",
   "@sentry/react-native": "~6.20.0",
   "react-native-bootsplash": "^6.3.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3751,10 +3751,10 @@
   dependencies:
     tslib "2.8.1"
 
-"@shopify/react-native-skia@2.2.3":
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-2.2.3.tgz#18ba6c12f5e23a851bc3738576ae3bdb53427097"
-  integrity sha512-B2g/V5HVbsGblUDjETDh+Vo91PQoZnqufYcXBFA3zD6GkNG+BNyU4SiDnXye27hpJ+ZvcJopXGwDCc4b2m8dqQ==
+"@shopify/react-native-skia@2.2.12":
+  version "2.2.12"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-2.2.12.tgz#1c27613035952772ce07418ace866b56df403546"
+  integrity sha512-P5wZSMPTp00hM0do+awNFtb5aPh5hSpodMGwy7NaxK90AV+SmUu7wZe6NGevzQIwgFa89Epn6xK3j4jKWdQi+A==
   dependencies:
     canvaskit-wasm "0.40.0"
     react-reconciler "0.31.0"


### PR DESCRIPTION
# Why

This version has some benefits that William pinged us about, most important might be the use of the setExternalMemoryPressure JSI method that helps keep memory allocated in C++ in sync with the Hermes garbage collector.

# How

Upgraded from 2.2.3 -> 2.2.12

# Testing

- BareExpo
  - ✅ Android
  - ✅ iOS

# Checklist 

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
