### PR TITLE
feat(babel-preset-expo,expo): Add `ImportMetaRegistry.env` getter and `import.meta.env` inlining (with well knowns)

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Support inlining `import.meta.env` with well-known values when `unstable_transformImportMeta` is enabled ([#39484](https://github.com/expo/expo/pull/39484) by [@kitten](https://github.com/kitten))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/babel-preset-expo/build/inline-env-vars.d.ts
+++ b/packages/babel-preset-expo/build/inline-env-vars.d.ts
@@ -1,2 +1,8 @@
-import type { ConfigAPI, PluginObj } from '@babel/core';
-export declare function expoInlineEnvVars(api: ConfigAPI & typeof import('@babel/core')): PluginObj;
+import type { ConfigAPI, PluginObj, PluginPass } from '@babel/core';
+interface ExpoInlineEnvVarsOpts extends PluginPass {
+    opts: {
+        polyfillImportMeta?: boolean;
+    };
+}
+export declare function expoInlineEnvVars(api: ConfigAPI & typeof import('@babel/core')): PluginObj<ExpoInlineEnvVarsOpts>;
+export {};

--- a/packages/babel-preset-expo/build/inline-env-vars.js
+++ b/packages/babel-preset-expo/build/inline-env-vars.js
@@ -21,8 +21,10 @@ function expoInlineEnvVars(api) {
         },
         visitor: {
             MemberExpression(path, state) {
+                const { polyfillImportMeta } = state.opts;
                 const filename = state.filename;
-                if (path.get('object').matchesPattern('process.env')) {
+                if (path.get('object').matchesPattern('process.env') ||
+                    (polyfillImportMeta && path.get('object').matchesPattern('import.meta.env'))) {
                     const key = path.toComputedKey();
                     if (t.isStringLiteral(key) &&
                         !isFirstInAssign(path) &&

--- a/packages/babel-preset-expo/src/__tests__/__snapshots__/inline-env-vars.test.ts.snap
+++ b/packages/babel-preset-expo/src/__tests__/__snapshots__/inline-env-vars.test.ts.snap
@@ -43,3 +43,20 @@ function App() {
   },
 }
 `;
+
+exports[`inlines import.env variables 1`] = `
+"
+var test = {
+  MODE: "production",
+  PROD: true,
+  DEV: false,
+  SSR: false,
+  PUBLIC_NODE_ENV: "development",
+  PUBLIC_NODE_ENV: "development",
+  EXPO_SERVER: false,
+  EXPO_OS: "ios"
+};
+
+globalThis.__ExpoImportMetaRegistry.env['other'];
+globalThis.__ExpoImportMetaRegistry.env.other;"
+`;

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add `env` getter returning `process.env` to `ImportMetaRegistry` ([#39484](https://github.com/expo/expo/pull/39484) by [@kitten](https://github.com/kitten))
+
 ## 54.0.0-preview.16 — 2025-09-08
 
 ### 🐛 Bug fixes

--- a/packages/expo/build/winter/ImportMetaRegistry.d.ts
+++ b/packages/expo/build/winter/ImportMetaRegistry.d.ts
@@ -5,5 +5,6 @@
  */
 export declare const ImportMetaRegistry: {
     readonly url: string | null;
+    readonly env: NodeJS.ProcessEnv;
 };
 //# sourceMappingURL=ImportMetaRegistry.d.ts.map

--- a/packages/expo/build/winter/ImportMetaRegistry.d.ts.map
+++ b/packages/expo/build/winter/ImportMetaRegistry.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ImportMetaRegistry.d.ts","sourceRoot":"","sources":["../../src/winter/ImportMetaRegistry.ts"],"names":[],"mappings":"AAIA;;;;GAIG;AACH,eAAO,MAAM,kBAAkB;;CAI9B,CAAC"}
+{"version":3,"file":"ImportMetaRegistry.d.ts","sourceRoot":"","sources":["../../src/winter/ImportMetaRegistry.ts"],"names":[],"mappings":"AAIA;;;;GAIG;AACH,eAAO,MAAM,kBAAkB;;;CAO9B,CAAC"}

--- a/packages/expo/src/winter/ImportMetaRegistry.ts
+++ b/packages/expo/src/winter/ImportMetaRegistry.ts
@@ -11,4 +11,7 @@ export const ImportMetaRegistry = {
   get url() {
     return getBundleUrl();
   },
+  get env() {
+    return process.env;
+  },
 };


### PR DESCRIPTION
# Why

This isn't quite a priority, but as we support for ESM packages and allowing people to match more `import`-condition modules, it's going to become more likely that:
- `import.meta.env` is expected to be present
- `import.meta.env.X` variables are expected to behave the same as `process.env.X` inlining

# How

When applied, this PR adds a `ImportMetaRegistry.env` getter, returning the globally defined `process.env` object, as a fallback.

The `babel-preset-expo` code has been modified to inline `import.meta.env` variables, the same as `process.env`, when `unstable_transformImportMeta` is enabled.

The special properties `MODE`, `DEV`, `PROD`, and `SSR` are set, as per: https://vite.dev/guide/env-and-mode.html#built-in-constants
We can potentially reduce these if we find out how many are now commonly used. At least `MODE` seems to be used sometimes now. There's no clear standard or de-facto standard yet.

We also inline `EXPO_OS`, `EXPO_SERVER`, and `EXPO_BASE_URL` for parity with `process.env`.

# Test Plan

- Unit tests with snapshots added

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
