### PR TITLE
[expo-router] tabs nested in stack with param reproduction

### DIFF
--- a/packages/expo-router/src/__tests__/tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/tabs.test.ios.tsx
@@ -595,3 +595,48 @@ it('can set params for dynamic routes using href when nested stack is used', () 
   expect(screen.getByTestId('id-index')).toBeVisible();
   expect(screen.getByTestId('id-index')).toHaveTextContent('1234');
 });
+
+it('propagates params inside tabs', () => {
+  renderRouter(
+    {
+      _layout: () => <Stack />,
+      '[id]/_layout': () => <Tabs />,
+      '[id]/index': function Index() {
+        const params = useLocalSearchParams();
+        return <Text testID="index">{JSON.stringify(params)}</Text>;
+      },
+      '[id]/two': function Two() {
+        const params = useLocalSearchParams();
+        return <Text testID="two">{JSON.stringify(params)}</Text>;
+      },
+      '[id]/three': function Three() {
+        const params = useLocalSearchParams();
+        return <Text testID="three">{JSON.stringify(params)}</Text>;
+      },
+    },
+    {
+      initialUrl: '/test/',
+    }
+  );
+
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen.getByTestId('index').children).toEqual(['{"id":"test"}']);
+
+  expect(screen.getByLabelText('index, tab, 1 of 3')).toBeVisible();
+  expect(screen.getByLabelText('two, tab, 2 of 3')).toBeVisible();
+  expect(screen.getByLabelText('three, tab, 3 of 3')).toBeVisible();
+
+  act(() => fireEvent.press(screen.getByLabelText('two, tab, 2 of 3')));
+
+  expect(screen.getByTestId('two')).toBeVisible();
+  expect(screen.getByTestId('two').children).toEqual(['{"id":"test"}']);
+
+  act(() => fireEvent.press(screen.getByLabelText('three, tab, 3 of 3')));
+
+  expect(screen.getByTestId('three')).toBeVisible();
+  expect(screen.getByTestId('three').children).toEqual(['{"id":"test"}']);
+
+  act(() => fireEvent.press(screen.getByLabelText('index, tab, 1 of 3')));
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen.getByTestId('index').children).toEqual(['{"id":"test"}']);
+});

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -12,7 +12,14 @@ import {
 import type { NativeStackNavigationEventMap } from '@react-navigation/native-stack';
 import React, { useEffect, useMemo } from 'react';
 
-import { LoadedRoute, Route, RouteNode, sortRoutesWithInitial, useRouteNode } from './Route';
+import {
+  LoadedRoute,
+  LocalRouteParamsContext,
+  Route,
+  RouteNode,
+  sortRoutesWithInitial,
+  useRouteNode,
+} from './Route';
 import { getPathFromState } from './fork/getPathFromState';
 import { useExpoRouterStore } from './global-state/storeContext';
 import EXPO_ROUTER_IMPORT_MODE from './import-mode';
@@ -161,6 +168,23 @@ export function useSortedScreens(
   useOnlyUserDefinedScreens: boolean = false
 ): React.ReactNode[] {
   const node = useRouteNode();
+  const parentParams = React.use(LocalRouteParamsContext);
+
+  // Extract only the dynamic segment params from the parent route.
+  // This ensures that child routes (e.g. tabs) nested inside a dynamic segment
+  // like [id] inherit the parent's dynamic params (e.g. { id: 'test' }).
+  const dynamicParentParams = React.useMemo(() => {
+    if (!node?.dynamic || !parentParams) return undefined;
+    const params: Record<string, string | undefined> = {};
+    let hasParams = false;
+    for (const d of node.dynamic) {
+      if (d.name in parentParams) {
+        params[d.name] = parentParams[d.name];
+        hasParams = true;
+      }
+    }
+    return hasParams ? params : undefined;
+  }, [node?.dynamic, parentParams]);
 
   const nodeChildren = node?.children ?? [];
   const children = useOnlyUserDefinedScreens
@@ -175,9 +199,15 @@ export function useSortedScreens(
       sorted
         .filter((item) => !protectedScreens.has(item.route.route))
         .map((value) => {
-          return routeToScreen(value.route, value.props);
+          const props = dynamicParentParams
+            ? {
+                ...value.props,
+                initialParams: { ...dynamicParentParams, ...value.props.initialParams },
+              }
+            : value.props;
+          return routeToScreen(value.route, props);
         }),
-    [sorted, protectedScreens]
+    [sorted, protectedScreens, dynamicParentParams]
   );
 }
 


### PR DESCRIPTION
# Why

Right now this is a test with the reproduction, without the fix

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
