### PR TITLE
[cli] Fork MetroServer `_symbolicate` to remove disruptive error logging

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fork MetroServer `_symbolicate` to remove disruptive error logging
+
 ## 0.26.9 — 2025-09-08
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -41,6 +41,7 @@
   "homepage": "https://github.com/expo/expo/tree/main/packages/@expo/cli",
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.8",
+    "@babel/code-frame": "^7.20.0",
     "@expo/code-signing-certificates": "^0.0.5",
     "@expo/config": "~12.0.7",
     "@expo/config-plugins": "~11.0.7",
@@ -76,6 +77,8 @@
     "freeport-async": "^2.0.0",
     "getenv": "^2.0.0",
     "glob": "^10.4.2",
+    "invariant": "^2.2.4",
+    "jsc-safe-url": "^0.2.4",
     "lan-network": "^0.1.6",
     "minimatch": "^9.0.0",
     "node-forge": "^1.3.1",

--- a/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMetroMiddleware.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMetroMiddleware.test.ts
@@ -50,33 +50,6 @@ describe(createMetroMiddleware, () => {
     expect(openInEditorAsync).toHaveBeenCalledWith('test-file.ts', 1337);
   });
 
-  it('prepares /symbolicate requests with raw body', async () => {
-    // Create a fake middleware to capture the request and respond with OK
-    const middleware = jest.fn((_req, res) => res.end('OK'));
-    // Create a fake symbolicate request body
-    const body = JSON.stringify({
-      stack: [
-        {
-          file: 'test-file.ts',
-          methodName: 'testMethod',
-          arguments: [],
-          lineNumber: 1337,
-          column: 0,
-        },
-      ],
-    });
-
-    // Register the middleware to capture the request
-    metro.middleware.use('/symbolicate', middleware);
-
-    const response = await server.fetch('/symbolicate', { method: 'POST', body });
-
-    // Ensure the request is successful
-    expect(response.status).toBe(200);
-    // Ensure the request body was loaded as `rawBody` string
-    expect(middleware.mock.calls[0][0]).toHaveProperty('rawBody', body);
-  });
-
   describe('websockets', () => {
     it('creates the /message websocket', () => {
       expect(metro.messagesSocket).toBeDefined();

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -18,9 +18,6 @@ export function createMetroMiddleware(metroConfig: Pick<MetroConfig, 'projectRoo
     // Support opening stack frames from clients directly in the editor
     .use('/open-stack-frame', rawBodyMiddleware)
     .use('/open-stack-frame', metroOpenStackFrameMiddleware)
-    // Support the symbolication endpoint of Metro
-    // See: https://github.com/facebook/metro/blob/a792d85ffde3c21c3fbf64ac9404ab0afe5ff957/packages/metro/src/Server.js#L1266
-    .use('/symbolicate', rawBodyMiddleware)
     // Support status check to detect if the packager needs to be started from the native side
     .use('/status', createMetroStatusMiddleware(metroConfig));
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -30,6 +30,7 @@ import { createCorsMiddleware } from '../middleware/CorsMiddleware';
 import { createJsInspectorMiddleware } from '../middleware/inspector/createJsInspectorMiddleware';
 import { prependMiddleware } from '../middleware/mutations';
 import { getPlatformBundlers } from '../platformBundlers';
+import { createSymbolicate } from './symbolicate';
 
 // From expo/dev-server but with ability to use custom logger.
 type MessageSocket = {
@@ -292,6 +293,15 @@ export async function instantiateMetroAsync(
       fileBuffer
     );
   };
+
+  // Overwrite _symbolicate
+  metro._symbolicate = createSymbolicate({
+    projectRoot,
+    metroConfig,
+    rewriteRequestUrl: metroConfig.server.rewriteRequestUrl,
+    explodedSourceMapForBundleOptions: metro._explodedSourceMapForBundleOptions.bind(metro),
+    parseOptions: metro._parseOptions.bind(metro),
+  });
 
   setEventReporter(eventsSocket.reportMetroEvent);
 

--- a/packages/@expo/cli/src/start/server/metro/symbolicate.ts
+++ b/packages/@expo/cli/src/start/server/metro/symbolicate.ts
@@ -1,3 +1,25 @@
+/**
+ * Copyright 2025-present 650 Industries (Expo). All rights reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `symbolicate` forked from https://github.com/facebook/metro/blob/95f880f48c9bff3255d8ed5846233ae1911a1a14/packages/metro/src/Server.js#L1281
+ */
+
+import { codeFrameColumns } from '@babel/code-frame';
+import { ExplodedSourceMap } from '@expo/metro/metro/DeltaBundler/Serializers/getExplodedSourceMap';
+import symbolicate from '@expo/metro/metro/Server/symbolicate';
+import parseJsonBody from '@expo/metro/metro/lib/parseJsonBody';
+import { BundleOptions } from '@expo/metro/metro/shared/types.flow';
+import type { ConfigT } from '@expo/metro/metro-config';
+import type { IncomingMessage } from 'connect';
+import * as fs from 'fs';
+import type { ServerResponse } from 'http';
+import invariant from 'invariant';
+import jscSafeUrl from 'jsc-safe-url';
+import * as path from 'path';
 import { StackFrame } from 'stacktrace-parser';
 
 export type CodeFrame = {
@@ -12,3 +34,168 @@ export type CodeFrame = {
 
 export type MetroStackFrame = StackFrame & { collapse?: boolean };
 export type Stack = StackFrame[];
+
+type StackFrameInput = {
+  file?: string | null;
+  lineNumber?: number | null;
+  column?: number | null;
+  methodName?: string | null;
+};
+
+type IntermediateStackFrame = StackFrameInput & {
+  collapse?: boolean;
+};
+
+type StackFrameOutput = IntermediateStackFrame;
+
+const debug = require('debug')('expo:start:server:metro:symbolicate') as typeof console.log;
+
+export const createSymbolicate = ({
+  projectRoot,
+  metroConfig,
+  rewriteRequestUrl,
+  explodedSourceMapForBundleOptions,
+  parseOptions,
+}: {
+  projectRoot: string;
+  metroConfig: ConfigT;
+  rewriteRequestUrl: (url: string) => string;
+  explodedSourceMapForBundleOptions: (bundleOptions: BundleOptions) => Promise<ExplodedSourceMap>;
+  parseOptions: (url: string) => BundleOptions;
+}) => {
+  function rewriteAndNormalizeUrl(requestUrl: string): string {
+    return jscSafeUrl.toNormalUrl(rewriteRequestUrl(jscSafeUrl.toNormalUrl(requestUrl)));
+  }
+
+  function getCodeFrame(urls: Set<string>, symbolicatedStack: readonly StackFrameOutput[]) {
+    const allFramesCollapsed = symbolicatedStack.every(({ collapse }) => collapse);
+
+    for (let i = 0; i < symbolicatedStack.length; i++) {
+      const { collapse, column, file, lineNumber } = symbolicatedStack[i];
+
+      if (
+        // If all the frames are collapsed then we should ignore the collapse flag
+        // and always show the first valid frame.
+        (!allFramesCollapsed && collapse) ||
+        lineNumber == null ||
+        (file != null && urls.has(file))
+      ) {
+        continue;
+      }
+
+      const fileAbsolute = path.resolve(projectRoot, file ?? '');
+      try {
+        return {
+          content: codeFrameColumns(
+            fs.readFileSync(fileAbsolute, 'utf8'),
+            {
+              // Metro returns 0 based columns but codeFrameColumns expects 1-based columns
+              start: { column: column == null ? undefined : column + 1, line: lineNumber },
+            },
+            { forceColor: true }
+          ),
+          location: {
+            row: lineNumber,
+            column,
+          },
+          fileName: file,
+        };
+      } catch (error) {
+        debug(`Failed to read code frame from file`, fileAbsolute, error);
+      }
+    }
+
+    return null;
+  }
+
+  return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    try {
+      debug('Start symbolication');
+
+      const parsedBody = (await parseJsonBody(req)) as {
+        stack: readonly StackFrameInput[];
+        extraData: { [key: string]: unknown };
+      };
+
+      const rewriteAndNormalizeStackFrame = <T extends StackFrameInput>(
+        frame: T,
+        lineNumber: number
+      ): T => {
+        invariant(
+          frame != null && typeof frame === 'object',
+          'Bad stack frame at line %d, expected object, received: %s',
+          lineNumber,
+          typeof frame
+        );
+        const frameFile = frame.file;
+        if (typeof frameFile === 'string' && frameFile.includes('://')) {
+          return {
+            ...frame,
+            file: rewriteAndNormalizeUrl(frameFile),
+          };
+        }
+        return frame;
+      };
+
+      const stack = parsedBody.stack.map(rewriteAndNormalizeStackFrame);
+      // In case of multiple bundles / HMR, some stack frames can have different URLs from others
+      const urls = new Set<string>();
+
+      stack.forEach((frame) => {
+        // These urls have been rewritten and normalized above.
+        const sourceUrl = frame.file;
+        // Skip `/debuggerWorker.js` which does not need symbolication.
+        if (
+          sourceUrl != null &&
+          !urls.has(sourceUrl) &&
+          !sourceUrl.endsWith('/debuggerWorker.js') &&
+          sourceUrl.startsWith('http')
+        ) {
+          urls.add(sourceUrl);
+        }
+      });
+
+      debug('Getting source maps for symbolication');
+      const sourceMaps = await Promise.all(
+        Array.from(urls.values()).map((normalizedUrl) =>
+          explodedSourceMapForBundleOptions(parseOptions(normalizedUrl))
+        )
+      );
+
+      debug('Performing fast symbolication');
+      const symbolicatedStack = await symbolicate(
+        stack,
+        zip(urls.values(), sourceMaps),
+        metroConfig,
+        parsedBody.extraData ?? {}
+      );
+
+      debug('Symbolication done');
+      res.end(
+        JSON.stringify({
+          codeFrame: getCodeFrame(urls, symbolicatedStack),
+          stack: symbolicatedStack,
+        })
+      );
+    } catch (error) {
+      debug('Symbolication failed', error);
+      res.statusCode = 500;
+      if (error instanceof Error) {
+        res.end(JSON.stringify({ error: error.message }));
+      } else {
+        res.end(JSON.stringify({ error: String(error) }));
+      }
+    }
+  };
+};
+
+function* zip<X, Y>(xs: Iterable<X>, ys: Iterable<Y>): Iterable<[X, Y]> {
+  const ysIter: Iterator<Y> = ys[Symbol.iterator]();
+  for (const x of xs) {
+    const y = ysIter.next();
+    if (y.done) {
+      return;
+    }
+    yield [x, y.value];
+  }
+}


### PR DESCRIPTION
# Related Metro PR

- If the `console.error` -> `debug` change gets accepted upstream in Metro, this PR can be close. We don't have to patch `_symbolicate` which unavoidable would higher maintenance of the expo/metro-config package.  
  - https://github.com/facebook/metro/pull/1573

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The original `_symbolicate` disrupts the error output by unconditional `console.error` log when file could not be found or symbolicated.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fork the implementation, patch the `metroServer._symbolicate`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

E2E test, mocked test from `Server-test.js`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
