### PR TITLE
[docs] Adds `set-output` function documentation

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1317,7 +1317,7 @@ Example usage for sharing a variable with another job:
 jobs:
   job_1:
     outputs:
-      variable_1: ${{ steps.get_date.outputs.variable_1 }}
+      variable_1: ${{ steps.step_1.outputs.variable_1 }}
     steps:
       - id: step_1
         # @info #

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -922,7 +922,7 @@ jobs:
 
 ### `jobs.<job_id>.outputs`
 
-A list of outputs defined by the job. These outputs are accessible to all downstream jobs that depend on this job. To set outputs, use the `set-output` function within a job step.
+A list of outputs defined by the job. These outputs are accessible to all downstream jobs that depend on this job. To set outputs, use the [`set-output`](#set-output) function within a job step.
 
 Downstream jobs can access these outputs using the following expressions within [interpolation contexts](#interpolation):
 
@@ -1284,3 +1284,47 @@ jobs:
   Icon={GithubIcon}
   href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/useNpmToken.ts"
 />
+
+## Built-in shell functions
+
+EAS Workflows provides the following shell function that you can use in your workflow steps to set variable outputs.
+
+### `set-output`
+
+Sets an output variable that can be accessed by other steps or other jobs in the workflow.
+
+```bash
+set-output <name> <value>
+```
+
+Example usage for sharing a variable with another step:
+
+```yaml
+jobs:
+  my_job:
+    steps:
+      - id: step_1
+        # @info #
+        run: set-output variable_1 "Variable 1"
+        # @end #
+      - id: step_2
+        run: echo ${{ steps.step_1.outputs.variable_1 }} # prints: Variable 1
+```
+
+Example usage for sharing a variable with another job:
+
+```yaml
+jobs:
+  job_1:
+    outputs:
+      variable_1: ${{ steps.get_date.outputs.variable_1 }}
+    steps:
+      - id: step_1
+        # @info #
+        run: set-output variable_1 "Variable 1"
+        # @end #
+  job_2:
+    needs: [job_1]
+    steps:
+      - run: echo ${{ needs.job_1.outputs.variable_1 }} # prints: Variable 1
+```


### PR DESCRIPTION
# Why

There is a built-in function named `set-output` available in workflows. We mention it in the `outputs` section, however it's not explicitly documented. We also don't show what sharing variables between steps looks like.

This PR adds a section for built-in functions and documents `set-output` with two examples. One sharing a variable between steps of a job and one sharing a variable between separate jobs.

# Test Plan

Make sure the changes read well and are accurate. I ran both example workflows to confirm they work.

<img width="699" height="763" alt="Screenshot 2025-09-09 at 8 40 06 AM" src="https://github.com/user-attachments/assets/0a0e12db-854e-464f-9dbe-e6f159d30d79" />
