### PR TITLE
chore: Bump to `react-native-worklets@~0.5.1`

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -77,7 +77,7 @@
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",
-    "react-native-worklets": "0.5.0",
+    "react-native-worklets": "0.5.1",
     "test-suite": "*"
   },
   "devDependencies": {

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -84,7 +84,7 @@
     "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.15.0",
-    "react-native-worklets": "0.5.0",
+    "react-native-worklets": "0.5.1",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",
     "redux": "^4.0.5",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -147,7 +147,7 @@
     "react-native-maps": "1.20.1",
     "react-native-pager-view": "6.9.1",
     "react-native-paper": "^5.12.5",
-    "react-native-worklets": "0.5.0",
+    "react-native-worklets": "0.5.1",
     "react-native-reanimated": "4.1.0",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -99,7 +99,7 @@
   "react-native-keyboard-controller": "1.18.5",
   "react-native-maps": "1.20.1",
   "react-native-pager-view": "6.9.1",
-  "react-native-worklets": "~0.5.0",
+  "react-native-worklets": "~0.5.1",
   "react-native-reanimated": "~4.1.0",
   "react-native-screens": "~4.16.0",
   "react-native-safe-area-context": "~5.6.0",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -31,7 +31,7 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.1",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-worklets": "~0.5.0",
+    "react-native-worklets": "~0.5.1",
     "react-native-reanimated": "~4.1.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -24,7 +24,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.1",
-    "react-native-worklets": "~0.5.0",
+    "react-native-worklets": "~0.5.1",
     "react-native-reanimated": "~4.1.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13890,10 +13890,10 @@ react-native-webview@13.15.0:
     escape-string-regexp "^4.0.0"
     invariant "2.2.4"
 
-react-native-worklets@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/react-native-worklets/-/react-native-worklets-0.5.0.tgz#ed25b55f3d14b8f66db7a9a5148c609e51eca801"
-  integrity sha512-+/tbUCBEVchxe5xxFvvdC18PRZFCoxq1emcjIezXodElFguk1MaBYpbqABvZHBGrrEOo9k99h4Jbt0i9ArCbxg==
+react-native-worklets@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/react-native-worklets/-/react-native-worklets-0.5.1.tgz#d153242655e3757b6c62a474768831157316ad33"
+  integrity sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==
   dependencies:
     "@babel/plugin-transform-arrow-functions" "^7.0.0-0"
     "@babel/plugin-transform-class-properties" "^7.0.0-0"


### PR DESCRIPTION
`react-native-worklets@0.5.1` contains a Babel plugin fix, but shouldn't contain native code changes. We should still distribute it as the required version, since the Babel failures, while rare, can be confusing.