### PR TITLE
[docs] ensure Stack.Protected guard is boolean

### DIFF
--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -263,7 +263,7 @@ function RootNavigator() {
 
   return (
     <Stack>
-      <Stack.Protected guard={session}>
+      <Stack.Protected guard={!!session}>
         <Stack.Screen name="(app)" />
       </Stack.Protected>
 


### PR DESCRIPTION
# [docs] ensure Stack.Protected guard is boolean

- Use guard={!!session} for authenticated stack.
- Use guard={!session} for the sign-in screen.
- Avoids truthy/falsy pitfalls and matches expected boolean API. File: app/_layout.tsx.

# Why

- Ensure navigation guards evaluate explicitly to booleans.
- Prevent accidental truthy values from bypassing route protection.
- Align with Stack.Protected’s expected boolean API for clarity.

# How

- Cast session to boolean via !!session for the authenticated stack.
- Use !session for the unauthenticated sign-in route.
- No other logic or routes changed.
- File: app/_layout.tsx.

# Test Plan

- Fresh start with no stored session: lands on sign-in.
- Call signIn() (stores session): navigates to (tabs).
- Reload with stored session present: goes directly to (tabs).
- Call signOut(): returns to sign-in.
Edge: set session to empty string in storage; verify !!session is false and sign-in shows.

# Checklist
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
