### PR TITLE
Upgrade React Native to 0.81.3

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -632,10 +632,10 @@ PODS:
     - Yoga
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
-  - FBLazyVector (0.81.2)
-  - hermes-engine (0.81.2):
-    - hermes-engine/Pre-built (= 0.81.2)
-  - hermes-engine/Pre-built (0.81.2)
+  - FBLazyVector (0.81.3)
+  - hermes-engine (0.81.3):
+    - hermes-engine/Pre-built (= 0.81.3)
+  - hermes-engine/Pre-built (0.81.3)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -692,32 +692,32 @@ PODS:
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - Quick (7.3.1)
-  - RCTDeprecation (0.81.2)
-  - RCTRequired (0.81.2)
-  - RCTTypeSafety (0.81.2):
-    - FBLazyVector (= 0.81.2)
-    - RCTRequired (= 0.81.2)
-    - React-Core (= 0.81.2)
+  - RCTDeprecation (0.81.3)
+  - RCTRequired (0.81.3)
+  - RCTTypeSafety (0.81.3):
+    - FBLazyVector (= 0.81.3)
+    - RCTRequired (= 0.81.3)
+    - React-Core (= 0.81.3)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.2):
-    - React-Core (= 0.81.2)
-    - React-Core/DevSupport (= 0.81.2)
-    - React-Core/RCTWebSocket (= 0.81.2)
-    - React-RCTActionSheet (= 0.81.2)
-    - React-RCTAnimation (= 0.81.2)
-    - React-RCTBlob (= 0.81.2)
-    - React-RCTImage (= 0.81.2)
-    - React-RCTLinking (= 0.81.2)
-    - React-RCTNetwork (= 0.81.2)
-    - React-RCTSettings (= 0.81.2)
-    - React-RCTText (= 0.81.2)
-    - React-RCTVibration (= 0.81.2)
-  - React-callinvoker (0.81.2)
-  - React-Core (0.81.2):
+  - React (0.81.3):
+    - React-Core (= 0.81.3)
+    - React-Core/DevSupport (= 0.81.3)
+    - React-Core/RCTWebSocket (= 0.81.3)
+    - React-RCTActionSheet (= 0.81.3)
+    - React-RCTAnimation (= 0.81.3)
+    - React-RCTBlob (= 0.81.3)
+    - React-RCTImage (= 0.81.3)
+    - React-RCTLinking (= 0.81.3)
+    - React-RCTNetwork (= 0.81.3)
+    - React-RCTSettings (= 0.81.3)
+    - React-RCTText (= 0.81.3)
+    - React-RCTVibration (= 0.81.3)
+  - React-callinvoker (0.81.3)
+  - React-Core (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.81.2)
+    - React-Core/Default (= 0.81.3)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -732,66 +732,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.81.2):
+  - React-Core-prebuilt (0.81.3):
     - ReactNativeDependencies
-  - React-Core/CoreModulesHeaders (0.81.2):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/Default (0.81.2):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/DevSupport (0.81.2):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default (= 0.81.2)
-    - React-Core/RCTWebSocket (= 0.81.2)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.2):
+  - React-Core/CoreModulesHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -810,7 +753,45 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.2):
+  - React-Core/Default (0.81.3):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/DevSupport (0.81.3):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-Core/Default (= 0.81.3)
+    - React-Core/RCTWebSocket (= 0.81.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -829,7 +810,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.2):
+  - React-Core/RCTAnimationHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -848,7 +829,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.2):
+  - React-Core/RCTBlobHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -867,7 +848,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.2):
+  - React-Core/RCTImageHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -886,7 +867,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.2):
+  - React-Core/RCTLinkingHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -905,7 +886,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.2):
+  - React-Core/RCTNetworkHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -924,7 +905,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.2):
+  - React-Core/RCTSettingsHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -943,7 +924,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.2):
+  - React-Core/RCTTextHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -962,11 +943,11 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTWebSocket (0.81.2):
+  - React-Core/RCTVibrationHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.81.2)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -981,37 +962,56 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-CoreModules (0.81.2):
-    - RCTTypeSafety (= 0.81.2)
+  - React-Core/RCTWebSocket (0.81.3):
+    - hermes-engine
+    - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/CoreModulesHeaders (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - React-Core/Default (= 0.81.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-CoreModules (0.81.3):
+    - RCTTypeSafety (= 0.81.3)
+    - React-Core-prebuilt
+    - React-Core/CoreModulesHeaders (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.2)
+    - React-RCTImage (= 0.81.3)
     - React-runtimeexecutor
     - ReactCommon
     - ReactNativeDependencies
-  - React-cxxreact (0.81.2):
+  - React-cxxreact (0.81.3):
     - hermes-engine
-    - React-callinvoker (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
     - React-Core-prebuilt
-    - React-debug (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - React-debug (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
-    - React-timing (= 0.81.2)
+    - React-timing (= 0.81.3)
     - ReactNativeDependencies
-  - React-debug (0.81.2)
-  - React-defaultsnativemodule (0.81.2):
+  - React-debug (0.81.3)
+  - React-defaultsnativemodule (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-domnativemodule
@@ -1022,7 +1022,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - ReactNativeDependencies
-  - React-domnativemodule (0.81.2):
+  - React-domnativemodule (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-Fabric
@@ -1036,7 +1036,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric (0.81.2):
+  - React-Fabric (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1044,23 +1044,23 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.2)
-    - React-Fabric/attributedstring (= 0.81.2)
-    - React-Fabric/bridging (= 0.81.2)
-    - React-Fabric/componentregistry (= 0.81.2)
-    - React-Fabric/componentregistrynative (= 0.81.2)
-    - React-Fabric/components (= 0.81.2)
-    - React-Fabric/consistency (= 0.81.2)
-    - React-Fabric/core (= 0.81.2)
-    - React-Fabric/dom (= 0.81.2)
-    - React-Fabric/imagemanager (= 0.81.2)
-    - React-Fabric/leakchecker (= 0.81.2)
-    - React-Fabric/mounting (= 0.81.2)
-    - React-Fabric/observers (= 0.81.2)
-    - React-Fabric/scheduler (= 0.81.2)
-    - React-Fabric/telemetry (= 0.81.2)
-    - React-Fabric/templateprocessor (= 0.81.2)
-    - React-Fabric/uimanager (= 0.81.2)
+    - React-Fabric/animations (= 0.81.3)
+    - React-Fabric/attributedstring (= 0.81.3)
+    - React-Fabric/bridging (= 0.81.3)
+    - React-Fabric/componentregistry (= 0.81.3)
+    - React-Fabric/componentregistrynative (= 0.81.3)
+    - React-Fabric/components (= 0.81.3)
+    - React-Fabric/consistency (= 0.81.3)
+    - React-Fabric/core (= 0.81.3)
+    - React-Fabric/dom (= 0.81.3)
+    - React-Fabric/imagemanager (= 0.81.3)
+    - React-Fabric/leakchecker (= 0.81.3)
+    - React-Fabric/mounting (= 0.81.3)
+    - React-Fabric/observers (= 0.81.3)
+    - React-Fabric/scheduler (= 0.81.3)
+    - React-Fabric/telemetry (= 0.81.3)
+    - React-Fabric/templateprocessor (= 0.81.3)
+    - React-Fabric/uimanager (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1072,26 +1072,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animations (0.81.2):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/attributedstring (0.81.2):
+  - React-Fabric/animations (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1110,7 +1091,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/bridging (0.81.2):
+  - React-Fabric/attributedstring (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1129,7 +1110,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistry (0.81.2):
+  - React-Fabric/bridging (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1148,7 +1129,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistrynative (0.81.2):
+  - React-Fabric/componentregistry (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1167,30 +1148,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components (0.81.2):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.2)
-    - React-Fabric/components/root (= 0.81.2)
-    - React-Fabric/components/scrollview (= 0.81.2)
-    - React-Fabric/components/view (= 0.81.2)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.2):
+  - React-Fabric/componentregistrynative (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1209,7 +1167,30 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/root (0.81.2):
+  - React-Fabric/components (0.81.3):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.3)
+    - React-Fabric/components/root (= 0.81.3)
+    - React-Fabric/components/scrollview (= 0.81.3)
+    - React-Fabric/components/view (= 0.81.3)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1228,7 +1209,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/scrollview (0.81.2):
+  - React-Fabric/components/root (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1247,7 +1228,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/view (0.81.2):
+  - React-Fabric/components/scrollview (0.81.3):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/view (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1268,7 +1268,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric/consistency (0.81.2):
+  - React-Fabric/consistency (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1287,7 +1287,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/core (0.81.2):
+  - React-Fabric/core (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1306,7 +1306,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/dom (0.81.2):
+  - React-Fabric/dom (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1325,7 +1325,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/imagemanager (0.81.2):
+  - React-Fabric/imagemanager (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1344,7 +1344,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/leakchecker (0.81.2):
+  - React-Fabric/leakchecker (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1363,7 +1363,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/mounting (0.81.2):
+  - React-Fabric/mounting (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1382,7 +1382,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers (0.81.2):
+  - React-Fabric/observers (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1390,7 +1390,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.2)
+    - React-Fabric/observers/events (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1402,7 +1402,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers/events (0.81.2):
+  - React-Fabric/observers/events (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1421,7 +1421,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/scheduler (0.81.2):
+  - React-Fabric/scheduler (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1442,7 +1442,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/telemetry (0.81.2):
+  - React-Fabric/telemetry (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1461,7 +1461,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/templateprocessor (0.81.2):
+  - React-Fabric/templateprocessor (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1480,7 +1480,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager (0.81.2):
+  - React-Fabric/uimanager (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1488,7 +1488,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.2)
+    - React-Fabric/uimanager/consistency (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1501,7 +1501,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager/consistency (0.81.2):
+  - React-Fabric/uimanager/consistency (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1521,7 +1521,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-FabricComponents (0.81.2):
+  - React-FabricComponents (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1530,8 +1530,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.2)
-    - React-FabricComponents/textlayoutmanager (= 0.81.2)
+    - React-FabricComponents/components (= 0.81.3)
+    - React-FabricComponents/textlayoutmanager (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1544,7 +1544,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components (0.81.2):
+  - React-FabricComponents/components (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1553,17 +1553,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.2)
-    - React-FabricComponents/components/iostextinput (= 0.81.2)
-    - React-FabricComponents/components/modal (= 0.81.2)
-    - React-FabricComponents/components/rncore (= 0.81.2)
-    - React-FabricComponents/components/safeareaview (= 0.81.2)
-    - React-FabricComponents/components/scrollview (= 0.81.2)
-    - React-FabricComponents/components/switch (= 0.81.2)
-    - React-FabricComponents/components/text (= 0.81.2)
-    - React-FabricComponents/components/textinput (= 0.81.2)
-    - React-FabricComponents/components/unimplementedview (= 0.81.2)
-    - React-FabricComponents/components/virtualview (= 0.81.2)
+    - React-FabricComponents/components/inputaccessory (= 0.81.3)
+    - React-FabricComponents/components/iostextinput (= 0.81.3)
+    - React-FabricComponents/components/modal (= 0.81.3)
+    - React-FabricComponents/components/rncore (= 0.81.3)
+    - React-FabricComponents/components/safeareaview (= 0.81.3)
+    - React-FabricComponents/components/scrollview (= 0.81.3)
+    - React-FabricComponents/components/switch (= 0.81.3)
+    - React-FabricComponents/components/text (= 0.81.3)
+    - React-FabricComponents/components/textinput (= 0.81.3)
+    - React-FabricComponents/components/unimplementedview (= 0.81.3)
+    - React-FabricComponents/components/virtualview (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1576,28 +1576,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.2):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.2):
+  - React-FabricComponents/components/inputaccessory (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1618,7 +1597,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/modal (0.81.2):
+  - React-FabricComponents/components/iostextinput (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1639,7 +1618,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.2):
+  - React-FabricComponents/components/modal (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1660,7 +1639,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.2):
+  - React-FabricComponents/components/rncore (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1681,7 +1660,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.2):
+  - React-FabricComponents/components/safeareaview (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1702,7 +1681,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/switch (0.81.2):
+  - React-FabricComponents/components/scrollview (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1723,7 +1702,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/text (0.81.2):
+  - React-FabricComponents/components/switch (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1744,7 +1723,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.2):
+  - React-FabricComponents/components/text (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1765,7 +1744,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.2):
+  - React-FabricComponents/components/textinput (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1786,7 +1765,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.2):
+  - React-FabricComponents/components/unimplementedview (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1807,7 +1786,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.2):
+  - React-FabricComponents/components/virtualview (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1828,27 +1807,48 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricImage (0.81.2):
+  - React-FabricComponents/textlayoutmanager (0.81.3):
     - hermes-engine
-    - RCTRequired (= 0.81.2)
-    - RCTTypeSafety (= 0.81.2)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - React-FabricImage (0.81.3):
+    - hermes-engine
+    - RCTRequired (= 0.81.3)
+    - RCTTypeSafety (= 0.81.3)
     - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.2)
+    - React-jsiexecutor (= 0.81.3)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-featureflags (0.81.2):
+  - React-featureflags (0.81.3):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-featureflagsnativemodule (0.81.2):
+  - React-featureflagsnativemodule (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1857,26 +1857,26 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-graphics (0.81.2):
+  - React-graphics (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
     - React-jsiexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-hermes (0.81.2):
+  - React-hermes (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
     - React-jsi
-    - React-jsiexecutor (= 0.81.2)
+    - React-jsiexecutor (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.2)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-idlecallbacksnativemodule (0.81.2):
+  - React-idlecallbacksnativemodule (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1886,7 +1886,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-ImageManager (0.81.2):
+  - React-ImageManager (0.81.3):
     - React-Core-prebuilt
     - React-Core/Default
     - React-debug
@@ -1895,7 +1895,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - ReactNativeDependencies
-  - React-jserrorhandler (0.81.2):
+  - React-jserrorhandler (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1904,22 +1904,22 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - ReactNativeDependencies
-  - React-jsi (0.81.2):
+  - React-jsi (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsiexecutor (0.81.2):
+  - React-jsiexecutor (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.2)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspector (0.81.2):
+  - React-jsinspector (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1928,43 +1928,43 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.81.2)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspectorcdp (0.81.2):
+  - React-jsinspectorcdp (0.81.3):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsinspectornetwork (0.81.2):
+  - React-jsinspectornetwork (0.81.3):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectorcdp
     - React-performancetimeline
     - React-timing
     - ReactNativeDependencies
-  - React-jsinspectortracing (0.81.2):
+  - React-jsinspectortracing (0.81.3):
     - React-Core-prebuilt
     - React-oscompat
     - React-timing
     - ReactNativeDependencies
-  - React-jsitooling (0.81.2):
+  - React-jsitooling (0.81.3):
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsitracing (0.81.2):
+  - React-jsitracing (0.81.3):
     - React-jsi
-  - React-logger (0.81.2):
+  - React-logger (0.81.3):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-Mapbuffer (0.81.2):
+  - React-Mapbuffer (0.81.3):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-microtasksnativemodule (0.81.2):
+  - React-microtasksnativemodule (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -2225,7 +2225,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-NativeModulesApple (0.81.2):
+  - React-NativeModulesApple (0.81.3):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -2239,20 +2239,20 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-oscompat (0.81.2)
-  - React-perflogger (0.81.2):
+  - React-oscompat (0.81.3)
+  - React-perflogger (0.81.3):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-performancetimeline (0.81.2):
+  - React-performancetimeline (0.81.3):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
     - ReactNativeDependencies
-  - React-RCTActionSheet (0.81.2):
-    - React-Core/RCTActionSheetHeaders (= 0.81.2)
-  - React-RCTAnimation (0.81.2):
+  - React-RCTActionSheet (0.81.3):
+    - React-Core/RCTActionSheetHeaders (= 0.81.3)
+  - React-RCTAnimation (0.81.3):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
@@ -2262,7 +2262,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTAppDelegate (0.81.2):
+  - React-RCTAppDelegate (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2290,7 +2290,7 @@ PODS:
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTBlob (0.81.2):
+  - React-RCTBlob (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
@@ -2303,7 +2303,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFabric (0.81.2):
+  - React-RCTFabric (0.81.3):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -2332,7 +2332,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.2):
+  - React-RCTFBReactNativeSpec (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2340,10 +2340,10 @@ PODS:
     - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.2)
+    - React-RCTFBReactNativeSpec/components (= 0.81.3)
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFBReactNativeSpec/components (0.81.2):
+  - React-RCTFBReactNativeSpec/components (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2360,7 +2360,7 @@ PODS:
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-RCTImage (0.81.2):
+  - React-RCTImage (0.81.3):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTImageHeaders
@@ -2370,14 +2370,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTLinking (0.81.2):
-    - React-Core/RCTLinkingHeaders (= 0.81.2)
-    - React-jsi (= 0.81.2)
+  - React-RCTLinking (0.81.3):
+    - React-Core/RCTLinkingHeaders (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.2)
-  - React-RCTNetwork (0.81.2):
+    - ReactCommon/turbomodule/core (= 0.81.3)
+  - React-RCTNetwork (0.81.3):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
@@ -2389,7 +2389,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTRuntime (0.81.2):
+  - React-RCTRuntime (0.81.3):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -2403,7 +2403,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - ReactNativeDependencies
-  - React-RCTSettings (0.81.2):
+  - React-RCTSettings (0.81.3):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
@@ -2412,10 +2412,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTText (0.81.2):
-    - React-Core/RCTTextHeaders (= 0.81.2)
+  - React-RCTText (0.81.3):
+    - React-Core/RCTTextHeaders (= 0.81.3)
     - Yoga
-  - React-RCTVibration (0.81.2):
+  - React-RCTVibration (0.81.3):
     - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
@@ -2423,15 +2423,15 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-rendererconsistency (0.81.2)
-  - React-renderercss (0.81.2):
+  - React-rendererconsistency (0.81.3)
+  - React-renderercss (0.81.3):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.2):
+  - React-rendererdebug (0.81.3):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-RuntimeApple (0.81.2):
+  - React-RuntimeApple (0.81.3):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2454,7 +2454,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeCore (0.81.2):
+  - React-RuntimeCore (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -2470,14 +2470,14 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-runtimeexecutor (0.81.2):
+  - React-runtimeexecutor (0.81.3):
     - React-Core-prebuilt
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.2)
+    - React-jsi (= 0.81.3)
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeHermes (0.81.2):
+  - React-RuntimeHermes (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -2492,7 +2492,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-runtimescheduler (0.81.2):
+  - React-runtimescheduler (0.81.3):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2508,17 +2508,17 @@ PODS:
     - React-timing
     - React-utils
     - ReactNativeDependencies
-  - React-timing (0.81.2):
+  - React-timing (0.81.3):
     - React-debug
-  - React-utils (0.81.2):
+  - React-utils (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-debug
-    - React-jsi (= 0.81.2)
+    - React-jsi (= 0.81.3)
     - ReactNativeDependencies
-  - ReactAppDependencyProvider (0.81.2):
+  - ReactAppDependencyProvider (0.81.3):
     - ReactCodegen
-  - ReactCodegen (0.81.2):
+  - ReactCodegen (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2538,43 +2538,43 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactCommon (0.81.2):
+  - ReactCommon (0.81.3):
     - React-Core-prebuilt
-    - ReactCommon/turbomodule (= 0.81.2)
+    - ReactCommon/turbomodule (= 0.81.3)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule (0.81.2):
+  - ReactCommon/turbomodule (0.81.3):
     - hermes-engine
-    - React-callinvoker (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
-    - ReactCommon/turbomodule/bridging (= 0.81.2)
-    - ReactCommon/turbomodule/core (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
+    - ReactCommon/turbomodule/bridging (= 0.81.3)
+    - ReactCommon/turbomodule/core (= 0.81.3)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/bridging (0.81.2):
+  - ReactCommon/turbomodule/bridging (0.81.3):
     - hermes-engine
-    - React-callinvoker (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/core (0.81.2):
+  - ReactCommon/turbomodule/core (0.81.3):
     - hermes-engine
-    - React-callinvoker (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.2)
-    - React-debug (= 0.81.2)
-    - React-featureflags (= 0.81.2)
-    - React-jsi (= 0.81.2)
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
-    - React-utils (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
+    - React-debug (= 0.81.3)
+    - React-featureflags (= 0.81.3)
+    - React-jsi (= 0.81.3)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
+    - React-utils (= 0.81.3)
     - ReactNativeDependencies
-  - ReactNativeDependencies (0.81.2)
+  - ReactNativeDependencies (0.81.3)
   - RNCAsyncStorage (2.2.0):
     - hermes-engine
     - RCTRequired
@@ -3627,8 +3627,8 @@ SPEC CHECKSUMS:
   EXTaskManager: 19451783dfb545748126ad2d5ecdf535daf8d6da
   EXUpdates: acd31e646f9ca7e4efb3747b590210f297ec6938
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
-  FBLazyVector: 77485268e564ddf67fa5045947653a87b4531a47
-  hermes-engine: ceacb56b83367e3c4f7ed5ab0e93f92a89e4575b
+  FBLazyVector: d06087501b6a425c222a186e94ce92aa4d3fb37c
+  hermes-engine: 5463d3c4a8a0d35701605934008f34c171ce71d5
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3637,40 +3637,40 @@ SPEC CHECKSUMS:
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCTDeprecation: 4d678ef4dca05565072e9ceace59e4fb8a33da81
-  RCTRequired: 35279f87ab747ff65303485f0ea3b92c508fddff
-  RCTTypeSafety: c8de06496c6ce0f746b56dbc5bfc299dcfa5b008
+  RCTDeprecation: 0b7e84477d8780fc8dff04fc1ec89cb93f8f5c04
+  RCTRequired: 497c1356844e5e95975ff2259bedc2db446c4ed0
+  RCTTypeSafety: 6105baaba5a22b1ff4f2e420eda172aa423acd01
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 7cee6da22b893d581d51397032d4a3951c03cb17
-  React-callinvoker: 5ea70569ceece01e1996c85f9cb1c689bec71c9b
-  React-Core: 6d23dc59f228c62ee15e993311c2942d304624c2
-  React-Core-prebuilt: 1ce36105edd4c579e7117f97ba65ad1ba583e517
-  React-CoreModules: 1f20825829502f28e2bdda25cc0ea2adcb8164e0
-  React-cxxreact: a1bf41dddce13a969c427b3ec81f66254d312775
-  React-debug: d860c135c213f12e841342ff2a6c14d5afb9e419
-  React-defaultsnativemodule: 470b797179649c6b2950e2f71503fc8a7f753878
-  React-domnativemodule: 360dff03a2974551afcd7a0e0f3da7febbcd4950
-  React-Fabric: d474e965ca02954854b77279c33a41e38feb1cfb
-  React-FabricComponents: e6d1b0189c68f1d4e18d20a18d2b2c23ba7faa65
-  React-FabricImage: 5b2da3539c4b4d55f9e9c20acf49ab642eddc457
-  React-featureflags: 63125b1d5ee27579ffee872d4a8980f044733935
-  React-featureflagsnativemodule: ff9aeb43ede668b8e04c36c7f10ea2b3d7a03a7f
-  React-graphics: c2d8b4eec2c4fd73b2cc141c992e7149b4220844
-  React-hermes: 198b38686a436f2fba3f605ac3fb55fea9dba4b3
-  React-idlecallbacksnativemodule: 4a640d71f7e4c75a36b0e138a196c4f7bb11b377
-  React-ImageManager: 1bb91c56c3bedd9abe7b029c4b5dd7f80a66b0f2
-  React-jserrorhandler: 4ac198ede40dd986f3efd7986cafad19f099e32c
-  React-jsi: 7d41c57eaac52e6279145e942ebdc5246c5f4ab0
-  React-jsiexecutor: 4435b1ad246cacd0be474f314764280fd41307bf
-  React-jsinspector: 51599b1c435be9b3936e1114499c6110852f4d75
-  React-jsinspectorcdp: 1bbbe3c04751c10333ee1fe939d97055bb10725a
-  React-jsinspectornetwork: c3dbe28b67ead6b3abdc569e3dafcfd8fca7ac5f
-  React-jsinspectortracing: 70368406508ecfa2ce6b929858f1a8ed8493282d
-  React-jsitooling: 5fa9819f41fff7ea081406b4462dc9d4b38e7bbd
-  React-jsitracing: 87af8fac96118ed50def3ca0e52635598ef8ae8d
-  React-logger: 51cdc4a1f7f534b535b461644ebba9fdbc0baf4c
-  React-Mapbuffer: 67755dc0cb0647ad6294a3bc02181d9daf08b17f
-  React-microtasksnativemodule: cd10fe63b700365a362d750f0a8c94cff59eeebb
+  React: 639d04fed84b2ff824861d863891eaef7cb92f9c
+  React-callinvoker: 9eff267e8435b7ab377acf16a64d69e897f35c25
+  React-Core: 114001953b5444cc62d652d0afdda9eefdba5362
+  React-Core-prebuilt: 39d0f778d6e21201895baec61c746843d1392984
+  React-CoreModules: 08308a974bbce620cb3abac6e2761a5245c96621
+  React-cxxreact: 302ece9f2b119a875a0d9d22dffb57557394e242
+  React-debug: 9c09818ae432a10ab72c973b727b944b75ccadb9
+  React-defaultsnativemodule: 4955e87b2b0ee8be90625b579658c57b04438cb4
+  React-domnativemodule: af79168a06f4da71b515ee63fa94072a395fd2a7
+  React-Fabric: 0f1cb599f71d2749a6aac92b07d243afaf8b5fb4
+  React-FabricComponents: 831e1af20196101467532a1e9947070a57b30f8f
+  React-FabricImage: 0cb0f9c8b0f58cc3ab21d9bcb02c5580de33ea19
+  React-featureflags: 50f6c269087123f68c5f3b7f1c5847a7328e4713
+  React-featureflagsnativemodule: 4fd687c47b7d68ee45ae39bc2d3bfc087292d8d4
+  React-graphics: 85d61c25ad0e2feb82703d830cb5f1447f26776c
+  React-hermes: 06fd40f5d8ca9cc60247f08feac9c2e4b5a11caa
+  React-idlecallbacksnativemodule: 7bc42c314257dfe112330afb3d63bffe0c712968
+  React-ImageManager: a93bb2a53c7f69b49feb13731c1dfe76cd123cd6
+  React-jserrorhandler: 7a10f7236723aec83dd81db9e22ab453a0ec4a01
+  React-jsi: 4867a7cc7638c5580f6bcc5af6009e5e53efc216
+  React-jsiexecutor: c22b20b5a1615878cfdaa7a1d0bfd363d3f34728
+  React-jsinspector: 233b55315afc9c5c46ba8a28b5ac70a1d844cb29
+  React-jsinspectorcdp: 085d8c4f96335f897cde933f06254cc9ed33040e
+  React-jsinspectornetwork: 7cb1c98c63979c9fe5d1e10660368ef86227bbd1
+  React-jsinspectortracing: 52d2b1534cdd7c01f8bf20921522b747d68d9ef8
+  React-jsitooling: 5e888c5c6f24e48e1978535a70e2296a57b21549
+  React-jsitracing: da1c7edd78c35dfdf7e26111888894ff9dec7880
+  React-logger: 793cf0a405596fc047e192f9e9b2f0565c8b97d9
+  React-Mapbuffer: 82cd04b7e0f4ee713fd848bd41f004659e82301e
+  React-microtasksnativemodule: 7604bc6677ca1c9c184ac217952394d6dc5534dc
   react-native-keyboard-controller: 5587bad7f102125e2020720c4e37e0b58ff5e52e
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-pager-view: e37989fc447aa4b5de6d0d2ffb0229e817329246
@@ -3680,37 +3680,37 @@ SPEC CHECKSUMS:
   react-native-slider: b76fa3dd989d25e8c2751c2a546674dfc0c2b6f8
   react-native-view-shot: 26174e54ec6b4b7c5d70b86964b747919759adc1
   react-native-webview: a4f0775a31b73cf13cfc3d2d2b119aa94ec76e49
-  React-NativeModulesApple: bd258b9485e456d84f9584523ad3c3c8ba0b51e9
-  React-oscompat: ade00f2748c52568bec65682448d74fe6df6f2d3
-  React-perflogger: 7899e64980a940a71005d4752fc03dd4e61d4247
-  React-performancetimeline: 31b6d62cb743fc136117fd5f221c75bb3a282276
-  React-RCTActionSheet: ffab08a04e6fe47dbb6623ae950427ce61b1df47
-  React-RCTAnimation: 5db15314c4528647a6419c3ab3482044549bc722
-  React-RCTAppDelegate: d07b00d43ce1f6e947da3a2ff660147d4e82f909
-  React-RCTBlob: 8251a93151631fc7a6446e756771288e01bb4fea
-  React-RCTFabric: 62aad1b3308a341658ecfc74e83f1b95f0dbb024
-  React-RCTFBReactNativeSpec: 6c671dbc26713886f91c071e7e27f7fdcdcc5420
-  React-RCTImage: 2ac66fd27553f56f551aaa565204f8e822c1abb0
-  React-RCTLinking: 5720f30f765a2bbbd79f4b0b97c04a60924ad0e6
-  React-RCTNetwork: 3082a19df28509afcc2e48709769a784050c0d23
-  React-RCTRuntime: 7ee4a2b7d9a270a1b9e0675fa49811f64c6863ad
-  React-RCTSettings: cd54e1057599bf6df23f1aeec073de182c90e9e5
-  React-RCTText: ea2ae68038930a06276807c742afa37cfd811e29
-  React-RCTVibration: c7acf3d6c345182887f1d4765623bfd2d4a723c0
-  React-rendererconsistency: bc382ce33dfa11ea371c1174db34c56c897aa3e3
-  React-renderercss: e047767f4219d999efd4588321b1fc14f6f6e18a
-  React-rendererdebug: 22dda44f8931d67a93efcb47f9e89bf3e46f1271
-  React-RuntimeApple: c9ccccc3c3e1c819d66b7b99ee79af7eb3985e50
-  React-RuntimeCore: cda0561ca45e6c282d16527f5e3339a956599fe0
-  React-runtimeexecutor: 94f916248385c0006c83f51d2a33fa40f8dfb5de
-  React-RuntimeHermes: 26f08e51bbac484fa5e0f88f40c4a27ed14d1f77
-  React-runtimescheduler: bd29b8e1664b5b1859fe602a9148d7a619fd7ac3
-  React-timing: 990f6836757f7fe69e5b97b18435b815aac7f046
-  React-utils: 409fa5cb4574fa1c0f8002a463518b63c69fea83
-  ReactAppDependencyProvider: 319be07ed29c6a24b30b700ebf6f667c9d49a511
-  ReactCodegen: e0994138c24ea4b895ad41836a4a190f42567df1
-  ReactCommon: 5cabaa414dfa310990a62264693d4f8e61b88fdf
-  ReactNativeDependencies: 316e0ff865f50a287726f6b002c607f90ad878fb
+  React-NativeModulesApple: dc4d40310448a70b2a7b25f7280a501150b88fe2
+  React-oscompat: 94245768a4c9e912776373255e9b9497d634b284
+  React-perflogger: e58b0e28f1ee95e99e330dcde8b0beb710199e10
+  React-performancetimeline: a770d9c95f897c07e35f43247afc16c7b569737f
+  React-RCTActionSheet: dee4c5e267ec056f5ef912196a856df035e685ff
+  React-RCTAnimation: e3a5ce2e53f482e2daa2f8f43468abdbe0260c76
+  React-RCTAppDelegate: 4c9bcaaad7af57c5dd97561dba236d5a3baecd20
+  React-RCTBlob: 062da7c13848cc643589becc7b190900ad7e2499
+  React-RCTFabric: 37f875131330036c090d6b01f21b5285dee77757
+  React-RCTFBReactNativeSpec: 354e6cc4e681eb0f8cda9571d7a2fd00d6674b29
+  React-RCTImage: d32d7056068751e45b383561705bac719dedcbc7
+  React-RCTLinking: add103c480ae3f1d6fdbead7ecfa22eb6dbb1c4a
+  React-RCTNetwork: 0e3cc2664d73e11b3b97a8f7d318fa1034328394
+  React-RCTRuntime: 40092cdd126b1d3a2f240e13e94f36fdf8a4a05f
+  React-RCTSettings: ac3ea5b32e8542c7eac0701305214815594cb188
+  React-RCTText: 4d1c4ddab66b6170977a695348cdb0f989005192
+  React-RCTVibration: 20ec75d11d2cd2cecf82772a7d5101af20d2a322
+  React-rendererconsistency: 9cbc91c7a1890be02c2279ddf3f539dc24d0cdf7
+  React-renderercss: 6a9d220ffda31f005fbe2021633481c9343e603c
+  React-rendererdebug: 6531aa831f830e03b456469cfe3c1e4c8b98baf6
+  React-RuntimeApple: c0d858b8fe462ec9c435fd130348b7e89b6932fa
+  React-RuntimeCore: 3f868e7a500bcf5bc30fc0e6edb1e54e12b220ce
+  React-runtimeexecutor: 918598152c33b701821e0b9cb16472badbf23b3e
+  React-RuntimeHermes: ffb292bf8a08a3c674ee213c6bfe0ee3e2ae528d
+  React-runtimescheduler: d57929ce939bd518243e42614f9a95add27ba6f7
+  React-timing: cf0652d4c8a5bf1c48aef5b70eb3fa6f50c7f2ac
+  React-utils: 4687ee48d76381ceb583479fbc7026eae8adc744
+  ReactAppDependencyProvider: f9317094ed209f55ecbdd9ba792843cfb1c45c29
+  ReactCodegen: ed035c4f9a598b00b5707a52a6b3da4a4228bb1b
+  ReactCommon: c7ad14babdb12b84989965987f87baebe062e6a5
+  ReactNativeDependencies: 1d2c24fee8694aaf7cf5589288418cd78a24ec19
   RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
   RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
   RNCPicker: f97c908b7774248c1093ec3831ca70d338627bf7
@@ -3725,7 +3725,7 @@ SPEC CHECKSUMS:
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   UMAppLoader: 2af2cc05fcaa9851233893c0e3dbc56a99f57e36
-  Yoga: 82e60295fd61743ed3c218e3873faf184646f99a
+  Yoga: f9025ab908f89228f6ab399c59bfcc334b53a734
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 07ca240dc3c89dc461c221729e3f0a73e14e9ad8

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -632,10 +632,10 @@ PODS:
     - Yoga
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
-  - FBLazyVector (0.81.1)
-  - hermes-engine (0.81.1):
-    - hermes-engine/Pre-built (= 0.81.1)
-  - hermes-engine/Pre-built (0.81.1)
+  - FBLazyVector (0.81.2)
+  - hermes-engine (0.81.2):
+    - hermes-engine/Pre-built (= 0.81.2)
+  - hermes-engine/Pre-built (0.81.2)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -692,32 +692,32 @@ PODS:
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - Quick (7.3.1)
-  - RCTDeprecation (0.81.1)
-  - RCTRequired (0.81.1)
-  - RCTTypeSafety (0.81.1):
-    - FBLazyVector (= 0.81.1)
-    - RCTRequired (= 0.81.1)
-    - React-Core (= 0.81.1)
+  - RCTDeprecation (0.81.2)
+  - RCTRequired (0.81.2)
+  - RCTTypeSafety (0.81.2):
+    - FBLazyVector (= 0.81.2)
+    - RCTRequired (= 0.81.2)
+    - React-Core (= 0.81.2)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.1):
-    - React-Core (= 0.81.1)
-    - React-Core/DevSupport (= 0.81.1)
-    - React-Core/RCTWebSocket (= 0.81.1)
-    - React-RCTActionSheet (= 0.81.1)
-    - React-RCTAnimation (= 0.81.1)
-    - React-RCTBlob (= 0.81.1)
-    - React-RCTImage (= 0.81.1)
-    - React-RCTLinking (= 0.81.1)
-    - React-RCTNetwork (= 0.81.1)
-    - React-RCTSettings (= 0.81.1)
-    - React-RCTText (= 0.81.1)
-    - React-RCTVibration (= 0.81.1)
-  - React-callinvoker (0.81.1)
-  - React-Core (0.81.1):
+  - React (0.81.2):
+    - React-Core (= 0.81.2)
+    - React-Core/DevSupport (= 0.81.2)
+    - React-Core/RCTWebSocket (= 0.81.2)
+    - React-RCTActionSheet (= 0.81.2)
+    - React-RCTAnimation (= 0.81.2)
+    - React-RCTBlob (= 0.81.2)
+    - React-RCTImage (= 0.81.2)
+    - React-RCTLinking (= 0.81.2)
+    - React-RCTNetwork (= 0.81.2)
+    - React-RCTSettings (= 0.81.2)
+    - React-RCTText (= 0.81.2)
+    - React-RCTVibration (= 0.81.2)
+  - React-callinvoker (0.81.2)
+  - React-Core (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.81.1)
+    - React-Core/Default (= 0.81.2)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -732,66 +732,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.81.1):
+  - React-Core-prebuilt (0.81.2):
     - ReactNativeDependencies
-  - React-Core/CoreModulesHeaders (0.81.1):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/Default (0.81.1):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/DevSupport (0.81.1):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default (= 0.81.1)
-    - React-Core/RCTWebSocket (= 0.81.1)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.1):
+  - React-Core/CoreModulesHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -810,7 +753,45 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.1):
+  - React-Core/Default (0.81.2):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/DevSupport (0.81.2):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-Core/Default (= 0.81.2)
+    - React-Core/RCTWebSocket (= 0.81.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -829,7 +810,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.1):
+  - React-Core/RCTAnimationHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -848,7 +829,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.1):
+  - React-Core/RCTBlobHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -867,7 +848,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.1):
+  - React-Core/RCTImageHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -886,7 +867,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.1):
+  - React-Core/RCTLinkingHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -905,7 +886,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.1):
+  - React-Core/RCTNetworkHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -924,7 +905,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.1):
+  - React-Core/RCTSettingsHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -943,7 +924,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.1):
+  - React-Core/RCTTextHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -962,11 +943,11 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTWebSocket (0.81.1):
+  - React-Core/RCTVibrationHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.81.1)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -981,37 +962,56 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-CoreModules (0.81.1):
-    - RCTTypeSafety (= 0.81.1)
+  - React-Core/RCTWebSocket (0.81.2):
+    - hermes-engine
+    - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/CoreModulesHeaders (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - React-Core/Default (= 0.81.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-CoreModules (0.81.2):
+    - RCTTypeSafety (= 0.81.2)
+    - React-Core-prebuilt
+    - React-Core/CoreModulesHeaders (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.1)
+    - React-RCTImage (= 0.81.2)
     - React-runtimeexecutor
     - ReactCommon
     - ReactNativeDependencies
-  - React-cxxreact (0.81.1):
+  - React-cxxreact (0.81.2):
     - hermes-engine
-    - React-callinvoker (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
     - React-Core-prebuilt
-    - React-debug (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - React-debug (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
-    - React-timing (= 0.81.1)
+    - React-timing (= 0.81.2)
     - ReactNativeDependencies
-  - React-debug (0.81.1)
-  - React-defaultsnativemodule (0.81.1):
+  - React-debug (0.81.2)
+  - React-defaultsnativemodule (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-domnativemodule
@@ -1022,7 +1022,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - ReactNativeDependencies
-  - React-domnativemodule (0.81.1):
+  - React-domnativemodule (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-Fabric
@@ -1036,7 +1036,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric (0.81.1):
+  - React-Fabric (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1044,23 +1044,23 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.1)
-    - React-Fabric/attributedstring (= 0.81.1)
-    - React-Fabric/bridging (= 0.81.1)
-    - React-Fabric/componentregistry (= 0.81.1)
-    - React-Fabric/componentregistrynative (= 0.81.1)
-    - React-Fabric/components (= 0.81.1)
-    - React-Fabric/consistency (= 0.81.1)
-    - React-Fabric/core (= 0.81.1)
-    - React-Fabric/dom (= 0.81.1)
-    - React-Fabric/imagemanager (= 0.81.1)
-    - React-Fabric/leakchecker (= 0.81.1)
-    - React-Fabric/mounting (= 0.81.1)
-    - React-Fabric/observers (= 0.81.1)
-    - React-Fabric/scheduler (= 0.81.1)
-    - React-Fabric/telemetry (= 0.81.1)
-    - React-Fabric/templateprocessor (= 0.81.1)
-    - React-Fabric/uimanager (= 0.81.1)
+    - React-Fabric/animations (= 0.81.2)
+    - React-Fabric/attributedstring (= 0.81.2)
+    - React-Fabric/bridging (= 0.81.2)
+    - React-Fabric/componentregistry (= 0.81.2)
+    - React-Fabric/componentregistrynative (= 0.81.2)
+    - React-Fabric/components (= 0.81.2)
+    - React-Fabric/consistency (= 0.81.2)
+    - React-Fabric/core (= 0.81.2)
+    - React-Fabric/dom (= 0.81.2)
+    - React-Fabric/imagemanager (= 0.81.2)
+    - React-Fabric/leakchecker (= 0.81.2)
+    - React-Fabric/mounting (= 0.81.2)
+    - React-Fabric/observers (= 0.81.2)
+    - React-Fabric/scheduler (= 0.81.2)
+    - React-Fabric/telemetry (= 0.81.2)
+    - React-Fabric/templateprocessor (= 0.81.2)
+    - React-Fabric/uimanager (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1072,26 +1072,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animations (0.81.1):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/attributedstring (0.81.1):
+  - React-Fabric/animations (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1110,7 +1091,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/bridging (0.81.1):
+  - React-Fabric/attributedstring (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1129,7 +1110,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistry (0.81.1):
+  - React-Fabric/bridging (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1148,7 +1129,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistrynative (0.81.1):
+  - React-Fabric/componentregistry (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1167,30 +1148,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components (0.81.1):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.1)
-    - React-Fabric/components/root (= 0.81.1)
-    - React-Fabric/components/scrollview (= 0.81.1)
-    - React-Fabric/components/view (= 0.81.1)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.1):
+  - React-Fabric/componentregistrynative (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1209,7 +1167,30 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/root (0.81.1):
+  - React-Fabric/components (0.81.2):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.2)
+    - React-Fabric/components/root (= 0.81.2)
+    - React-Fabric/components/scrollview (= 0.81.2)
+    - React-Fabric/components/view (= 0.81.2)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1228,7 +1209,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/scrollview (0.81.1):
+  - React-Fabric/components/root (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1247,7 +1228,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/view (0.81.1):
+  - React-Fabric/components/scrollview (0.81.2):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/view (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1268,7 +1268,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric/consistency (0.81.1):
+  - React-Fabric/consistency (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1287,7 +1287,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/core (0.81.1):
+  - React-Fabric/core (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1306,7 +1306,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/dom (0.81.1):
+  - React-Fabric/dom (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1325,7 +1325,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/imagemanager (0.81.1):
+  - React-Fabric/imagemanager (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1344,7 +1344,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/leakchecker (0.81.1):
+  - React-Fabric/leakchecker (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1363,7 +1363,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/mounting (0.81.1):
+  - React-Fabric/mounting (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1382,7 +1382,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers (0.81.1):
+  - React-Fabric/observers (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1390,7 +1390,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.1)
+    - React-Fabric/observers/events (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1402,7 +1402,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers/events (0.81.1):
+  - React-Fabric/observers/events (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1421,7 +1421,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/scheduler (0.81.1):
+  - React-Fabric/scheduler (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1442,7 +1442,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/telemetry (0.81.1):
+  - React-Fabric/telemetry (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1461,7 +1461,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/templateprocessor (0.81.1):
+  - React-Fabric/templateprocessor (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1480,7 +1480,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager (0.81.1):
+  - React-Fabric/uimanager (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1488,7 +1488,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.1)
+    - React-Fabric/uimanager/consistency (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1501,7 +1501,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager/consistency (0.81.1):
+  - React-Fabric/uimanager/consistency (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1521,7 +1521,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-FabricComponents (0.81.1):
+  - React-FabricComponents (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1530,8 +1530,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.1)
-    - React-FabricComponents/textlayoutmanager (= 0.81.1)
+    - React-FabricComponents/components (= 0.81.2)
+    - React-FabricComponents/textlayoutmanager (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1544,7 +1544,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components (0.81.1):
+  - React-FabricComponents/components (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1553,17 +1553,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.1)
-    - React-FabricComponents/components/iostextinput (= 0.81.1)
-    - React-FabricComponents/components/modal (= 0.81.1)
-    - React-FabricComponents/components/rncore (= 0.81.1)
-    - React-FabricComponents/components/safeareaview (= 0.81.1)
-    - React-FabricComponents/components/scrollview (= 0.81.1)
-    - React-FabricComponents/components/switch (= 0.81.1)
-    - React-FabricComponents/components/text (= 0.81.1)
-    - React-FabricComponents/components/textinput (= 0.81.1)
-    - React-FabricComponents/components/unimplementedview (= 0.81.1)
-    - React-FabricComponents/components/virtualview (= 0.81.1)
+    - React-FabricComponents/components/inputaccessory (= 0.81.2)
+    - React-FabricComponents/components/iostextinput (= 0.81.2)
+    - React-FabricComponents/components/modal (= 0.81.2)
+    - React-FabricComponents/components/rncore (= 0.81.2)
+    - React-FabricComponents/components/safeareaview (= 0.81.2)
+    - React-FabricComponents/components/scrollview (= 0.81.2)
+    - React-FabricComponents/components/switch (= 0.81.2)
+    - React-FabricComponents/components/text (= 0.81.2)
+    - React-FabricComponents/components/textinput (= 0.81.2)
+    - React-FabricComponents/components/unimplementedview (= 0.81.2)
+    - React-FabricComponents/components/virtualview (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1576,28 +1576,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.1):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.1):
+  - React-FabricComponents/components/inputaccessory (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1618,7 +1597,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/modal (0.81.1):
+  - React-FabricComponents/components/iostextinput (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1639,7 +1618,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.1):
+  - React-FabricComponents/components/modal (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1660,7 +1639,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.1):
+  - React-FabricComponents/components/rncore (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1681,7 +1660,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.1):
+  - React-FabricComponents/components/safeareaview (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1702,7 +1681,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/switch (0.81.1):
+  - React-FabricComponents/components/scrollview (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1723,7 +1702,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/text (0.81.1):
+  - React-FabricComponents/components/switch (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1744,7 +1723,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.1):
+  - React-FabricComponents/components/text (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1765,7 +1744,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.1):
+  - React-FabricComponents/components/textinput (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1786,7 +1765,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.1):
+  - React-FabricComponents/components/unimplementedview (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1807,7 +1786,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.1):
+  - React-FabricComponents/components/virtualview (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1828,27 +1807,48 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricImage (0.81.1):
+  - React-FabricComponents/textlayoutmanager (0.81.2):
     - hermes-engine
-    - RCTRequired (= 0.81.1)
-    - RCTTypeSafety (= 0.81.1)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - React-FabricImage (0.81.2):
+    - hermes-engine
+    - RCTRequired (= 0.81.2)
+    - RCTTypeSafety (= 0.81.2)
     - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.1)
+    - React-jsiexecutor (= 0.81.2)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-featureflags (0.81.1):
+  - React-featureflags (0.81.2):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-featureflagsnativemodule (0.81.1):
+  - React-featureflagsnativemodule (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1857,26 +1857,26 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-graphics (0.81.1):
+  - React-graphics (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
     - React-jsiexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-hermes (0.81.1):
+  - React-hermes (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
     - React-jsi
-    - React-jsiexecutor (= 0.81.1)
+    - React-jsiexecutor (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.1)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-idlecallbacksnativemodule (0.81.1):
+  - React-idlecallbacksnativemodule (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1886,7 +1886,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-ImageManager (0.81.1):
+  - React-ImageManager (0.81.2):
     - React-Core-prebuilt
     - React-Core/Default
     - React-debug
@@ -1895,7 +1895,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - ReactNativeDependencies
-  - React-jserrorhandler (0.81.1):
+  - React-jserrorhandler (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1904,22 +1904,22 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - ReactNativeDependencies
-  - React-jsi (0.81.1):
+  - React-jsi (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsiexecutor (0.81.1):
+  - React-jsiexecutor (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.1)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspector (0.81.1):
+  - React-jsinspector (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1928,43 +1928,43 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.81.1)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspectorcdp (0.81.1):
+  - React-jsinspectorcdp (0.81.2):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsinspectornetwork (0.81.1):
+  - React-jsinspectornetwork (0.81.2):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectorcdp
     - React-performancetimeline
     - React-timing
     - ReactNativeDependencies
-  - React-jsinspectortracing (0.81.1):
+  - React-jsinspectortracing (0.81.2):
     - React-Core-prebuilt
     - React-oscompat
     - React-timing
     - ReactNativeDependencies
-  - React-jsitooling (0.81.1):
+  - React-jsitooling (0.81.2):
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsitracing (0.81.1):
+  - React-jsitracing (0.81.2):
     - React-jsi
-  - React-logger (0.81.1):
+  - React-logger (0.81.2):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-Mapbuffer (0.81.1):
+  - React-Mapbuffer (0.81.2):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-microtasksnativemodule (0.81.1):
+  - React-microtasksnativemodule (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -2225,7 +2225,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-NativeModulesApple (0.81.1):
+  - React-NativeModulesApple (0.81.2):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -2239,20 +2239,20 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-oscompat (0.81.1)
-  - React-perflogger (0.81.1):
+  - React-oscompat (0.81.2)
+  - React-perflogger (0.81.2):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-performancetimeline (0.81.1):
+  - React-performancetimeline (0.81.2):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
     - ReactNativeDependencies
-  - React-RCTActionSheet (0.81.1):
-    - React-Core/RCTActionSheetHeaders (= 0.81.1)
-  - React-RCTAnimation (0.81.1):
+  - React-RCTActionSheet (0.81.2):
+    - React-Core/RCTActionSheetHeaders (= 0.81.2)
+  - React-RCTAnimation (0.81.2):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
@@ -2262,7 +2262,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTAppDelegate (0.81.1):
+  - React-RCTAppDelegate (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2290,7 +2290,7 @@ PODS:
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTBlob (0.81.1):
+  - React-RCTBlob (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
@@ -2303,7 +2303,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFabric (0.81.1):
+  - React-RCTFabric (0.81.2):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -2332,7 +2332,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.1):
+  - React-RCTFBReactNativeSpec (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2340,10 +2340,10 @@ PODS:
     - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.1)
+    - React-RCTFBReactNativeSpec/components (= 0.81.2)
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFBReactNativeSpec/components (0.81.1):
+  - React-RCTFBReactNativeSpec/components (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2360,7 +2360,7 @@ PODS:
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-RCTImage (0.81.1):
+  - React-RCTImage (0.81.2):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTImageHeaders
@@ -2370,14 +2370,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTLinking (0.81.1):
-    - React-Core/RCTLinkingHeaders (= 0.81.1)
-    - React-jsi (= 0.81.1)
+  - React-RCTLinking (0.81.2):
+    - React-Core/RCTLinkingHeaders (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.1)
-  - React-RCTNetwork (0.81.1):
+    - ReactCommon/turbomodule/core (= 0.81.2)
+  - React-RCTNetwork (0.81.2):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
@@ -2389,7 +2389,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTRuntime (0.81.1):
+  - React-RCTRuntime (0.81.2):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -2403,7 +2403,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - ReactNativeDependencies
-  - React-RCTSettings (0.81.1):
+  - React-RCTSettings (0.81.2):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
@@ -2412,10 +2412,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTText (0.81.1):
-    - React-Core/RCTTextHeaders (= 0.81.1)
+  - React-RCTText (0.81.2):
+    - React-Core/RCTTextHeaders (= 0.81.2)
     - Yoga
-  - React-RCTVibration (0.81.1):
+  - React-RCTVibration (0.81.2):
     - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
@@ -2423,15 +2423,15 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-rendererconsistency (0.81.1)
-  - React-renderercss (0.81.1):
+  - React-rendererconsistency (0.81.2)
+  - React-renderercss (0.81.2):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.1):
+  - React-rendererdebug (0.81.2):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-RuntimeApple (0.81.1):
+  - React-RuntimeApple (0.81.2):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2454,7 +2454,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeCore (0.81.1):
+  - React-RuntimeCore (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -2470,14 +2470,14 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-runtimeexecutor (0.81.1):
+  - React-runtimeexecutor (0.81.2):
     - React-Core-prebuilt
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.1)
+    - React-jsi (= 0.81.2)
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeHermes (0.81.1):
+  - React-RuntimeHermes (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -2492,7 +2492,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-runtimescheduler (0.81.1):
+  - React-runtimescheduler (0.81.2):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2508,17 +2508,17 @@ PODS:
     - React-timing
     - React-utils
     - ReactNativeDependencies
-  - React-timing (0.81.1):
+  - React-timing (0.81.2):
     - React-debug
-  - React-utils (0.81.1):
+  - React-utils (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-debug
-    - React-jsi (= 0.81.1)
+    - React-jsi (= 0.81.2)
     - ReactNativeDependencies
-  - ReactAppDependencyProvider (0.81.1):
+  - ReactAppDependencyProvider (0.81.2):
     - ReactCodegen
-  - ReactCodegen (0.81.1):
+  - ReactCodegen (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2538,43 +2538,43 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactCommon (0.81.1):
+  - ReactCommon (0.81.2):
     - React-Core-prebuilt
-    - ReactCommon/turbomodule (= 0.81.1)
+    - ReactCommon/turbomodule (= 0.81.2)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule (0.81.1):
+  - ReactCommon/turbomodule (0.81.2):
     - hermes-engine
-    - React-callinvoker (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
-    - ReactCommon/turbomodule/bridging (= 0.81.1)
-    - ReactCommon/turbomodule/core (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
+    - ReactCommon/turbomodule/bridging (= 0.81.2)
+    - ReactCommon/turbomodule/core (= 0.81.2)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/bridging (0.81.1):
+  - ReactCommon/turbomodule/bridging (0.81.2):
     - hermes-engine
-    - React-callinvoker (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/core (0.81.1):
+  - ReactCommon/turbomodule/core (0.81.2):
     - hermes-engine
-    - React-callinvoker (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.1)
-    - React-debug (= 0.81.1)
-    - React-featureflags (= 0.81.1)
-    - React-jsi (= 0.81.1)
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
-    - React-utils (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
+    - React-debug (= 0.81.2)
+    - React-featureflags (= 0.81.2)
+    - React-jsi (= 0.81.2)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
+    - React-utils (= 0.81.2)
     - ReactNativeDependencies
-  - ReactNativeDependencies (0.81.1)
+  - ReactNativeDependencies (0.81.2)
   - RNCAsyncStorage (2.2.0):
     - hermes-engine
     - RCTRequired
@@ -3549,183 +3549,183 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  BenchmarkingModule: 272c02f4a7e9e0d9e9f25d018661094608e2d91f
-  EASClient: 4e721c008528e7e2637be5913500744ea0d1d75c
-  EXApplication: f5219af375d2bcff2596ac5c586d3b62c587c0d8
-  EXAV: b4c4c6ee295cf276f046b321c92b10eddc4f0c11
-  EXConstants: 91a5ab4e4314979d750af66da2d030bb54bb0135
-  EXImageLoader: 189e3476581efe3ad4d1d3fb4735b7179eb26f05
+  BenchmarkingModule: 69aa39c6f6d42bf6fc47caeacb070d24de22d54f
+  EASClient: cfb28a340d86eeb03c2c67a2c34cd664c97dbc51
+  EXApplication: 724353e341d7ece0bade87d437926fa8b3132c5d
+  EXAV: c384f66c1f1a33a7bcb060a1cb39ea8807a8c268
+  EXConstants: 4d89ce3567191d8c940b0aab5ba7ddd310c59ad2
+  EXImageLoader: e501c001bc40b8326605e82e6e80363c80fe06b5
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: 8c3a1dc3d2cd353107616180b090b6cb8424e0ca
-  EXNotifications: bfcda0c49edd979747e1e50340de7bb0e9729ef5
-  Expo: 4baf76a592eb9aeef2d23da756126219c410cde6
-  expo-dev-client: bd3c15e38191cccb11aa550ff173503012a6fbc2
-  expo-dev-launcher: 9bcafddbb217a4964e54571b0eacb0559bb6a375
-  expo-dev-menu: 32b27401b34be4752f4cb5c62d898a5bc5d134a2
+  EXManifests: 9b19413c322564f3c2dce83006f1d71a4df79ba9
+  EXNotifications: 41233e5c2c4a795139d08a9ff8bb3de2536b86f5
+  Expo: 05129f4ae3d73e0d362c88e767d73943663dd1c0
+  expo-dev-client: 0835e70a399f4533b7898eba89bbc7406c7e5027
+  expo-dev-launcher: 30f8a8f913bd2bd51820af9cfe821d75d7e01609
+  expo-dev-menu: 7e3a1079f69e4cd1de6ce9c05ad484f68b4666d4
   expo-dev-menu-interface: 600df12ea01efecdd822daaf13cc0ac091775533
-  ExpoAppIntegrity: 4d55bc0ad85687e78b1aab67f9ca36bec9f41015
-  ExpoAppleAuthentication: 9eb1ec7213ee9c9797951df89975136db89bf8ac
-  ExpoAsset: 715e62292ae4c259581bc9106d68d79030c49cae
-  ExpoAudio: e816a3060882f1adb7f61c7598b64abba1eeff6b
-  ExpoBackgroundFetch: 17a6e1a6b49f04b2a69dcafae40001c9d7610b54
-  ExpoBackgroundTask: f4dac8f09f3b187e464af7a1088d9fd5ae48a836
-  ExpoBattery: e27805699e588eabb1a5385b6cfbb2e2bdb224b1
-  ExpoBlob: 02dd34acb5e1161585222a88f56d420f5660c82b
-  ExpoBlur: 9bde58a4de1d24a02575d0e24290f2026ce8dc3a
-  ExpoBrightness: 44da0051eb2cddfba9df7344ba5ecbbe3bf06dd2
-  ExpoCalendar: cc6fe1c3f390cc75b57c098cea9615e555f3676b
-  ExpoCamera: 576c54713c0707543b8e01b22661209b24334b32
-  ExpoCellular: f6d4c311bd41d483c99d1d2111f844e5220eb897
-  ExpoClipboard: c87f8148d16283e65a164a619232350312333c96
-  ExpoContacts: 6862b0b8d7a03991242dae35aea5dd22cd1779ac
-  ExpoCrypto: 834a7a7dd02fe646690f9316e8ce0abdb9f4a821
-  ExpoDevice: eb3409124f873fb3d010319288e1e1e6b375fa9b
-  ExpoDocumentPicker: 073709cd17c2966db55e616326984ea9db4c62ad
-  ExpoDomWebView: 5f7132d75491445cb649a1a889e41b98500ee0d9
-  ExpoFileSystem: df33ab3f36961a043fd9b502d91b102de1856839
-  ExpoFont: 74a14c605637c2d32337a2f542065408a8ca3454
-  ExpoGL: 0f7da153b7eaa919552bde3f31470fb64967f827
-  ExpoGlassEffect: 9aa58a46e8abe720971f2b588bc1e10d58728ba8
-  ExpoHaptics: e0912a9cf05ba958eefdc595f1990b8f89aa1f3f
-  ExpoImage: 18d9836939f8e271364a5a2a3566f099ea73b2e4
-  ExpoImageManipulator: a9daa4d53280c87a76863e132403f29ca575e4b1
-  ExpoImagePicker: 66195293e95879fa5ee3eb1319f10b5de0ffccbb
-  ExpoInsights: adbfe8040b4ad65e1bd98084faca4b8be8fff457
-  ExpoKeepAwake: eba81dfb5728be8c46e382b9314dfa14f40d8764
-  ExpoLinearGradient: 74d67832cdb0d2ef91f718d50dd82b273ce2812e
-  ExpoLinking: dadcc1205351c1108b7c5bab4b7891e744fc8c89
-  ExpoLivePhoto: be22ba05ccfa0997402d89890ee3335857268f7b
-  ExpoLocalAuthentication: badfe0eb0256bcf2cc294b9a32c5038944a22e41
-  ExpoLocalization: 540bc28ae55353eff0dfd1f092d389741c6f575e
-  ExpoLocation: 8ca995b4cda5e35f60c04cf8fbfde81e599520bf
-  ExpoMailComposer: 0e6cd4877c8b8d692da5c85a9393ceafb27a6d91
-  ExpoMaps: 95df66f94ffadd965fc272d6fe97ac48ddb0afb3
-  ExpoMediaLibrary: 7c555ad5d9234c0e9548e538bd892b695cd1355b
-  ExpoMeshGradient: 3927080271353e924f92780eb28d0e6f609cd99c
-  ExpoModulesCore: a8e30f3757db7bc381d77b02d1f743439ed954a9
-  ExpoModulesTestCore: be5073c51ffe7c2db9f14aedfce7d8cdc141f55a
-  ExpoNetwork: d2f8b8f9b64af48dc9695bafa8b0a34611f7127b
-  ExpoPrint: cbe3188bd6ff0c8b2ee92e7253771290a0a9c78e
-  ExpoScreenCapture: fe1d46f1263ad5b409eaf7e7b072b45053e9122e
-  ExpoScreenOrientation: 0d73404e96ee41908125e9a5207cc08abd00f784
-  ExpoSecureStore: 57327b9a484ad730cf823c82d092e0bf71e11512
-  ExpoSensors: a04e0d47652b6c15c958e6d340f9af7d586bb3d9
-  ExpoSharing: 48a58c41063f07667cf19b7100a2f2559eada6a9
-  ExpoSMS: 5c1be8781920b5324ef84ca43feee99d7ab3805b
-  ExpoSpeech: 5bbb4eeb486ffb16b3d25cdf3b8d5d5f3e134ba0
-  ExpoSplashScreen: 1665809071bd907c6fdbfd9c09583ee4d51b41d4
-  ExpoSQLite: 460503f8835ff8799694a2ba26605086f5446424
-  ExpoStoreReview: d26daaa2e20e8bb095dc731febbebc9ce08f5991
-  ExpoSymbols: 3efee6865b1955fe3805ca88b36e8674ce6970dd
-  ExpoSystemUI: a3b1bb2e4d28ae65a09b64517ad93096ca88ac5e
-  ExpoTrackingTransparency: 30eae1898910829ce661c85fd44b2b89f84fd0e4
-  ExpoUI: 11f38320798c3ca7d74a28fe8d47be9d66cf1af0
-  ExpoVideo: ee4bfbec2b91f982ba20ad5d8cc6311a0a7b3d7f
-  ExpoVideoThumbnails: dece56760a10d4d47c1cde7850e2aac396921a74
-  ExpoWebBrowser: 84d4438464d9754a4c1f1eaa97cd747f3752187e
+  ExpoAppIntegrity: 9c5a0de38c9c536008705c98e2e45a8ed0444472
+  ExpoAppleAuthentication: a42dfc311de6767c0529fb6d7f301915f651c7eb
+  ExpoAsset: 6ba39c035bda80b5561acdc7d6e869c0adc571a0
+  ExpoAudio: 9f25a54a380f761c5bf233197582f7b870a08e8d
+  ExpoBackgroundFetch: e51c22117fb1f43fdd58c8f4def0e9a8fffb539a
+  ExpoBackgroundTask: 0db04d59d07e8d8821dd3c207ed5d297b783054d
+  ExpoBattery: 79d7792eaeaeb5dbb83c5fd50b6bf3ecdaac2b76
+  ExpoBlob: 11770f2ec82510d4c483690543afa11f4a451885
+  ExpoBlur: 33c9fc0c18ba192d181e5a650d4cae8c179857df
+  ExpoBrightness: 4c4e7d51dd883fde58696ca37c6498bf38fbeedb
+  ExpoCalendar: 863b0ee27b1b0435bb3d6cd388dbd48582ecd77c
+  ExpoCamera: 248b0ee69661779bbd5d07e55c8a5065045020dd
+  ExpoCellular: 1cfeb3256424e00ff94129a2d318d94a3caa0e13
+  ExpoClipboard: 9e1809dd6ffdc08ce990f9bf22dcab3791b694aa
+  ExpoContacts: f1f9cf1a997baed0c1861bd6c4121b77077ffbc3
+  ExpoCrypto: 7464dd47a9c90c027555fc472d4ba2d91ff08537
+  ExpoDevice: 6ba9b52c39f7c659a65a7b44da36d3937ec2c05c
+  ExpoDocumentPicker: 23c8e6b16c8594ea6c39cb7a55605ce67c2c24d2
+  ExpoDomWebView: 2dcc93211b8e3614e4ffe3dc91d4c181763686f2
+  ExpoFileSystem: 229cf540729847f8f4556677d36d45cedb9af9ab
+  ExpoFont: 3cb68f520e9349141a28fed6dd94e6cc6bf1453f
+  ExpoGL: ae5e6fee5b104b9f6486f7f4458c25128edc4278
+  ExpoGlassEffect: 865bcf7faa4a5c024654260722d5cd74a9342d2b
+  ExpoHaptics: a8f7720a74b885f8a23e0836e2b91d69883968fe
+  ExpoImage: 2708a5a9e69b6432f43d368379cc7c9b5165048b
+  ExpoImageManipulator: 29c6c60f87b158a3905ff07c4e14fcb55e444df0
+  ExpoImagePicker: 1cd4a47c463806acc23f9e1990a296cce2c496d4
+  ExpoInsights: 3a1576aa41ab01691b18111033a109c82186a553
+  ExpoKeepAwake: e5bb3832a4735ee580ac6aa28130d44e1203f11f
+  ExpoLinearGradient: aa4ae248706a0da6bd59a5aae6e2bf24de04dfa8
+  ExpoLinking: 01b4b07a8647880a32f1acf608fa3b7cb7557e0c
+  ExpoLivePhoto: 8e3519912b987f02b1ed7a58e69f6f3052ab349f
+  ExpoLocalAuthentication: 44dedf22fe8a86c445677db4e4e1a6dc2b5d35e4
+  ExpoLocalization: d52f78c3f7826fe09ac0de785d8b52c7187fe7a9
+  ExpoLocation: 21f48c52d176f4a4c136b653a9345ebc5873a498
+  ExpoMailComposer: 071ff674188880be8c8b970d8db2178ea240978f
+  ExpoMaps: b75c700bbf7eae4f42a26a6752a6b85e7aae1c29
+  ExpoMediaLibrary: 3204a2cb76b8f9822d8631d801b60f9feb6792e4
+  ExpoMeshGradient: 7d7918322943482f2e36e357caf2652f29d9c174
+  ExpoModulesCore: e024de04e62251f18e893c9040389da95a0c1862
+  ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
+  ExpoNetwork: 18f90d4d7d487cb7ef1e4400b7a585618f4235fc
+  ExpoPrint: afbfbbf5e6d78bc002223e9ee20a46c2be8bda29
+  ExpoScreenCapture: d4ac3a77b3d108d52d56e5b1086793f53dd347d5
+  ExpoScreenOrientation: 4e9ca1daf0e84f3b91757b4cd0303e0aa8dc80e3
+  ExpoSecureStore: fb9f6ec0614d4d9c2ae4c2a91999f231aa6606c1
+  ExpoSensors: e4e13463d1ba75f4c69c9fdf9ee5ff5304aa2d6d
+  ExpoSharing: bd81fdc1c01113496af43b941b6544eb1b5d7ae4
+  ExpoSMS: fcca75e971f990e3e112b4478b86b426a2797cc1
+  ExpoSpeech: 4662fa3f5c240b876733b12490ca034ee4c084a3
+  ExpoSplashScreen: 4d1ecd2b6955b99a958e7e39ca3fb89b9b9137dc
+  ExpoSQLite: 8199fa6d2ac75131781b5a9fba23f7617862feb9
+  ExpoStoreReview: 10e4e452452ed3ed28d94a3bcacdc063bc4ff763
+  ExpoSymbols: 944e3a6a39527f91c4bad8b7c0fcd3e0086a2248
+  ExpoSystemUI: 031356e6df193703437151080704ca81234170c4
+  ExpoTrackingTransparency: aaf012895c814bd9000cf8f89477063eac7cc556
+  ExpoUI: 302d21bbd20a0d758c8a3124334829cadf25558d
+  ExpoVideo: 9d2f8164d81d2c839b5cf894b19b56294ebc0a27
+  ExpoVideoThumbnails: 5eeb2fc42ed681082d318c00986ef0edc1d08b48
+  ExpoWebBrowser: 111faed02d1dd79eb556450694724adf390d6091
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
-  EXTaskManager: eedcd03c1a574c47d3f48d83d4e4659b3c1fa29b
-  EXUpdates: dea432165f9769babf63e152969c42f0f881ec44
-  EXUpdatesInterface: 5adf50cb41e079c861da6d9b4b954c3db9a50734
-  FBLazyVector: 8da1272845e10a35c1e661a4c8ba644526c014fb
-  hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
+  EXTaskManager: 19451783dfb545748126ad2d5ecdf535daf8d6da
+  EXUpdates: acd31e646f9ca7e4efb3747b590210f297ec6938
+  EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
+  FBLazyVector: 77485268e564ddf67fa5045947653a87b4531a47
+  hermes-engine: ceacb56b83367e3c4f7ed5ab0e93f92a89e4575b
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: 3aaf4e04de466d1ac3a0456381d88be02ef9f66d
+  lottie-react-native: 29a3610e350f54856048ff5e408032596c45fb26
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCTDeprecation: 24056820c873bf5115c0441651440bfde2b82d51
-  RCTRequired: d0b6e766be3c17896d92059c917d682433ff8a34
-  RCTTypeSafety: 1954dcf545fe67e969e11e1b4fe6cf864e1ac632
+  RCTDeprecation: 4d678ef4dca05565072e9ceace59e4fb8a33da81
+  RCTRequired: 35279f87ab747ff65303485f0ea3b92c508fddff
+  RCTTypeSafety: c8de06496c6ce0f746b56dbc5bfc299dcfa5b008
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: f1486d005993b0af01943af1850d3d4f3b597545
-  React-callinvoker: 944c9e97ef08e3995b05cc29b40c071a7bd0eaec
-  React-Core: 33c2f29eb1054f2fe4b6c7bb1e595495170f6c15
-  React-Core-prebuilt: 70adad8a28cf9ec5c1f349ced6375354644500ac
-  React-CoreModules: 6d0945fdc20d150789baaeefe2794b0dbc8f6379
-  React-cxxreact: 1d8096423b2b3e7b05c24f40277d117896e8873f
-  React-debug: 0268bacb2cc38d98790ce15159e962a6b0b1895e
-  React-defaultsnativemodule: 5f2f1cdd3765b7fd7aed963e9b61cc6292343c46
-  React-domnativemodule: 4407d05b3bf87d604be08307e71ca308c7201043
-  React-Fabric: f68b67dd472fc90352fe80e2a6837a8642e7ef23
-  React-FabricComponents: e138111ec8093b42a3d74dc75865091d99bace64
-  React-FabricImage: cedf4cee2a69eb3518753291aa056f65189f09ef
-  React-featureflags: 7a70fce3a3c7c7745560d5c0ade1d46d7460c9c7
-  React-featureflagsnativemodule: 267f61c8648729837851cefe9a5017eb40855473
-  React-graphics: 70d3b71cde945c870d5528a4763abc34456a35d8
-  React-hermes: 66d0e0adcd5d7d8852efcee7129b1d248d9e76fc
-  React-idlecallbacksnativemodule: 987fcd4d77fed9d7f3ed5595d08bc283ac302d28
-  React-ImageManager: ceccf49e14a8c306e144ed192fe16f7704fbe6dd
-  React-jserrorhandler: e58b58bd3135795310b52d18d37d86b339d3753e
-  React-jsi: 1a403eb9781c8ab89d27bbe9a0573d9bb039b6a5
-  React-jsiexecutor: 81ea81bfd3f2ef78858e11d13179b740e2ea46d8
-  React-jsinspector: 5677b6102cc59b5c89ff471c1f461c8af99ed648
-  React-jsinspectorcdp: b4f743cb748c30677faf600f093c6bbd2aa5352b
-  React-jsinspectornetwork: 4c3fe84b72157f483a292e2605af88ace0c20177
-  React-jsinspectortracing: 4313f327e2bf0c6e4e0cfda1949734732e9f5530
-  React-jsitooling: 8a6546ee9c511c5497e013c05abbbc4f2dd1e87c
-  React-jsitracing: 8d11a4f0d444dbc9cf24862728d16afbb0cf67bb
-  React-logger: a1c9c8dfc56711d06a21109b55908e177113e554
-  React-Mapbuffer: bc36232966c55d5b1cbef3b84cb97c4317fa4403
-  React-microtasksnativemodule: cbabfedcf6c2984e59d07f9ab553f3d277599b1b
-  react-native-keyboard-controller: 1ad78688f744e0ebdf3b04007b91089a254b80f9
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-pager-view: c8817c1d9f4643417e68f0b846c51214b2252eea
-  react-native-safe-area-context: eb2fb5c796f18a08959ee5400bb1c65e4c1b4833
-  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
-  react-native-skia: 05327e7acee05e7c27b68a5da0bc80d65f5d790c
-  react-native-slider: 8c562583722c396a3682f451f0b6e68e351ec3b9
-  react-native-view-shot: fb3c0774edb448f42705491802a455beac1502a2
-  react-native-webview: b29007f4723bca10872028067b07abacfa1cb35a
-  React-NativeModulesApple: 055e2d1417c663e7a26fc0847609f503e626e9e1
-  React-oscompat: 8f2893713639e12c7558750a9f7de3f08ac255b0
-  React-perflogger: 34b632f94b15e1068f7997e5a68b40a55162ad13
-  React-performancetimeline: 6e067040e1af47a26e306c726e228e53718518ac
-  React-RCTActionSheet: 0280ff8cf63ef67a5a74898b18316b204d686c83
-  React-RCTAnimation: a33e999cdfc9ebc8eb17f8f9f262ac765635d3b8
-  React-RCTAppDelegate: 8ca4feb7290edf02f70ee824b0ef735c24d78b0e
-  React-RCTBlob: ab87e8283899ec563c429f55a7a584c8bae78f17
-  React-RCTFabric: 465111d965717cbe4e1fe4a5caffc66723423d68
-  React-RCTFBReactNativeSpec: 7637e1b9e3838c7a43e870a1c519346ec1787e90
-  React-RCTImage: 7e07ef9065bf18dd8566421b550c041455f24bdb
-  React-RCTLinking: 0877fa82d7a04bbdd6167e7d93ebbab2147d4398
-  React-RCTNetwork: f26cc6a43530af00bc6c3c73cfdb0df58e319126
-  React-RCTRuntime: c22ce17d068c7447c7406c00050785776cb376a4
-  React-RCTSettings: 58a19d845f0e05555246c8325b527bd90cdc88e7
-  React-RCTText: 972fe79182d4082d36e988c094c5876f9ddfaab0
-  React-RCTVibration: 56c26c46c7c574a46fb424e9ba9445e686ddf53f
-  React-rendererconsistency: 4917405e8864ded5d3b350f04ee7f1712435d8e7
-  React-renderercss: dd4f24445dcb209267e1034df31cc156e336342d
-  React-rendererdebug: c335166d55d20a7c1a7a7ac0ca491d996f4adf5b
-  React-RuntimeApple: 9e7edf7c631cf2446fbb728e68bfbbc859d8aabd
-  React-RuntimeCore: a6a70ca5ab98f08191f6c7dfd3424b4fc86ed24d
-  React-runtimeexecutor: 2d4128882cf41c7824e9d8a72c6b9461897889af
-  React-RuntimeHermes: 4e74b3ea837c4bae9903b6a9210f97329007b7f2
-  React-runtimescheduler: 5ec6bcc02a05de1e87b9830dbfccff4dc1bddcae
-  React-timing: b49069174c0330be78b67c8a24d7127dfca99bba
-  React-utils: de22e0dfdd4494e401dfd0194f552c7175480939
-  ReactAppDependencyProvider: 3eb9096cb139eb433965693bbe541d96eb3d3ec9
-  ReactCodegen: ca588e96c4a81c9bfe4caedbb47f76f709851815
-  ReactCommon: 3579ef7cd884fbb5218bed929f25b7b212299700
-  ReactNativeDependencies: 9444683ddc7eaa98d2289224ce730a7632b705ff
-  RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
-  RNCMaskedView: d2578d41c59b936db122b2798ba37e4722d21035
-  RNCPicker: a7170edbcbf8288de8edb2502e08e7fc757fa755
-  RNDateTimePicker: be0e44bcb9ed0607c7c5f47dbedd88cf091f6791
-  RNGestureHandler: 2914750df066d89bf9d8f48a10ad5f0051108ac3
-  RNReanimated: 3ab91aa335aa43423ecbf6606b08893718ebcc79
-  RNScreens: d8d6f1792f6e7ac12b0190d33d8d390efc0c1845
-  RNSVG: 31d6639663c249b7d5abc9728dde2041eb2a3c34
-  RNWorklets: d2404efd906e19d5656e552982885588738cc599
+  React: 7cee6da22b893d581d51397032d4a3951c03cb17
+  React-callinvoker: 5ea70569ceece01e1996c85f9cb1c689bec71c9b
+  React-Core: 6d23dc59f228c62ee15e993311c2942d304624c2
+  React-Core-prebuilt: 1ce36105edd4c579e7117f97ba65ad1ba583e517
+  React-CoreModules: 1f20825829502f28e2bdda25cc0ea2adcb8164e0
+  React-cxxreact: a1bf41dddce13a969c427b3ec81f66254d312775
+  React-debug: d860c135c213f12e841342ff2a6c14d5afb9e419
+  React-defaultsnativemodule: 470b797179649c6b2950e2f71503fc8a7f753878
+  React-domnativemodule: 360dff03a2974551afcd7a0e0f3da7febbcd4950
+  React-Fabric: d474e965ca02954854b77279c33a41e38feb1cfb
+  React-FabricComponents: e6d1b0189c68f1d4e18d20a18d2b2c23ba7faa65
+  React-FabricImage: 5b2da3539c4b4d55f9e9c20acf49ab642eddc457
+  React-featureflags: 63125b1d5ee27579ffee872d4a8980f044733935
+  React-featureflagsnativemodule: ff9aeb43ede668b8e04c36c7f10ea2b3d7a03a7f
+  React-graphics: c2d8b4eec2c4fd73b2cc141c992e7149b4220844
+  React-hermes: 198b38686a436f2fba3f605ac3fb55fea9dba4b3
+  React-idlecallbacksnativemodule: 4a640d71f7e4c75a36b0e138a196c4f7bb11b377
+  React-ImageManager: 1bb91c56c3bedd9abe7b029c4b5dd7f80a66b0f2
+  React-jserrorhandler: 4ac198ede40dd986f3efd7986cafad19f099e32c
+  React-jsi: 7d41c57eaac52e6279145e942ebdc5246c5f4ab0
+  React-jsiexecutor: 4435b1ad246cacd0be474f314764280fd41307bf
+  React-jsinspector: 51599b1c435be9b3936e1114499c6110852f4d75
+  React-jsinspectorcdp: 1bbbe3c04751c10333ee1fe939d97055bb10725a
+  React-jsinspectornetwork: c3dbe28b67ead6b3abdc569e3dafcfd8fca7ac5f
+  React-jsinspectortracing: 70368406508ecfa2ce6b929858f1a8ed8493282d
+  React-jsitooling: 5fa9819f41fff7ea081406b4462dc9d4b38e7bbd
+  React-jsitracing: 87af8fac96118ed50def3ca0e52635598ef8ae8d
+  React-logger: 51cdc4a1f7f534b535b461644ebba9fdbc0baf4c
+  React-Mapbuffer: 67755dc0cb0647ad6294a3bc02181d9daf08b17f
+  React-microtasksnativemodule: cd10fe63b700365a362d750f0a8c94cff59eeebb
+  react-native-keyboard-controller: 5587bad7f102125e2020720c4e37e0b58ff5e52e
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-pager-view: e37989fc447aa4b5de6d0d2ffb0229e817329246
+  react-native-safe-area-context: d46695b29119ba0871705c55c8ac2868888dcca4
+  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
+  react-native-skia: 009c318120ef7c6000bf14a6342ad8a89b44070b
+  react-native-slider: b76fa3dd989d25e8c2751c2a546674dfc0c2b6f8
+  react-native-view-shot: 26174e54ec6b4b7c5d70b86964b747919759adc1
+  react-native-webview: a4f0775a31b73cf13cfc3d2d2b119aa94ec76e49
+  React-NativeModulesApple: bd258b9485e456d84f9584523ad3c3c8ba0b51e9
+  React-oscompat: ade00f2748c52568bec65682448d74fe6df6f2d3
+  React-perflogger: 7899e64980a940a71005d4752fc03dd4e61d4247
+  React-performancetimeline: 31b6d62cb743fc136117fd5f221c75bb3a282276
+  React-RCTActionSheet: ffab08a04e6fe47dbb6623ae950427ce61b1df47
+  React-RCTAnimation: 5db15314c4528647a6419c3ab3482044549bc722
+  React-RCTAppDelegate: d07b00d43ce1f6e947da3a2ff660147d4e82f909
+  React-RCTBlob: 8251a93151631fc7a6446e756771288e01bb4fea
+  React-RCTFabric: 62aad1b3308a341658ecfc74e83f1b95f0dbb024
+  React-RCTFBReactNativeSpec: 6c671dbc26713886f91c071e7e27f7fdcdcc5420
+  React-RCTImage: 2ac66fd27553f56f551aaa565204f8e822c1abb0
+  React-RCTLinking: 5720f30f765a2bbbd79f4b0b97c04a60924ad0e6
+  React-RCTNetwork: 3082a19df28509afcc2e48709769a784050c0d23
+  React-RCTRuntime: 7ee4a2b7d9a270a1b9e0675fa49811f64c6863ad
+  React-RCTSettings: cd54e1057599bf6df23f1aeec073de182c90e9e5
+  React-RCTText: ea2ae68038930a06276807c742afa37cfd811e29
+  React-RCTVibration: c7acf3d6c345182887f1d4765623bfd2d4a723c0
+  React-rendererconsistency: bc382ce33dfa11ea371c1174db34c56c897aa3e3
+  React-renderercss: e047767f4219d999efd4588321b1fc14f6f6e18a
+  React-rendererdebug: 22dda44f8931d67a93efcb47f9e89bf3e46f1271
+  React-RuntimeApple: c9ccccc3c3e1c819d66b7b99ee79af7eb3985e50
+  React-RuntimeCore: cda0561ca45e6c282d16527f5e3339a956599fe0
+  React-runtimeexecutor: 94f916248385c0006c83f51d2a33fa40f8dfb5de
+  React-RuntimeHermes: 26f08e51bbac484fa5e0f88f40c4a27ed14d1f77
+  React-runtimescheduler: bd29b8e1664b5b1859fe602a9148d7a619fd7ac3
+  React-timing: 990f6836757f7fe69e5b97b18435b815aac7f046
+  React-utils: 409fa5cb4574fa1c0f8002a463518b63c69fea83
+  ReactAppDependencyProvider: 319be07ed29c6a24b30b700ebf6f667c9d49a511
+  ReactCodegen: e0994138c24ea4b895ad41836a4a190f42567df1
+  ReactCommon: 5cabaa414dfa310990a62264693d4f8e61b88fdf
+  ReactNativeDependencies: 316e0ff865f50a287726f6b002c607f90ad878fb
+  RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
+  RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
+  RNCPicker: f97c908b7774248c1093ec3831ca70d338627bf7
+  RNDateTimePicker: 6fdd63f5d1e0f21faf4cc8674957c52958a7efae
+  RNGestureHandler: 6a488ce85c88e82d8610db1108daf04e9b2d5162
+  RNReanimated: ec8886a7ff1bc514c5757c0a18d9c4a65ea00364
+  RNScreens: dd61bc3a3e6f6901ad833efa411917d44827cf51
+  RNSVG: 2825ee146e0f6a16221e852299943e4cceef4528
+  RNWorklets: 19c7213a8e3e11796493e77814ad7e15ce1f0e47
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   UMAppLoader: 2af2cc05fcaa9851233893c0e3dbc56a99f57e36
-  Yoga: 18b87f28df0aee34fa7370518a35aa8107ba47b9
+  Yoga: 82e60295fd61743ed3c218e3873faf184646f99a
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 07ca240dc3c89dc461c221729e3f0a73e14e9ad8

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -66,7 +66,7 @@
     "native-component-list": "*",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.1",
+    "react-native": "0.81.2",
     "react-native-edge-to-edge": "~1.6.1",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.5",

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -66,7 +66,7 @@
     "native-component-list": "*",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.2",
+    "react-native": "0.81.3",
     "react-native-edge-to-edge": "~1.6.1",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.5",

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -22,7 +22,7 @@
       },
       "ios": {
         "cache": {
-          "key": "sdk54-0.81.1",
+          "key": "sdk54-0.81.2",
           "customPaths": ["../expo-go/ios/Pods"]
         },
         "image": "latest",

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -22,7 +22,7 @@
       },
       "ios": {
         "cache": {
-          "key": "sdk54-0.81.2",
+          "key": "sdk54-0.81.3",
           "customPaths": ["../expo-go/ios/Pods"]
         },
         "image": "latest",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -363,7 +363,7 @@ PODS:
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.81.1)
+  - FBLazyVector (0.81.2)
   - FirebaseAnalytics (11.11.0):
     - FirebaseAnalytics/AdIdSupport (= 11.11.0)
     - FirebaseCore (~> 11.11.0)
@@ -486,17 +486,17 @@ PODS:
   - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - hermes-engine (0.81.1):
-    - hermes-engine/cdp (= 0.81.1)
-    - hermes-engine/Hermes (= 0.81.1)
-    - hermes-engine/inspector (= 0.81.1)
-    - hermes-engine/inspector_chrome (= 0.81.1)
-    - hermes-engine/Public (= 0.81.1)
-  - hermes-engine/cdp (0.81.1)
-  - hermes-engine/Hermes (0.81.1)
-  - hermes-engine/inspector (0.81.1)
-  - hermes-engine/inspector_chrome (0.81.1)
-  - hermes-engine/Public (0.81.1)
+  - hermes-engine (0.81.2):
+    - hermes-engine/cdp (= 0.81.2)
+    - hermes-engine/Hermes (= 0.81.2)
+    - hermes-engine/inspector (= 0.81.2)
+    - hermes-engine/inspector_chrome (= 0.81.2)
+    - hermes-engine/Public (= 0.81.2)
+  - hermes-engine/cdp (0.81.2)
+  - hermes-engine/Hermes (0.81.2)
+  - hermes-engine/inspector (0.81.2)
+  - hermes-engine/inspector_chrome (0.81.2)
+  - hermes-engine/Public (0.81.2)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -574,28 +574,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.81.1)
-  - RCTRequired (0.81.1)
-  - RCTTypeSafety (0.81.1):
-    - FBLazyVector (= 0.81.1)
-    - RCTRequired (= 0.81.1)
-    - React-Core (= 0.81.1)
+  - RCTDeprecation (0.81.2)
+  - RCTRequired (0.81.2)
+  - RCTTypeSafety (0.81.2):
+    - FBLazyVector (= 0.81.2)
+    - RCTRequired (= 0.81.2)
+    - React-Core (= 0.81.2)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.1):
-    - React-Core (= 0.81.1)
-    - React-Core/DevSupport (= 0.81.1)
-    - React-Core/RCTWebSocket (= 0.81.1)
-    - React-RCTActionSheet (= 0.81.1)
-    - React-RCTAnimation (= 0.81.1)
-    - React-RCTBlob (= 0.81.1)
-    - React-RCTImage (= 0.81.1)
-    - React-RCTLinking (= 0.81.1)
-    - React-RCTNetwork (= 0.81.1)
-    - React-RCTSettings (= 0.81.1)
-    - React-RCTText (= 0.81.1)
-    - React-RCTVibration (= 0.81.1)
-  - React-callinvoker (0.81.1)
-  - React-Core (0.81.1):
+  - React (0.81.2):
+    - React-Core (= 0.81.2)
+    - React-Core/DevSupport (= 0.81.2)
+    - React-Core/RCTWebSocket (= 0.81.2)
+    - React-RCTActionSheet (= 0.81.2)
+    - React-RCTAnimation (= 0.81.2)
+    - React-RCTBlob (= 0.81.2)
+    - React-RCTImage (= 0.81.2)
+    - React-RCTLinking (= 0.81.2)
+    - React-RCTNetwork (= 0.81.2)
+    - React-RCTSettings (= 0.81.2)
+    - React-RCTText (= 0.81.2)
+    - React-RCTVibration (= 0.81.2)
+  - React-callinvoker (0.81.2)
+  - React-Core (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -605,7 +605,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.1)
+    - React-Core/Default (= 0.81.2)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -620,82 +620,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.81.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.81.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.81.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.81.1)
-    - React-Core/RCTWebSocket (= 0.81.1)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.1):
+  - React-Core/CoreModulesHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -720,7 +645,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.1):
+  - React-Core/Default (0.81.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.81.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.2)
+    - React-Core/RCTWebSocket (= 0.81.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -745,7 +720,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.1):
+  - React-Core/RCTAnimationHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -770,7 +745,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.1):
+  - React-Core/RCTBlobHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -795,7 +770,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.1):
+  - React-Core/RCTImageHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -820,7 +795,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.1):
+  - React-Core/RCTLinkingHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -845,7 +820,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.1):
+  - React-Core/RCTNetworkHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -870,7 +845,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.1):
+  - React-Core/RCTSettingsHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -895,7 +870,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.1):
+  - React-Core/RCTTextHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -920,7 +895,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.81.1):
+  - React-Core/RCTVibrationHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -930,7 +905,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.1)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -945,7 +920,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.81.1):
+  - React-Core/RCTWebSocket (0.81.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -953,20 +953,20 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.81.1)
-    - React-Core/CoreModulesHeaders (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - RCTTypeSafety (= 0.81.2)
+    - React-Core/CoreModulesHeaders (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.1)
+    - React-RCTImage (= 0.81.2)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.81.1):
+  - React-cxxreact (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -975,19 +975,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.1)
-    - React-debug (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
+    - React-debug (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
-    - React-timing (= 0.81.1)
+    - React-timing (= 0.81.2)
     - SocketRocket
-  - React-debug (0.81.1)
-  - React-defaultsnativemodule (0.81.1):
+  - React-debug (0.81.2)
+  - React-defaultsnativemodule (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1004,7 +1004,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.81.1):
+  - React-domnativemodule (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1024,7 +1024,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.81.1):
+  - React-Fabric (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1038,23 +1038,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.1)
-    - React-Fabric/attributedstring (= 0.81.1)
-    - React-Fabric/bridging (= 0.81.1)
-    - React-Fabric/componentregistry (= 0.81.1)
-    - React-Fabric/componentregistrynative (= 0.81.1)
-    - React-Fabric/components (= 0.81.1)
-    - React-Fabric/consistency (= 0.81.1)
-    - React-Fabric/core (= 0.81.1)
-    - React-Fabric/dom (= 0.81.1)
-    - React-Fabric/imagemanager (= 0.81.1)
-    - React-Fabric/leakchecker (= 0.81.1)
-    - React-Fabric/mounting (= 0.81.1)
-    - React-Fabric/observers (= 0.81.1)
-    - React-Fabric/scheduler (= 0.81.1)
-    - React-Fabric/telemetry (= 0.81.1)
-    - React-Fabric/templateprocessor (= 0.81.1)
-    - React-Fabric/uimanager (= 0.81.1)
+    - React-Fabric/animations (= 0.81.2)
+    - React-Fabric/attributedstring (= 0.81.2)
+    - React-Fabric/bridging (= 0.81.2)
+    - React-Fabric/componentregistry (= 0.81.2)
+    - React-Fabric/componentregistrynative (= 0.81.2)
+    - React-Fabric/components (= 0.81.2)
+    - React-Fabric/consistency (= 0.81.2)
+    - React-Fabric/core (= 0.81.2)
+    - React-Fabric/dom (= 0.81.2)
+    - React-Fabric/imagemanager (= 0.81.2)
+    - React-Fabric/leakchecker (= 0.81.2)
+    - React-Fabric/mounting (= 0.81.2)
+    - React-Fabric/observers (= 0.81.2)
+    - React-Fabric/scheduler (= 0.81.2)
+    - React-Fabric/telemetry (= 0.81.2)
+    - React-Fabric/templateprocessor (= 0.81.2)
+    - React-Fabric/uimanager (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1066,32 +1066,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.81.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.81.1):
+  - React-Fabric/animations (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1116,7 +1091,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.81.1):
+  - React-Fabric/attributedstring (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1141,7 +1116,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.81.1):
+  - React-Fabric/bridging (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1166,7 +1141,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.81.1):
+  - React-Fabric/componentregistry (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1191,36 +1166,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.81.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.1)
-    - React-Fabric/components/root (= 0.81.1)
-    - React-Fabric/components/scrollview (= 0.81.1)
-    - React-Fabric/components/view (= 0.81.1)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.1):
+  - React-Fabric/componentregistrynative (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1245,7 +1191,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.81.1):
+  - React-Fabric/components (0.81.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.2)
+    - React-Fabric/components/root (= 0.81.2)
+    - React-Fabric/components/scrollview (= 0.81.2)
+    - React-Fabric/components/view (= 0.81.2)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1270,7 +1245,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.81.1):
+  - React-Fabric/components/root (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1295,7 +1270,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.81.1):
+  - React-Fabric/components/scrollview (0.81.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1322,7 +1322,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.81.1):
+  - React-Fabric/consistency (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1347,7 +1347,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.81.1):
+  - React-Fabric/core (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1372,7 +1372,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.81.1):
+  - React-Fabric/dom (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1397,7 +1397,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.81.1):
+  - React-Fabric/imagemanager (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1422,7 +1422,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.81.1):
+  - React-Fabric/leakchecker (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1447,7 +1447,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.81.1):
+  - React-Fabric/mounting (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1472,7 +1472,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.81.1):
+  - React-Fabric/observers (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1486,7 +1486,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.1)
+    - React-Fabric/observers/events (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1498,7 +1498,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.81.1):
+  - React-Fabric/observers/events (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1523,7 +1523,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.81.1):
+  - React-Fabric/scheduler (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1550,7 +1550,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.81.1):
+  - React-Fabric/telemetry (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1575,7 +1575,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.81.1):
+  - React-Fabric/templateprocessor (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1600,7 +1600,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.81.1):
+  - React-Fabric/uimanager (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1614,7 +1614,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.1)
+    - React-Fabric/uimanager/consistency (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1627,7 +1627,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.81.1):
+  - React-Fabric/uimanager/consistency (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1653,7 +1653,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.81.1):
+  - React-FabricComponents (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1668,8 +1668,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.1)
-    - React-FabricComponents/textlayoutmanager (= 0.81.1)
+    - React-FabricComponents/components (= 0.81.2)
+    - React-FabricComponents/textlayoutmanager (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1682,7 +1682,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.81.1):
+  - React-FabricComponents/components (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1697,17 +1697,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.1)
-    - React-FabricComponents/components/iostextinput (= 0.81.1)
-    - React-FabricComponents/components/modal (= 0.81.1)
-    - React-FabricComponents/components/rncore (= 0.81.1)
-    - React-FabricComponents/components/safeareaview (= 0.81.1)
-    - React-FabricComponents/components/scrollview (= 0.81.1)
-    - React-FabricComponents/components/switch (= 0.81.1)
-    - React-FabricComponents/components/text (= 0.81.1)
-    - React-FabricComponents/components/textinput (= 0.81.1)
-    - React-FabricComponents/components/unimplementedview (= 0.81.1)
-    - React-FabricComponents/components/virtualview (= 0.81.1)
+    - React-FabricComponents/components/inputaccessory (= 0.81.2)
+    - React-FabricComponents/components/iostextinput (= 0.81.2)
+    - React-FabricComponents/components/modal (= 0.81.2)
+    - React-FabricComponents/components/rncore (= 0.81.2)
+    - React-FabricComponents/components/safeareaview (= 0.81.2)
+    - React-FabricComponents/components/scrollview (= 0.81.2)
+    - React-FabricComponents/components/switch (= 0.81.2)
+    - React-FabricComponents/components/text (= 0.81.2)
+    - React-FabricComponents/components/textinput (= 0.81.2)
+    - React-FabricComponents/components/unimplementedview (= 0.81.2)
+    - React-FabricComponents/components/virtualview (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1720,34 +1720,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.1):
+  - React-FabricComponents/components/inputaccessory (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1774,7 +1747,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.81.1):
+  - React-FabricComponents/components/iostextinput (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1801,7 +1774,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.1):
+  - React-FabricComponents/components/modal (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1828,7 +1801,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.1):
+  - React-FabricComponents/components/rncore (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1855,7 +1828,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.1):
+  - React-FabricComponents/components/safeareaview (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1882,7 +1855,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.81.1):
+  - React-FabricComponents/components/scrollview (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1909,7 +1882,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.81.1):
+  - React-FabricComponents/components/switch (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1936,7 +1909,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.1):
+  - React-FabricComponents/components/text (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1963,7 +1936,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.1):
+  - React-FabricComponents/components/textinput (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1990,7 +1963,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.1):
+  - React-FabricComponents/components/unimplementedview (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2017,7 +1990,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.1):
+  - React-FabricComponents/components/virtualview (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2044,7 +2017,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.81.1):
+  - React-FabricComponents/textlayoutmanager (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2053,21 +2026,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.81.1)
-    - RCTTypeSafety (= 0.81.1)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.81.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.81.2)
+    - RCTTypeSafety (= 0.81.2)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.1)
+    - React-jsiexecutor (= 0.81.2)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.81.1):
+  - React-featureflags (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2076,7 +2076,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.81.1):
+  - React-featureflagsnativemodule (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2091,7 +2091,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.81.1):
+  - React-graphics (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2104,7 +2104,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.81.1):
+  - React-hermes (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2113,16 +2113,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
     - React-jsi
-    - React-jsiexecutor (= 0.81.1)
+    - React-jsiexecutor (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.1)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.81.1):
+  - React-idlecallbacksnativemodule (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2138,7 +2138,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.81.1):
+  - React-ImageManager (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2153,7 +2153,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.81.1):
+  - React-jserrorhandler (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2168,7 +2168,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.81.1):
+  - React-jsi (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2178,7 +2178,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.81.1):
+  - React-jsiexecutor (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2187,15 +2187,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.1)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.81.1):
+  - React-jsinspector (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2210,10 +2210,10 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.81.1)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.81.1):
+  - React-jsinspectorcdp (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2222,7 +2222,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.81.1):
+  - React-jsinspectornetwork (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2235,7 +2235,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.81.1):
+  - React-jsinspectortracing (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2246,7 +2246,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.81.1):
+  - React-jsitooling (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2254,16 +2254,16 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.81.1):
+  - React-jsitracing (0.81.2):
     - React-jsi
-  - React-logger (0.81.1):
+  - React-logger (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2272,7 +2272,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.81.1):
+  - React-Mapbuffer (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2282,7 +2282,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.81.1):
+  - React-microtasksnativemodule (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2621,7 +2621,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.81.1):
+  - React-NativeModulesApple (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2641,8 +2641,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.81.1)
-  - React-perflogger (0.81.1):
+  - React-oscompat (0.81.2)
+  - React-perflogger (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2651,7 +2651,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.81.1):
+  - React-performancetimeline (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2664,9 +2664,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.81.1):
-    - React-Core/RCTActionSheetHeaders (= 0.81.1)
-  - React-RCTAnimation (0.81.1):
+  - React-RCTActionSheet (0.81.2):
+    - React-Core/RCTActionSheetHeaders (= 0.81.2)
+  - React-RCTAnimation (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2682,7 +2682,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.81.1):
+  - React-RCTAppDelegate (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2716,7 +2716,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.81.1):
+  - React-RCTBlob (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2735,7 +2735,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.81.1):
+  - React-RCTFabric (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2770,7 +2770,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.1):
+  - React-RCTFBReactNativeSpec (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2784,10 +2784,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.1)
+    - React-RCTFBReactNativeSpec/components (= 0.81.2)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.81.1):
+  - React-RCTFBReactNativeSpec/components (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2810,7 +2810,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.81.1):
+  - React-RCTImage (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2826,14 +2826,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.81.1):
-    - React-Core/RCTLinkingHeaders (= 0.81.1)
-    - React-jsi (= 0.81.1)
+  - React-RCTLinking (0.81.2):
+    - React-Core/RCTLinkingHeaders (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.1)
-  - React-RCTNetwork (0.81.1):
+    - ReactCommon/turbomodule/core (= 0.81.2)
+  - React-RCTNetwork (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2851,7 +2851,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.81.1):
+  - React-RCTRuntime (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2871,7 +2871,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.81.1):
+  - React-RCTSettings (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2886,10 +2886,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.81.1):
-    - React-Core/RCTTextHeaders (= 0.81.1)
+  - React-RCTText (0.81.2):
+    - React-Core/RCTTextHeaders (= 0.81.2)
     - Yoga
-  - React-RCTVibration (0.81.1):
+  - React-RCTVibration (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2903,11 +2903,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.81.1)
-  - React-renderercss (0.81.1):
+  - React-rendererconsistency (0.81.2)
+  - React-renderercss (0.81.2):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.1):
+  - React-rendererdebug (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2917,7 +2917,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.81.1):
+  - React-RuntimeApple (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2946,7 +2946,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.81.1):
+  - React-RuntimeCore (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2968,7 +2968,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.81.1):
+  - React-runtimeexecutor (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2978,10 +2978,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.1)
+    - React-jsi (= 0.81.2)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.81.1):
+  - React-RuntimeHermes (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3002,7 +3002,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.81.1):
+  - React-runtimescheduler (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3024,9 +3024,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.81.1):
+  - React-timing (0.81.2):
     - React-debug
-  - React-utils (0.81.1):
+  - React-utils (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3036,11 +3036,11 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.81.1)
+    - React-jsi (= 0.81.2)
     - SocketRocket
-  - ReactAppDependencyProvider (0.81.1):
+  - ReactAppDependencyProvider (0.81.2):
     - ReactCodegen
-  - ReactCodegen (0.81.1):
+  - ReactCodegen (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3066,7 +3066,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.81.1):
+  - ReactCommon (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3074,9 +3074,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.81.1)
+    - ReactCommon/turbomodule (= 0.81.2)
     - SocketRocket
-  - ReactCommon/turbomodule (0.81.1):
+  - ReactCommon/turbomodule (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3085,15 +3085,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.1)
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
-    - ReactCommon/turbomodule/bridging (= 0.81.1)
-    - ReactCommon/turbomodule/core (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
+    - ReactCommon/turbomodule/bridging (= 0.81.2)
+    - ReactCommon/turbomodule/core (= 0.81.2)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.81.1):
+  - ReactCommon/turbomodule/bridging (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3102,13 +3102,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.1)
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.81.1):
+  - ReactCommon/turbomodule/core (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -3117,14 +3117,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.1)
-    - React-cxxreact (= 0.81.1)
-    - React-debug (= 0.81.1)
-    - React-featureflags (= 0.81.1)
-    - React-jsi (= 0.81.1)
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
-    - React-utils (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
+    - React-cxxreact (= 0.81.2)
+    - React-debug (= 0.81.2)
+    - React-featureflags (= 0.81.2)
+    - React-jsi (= 0.81.2)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
+    - React-utils (= 0.81.2)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -4239,76 +4239,76 @@ SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EASClient: 4e721c008528e7e2637be5913500744ea0d1d75c
-  EXApplication: f5219af375d2bcff2596ac5c586d3b62c587c0d8
-  EXAV: b4c4c6ee295cf276f046b321c92b10eddc4f0c11
-  EXConstants: 91a5ab4e4314979d750af66da2d030bb54bb0135
-  EXImageLoader: 189e3476581efe3ad4d1d3fb4735b7179eb26f05
+  EASClient: cfb28a340d86eeb03c2c67a2c34cd664c97dbc51
+  EXApplication: 724353e341d7ece0bade87d437926fa8b3132c5d
+  EXAV: c384f66c1f1a33a7bcb060a1cb39ea8807a8c268
+  EXConstants: 4d89ce3567191d8c940b0aab5ba7ddd310c59ad2
+  EXImageLoader: e501c001bc40b8326605e82e6e80363c80fe06b5
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: 8c3a1dc3d2cd353107616180b090b6cb8424e0ca
-  EXNotifications: bfcda0c49edd979747e1e50340de7bb0e9729ef5
-  Expo: f6d32e30924ae2710c7d55a8360a7f05bff6f1c4
-  ExpoAppleAuthentication: 9eb1ec7213ee9c9797951df89975136db89bf8ac
-  ExpoAsset: 715e62292ae4c259581bc9106d68d79030c49cae
-  ExpoAudio: e816a3060882f1adb7f61c7598b64abba1eeff6b
-  ExpoBackgroundFetch: 17a6e1a6b49f04b2a69dcafae40001c9d7610b54
-  ExpoBackgroundTask: f4dac8f09f3b187e464af7a1088d9fd5ae48a836
-  ExpoBattery: e27805699e588eabb1a5385b6cfbb2e2bdb224b1
-  ExpoBlur: 9bde58a4de1d24a02575d0e24290f2026ce8dc3a
-  ExpoBrightness: 44da0051eb2cddfba9df7344ba5ecbbe3bf06dd2
-  ExpoCalendar: cc6fe1c3f390cc75b57c098cea9615e555f3676b
-  ExpoCamera: 576c54713c0707543b8e01b22661209b24334b32
-  ExpoCellular: f6d4c311bd41d483c99d1d2111f844e5220eb897
-  ExpoClipboard: c87f8148d16283e65a164a619232350312333c96
-  ExpoContacts: 6862b0b8d7a03991242dae35aea5dd22cd1779ac
-  ExpoCrypto: 834a7a7dd02fe646690f9316e8ce0abdb9f4a821
-  ExpoDevice: eb3409124f873fb3d010319288e1e1e6b375fa9b
-  ExpoDocumentPicker: 073709cd17c2966db55e616326984ea9db4c62ad
-  ExpoDomWebView: 5f7132d75491445cb649a1a889e41b98500ee0d9
-  ExpoFileSystem: df33ab3f36961a043fd9b502d91b102de1856839
-  ExpoFont: 74a14c605637c2d32337a2f542065408a8ca3454
-  ExpoGL: 0f7da153b7eaa919552bde3f31470fb64967f827
-  ExpoGlassEffect: 9aa58a46e8abe720971f2b588bc1e10d58728ba8
-  ExpoHaptics: e0912a9cf05ba958eefdc595f1990b8f89aa1f3f
-  ExpoHead: 91ed6ab650e5a8032573cbb77dd79431e8b18f00
-  ExpoImage: 18d9836939f8e271364a5a2a3566f099ea73b2e4
-  ExpoImageManipulator: a9daa4d53280c87a76863e132403f29ca575e4b1
-  ExpoImagePicker: 66195293e95879fa5ee3eb1319f10b5de0ffccbb
-  ExpoKeepAwake: eba81dfb5728be8c46e382b9314dfa14f40d8764
-  ExpoLinearGradient: 74d67832cdb0d2ef91f718d50dd82b273ce2812e
-  ExpoLinking: dadcc1205351c1108b7c5bab4b7891e744fc8c89
-  ExpoLivePhoto: be22ba05ccfa0997402d89890ee3335857268f7b
-  ExpoLocalAuthentication: badfe0eb0256bcf2cc294b9a32c5038944a22e41
-  ExpoLocalization: 540bc28ae55353eff0dfd1f092d389741c6f575e
-  ExpoLocation: 8ca995b4cda5e35f60c04cf8fbfde81e599520bf
-  ExpoMailComposer: 0e6cd4877c8b8d692da5c85a9393ceafb27a6d91
-  ExpoMediaLibrary: 7c555ad5d9234c0e9548e538bd892b695cd1355b
-  ExpoMeshGradient: 3927080271353e924f92780eb28d0e6f609cd99c
-  ExpoModulesCore: 3d0f2c43a5198af90e40522ed60a7c278612c953
-  ExpoModulesTestCore: be5073c51ffe7c2db9f14aedfce7d8cdc141f55a
-  ExpoNetwork: d2f8b8f9b64af48dc9695bafa8b0a34611f7127b
-  ExpoPrint: cbe3188bd6ff0c8b2ee92e7253771290a0a9c78e
-  ExpoScreenCapture: fe1d46f1263ad5b409eaf7e7b072b45053e9122e
-  ExpoScreenOrientation: 9dc3a932e7e6cfed8b2eb99db4306b929739e817
-  ExpoSecureStore: 57327b9a484ad730cf823c82d092e0bf71e11512
-  ExpoSensors: a04e0d47652b6c15c958e6d340f9af7d586bb3d9
-  ExpoSharing: 48a58c41063f07667cf19b7100a2f2559eada6a9
-  ExpoSMS: 5c1be8781920b5324ef84ca43feee99d7ab3805b
-  ExpoSpeech: 5bbb4eeb486ffb16b3d25cdf3b8d5d5f3e134ba0
-  ExpoSQLite: 460503f8835ff8799694a2ba26605086f5446424
-  ExpoStoreReview: d26daaa2e20e8bb095dc731febbebc9ce08f5991
-  ExpoSymbols: 3efee6865b1955fe3805ca88b36e8674ce6970dd
-  ExpoSystemUI: a3b1bb2e4d28ae65a09b64517ad93096ca88ac5e
-  ExpoTrackingTransparency: 30eae1898910829ce661c85fd44b2b89f84fd0e4
-  ExpoVideo: ee4bfbec2b91f982ba20ad5d8cc6311a0a7b3d7f
-  ExpoVideoThumbnails: dece56760a10d4d47c1cde7850e2aac396921a74
-  ExpoWebBrowser: 84d4438464d9754a4c1f1eaa97cd747f3752187e
+  EXManifests: 9b19413c322564f3c2dce83006f1d71a4df79ba9
+  EXNotifications: 41233e5c2c4a795139d08a9ff8bb3de2536b86f5
+  Expo: d0b6482934e91f79a74d3768af9e5c671b9b1f51
+  ExpoAppleAuthentication: a42dfc311de6767c0529fb6d7f301915f651c7eb
+  ExpoAsset: 6ba39c035bda80b5561acdc7d6e869c0adc571a0
+  ExpoAudio: 9f25a54a380f761c5bf233197582f7b870a08e8d
+  ExpoBackgroundFetch: e51c22117fb1f43fdd58c8f4def0e9a8fffb539a
+  ExpoBackgroundTask: 0db04d59d07e8d8821dd3c207ed5d297b783054d
+  ExpoBattery: 79d7792eaeaeb5dbb83c5fd50b6bf3ecdaac2b76
+  ExpoBlur: 33c9fc0c18ba192d181e5a650d4cae8c179857df
+  ExpoBrightness: 4c4e7d51dd883fde58696ca37c6498bf38fbeedb
+  ExpoCalendar: 863b0ee27b1b0435bb3d6cd388dbd48582ecd77c
+  ExpoCamera: 248b0ee69661779bbd5d07e55c8a5065045020dd
+  ExpoCellular: 1cfeb3256424e00ff94129a2d318d94a3caa0e13
+  ExpoClipboard: 9e1809dd6ffdc08ce990f9bf22dcab3791b694aa
+  ExpoContacts: f1f9cf1a997baed0c1861bd6c4121b77077ffbc3
+  ExpoCrypto: 7464dd47a9c90c027555fc472d4ba2d91ff08537
+  ExpoDevice: 6ba9b52c39f7c659a65a7b44da36d3937ec2c05c
+  ExpoDocumentPicker: 23c8e6b16c8594ea6c39cb7a55605ce67c2c24d2
+  ExpoDomWebView: 2dcc93211b8e3614e4ffe3dc91d4c181763686f2
+  ExpoFileSystem: 229cf540729847f8f4556677d36d45cedb9af9ab
+  ExpoFont: 3cb68f520e9349141a28fed6dd94e6cc6bf1453f
+  ExpoGL: ae5e6fee5b104b9f6486f7f4458c25128edc4278
+  ExpoGlassEffect: 865bcf7faa4a5c024654260722d5cd74a9342d2b
+  ExpoHaptics: a8f7720a74b885f8a23e0836e2b91d69883968fe
+  ExpoHead: 00f5c44a7aecaa241712d6f738041b1078f8a5d4
+  ExpoImage: 2708a5a9e69b6432f43d368379cc7c9b5165048b
+  ExpoImageManipulator: 29c6c60f87b158a3905ff07c4e14fcb55e444df0
+  ExpoImagePicker: 1cd4a47c463806acc23f9e1990a296cce2c496d4
+  ExpoKeepAwake: e5bb3832a4735ee580ac6aa28130d44e1203f11f
+  ExpoLinearGradient: aa4ae248706a0da6bd59a5aae6e2bf24de04dfa8
+  ExpoLinking: 01b4b07a8647880a32f1acf608fa3b7cb7557e0c
+  ExpoLivePhoto: 8e3519912b987f02b1ed7a58e69f6f3052ab349f
+  ExpoLocalAuthentication: 44dedf22fe8a86c445677db4e4e1a6dc2b5d35e4
+  ExpoLocalization: d52f78c3f7826fe09ac0de785d8b52c7187fe7a9
+  ExpoLocation: 21f48c52d176f4a4c136b653a9345ebc5873a498
+  ExpoMailComposer: 071ff674188880be8c8b970d8db2178ea240978f
+  ExpoMediaLibrary: 3204a2cb76b8f9822d8631d801b60f9feb6792e4
+  ExpoMeshGradient: 7d7918322943482f2e36e357caf2652f29d9c174
+  ExpoModulesCore: b67be3679df11c41ba37c5434e6a6caac31e960b
+  ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
+  ExpoNetwork: 18f90d4d7d487cb7ef1e4400b7a585618f4235fc
+  ExpoPrint: afbfbbf5e6d78bc002223e9ee20a46c2be8bda29
+  ExpoScreenCapture: d4ac3a77b3d108d52d56e5b1086793f53dd347d5
+  ExpoScreenOrientation: 589816bba7f599ce22b41626a5e688aec91f1448
+  ExpoSecureStore: fb9f6ec0614d4d9c2ae4c2a91999f231aa6606c1
+  ExpoSensors: e4e13463d1ba75f4c69c9fdf9ee5ff5304aa2d6d
+  ExpoSharing: bd81fdc1c01113496af43b941b6544eb1b5d7ae4
+  ExpoSMS: fcca75e971f990e3e112b4478b86b426a2797cc1
+  ExpoSpeech: 4662fa3f5c240b876733b12490ca034ee4c084a3
+  ExpoSQLite: 8199fa6d2ac75131781b5a9fba23f7617862feb9
+  ExpoStoreReview: 10e4e452452ed3ed28d94a3bcacdc063bc4ff763
+  ExpoSymbols: 944e3a6a39527f91c4bad8b7c0fcd3e0086a2248
+  ExpoSystemUI: 031356e6df193703437151080704ca81234170c4
+  ExpoTrackingTransparency: aaf012895c814bd9000cf8f89477063eac7cc556
+  ExpoVideo: 9d2f8164d81d2c839b5cf894b19b56294ebc0a27
+  ExpoVideoThumbnails: 5eeb2fc42ed681082d318c00986ef0edc1d08b48
+  ExpoWebBrowser: 111faed02d1dd79eb556450694724adf390d6091
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
-  EXTaskManager: eedcd03c1a574c47d3f48d83d4e4659b3c1fa29b
-  EXUpdates: f307db2203f4568c7e2e986508b9cc9e93c94c5d
-  EXUpdatesInterface: 5adf50cb41e079c861da6d9b4b954c3db9a50734
+  EXTaskManager: 19451783dfb545748126ad2d5ecdf535daf8d6da
+  EXUpdates: 8a7b18d0ca4f2e59a486bc6472fb9bed6df00ba5
+  EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: b8f1312d48447cca7b4abc21ed155db14742bd03
+  FBLazyVector: 89a8574f4a4ea67295ad2e8f84b764e4b1162f64
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
   FirebaseCore: 2321536f9c423b1f857e047a82b8a42abc6d9e2c
   FirebaseCoreExtension: 3a64994969dd05f4bcb7e6896c654eded238e75b
@@ -4324,109 +4324,109 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 58c28ef03bc3ad3ddfef92f25c7e49dedc8baa36
+  hermes-engine: fef68fd284c6543da58c333a888adeba82c791d6
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: ee739c59b332297996b1a1a73884ee75d95a7562
+  lottie-react-native: 8a08f0554027f07f5370bf9129ca5da0878fe5b3
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
-  RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
-  RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a
-  RCTTypeSafety: 720403058b7c1380c6a3ae5706981d6362962c89
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
+  RCTDeprecation: b60b889eafa75f46c3d6be5332681efbb16ad0c7
+  RCTRequired: fbdcc9ee2826c0a2ed5bd77a8375b3613d087e99
+  RCTTypeSafety: e1fa82493c521eba295c7ed0d2de80e3d4f22853
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: f1486d005993b0af01943af1850d3d4f3b597545
-  React-callinvoker: 133f69368c8559e744efa345223625d412f5dfbe
-  React-Core: 559823921b4f294c2840fa8238ca958a29ddc211
-  React-CoreModules: c41e7bbfabbc420783bb926f45837a0d5e53341e
-  React-cxxreact: 9cb9fa738274a1b36b97ede09c8a6717dec1a20b
-  React-debug: e01581e1589f329e61c95b332bf7f4969b10564b
-  React-defaultsnativemodule: bbb39447caa6b6cf9405fa0099f828c083640faa
-  React-domnativemodule: 03744d12b6d56d098531a933730bf1d4cb79bdfb
-  React-Fabric: 530b3993a12a96e8a7cdb9f0ef48e605277b572e
-  React-FabricComponents: 271ec2a9b2c00ac66fd6d1fd24e9e964d907751d
-  React-FabricImage: d0af66e976dbab7f8b81e36dd369fc70727d2695
-  React-featureflags: 269704c8eff86e0485c9d384e286350fcda6eb70
-  React-featureflagsnativemodule: db1e5d88a912fb08a5ece33fcf64e1b732da8467
-  React-graphics: b19d03a01b0722b4dc82f47acb56dc3ed41937e7
-  React-hermes: 811606c0aca5a3f9c6fa8e4994e02ca8f677e68e
-  React-idlecallbacksnativemodule: 3a3df629cd50046c7e4354f9025aefe8f2c84601
-  React-ImageManager: 0d53866c63132791e37bb2373f93044fdef14aa3
-  React-jserrorhandler: d5700d6ab7162fd575287502a3c5d601d98e7f09
-  React-jsi: ece95417fedbed0e7153a855cb8342b7c72ab75e
-  React-jsiexecutor: 2b0bb644b533df2f5c0cd6ade9a4560d0bf1dd84
-  React-jsinspector: 0c160f8510a8852bdf2dac12f0b1949efc18200b
-  React-jsinspectorcdp: f4b84409f453f61ddd8614ad45139bc594ec6bb5
-  React-jsinspectornetwork: 8f2f0ca8c871ca19b571f426002c0012e7fb2aee
-  React-jsinspectortracing: 33f6b977eb8a4bc1e3d1a4b948809aca083143f9
-  React-jsitooling: 2c61529b589e17229a9f0a4a4fc35aa7ad495850
-  React-jsitracing: 838a7b0c013c4aff7d382d7fdc78cf442013ba1d
-  React-logger: 7aef4d74123e5e3d267e5af1fbf5135b5a0d8381
-  React-Mapbuffer: 91e0eab42a6ae7f3e34091a126d70fc53bd3823e
-  React-microtasksnativemodule: 1ead4fe154df3b1ba34b5a9e35ef3c4bdfa72ccb
-  react-native-google-maps: c4f5c5b2dda17e7cb2cb2b37a81f140b039b3e7e
-  react-native-keyboard-controller: 8bd5f5572b6d5d402a2f77987a17492f869e5d62
-  react-native-maps: 9febd31278b35cd21e4fad2cf6fa708993be5dab
-  react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
-  react-native-pager-view: a0516effb17ca5120ac2113bfd21b91130ad5748
-  react-native-safe-area-context: a72764e0eb5d6b79b7450e5d0ae919eb1a4567b4
-  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
-  react-native-skia: 665cd52db7ad3d41e2a59c84e9c097343745c088
-  react-native-slider: 663776e5683e257de8df8091abc2d93ff6ec67db
-  react-native-view-shot: 6c008e58f4720de58370848201c5d4a082c6d4ca
-  react-native-webview: 4cbb7f05f2c50671a7dcff4012d3e85faad271e4
-  React-NativeModulesApple: eff2eba56030eb0d107b1642b8f853bc36a833ac
-  React-oscompat: b12c633e9c00f1f99467b1e0e0b8038895dae436
-  React-perflogger: 58d12c4e5df1403030c97b9c621375c312cca454
-  React-performancetimeline: 0ee0a3236c77a4ee6d8a6189089e41e4003d292e
-  React-RCTActionSheet: 3f741a3712653611a6bfc5abceb8260af9d0b218
-  React-RCTAnimation: 408ad69ea136e99a463dd33eadecc29e586b3d72
-  React-RCTAppDelegate: f03b46e80b8a3dbfa84b35abfe123e02f3ceef83
-  React-RCTBlob: bd42e92a00ad22eaab92ffe5c137e7a2f725887a
-  React-RCTFabric: b99ab638c73cf2d57b886eafdbfb2e4909b0eb9a
-  React-RCTFBReactNativeSpec: 7ad9aba0e0655e3f29be0a1c3fd4a888fab04dcf
-  React-RCTImage: 0f1c74f7cd20027f8c34976a211b35d4263a0add
-  React-RCTLinking: 6d7dfc3a74110df56c3a73cc7626bf4415656542
-  React-RCTNetwork: 6a25d8645a80d5b86098675ca39bf8fcf1afa08b
-  React-RCTRuntime: 38bfe9766565ae3293ca230bc51c9c020a8bc98a
-  React-RCTSettings: 651d9ae2cdd32f547ad0d225a2c13886d6ad2358
-  React-RCTText: 9bc66cd288478e23195e01f5cb45eba79986b2b4
-  React-RCTVibration: 371226f5667a00c76d792dcdb5c2e0fcbcde0c3b
-  React-rendererconsistency: a05f6c37f9389c53213d1e28798e441fa6fbdbcd
-  React-renderercss: 6e4febfa014b0f53bc171a62b0f713ddbdbb9860
-  React-rendererdebug: e94bf27b9d55ef2795caa8e43aa92abc4a373b8b
-  React-RuntimeApple: 723be5159519eba1cd92449acb29436d21571b82
-  React-RuntimeCore: f58eb0f01065c9d27d91de10b2e4ab4c76d83b0e
-  React-runtimeexecutor: f615ec8742d0b5820170f7c8b4d2c7cb75d93ac9
-  React-RuntimeHermes: fddb258e03d330d1132bb19e78fe51ac2f3f41ac
-  React-runtimescheduler: e92a31460e654ced8587debeec37553315e1b6a5
-  React-timing: 97ada2c47b4c5932e7f773c7d239c52b90d6ca68
-  React-utils: f0949d247a46b4c09f03e5a3cb1167602d0b729a
-  ReactAppDependencyProvider: 3eb9096cb139eb433965693bbe541d96eb3d3ec9
-  ReactCodegen: da219247e01e4c60850c38eee67eba211248fecf
-  ReactCommon: ce5d4226dfaf9d5dacbef57b4528819e39d3a120
-  RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
-  RNCMaskedView: 5ef8c95cbab95334a32763b72896a7b7d07e6299
-  RNCPicker: 66c392786945ecee5275242c148e6a4601221d3a
-  RNDateTimePicker: cda4c045beca864cebb3209ef9cc4094f974864c
-  RNGestureHandler: 3a73f098d74712952870e948b3d9cf7b6cae9961
-  RNReanimated: c07a21c72b8e5a88110406519c7ba3dd2fd66f2e
-  RNScreens: 0bbf16c074ae6bb1058a7bf2d1ae017f4306797c
-  RNSVG: 6f39605a4c4d200b11435c35bd077553c6b5963a
-  RNWorklets: 8cb8067efd9f4d25785546f0e57a4c825837a9dc
+  React: 7cee6da22b893d581d51397032d4a3951c03cb17
+  React-callinvoker: 58d4d5a586a1523752a9fa58ef3fc6d0b7fbcbad
+  React-Core: 2a00139af1a13cd5d6234b96024c2e8c609c0486
+  React-CoreModules: 544ebf2a4ef99090ab5f26d3f44e693def986f2f
+  React-cxxreact: 3c2ff1c8c1739ba3827d50c844e7a0e1da2bbd45
+  React-debug: f86bd380de1d8bc8a3ba13eed20f7a7c10290e3a
+  React-defaultsnativemodule: 190bd39694d6b04ed6ff3c6127dab92e3465c99b
+  React-domnativemodule: 160a6555391b13810e633991626c0547c8bffa0f
+  React-Fabric: 1fb8455cf7fc6089aa4e96c4307bd1b7cc1915ca
+  React-FabricComponents: cf05fb1b9a1a16ca700f58c7ab60c1c0d494fe05
+  React-FabricImage: 79676806e07bedf45ecb401242fec00712b95ca2
+  React-featureflags: 7f31869ec867c45a93b93d9079b62d7bfbc29a3c
+  React-featureflagsnativemodule: 31cf067d284d1e5843a810218e57fe9342173b2f
+  React-graphics: c065f94afba7661e192ea8a48e19bcc8fccfb5f6
+  React-hermes: 05f8be1795884b94a4a79deafbd306fde2ac1218
+  React-idlecallbacksnativemodule: 31f3701cdf8cac09cead1115971fc1198a07a923
+  React-ImageManager: 121af59488820720d1158cdd8ae6478b622b2575
+  React-jserrorhandler: eee16d033dc7fc73f4b57a1d038905e4ce8e05e5
+  React-jsi: ff804868b503f2f7ed5f8b7bb780cd036c79a806
+  React-jsiexecutor: d489788717a8577e65c992a352a8fbaa4f699d5c
+  React-jsinspector: 965088adbcd1a3d907cdff2d5b0c840112cdbfb7
+  React-jsinspectorcdp: 2718e82fd69b9ff77b7795f3a99964690f7bd0bd
+  React-jsinspectornetwork: 92a5da5a8c77806d52de3a711d8200f9a0eb1c6e
+  React-jsinspectortracing: da0085d4b8976280ebdc8d308c265dd2ad6e8f4f
+  React-jsitooling: ecd194e4a18aa65f9bf9c99285d3d7dc2d77bda9
+  React-jsitracing: 57cc77243a7feb4c7b851a51ac18261846a51251
+  React-logger: 3d3d703c13b7d0130fa3842f836e93794f6b0589
+  React-Mapbuffer: 689ffb875cf6b1cc9b6be7a587c33ac729d84fd4
+  React-microtasksnativemodule: 94d4726672b7f010ce828f87c4c7305796af4e4e
+  react-native-google-maps: 7cc1184afe41fbd15a3dffd53c924819f6587b69
+  react-native-keyboard-controller: 5e209d13d4c5355ddf8c36be3d41b8dfc879cd91
+  react-native-maps: ee1e65647460c3d41e778071be5eda10e3da6225
+  react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
+  react-native-pager-view: 899989dd025d219d3ac0d386b2bc162f81ae8330
+  react-native-safe-area-context: 2249e17382bd5a97cbccaa89e22af8756188c0fb
+  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
+  react-native-skia: 6fe142fbe7f93579e6205d4045abdf5d6574b942
+  react-native-slider: 30cea7008de785564de2f4fd064f2deb38614a4a
+  react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
+  react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
+  React-NativeModulesApple: 1b204ec5f197270987fe27f86b3d34b5d8406631
+  React-oscompat: 1b3446acd10cdfd739655206b912db37f5e5a80f
+  React-perflogger: d8bb76530906ba368ecb8af364e8c2b3252ec5e0
+  React-performancetimeline: 426ca4f701729c67bd4f2883ce779765a3e6d77c
+  React-RCTActionSheet: fc83c5b18f638ba92ad22005da9d82fb1ba29ab4
+  React-RCTAnimation: 645e538d49be0ae77a399379bf6dec65dccc9e53
+  React-RCTAppDelegate: f347f16e726ccc54e9724f5c733e2a642f740588
+  React-RCTBlob: 13e8423a3097e33a230488593c27a6b852d07957
+  React-RCTFabric: 9259a5d52481bc6d96afe953790ee40f7af753a6
+  React-RCTFBReactNativeSpec: 256a5a0a3c23f290fa65fc1d826bd0456e01c657
+  React-RCTImage: 03ef0e56bafd30ebf1e5030c6faf1a96f725b752
+  React-RCTLinking: 392255aec37cf9ed602c602e338f0ee94722fc7c
+  React-RCTNetwork: f4f0d24c4a1b7e7f1a011767231dc8617f8be7ff
+  React-RCTRuntime: d062784c65b50af9c161f9f361f5cde6da490214
+  React-RCTSettings: 2dbfab042c4063c5788e85e0f5b6ea32d9ab32bb
+  React-RCTText: 55cd9cf7c0c7d26aae506ac8570361dd1f5fabdb
+  React-RCTVibration: 8f5a49199ca5ce898e5d785beca39bc0f1a312e8
+  React-rendererconsistency: fb8d9afcedef714822676c17fa47f782eb690ec4
+  React-renderercss: d3a392fa3da45987e03a6080c5c8d390c62e46c5
+  React-rendererdebug: bee210d645c71613eb7464b1f7583813fe7bb34c
+  React-RuntimeApple: c4c64bb5ac6f907c17b20eb7872668a0f7c4b6fd
+  React-RuntimeCore: 4030ecfba4a1b4a4b67a1a83ccf8a2090860e469
+  React-runtimeexecutor: a07fc15d2b8899b5254fc9e3cc35d0b508e5c47f
+  React-RuntimeHermes: ff7f38c58af45f08488d4d39d3163582f3c5ab2e
+  React-runtimescheduler: 814cd8985699d2af1809cf628ae0ef1f1d07630a
+  React-timing: 9919d1154651af97f6191150f5af00f833cf598a
+  React-utils: f95d319648c01fc920c717acfbccad3fe92a8cdf
+  ReactAppDependencyProvider: 319be07ed29c6a24b30b700ebf6f667c9d49a511
+  ReactCodegen: d90c24f0be7cbe9f4b805c95a75f12318724755b
+  ReactCommon: 6753d98e6793890f2d0b1b678592c497bc0987ea
+  RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
+  RNCMaskedView: 63268de1986a098b5f4d1fb5b1bc1e97fade0aee
+  RNCPicker: 6da395ee9db8d67a38c6102d4128b5a0b9ec0e21
+  RNDateTimePicker: c4a42c6a77d474f05162d61a4ab4253d13008277
+  RNGestureHandler: 4f7cc97a71d4fe0fcba38c94acdd969f5f17c91c
+  RNReanimated: 0cb057fceda450a0eb6dff9b7dc10bdd9f59b24f
+  RNScreens: 74985ca8e102294a60cec7513fa84c936fa0b20b
+  RNSVG: 8d87cff016edf1b6ca409ed39804101836d75e90
+  RNWorklets: c68e8fef9713b88c91f27f122fe15f2fb91793d6
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Stripe: d1824162e4bcb6ead10401a0dc8e8a3d5ffee41f
-  stripe-react-native: f2af1d3769363ae90b2a6c4bb9642232c2c4d2c9
+  stripe-react-native: fd628fd2cd45a6d06700cdf499f23dbcb4d5f8d9
   StripeApplePay: eb64705d3c919492b1b28876652fd0aca2db38cc
   StripeCore: b5bee05167f0c8ccce936244a031a9972fdeade8
   StripeFinancialConnections: fd6c661f86f47b1d26a32f588b3a0b09826aba84
@@ -4435,7 +4435,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: 05d4be35b34f821d5ddc8617dee04219f3646253
   StripeUICore: d07bd63a4b53dee8cab4d6f81ce5a7ab3e28511e
   UMAppLoader: 2af2cc05fcaa9851233893c0e3dbc56a99f57e36
-  Yoga: 11c9686a21e2cd82a094a723649d9f4507200fb0
+  Yoga: b9dc6c508cca59caf2f7462189a74359c6c680b6
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: aaaa821356ecede13bd3ebe65b62ce223458b0fa

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -363,7 +363,7 @@ PODS:
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.81.2)
+  - FBLazyVector (0.81.3)
   - FirebaseAnalytics (11.11.0):
     - FirebaseAnalytics/AdIdSupport (= 11.11.0)
     - FirebaseCore (~> 11.11.0)
@@ -486,17 +486,17 @@ PODS:
   - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - hermes-engine (0.81.2):
-    - hermes-engine/cdp (= 0.81.2)
-    - hermes-engine/Hermes (= 0.81.2)
-    - hermes-engine/inspector (= 0.81.2)
-    - hermes-engine/inspector_chrome (= 0.81.2)
-    - hermes-engine/Public (= 0.81.2)
-  - hermes-engine/cdp (0.81.2)
-  - hermes-engine/Hermes (0.81.2)
-  - hermes-engine/inspector (0.81.2)
-  - hermes-engine/inspector_chrome (0.81.2)
-  - hermes-engine/Public (0.81.2)
+  - hermes-engine (0.81.3):
+    - hermes-engine/cdp (= 0.81.3)
+    - hermes-engine/Hermes (= 0.81.3)
+    - hermes-engine/inspector (= 0.81.3)
+    - hermes-engine/inspector_chrome (= 0.81.3)
+    - hermes-engine/Public (= 0.81.3)
+  - hermes-engine/cdp (0.81.3)
+  - hermes-engine/Hermes (0.81.3)
+  - hermes-engine/inspector (0.81.3)
+  - hermes-engine/inspector_chrome (0.81.3)
+  - hermes-engine/Public (0.81.3)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -574,28 +574,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.81.2)
-  - RCTRequired (0.81.2)
-  - RCTTypeSafety (0.81.2):
-    - FBLazyVector (= 0.81.2)
-    - RCTRequired (= 0.81.2)
-    - React-Core (= 0.81.2)
+  - RCTDeprecation (0.81.3)
+  - RCTRequired (0.81.3)
+  - RCTTypeSafety (0.81.3):
+    - FBLazyVector (= 0.81.3)
+    - RCTRequired (= 0.81.3)
+    - React-Core (= 0.81.3)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.2):
-    - React-Core (= 0.81.2)
-    - React-Core/DevSupport (= 0.81.2)
-    - React-Core/RCTWebSocket (= 0.81.2)
-    - React-RCTActionSheet (= 0.81.2)
-    - React-RCTAnimation (= 0.81.2)
-    - React-RCTBlob (= 0.81.2)
-    - React-RCTImage (= 0.81.2)
-    - React-RCTLinking (= 0.81.2)
-    - React-RCTNetwork (= 0.81.2)
-    - React-RCTSettings (= 0.81.2)
-    - React-RCTText (= 0.81.2)
-    - React-RCTVibration (= 0.81.2)
-  - React-callinvoker (0.81.2)
-  - React-Core (0.81.2):
+  - React (0.81.3):
+    - React-Core (= 0.81.3)
+    - React-Core/DevSupport (= 0.81.3)
+    - React-Core/RCTWebSocket (= 0.81.3)
+    - React-RCTActionSheet (= 0.81.3)
+    - React-RCTAnimation (= 0.81.3)
+    - React-RCTBlob (= 0.81.3)
+    - React-RCTImage (= 0.81.3)
+    - React-RCTLinking (= 0.81.3)
+    - React-RCTNetwork (= 0.81.3)
+    - React-RCTSettings (= 0.81.3)
+    - React-RCTText (= 0.81.3)
+    - React-RCTVibration (= 0.81.3)
+  - React-callinvoker (0.81.3)
+  - React-Core (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -605,7 +605,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.2)
+    - React-Core/Default (= 0.81.3)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -620,82 +620,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.81.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.81.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.81.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.81.2)
-    - React-Core/RCTWebSocket (= 0.81.2)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.2):
+  - React-Core/CoreModulesHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -720,7 +645,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.2):
+  - React-Core/Default (0.81.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.81.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.3)
+    - React-Core/RCTWebSocket (= 0.81.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -745,7 +720,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.2):
+  - React-Core/RCTAnimationHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -770,7 +745,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.2):
+  - React-Core/RCTBlobHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -795,7 +770,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.2):
+  - React-Core/RCTImageHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -820,7 +795,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.2):
+  - React-Core/RCTLinkingHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -845,7 +820,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.2):
+  - React-Core/RCTNetworkHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -870,7 +845,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.2):
+  - React-Core/RCTSettingsHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -895,7 +870,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.2):
+  - React-Core/RCTTextHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -920,7 +895,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.81.2):
+  - React-Core/RCTVibrationHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -930,7 +905,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.2)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -945,7 +920,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.81.2):
+  - React-Core/RCTWebSocket (0.81.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -953,20 +953,20 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.81.2)
-    - React-Core/CoreModulesHeaders (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - RCTTypeSafety (= 0.81.3)
+    - React-Core/CoreModulesHeaders (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.2)
+    - React-RCTImage (= 0.81.3)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.81.2):
+  - React-cxxreact (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -975,19 +975,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.2)
-    - React-debug (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
+    - React-debug (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
-    - React-timing (= 0.81.2)
+    - React-timing (= 0.81.3)
     - SocketRocket
-  - React-debug (0.81.2)
-  - React-defaultsnativemodule (0.81.2):
+  - React-debug (0.81.3)
+  - React-defaultsnativemodule (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1004,7 +1004,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.81.2):
+  - React-domnativemodule (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1024,7 +1024,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.81.2):
+  - React-Fabric (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1038,23 +1038,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.2)
-    - React-Fabric/attributedstring (= 0.81.2)
-    - React-Fabric/bridging (= 0.81.2)
-    - React-Fabric/componentregistry (= 0.81.2)
-    - React-Fabric/componentregistrynative (= 0.81.2)
-    - React-Fabric/components (= 0.81.2)
-    - React-Fabric/consistency (= 0.81.2)
-    - React-Fabric/core (= 0.81.2)
-    - React-Fabric/dom (= 0.81.2)
-    - React-Fabric/imagemanager (= 0.81.2)
-    - React-Fabric/leakchecker (= 0.81.2)
-    - React-Fabric/mounting (= 0.81.2)
-    - React-Fabric/observers (= 0.81.2)
-    - React-Fabric/scheduler (= 0.81.2)
-    - React-Fabric/telemetry (= 0.81.2)
-    - React-Fabric/templateprocessor (= 0.81.2)
-    - React-Fabric/uimanager (= 0.81.2)
+    - React-Fabric/animations (= 0.81.3)
+    - React-Fabric/attributedstring (= 0.81.3)
+    - React-Fabric/bridging (= 0.81.3)
+    - React-Fabric/componentregistry (= 0.81.3)
+    - React-Fabric/componentregistrynative (= 0.81.3)
+    - React-Fabric/components (= 0.81.3)
+    - React-Fabric/consistency (= 0.81.3)
+    - React-Fabric/core (= 0.81.3)
+    - React-Fabric/dom (= 0.81.3)
+    - React-Fabric/imagemanager (= 0.81.3)
+    - React-Fabric/leakchecker (= 0.81.3)
+    - React-Fabric/mounting (= 0.81.3)
+    - React-Fabric/observers (= 0.81.3)
+    - React-Fabric/scheduler (= 0.81.3)
+    - React-Fabric/telemetry (= 0.81.3)
+    - React-Fabric/templateprocessor (= 0.81.3)
+    - React-Fabric/uimanager (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1066,32 +1066,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.81.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.81.2):
+  - React-Fabric/animations (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1116,7 +1091,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.81.2):
+  - React-Fabric/attributedstring (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1141,7 +1116,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.81.2):
+  - React-Fabric/bridging (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1166,7 +1141,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.81.2):
+  - React-Fabric/componentregistry (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1191,36 +1166,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.81.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.2)
-    - React-Fabric/components/root (= 0.81.2)
-    - React-Fabric/components/scrollview (= 0.81.2)
-    - React-Fabric/components/view (= 0.81.2)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.2):
+  - React-Fabric/componentregistrynative (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1245,7 +1191,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.81.2):
+  - React-Fabric/components (0.81.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.3)
+    - React-Fabric/components/root (= 0.81.3)
+    - React-Fabric/components/scrollview (= 0.81.3)
+    - React-Fabric/components/view (= 0.81.3)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1270,7 +1245,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.81.2):
+  - React-Fabric/components/root (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1295,7 +1270,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.81.2):
+  - React-Fabric/components/scrollview (0.81.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1322,7 +1322,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.81.2):
+  - React-Fabric/consistency (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1347,7 +1347,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.81.2):
+  - React-Fabric/core (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1372,7 +1372,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.81.2):
+  - React-Fabric/dom (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1397,7 +1397,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.81.2):
+  - React-Fabric/imagemanager (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1422,7 +1422,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.81.2):
+  - React-Fabric/leakchecker (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1447,7 +1447,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.81.2):
+  - React-Fabric/mounting (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1472,7 +1472,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.81.2):
+  - React-Fabric/observers (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1486,7 +1486,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.2)
+    - React-Fabric/observers/events (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1498,7 +1498,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.81.2):
+  - React-Fabric/observers/events (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1523,7 +1523,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.81.2):
+  - React-Fabric/scheduler (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1550,7 +1550,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.81.2):
+  - React-Fabric/telemetry (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1575,7 +1575,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.81.2):
+  - React-Fabric/templateprocessor (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1600,7 +1600,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.81.2):
+  - React-Fabric/uimanager (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1614,7 +1614,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.2)
+    - React-Fabric/uimanager/consistency (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1627,7 +1627,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.81.2):
+  - React-Fabric/uimanager/consistency (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1653,7 +1653,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.81.2):
+  - React-FabricComponents (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1668,8 +1668,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.2)
-    - React-FabricComponents/textlayoutmanager (= 0.81.2)
+    - React-FabricComponents/components (= 0.81.3)
+    - React-FabricComponents/textlayoutmanager (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1682,7 +1682,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.81.2):
+  - React-FabricComponents/components (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1697,17 +1697,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.2)
-    - React-FabricComponents/components/iostextinput (= 0.81.2)
-    - React-FabricComponents/components/modal (= 0.81.2)
-    - React-FabricComponents/components/rncore (= 0.81.2)
-    - React-FabricComponents/components/safeareaview (= 0.81.2)
-    - React-FabricComponents/components/scrollview (= 0.81.2)
-    - React-FabricComponents/components/switch (= 0.81.2)
-    - React-FabricComponents/components/text (= 0.81.2)
-    - React-FabricComponents/components/textinput (= 0.81.2)
-    - React-FabricComponents/components/unimplementedview (= 0.81.2)
-    - React-FabricComponents/components/virtualview (= 0.81.2)
+    - React-FabricComponents/components/inputaccessory (= 0.81.3)
+    - React-FabricComponents/components/iostextinput (= 0.81.3)
+    - React-FabricComponents/components/modal (= 0.81.3)
+    - React-FabricComponents/components/rncore (= 0.81.3)
+    - React-FabricComponents/components/safeareaview (= 0.81.3)
+    - React-FabricComponents/components/scrollview (= 0.81.3)
+    - React-FabricComponents/components/switch (= 0.81.3)
+    - React-FabricComponents/components/text (= 0.81.3)
+    - React-FabricComponents/components/textinput (= 0.81.3)
+    - React-FabricComponents/components/unimplementedview (= 0.81.3)
+    - React-FabricComponents/components/virtualview (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1720,34 +1720,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.2):
+  - React-FabricComponents/components/inputaccessory (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1774,7 +1747,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.81.2):
+  - React-FabricComponents/components/iostextinput (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1801,7 +1774,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.2):
+  - React-FabricComponents/components/modal (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1828,7 +1801,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.2):
+  - React-FabricComponents/components/rncore (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1855,7 +1828,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.2):
+  - React-FabricComponents/components/safeareaview (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1882,7 +1855,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.81.2):
+  - React-FabricComponents/components/scrollview (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1909,7 +1882,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.81.2):
+  - React-FabricComponents/components/switch (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1936,7 +1909,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.2):
+  - React-FabricComponents/components/text (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1963,7 +1936,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.2):
+  - React-FabricComponents/components/textinput (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1990,7 +1963,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.2):
+  - React-FabricComponents/components/unimplementedview (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2017,7 +1990,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.2):
+  - React-FabricComponents/components/virtualview (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2044,7 +2017,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.81.2):
+  - React-FabricComponents/textlayoutmanager (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2053,21 +2026,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.81.2)
-    - RCTTypeSafety (= 0.81.2)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.81.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.81.3)
+    - RCTTypeSafety (= 0.81.3)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.2)
+    - React-jsiexecutor (= 0.81.3)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.81.2):
+  - React-featureflags (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2076,7 +2076,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.81.2):
+  - React-featureflagsnativemodule (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2091,7 +2091,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.81.2):
+  - React-graphics (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2104,7 +2104,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.81.2):
+  - React-hermes (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2113,16 +2113,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
     - React-jsi
-    - React-jsiexecutor (= 0.81.2)
+    - React-jsiexecutor (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.2)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.81.2):
+  - React-idlecallbacksnativemodule (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2138,7 +2138,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.81.2):
+  - React-ImageManager (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2153,7 +2153,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.81.2):
+  - React-jserrorhandler (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2168,7 +2168,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.81.2):
+  - React-jsi (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2178,7 +2178,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.81.2):
+  - React-jsiexecutor (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2187,15 +2187,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.2)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.81.2):
+  - React-jsinspector (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2210,10 +2210,10 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.81.2)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.81.2):
+  - React-jsinspectorcdp (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2222,7 +2222,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.81.2):
+  - React-jsinspectornetwork (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2235,7 +2235,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.81.2):
+  - React-jsinspectortracing (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2246,7 +2246,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.81.2):
+  - React-jsitooling (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2254,16 +2254,16 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.81.2):
+  - React-jsitracing (0.81.3):
     - React-jsi
-  - React-logger (0.81.2):
+  - React-logger (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2272,7 +2272,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.81.2):
+  - React-Mapbuffer (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2282,7 +2282,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.81.2):
+  - React-microtasksnativemodule (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2621,7 +2621,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.81.2):
+  - React-NativeModulesApple (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2641,8 +2641,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.81.2)
-  - React-perflogger (0.81.2):
+  - React-oscompat (0.81.3)
+  - React-perflogger (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2651,7 +2651,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.81.2):
+  - React-performancetimeline (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2664,9 +2664,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.81.2):
-    - React-Core/RCTActionSheetHeaders (= 0.81.2)
-  - React-RCTAnimation (0.81.2):
+  - React-RCTActionSheet (0.81.3):
+    - React-Core/RCTActionSheetHeaders (= 0.81.3)
+  - React-RCTAnimation (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2682,7 +2682,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.81.2):
+  - React-RCTAppDelegate (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2716,7 +2716,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.81.2):
+  - React-RCTBlob (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2735,7 +2735,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.81.2):
+  - React-RCTFabric (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2770,7 +2770,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.2):
+  - React-RCTFBReactNativeSpec (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2784,10 +2784,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.2)
+    - React-RCTFBReactNativeSpec/components (= 0.81.3)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.81.2):
+  - React-RCTFBReactNativeSpec/components (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2810,7 +2810,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.81.2):
+  - React-RCTImage (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2826,14 +2826,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.81.2):
-    - React-Core/RCTLinkingHeaders (= 0.81.2)
-    - React-jsi (= 0.81.2)
+  - React-RCTLinking (0.81.3):
+    - React-Core/RCTLinkingHeaders (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.2)
-  - React-RCTNetwork (0.81.2):
+    - ReactCommon/turbomodule/core (= 0.81.3)
+  - React-RCTNetwork (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2851,7 +2851,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.81.2):
+  - React-RCTRuntime (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2871,7 +2871,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.81.2):
+  - React-RCTSettings (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2886,10 +2886,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.81.2):
-    - React-Core/RCTTextHeaders (= 0.81.2)
+  - React-RCTText (0.81.3):
+    - React-Core/RCTTextHeaders (= 0.81.3)
     - Yoga
-  - React-RCTVibration (0.81.2):
+  - React-RCTVibration (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2903,11 +2903,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.81.2)
-  - React-renderercss (0.81.2):
+  - React-rendererconsistency (0.81.3)
+  - React-renderercss (0.81.3):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.2):
+  - React-rendererdebug (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2917,7 +2917,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.81.2):
+  - React-RuntimeApple (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2946,7 +2946,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.81.2):
+  - React-RuntimeCore (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2968,7 +2968,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.81.2):
+  - React-runtimeexecutor (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2978,10 +2978,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.2)
+    - React-jsi (= 0.81.3)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.81.2):
+  - React-RuntimeHermes (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3002,7 +3002,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.81.2):
+  - React-runtimescheduler (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3024,9 +3024,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.81.2):
+  - React-timing (0.81.3):
     - React-debug
-  - React-utils (0.81.2):
+  - React-utils (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3036,11 +3036,11 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.81.2)
+    - React-jsi (= 0.81.3)
     - SocketRocket
-  - ReactAppDependencyProvider (0.81.2):
+  - ReactAppDependencyProvider (0.81.3):
     - ReactCodegen
-  - ReactCodegen (0.81.2):
+  - ReactCodegen (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3066,7 +3066,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.81.2):
+  - ReactCommon (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3074,9 +3074,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.81.2)
+    - ReactCommon/turbomodule (= 0.81.3)
     - SocketRocket
-  - ReactCommon/turbomodule (0.81.2):
+  - ReactCommon/turbomodule (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3085,15 +3085,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.2)
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
-    - ReactCommon/turbomodule/bridging (= 0.81.2)
-    - ReactCommon/turbomodule/core (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
+    - ReactCommon/turbomodule/bridging (= 0.81.3)
+    - ReactCommon/turbomodule/core (= 0.81.3)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.81.2):
+  - ReactCommon/turbomodule/bridging (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3102,13 +3102,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.2)
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.81.2):
+  - ReactCommon/turbomodule/core (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -3117,14 +3117,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.2)
-    - React-cxxreact (= 0.81.2)
-    - React-debug (= 0.81.2)
-    - React-featureflags (= 0.81.2)
-    - React-jsi (= 0.81.2)
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
-    - React-utils (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
+    - React-cxxreact (= 0.81.3)
+    - React-debug (= 0.81.3)
+    - React-featureflags (= 0.81.3)
+    - React-jsi (= 0.81.3)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
+    - React-utils (= 0.81.3)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -4308,7 +4308,7 @@ SPEC CHECKSUMS:
   EXUpdates: 8a7b18d0ca4f2e59a486bc6472fb9bed6df00ba5
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: 89a8574f4a4ea67295ad2e8f84b764e4b1162f64
+  FBLazyVector: a80c331df9c6958a9cc391631578602b7973b0c7
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
   FirebaseCore: 2321536f9c423b1f857e047a82b8a42abc6d9e2c
   FirebaseCoreExtension: 3a64994969dd05f4bcb7e6896c654eded238e75b
@@ -4324,7 +4324,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: fef68fd284c6543da58c333a888adeba82c791d6
+  hermes-engine: cf8e3fb394a4e695b94337d047b0510b2834caea
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4337,39 +4337,39 @@ SPEC CHECKSUMS:
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: b60b889eafa75f46c3d6be5332681efbb16ad0c7
-  RCTRequired: fbdcc9ee2826c0a2ed5bd77a8375b3613d087e99
-  RCTTypeSafety: e1fa82493c521eba295c7ed0d2de80e3d4f22853
+  RCTDeprecation: 78aa7764dbddbc2c87060d26a3ab19fb65dad4ce
+  RCTRequired: df28d0769df9b6ace47200ac80095f9dffba555d
+  RCTTypeSafety: ffa3fa28228934f05db6d9d31dc746542fc447e0
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 7cee6da22b893d581d51397032d4a3951c03cb17
-  React-callinvoker: 58d4d5a586a1523752a9fa58ef3fc6d0b7fbcbad
-  React-Core: 2a00139af1a13cd5d6234b96024c2e8c609c0486
-  React-CoreModules: 544ebf2a4ef99090ab5f26d3f44e693def986f2f
-  React-cxxreact: 3c2ff1c8c1739ba3827d50c844e7a0e1da2bbd45
-  React-debug: f86bd380de1d8bc8a3ba13eed20f7a7c10290e3a
-  React-defaultsnativemodule: 190bd39694d6b04ed6ff3c6127dab92e3465c99b
-  React-domnativemodule: 160a6555391b13810e633991626c0547c8bffa0f
-  React-Fabric: 1fb8455cf7fc6089aa4e96c4307bd1b7cc1915ca
-  React-FabricComponents: cf05fb1b9a1a16ca700f58c7ab60c1c0d494fe05
-  React-FabricImage: 79676806e07bedf45ecb401242fec00712b95ca2
-  React-featureflags: 7f31869ec867c45a93b93d9079b62d7bfbc29a3c
-  React-featureflagsnativemodule: 31cf067d284d1e5843a810218e57fe9342173b2f
-  React-graphics: c065f94afba7661e192ea8a48e19bcc8fccfb5f6
-  React-hermes: 05f8be1795884b94a4a79deafbd306fde2ac1218
-  React-idlecallbacksnativemodule: 31f3701cdf8cac09cead1115971fc1198a07a923
-  React-ImageManager: 121af59488820720d1158cdd8ae6478b622b2575
-  React-jserrorhandler: eee16d033dc7fc73f4b57a1d038905e4ce8e05e5
-  React-jsi: ff804868b503f2f7ed5f8b7bb780cd036c79a806
-  React-jsiexecutor: d489788717a8577e65c992a352a8fbaa4f699d5c
-  React-jsinspector: 965088adbcd1a3d907cdff2d5b0c840112cdbfb7
-  React-jsinspectorcdp: 2718e82fd69b9ff77b7795f3a99964690f7bd0bd
-  React-jsinspectornetwork: 92a5da5a8c77806d52de3a711d8200f9a0eb1c6e
-  React-jsinspectortracing: da0085d4b8976280ebdc8d308c265dd2ad6e8f4f
-  React-jsitooling: ecd194e4a18aa65f9bf9c99285d3d7dc2d77bda9
-  React-jsitracing: 57cc77243a7feb4c7b851a51ac18261846a51251
-  React-logger: 3d3d703c13b7d0130fa3842f836e93794f6b0589
-  React-Mapbuffer: 689ffb875cf6b1cc9b6be7a587c33ac729d84fd4
-  React-microtasksnativemodule: 94d4726672b7f010ce828f87c4c7305796af4e4e
+  React: 639d04fed84b2ff824861d863891eaef7cb92f9c
+  React-callinvoker: adedd891222fbe90849c0bdc8873b9b94f061a03
+  React-Core: 818ff611f7d731b01d8e7f814d6b8e25ae651af2
+  React-CoreModules: 004f4a9ecca043d9904cb5cdecde607b9bd0f0d4
+  React-cxxreact: 68c0b41835c694d86e20e0f61332ef42eabe6606
+  React-debug: e7fa634481419ac0b821224af2113001a997b5f3
+  React-defaultsnativemodule: 2913014b0b8fc3ed6e743b1743e350c1f14e90a3
+  React-domnativemodule: 616f04796884eb2adfb4a1ee83b26dd2eb9788b2
+  React-Fabric: ed41aaa5eec57907dd4770b1e218180aba51d5e2
+  React-FabricComponents: 3f4ffbe0002cc468970dd4069182005c2b5dad6e
+  React-FabricImage: fcfb94a1436d141961c22c0f8cd3f5417a261321
+  React-featureflags: a9ac0c00b03d4cba3352fe8624ace68a51786fe5
+  React-featureflagsnativemodule: 14606b5dcb94600fdf27e0dc3360672a78ec54ec
+  React-graphics: 51c15e35f57310bd2b27468b4cabb0041d42810b
+  React-hermes: 483faa2436b2e7af246be856cc3006d533ee7c97
+  React-idlecallbacksnativemodule: 325aae5afd7b0d14908b6e9827223c05dc9603fb
+  React-ImageManager: 8a4a1689a96f34ae7a5d4bf6f1c2be48aed7c993
+  React-jserrorhandler: e94779f9880d94ab4f88a795b73c14308b917be5
+  React-jsi: c8b25f19c5abc577ef32ab5dacb053e179450d19
+  React-jsiexecutor: 3f7fea04f52f5a58c679be2ffe54a5dc243b219d
+  React-jsinspector: 72bcbd3506d8e9f0e52652c8d2f0857b3a88f8aa
+  React-jsinspectorcdp: b3e25045cb47289e7aabf5c62fa4036d2bd1a734
+  React-jsinspectornetwork: 5758a484c29bb564e20bcd052e3303ea940b8c43
+  React-jsinspectortracing: 301ab935b30dc3b9a649973273aa26e88d42408c
+  React-jsitooling: a5d9b4202c5d25aaef811c5724a7b085e86d7a40
+  React-jsitracing: 9069c1e77deb443d4b6516e88ef3890328300b9a
+  React-logger: ad9935416f3fee15becd44b7b291a440ea952271
+  React-Mapbuffer: 5311cd406de0076f1ef9373488ef628c7cfd0a66
+  React-microtasksnativemodule: 460d58ae1a1aa90f8d3b743d01e677c7a4a1b89b
   react-native-google-maps: 7cc1184afe41fbd15a3dffd53c924819f6587b69
   react-native-keyboard-controller: 5e209d13d4c5355ddf8c36be3d41b8dfc879cd91
   react-native-maps: ee1e65647460c3d41e778071be5eda10e3da6225
@@ -4381,36 +4381,36 @@ SPEC CHECKSUMS:
   react-native-slider: 30cea7008de785564de2f4fd064f2deb38614a4a
   react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
   react-native-webview: 183e0d1f10b3c61c5ddd70f4ecd46488856a3573
-  React-NativeModulesApple: 1b204ec5f197270987fe27f86b3d34b5d8406631
-  React-oscompat: 1b3446acd10cdfd739655206b912db37f5e5a80f
-  React-perflogger: d8bb76530906ba368ecb8af364e8c2b3252ec5e0
-  React-performancetimeline: 426ca4f701729c67bd4f2883ce779765a3e6d77c
-  React-RCTActionSheet: fc83c5b18f638ba92ad22005da9d82fb1ba29ab4
-  React-RCTAnimation: 645e538d49be0ae77a399379bf6dec65dccc9e53
-  React-RCTAppDelegate: f347f16e726ccc54e9724f5c733e2a642f740588
-  React-RCTBlob: 13e8423a3097e33a230488593c27a6b852d07957
-  React-RCTFabric: 9259a5d52481bc6d96afe953790ee40f7af753a6
-  React-RCTFBReactNativeSpec: 256a5a0a3c23f290fa65fc1d826bd0456e01c657
-  React-RCTImage: 03ef0e56bafd30ebf1e5030c6faf1a96f725b752
-  React-RCTLinking: 392255aec37cf9ed602c602e338f0ee94722fc7c
-  React-RCTNetwork: f4f0d24c4a1b7e7f1a011767231dc8617f8be7ff
-  React-RCTRuntime: d062784c65b50af9c161f9f361f5cde6da490214
-  React-RCTSettings: 2dbfab042c4063c5788e85e0f5b6ea32d9ab32bb
-  React-RCTText: 55cd9cf7c0c7d26aae506ac8570361dd1f5fabdb
-  React-RCTVibration: 8f5a49199ca5ce898e5d785beca39bc0f1a312e8
-  React-rendererconsistency: fb8d9afcedef714822676c17fa47f782eb690ec4
-  React-renderercss: d3a392fa3da45987e03a6080c5c8d390c62e46c5
-  React-rendererdebug: bee210d645c71613eb7464b1f7583813fe7bb34c
-  React-RuntimeApple: c4c64bb5ac6f907c17b20eb7872668a0f7c4b6fd
-  React-RuntimeCore: 4030ecfba4a1b4a4b67a1a83ccf8a2090860e469
-  React-runtimeexecutor: a07fc15d2b8899b5254fc9e3cc35d0b508e5c47f
-  React-RuntimeHermes: ff7f38c58af45f08488d4d39d3163582f3c5ab2e
-  React-runtimescheduler: 814cd8985699d2af1809cf628ae0ef1f1d07630a
-  React-timing: 9919d1154651af97f6191150f5af00f833cf598a
-  React-utils: f95d319648c01fc920c717acfbccad3fe92a8cdf
-  ReactAppDependencyProvider: 319be07ed29c6a24b30b700ebf6f667c9d49a511
-  ReactCodegen: d90c24f0be7cbe9f4b805c95a75f12318724755b
-  ReactCommon: 6753d98e6793890f2d0b1b678592c497bc0987ea
+  React-NativeModulesApple: 56b427e2d317117e81d863a69d4ffc44ad37c283
+  React-oscompat: 16640399a646baeac6baab4264891cc4892eeb56
+  React-perflogger: 5321bb08e84a12b34adcf167197171a5e20b3ef0
+  React-performancetimeline: 28d9871743287f1b18905cc63249fbfdbefa914a
+  React-RCTActionSheet: 4c4adabfd8bc747cf39ed7f3e8691eb060a59ba3
+  React-RCTAnimation: 20aa6c6408ec6772c137242761748b7d2dbf95d2
+  React-RCTAppDelegate: 175b0668a2af125bc0a8f11393e176e6fd8cc01b
+  React-RCTBlob: 485e656d54a6847a48e8c68b4d72f219d0834fe5
+  React-RCTFabric: af3692df504545f19bf8e82bb4b2b222afeaabce
+  React-RCTFBReactNativeSpec: 5a476ef41c53fa0d20bcaec13bb28a557f3d7c69
+  React-RCTImage: 0d35f116486079b66f794e46e480d2707809bf8a
+  React-RCTLinking: 54734cb51443d59a566950be5daf4246820c8322
+  React-RCTNetwork: 3fb5688ab706f8b49ff4c5d5d159bfa6886dc40b
+  React-RCTRuntime: abdb1cd00a95fd3b5f6aeb1638b93177832a6af6
+  React-RCTSettings: 414ff12fe3293533218219ff99b0827f4042ba50
+  React-RCTText: 31e965f779e78999d414ba7f30296bead9d387d5
+  React-RCTVibration: 25224f65ac65d43d81011810a3bf33675024cbb7
+  React-rendererconsistency: 234fcdca03f9380acd8f85bb11c4bcbd6901b3cb
+  React-renderercss: f7924d63bb7d07c7d6364fc89e31b95e67b7bed8
+  React-rendererdebug: acd2b8110e1b52edbd1fec26f9fefd75d314902a
+  React-RuntimeApple: be5cc450a08d6f23103238db9e2c9fc16a628fbb
+  React-RuntimeCore: b2cb88dff0429cfeb1cb964e0a4da4f6647a7da0
+  React-runtimeexecutor: 08274efba84d317b506454edee6c95d3224de8a8
+  React-RuntimeHermes: 3d2bc4c4b6f16752f456514d970030e5a5fd3731
+  React-runtimescheduler: f5e61d19f60707af29f03a36f7ad32b859c5d69b
+  React-timing: 8f044ff70498806e0ac55c1637f641716536c1a2
+  React-utils: b30b0d4f53cf9fbc14cd08c8a11cdfe89317e0de
+  ReactAppDependencyProvider: f9317094ed209f55ecbdd9ba792843cfb1c45c29
+  ReactCodegen: a6420e744af1cdbd291a8e1dca0ae3cf1dc67b06
+  ReactCommon: 66dacee1a7de79afeba15b8174107de347dfbecb
   RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
   RNCMaskedView: 63268de1986a098b5f4d1fb5b1bc1e97fade0aee
   RNCPicker: 6da395ee9db8d67a38c6102d4128b5a0b9ec0e21
@@ -4435,7 +4435,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: 05d4be35b34f821d5ddc8617dee04219f3646253
   StripeUICore: d07bd63a4b53dee8cab4d6f81ce5a7ab3e28511e
   UMAppLoader: 2af2cc05fcaa9851233893c0e3dbc56a99f57e36
-  Yoga: b9dc6c508cca59caf2f7462189a74359c6c680b6
+  Yoga: 6b30b3f0beeeacf5a3fe68af23442196b196959a
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: aaaa821356ecede13bd3ebe65b62ce223458b0fa

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -68,7 +68,7 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "19.1.0",
-    "react-native": "0.81.1",
+    "react-native": "0.81.2",
     "react-native-edge-to-edge": "1.6.0",
     "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~2.28.0",

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -68,7 +68,7 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "19.1.0",
-    "react-native": "0.81.2",
+    "react-native": "0.81.3",
     "react-native-edge-to-edge": "1.6.0",
     "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~2.28.0",

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -9,6 +9,6 @@
     "expo": "~54.0.0-preview.16",
     "expo-clipboard": "~8.0.6",
     "react": "19.1.0",
-    "react-native": "0.81.2"
+    "react-native": "0.81.3"
   }
 }

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -9,6 +9,6 @@
     "expo": "~54.0.0-preview.16",
     "expo-clipboard": "~8.0.6",
     "react": "19.1.0",
-    "react-native": "0.81.1"
+    "react-native": "0.81.2"
   }
 }

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -140,7 +140,7 @@
     "processing-js": "^1.6.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.2",
+    "react-native": "0.81.3",
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.5",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -140,7 +140,7 @@
     "processing-js": "^1.6.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.1",
+    "react-native": "0.81.2",
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.5",

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -432,10 +432,10 @@ PODS:
     - Yoga
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
-  - FBLazyVector (0.81.2)
-  - hermes-engine (0.81.2):
-    - hermes-engine/Pre-built (= 0.81.2)
-  - hermes-engine/Pre-built (0.81.2)
+  - FBLazyVector (0.81.3)
+  - hermes-engine (0.81.3):
+    - hermes-engine/Pre-built (= 0.81.3)
+  - hermes-engine/Pre-built (0.81.3)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -468,32 +468,32 @@ PODS:
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - Quick (7.3.0)
-  - RCTDeprecation (0.81.2)
-  - RCTRequired (0.81.2)
-  - RCTTypeSafety (0.81.2):
-    - FBLazyVector (= 0.81.2)
-    - RCTRequired (= 0.81.2)
-    - React-Core (= 0.81.2)
+  - RCTDeprecation (0.81.3)
+  - RCTRequired (0.81.3)
+  - RCTTypeSafety (0.81.3):
+    - FBLazyVector (= 0.81.3)
+    - RCTRequired (= 0.81.3)
+    - React-Core (= 0.81.3)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.2):
-    - React-Core (= 0.81.2)
-    - React-Core/DevSupport (= 0.81.2)
-    - React-Core/RCTWebSocket (= 0.81.2)
-    - React-RCTActionSheet (= 0.81.2)
-    - React-RCTAnimation (= 0.81.2)
-    - React-RCTBlob (= 0.81.2)
-    - React-RCTImage (= 0.81.2)
-    - React-RCTLinking (= 0.81.2)
-    - React-RCTNetwork (= 0.81.2)
-    - React-RCTSettings (= 0.81.2)
-    - React-RCTText (= 0.81.2)
-    - React-RCTVibration (= 0.81.2)
-  - React-callinvoker (0.81.2)
-  - React-Core (0.81.2):
+  - React (0.81.3):
+    - React-Core (= 0.81.3)
+    - React-Core/DevSupport (= 0.81.3)
+    - React-Core/RCTWebSocket (= 0.81.3)
+    - React-RCTActionSheet (= 0.81.3)
+    - React-RCTAnimation (= 0.81.3)
+    - React-RCTBlob (= 0.81.3)
+    - React-RCTImage (= 0.81.3)
+    - React-RCTLinking (= 0.81.3)
+    - React-RCTNetwork (= 0.81.3)
+    - React-RCTSettings (= 0.81.3)
+    - React-RCTText (= 0.81.3)
+    - React-RCTVibration (= 0.81.3)
+  - React-callinvoker (0.81.3)
+  - React-Core (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.81.2)
+    - React-Core/Default (= 0.81.3)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -508,66 +508,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.81.2):
+  - React-Core-prebuilt (0.81.3):
     - ReactNativeDependencies
-  - React-Core/CoreModulesHeaders (0.81.2):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/Default (0.81.2):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/DevSupport (0.81.2):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default (= 0.81.2)
-    - React-Core/RCTWebSocket (= 0.81.2)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.2):
+  - React-Core/CoreModulesHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -586,7 +529,45 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.2):
+  - React-Core/Default (0.81.3):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/DevSupport (0.81.3):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-Core/Default (= 0.81.3)
+    - React-Core/RCTWebSocket (= 0.81.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -605,7 +586,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.2):
+  - React-Core/RCTAnimationHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -624,7 +605,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.2):
+  - React-Core/RCTBlobHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -643,7 +624,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.2):
+  - React-Core/RCTImageHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -662,7 +643,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.2):
+  - React-Core/RCTLinkingHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -681,7 +662,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.2):
+  - React-Core/RCTNetworkHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -700,7 +681,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.2):
+  - React-Core/RCTSettingsHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -719,7 +700,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.2):
+  - React-Core/RCTTextHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -738,11 +719,11 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTWebSocket (0.81.2):
+  - React-Core/RCTVibrationHeaders (0.81.3):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.81.2)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -757,37 +738,56 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-CoreModules (0.81.2):
-    - RCTTypeSafety (= 0.81.2)
+  - React-Core/RCTWebSocket (0.81.3):
+    - hermes-engine
+    - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/CoreModulesHeaders (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - React-Core/Default (= 0.81.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-CoreModules (0.81.3):
+    - RCTTypeSafety (= 0.81.3)
+    - React-Core-prebuilt
+    - React-Core/CoreModulesHeaders (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.2)
+    - React-RCTImage (= 0.81.3)
     - React-runtimeexecutor
     - ReactCommon
     - ReactNativeDependencies
-  - React-cxxreact (0.81.2):
+  - React-cxxreact (0.81.3):
     - hermes-engine
-    - React-callinvoker (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
     - React-Core-prebuilt
-    - React-debug (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - React-debug (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
-    - React-timing (= 0.81.2)
+    - React-timing (= 0.81.3)
     - ReactNativeDependencies
-  - React-debug (0.81.2)
-  - React-defaultsnativemodule (0.81.2):
+  - React-debug (0.81.3)
+  - React-defaultsnativemodule (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-domnativemodule
@@ -798,7 +798,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - ReactNativeDependencies
-  - React-domnativemodule (0.81.2):
+  - React-domnativemodule (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-Fabric
@@ -812,7 +812,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric (0.81.2):
+  - React-Fabric (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -820,23 +820,23 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.2)
-    - React-Fabric/attributedstring (= 0.81.2)
-    - React-Fabric/bridging (= 0.81.2)
-    - React-Fabric/componentregistry (= 0.81.2)
-    - React-Fabric/componentregistrynative (= 0.81.2)
-    - React-Fabric/components (= 0.81.2)
-    - React-Fabric/consistency (= 0.81.2)
-    - React-Fabric/core (= 0.81.2)
-    - React-Fabric/dom (= 0.81.2)
-    - React-Fabric/imagemanager (= 0.81.2)
-    - React-Fabric/leakchecker (= 0.81.2)
-    - React-Fabric/mounting (= 0.81.2)
-    - React-Fabric/observers (= 0.81.2)
-    - React-Fabric/scheduler (= 0.81.2)
-    - React-Fabric/telemetry (= 0.81.2)
-    - React-Fabric/templateprocessor (= 0.81.2)
-    - React-Fabric/uimanager (= 0.81.2)
+    - React-Fabric/animations (= 0.81.3)
+    - React-Fabric/attributedstring (= 0.81.3)
+    - React-Fabric/bridging (= 0.81.3)
+    - React-Fabric/componentregistry (= 0.81.3)
+    - React-Fabric/componentregistrynative (= 0.81.3)
+    - React-Fabric/components (= 0.81.3)
+    - React-Fabric/consistency (= 0.81.3)
+    - React-Fabric/core (= 0.81.3)
+    - React-Fabric/dom (= 0.81.3)
+    - React-Fabric/imagemanager (= 0.81.3)
+    - React-Fabric/leakchecker (= 0.81.3)
+    - React-Fabric/mounting (= 0.81.3)
+    - React-Fabric/observers (= 0.81.3)
+    - React-Fabric/scheduler (= 0.81.3)
+    - React-Fabric/telemetry (= 0.81.3)
+    - React-Fabric/templateprocessor (= 0.81.3)
+    - React-Fabric/uimanager (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -848,26 +848,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animations (0.81.2):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/attributedstring (0.81.2):
+  - React-Fabric/animations (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -886,7 +867,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/bridging (0.81.2):
+  - React-Fabric/attributedstring (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -905,7 +886,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistry (0.81.2):
+  - React-Fabric/bridging (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -924,7 +905,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistrynative (0.81.2):
+  - React-Fabric/componentregistry (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -943,30 +924,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components (0.81.2):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.2)
-    - React-Fabric/components/root (= 0.81.2)
-    - React-Fabric/components/scrollview (= 0.81.2)
-    - React-Fabric/components/view (= 0.81.2)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.2):
+  - React-Fabric/componentregistrynative (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -985,7 +943,30 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/root (0.81.2):
+  - React-Fabric/components (0.81.3):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.3)
+    - React-Fabric/components/root (= 0.81.3)
+    - React-Fabric/components/scrollview (= 0.81.3)
+    - React-Fabric/components/view (= 0.81.3)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1004,7 +985,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/scrollview (0.81.2):
+  - React-Fabric/components/root (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1023,7 +1004,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/view (0.81.2):
+  - React-Fabric/components/scrollview (0.81.3):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/view (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1044,7 +1044,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric/consistency (0.81.2):
+  - React-Fabric/consistency (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1063,7 +1063,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/core (0.81.2):
+  - React-Fabric/core (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1082,7 +1082,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/dom (0.81.2):
+  - React-Fabric/dom (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1101,7 +1101,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/imagemanager (0.81.2):
+  - React-Fabric/imagemanager (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1120,7 +1120,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/leakchecker (0.81.2):
+  - React-Fabric/leakchecker (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1139,7 +1139,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/mounting (0.81.2):
+  - React-Fabric/mounting (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1158,7 +1158,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers (0.81.2):
+  - React-Fabric/observers (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1166,7 +1166,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.2)
+    - React-Fabric/observers/events (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1178,7 +1178,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers/events (0.81.2):
+  - React-Fabric/observers/events (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1197,7 +1197,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/scheduler (0.81.2):
+  - React-Fabric/scheduler (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1218,7 +1218,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/telemetry (0.81.2):
+  - React-Fabric/telemetry (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1237,7 +1237,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/templateprocessor (0.81.2):
+  - React-Fabric/templateprocessor (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1256,7 +1256,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager (0.81.2):
+  - React-Fabric/uimanager (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1264,7 +1264,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.2)
+    - React-Fabric/uimanager/consistency (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1277,7 +1277,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager/consistency (0.81.2):
+  - React-Fabric/uimanager/consistency (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1297,7 +1297,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-FabricComponents (0.81.2):
+  - React-FabricComponents (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1306,8 +1306,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.2)
-    - React-FabricComponents/textlayoutmanager (= 0.81.2)
+    - React-FabricComponents/components (= 0.81.3)
+    - React-FabricComponents/textlayoutmanager (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1320,7 +1320,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components (0.81.2):
+  - React-FabricComponents/components (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1329,17 +1329,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.2)
-    - React-FabricComponents/components/iostextinput (= 0.81.2)
-    - React-FabricComponents/components/modal (= 0.81.2)
-    - React-FabricComponents/components/rncore (= 0.81.2)
-    - React-FabricComponents/components/safeareaview (= 0.81.2)
-    - React-FabricComponents/components/scrollview (= 0.81.2)
-    - React-FabricComponents/components/switch (= 0.81.2)
-    - React-FabricComponents/components/text (= 0.81.2)
-    - React-FabricComponents/components/textinput (= 0.81.2)
-    - React-FabricComponents/components/unimplementedview (= 0.81.2)
-    - React-FabricComponents/components/virtualview (= 0.81.2)
+    - React-FabricComponents/components/inputaccessory (= 0.81.3)
+    - React-FabricComponents/components/iostextinput (= 0.81.3)
+    - React-FabricComponents/components/modal (= 0.81.3)
+    - React-FabricComponents/components/rncore (= 0.81.3)
+    - React-FabricComponents/components/safeareaview (= 0.81.3)
+    - React-FabricComponents/components/scrollview (= 0.81.3)
+    - React-FabricComponents/components/switch (= 0.81.3)
+    - React-FabricComponents/components/text (= 0.81.3)
+    - React-FabricComponents/components/textinput (= 0.81.3)
+    - React-FabricComponents/components/unimplementedview (= 0.81.3)
+    - React-FabricComponents/components/virtualview (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1352,28 +1352,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.2):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.2):
+  - React-FabricComponents/components/inputaccessory (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1394,7 +1373,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/modal (0.81.2):
+  - React-FabricComponents/components/iostextinput (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1415,7 +1394,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.2):
+  - React-FabricComponents/components/modal (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1436,7 +1415,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.2):
+  - React-FabricComponents/components/rncore (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1457,7 +1436,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.2):
+  - React-FabricComponents/components/safeareaview (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1478,7 +1457,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/switch (0.81.2):
+  - React-FabricComponents/components/scrollview (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1499,7 +1478,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/text (0.81.2):
+  - React-FabricComponents/components/switch (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1520,7 +1499,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.2):
+  - React-FabricComponents/components/text (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1541,7 +1520,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.2):
+  - React-FabricComponents/components/textinput (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1562,7 +1541,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.2):
+  - React-FabricComponents/components/unimplementedview (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1583,7 +1562,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.2):
+  - React-FabricComponents/components/virtualview (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1604,27 +1583,48 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricImage (0.81.2):
+  - React-FabricComponents/textlayoutmanager (0.81.3):
     - hermes-engine
-    - RCTRequired (= 0.81.2)
-    - RCTTypeSafety (= 0.81.2)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - React-FabricImage (0.81.3):
+    - hermes-engine
+    - RCTRequired (= 0.81.3)
+    - RCTTypeSafety (= 0.81.3)
     - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.2)
+    - React-jsiexecutor (= 0.81.3)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-featureflags (0.81.2):
+  - React-featureflags (0.81.3):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-featureflagsnativemodule (0.81.2):
+  - React-featureflagsnativemodule (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1633,26 +1633,26 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-graphics (0.81.2):
+  - React-graphics (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
     - React-jsiexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-hermes (0.81.2):
+  - React-hermes (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
     - React-jsi
-    - React-jsiexecutor (= 0.81.2)
+    - React-jsiexecutor (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.2)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-idlecallbacksnativemodule (0.81.2):
+  - React-idlecallbacksnativemodule (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1662,7 +1662,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-ImageManager (0.81.2):
+  - React-ImageManager (0.81.3):
     - React-Core-prebuilt
     - React-Core/Default
     - React-debug
@@ -1671,7 +1671,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - ReactNativeDependencies
-  - React-jserrorhandler (0.81.2):
+  - React-jserrorhandler (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1680,22 +1680,22 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - ReactNativeDependencies
-  - React-jsi (0.81.2):
+  - React-jsi (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsiexecutor (0.81.2):
+  - React-jsiexecutor (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.2)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspector (0.81.2):
+  - React-jsinspector (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1704,43 +1704,43 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.81.2)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspectorcdp (0.81.2):
+  - React-jsinspectorcdp (0.81.3):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsinspectornetwork (0.81.2):
+  - React-jsinspectornetwork (0.81.3):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectorcdp
     - React-performancetimeline
     - React-timing
     - ReactNativeDependencies
-  - React-jsinspectortracing (0.81.2):
+  - React-jsinspectortracing (0.81.3):
     - React-Core-prebuilt
     - React-oscompat
     - React-timing
     - ReactNativeDependencies
-  - React-jsitooling (0.81.2):
+  - React-jsitooling (0.81.3):
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsitracing (0.81.2):
+  - React-jsitracing (0.81.3):
     - React-jsi
-  - React-logger (0.81.2):
+  - React-logger (0.81.3):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-Mapbuffer (0.81.2):
+  - React-Mapbuffer (0.81.3):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-microtasksnativemodule (0.81.2):
+  - React-microtasksnativemodule (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1748,7 +1748,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-NativeModulesApple (0.81.2):
+  - React-NativeModulesApple (0.81.3):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -1762,20 +1762,20 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-oscompat (0.81.2)
-  - React-perflogger (0.81.2):
+  - React-oscompat (0.81.3)
+  - React-perflogger (0.81.3):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-performancetimeline (0.81.2):
+  - React-performancetimeline (0.81.3):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
     - ReactNativeDependencies
-  - React-RCTActionSheet (0.81.2):
-    - React-Core/RCTActionSheetHeaders (= 0.81.2)
-  - React-RCTAnimation (0.81.2):
+  - React-RCTActionSheet (0.81.3):
+    - React-Core/RCTActionSheetHeaders (= 0.81.3)
+  - React-RCTAnimation (0.81.3):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
@@ -1785,7 +1785,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTAppDelegate (0.81.2):
+  - React-RCTAppDelegate (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1813,7 +1813,7 @@ PODS:
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTBlob (0.81.2):
+  - React-RCTBlob (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
@@ -1826,7 +1826,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFabric (0.81.2):
+  - React-RCTFabric (0.81.3):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -1855,7 +1855,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.2):
+  - React-RCTFBReactNativeSpec (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1863,10 +1863,10 @@ PODS:
     - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.2)
+    - React-RCTFBReactNativeSpec/components (= 0.81.3)
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFBReactNativeSpec/components (0.81.2):
+  - React-RCTFBReactNativeSpec/components (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1883,7 +1883,7 @@ PODS:
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-RCTImage (0.81.2):
+  - React-RCTImage (0.81.3):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTImageHeaders
@@ -1893,14 +1893,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTLinking (0.81.2):
-    - React-Core/RCTLinkingHeaders (= 0.81.2)
-    - React-jsi (= 0.81.2)
+  - React-RCTLinking (0.81.3):
+    - React-Core/RCTLinkingHeaders (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.2)
-  - React-RCTNetwork (0.81.2):
+    - ReactCommon/turbomodule/core (= 0.81.3)
+  - React-RCTNetwork (0.81.3):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
@@ -1912,7 +1912,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTRuntime (0.81.2):
+  - React-RCTRuntime (0.81.3):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -1926,7 +1926,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - ReactNativeDependencies
-  - React-RCTSettings (0.81.2):
+  - React-RCTSettings (0.81.3):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
@@ -1935,10 +1935,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTText (0.81.2):
-    - React-Core/RCTTextHeaders (= 0.81.2)
+  - React-RCTText (0.81.3):
+    - React-Core/RCTTextHeaders (= 0.81.3)
     - Yoga
-  - React-RCTVibration (0.81.2):
+  - React-RCTVibration (0.81.3):
     - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
@@ -1946,15 +1946,15 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-rendererconsistency (0.81.2)
-  - React-renderercss (0.81.2):
+  - React-rendererconsistency (0.81.3)
+  - React-renderercss (0.81.3):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.2):
+  - React-rendererdebug (0.81.3):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-RuntimeApple (0.81.2):
+  - React-RuntimeApple (0.81.3):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -1977,7 +1977,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeCore (0.81.2):
+  - React-RuntimeCore (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1993,14 +1993,14 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-runtimeexecutor (0.81.2):
+  - React-runtimeexecutor (0.81.3):
     - React-Core-prebuilt
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.2)
+    - React-jsi (= 0.81.3)
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeHermes (0.81.2):
+  - React-RuntimeHermes (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -2015,7 +2015,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-runtimescheduler (0.81.2):
+  - React-runtimescheduler (0.81.3):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2031,17 +2031,17 @@ PODS:
     - React-timing
     - React-utils
     - ReactNativeDependencies
-  - React-timing (0.81.2):
+  - React-timing (0.81.3):
     - React-debug
-  - React-utils (0.81.2):
+  - React-utils (0.81.3):
     - hermes-engine
     - React-Core-prebuilt
     - React-debug
-    - React-jsi (= 0.81.2)
+    - React-jsi (= 0.81.3)
     - ReactNativeDependencies
-  - ReactAppDependencyProvider (0.81.2):
+  - ReactAppDependencyProvider (0.81.3):
     - ReactCodegen
-  - ReactCodegen (0.81.2):
+  - ReactCodegen (0.81.3):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2061,43 +2061,43 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactCommon (0.81.2):
+  - ReactCommon (0.81.3):
     - React-Core-prebuilt
-    - ReactCommon/turbomodule (= 0.81.2)
+    - ReactCommon/turbomodule (= 0.81.3)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule (0.81.2):
+  - ReactCommon/turbomodule (0.81.3):
     - hermes-engine
-    - React-callinvoker (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
-    - ReactCommon/turbomodule/bridging (= 0.81.2)
-    - ReactCommon/turbomodule/core (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
+    - ReactCommon/turbomodule/bridging (= 0.81.3)
+    - ReactCommon/turbomodule/core (= 0.81.3)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/bridging (0.81.2):
+  - ReactCommon/turbomodule/bridging (0.81.3):
     - hermes-engine
-    - React-callinvoker (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/core (0.81.2):
+  - ReactCommon/turbomodule/core (0.81.3):
     - hermes-engine
-    - React-callinvoker (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.2)
-    - React-debug (= 0.81.2)
-    - React-featureflags (= 0.81.2)
-    - React-jsi (= 0.81.2)
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
-    - React-utils (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
+    - React-debug (= 0.81.3)
+    - React-featureflags (= 0.81.3)
+    - React-jsi (= 0.81.3)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
+    - React-utils (= 0.81.3)
     - ReactNativeDependencies
-  - ReactNativeDependencies (0.81.2)
+  - ReactNativeDependencies (0.81.3)
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
   - SDWebImage/Core (5.21.0)
@@ -2422,84 +2422,84 @@ SPEC CHECKSUMS:
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
   EXUpdates: acd31e646f9ca7e4efb3747b590210f297ec6938
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
-  FBLazyVector: 77485268e564ddf67fa5045947653a87b4531a47
-  hermes-engine: ceacb56b83367e3c4f7ed5ab0e93f92a89e4575b
+  FBLazyVector: d06087501b6a425c222a186e94ce92aa4d3fb37c
+  hermes-engine: 5463d3c4a8a0d35701605934008f34c171ce71d5
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
-  RCTDeprecation: 4d678ef4dca05565072e9ceace59e4fb8a33da81
-  RCTRequired: 35279f87ab747ff65303485f0ea3b92c508fddff
-  RCTTypeSafety: c8de06496c6ce0f746b56dbc5bfc299dcfa5b008
+  RCTDeprecation: 0b7e84477d8780fc8dff04fc1ec89cb93f8f5c04
+  RCTRequired: 497c1356844e5e95975ff2259bedc2db446c4ed0
+  RCTTypeSafety: 6105baaba5a22b1ff4f2e420eda172aa423acd01
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 7cee6da22b893d581d51397032d4a3951c03cb17
-  React-callinvoker: 5ea70569ceece01e1996c85f9cb1c689bec71c9b
-  React-Core: 6d23dc59f228c62ee15e993311c2942d304624c2
-  React-Core-prebuilt: 1ce36105edd4c579e7117f97ba65ad1ba583e517
-  React-CoreModules: 1f20825829502f28e2bdda25cc0ea2adcb8164e0
-  React-cxxreact: a1bf41dddce13a969c427b3ec81f66254d312775
-  React-debug: d860c135c213f12e841342ff2a6c14d5afb9e419
-  React-defaultsnativemodule: 470b797179649c6b2950e2f71503fc8a7f753878
-  React-domnativemodule: 360dff03a2974551afcd7a0e0f3da7febbcd4950
-  React-Fabric: d474e965ca02954854b77279c33a41e38feb1cfb
-  React-FabricComponents: e6d1b0189c68f1d4e18d20a18d2b2c23ba7faa65
-  React-FabricImage: 5b2da3539c4b4d55f9e9c20acf49ab642eddc457
-  React-featureflags: 63125b1d5ee27579ffee872d4a8980f044733935
-  React-featureflagsnativemodule: ff9aeb43ede668b8e04c36c7f10ea2b3d7a03a7f
-  React-graphics: c2d8b4eec2c4fd73b2cc141c992e7149b4220844
-  React-hermes: 198b38686a436f2fba3f605ac3fb55fea9dba4b3
-  React-idlecallbacksnativemodule: 4a640d71f7e4c75a36b0e138a196c4f7bb11b377
-  React-ImageManager: 1bb91c56c3bedd9abe7b029c4b5dd7f80a66b0f2
-  React-jserrorhandler: 4ac198ede40dd986f3efd7986cafad19f099e32c
-  React-jsi: 7d41c57eaac52e6279145e942ebdc5246c5f4ab0
-  React-jsiexecutor: 4435b1ad246cacd0be474f314764280fd41307bf
-  React-jsinspector: 51599b1c435be9b3936e1114499c6110852f4d75
-  React-jsinspectorcdp: 1bbbe3c04751c10333ee1fe939d97055bb10725a
-  React-jsinspectornetwork: c3dbe28b67ead6b3abdc569e3dafcfd8fca7ac5f
-  React-jsinspectortracing: 70368406508ecfa2ce6b929858f1a8ed8493282d
-  React-jsitooling: 5fa9819f41fff7ea081406b4462dc9d4b38e7bbd
-  React-jsitracing: 87af8fac96118ed50def3ca0e52635598ef8ae8d
-  React-logger: 51cdc4a1f7f534b535b461644ebba9fdbc0baf4c
-  React-Mapbuffer: 67755dc0cb0647ad6294a3bc02181d9daf08b17f
-  React-microtasksnativemodule: cd10fe63b700365a362d750f0a8c94cff59eeebb
-  React-NativeModulesApple: bd258b9485e456d84f9584523ad3c3c8ba0b51e9
-  React-oscompat: ade00f2748c52568bec65682448d74fe6df6f2d3
-  React-perflogger: 7899e64980a940a71005d4752fc03dd4e61d4247
-  React-performancetimeline: 31b6d62cb743fc136117fd5f221c75bb3a282276
-  React-RCTActionSheet: ffab08a04e6fe47dbb6623ae950427ce61b1df47
-  React-RCTAnimation: 5db15314c4528647a6419c3ab3482044549bc722
-  React-RCTAppDelegate: d07b00d43ce1f6e947da3a2ff660147d4e82f909
-  React-RCTBlob: 8251a93151631fc7a6446e756771288e01bb4fea
-  React-RCTFabric: 62aad1b3308a341658ecfc74e83f1b95f0dbb024
-  React-RCTFBReactNativeSpec: 6c671dbc26713886f91c071e7e27f7fdcdcc5420
-  React-RCTImage: 2ac66fd27553f56f551aaa565204f8e822c1abb0
-  React-RCTLinking: 5720f30f765a2bbbd79f4b0b97c04a60924ad0e6
-  React-RCTNetwork: 3082a19df28509afcc2e48709769a784050c0d23
-  React-RCTRuntime: 7ee4a2b7d9a270a1b9e0675fa49811f64c6863ad
-  React-RCTSettings: cd54e1057599bf6df23f1aeec073de182c90e9e5
-  React-RCTText: ea2ae68038930a06276807c742afa37cfd811e29
-  React-RCTVibration: c7acf3d6c345182887f1d4765623bfd2d4a723c0
-  React-rendererconsistency: bc382ce33dfa11ea371c1174db34c56c897aa3e3
-  React-renderercss: e047767f4219d999efd4588321b1fc14f6f6e18a
-  React-rendererdebug: 22dda44f8931d67a93efcb47f9e89bf3e46f1271
-  React-RuntimeApple: c9ccccc3c3e1c819d66b7b99ee79af7eb3985e50
-  React-RuntimeCore: cda0561ca45e6c282d16527f5e3339a956599fe0
-  React-runtimeexecutor: 94f916248385c0006c83f51d2a33fa40f8dfb5de
-  React-RuntimeHermes: 26f08e51bbac484fa5e0f88f40c4a27ed14d1f77
-  React-runtimescheduler: bd29b8e1664b5b1859fe602a9148d7a619fd7ac3
-  React-timing: 990f6836757f7fe69e5b97b18435b815aac7f046
-  React-utils: 409fa5cb4574fa1c0f8002a463518b63c69fea83
-  ReactAppDependencyProvider: 319be07ed29c6a24b30b700ebf6f667c9d49a511
-  ReactCodegen: ebd6a570d0441312bbd19b817ad1324fb0a41bb9
-  ReactCommon: 5cabaa414dfa310990a62264693d4f8e61b88fdf
-  ReactNativeDependencies: 316e0ff865f50a287726f6b002c607f90ad878fb
+  React: 639d04fed84b2ff824861d863891eaef7cb92f9c
+  React-callinvoker: 9eff267e8435b7ab377acf16a64d69e897f35c25
+  React-Core: 114001953b5444cc62d652d0afdda9eefdba5362
+  React-Core-prebuilt: 39d0f778d6e21201895baec61c746843d1392984
+  React-CoreModules: 08308a974bbce620cb3abac6e2761a5245c96621
+  React-cxxreact: 302ece9f2b119a875a0d9d22dffb57557394e242
+  React-debug: 9c09818ae432a10ab72c973b727b944b75ccadb9
+  React-defaultsnativemodule: 4955e87b2b0ee8be90625b579658c57b04438cb4
+  React-domnativemodule: af79168a06f4da71b515ee63fa94072a395fd2a7
+  React-Fabric: 0f1cb599f71d2749a6aac92b07d243afaf8b5fb4
+  React-FabricComponents: 831e1af20196101467532a1e9947070a57b30f8f
+  React-FabricImage: 0cb0f9c8b0f58cc3ab21d9bcb02c5580de33ea19
+  React-featureflags: 50f6c269087123f68c5f3b7f1c5847a7328e4713
+  React-featureflagsnativemodule: 4fd687c47b7d68ee45ae39bc2d3bfc087292d8d4
+  React-graphics: 85d61c25ad0e2feb82703d830cb5f1447f26776c
+  React-hermes: 06fd40f5d8ca9cc60247f08feac9c2e4b5a11caa
+  React-idlecallbacksnativemodule: 7bc42c314257dfe112330afb3d63bffe0c712968
+  React-ImageManager: a93bb2a53c7f69b49feb13731c1dfe76cd123cd6
+  React-jserrorhandler: 7a10f7236723aec83dd81db9e22ab453a0ec4a01
+  React-jsi: 4867a7cc7638c5580f6bcc5af6009e5e53efc216
+  React-jsiexecutor: c22b20b5a1615878cfdaa7a1d0bfd363d3f34728
+  React-jsinspector: 233b55315afc9c5c46ba8a28b5ac70a1d844cb29
+  React-jsinspectorcdp: 085d8c4f96335f897cde933f06254cc9ed33040e
+  React-jsinspectornetwork: 7cb1c98c63979c9fe5d1e10660368ef86227bbd1
+  React-jsinspectortracing: 52d2b1534cdd7c01f8bf20921522b747d68d9ef8
+  React-jsitooling: 5e888c5c6f24e48e1978535a70e2296a57b21549
+  React-jsitracing: da1c7edd78c35dfdf7e26111888894ff9dec7880
+  React-logger: 793cf0a405596fc047e192f9e9b2f0565c8b97d9
+  React-Mapbuffer: 82cd04b7e0f4ee713fd848bd41f004659e82301e
+  React-microtasksnativemodule: 7604bc6677ca1c9c184ac217952394d6dc5534dc
+  React-NativeModulesApple: dc4d40310448a70b2a7b25f7280a501150b88fe2
+  React-oscompat: 94245768a4c9e912776373255e9b9497d634b284
+  React-perflogger: e58b0e28f1ee95e99e330dcde8b0beb710199e10
+  React-performancetimeline: a770d9c95f897c07e35f43247afc16c7b569737f
+  React-RCTActionSheet: dee4c5e267ec056f5ef912196a856df035e685ff
+  React-RCTAnimation: e3a5ce2e53f482e2daa2f8f43468abdbe0260c76
+  React-RCTAppDelegate: 4c9bcaaad7af57c5dd97561dba236d5a3baecd20
+  React-RCTBlob: 062da7c13848cc643589becc7b190900ad7e2499
+  React-RCTFabric: 37f875131330036c090d6b01f21b5285dee77757
+  React-RCTFBReactNativeSpec: 354e6cc4e681eb0f8cda9571d7a2fd00d6674b29
+  React-RCTImage: d32d7056068751e45b383561705bac719dedcbc7
+  React-RCTLinking: add103c480ae3f1d6fdbead7ecfa22eb6dbb1c4a
+  React-RCTNetwork: 0e3cc2664d73e11b3b97a8f7d318fa1034328394
+  React-RCTRuntime: 40092cdd126b1d3a2f240e13e94f36fdf8a4a05f
+  React-RCTSettings: ac3ea5b32e8542c7eac0701305214815594cb188
+  React-RCTText: 4d1c4ddab66b6170977a695348cdb0f989005192
+  React-RCTVibration: 20ec75d11d2cd2cecf82772a7d5101af20d2a322
+  React-rendererconsistency: 9cbc91c7a1890be02c2279ddf3f539dc24d0cdf7
+  React-renderercss: 6a9d220ffda31f005fbe2021633481c9343e603c
+  React-rendererdebug: 6531aa831f830e03b456469cfe3c1e4c8b98baf6
+  React-RuntimeApple: c0d858b8fe462ec9c435fd130348b7e89b6932fa
+  React-RuntimeCore: 3f868e7a500bcf5bc30fc0e6edb1e54e12b220ce
+  React-runtimeexecutor: 918598152c33b701821e0b9cb16472badbf23b3e
+  React-RuntimeHermes: ffb292bf8a08a3c674ee213c6bfe0ee3e2ae528d
+  React-runtimescheduler: d57929ce939bd518243e42614f9a95add27ba6f7
+  React-timing: cf0652d4c8a5bf1c48aef5b70eb3fa6f50c7f2ac
+  React-utils: 4687ee48d76381ceb583479fbc7026eae8adc744
+  ReactAppDependencyProvider: f9317094ed209f55ecbdd9ba792843cfb1c45c29
+  ReactCodegen: 973950553b2de05c8a261402b5034336207dee6b
+  ReactCommon: c7ad14babdb12b84989965987f87baebe062e6a5
+  ReactNativeDependencies: 1d2c24fee8694aaf7cf5589288418cd78a24ec19
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  Yoga: 82e60295fd61743ed3c218e3873faf184646f99a
+  Yoga: f9025ab908f89228f6ab399c59bfcc334b53a734
 
 PODFILE CHECKSUM: 7b324c13881703a862f70f400c68133d3b5568d5
 

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -1,22 +1,22 @@
 PODS:
-  - EASClient (1.0.5):
+  - EASClient (1.0.6):
     - ExpoModulesCore
-  - EASClient/Tests (1.0.5):
+  - EASClient/Tests (1.0.6):
     - ExpoModulesCore
     - ExpoModulesTestCore
   - EXJSONUtils (0.15.0)
   - EXJSONUtils/Tests (0.15.0)
-  - EXManifests (1.0.6):
+  - EXManifests (1.0.7):
     - ExpoModulesCore
-  - EXManifests/Tests (1.0.6):
-    - ExpoModulesCore
-    - ExpoModulesTestCore
-  - EXNotifications (0.32.7):
-    - ExpoModulesCore
-  - EXNotifications/Tests (0.32.7):
+  - EXManifests/Tests (1.0.7):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - Expo (54.0.0-preview.12):
+  - EXNotifications (0.32.10):
+    - ExpoModulesCore
+  - EXNotifications/Tests (0.32.10):
+    - ExpoModulesCore
+    - ExpoModulesTestCore
+  - Expo (54.0.0-preview.16):
     - ExpoModulesCore
     - hermes-engine
     - RCTRequired
@@ -41,9 +41,9 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-launcher (6.0.8):
+  - expo-dev-launcher (6.0.10):
     - EXManifests
-    - expo-dev-launcher/Main (= 6.0.8)
+    - expo-dev-launcher/Main (= 6.0.10)
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -72,7 +72,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-launcher/Main (6.0.8):
+  - expo-dev-launcher/Main (6.0.10):
     - EXManifests
     - expo-dev-launcher/Unsafe
     - expo-dev-menu
@@ -103,7 +103,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-launcher/Tests (6.0.8):
+  - expo-dev-launcher/Tests (6.0.10):
     - EXManifests
     - expo-dev-menu
     - expo-dev-menu-interface
@@ -138,7 +138,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-launcher/Unsafe (6.0.8):
+  - expo-dev-launcher/Unsafe (6.0.10):
     - EXManifests
     - expo-dev-menu
     - expo-dev-menu-interface
@@ -168,9 +168,9 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-menu (7.0.7):
-    - expo-dev-menu/Main (= 7.0.7)
-    - expo-dev-menu/ReactNativeCompatibles (= 7.0.7)
+  - expo-dev-menu (7.0.9):
+    - expo-dev-menu/Main (= 7.0.9)
+    - expo-dev-menu/ReactNativeCompatibles (= 7.0.9)
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -193,7 +193,7 @@ PODS:
     - ReactNativeDependencies
     - Yoga
   - expo-dev-menu-interface (2.0.0)
-  - expo-dev-menu/Main (7.0.7):
+  - expo-dev-menu/Main (7.0.9):
     - EXManifests
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -219,7 +219,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-menu/ReactNativeCompatibles (7.0.7):
+  - expo-dev-menu/ReactNativeCompatibles (7.0.9):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -241,7 +241,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-menu/Tests (7.0.7):
+  - expo-dev-menu/Tests (7.0.9):
     - ExpoModulesTestCore
     - hermes-engine
     - Nimble
@@ -267,7 +267,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-menu/UITests (7.0.7):
+  - expo-dev-menu/UITests (7.0.9):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -292,19 +292,19 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - ExpoClipboard (8.0.5):
+  - ExpoClipboard (8.0.6):
     - ExpoModulesCore
-  - ExpoClipboard/Tests (8.0.5):
+  - ExpoClipboard/Tests (8.0.6):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - ExpoImage (3.0.5):
+  - ExpoImage (3.0.7):
     - ExpoModulesCore
     - libavif/libdav1d
     - SDWebImage (~> 5.21.0)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
     - SDWebImageWebPCoder (~> 0.14.6)
-  - ExpoImage/Tests (3.0.5):
+  - ExpoImage/Tests (3.0.7):
     - ExpoModulesCore
     - ExpoModulesTestCore
     - libavif/libdav1d
@@ -312,14 +312,14 @@ PODS:
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
     - SDWebImageWebPCoder (~> 0.14.6)
-  - ExpoMediaLibrary (18.0.5):
+  - ExpoMediaLibrary (18.1.0):
     - ExpoModulesCore
     - React-Core
-  - ExpoMediaLibrary/Tests (18.0.5):
+  - ExpoMediaLibrary/Tests (18.1.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
     - React-Core
-  - ExpoModulesCore (3.0.10):
+  - ExpoModulesCore (3.0.14):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -342,7 +342,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - ExpoModulesCore/Tests (3.0.10):
+  - ExpoModulesCore/Tests (3.0.14):
     - ExpoModulesTestCore
     - hermes-engine
     - RCTRequired
@@ -373,7 +373,7 @@ PODS:
     - React-hermes
   - EXStructuredHeaders (5.0.0)
   - EXStructuredHeaders/Tests (5.0.0)
-  - EXUpdates (29.0.7):
+  - EXUpdates (29.0.8):
     - EASClient
     - EXManifests
     - ExpoModulesCore
@@ -401,7 +401,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - EXUpdates/Tests (29.0.7):
+  - EXUpdates/Tests (29.0.8):
     - EASClient
     - EXManifests
     - ExpoModulesCore
@@ -432,10 +432,10 @@ PODS:
     - Yoga
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
-  - FBLazyVector (0.81.1)
-  - hermes-engine (0.81.1):
-    - hermes-engine/Pre-built (= 0.81.1)
-  - hermes-engine/Pre-built (0.81.1)
+  - FBLazyVector (0.81.2)
+  - hermes-engine (0.81.2):
+    - hermes-engine/Pre-built (= 0.81.2)
+  - hermes-engine/Pre-built (0.81.2)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -468,32 +468,32 @@ PODS:
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - Quick (7.3.0)
-  - RCTDeprecation (0.81.1)
-  - RCTRequired (0.81.1)
-  - RCTTypeSafety (0.81.1):
-    - FBLazyVector (= 0.81.1)
-    - RCTRequired (= 0.81.1)
-    - React-Core (= 0.81.1)
+  - RCTDeprecation (0.81.2)
+  - RCTRequired (0.81.2)
+  - RCTTypeSafety (0.81.2):
+    - FBLazyVector (= 0.81.2)
+    - RCTRequired (= 0.81.2)
+    - React-Core (= 0.81.2)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.1):
-    - React-Core (= 0.81.1)
-    - React-Core/DevSupport (= 0.81.1)
-    - React-Core/RCTWebSocket (= 0.81.1)
-    - React-RCTActionSheet (= 0.81.1)
-    - React-RCTAnimation (= 0.81.1)
-    - React-RCTBlob (= 0.81.1)
-    - React-RCTImage (= 0.81.1)
-    - React-RCTLinking (= 0.81.1)
-    - React-RCTNetwork (= 0.81.1)
-    - React-RCTSettings (= 0.81.1)
-    - React-RCTText (= 0.81.1)
-    - React-RCTVibration (= 0.81.1)
-  - React-callinvoker (0.81.1)
-  - React-Core (0.81.1):
+  - React (0.81.2):
+    - React-Core (= 0.81.2)
+    - React-Core/DevSupport (= 0.81.2)
+    - React-Core/RCTWebSocket (= 0.81.2)
+    - React-RCTActionSheet (= 0.81.2)
+    - React-RCTAnimation (= 0.81.2)
+    - React-RCTBlob (= 0.81.2)
+    - React-RCTImage (= 0.81.2)
+    - React-RCTLinking (= 0.81.2)
+    - React-RCTNetwork (= 0.81.2)
+    - React-RCTSettings (= 0.81.2)
+    - React-RCTText (= 0.81.2)
+    - React-RCTVibration (= 0.81.2)
+  - React-callinvoker (0.81.2)
+  - React-Core (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.81.1)
+    - React-Core/Default (= 0.81.2)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -508,66 +508,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.81.1):
+  - React-Core-prebuilt (0.81.2):
     - ReactNativeDependencies
-  - React-Core/CoreModulesHeaders (0.81.1):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/Default (0.81.1):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/DevSupport (0.81.1):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default (= 0.81.1)
-    - React-Core/RCTWebSocket (= 0.81.1)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.1):
+  - React-Core/CoreModulesHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -586,7 +529,45 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.1):
+  - React-Core/Default (0.81.2):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/DevSupport (0.81.2):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-Core/Default (= 0.81.2)
+    - React-Core/RCTWebSocket (= 0.81.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -605,7 +586,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.1):
+  - React-Core/RCTAnimationHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -624,7 +605,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.1):
+  - React-Core/RCTBlobHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -643,7 +624,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.1):
+  - React-Core/RCTImageHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -662,7 +643,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.1):
+  - React-Core/RCTLinkingHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -681,7 +662,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.1):
+  - React-Core/RCTNetworkHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -700,7 +681,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.1):
+  - React-Core/RCTSettingsHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -719,7 +700,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.1):
+  - React-Core/RCTTextHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -738,11 +719,11 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTWebSocket (0.81.1):
+  - React-Core/RCTVibrationHeaders (0.81.2):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.81.1)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -757,37 +738,56 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-CoreModules (0.81.1):
-    - RCTTypeSafety (= 0.81.1)
+  - React-Core/RCTWebSocket (0.81.2):
+    - hermes-engine
+    - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/CoreModulesHeaders (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - React-Core/Default (= 0.81.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-CoreModules (0.81.2):
+    - RCTTypeSafety (= 0.81.2)
+    - React-Core-prebuilt
+    - React-Core/CoreModulesHeaders (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.1)
+    - React-RCTImage (= 0.81.2)
     - React-runtimeexecutor
     - ReactCommon
     - ReactNativeDependencies
-  - React-cxxreact (0.81.1):
+  - React-cxxreact (0.81.2):
     - hermes-engine
-    - React-callinvoker (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
     - React-Core-prebuilt
-    - React-debug (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - React-debug (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
-    - React-timing (= 0.81.1)
+    - React-timing (= 0.81.2)
     - ReactNativeDependencies
-  - React-debug (0.81.1)
-  - React-defaultsnativemodule (0.81.1):
+  - React-debug (0.81.2)
+  - React-defaultsnativemodule (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-domnativemodule
@@ -798,7 +798,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - ReactNativeDependencies
-  - React-domnativemodule (0.81.1):
+  - React-domnativemodule (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-Fabric
@@ -812,7 +812,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric (0.81.1):
+  - React-Fabric (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -820,23 +820,23 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.1)
-    - React-Fabric/attributedstring (= 0.81.1)
-    - React-Fabric/bridging (= 0.81.1)
-    - React-Fabric/componentregistry (= 0.81.1)
-    - React-Fabric/componentregistrynative (= 0.81.1)
-    - React-Fabric/components (= 0.81.1)
-    - React-Fabric/consistency (= 0.81.1)
-    - React-Fabric/core (= 0.81.1)
-    - React-Fabric/dom (= 0.81.1)
-    - React-Fabric/imagemanager (= 0.81.1)
-    - React-Fabric/leakchecker (= 0.81.1)
-    - React-Fabric/mounting (= 0.81.1)
-    - React-Fabric/observers (= 0.81.1)
-    - React-Fabric/scheduler (= 0.81.1)
-    - React-Fabric/telemetry (= 0.81.1)
-    - React-Fabric/templateprocessor (= 0.81.1)
-    - React-Fabric/uimanager (= 0.81.1)
+    - React-Fabric/animations (= 0.81.2)
+    - React-Fabric/attributedstring (= 0.81.2)
+    - React-Fabric/bridging (= 0.81.2)
+    - React-Fabric/componentregistry (= 0.81.2)
+    - React-Fabric/componentregistrynative (= 0.81.2)
+    - React-Fabric/components (= 0.81.2)
+    - React-Fabric/consistency (= 0.81.2)
+    - React-Fabric/core (= 0.81.2)
+    - React-Fabric/dom (= 0.81.2)
+    - React-Fabric/imagemanager (= 0.81.2)
+    - React-Fabric/leakchecker (= 0.81.2)
+    - React-Fabric/mounting (= 0.81.2)
+    - React-Fabric/observers (= 0.81.2)
+    - React-Fabric/scheduler (= 0.81.2)
+    - React-Fabric/telemetry (= 0.81.2)
+    - React-Fabric/templateprocessor (= 0.81.2)
+    - React-Fabric/uimanager (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -848,26 +848,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animations (0.81.1):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/attributedstring (0.81.1):
+  - React-Fabric/animations (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -886,7 +867,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/bridging (0.81.1):
+  - React-Fabric/attributedstring (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -905,7 +886,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistry (0.81.1):
+  - React-Fabric/bridging (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -924,7 +905,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistrynative (0.81.1):
+  - React-Fabric/componentregistry (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -943,30 +924,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components (0.81.1):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.1)
-    - React-Fabric/components/root (= 0.81.1)
-    - React-Fabric/components/scrollview (= 0.81.1)
-    - React-Fabric/components/view (= 0.81.1)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.1):
+  - React-Fabric/componentregistrynative (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -985,7 +943,30 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/root (0.81.1):
+  - React-Fabric/components (0.81.2):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.2)
+    - React-Fabric/components/root (= 0.81.2)
+    - React-Fabric/components/scrollview (= 0.81.2)
+    - React-Fabric/components/view (= 0.81.2)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1004,7 +985,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/scrollview (0.81.1):
+  - React-Fabric/components/root (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1023,7 +1004,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/view (0.81.1):
+  - React-Fabric/components/scrollview (0.81.2):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/view (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1044,7 +1044,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric/consistency (0.81.1):
+  - React-Fabric/consistency (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1063,7 +1063,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/core (0.81.1):
+  - React-Fabric/core (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1082,7 +1082,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/dom (0.81.1):
+  - React-Fabric/dom (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1101,7 +1101,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/imagemanager (0.81.1):
+  - React-Fabric/imagemanager (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1120,7 +1120,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/leakchecker (0.81.1):
+  - React-Fabric/leakchecker (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1139,7 +1139,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/mounting (0.81.1):
+  - React-Fabric/mounting (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1158,7 +1158,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers (0.81.1):
+  - React-Fabric/observers (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1166,7 +1166,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.1)
+    - React-Fabric/observers/events (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1178,7 +1178,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers/events (0.81.1):
+  - React-Fabric/observers/events (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1197,7 +1197,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/scheduler (0.81.1):
+  - React-Fabric/scheduler (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1218,7 +1218,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/telemetry (0.81.1):
+  - React-Fabric/telemetry (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1237,7 +1237,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/templateprocessor (0.81.1):
+  - React-Fabric/templateprocessor (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1256,7 +1256,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager (0.81.1):
+  - React-Fabric/uimanager (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1264,7 +1264,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.1)
+    - React-Fabric/uimanager/consistency (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1277,7 +1277,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager/consistency (0.81.1):
+  - React-Fabric/uimanager/consistency (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1297,7 +1297,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-FabricComponents (0.81.1):
+  - React-FabricComponents (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1306,8 +1306,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.1)
-    - React-FabricComponents/textlayoutmanager (= 0.81.1)
+    - React-FabricComponents/components (= 0.81.2)
+    - React-FabricComponents/textlayoutmanager (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1320,7 +1320,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components (0.81.1):
+  - React-FabricComponents/components (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1329,17 +1329,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.1)
-    - React-FabricComponents/components/iostextinput (= 0.81.1)
-    - React-FabricComponents/components/modal (= 0.81.1)
-    - React-FabricComponents/components/rncore (= 0.81.1)
-    - React-FabricComponents/components/safeareaview (= 0.81.1)
-    - React-FabricComponents/components/scrollview (= 0.81.1)
-    - React-FabricComponents/components/switch (= 0.81.1)
-    - React-FabricComponents/components/text (= 0.81.1)
-    - React-FabricComponents/components/textinput (= 0.81.1)
-    - React-FabricComponents/components/unimplementedview (= 0.81.1)
-    - React-FabricComponents/components/virtualview (= 0.81.1)
+    - React-FabricComponents/components/inputaccessory (= 0.81.2)
+    - React-FabricComponents/components/iostextinput (= 0.81.2)
+    - React-FabricComponents/components/modal (= 0.81.2)
+    - React-FabricComponents/components/rncore (= 0.81.2)
+    - React-FabricComponents/components/safeareaview (= 0.81.2)
+    - React-FabricComponents/components/scrollview (= 0.81.2)
+    - React-FabricComponents/components/switch (= 0.81.2)
+    - React-FabricComponents/components/text (= 0.81.2)
+    - React-FabricComponents/components/textinput (= 0.81.2)
+    - React-FabricComponents/components/unimplementedview (= 0.81.2)
+    - React-FabricComponents/components/virtualview (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1352,28 +1352,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.1):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.1):
+  - React-FabricComponents/components/inputaccessory (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1394,7 +1373,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/modal (0.81.1):
+  - React-FabricComponents/components/iostextinput (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1415,7 +1394,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.1):
+  - React-FabricComponents/components/modal (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1436,7 +1415,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.1):
+  - React-FabricComponents/components/rncore (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1457,7 +1436,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.1):
+  - React-FabricComponents/components/safeareaview (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1478,7 +1457,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/switch (0.81.1):
+  - React-FabricComponents/components/scrollview (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1499,7 +1478,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/text (0.81.1):
+  - React-FabricComponents/components/switch (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1520,7 +1499,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.1):
+  - React-FabricComponents/components/text (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1541,7 +1520,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.1):
+  - React-FabricComponents/components/textinput (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1562,7 +1541,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.1):
+  - React-FabricComponents/components/unimplementedview (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1583,7 +1562,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.1):
+  - React-FabricComponents/components/virtualview (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1604,27 +1583,48 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricImage (0.81.1):
+  - React-FabricComponents/textlayoutmanager (0.81.2):
     - hermes-engine
-    - RCTRequired (= 0.81.1)
-    - RCTTypeSafety (= 0.81.1)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - React-FabricImage (0.81.2):
+    - hermes-engine
+    - RCTRequired (= 0.81.2)
+    - RCTTypeSafety (= 0.81.2)
     - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.1)
+    - React-jsiexecutor (= 0.81.2)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-featureflags (0.81.1):
+  - React-featureflags (0.81.2):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-featureflagsnativemodule (0.81.1):
+  - React-featureflagsnativemodule (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1633,26 +1633,26 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-graphics (0.81.1):
+  - React-graphics (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
     - React-jsiexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-hermes (0.81.1):
+  - React-hermes (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
     - React-jsi
-    - React-jsiexecutor (= 0.81.1)
+    - React-jsiexecutor (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.1)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-idlecallbacksnativemodule (0.81.1):
+  - React-idlecallbacksnativemodule (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1662,7 +1662,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-ImageManager (0.81.1):
+  - React-ImageManager (0.81.2):
     - React-Core-prebuilt
     - React-Core/Default
     - React-debug
@@ -1671,7 +1671,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - ReactNativeDependencies
-  - React-jserrorhandler (0.81.1):
+  - React-jserrorhandler (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1680,22 +1680,22 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - ReactNativeDependencies
-  - React-jsi (0.81.1):
+  - React-jsi (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsiexecutor (0.81.1):
+  - React-jsiexecutor (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.1)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspector (0.81.1):
+  - React-jsinspector (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1704,43 +1704,43 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.81.1)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspectorcdp (0.81.1):
+  - React-jsinspectorcdp (0.81.2):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsinspectornetwork (0.81.1):
+  - React-jsinspectornetwork (0.81.2):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectorcdp
     - React-performancetimeline
     - React-timing
     - ReactNativeDependencies
-  - React-jsinspectortracing (0.81.1):
+  - React-jsinspectortracing (0.81.2):
     - React-Core-prebuilt
     - React-oscompat
     - React-timing
     - ReactNativeDependencies
-  - React-jsitooling (0.81.1):
+  - React-jsitooling (0.81.2):
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsitracing (0.81.1):
+  - React-jsitracing (0.81.2):
     - React-jsi
-  - React-logger (0.81.1):
+  - React-logger (0.81.2):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-Mapbuffer (0.81.1):
+  - React-Mapbuffer (0.81.2):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-microtasksnativemodule (0.81.1):
+  - React-microtasksnativemodule (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1748,7 +1748,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-NativeModulesApple (0.81.1):
+  - React-NativeModulesApple (0.81.2):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -1762,20 +1762,20 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-oscompat (0.81.1)
-  - React-perflogger (0.81.1):
+  - React-oscompat (0.81.2)
+  - React-perflogger (0.81.2):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-performancetimeline (0.81.1):
+  - React-performancetimeline (0.81.2):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
     - ReactNativeDependencies
-  - React-RCTActionSheet (0.81.1):
-    - React-Core/RCTActionSheetHeaders (= 0.81.1)
-  - React-RCTAnimation (0.81.1):
+  - React-RCTActionSheet (0.81.2):
+    - React-Core/RCTActionSheetHeaders (= 0.81.2)
+  - React-RCTAnimation (0.81.2):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
@@ -1785,7 +1785,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTAppDelegate (0.81.1):
+  - React-RCTAppDelegate (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1813,7 +1813,7 @@ PODS:
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTBlob (0.81.1):
+  - React-RCTBlob (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
@@ -1826,7 +1826,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFabric (0.81.1):
+  - React-RCTFabric (0.81.2):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -1855,7 +1855,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.1):
+  - React-RCTFBReactNativeSpec (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1863,10 +1863,10 @@ PODS:
     - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.1)
+    - React-RCTFBReactNativeSpec/components (= 0.81.2)
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFBReactNativeSpec/components (0.81.1):
+  - React-RCTFBReactNativeSpec/components (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1883,7 +1883,7 @@ PODS:
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-RCTImage (0.81.1):
+  - React-RCTImage (0.81.2):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTImageHeaders
@@ -1893,14 +1893,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTLinking (0.81.1):
-    - React-Core/RCTLinkingHeaders (= 0.81.1)
-    - React-jsi (= 0.81.1)
+  - React-RCTLinking (0.81.2):
+    - React-Core/RCTLinkingHeaders (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.1)
-  - React-RCTNetwork (0.81.1):
+    - ReactCommon/turbomodule/core (= 0.81.2)
+  - React-RCTNetwork (0.81.2):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
@@ -1912,7 +1912,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTRuntime (0.81.1):
+  - React-RCTRuntime (0.81.2):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -1926,7 +1926,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - ReactNativeDependencies
-  - React-RCTSettings (0.81.1):
+  - React-RCTSettings (0.81.2):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
@@ -1935,10 +1935,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTText (0.81.1):
-    - React-Core/RCTTextHeaders (= 0.81.1)
+  - React-RCTText (0.81.2):
+    - React-Core/RCTTextHeaders (= 0.81.2)
     - Yoga
-  - React-RCTVibration (0.81.1):
+  - React-RCTVibration (0.81.2):
     - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
@@ -1946,15 +1946,15 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-rendererconsistency (0.81.1)
-  - React-renderercss (0.81.1):
+  - React-rendererconsistency (0.81.2)
+  - React-renderercss (0.81.2):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.1):
+  - React-rendererdebug (0.81.2):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-RuntimeApple (0.81.1):
+  - React-RuntimeApple (0.81.2):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -1977,7 +1977,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeCore (0.81.1):
+  - React-RuntimeCore (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1993,14 +1993,14 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-runtimeexecutor (0.81.1):
+  - React-runtimeexecutor (0.81.2):
     - React-Core-prebuilt
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.1)
+    - React-jsi (= 0.81.2)
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeHermes (0.81.1):
+  - React-RuntimeHermes (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -2015,7 +2015,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-runtimescheduler (0.81.1):
+  - React-runtimescheduler (0.81.2):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2031,17 +2031,17 @@ PODS:
     - React-timing
     - React-utils
     - ReactNativeDependencies
-  - React-timing (0.81.1):
+  - React-timing (0.81.2):
     - React-debug
-  - React-utils (0.81.1):
+  - React-utils (0.81.2):
     - hermes-engine
     - React-Core-prebuilt
     - React-debug
-    - React-jsi (= 0.81.1)
+    - React-jsi (= 0.81.2)
     - ReactNativeDependencies
-  - ReactAppDependencyProvider (0.81.1):
+  - ReactAppDependencyProvider (0.81.2):
     - ReactCodegen
-  - ReactCodegen (0.81.1):
+  - ReactCodegen (0.81.2):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2061,43 +2061,43 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactCommon (0.81.1):
+  - ReactCommon (0.81.2):
     - React-Core-prebuilt
-    - ReactCommon/turbomodule (= 0.81.1)
+    - ReactCommon/turbomodule (= 0.81.2)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule (0.81.1):
+  - ReactCommon/turbomodule (0.81.2):
     - hermes-engine
-    - React-callinvoker (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
-    - ReactCommon/turbomodule/bridging (= 0.81.1)
-    - ReactCommon/turbomodule/core (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
+    - ReactCommon/turbomodule/bridging (= 0.81.2)
+    - ReactCommon/turbomodule/core (= 0.81.2)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/bridging (0.81.1):
+  - ReactCommon/turbomodule/bridging (0.81.2):
     - hermes-engine
-    - React-callinvoker (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/core (0.81.1):
+  - ReactCommon/turbomodule/core (0.81.2):
     - hermes-engine
-    - React-callinvoker (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.1)
-    - React-debug (= 0.81.1)
-    - React-featureflags (= 0.81.1)
-    - React-jsi (= 0.81.1)
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
-    - React-utils (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
+    - React-debug (= 0.81.2)
+    - React-featureflags (= 0.81.2)
+    - React-jsi (= 0.81.2)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
+    - React-utils (= 0.81.2)
     - ReactNativeDependencies
-  - ReactNativeDependencies (0.81.1)
+  - ReactNativeDependencies (0.81.2)
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
   - SDWebImage/Core (5.21.0)
@@ -2406,100 +2406,100 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  EASClient: 7484d2e32e19f8ad1afb7f35d9466957baddf9b8
+  EASClient: cfb28a340d86eeb03c2c67a2c34cd664c97dbc51
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: cb359a63f88e471a0f666b7d88694f6e594a594e
-  EXNotifications: 1e2dca895165599b1a55f986bb6d03a376bff31a
-  Expo: dd3b075380efd820bf02d81f25850a1014d746f0
-  expo-dev-launcher: 3be0f3694f8040601b750d56e9fd0bd717b76118
-  expo-dev-menu: ebda728f24691c15aeca66d35cf30fa0dca479d4
+  EXManifests: 9b19413c322564f3c2dce83006f1d71a4df79ba9
+  EXNotifications: 41233e5c2c4a795139d08a9ff8bb3de2536b86f5
+  Expo: 05129f4ae3d73e0d362c88e767d73943663dd1c0
+  expo-dev-launcher: 30f8a8f913bd2bd51820af9cfe821d75d7e01609
+  expo-dev-menu: 7e3a1079f69e4cd1de6ce9c05ad484f68b4666d4
   expo-dev-menu-interface: 600df12ea01efecdd822daaf13cc0ac091775533
-  ExpoClipboard: ef7895b1537eda918efd72a2afa471ba6466aa6f
-  ExpoImage: 33c6b81e193f8a3c765d248d93737f3f7f2031b3
-  ExpoMediaLibrary: 7c81ce72041cb0fd313dcb137e4f19e91a6c264f
-  ExpoModulesCore: 645ef6bfe7b81a2317407eede216915b2a4de61c
+  ExpoClipboard: 9e1809dd6ffdc08ce990f9bf22dcab3791b694aa
+  ExpoImage: 2708a5a9e69b6432f43d368379cc7c9b5165048b
+  ExpoMediaLibrary: 3204a2cb76b8f9822d8631d801b60f9feb6792e4
+  ExpoModulesCore: e024de04e62251f18e893c9040389da95a0c1862
   ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
-  EXUpdates: 939239345d5bb00ea6b047752847bb266a927a06
+  EXUpdates: acd31e646f9ca7e4efb3747b590210f297ec6938
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
-  FBLazyVector: 8da1272845e10a35c1e661a4c8ba644526c014fb
-  hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
+  FBLazyVector: 77485268e564ddf67fa5045947653a87b4531a47
+  hermes-engine: ceacb56b83367e3c4f7ed5ab0e93f92a89e4575b
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
-  RCTDeprecation: 24056820c873bf5115c0441651440bfde2b82d51
-  RCTRequired: d0b6e766be3c17896d92059c917d682433ff8a34
-  RCTTypeSafety: 1954dcf545fe67e969e11e1b4fe6cf864e1ac632
+  RCTDeprecation: 4d678ef4dca05565072e9ceace59e4fb8a33da81
+  RCTRequired: 35279f87ab747ff65303485f0ea3b92c508fddff
+  RCTTypeSafety: c8de06496c6ce0f746b56dbc5bfc299dcfa5b008
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: f1486d005993b0af01943af1850d3d4f3b597545
-  React-callinvoker: 944c9e97ef08e3995b05cc29b40c071a7bd0eaec
-  React-Core: 82b0d1d786602971d6ada67644599bba504e4f05
-  React-Core-prebuilt: 3f8f6d2c0c922cef26e1d9a385eeedbc91b8a495
-  React-CoreModules: db30069ee05bf3d4f8c26fbd1bcf8b9ce19efe3a
-  React-cxxreact: 0b53ae8c621ca115a390fd2546eae1c066a82d61
-  React-debug: 0268bacb2cc38d98790ce15159e962a6b0b1895e
-  React-defaultsnativemodule: f14128fd8ae509b5b51ccec568b93b98e1041be5
-  React-domnativemodule: 2ade4dffd56afd15bd93b488c64dd73fb351f3a8
-  React-Fabric: a3d6cb96b6b7ed39ef0d864cbe41c74c7e284b97
-  React-FabricComponents: 7c72646d6045f44efa04c90f79c5a97c121e5de1
-  React-FabricImage: b79cabc0f325b794ba6b8f14ff9a99f53a17d099
-  React-featureflags: a0bfc1ff76a81490a58a0d9e204bb9a33d2c8214
-  React-featureflagsnativemodule: 4672fd8ff443e5bc75d6ab5db99e4d7d08e6f974
-  React-graphics: a60e11059d736649f585255e01926d2b3170575f
-  React-hermes: 64a6b17a933d2e1d8d2be744388a5559afb81970
-  React-idlecallbacksnativemodule: 2b92149958695ceee2d4650ae6a019c2548397b1
-  React-ImageManager: ba24d3464a6e744fd2a4ff3d360c51e682d48161
-  React-jserrorhandler: 97af7bef2872f4d2f5473c259e285b73449c128a
-  React-jsi: 4726ae342196e7c47473a12877aa5cd15ac84938
-  React-jsiexecutor: 41510e615e89031d52349942753a157ca95e98b9
-  React-jsinspector: 56acf32e7fa571aacff9d0b0b63be26a26e046eb
-  React-jsinspectorcdp: 684c504f4b3e9cc7f32a67b0be0a912b7814bb1e
-  React-jsinspectornetwork: 474c1b45712c84cd8e5f2e06d34579fa8d288e1d
-  React-jsinspectortracing: 97f8cad22aa70a3afd1e400c36ca9a025413ff4d
-  React-jsitooling: 65a70b922d21ea0ff62da79702a7e63290b26e18
-  React-jsitracing: c11208843b9704c3529e29be6e66c7553f8a754f
-  React-logger: 57463ca0b4e2821e99de5d3e169c73bb44747fa8
-  React-Mapbuffer: 1c2d763cab246940480c26f7783fea3158328e6e
-  React-microtasksnativemodule: fd8ba0661426ff3b0d75420d9735c06d1267a65e
-  React-NativeModulesApple: 9d84ce1083672774f99e47db67b72a1754a229f4
-  React-oscompat: 8f2893713639e12c7558750a9f7de3f08ac255b0
-  React-perflogger: 8b2e23af5d2ad2af3564dc5b39e8f645fe6e213e
-  React-performancetimeline: 181ca89f10ecb72ba69a8f18d53d1501f36192d2
-  React-RCTActionSheet: 0280ff8cf63ef67a5a74898b18316b204d686c83
-  React-RCTAnimation: 2e460cb0e6bab212da0d51ae2fa06d4940f57dc7
-  React-RCTAppDelegate: bd20359306c39f4c681b0a8178524f36876dc349
-  React-RCTBlob: 9f7666589118df1b878506ac0cdb4c95909f57d9
-  React-RCTFabric: 2c6476d5f1afe558cae3c95609ff460140bcf30b
-  React-RCTFBReactNativeSpec: 9aa6e59bc8b16bcf0bd08854a0eec2fce69a8b76
-  React-RCTImage: d28b4429d50041b21a94b6a924d68bf2ea657a0c
-  React-RCTLinking: 8c1e982add09a0112d38ff0bd0da54f12d8bfb1a
-  React-RCTNetwork: ba16bcc6dbfbdd1b27597ffbe6ea77477db51b3a
-  React-RCTRuntime: 22c74af836f6dc4f9ffcb288a2765a6674538130
-  React-RCTSettings: e0401d546157fc9ee538edcca289d37c4d1e477e
-  React-RCTText: 794b6c97c1ea30ae9636c46187ff5f4569a54b1e
-  React-RCTVibration: f161f990b05224043b2449ec26fd03c5d355446f
-  React-rendererconsistency: 4917405e8864ded5d3b350f04ee7f1712435d8e7
-  React-renderercss: 3b00d7534182d59cca0a1f2a5d1606ea6d4c5656
-  React-rendererdebug: 326ee2825f7feb069b0b0edc3fc0703d9f176314
-  React-RuntimeApple: ab3d39b4c94d2238f69d85f1668d7c7b597a769c
-  React-RuntimeCore: 2452c439b756946f71147057b5da445df15077d9
-  React-runtimeexecutor: 54de512bb6e263df659dd47736f78d2dc8b4b46c
-  React-RuntimeHermes: 8d5aa86d1b54fca18895d8e3e8ddede07010cf42
-  React-runtimescheduler: 21e5deedc055fe04605ed8e4078ed281d17e3df0
-  React-timing: 2502b4a021b00d98bca9d0ded432306e19dfe13d
-  React-utils: f5f16cbfd98f4e5b66584e1ddc75c6b58a5b3680
-  ReactAppDependencyProvider: 448b422f8af1dedf81374eacc90a15439a0ed7f5
-  ReactCodegen: d1d3cbc78e263fc503087609698cca85243a7334
-  ReactCommon: b5d0aa700194902664f749d300e7f9478f5759c6
-  ReactNativeDependencies: 9444683ddc7eaa98d2289224ce730a7632b705ff
+  React: 7cee6da22b893d581d51397032d4a3951c03cb17
+  React-callinvoker: 5ea70569ceece01e1996c85f9cb1c689bec71c9b
+  React-Core: 6d23dc59f228c62ee15e993311c2942d304624c2
+  React-Core-prebuilt: 1ce36105edd4c579e7117f97ba65ad1ba583e517
+  React-CoreModules: 1f20825829502f28e2bdda25cc0ea2adcb8164e0
+  React-cxxreact: a1bf41dddce13a969c427b3ec81f66254d312775
+  React-debug: d860c135c213f12e841342ff2a6c14d5afb9e419
+  React-defaultsnativemodule: 470b797179649c6b2950e2f71503fc8a7f753878
+  React-domnativemodule: 360dff03a2974551afcd7a0e0f3da7febbcd4950
+  React-Fabric: d474e965ca02954854b77279c33a41e38feb1cfb
+  React-FabricComponents: e6d1b0189c68f1d4e18d20a18d2b2c23ba7faa65
+  React-FabricImage: 5b2da3539c4b4d55f9e9c20acf49ab642eddc457
+  React-featureflags: 63125b1d5ee27579ffee872d4a8980f044733935
+  React-featureflagsnativemodule: ff9aeb43ede668b8e04c36c7f10ea2b3d7a03a7f
+  React-graphics: c2d8b4eec2c4fd73b2cc141c992e7149b4220844
+  React-hermes: 198b38686a436f2fba3f605ac3fb55fea9dba4b3
+  React-idlecallbacksnativemodule: 4a640d71f7e4c75a36b0e138a196c4f7bb11b377
+  React-ImageManager: 1bb91c56c3bedd9abe7b029c4b5dd7f80a66b0f2
+  React-jserrorhandler: 4ac198ede40dd986f3efd7986cafad19f099e32c
+  React-jsi: 7d41c57eaac52e6279145e942ebdc5246c5f4ab0
+  React-jsiexecutor: 4435b1ad246cacd0be474f314764280fd41307bf
+  React-jsinspector: 51599b1c435be9b3936e1114499c6110852f4d75
+  React-jsinspectorcdp: 1bbbe3c04751c10333ee1fe939d97055bb10725a
+  React-jsinspectornetwork: c3dbe28b67ead6b3abdc569e3dafcfd8fca7ac5f
+  React-jsinspectortracing: 70368406508ecfa2ce6b929858f1a8ed8493282d
+  React-jsitooling: 5fa9819f41fff7ea081406b4462dc9d4b38e7bbd
+  React-jsitracing: 87af8fac96118ed50def3ca0e52635598ef8ae8d
+  React-logger: 51cdc4a1f7f534b535b461644ebba9fdbc0baf4c
+  React-Mapbuffer: 67755dc0cb0647ad6294a3bc02181d9daf08b17f
+  React-microtasksnativemodule: cd10fe63b700365a362d750f0a8c94cff59eeebb
+  React-NativeModulesApple: bd258b9485e456d84f9584523ad3c3c8ba0b51e9
+  React-oscompat: ade00f2748c52568bec65682448d74fe6df6f2d3
+  React-perflogger: 7899e64980a940a71005d4752fc03dd4e61d4247
+  React-performancetimeline: 31b6d62cb743fc136117fd5f221c75bb3a282276
+  React-RCTActionSheet: ffab08a04e6fe47dbb6623ae950427ce61b1df47
+  React-RCTAnimation: 5db15314c4528647a6419c3ab3482044549bc722
+  React-RCTAppDelegate: d07b00d43ce1f6e947da3a2ff660147d4e82f909
+  React-RCTBlob: 8251a93151631fc7a6446e756771288e01bb4fea
+  React-RCTFabric: 62aad1b3308a341658ecfc74e83f1b95f0dbb024
+  React-RCTFBReactNativeSpec: 6c671dbc26713886f91c071e7e27f7fdcdcc5420
+  React-RCTImage: 2ac66fd27553f56f551aaa565204f8e822c1abb0
+  React-RCTLinking: 5720f30f765a2bbbd79f4b0b97c04a60924ad0e6
+  React-RCTNetwork: 3082a19df28509afcc2e48709769a784050c0d23
+  React-RCTRuntime: 7ee4a2b7d9a270a1b9e0675fa49811f64c6863ad
+  React-RCTSettings: cd54e1057599bf6df23f1aeec073de182c90e9e5
+  React-RCTText: ea2ae68038930a06276807c742afa37cfd811e29
+  React-RCTVibration: c7acf3d6c345182887f1d4765623bfd2d4a723c0
+  React-rendererconsistency: bc382ce33dfa11ea371c1174db34c56c897aa3e3
+  React-renderercss: e047767f4219d999efd4588321b1fc14f6f6e18a
+  React-rendererdebug: 22dda44f8931d67a93efcb47f9e89bf3e46f1271
+  React-RuntimeApple: c9ccccc3c3e1c819d66b7b99ee79af7eb3985e50
+  React-RuntimeCore: cda0561ca45e6c282d16527f5e3339a956599fe0
+  React-runtimeexecutor: 94f916248385c0006c83f51d2a33fa40f8dfb5de
+  React-RuntimeHermes: 26f08e51bbac484fa5e0f88f40c4a27ed14d1f77
+  React-runtimescheduler: bd29b8e1664b5b1859fe602a9148d7a619fd7ac3
+  React-timing: 990f6836757f7fe69e5b97b18435b815aac7f046
+  React-utils: 409fa5cb4574fa1c0f8002a463518b63c69fea83
+  ReactAppDependencyProvider: 319be07ed29c6a24b30b700ebf6f667c9d49a511
+  ReactCodegen: ebd6a570d0441312bbd19b817ad1324fb0a41bb9
+  ReactCommon: 5cabaa414dfa310990a62264693d4f8e61b88fdf
+  ReactNativeDependencies: 316e0ff865f50a287726f6b002c607f90ad878fb
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  Yoga: 18b87f28df0aee34fa7370518a35aa8107ba47b9
+  Yoga: 82e60295fd61743ed3c218e3873faf184646f99a
 
 PODFILE CHECKSUM: 7b324c13881703a862f70f400c68133d3b5568d5
 

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -19,7 +19,7 @@
     "expo-updates": "29.0.8",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.2"
+    "react-native": "0.81.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -19,7 +19,7 @@
     "expo-updates": "29.0.8",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.1"
+    "react-native": "0.81.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -31,7 +31,7 @@
     "expo-task-manager": "14.0.6",
     "react-native-gesture-handler": "~2.28.0",
     "react": "19.1.0",
-    "react-native": "0.81.1",
+    "react-native": "0.81.2",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0"
   },

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -31,7 +31,7 @@
     "expo-task-manager": "14.0.6",
     "react-native-gesture-handler": "~2.28.0",
     "react": "19.1.0",
-    "react-native": "0.81.2",
+    "react-native": "0.81.3",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0"
   },

--- a/apps/paper-tester/ios/Podfile.lock
+++ b/apps/paper-tester/ios/Podfile.lock
@@ -342,12 +342,12 @@ PODS:
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.81.2)
+  - FBLazyVector (0.81.3)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.81.2):
-    - hermes-engine/Pre-built (= 0.81.2)
-  - hermes-engine/Pre-built (0.81.2)
+  - hermes-engine (0.81.3):
+    - hermes-engine/Pre-built (= 0.81.3)
+  - hermes-engine/Pre-built (0.81.3)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -384,28 +384,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.81.2)
-  - RCTRequired (0.81.2)
-  - RCTTypeSafety (0.81.2):
-    - FBLazyVector (= 0.81.2)
-    - RCTRequired (= 0.81.2)
-    - React-Core (= 0.81.2)
+  - RCTDeprecation (0.81.3)
+  - RCTRequired (0.81.3)
+  - RCTTypeSafety (0.81.3):
+    - FBLazyVector (= 0.81.3)
+    - RCTRequired (= 0.81.3)
+    - React-Core (= 0.81.3)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.2):
-    - React-Core (= 0.81.2)
-    - React-Core/DevSupport (= 0.81.2)
-    - React-Core/RCTWebSocket (= 0.81.2)
-    - React-RCTActionSheet (= 0.81.2)
-    - React-RCTAnimation (= 0.81.2)
-    - React-RCTBlob (= 0.81.2)
-    - React-RCTImage (= 0.81.2)
-    - React-RCTLinking (= 0.81.2)
-    - React-RCTNetwork (= 0.81.2)
-    - React-RCTSettings (= 0.81.2)
-    - React-RCTText (= 0.81.2)
-    - React-RCTVibration (= 0.81.2)
-  - React-callinvoker (0.81.2)
-  - React-Core (0.81.2):
+  - React (0.81.3):
+    - React-Core (= 0.81.3)
+    - React-Core/DevSupport (= 0.81.3)
+    - React-Core/RCTWebSocket (= 0.81.3)
+    - React-RCTActionSheet (= 0.81.3)
+    - React-RCTAnimation (= 0.81.3)
+    - React-RCTBlob (= 0.81.3)
+    - React-RCTImage (= 0.81.3)
+    - React-RCTLinking (= 0.81.3)
+    - React-RCTNetwork (= 0.81.3)
+    - React-RCTSettings (= 0.81.3)
+    - React-RCTText (= 0.81.3)
+    - React-RCTVibration (= 0.81.3)
+  - React-callinvoker (0.81.3)
+  - React-Core (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -415,7 +415,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.2)
+    - React-Core/Default (= 0.81.3)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -430,82 +430,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.81.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.81.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.81.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.81.2)
-    - React-Core/RCTWebSocket (= 0.81.2)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.2):
+  - React-Core/CoreModulesHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -530,7 +455,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.2):
+  - React-Core/Default (0.81.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.81.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.3)
+    - React-Core/RCTWebSocket (= 0.81.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -555,7 +530,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.2):
+  - React-Core/RCTAnimationHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -580,7 +555,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.2):
+  - React-Core/RCTBlobHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -605,7 +580,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.2):
+  - React-Core/RCTImageHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -630,7 +605,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.2):
+  - React-Core/RCTLinkingHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -655,7 +630,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.2):
+  - React-Core/RCTNetworkHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -680,7 +655,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.2):
+  - React-Core/RCTSettingsHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -705,7 +680,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.2):
+  - React-Core/RCTTextHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -730,7 +705,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.81.2):
+  - React-Core/RCTVibrationHeaders (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -740,7 +715,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.2)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -755,7 +730,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.81.2):
+  - React-Core/RCTWebSocket (0.81.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.3)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -763,20 +763,20 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.81.2)
-    - React-Core/CoreModulesHeaders (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - RCTTypeSafety (= 0.81.3)
+    - React-Core/CoreModulesHeaders (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.2)
+    - React-RCTImage (= 0.81.3)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.81.2):
+  - React-cxxreact (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -785,19 +785,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.2)
-    - React-debug (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
+    - React-debug (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
-    - React-timing (= 0.81.2)
+    - React-timing (= 0.81.3)
     - SocketRocket
-  - React-debug (0.81.2)
-  - React-defaultsnativemodule (0.81.2):
+  - React-debug (0.81.3)
+  - React-defaultsnativemodule (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -814,7 +814,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.81.2):
+  - React-domnativemodule (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -834,7 +834,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.81.2):
+  - React-Fabric (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -848,23 +848,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.2)
-    - React-Fabric/attributedstring (= 0.81.2)
-    - React-Fabric/bridging (= 0.81.2)
-    - React-Fabric/componentregistry (= 0.81.2)
-    - React-Fabric/componentregistrynative (= 0.81.2)
-    - React-Fabric/components (= 0.81.2)
-    - React-Fabric/consistency (= 0.81.2)
-    - React-Fabric/core (= 0.81.2)
-    - React-Fabric/dom (= 0.81.2)
-    - React-Fabric/imagemanager (= 0.81.2)
-    - React-Fabric/leakchecker (= 0.81.2)
-    - React-Fabric/mounting (= 0.81.2)
-    - React-Fabric/observers (= 0.81.2)
-    - React-Fabric/scheduler (= 0.81.2)
-    - React-Fabric/telemetry (= 0.81.2)
-    - React-Fabric/templateprocessor (= 0.81.2)
-    - React-Fabric/uimanager (= 0.81.2)
+    - React-Fabric/animations (= 0.81.3)
+    - React-Fabric/attributedstring (= 0.81.3)
+    - React-Fabric/bridging (= 0.81.3)
+    - React-Fabric/componentregistry (= 0.81.3)
+    - React-Fabric/componentregistrynative (= 0.81.3)
+    - React-Fabric/components (= 0.81.3)
+    - React-Fabric/consistency (= 0.81.3)
+    - React-Fabric/core (= 0.81.3)
+    - React-Fabric/dom (= 0.81.3)
+    - React-Fabric/imagemanager (= 0.81.3)
+    - React-Fabric/leakchecker (= 0.81.3)
+    - React-Fabric/mounting (= 0.81.3)
+    - React-Fabric/observers (= 0.81.3)
+    - React-Fabric/scheduler (= 0.81.3)
+    - React-Fabric/telemetry (= 0.81.3)
+    - React-Fabric/templateprocessor (= 0.81.3)
+    - React-Fabric/uimanager (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -876,32 +876,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.81.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.81.2):
+  - React-Fabric/animations (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -926,7 +901,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.81.2):
+  - React-Fabric/attributedstring (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -951,7 +926,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.81.2):
+  - React-Fabric/bridging (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -976,7 +951,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.81.2):
+  - React-Fabric/componentregistry (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1001,36 +976,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.81.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.2)
-    - React-Fabric/components/root (= 0.81.2)
-    - React-Fabric/components/scrollview (= 0.81.2)
-    - React-Fabric/components/view (= 0.81.2)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.2):
+  - React-Fabric/componentregistrynative (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1055,7 +1001,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.81.2):
+  - React-Fabric/components (0.81.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.3)
+    - React-Fabric/components/root (= 0.81.3)
+    - React-Fabric/components/scrollview (= 0.81.3)
+    - React-Fabric/components/view (= 0.81.3)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1080,7 +1055,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.81.2):
+  - React-Fabric/components/root (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1105,7 +1080,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.81.2):
+  - React-Fabric/components/scrollview (0.81.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1132,7 +1132,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.81.2):
+  - React-Fabric/consistency (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1157,7 +1157,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.81.2):
+  - React-Fabric/core (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1182,7 +1182,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.81.2):
+  - React-Fabric/dom (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1207,7 +1207,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.81.2):
+  - React-Fabric/imagemanager (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1232,7 +1232,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.81.2):
+  - React-Fabric/leakchecker (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1257,7 +1257,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.81.2):
+  - React-Fabric/mounting (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1282,7 +1282,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.81.2):
+  - React-Fabric/observers (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1296,7 +1296,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.2)
+    - React-Fabric/observers/events (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1308,7 +1308,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.81.2):
+  - React-Fabric/observers/events (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1333,7 +1333,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.81.2):
+  - React-Fabric/scheduler (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1360,7 +1360,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.81.2):
+  - React-Fabric/telemetry (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1385,7 +1385,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.81.2):
+  - React-Fabric/templateprocessor (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1410,7 +1410,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.81.2):
+  - React-Fabric/uimanager (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1424,7 +1424,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.2)
+    - React-Fabric/uimanager/consistency (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1437,7 +1437,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.81.2):
+  - React-Fabric/uimanager/consistency (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1463,7 +1463,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.81.2):
+  - React-FabricComponents (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1478,8 +1478,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.2)
-    - React-FabricComponents/textlayoutmanager (= 0.81.2)
+    - React-FabricComponents/components (= 0.81.3)
+    - React-FabricComponents/textlayoutmanager (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1492,7 +1492,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.81.2):
+  - React-FabricComponents/components (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1507,17 +1507,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.2)
-    - React-FabricComponents/components/iostextinput (= 0.81.2)
-    - React-FabricComponents/components/modal (= 0.81.2)
-    - React-FabricComponents/components/rncore (= 0.81.2)
-    - React-FabricComponents/components/safeareaview (= 0.81.2)
-    - React-FabricComponents/components/scrollview (= 0.81.2)
-    - React-FabricComponents/components/switch (= 0.81.2)
-    - React-FabricComponents/components/text (= 0.81.2)
-    - React-FabricComponents/components/textinput (= 0.81.2)
-    - React-FabricComponents/components/unimplementedview (= 0.81.2)
-    - React-FabricComponents/components/virtualview (= 0.81.2)
+    - React-FabricComponents/components/inputaccessory (= 0.81.3)
+    - React-FabricComponents/components/iostextinput (= 0.81.3)
+    - React-FabricComponents/components/modal (= 0.81.3)
+    - React-FabricComponents/components/rncore (= 0.81.3)
+    - React-FabricComponents/components/safeareaview (= 0.81.3)
+    - React-FabricComponents/components/scrollview (= 0.81.3)
+    - React-FabricComponents/components/switch (= 0.81.3)
+    - React-FabricComponents/components/text (= 0.81.3)
+    - React-FabricComponents/components/textinput (= 0.81.3)
+    - React-FabricComponents/components/unimplementedview (= 0.81.3)
+    - React-FabricComponents/components/virtualview (= 0.81.3)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1530,34 +1530,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.2):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.2):
+  - React-FabricComponents/components/inputaccessory (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1584,7 +1557,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.81.2):
+  - React-FabricComponents/components/iostextinput (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1611,7 +1584,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.2):
+  - React-FabricComponents/components/modal (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1638,7 +1611,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.2):
+  - React-FabricComponents/components/rncore (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1665,7 +1638,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.2):
+  - React-FabricComponents/components/safeareaview (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1692,7 +1665,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.81.2):
+  - React-FabricComponents/components/scrollview (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1719,7 +1692,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.81.2):
+  - React-FabricComponents/components/switch (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1746,7 +1719,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.2):
+  - React-FabricComponents/components/text (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1773,7 +1746,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.2):
+  - React-FabricComponents/components/textinput (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1800,7 +1773,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.2):
+  - React-FabricComponents/components/unimplementedview (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1827,7 +1800,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.2):
+  - React-FabricComponents/components/virtualview (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1854,7 +1827,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.81.2):
+  - React-FabricComponents/textlayoutmanager (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1863,21 +1836,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.81.2)
-    - RCTTypeSafety (= 0.81.2)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.81.3):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.81.3)
+    - RCTTypeSafety (= 0.81.3)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.2)
+    - React-jsiexecutor (= 0.81.3)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.81.2):
+  - React-featureflags (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1886,7 +1886,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.81.2):
+  - React-featureflagsnativemodule (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1901,7 +1901,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.81.2):
+  - React-graphics (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1914,7 +1914,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.81.2):
+  - React-hermes (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1923,16 +1923,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
     - React-jsi
-    - React-jsiexecutor (= 0.81.2)
+    - React-jsiexecutor (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.2)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.81.2):
+  - React-idlecallbacksnativemodule (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1948,7 +1948,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.81.2):
+  - React-ImageManager (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1963,7 +1963,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.81.2):
+  - React-jserrorhandler (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1978,7 +1978,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.81.2):
+  - React-jsi (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1988,7 +1988,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.81.2):
+  - React-jsiexecutor (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -1997,15 +1997,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.2)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.81.2):
+  - React-jsinspector (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2020,10 +2020,10 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.81.2)
+    - React-perflogger (= 0.81.3)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.81.2):
+  - React-jsinspectorcdp (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2032,7 +2032,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.81.2):
+  - React-jsinspectornetwork (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2045,7 +2045,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.81.2):
+  - React-jsinspectortracing (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2056,7 +2056,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.81.2):
+  - React-jsitooling (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2064,16 +2064,16 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.81.2):
+  - React-jsitracing (0.81.3):
     - React-jsi
-  - React-logger (0.81.2):
+  - React-logger (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2082,7 +2082,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.81.2):
+  - React-Mapbuffer (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2092,7 +2092,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.81.2):
+  - React-microtasksnativemodule (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2106,7 +2106,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-NativeModulesApple (0.81.2):
+  - React-NativeModulesApple (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2126,8 +2126,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.81.2)
-  - React-perflogger (0.81.2):
+  - React-oscompat (0.81.3)
+  - React-perflogger (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2136,7 +2136,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.81.2):
+  - React-performancetimeline (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2149,9 +2149,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.81.2):
-    - React-Core/RCTActionSheetHeaders (= 0.81.2)
-  - React-RCTAnimation (0.81.2):
+  - React-RCTActionSheet (0.81.3):
+    - React-Core/RCTActionSheetHeaders (= 0.81.3)
+  - React-RCTAnimation (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2167,7 +2167,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.81.2):
+  - React-RCTAppDelegate (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2201,7 +2201,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.81.2):
+  - React-RCTBlob (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2220,7 +2220,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.81.2):
+  - React-RCTFabric (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2255,7 +2255,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.2):
+  - React-RCTFBReactNativeSpec (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2269,10 +2269,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.2)
+    - React-RCTFBReactNativeSpec/components (= 0.81.3)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.81.2):
+  - React-RCTFBReactNativeSpec/components (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2295,7 +2295,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.81.2):
+  - React-RCTImage (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2311,14 +2311,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.81.2):
-    - React-Core/RCTLinkingHeaders (= 0.81.2)
-    - React-jsi (= 0.81.2)
+  - React-RCTLinking (0.81.3):
+    - React-Core/RCTLinkingHeaders (= 0.81.3)
+    - React-jsi (= 0.81.3)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.2)
-  - React-RCTNetwork (0.81.2):
+    - ReactCommon/turbomodule/core (= 0.81.3)
+  - React-RCTNetwork (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2336,7 +2336,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.81.2):
+  - React-RCTRuntime (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2356,7 +2356,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.81.2):
+  - React-RCTSettings (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2371,10 +2371,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.81.2):
-    - React-Core/RCTTextHeaders (= 0.81.2)
+  - React-RCTText (0.81.3):
+    - React-Core/RCTTextHeaders (= 0.81.3)
     - Yoga
-  - React-RCTVibration (0.81.2):
+  - React-RCTVibration (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2388,11 +2388,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.81.2)
-  - React-renderercss (0.81.2):
+  - React-rendererconsistency (0.81.3)
+  - React-renderercss (0.81.3):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.2):
+  - React-rendererdebug (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2402,7 +2402,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.81.2):
+  - React-RuntimeApple (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2431,7 +2431,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.81.2):
+  - React-RuntimeCore (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2453,7 +2453,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.81.2):
+  - React-runtimeexecutor (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2463,10 +2463,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.2)
+    - React-jsi (= 0.81.3)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.81.2):
+  - React-RuntimeHermes (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2487,7 +2487,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.81.2):
+  - React-runtimescheduler (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2509,9 +2509,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.81.2):
+  - React-timing (0.81.3):
     - React-debug
-  - React-utils (0.81.2):
+  - React-utils (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2521,11 +2521,11 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.81.2)
+    - React-jsi (= 0.81.3)
     - SocketRocket
-  - ReactAppDependencyProvider (0.81.2):
+  - ReactAppDependencyProvider (0.81.3):
     - ReactCodegen
-  - ReactCodegen (0.81.2):
+  - ReactCodegen (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2551,7 +2551,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.81.2):
+  - ReactCommon (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2559,9 +2559,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.81.2)
+    - ReactCommon/turbomodule (= 0.81.3)
     - SocketRocket
-  - ReactCommon/turbomodule (0.81.2):
+  - ReactCommon/turbomodule (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2570,15 +2570,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.2)
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
-    - ReactCommon/turbomodule/bridging (= 0.81.2)
-    - ReactCommon/turbomodule/core (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
+    - ReactCommon/turbomodule/bridging (= 0.81.3)
+    - ReactCommon/turbomodule/core (= 0.81.3)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.81.2):
+  - ReactCommon/turbomodule/bridging (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2587,13 +2587,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.2)
-    - React-cxxreact (= 0.81.2)
-    - React-jsi (= 0.81.2)
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
+    - React-cxxreact (= 0.81.3)
+    - React-jsi (= 0.81.3)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.81.2):
+  - ReactCommon/turbomodule/core (0.81.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2602,14 +2602,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.2)
-    - React-cxxreact (= 0.81.2)
-    - React-debug (= 0.81.2)
-    - React-featureflags (= 0.81.2)
-    - React-jsi (= 0.81.2)
-    - React-logger (= 0.81.2)
-    - React-perflogger (= 0.81.2)
-    - React-utils (= 0.81.2)
+    - React-callinvoker (= 0.81.3)
+    - React-cxxreact (= 0.81.3)
+    - React-debug (= 0.81.3)
+    - React-featureflags (= 0.81.3)
+    - React-jsi (= 0.81.3)
+    - React-logger (= 0.81.3)
+    - React-perflogger (= 0.81.3)
+    - React-utils (= 0.81.3)
     - SocketRocket
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
@@ -2963,83 +2963,83 @@ SPEC CHECKSUMS:
   EXUpdates: 19113c09152965c07c1a63cf47f457b4f43394a0
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: 89a8574f4a4ea67295ad2e8f84b764e4b1162f64
+  FBLazyVector: a80c331df9c6958a9cc391631578602b7973b0c7
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: ceacb56b83367e3c4f7ed5ab0e93f92a89e4575b
+  hermes-engine: 5463d3c4a8a0d35701605934008f34c171ce71d5
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: b60b889eafa75f46c3d6be5332681efbb16ad0c7
-  RCTRequired: fbdcc9ee2826c0a2ed5bd77a8375b3613d087e99
-  RCTTypeSafety: e1fa82493c521eba295c7ed0d2de80e3d4f22853
+  RCTDeprecation: 78aa7764dbddbc2c87060d26a3ab19fb65dad4ce
+  RCTRequired: df28d0769df9b6ace47200ac80095f9dffba555d
+  RCTTypeSafety: ffa3fa28228934f05db6d9d31dc746542fc447e0
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 7cee6da22b893d581d51397032d4a3951c03cb17
-  React-callinvoker: 58d4d5a586a1523752a9fa58ef3fc6d0b7fbcbad
-  React-Core: 2a00139af1a13cd5d6234b96024c2e8c609c0486
-  React-CoreModules: 544ebf2a4ef99090ab5f26d3f44e693def986f2f
-  React-cxxreact: 3c2ff1c8c1739ba3827d50c844e7a0e1da2bbd45
-  React-debug: f86bd380de1d8bc8a3ba13eed20f7a7c10290e3a
-  React-defaultsnativemodule: 190bd39694d6b04ed6ff3c6127dab92e3465c99b
-  React-domnativemodule: 160a6555391b13810e633991626c0547c8bffa0f
-  React-Fabric: 1fb8455cf7fc6089aa4e96c4307bd1b7cc1915ca
-  React-FabricComponents: cf05fb1b9a1a16ca700f58c7ab60c1c0d494fe05
-  React-FabricImage: 79676806e07bedf45ecb401242fec00712b95ca2
-  React-featureflags: 7f31869ec867c45a93b93d9079b62d7bfbc29a3c
-  React-featureflagsnativemodule: 31cf067d284d1e5843a810218e57fe9342173b2f
-  React-graphics: c065f94afba7661e192ea8a48e19bcc8fccfb5f6
-  React-hermes: 05f8be1795884b94a4a79deafbd306fde2ac1218
-  React-idlecallbacksnativemodule: 31f3701cdf8cac09cead1115971fc1198a07a923
-  React-ImageManager: 121af59488820720d1158cdd8ae6478b622b2575
-  React-jserrorhandler: eee16d033dc7fc73f4b57a1d038905e4ce8e05e5
-  React-jsi: ff804868b503f2f7ed5f8b7bb780cd036c79a806
-  React-jsiexecutor: d489788717a8577e65c992a352a8fbaa4f699d5c
-  React-jsinspector: 965088adbcd1a3d907cdff2d5b0c840112cdbfb7
-  React-jsinspectorcdp: 2718e82fd69b9ff77b7795f3a99964690f7bd0bd
-  React-jsinspectornetwork: 92a5da5a8c77806d52de3a711d8200f9a0eb1c6e
-  React-jsinspectortracing: da0085d4b8976280ebdc8d308c265dd2ad6e8f4f
-  React-jsitooling: ecd194e4a18aa65f9bf9c99285d3d7dc2d77bda9
-  React-jsitracing: 57cc77243a7feb4c7b851a51ac18261846a51251
-  React-logger: 3d3d703c13b7d0130fa3842f836e93794f6b0589
-  React-Mapbuffer: 689ffb875cf6b1cc9b6be7a587c33ac729d84fd4
-  React-microtasksnativemodule: 94d4726672b7f010ce828f87c4c7305796af4e4e
-  React-NativeModulesApple: 1b204ec5f197270987fe27f86b3d34b5d8406631
-  React-oscompat: 1b3446acd10cdfd739655206b912db37f5e5a80f
-  React-perflogger: d8bb76530906ba368ecb8af364e8c2b3252ec5e0
-  React-performancetimeline: 426ca4f701729c67bd4f2883ce779765a3e6d77c
-  React-RCTActionSheet: fc83c5b18f638ba92ad22005da9d82fb1ba29ab4
-  React-RCTAnimation: 645e538d49be0ae77a399379bf6dec65dccc9e53
-  React-RCTAppDelegate: cc5d6e15e4b62a32d9ba24d01f179e7bcfe3619e
-  React-RCTBlob: 13e8423a3097e33a230488593c27a6b852d07957
-  React-RCTFabric: 9d75135ce412818ff82644c6c8213f8e0c9bf4e7
-  React-RCTFBReactNativeSpec: 6c498fc2c95650b8bdac32de8bbf02419989c036
-  React-RCTImage: 03ef0e56bafd30ebf1e5030c6faf1a96f725b752
-  React-RCTLinking: 392255aec37cf9ed602c602e338f0ee94722fc7c
-  React-RCTNetwork: f4f0d24c4a1b7e7f1a011767231dc8617f8be7ff
-  React-RCTRuntime: 7ea203a206fe18f60106b261d5cb36c1fce8b915
-  React-RCTSettings: 2dbfab042c4063c5788e85e0f5b6ea32d9ab32bb
-  React-RCTText: 55cd9cf7c0c7d26aae506ac8570361dd1f5fabdb
-  React-RCTVibration: 8f5a49199ca5ce898e5d785beca39bc0f1a312e8
-  React-rendererconsistency: fb8d9afcedef714822676c17fa47f782eb690ec4
-  React-renderercss: d3a392fa3da45987e03a6080c5c8d390c62e46c5
-  React-rendererdebug: bee210d645c71613eb7464b1f7583813fe7bb34c
-  React-RuntimeApple: c4c64bb5ac6f907c17b20eb7872668a0f7c4b6fd
-  React-RuntimeCore: 4030ecfba4a1b4a4b67a1a83ccf8a2090860e469
-  React-runtimeexecutor: a07fc15d2b8899b5254fc9e3cc35d0b508e5c47f
-  React-RuntimeHermes: ff7f38c58af45f08488d4d39d3163582f3c5ab2e
-  React-runtimescheduler: 814cd8985699d2af1809cf628ae0ef1f1d07630a
-  React-timing: 9919d1154651af97f6191150f5af00f833cf598a
-  React-utils: f95d319648c01fc920c717acfbccad3fe92a8cdf
-  ReactAppDependencyProvider: 319be07ed29c6a24b30b700ebf6f667c9d49a511
-  ReactCodegen: 5861a6d5e755820ca2bb0d23792a33e71af357f6
-  ReactCommon: 6753d98e6793890f2d0b1b678592c497bc0987ea
+  React: 639d04fed84b2ff824861d863891eaef7cb92f9c
+  React-callinvoker: adedd891222fbe90849c0bdc8873b9b94f061a03
+  React-Core: 818ff611f7d731b01d8e7f814d6b8e25ae651af2
+  React-CoreModules: 004f4a9ecca043d9904cb5cdecde607b9bd0f0d4
+  React-cxxreact: 68c0b41835c694d86e20e0f61332ef42eabe6606
+  React-debug: e7fa634481419ac0b821224af2113001a997b5f3
+  React-defaultsnativemodule: 2913014b0b8fc3ed6e743b1743e350c1f14e90a3
+  React-domnativemodule: 616f04796884eb2adfb4a1ee83b26dd2eb9788b2
+  React-Fabric: ed41aaa5eec57907dd4770b1e218180aba51d5e2
+  React-FabricComponents: 3f4ffbe0002cc468970dd4069182005c2b5dad6e
+  React-FabricImage: fcfb94a1436d141961c22c0f8cd3f5417a261321
+  React-featureflags: a9ac0c00b03d4cba3352fe8624ace68a51786fe5
+  React-featureflagsnativemodule: 14606b5dcb94600fdf27e0dc3360672a78ec54ec
+  React-graphics: 51c15e35f57310bd2b27468b4cabb0041d42810b
+  React-hermes: 483faa2436b2e7af246be856cc3006d533ee7c97
+  React-idlecallbacksnativemodule: 325aae5afd7b0d14908b6e9827223c05dc9603fb
+  React-ImageManager: 8a4a1689a96f34ae7a5d4bf6f1c2be48aed7c993
+  React-jserrorhandler: e94779f9880d94ab4f88a795b73c14308b917be5
+  React-jsi: c8b25f19c5abc577ef32ab5dacb053e179450d19
+  React-jsiexecutor: 3f7fea04f52f5a58c679be2ffe54a5dc243b219d
+  React-jsinspector: 72bcbd3506d8e9f0e52652c8d2f0857b3a88f8aa
+  React-jsinspectorcdp: b3e25045cb47289e7aabf5c62fa4036d2bd1a734
+  React-jsinspectornetwork: 5758a484c29bb564e20bcd052e3303ea940b8c43
+  React-jsinspectortracing: 301ab935b30dc3b9a649973273aa26e88d42408c
+  React-jsitooling: a5d9b4202c5d25aaef811c5724a7b085e86d7a40
+  React-jsitracing: 9069c1e77deb443d4b6516e88ef3890328300b9a
+  React-logger: ad9935416f3fee15becd44b7b291a440ea952271
+  React-Mapbuffer: 5311cd406de0076f1ef9373488ef628c7cfd0a66
+  React-microtasksnativemodule: 460d58ae1a1aa90f8d3b743d01e677c7a4a1b89b
+  React-NativeModulesApple: 56b427e2d317117e81d863a69d4ffc44ad37c283
+  React-oscompat: 16640399a646baeac6baab4264891cc4892eeb56
+  React-perflogger: 5321bb08e84a12b34adcf167197171a5e20b3ef0
+  React-performancetimeline: 28d9871743287f1b18905cc63249fbfdbefa914a
+  React-RCTActionSheet: 4c4adabfd8bc747cf39ed7f3e8691eb060a59ba3
+  React-RCTAnimation: 20aa6c6408ec6772c137242761748b7d2dbf95d2
+  React-RCTAppDelegate: 61de2f9db0007c721c8bc22b09a194cf6f118339
+  React-RCTBlob: 485e656d54a6847a48e8c68b4d72f219d0834fe5
+  React-RCTFabric: 5c95f9e01c2924cf17ae4e6df77974c833fded67
+  React-RCTFBReactNativeSpec: 6e1c92d52bf9778caf8787cf75ce37c31bf187b0
+  React-RCTImage: 0d35f116486079b66f794e46e480d2707809bf8a
+  React-RCTLinking: 54734cb51443d59a566950be5daf4246820c8322
+  React-RCTNetwork: 3fb5688ab706f8b49ff4c5d5d159bfa6886dc40b
+  React-RCTRuntime: c25b217f022203cf95fef0c2aff70c5c5a9f035c
+  React-RCTSettings: 414ff12fe3293533218219ff99b0827f4042ba50
+  React-RCTText: 31e965f779e78999d414ba7f30296bead9d387d5
+  React-RCTVibration: 25224f65ac65d43d81011810a3bf33675024cbb7
+  React-rendererconsistency: 234fcdca03f9380acd8f85bb11c4bcbd6901b3cb
+  React-renderercss: f7924d63bb7d07c7d6364fc89e31b95e67b7bed8
+  React-rendererdebug: acd2b8110e1b52edbd1fec26f9fefd75d314902a
+  React-RuntimeApple: be5cc450a08d6f23103238db9e2c9fc16a628fbb
+  React-RuntimeCore: b2cb88dff0429cfeb1cb964e0a4da4f6647a7da0
+  React-runtimeexecutor: 08274efba84d317b506454edee6c95d3224de8a8
+  React-RuntimeHermes: 3d2bc4c4b6f16752f456514d970030e5a5fd3731
+  React-runtimescheduler: f5e61d19f60707af29f03a36f7ad32b859c5d69b
+  React-timing: 8f044ff70498806e0ac55c1637f641716536c1a2
+  React-utils: b30b0d4f53cf9fbc14cd08c8a11cdfe89317e0de
+  ReactAppDependencyProvider: f9317094ed209f55ecbdd9ba792843cfb1c45c29
+  ReactCodegen: 619f99d374a8614d0f5d58c5a14b7cef258d6814
+  ReactCommon: 66dacee1a7de79afeba15b8174107de347dfbecb
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: b9dc6c508cca59caf2f7462189a74359c6c680b6
+  Yoga: 6b30b3f0beeeacf5a3fe68af23442196b196959a
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: e5e6a8786a10ba50f5287a0a8873ff45bc531270

--- a/apps/paper-tester/ios/Podfile.lock
+++ b/apps/paper-tester/ios/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
-  - EASClient (1.0.3):
+  - EASClient (1.0.6):
     - ExpoModulesCore
-  - EXConstants (18.0.4):
+  - EXConstants (18.0.7):
     - ExpoModulesCore
   - EXJSONUtils (0.15.0)
-  - EXManifests (1.0.4):
+  - EXManifests (1.0.7):
     - ExpoModulesCore
-  - Expo (54.0.0-preview.9):
+  - Expo (54.0.0-preview.16):
     - boost
     - DoubleConversion
     - ExpoModulesCore
@@ -39,17 +39,17 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-client (6.0.5):
+  - expo-dev-client (6.0.10):
     - EXManifests
     - expo-dev-launcher
     - expo-dev-menu
     - expo-dev-menu-interface
     - EXUpdatesInterface
-  - expo-dev-launcher (6.0.5):
+  - expo-dev-launcher (6.0.10):
     - boost
     - DoubleConversion
     - EXManifests
-    - expo-dev-launcher/Main (= 6.0.5)
+    - expo-dev-launcher/Main (= 6.0.10)
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -82,7 +82,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-launcher/Main (6.0.5):
+  - expo-dev-launcher/Main (6.0.10):
     - boost
     - DoubleConversion
     - EXManifests
@@ -119,7 +119,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-launcher/Unsafe (6.0.5):
+  - expo-dev-launcher/Unsafe (6.0.10):
     - boost
     - DoubleConversion
     - EXManifests
@@ -155,11 +155,11 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-menu (7.0.4):
+  - expo-dev-menu (7.0.9):
     - boost
     - DoubleConversion
-    - expo-dev-menu/Main (= 7.0.4)
-    - expo-dev-menu/ReactNativeCompatibles (= 7.0.4)
+    - expo-dev-menu/Main (= 7.0.9)
+    - expo-dev-menu/ReactNativeCompatibles (= 7.0.9)
     - fast_float
     - fmt
     - glog
@@ -186,7 +186,7 @@ PODS:
     - SocketRocket
     - Yoga
   - expo-dev-menu-interface (2.0.0)
-  - expo-dev-menu/Main (7.0.4):
+  - expo-dev-menu/Main (7.0.9):
     - boost
     - DoubleConversion
     - EXManifests
@@ -218,7 +218,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-menu/ReactNativeCompatibles (7.0.4):
+  - expo-dev-menu/ReactNativeCompatibles (7.0.9):
     - boost
     - DoubleConversion
     - fast_float
@@ -246,32 +246,32 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ExpoAppleAuthentication (8.0.3):
+  - ExpoAppleAuthentication (8.0.6):
     - ExpoModulesCore
-  - ExpoAsset (12.0.4):
+  - ExpoAsset (12.0.7):
     - ExpoModulesCore
-  - ExpoBlur (15.0.3):
+  - ExpoBlur (15.0.6):
     - ExpoModulesCore
-  - ExpoCamera (17.0.3):
+  - ExpoCamera (17.0.6):
     - ExpoModulesCore
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
-  - ExpoFileSystem (19.0.6):
+  - ExpoFileSystem (19.0.10):
     - ExpoModulesCore
-  - ExpoFont (14.0.4):
+  - ExpoFont (14.0.7):
     - ExpoModulesCore
-  - ExpoImage (3.0.4):
+  - ExpoImage (3.0.7):
     - ExpoModulesCore
     - libavif/libdav1d
     - SDWebImage (~> 5.21.0)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
     - SDWebImageWebPCoder (~> 0.14.6)
-  - ExpoKeepAwake (15.0.3):
+  - ExpoKeepAwake (15.0.6):
     - ExpoModulesCore
-  - ExpoLinearGradient (15.0.3):
+  - ExpoLinearGradient (15.0.6):
     - ExpoModulesCore
-  - ExpoModulesCore (3.0.7):
+  - ExpoModulesCore (3.0.14):
     - boost
     - DoubleConversion
     - fast_float
@@ -300,12 +300,12 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ExpoSplashScreen (31.0.5):
+  - ExpoSplashScreen (31.0.8):
     - ExpoModulesCore
-  - ExpoVideo (3.0.5):
+  - ExpoVideo (3.0.10):
     - ExpoModulesCore
   - EXStructuredHeaders (5.0.0)
-  - EXUpdates (29.0.5):
+  - EXUpdates (29.0.8):
     - boost
     - DoubleConversion
     - EASClient
@@ -342,12 +342,12 @@ PODS:
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.81.1)
+  - FBLazyVector (0.81.2)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.81.1):
-    - hermes-engine/Pre-built (= 0.81.1)
-  - hermes-engine/Pre-built (0.81.1)
+  - hermes-engine (0.81.2):
+    - hermes-engine/Pre-built (= 0.81.2)
+  - hermes-engine/Pre-built (0.81.2)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -384,28 +384,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.81.1)
-  - RCTRequired (0.81.1)
-  - RCTTypeSafety (0.81.1):
-    - FBLazyVector (= 0.81.1)
-    - RCTRequired (= 0.81.1)
-    - React-Core (= 0.81.1)
+  - RCTDeprecation (0.81.2)
+  - RCTRequired (0.81.2)
+  - RCTTypeSafety (0.81.2):
+    - FBLazyVector (= 0.81.2)
+    - RCTRequired (= 0.81.2)
+    - React-Core (= 0.81.2)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.1):
-    - React-Core (= 0.81.1)
-    - React-Core/DevSupport (= 0.81.1)
-    - React-Core/RCTWebSocket (= 0.81.1)
-    - React-RCTActionSheet (= 0.81.1)
-    - React-RCTAnimation (= 0.81.1)
-    - React-RCTBlob (= 0.81.1)
-    - React-RCTImage (= 0.81.1)
-    - React-RCTLinking (= 0.81.1)
-    - React-RCTNetwork (= 0.81.1)
-    - React-RCTSettings (= 0.81.1)
-    - React-RCTText (= 0.81.1)
-    - React-RCTVibration (= 0.81.1)
-  - React-callinvoker (0.81.1)
-  - React-Core (0.81.1):
+  - React (0.81.2):
+    - React-Core (= 0.81.2)
+    - React-Core/DevSupport (= 0.81.2)
+    - React-Core/RCTWebSocket (= 0.81.2)
+    - React-RCTActionSheet (= 0.81.2)
+    - React-RCTAnimation (= 0.81.2)
+    - React-RCTBlob (= 0.81.2)
+    - React-RCTImage (= 0.81.2)
+    - React-RCTLinking (= 0.81.2)
+    - React-RCTNetwork (= 0.81.2)
+    - React-RCTSettings (= 0.81.2)
+    - React-RCTText (= 0.81.2)
+    - React-RCTVibration (= 0.81.2)
+  - React-callinvoker (0.81.2)
+  - React-Core (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -415,7 +415,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.1)
+    - React-Core/Default (= 0.81.2)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -430,82 +430,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.81.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.81.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.81.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.81.1)
-    - React-Core/RCTWebSocket (= 0.81.1)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.1):
+  - React-Core/CoreModulesHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -530,7 +455,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.1):
+  - React-Core/Default (0.81.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.81.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.2)
+    - React-Core/RCTWebSocket (= 0.81.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -555,7 +530,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.1):
+  - React-Core/RCTAnimationHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -580,7 +555,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.1):
+  - React-Core/RCTBlobHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -605,7 +580,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.1):
+  - React-Core/RCTImageHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -630,7 +605,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.1):
+  - React-Core/RCTLinkingHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -655,7 +630,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.1):
+  - React-Core/RCTNetworkHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -680,7 +655,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.1):
+  - React-Core/RCTSettingsHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -705,7 +680,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.1):
+  - React-Core/RCTTextHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -730,7 +705,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.81.1):
+  - React-Core/RCTVibrationHeaders (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -740,7 +715,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.1)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -755,7 +730,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.81.1):
+  - React-Core/RCTWebSocket (0.81.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.2)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -763,20 +763,20 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.81.1)
-    - React-Core/CoreModulesHeaders (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - RCTTypeSafety (= 0.81.2)
+    - React-Core/CoreModulesHeaders (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.1)
+    - React-RCTImage (= 0.81.2)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.81.1):
+  - React-cxxreact (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -785,19 +785,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.1)
-    - React-debug (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
+    - React-debug (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
-    - React-timing (= 0.81.1)
+    - React-timing (= 0.81.2)
     - SocketRocket
-  - React-debug (0.81.1)
-  - React-defaultsnativemodule (0.81.1):
+  - React-debug (0.81.2)
+  - React-defaultsnativemodule (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -814,7 +814,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.81.1):
+  - React-domnativemodule (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -834,7 +834,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.81.1):
+  - React-Fabric (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -848,23 +848,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.1)
-    - React-Fabric/attributedstring (= 0.81.1)
-    - React-Fabric/bridging (= 0.81.1)
-    - React-Fabric/componentregistry (= 0.81.1)
-    - React-Fabric/componentregistrynative (= 0.81.1)
-    - React-Fabric/components (= 0.81.1)
-    - React-Fabric/consistency (= 0.81.1)
-    - React-Fabric/core (= 0.81.1)
-    - React-Fabric/dom (= 0.81.1)
-    - React-Fabric/imagemanager (= 0.81.1)
-    - React-Fabric/leakchecker (= 0.81.1)
-    - React-Fabric/mounting (= 0.81.1)
-    - React-Fabric/observers (= 0.81.1)
-    - React-Fabric/scheduler (= 0.81.1)
-    - React-Fabric/telemetry (= 0.81.1)
-    - React-Fabric/templateprocessor (= 0.81.1)
-    - React-Fabric/uimanager (= 0.81.1)
+    - React-Fabric/animations (= 0.81.2)
+    - React-Fabric/attributedstring (= 0.81.2)
+    - React-Fabric/bridging (= 0.81.2)
+    - React-Fabric/componentregistry (= 0.81.2)
+    - React-Fabric/componentregistrynative (= 0.81.2)
+    - React-Fabric/components (= 0.81.2)
+    - React-Fabric/consistency (= 0.81.2)
+    - React-Fabric/core (= 0.81.2)
+    - React-Fabric/dom (= 0.81.2)
+    - React-Fabric/imagemanager (= 0.81.2)
+    - React-Fabric/leakchecker (= 0.81.2)
+    - React-Fabric/mounting (= 0.81.2)
+    - React-Fabric/observers (= 0.81.2)
+    - React-Fabric/scheduler (= 0.81.2)
+    - React-Fabric/telemetry (= 0.81.2)
+    - React-Fabric/templateprocessor (= 0.81.2)
+    - React-Fabric/uimanager (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -876,32 +876,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.81.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.81.1):
+  - React-Fabric/animations (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -926,7 +901,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.81.1):
+  - React-Fabric/attributedstring (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -951,7 +926,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.81.1):
+  - React-Fabric/bridging (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -976,7 +951,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.81.1):
+  - React-Fabric/componentregistry (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1001,36 +976,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.81.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.1)
-    - React-Fabric/components/root (= 0.81.1)
-    - React-Fabric/components/scrollview (= 0.81.1)
-    - React-Fabric/components/view (= 0.81.1)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.1):
+  - React-Fabric/componentregistrynative (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1055,7 +1001,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.81.1):
+  - React-Fabric/components (0.81.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.2)
+    - React-Fabric/components/root (= 0.81.2)
+    - React-Fabric/components/scrollview (= 0.81.2)
+    - React-Fabric/components/view (= 0.81.2)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1080,7 +1055,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.81.1):
+  - React-Fabric/components/root (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1105,7 +1080,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.81.1):
+  - React-Fabric/components/scrollview (0.81.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1132,7 +1132,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.81.1):
+  - React-Fabric/consistency (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1157,7 +1157,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.81.1):
+  - React-Fabric/core (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1182,7 +1182,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.81.1):
+  - React-Fabric/dom (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1207,7 +1207,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.81.1):
+  - React-Fabric/imagemanager (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1232,7 +1232,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.81.1):
+  - React-Fabric/leakchecker (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1257,7 +1257,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.81.1):
+  - React-Fabric/mounting (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1282,7 +1282,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.81.1):
+  - React-Fabric/observers (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1296,7 +1296,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.1)
+    - React-Fabric/observers/events (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1308,7 +1308,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.81.1):
+  - React-Fabric/observers/events (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1333,7 +1333,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.81.1):
+  - React-Fabric/scheduler (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1360,7 +1360,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.81.1):
+  - React-Fabric/telemetry (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1385,7 +1385,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.81.1):
+  - React-Fabric/templateprocessor (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1410,7 +1410,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.81.1):
+  - React-Fabric/uimanager (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1424,7 +1424,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.1)
+    - React-Fabric/uimanager/consistency (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1437,7 +1437,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.81.1):
+  - React-Fabric/uimanager/consistency (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1463,7 +1463,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.81.1):
+  - React-FabricComponents (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1478,8 +1478,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.1)
-    - React-FabricComponents/textlayoutmanager (= 0.81.1)
+    - React-FabricComponents/components (= 0.81.2)
+    - React-FabricComponents/textlayoutmanager (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1492,7 +1492,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.81.1):
+  - React-FabricComponents/components (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1507,17 +1507,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.1)
-    - React-FabricComponents/components/iostextinput (= 0.81.1)
-    - React-FabricComponents/components/modal (= 0.81.1)
-    - React-FabricComponents/components/rncore (= 0.81.1)
-    - React-FabricComponents/components/safeareaview (= 0.81.1)
-    - React-FabricComponents/components/scrollview (= 0.81.1)
-    - React-FabricComponents/components/switch (= 0.81.1)
-    - React-FabricComponents/components/text (= 0.81.1)
-    - React-FabricComponents/components/textinput (= 0.81.1)
-    - React-FabricComponents/components/unimplementedview (= 0.81.1)
-    - React-FabricComponents/components/virtualview (= 0.81.1)
+    - React-FabricComponents/components/inputaccessory (= 0.81.2)
+    - React-FabricComponents/components/iostextinput (= 0.81.2)
+    - React-FabricComponents/components/modal (= 0.81.2)
+    - React-FabricComponents/components/rncore (= 0.81.2)
+    - React-FabricComponents/components/safeareaview (= 0.81.2)
+    - React-FabricComponents/components/scrollview (= 0.81.2)
+    - React-FabricComponents/components/switch (= 0.81.2)
+    - React-FabricComponents/components/text (= 0.81.2)
+    - React-FabricComponents/components/textinput (= 0.81.2)
+    - React-FabricComponents/components/unimplementedview (= 0.81.2)
+    - React-FabricComponents/components/virtualview (= 0.81.2)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1530,34 +1530,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.1):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.1):
+  - React-FabricComponents/components/inputaccessory (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1584,7 +1557,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.81.1):
+  - React-FabricComponents/components/iostextinput (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1611,7 +1584,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.1):
+  - React-FabricComponents/components/modal (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1638,7 +1611,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.1):
+  - React-FabricComponents/components/rncore (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1665,7 +1638,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.1):
+  - React-FabricComponents/components/safeareaview (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1692,7 +1665,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.81.1):
+  - React-FabricComponents/components/scrollview (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1719,7 +1692,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.81.1):
+  - React-FabricComponents/components/switch (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1746,7 +1719,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.1):
+  - React-FabricComponents/components/text (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1773,7 +1746,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.1):
+  - React-FabricComponents/components/textinput (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1800,7 +1773,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.1):
+  - React-FabricComponents/components/unimplementedview (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1827,7 +1800,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.1):
+  - React-FabricComponents/components/virtualview (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1854,7 +1827,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.81.1):
+  - React-FabricComponents/textlayoutmanager (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1863,21 +1836,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.81.1)
-    - RCTTypeSafety (= 0.81.1)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.81.2):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.81.2)
+    - RCTTypeSafety (= 0.81.2)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.1)
+    - React-jsiexecutor (= 0.81.2)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.81.1):
+  - React-featureflags (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1886,7 +1886,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.81.1):
+  - React-featureflagsnativemodule (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1901,7 +1901,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.81.1):
+  - React-graphics (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1914,7 +1914,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.81.1):
+  - React-hermes (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1923,16 +1923,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
     - React-jsi
-    - React-jsiexecutor (= 0.81.1)
+    - React-jsiexecutor (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.1)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.81.1):
+  - React-idlecallbacksnativemodule (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1948,7 +1948,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.81.1):
+  - React-ImageManager (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1963,7 +1963,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.81.1):
+  - React-jserrorhandler (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1978,7 +1978,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.81.1):
+  - React-jsi (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1988,7 +1988,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.81.1):
+  - React-jsiexecutor (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1997,15 +1997,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.1)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.81.1):
+  - React-jsinspector (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2020,10 +2020,10 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.81.1)
+    - React-perflogger (= 0.81.2)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.81.1):
+  - React-jsinspectorcdp (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2032,7 +2032,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.81.1):
+  - React-jsinspectornetwork (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2045,7 +2045,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.81.1):
+  - React-jsinspectortracing (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2056,7 +2056,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.81.1):
+  - React-jsitooling (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2064,16 +2064,16 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.81.1):
+  - React-jsitracing (0.81.2):
     - React-jsi
-  - React-logger (0.81.1):
+  - React-logger (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2082,7 +2082,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.81.1):
+  - React-Mapbuffer (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2092,7 +2092,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.81.1):
+  - React-microtasksnativemodule (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2106,7 +2106,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-NativeModulesApple (0.81.1):
+  - React-NativeModulesApple (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2126,8 +2126,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.81.1)
-  - React-perflogger (0.81.1):
+  - React-oscompat (0.81.2)
+  - React-perflogger (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2136,7 +2136,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.81.1):
+  - React-performancetimeline (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2149,9 +2149,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.81.1):
-    - React-Core/RCTActionSheetHeaders (= 0.81.1)
-  - React-RCTAnimation (0.81.1):
+  - React-RCTActionSheet (0.81.2):
+    - React-Core/RCTActionSheetHeaders (= 0.81.2)
+  - React-RCTAnimation (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2167,7 +2167,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.81.1):
+  - React-RCTAppDelegate (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2201,7 +2201,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.81.1):
+  - React-RCTBlob (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2220,7 +2220,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.81.1):
+  - React-RCTFabric (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2255,7 +2255,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.1):
+  - React-RCTFBReactNativeSpec (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2269,10 +2269,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.1)
+    - React-RCTFBReactNativeSpec/components (= 0.81.2)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.81.1):
+  - React-RCTFBReactNativeSpec/components (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2295,7 +2295,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.81.1):
+  - React-RCTImage (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2311,14 +2311,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.81.1):
-    - React-Core/RCTLinkingHeaders (= 0.81.1)
-    - React-jsi (= 0.81.1)
+  - React-RCTLinking (0.81.2):
+    - React-Core/RCTLinkingHeaders (= 0.81.2)
+    - React-jsi (= 0.81.2)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.1)
-  - React-RCTNetwork (0.81.1):
+    - ReactCommon/turbomodule/core (= 0.81.2)
+  - React-RCTNetwork (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2336,7 +2336,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.81.1):
+  - React-RCTRuntime (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2356,7 +2356,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.81.1):
+  - React-RCTSettings (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2371,10 +2371,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.81.1):
-    - React-Core/RCTTextHeaders (= 0.81.1)
+  - React-RCTText (0.81.2):
+    - React-Core/RCTTextHeaders (= 0.81.2)
     - Yoga
-  - React-RCTVibration (0.81.1):
+  - React-RCTVibration (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2388,11 +2388,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.81.1)
-  - React-renderercss (0.81.1):
+  - React-rendererconsistency (0.81.2)
+  - React-renderercss (0.81.2):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.1):
+  - React-rendererdebug (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2402,7 +2402,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.81.1):
+  - React-RuntimeApple (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2431,7 +2431,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.81.1):
+  - React-RuntimeCore (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2453,7 +2453,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.81.1):
+  - React-runtimeexecutor (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2463,10 +2463,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.1)
+    - React-jsi (= 0.81.2)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.81.1):
+  - React-RuntimeHermes (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2487,7 +2487,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.81.1):
+  - React-runtimescheduler (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2509,9 +2509,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.81.1):
+  - React-timing (0.81.2):
     - React-debug
-  - React-utils (0.81.1):
+  - React-utils (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2521,11 +2521,11 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.81.1)
+    - React-jsi (= 0.81.2)
     - SocketRocket
-  - ReactAppDependencyProvider (0.81.1):
+  - ReactAppDependencyProvider (0.81.2):
     - ReactCodegen
-  - ReactCodegen (0.81.1):
+  - ReactCodegen (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2551,7 +2551,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.81.1):
+  - ReactCommon (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2559,9 +2559,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.81.1)
+    - ReactCommon/turbomodule (= 0.81.2)
     - SocketRocket
-  - ReactCommon/turbomodule (0.81.1):
+  - ReactCommon/turbomodule (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2570,15 +2570,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.1)
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
-    - ReactCommon/turbomodule/bridging (= 0.81.1)
-    - ReactCommon/turbomodule/core (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
+    - ReactCommon/turbomodule/bridging (= 0.81.2)
+    - ReactCommon/turbomodule/core (= 0.81.2)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.81.1):
+  - ReactCommon/turbomodule/bridging (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2587,13 +2587,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.1)
-    - React-cxxreact (= 0.81.1)
-    - React-jsi (= 0.81.1)
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
+    - React-cxxreact (= 0.81.2)
+    - React-jsi (= 0.81.2)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.81.1):
+  - ReactCommon/turbomodule/core (0.81.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -2602,14 +2602,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.1)
-    - React-cxxreact (= 0.81.1)
-    - React-debug (= 0.81.1)
-    - React-featureflags (= 0.81.1)
-    - React-jsi (= 0.81.1)
-    - React-logger (= 0.81.1)
-    - React-perflogger (= 0.81.1)
-    - React-utils (= 0.81.1)
+    - React-callinvoker (= 0.81.2)
+    - React-cxxreact (= 0.81.2)
+    - React-debug (= 0.81.2)
+    - React-featureflags (= 0.81.2)
+    - React-jsi (= 0.81.2)
+    - React-logger (= 0.81.2)
+    - React-perflogger (= 0.81.2)
+    - React-utils (= 0.81.2)
     - SocketRocket
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
@@ -2938,108 +2938,108 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EASClient: 138582a9575c5a71418f6bdc4fd06bb226a3cc76
-  EXConstants: f7ecf52d3f843309cd3d8ecc0cb104f5ca3a4b31
+  EASClient: cfb28a340d86eeb03c2c67a2c34cd664c97dbc51
+  EXConstants: 4d89ce3567191d8c940b0aab5ba7ddd310c59ad2
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: c496080fa9cc6896c8c0e44de27f0f5d0ba9c6bc
-  Expo: e832107420ffc4a2a34c55005d8202e125e723ca
-  expo-dev-client: 915e39174758c482f43ae14919fadd0b6d877096
-  expo-dev-launcher: 4b4199c512d481fabd51f66baad3cc8d66a2647a
-  expo-dev-menu: f6d95e215f1a32b243f67e3693bad4277a8b4f47
+  EXManifests: 9b19413c322564f3c2dce83006f1d71a4df79ba9
+  Expo: 111f4b2548e241e9400971134fe6928bbf1abae8
+  expo-dev-client: 0835e70a399f4533b7898eba89bbc7406c7e5027
+  expo-dev-launcher: e4e76b2cdb19ccc2736da082f739635249ba396f
+  expo-dev-menu: e665956f0449779e40fc67e6f1fcfd8ab8e2f6db
   expo-dev-menu-interface: 600df12ea01efecdd822daaf13cc0ac091775533
-  ExpoAppleAuthentication: 349c76033258c9212e38f4274ed56ef95c154791
-  ExpoAsset: 035bfce2473fc1b5205705c05a05563985b906f5
-  ExpoBlur: f855bcba5d536cab048a0df0b1fe54306382af3e
-  ExpoCamera: 4f4fb3c8d91a1495f680d2c04ebb7445af50193f
-  ExpoFileSystem: fd826d115d4b3d9a7235a830410bbd8ff325ab70
-  ExpoFont: c34946ae6db5e34148fcc77a05df6a8d49cd2a59
-  ExpoImage: 12ae7ea83b5f8a8c7574577e11252c718ea72175
-  ExpoKeepAwake: 9b9af4742c8d69b0cfeb777ed8e909c1a9938c1d
-  ExpoLinearGradient: 3ecbb56043c494b48edfc29534eeec41351452ab
-  ExpoModulesCore: 3af8015fed7ac983e48212d90a0e3c710389a8bd
-  ExpoSplashScreen: ba6528a6989a5f2e033d8492586683d6df0eb3b4
-  ExpoVideo: e1b99a7404425eaaa026d85e1555d45f9e5a5541
+  ExpoAppleAuthentication: a42dfc311de6767c0529fb6d7f301915f651c7eb
+  ExpoAsset: 6ba39c035bda80b5561acdc7d6e869c0adc571a0
+  ExpoBlur: 33c9fc0c18ba192d181e5a650d4cae8c179857df
+  ExpoCamera: 248b0ee69661779bbd5d07e55c8a5065045020dd
+  ExpoFileSystem: 229cf540729847f8f4556677d36d45cedb9af9ab
+  ExpoFont: 3cb68f520e9349141a28fed6dd94e6cc6bf1453f
+  ExpoImage: 2708a5a9e69b6432f43d368379cc7c9b5165048b
+  ExpoKeepAwake: e5bb3832a4735ee580ac6aa28130d44e1203f11f
+  ExpoLinearGradient: aa4ae248706a0da6bd59a5aae6e2bf24de04dfa8
+  ExpoModulesCore: 70277110748085cd666f4ff8d84804692261a901
+  ExpoSplashScreen: c3d35398bd3678b570772216148791b70a284880
+  ExpoVideo: 9d2f8164d81d2c839b5cf894b19b56294ebc0a27
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
-  EXUpdates: d92c6d845ebd2599923446051da22b2f56a59efb
+  EXUpdates: 19113c09152965c07c1a63cf47f457b4f43394a0
   EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: b8f1312d48447cca7b4abc21ed155db14742bd03
+  FBLazyVector: 89a8574f4a4ea67295ad2e8f84b764e4b1162f64
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
+  hermes-engine: ceacb56b83367e3c4f7ed5ab0e93f92a89e4575b
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
-  RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
-  RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a
-  RCTTypeSafety: 720403058b7c1380c6a3ae5706981d6362962c89
+  RCTDeprecation: b60b889eafa75f46c3d6be5332681efbb16ad0c7
+  RCTRequired: fbdcc9ee2826c0a2ed5bd77a8375b3613d087e99
+  RCTTypeSafety: e1fa82493c521eba295c7ed0d2de80e3d4f22853
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: f1486d005993b0af01943af1850d3d4f3b597545
-  React-callinvoker: 133f69368c8559e744efa345223625d412f5dfbe
-  React-Core: d6d8c1fd33697cec596d33b820456505ee305686
-  React-CoreModules: 81ab751a7668ba161440f9623b994e1a6a3019fe
-  React-cxxreact: 16f2a2751d0dce8b569f23c1914edc90f655b01b
-  React-debug: e01581e1589f329e61c95b332bf7f4969b10564b
-  React-defaultsnativemodule: e956b1d8fe15cc79d23061db229bf88170565f2f
-  React-domnativemodule: a18b0f7a31b9c75f12fa369baece5542d1265b36
-  React-Fabric: c0237a32c3c0dbea2d2b294c8e95605e1dfe2f57
-  React-FabricComponents: 65b03884bd5d9f24c79a631d7d26f0fa079bc4aa
-  React-FabricImage: de1ea2f2a0b32ad02e5cbb64827d1eec0439cf0d
-  React-featureflags: 02de9c35256cc624269b01d670d99e1fd706ea8d
-  React-featureflagsnativemodule: 8b84e67edbaa7b9318390c5bd3ae19790a74f356
-  React-graphics: 004b40c1b236ea3bb8de6693439bef9797922ba9
-  React-hermes: 2179a018b2f86652f6f33ef23efd9e5ac284b247
-  React-idlecallbacksnativemodule: f54ea68f984b12e42feed1e7110623b2c38df4d1
-  React-ImageManager: 9dd04b7b62bc5397f876ca5fb1b712e700ce390c
-  React-jserrorhandler: 2f90bf50fffea1d012e7f3d717c6adf748b1813d
-  React-jsi: b27208f8866e53238534f65f304903e4eff25e05
-  React-jsiexecutor: 1d3e827797f592c393860dea91aaa6d53c7715e7
-  React-jsinspector: bda319277ae779bc476b736fe3a497c6aed304cd
-  React-jsinspectorcdp: 69e1736edfd5420037680b7b4557fa748c3c8216
-  React-jsinspectornetwork: 7aa707b057c6129b4af59e0c9160436bbab25022
-  React-jsinspectortracing: b4a8a328ad2697f9638daa4b7cc054e0303fa47f
-  React-jsitooling: a6c7e2829437b28665e97a398b3374d443125e24
-  React-jsitracing: d87ae17dd0eef7844e605945da926c5433fe2b51
-  React-logger: d27dd2000f520bf891d24f6e141cde34df41f0ee
-  React-Mapbuffer: 0746ffab5ac0f49b7c9347338e3d0c1d9dd634c8
-  React-microtasksnativemodule: b0fb3f97372df39bda3e657536039f1af227cc29
-  React-NativeModulesApple: 9ec9240159974c94886ebbe4caec18e3395f6aef
-  React-oscompat: b12c633e9c00f1f99467b1e0e0b8038895dae436
-  React-perflogger: ccf4fd2664b00818645e588623c7531a8b32d114
-  React-performancetimeline: a866ba759d8e06e9ba174b4421677edcae487baf
-  React-RCTActionSheet: 3f741a3712653611a6bfc5abceb8260af9d0b218
-  React-RCTAnimation: 2edeebfba175cc2e937e2752209ab605d3c48f21
-  React-RCTAppDelegate: a99ef112d5f199aba910c14e046e9dbc7fe89f75
-  React-RCTBlob: 8dfb24b6dd4a5af45e1e59e2fd925b2df1e44d08
-  React-RCTFabric: 2cb67c67e545c6ec76a853861aa275983fe5aca4
-  React-RCTFBReactNativeSpec: 174272d8db878578a7d282b137ccc2da4776877c
-  React-RCTImage: c7fe8c2f2ae8bad98ab4d944d5d50a889da4b652
-  React-RCTLinking: 9ac21ce9f1af914bb01c06af3752db2ec840d0ee
-  React-RCTNetwork: 09a5de71d757dbad4b3fe3615839290200b932aa
-  React-RCTRuntime: 5072e1dbb1ff6d455f0013db6f25d1fdba5f1844
-  React-RCTSettings: fee112652ac7569ea9abe910206e1685f5f9adba
-  React-RCTText: 7ee9d0bc16b3a8149f8df6d70c48e724d0db1d89
-  React-RCTVibration: 619d613abaeb05f6fbc2b2e5e33f724f05df8eb8
-  React-rendererconsistency: a05f6c37f9389c53213d1e28798e441fa6fbdbcd
-  React-renderercss: 3decb27a81648fcdee837c59994b51fff5be5a67
-  React-rendererdebug: 3b9a92d36932af52e1b473f2a89ea4b05dbdecdf
-  React-RuntimeApple: 4e35fb74be4b721c2e1fd6d54ec66456fa7043e9
-  React-RuntimeCore: 0fd7ac6e3e9dd20cb47e87c6b9f35832dd445d5e
-  React-runtimeexecutor: 7680156c9f3a5a49c688bc33f9ec5ea1b00527f5
-  React-RuntimeHermes: 435b7104a3c749af6251353dcb7317a8e53cbd73
-  React-runtimescheduler: 8056b916168e446ea44531883928034e62e76a81
-  React-timing: 36da85e32e53008ce73f87528818191e7f2508ba
-  React-utils: 71e53d55ce778c6e7c7c9db4b1b9d63ef8f55289
-  ReactAppDependencyProvider: 448b422f8af1dedf81374eacc90a15439a0ed7f5
-  ReactCodegen: c6ba7a4a1ef9b0a9f3585ae4c4794a56d0a447b9
-  ReactCommon: e897f9a1b4afab370cfefaaf5fb3c80371bc3937
+  React: 7cee6da22b893d581d51397032d4a3951c03cb17
+  React-callinvoker: 58d4d5a586a1523752a9fa58ef3fc6d0b7fbcbad
+  React-Core: 2a00139af1a13cd5d6234b96024c2e8c609c0486
+  React-CoreModules: 544ebf2a4ef99090ab5f26d3f44e693def986f2f
+  React-cxxreact: 3c2ff1c8c1739ba3827d50c844e7a0e1da2bbd45
+  React-debug: f86bd380de1d8bc8a3ba13eed20f7a7c10290e3a
+  React-defaultsnativemodule: 190bd39694d6b04ed6ff3c6127dab92e3465c99b
+  React-domnativemodule: 160a6555391b13810e633991626c0547c8bffa0f
+  React-Fabric: 1fb8455cf7fc6089aa4e96c4307bd1b7cc1915ca
+  React-FabricComponents: cf05fb1b9a1a16ca700f58c7ab60c1c0d494fe05
+  React-FabricImage: 79676806e07bedf45ecb401242fec00712b95ca2
+  React-featureflags: 7f31869ec867c45a93b93d9079b62d7bfbc29a3c
+  React-featureflagsnativemodule: 31cf067d284d1e5843a810218e57fe9342173b2f
+  React-graphics: c065f94afba7661e192ea8a48e19bcc8fccfb5f6
+  React-hermes: 05f8be1795884b94a4a79deafbd306fde2ac1218
+  React-idlecallbacksnativemodule: 31f3701cdf8cac09cead1115971fc1198a07a923
+  React-ImageManager: 121af59488820720d1158cdd8ae6478b622b2575
+  React-jserrorhandler: eee16d033dc7fc73f4b57a1d038905e4ce8e05e5
+  React-jsi: ff804868b503f2f7ed5f8b7bb780cd036c79a806
+  React-jsiexecutor: d489788717a8577e65c992a352a8fbaa4f699d5c
+  React-jsinspector: 965088adbcd1a3d907cdff2d5b0c840112cdbfb7
+  React-jsinspectorcdp: 2718e82fd69b9ff77b7795f3a99964690f7bd0bd
+  React-jsinspectornetwork: 92a5da5a8c77806d52de3a711d8200f9a0eb1c6e
+  React-jsinspectortracing: da0085d4b8976280ebdc8d308c265dd2ad6e8f4f
+  React-jsitooling: ecd194e4a18aa65f9bf9c99285d3d7dc2d77bda9
+  React-jsitracing: 57cc77243a7feb4c7b851a51ac18261846a51251
+  React-logger: 3d3d703c13b7d0130fa3842f836e93794f6b0589
+  React-Mapbuffer: 689ffb875cf6b1cc9b6be7a587c33ac729d84fd4
+  React-microtasksnativemodule: 94d4726672b7f010ce828f87c4c7305796af4e4e
+  React-NativeModulesApple: 1b204ec5f197270987fe27f86b3d34b5d8406631
+  React-oscompat: 1b3446acd10cdfd739655206b912db37f5e5a80f
+  React-perflogger: d8bb76530906ba368ecb8af364e8c2b3252ec5e0
+  React-performancetimeline: 426ca4f701729c67bd4f2883ce779765a3e6d77c
+  React-RCTActionSheet: fc83c5b18f638ba92ad22005da9d82fb1ba29ab4
+  React-RCTAnimation: 645e538d49be0ae77a399379bf6dec65dccc9e53
+  React-RCTAppDelegate: cc5d6e15e4b62a32d9ba24d01f179e7bcfe3619e
+  React-RCTBlob: 13e8423a3097e33a230488593c27a6b852d07957
+  React-RCTFabric: 9d75135ce412818ff82644c6c8213f8e0c9bf4e7
+  React-RCTFBReactNativeSpec: 6c498fc2c95650b8bdac32de8bbf02419989c036
+  React-RCTImage: 03ef0e56bafd30ebf1e5030c6faf1a96f725b752
+  React-RCTLinking: 392255aec37cf9ed602c602e338f0ee94722fc7c
+  React-RCTNetwork: f4f0d24c4a1b7e7f1a011767231dc8617f8be7ff
+  React-RCTRuntime: 7ea203a206fe18f60106b261d5cb36c1fce8b915
+  React-RCTSettings: 2dbfab042c4063c5788e85e0f5b6ea32d9ab32bb
+  React-RCTText: 55cd9cf7c0c7d26aae506ac8570361dd1f5fabdb
+  React-RCTVibration: 8f5a49199ca5ce898e5d785beca39bc0f1a312e8
+  React-rendererconsistency: fb8d9afcedef714822676c17fa47f782eb690ec4
+  React-renderercss: d3a392fa3da45987e03a6080c5c8d390c62e46c5
+  React-rendererdebug: bee210d645c71613eb7464b1f7583813fe7bb34c
+  React-RuntimeApple: c4c64bb5ac6f907c17b20eb7872668a0f7c4b6fd
+  React-RuntimeCore: 4030ecfba4a1b4a4b67a1a83ccf8a2090860e469
+  React-runtimeexecutor: a07fc15d2b8899b5254fc9e3cc35d0b508e5c47f
+  React-RuntimeHermes: ff7f38c58af45f08488d4d39d3163582f3c5ab2e
+  React-runtimescheduler: 814cd8985699d2af1809cf628ae0ef1f1d07630a
+  React-timing: 9919d1154651af97f6191150f5af00f833cf598a
+  React-utils: f95d319648c01fc920c717acfbccad3fe92a8cdf
+  ReactAppDependencyProvider: 319be07ed29c6a24b30b700ebf6f667c9d49a511
+  ReactCodegen: 5861a6d5e755820ca2bb0d23792a33e71af357f6
+  ReactCommon: 6753d98e6793890f2d0b1b678592c497bc0987ea
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 11c9686a21e2cd82a094a723649d9f4507200fb0
+  Yoga: b9dc6c508cca59caf2f7462189a74359c6c680b6
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: e5e6a8786a10ba50f5287a0a8873ff45bc531270

--- a/apps/paper-tester/package.json
+++ b/apps/paper-tester/package.json
@@ -22,7 +22,7 @@
     "expo-video": "~3.0.10",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.2",
+    "react-native": "0.81.3",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/apps/paper-tester/package.json
+++ b/apps/paper-tester/package.json
@@ -22,7 +22,7 @@
     "expo-video": "~3.0.10",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.1",
+    "react-native": "0.81.2",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -45,7 +45,7 @@
     "expo-sqlite": "~16.0.7",
     "jose": "^5",
     "react": "19.1.0",
-    "react-native": "0.81.1",
+    "react-native": "0.81.2",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0",
     "react-native-webview": "13.13.5"

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -45,7 +45,7 @@
     "expo-sqlite": "~16.0.7",
     "jose": "^5",
     "react": "19.1.0",
-    "react-native": "0.81.2",
+    "react-native": "0.81.3",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0",
     "react-native-webview": "13.13.5"

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -15,7 +15,7 @@
     "expo-router": "^6.0.0-preview.16",
     "expo-splash-screen": "~31.0.8",
     "react": "19.1.0",
-    "react-native": "0.81.1",
+    "react-native": "0.81.2",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.11.1-nightly-20250611-8b82e081e"
   },

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -15,7 +15,7 @@
     "expo-router": "^6.0.0-preview.16",
     "expo-splash-screen": "~31.0.8",
     "react": "19.1.0",
-    "react-native": "0.81.2",
+    "react-native": "0.81.3",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.11.1-nightly-20250611-8b82e081e"
   },

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -51,7 +51,7 @@
     "jasmine-core": "^2.4.1",
     "lodash": "^4.17.19",
     "react": "19.1.0",
-    "react-native": "0.81.2",
+    "react-native": "0.81.3",
     "react-native-gesture-handler": "~2.28.0",
     "sinon": "^7.1.1"
   },

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -51,7 +51,7 @@
     "jasmine-core": "^2.4.1",
     "lodash": "^4.17.19",
     "react": "19.1.0",
-    "react-native": "0.81.1",
+    "react-native": "0.81.2",
     "react-native-gesture-handler": "~2.28.0",
     "sinon": "^7.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "resolutions": {
     "@expo/metro": "~0.1.1",
-    "react-native": "0.81.1",
+    "react-native": "0.81.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "@types/babel__core": "^7.20.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "resolutions": {
     "@expo/metro": "~0.1.1",
-    "react-native": "0.81.2",
+    "react-native": "0.81.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "@types/babel__core": "^7.20.5",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -59,7 +59,7 @@
     "@expo/spawn-async": "^1.7.2",
     "@expo/ws-tunnel": "^1.0.1",
     "@expo/xcpretty": "^4.3.0",
-    "@react-native/dev-middleware": "0.81.1",
+    "@react-native/dev-middleware": "0.81.2",
     "@urql/core": "^5.0.6",
     "@urql/exchange-retry": "^1.3.0",
     "accepts": "^1.3.8",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -59,7 +59,7 @@
     "@expo/spawn-async": "^1.7.2",
     "@expo/ws-tunnel": "^1.0.1",
     "@expo/xcpretty": "^4.3.0",
-    "@react-native/dev-middleware": "0.81.2",
+    "@react-native/dev-middleware": "0.81.3",
     "@urql/core": "^5.0.6",
     "@urql/exchange-retry": "^1.3.0",
     "accepts": "^1.3.8",

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -45,7 +45,7 @@
     "@expo/config-types": "^54.0.7",
     "@expo/image-utils": "^0.8.6",
     "@expo/json-file": "^10.0.6",
-    "@react-native/normalize-colors": "0.81.2",
+    "@react-native/normalize-colors": "0.81.3",
     "debug": "^4.3.1",
     "resolve-from": "^5.0.0",
     "semver": "^7.6.0",

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -45,7 +45,7 @@
     "@expo/config-types": "^54.0.7",
     "@expo/image-utils": "^0.8.6",
     "@expo/json-file": "^10.0.6",
-    "@react-native/normalize-colors": "0.81.1",
+    "@react-native/normalize-colors": "0.81.2",
     "debug": "^4.3.1",
     "resolve-from": "^5.0.0",
     "semver": "^7.6.0",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -69,7 +69,7 @@
     "@babel/plugin-transform-parameters": "^7.24.7",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
-    "@react-native/babel-preset": "0.81.2",
+    "@react-native/babel-preset": "0.81.3",
     "babel-plugin-react-compiler": "^19.1.0-rc.2",
     "babel-plugin-react-native-web": "~0.21.0",
     "babel-plugin-transform-flow-enums": "^0.0.2",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -69,7 +69,7 @@
     "@babel/plugin-transform-parameters": "^7.24.7",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
-    "@react-native/babel-preset": "0.81.1",
+    "@react-native/babel-preset": "0.81.2",
     "babel-plugin-react-compiler": "^19.1.0-rc.2",
     "babel-plugin-react-native-web": "~0.21.0",
     "babel-plugin-transform-flow-enums": "^0.0.2",

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -45,7 +45,7 @@
     "expo-module-scripts": "^5.0.6",
     "fuse.js": "^6.4.6",
     "react": "19.1.0",
-    "react-native": "0.81.2",
+    "react-native": "0.81.3",
     "url": "^0.11.0",
     "use-subscription": "^1.8.0"
   },

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -45,7 +45,7 @@
     "expo-module-scripts": "^5.0.6",
     "fuse.js": "^6.4.6",
     "react": "19.1.0",
-    "react-native": "0.81.1",
+    "react-native": "0.81.2",
     "url": "^0.11.0",
     "use-subscription": "^1.8.0"
   },

--- a/packages/expo-module-template/$package.json
+++ b/packages/expo-module-template/$package.json
@@ -33,7 +33,7 @@
     "@types/react": "~19.1.0",
     "expo-module-scripts": "^5.0.6",
     "expo": "^54.0.0-preview.16",
-    "react-native": "0.81.1"
+    "react-native": "0.81.2"
   },
   "peerDependencies": {
     "expo": "*",

--- a/packages/expo-module-template/$package.json
+++ b/packages/expo-module-template/$package.json
@@ -33,7 +33,7 @@
     "@types/react": "~19.1.0",
     "expo-module-scripts": "^5.0.6",
     "expo": "^54.0.0-preview.16",
-    "react-native": "0.81.2"
+    "react-native": "0.81.3"
   },
   "peerDependencies": {
     "expo": "*",

--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/navigation-bar",
   "dependencies": {
-    "@react-native/normalize-colors": "0.81.1",
+    "@react-native/normalize-colors": "0.81.2",
     "debug": "^4.3.2",
     "react-native-is-edge-to-edge": "^1.2.1"
   },

--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/navigation-bar",
   "dependencies": {
-    "@react-native/normalize-colors": "0.81.2",
+    "@react-native/normalize-colors": "0.81.3",
     "debug": "^4.3.2",
     "react-native-is-edge-to-edge": "^1.2.1"
   },

--- a/packages/expo-system-ui/package.json
+++ b/packages/expo-system-ui/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/system-ui",
   "dependencies": {
-    "@react-native/normalize-colors": "0.81.2",
+    "@react-native/normalize-colors": "0.81.3",
     "debug": "^4.3.2"
   },
   "jest": {

--- a/packages/expo-system-ui/package.json
+++ b/packages/expo-system-ui/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/system-ui",
   "dependencies": {
-    "@react-native/normalize-colors": "0.81.1",
+    "@react-native/normalize-colors": "0.81.2",
     "debug": "^4.3.2"
   },
   "jest": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -92,7 +92,7 @@
   "lottie-react-native": "~7.3.1",
   "react": "19.1.0",
   "react-dom": "19.1.0",
-  "react-native": "0.81.2",
+  "react-native": "0.81.3",
   "react-native-web": "~0.21.0",
   "react-native-gesture-handler": "~2.28.0",
   "react-native-get-random-values": "~1.11.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -92,7 +92,7 @@
   "lottie-react-native": "~7.3.1",
   "react": "19.1.0",
   "react-dom": "19.1.0",
-  "react-native": "0.81.1",
+  "react-native": "0.81.2",
   "react-native-web": "~0.21.0",
   "react-native-gesture-handler": "~2.28.0",
   "react-native-get-random-values": "~1.11.0",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -103,7 +103,7 @@
     "expo-module-scripts": "^5.0.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.2",
+    "react-native": "0.81.3",
     "web-streams-polyfill": "^3.3.2"
   },
   "peerDependencies": {

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -103,7 +103,7 @@
     "expo-module-scripts": "^5.0.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.1",
+    "react-native": "0.81.2",
     "web-streams-polyfill": "^3.3.2"
   },
   "peerDependencies": {

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -14,6 +14,6 @@
     "expo": "~54.0.0-preview.16",
     "expo-status-bar": "~3.0.7",
     "react": "19.1.0",
-    "react-native": "0.81.1"
+    "react-native": "0.81.2"
   }
 }

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -14,6 +14,6 @@
     "expo": "~54.0.0-preview.16",
     "expo-status-bar": "~3.0.7",
     "react": "19.1.0",
-    "react-native": "0.81.2"
+    "react-native": "0.81.3"
   }
 }

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -14,7 +14,7 @@
     "expo": "~54.0.0-preview.16",
     "expo-status-bar": "~3.0.7",
     "react": "19.1.0",
-    "react-native": "0.81.2"
+    "react-native": "0.81.3"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -14,7 +14,7 @@
     "expo": "~54.0.0-preview.16",
     "expo-status-bar": "~3.0.7",
     "react": "19.1.0",
-    "react-native": "0.81.1"
+    "react-native": "0.81.2"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -14,6 +14,6 @@
     "expo": "~54.0.0-preview.16",
     "expo-status-bar": "~3.0.7",
     "react": "19.1.0",
-    "react-native": "0.81.1"
+    "react-native": "0.81.2"
   }
 }

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -14,6 +14,6 @@
     "expo": "~54.0.0-preview.16",
     "expo-status-bar": "~3.0.7",
     "react": "19.1.0",
-    "react-native": "0.81.2"
+    "react-native": "0.81.3"
   }
 }

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -29,7 +29,7 @@
     "expo-web-browser": "~15.0.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.1",
+    "react-native": "0.81.2",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-worklets": "~0.5.1",
     "react-native-reanimated": "~4.1.0",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -29,7 +29,7 @@
     "expo-web-browser": "~15.0.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.2",
+    "react-native": "0.81.3",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-worklets": "~0.5.1",
     "react-native-reanimated": "~4.1.0",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -23,7 +23,7 @@
     "expo-web-browser": "~15.0.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.1",
+    "react-native": "0.81.2",
     "react-native-worklets": "~0.5.1",
     "react-native-reanimated": "~4.1.0",
     "react-native-safe-area-context": "~5.6.0",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -23,7 +23,7 @@
     "expo-web-browser": "~15.0.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.2",
+    "react-native": "0.81.3",
     "react-native-worklets": "~0.5.1",
     "react-native-reanimated": "~4.1.0",
     "react-native-safe-area-context": "~5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3512,23 +3512,23 @@
   resolved "https://registry.yarnpkg.com/@react-native-segmented-control/segmented-control/-/segmented-control-2.5.7.tgz#7c91ef7dede8752796a234321fafa2c604fc82af"
   integrity sha512-l84YeVX8xAU3lvOJSvV4nK/NbGhIm2gBfveYolwaoCbRp+/SLXtc6mYrQmM9ScXNwU14mnzjQTpTHWl5YPnkzQ==
 
-"@react-native/assets-registry@0.81.2":
-  version "0.81.2"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.81.2.tgz#ef50f2f3f8ac6766d44dda5b86536625e0dd2dd5"
-  integrity sha512-4GyfRwSrArEYQo9MkL5nhmQIaBm97kgULiP6daP+yHBc4SB17lQFbPZrGZEpfNCh2bOsOERZ5vPoqAoCaJhC0w==
+"@react-native/assets-registry@0.81.3":
+  version "0.81.3"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.81.3.tgz#cabd36f8289c127ff4ddd353c228244d247943ca"
+  integrity sha512-vjLLbhhYA6JSW87flpf1TUciyCQOp7kwNZQaNqGPE6gRmqRDAf+3mwkSh96kaC4aa8Fqi5AFnMY8otfiKtiPGg==
 
-"@react-native/babel-plugin-codegen@0.81.2":
-  version "0.81.2"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.2.tgz#698b42e3cdfb0a652b19fc166432f133af956ac6"
-  integrity sha512-dAqKHIKdcIEz4WF4JITi2QbT7Asd+b01ZcepsQJUyiHPpS4mLJPiaF0jRQFUmrZbqoGUytz7dVl+cx9b62JR6g==
+"@react-native/babel-plugin-codegen@0.81.3":
+  version "0.81.3"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.3.tgz#64a9146cb9f3dd340dae2bfa551d762809b7c9cc"
+  integrity sha512-Fpo1hs0q5GGraPTlqKKl6JBKhPHTRX9vSLyObo0hr6NBYYAW1rML80ycaPAh65E6wYlylQzRHlM+3HVLnkHFcQ==
   dependencies:
     "@babel/traverse" "^7.25.3"
-    "@react-native/codegen" "0.81.2"
+    "@react-native/codegen" "0.81.3"
 
-"@react-native/babel-preset@0.81.2":
-  version "0.81.2"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.81.2.tgz#428a629b174e7edcc149c475c27eab3310c40e26"
-  integrity sha512-NChrgybA7YEkkgHkOmW0oIcjkJauwNYz0QFgl6OA3AqSKc5p9NZH29SisLi86t0K1BCOLdkc529As7W8TqMA6g==
+"@react-native/babel-preset@0.81.3":
+  version "0.81.3"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.81.3.tgz#48d03fe89e6babf26cb632f248bad497f6b24892"
+  integrity sha512-USi6dJH7FhJbu0cxrYGbcolfNUOMjpsytpP8vyi4nk7/OF6ZbH5lM2MmcJzBThd0Y2nauMosGgiTp6g6rbuhcg==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/plugin-proposal-export-default-from" "^7.24.7"
@@ -3571,15 +3571,15 @@
     "@babel/plugin-transform-typescript" "^7.25.2"
     "@babel/plugin-transform-unicode-regex" "^7.24.7"
     "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.81.2"
+    "@react-native/babel-plugin-codegen" "0.81.3"
     babel-plugin-syntax-hermes-parser "0.29.1"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
 
-"@react-native/codegen@0.81.2":
-  version "0.81.2"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.81.2.tgz#80995e8703e437287367f6c5ec2a9e5b083585ce"
-  integrity sha512-n6RTXBUELSd/xJ6b/6DzqLqk4K6TRqFMEQRwxOsBCJNtUzMN396FSBDB1SjasUQNLq1iP5/kTHCudVGkOXMvbw==
+"@react-native/codegen@0.81.3":
+  version "0.81.3"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.81.3.tgz#357449bc47ed375eeb153d2d26e726fafd3fe75f"
+  integrity sha512-nPphQP8EzeBsvsCGcsQV6juNeLyqyJWFAnKepXE6ERB1RKnv009cyjfbYs9f4dp4Bu8lgQpjlkW1q79KlKJu7Q==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/parser" "^7.25.3"
@@ -3589,12 +3589,12 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/community-cli-plugin@0.81.2":
-  version "0.81.2"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.81.2.tgz#d2d749cd8198e8fd58dfb3ea97902f0f8cc3b6b5"
-  integrity sha512-viKpvJZra1p9I2o0yMNRGrh8pX1L3mdzP3QEW6EneDfj1L09vm1Z6UxWdWsls3hD0idGSY1KFv7sRL7RpY10NQ==
+"@react-native/community-cli-plugin@0.81.3":
+  version "0.81.3"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.81.3.tgz#b02b4deb1c197de1d0bc3eb4723efbc202caaf96"
+  integrity sha512-6pDl9CfHsmuvYN/jdQlOfg1AJavYM+mIQr2LVDbw/0/JlsdvVUq0xCjXH+JlgzsyMihvNPZIwv16XAZ3yPnKYw==
   dependencies:
-    "@react-native/dev-middleware" "0.81.2"
+    "@react-native/dev-middleware" "0.81.3"
     debug "^4.4.0"
     invariant "^2.2.4"
     metro "^0.83.1"
@@ -3602,18 +3602,18 @@
     metro-core "^0.83.1"
     semver "^7.1.3"
 
-"@react-native/debugger-frontend@0.81.2":
-  version "0.81.2"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.81.2.tgz#469620ff0f3004f9afee4541c1b513fe38e0bdc7"
-  integrity sha512-Qt1oadqxgeUAgKnLvIgZp6d5purDVxh2AGSbkP1bj1VWa25DyYCKHRPrO2Ytco+IkLH+x/uXcceJSPEx3uuvXQ==
+"@react-native/debugger-frontend@0.81.3":
+  version "0.81.3"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.81.3.tgz#525e60216845f79f13ff9ffb91f57049a2eb0581"
+  integrity sha512-r85sd9lN/rVa8cQ1rEzUSFzBT3/Gt6HPPSLbqsvsNZFIRNoiSSLFsmkXTA6qxtAEtQfUm3Gr+6xfsNmO3Vvg3g==
 
-"@react-native/dev-middleware@0.81.2":
-  version "0.81.2"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.81.2.tgz#47eb8903a2b8ff10904bf0cf7fda9345854de238"
-  integrity sha512-2xwKG2cHJJ4/33s5yJ5WSLA5bOQq1aggUpABrMElLLiVFyeAj0XFIvSCKbEd4gXeHvReKgbYno/FyLrgQUJwBg==
+"@react-native/dev-middleware@0.81.3":
+  version "0.81.3"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.81.3.tgz#342e4aa676abc95cd9ab1fcb031285b217a4d0aa"
+  integrity sha512-USq6rvCqHdyjZLNUdAgFeJ1YW8shzXBu5OD1TnQ5yZ19UDBxnWQ36jl2vKvpi6qEH5VHddxoVLVrn9dBRBN8rA==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.81.2"
+    "@react-native/debugger-frontend" "0.81.3"
     chrome-launcher "^0.15.2"
     chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
@@ -3624,30 +3624,30 @@
     serve-static "^1.16.2"
     ws "^6.2.3"
 
-"@react-native/gradle-plugin@0.81.2":
-  version "0.81.2"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.81.2.tgz#1953914b8862bf6643a9ee3e78feab8852978d49"
-  integrity sha512-dM0mzumdCpZoxNRVxJQLbPNzUeyGdqJEqoEt4LeSNoHcUSeR0mLlXl6C6oWYVSuULcmVAu6y709ixkusiHBU9Q==
+"@react-native/gradle-plugin@0.81.3":
+  version "0.81.3"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.81.3.tgz#02f3d0fbc5077e3360647e1ecbd466eadb0b0c00"
+  integrity sha512-zEDhVWxrbl7lxg1qiWvIIL7KEdxWhRQ8G9kYbVCvjZE42xE5CXBqvZUEgZL5d2pUR6z/2HAbwjgk4gFYh5g3zg==
 
-"@react-native/js-polyfills@0.81.2":
-  version "0.81.2"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.81.2.tgz#203bfb96cfd4bed6f24502c86a5c302a8ce5dbb1"
-  integrity sha512-UAMNq0ybDn4fFov8pT13acKztOx/wqk80Wu03f9DLV3/FEliiQf7F6GVG1Vu7v0zARtVye8rlBxO7ykpjTWQOA==
+"@react-native/js-polyfills@0.81.3":
+  version "0.81.3"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.81.3.tgz#446728e1cdcf3b63d95711cc061f93c6945cacd7"
+  integrity sha512-YWLrA4fsxFJ5lhIQk+ZaHRL0TSZ0GK8QyJwuAwIExnIugIRSCm8f4qafkTxtDToygbbjGQm61y8hxDIGd9sEtg==
 
-"@react-native/normalize-colors@0.81.2":
-  version "0.81.2"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.81.2.tgz#531306b67278b96803306979c306e9dd505ef47d"
-  integrity sha512-ePS58Kriqsk4Ma8tVN2kUwCXyXr6sLlMpYPhJBejhAtV2n8OxB58TZiuZHMjV6FIQHvoMIH1PzOE9ozCbrjFUA==
+"@react-native/normalize-colors@0.81.3":
+  version "0.81.3"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.81.3.tgz#ecae9d5133511009180d712d7519666685ed46b3"
+  integrity sha512-RCyMSRpSgLPZcxIZVBirmsEJom7GHIP/4XlIepr85cM638t/YVr4S7pg7c79UXVgFJVGTDvBluORFXppJ0YHxQ==
 
 "@react-native/normalize-colors@^0.74.1":
   version "0.74.88"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.74.88.tgz#46f4c7270c8e6853281d7dd966e0eb362068e41a"
   integrity sha512-He5oTwPBxvXrxJ91dZzpxR7P+VYmc9IkJfhuH8zUiU50ckrt+xWNjtVugPdUv4LuVjmZ36Vk2EX8bl1gVn2dVA==
 
-"@react-native/virtualized-lists@0.81.2":
-  version "0.81.2"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.81.2.tgz#b35f3e2210328e83fa5b21509b579cf5bf2421fd"
-  integrity sha512-pVynUfZHghAItM0CyCZlgWOiMCG5PLr2mRsc8xqwbRL+zExIeTnJNGiB0KkVdm9t4j3TfBb5cVCB2p71NlpB3Q==
+"@react-native/virtualized-lists@0.81.3":
+  version "0.81.3"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.81.3.tgz#143cbab8c726e457e1ebea37a4707525d5b2d664"
+  integrity sha512-vYib5Ed4zTrJr+Hlv1mQ0JDNOUVoGoVsKIVn7UgxHwGv1M+a5Ehyze44chPQmq+7o7Y3ix3HwJZGV/tedthqGQ==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -13907,19 +13907,19 @@ react-native-worklets@0.5.1:
     convert-source-map "^2.0.0"
     semver "7.7.2"
 
-react-native@0.81.2:
-  version "0.81.2"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.81.2.tgz#1fb11df1407181ee16739ef9b433759874ef2c54"
-  integrity sha512-5ReSNXX4svm5mpqS5bZQCT7UzuyLgKdjEccvU8IZm3A5Hiv2Ay157jFBKRrZJrtmiqt7xMGQmqQqARD0cEFVUQ==
+react-native@0.81.3:
+  version "0.81.3"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.81.3.tgz#e9739ba3b3d7d6acc6e460605bd7c28885d6e0d0"
+  integrity sha512-8Rk2pLJ4DerW09Vxi0URG9QoPQPC9Q7Q7/CMSisr9qVIBuDQqv5TI+ESoJZjjAJdN1t4QqHrMbzUXpkLCohUNQ==
   dependencies:
     "@jest/create-cache-key-function" "^29.7.0"
-    "@react-native/assets-registry" "0.81.2"
-    "@react-native/codegen" "0.81.2"
-    "@react-native/community-cli-plugin" "0.81.2"
-    "@react-native/gradle-plugin" "0.81.2"
-    "@react-native/js-polyfills" "0.81.2"
-    "@react-native/normalize-colors" "0.81.2"
-    "@react-native/virtualized-lists" "0.81.2"
+    "@react-native/assets-registry" "0.81.3"
+    "@react-native/codegen" "0.81.3"
+    "@react-native/community-cli-plugin" "0.81.3"
+    "@react-native/gradle-plugin" "0.81.3"
+    "@react-native/js-polyfills" "0.81.3"
+    "@react-native/normalize-colors" "0.81.3"
+    "@react-native/virtualized-lists" "0.81.3"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3512,23 +3512,23 @@
   resolved "https://registry.yarnpkg.com/@react-native-segmented-control/segmented-control/-/segmented-control-2.5.7.tgz#7c91ef7dede8752796a234321fafa2c604fc82af"
   integrity sha512-l84YeVX8xAU3lvOJSvV4nK/NbGhIm2gBfveYolwaoCbRp+/SLXtc6mYrQmM9ScXNwU14mnzjQTpTHWl5YPnkzQ==
 
-"@react-native/assets-registry@0.81.1":
-  version "0.81.1"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.81.1.tgz#94993d165b79feeec09432f867ea2edc8a307e60"
-  integrity sha512-o/AeHeoiPW8x9MzxE1RSnKYc+KZMW9b7uaojobEz0G8fKgGD1R8n5CJSOiQ/0yO2fJdC5wFxMMOgy2IKwRrVgw==
+"@react-native/assets-registry@0.81.2":
+  version "0.81.2"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.81.2.tgz#ef50f2f3f8ac6766d44dda5b86536625e0dd2dd5"
+  integrity sha512-4GyfRwSrArEYQo9MkL5nhmQIaBm97kgULiP6daP+yHBc4SB17lQFbPZrGZEpfNCh2bOsOERZ5vPoqAoCaJhC0w==
 
-"@react-native/babel-plugin-codegen@0.81.1":
-  version "0.81.1"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.1.tgz#0681c8e40df0346a0481fb778eed818b6b6db70c"
-  integrity sha512-cxYq78YePcIX2871UiEItG7ibk+GeXRr7A3ZR2DN4fZ7X4An/734DwLVop/CcHpK3Ycr0Re8FKEVTcJRiVb1zg==
+"@react-native/babel-plugin-codegen@0.81.2":
+  version "0.81.2"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.2.tgz#698b42e3cdfb0a652b19fc166432f133af956ac6"
+  integrity sha512-dAqKHIKdcIEz4WF4JITi2QbT7Asd+b01ZcepsQJUyiHPpS4mLJPiaF0jRQFUmrZbqoGUytz7dVl+cx9b62JR6g==
   dependencies:
     "@babel/traverse" "^7.25.3"
-    "@react-native/codegen" "0.81.1"
+    "@react-native/codegen" "0.81.2"
 
-"@react-native/babel-preset@0.81.1":
-  version "0.81.1"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.81.1.tgz#87cef40bf77b25738d6e2dcb9ba0403b7d5c5630"
-  integrity sha512-dCxb4AdaoLZipfKNEpO70WK7cxbTsq62dzK2EuFta65WJO/K7+sMoF8V6P0MKfCaHwj/1Va2rp/LKtHd9ttPVw==
+"@react-native/babel-preset@0.81.2":
+  version "0.81.2"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.81.2.tgz#428a629b174e7edcc149c475c27eab3310c40e26"
+  integrity sha512-NChrgybA7YEkkgHkOmW0oIcjkJauwNYz0QFgl6OA3AqSKc5p9NZH29SisLi86t0K1BCOLdkc529As7W8TqMA6g==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/plugin-proposal-export-default-from" "^7.24.7"
@@ -3571,15 +3571,15 @@
     "@babel/plugin-transform-typescript" "^7.25.2"
     "@babel/plugin-transform-unicode-regex" "^7.24.7"
     "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.81.1"
+    "@react-native/babel-plugin-codegen" "0.81.2"
     babel-plugin-syntax-hermes-parser "0.29.1"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
 
-"@react-native/codegen@0.81.1":
-  version "0.81.1"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.81.1.tgz#6cbe4dbe0c85a260c1fb7dce301234f527771cd6"
-  integrity sha512-8KoUE1j65fF1PPHlAhSeUHmcyqpE+Z7Qv27A89vSZkz3s8eqWSRu2hZtCl0D3nSgS0WW0fyrIsFaRFj7azIiPw==
+"@react-native/codegen@0.81.2":
+  version "0.81.2"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.81.2.tgz#80995e8703e437287367f6c5ec2a9e5b083585ce"
+  integrity sha512-n6RTXBUELSd/xJ6b/6DzqLqk4K6TRqFMEQRwxOsBCJNtUzMN396FSBDB1SjasUQNLq1iP5/kTHCudVGkOXMvbw==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/parser" "^7.25.3"
@@ -3589,12 +3589,12 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/community-cli-plugin@0.81.1":
-  version "0.81.1"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.81.1.tgz#83110c7e839e9385b8ac5108f3c5600ce9db4f94"
-  integrity sha512-FuIpZcjBiiYcVMNx+1JBqTPLs2bUIm6X4F5enYGYcetNE2nfSMUVO8SGUtTkBdbUTfKesXYSYN8wungyro28Ag==
+"@react-native/community-cli-plugin@0.81.2":
+  version "0.81.2"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.81.2.tgz#d2d749cd8198e8fd58dfb3ea97902f0f8cc3b6b5"
+  integrity sha512-viKpvJZra1p9I2o0yMNRGrh8pX1L3mdzP3QEW6EneDfj1L09vm1Z6UxWdWsls3hD0idGSY1KFv7sRL7RpY10NQ==
   dependencies:
-    "@react-native/dev-middleware" "0.81.1"
+    "@react-native/dev-middleware" "0.81.2"
     debug "^4.4.0"
     invariant "^2.2.4"
     metro "^0.83.1"
@@ -3602,18 +3602,18 @@
     metro-core "^0.83.1"
     semver "^7.1.3"
 
-"@react-native/debugger-frontend@0.81.1":
-  version "0.81.1"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.81.1.tgz#db71318e9cfe973cd731c59d2361700b8422a304"
-  integrity sha512-dwKv1EqKD+vONN4xsfyTXxn291CNl1LeBpaHhNGWASK1GO4qlyExMs4TtTjN57BnYHikR9PzqPWcUcfzpVRaLg==
+"@react-native/debugger-frontend@0.81.2":
+  version "0.81.2"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.81.2.tgz#469620ff0f3004f9afee4541c1b513fe38e0bdc7"
+  integrity sha512-Qt1oadqxgeUAgKnLvIgZp6d5purDVxh2AGSbkP1bj1VWa25DyYCKHRPrO2Ytco+IkLH+x/uXcceJSPEx3uuvXQ==
 
-"@react-native/dev-middleware@0.81.1":
-  version "0.81.1"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.81.1.tgz#3a14f416a2fc80d4f993e22bcb84ad781ac4e638"
-  integrity sha512-hy3KlxNOfev3O5/IuyZSstixWo7E9FhljxKGHdvVtZVNjQdM+kPMh66mxeJbB2TjdJGAyBT4DjIwBaZnIFOGHQ==
+"@react-native/dev-middleware@0.81.2":
+  version "0.81.2"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.81.2.tgz#47eb8903a2b8ff10904bf0cf7fda9345854de238"
+  integrity sha512-2xwKG2cHJJ4/33s5yJ5WSLA5bOQq1aggUpABrMElLLiVFyeAj0XFIvSCKbEd4gXeHvReKgbYno/FyLrgQUJwBg==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.81.1"
+    "@react-native/debugger-frontend" "0.81.2"
     chrome-launcher "^0.15.2"
     chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
@@ -3624,30 +3624,30 @@
     serve-static "^1.16.2"
     ws "^6.2.3"
 
-"@react-native/gradle-plugin@0.81.1":
-  version "0.81.1"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.81.1.tgz#a7afdc962c298acf6a99142e6db78b554aba6006"
-  integrity sha512-RpRxs/LbWVM9Zi5jH1qBLgTX746Ei+Ui4vj3FmUCd9EXUSECM5bJpphcsvqjxM5Vfl/o2wDLSqIoFkVP/6Te7g==
+"@react-native/gradle-plugin@0.81.2":
+  version "0.81.2"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.81.2.tgz#1953914b8862bf6643a9ee3e78feab8852978d49"
+  integrity sha512-dM0mzumdCpZoxNRVxJQLbPNzUeyGdqJEqoEt4LeSNoHcUSeR0mLlXl6C6oWYVSuULcmVAu6y709ixkusiHBU9Q==
 
-"@react-native/js-polyfills@0.81.1":
-  version "0.81.1"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.81.1.tgz#066343aca3d3aaf846335492c7114e08e9a0e975"
-  integrity sha512-w093OkHFfCnJKnkiFizwwjgrjh5ra53BU0ebPM3uBLkIQ6ZMNSCTZhG8ZHIlAYeIGtEinvmnSUi3JySoxuDCAQ==
+"@react-native/js-polyfills@0.81.2":
+  version "0.81.2"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.81.2.tgz#203bfb96cfd4bed6f24502c86a5c302a8ce5dbb1"
+  integrity sha512-UAMNq0ybDn4fFov8pT13acKztOx/wqk80Wu03f9DLV3/FEliiQf7F6GVG1Vu7v0zARtVye8rlBxO7ykpjTWQOA==
 
-"@react-native/normalize-colors@0.81.1":
-  version "0.81.1"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.81.1.tgz#bf290526e1bcbb8d14e20b509ca1030d5df71585"
-  integrity sha512-TsaeZlE8OYFy3PSWc+1VBmAzI2T3kInzqxmwXoGU4w1d4XFkQFg271Ja9GmDi9cqV3CnBfqoF9VPwRxVlc/l5g==
+"@react-native/normalize-colors@0.81.2":
+  version "0.81.2"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.81.2.tgz#531306b67278b96803306979c306e9dd505ef47d"
+  integrity sha512-ePS58Kriqsk4Ma8tVN2kUwCXyXr6sLlMpYPhJBejhAtV2n8OxB58TZiuZHMjV6FIQHvoMIH1PzOE9ozCbrjFUA==
 
 "@react-native/normalize-colors@^0.74.1":
   version "0.74.88"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.74.88.tgz#46f4c7270c8e6853281d7dd966e0eb362068e41a"
   integrity sha512-He5oTwPBxvXrxJ91dZzpxR7P+VYmc9IkJfhuH8zUiU50ckrt+xWNjtVugPdUv4LuVjmZ36Vk2EX8bl1gVn2dVA==
 
-"@react-native/virtualized-lists@0.81.1":
-  version "0.81.1"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.81.1.tgz#b550d54a0762e85b88ba9be0b32a1675664f92ed"
-  integrity sha512-yG+zcMtyApW1yRwkNFvlXzEg3RIFdItuwr/zEvPCSdjaL+paX4rounpL0YX5kS9MsDIE5FXfcqINXg7L0xuwPg==
+"@react-native/virtualized-lists@0.81.2":
+  version "0.81.2"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.81.2.tgz#b35f3e2210328e83fa5b21509b579cf5bf2421fd"
+  integrity sha512-pVynUfZHghAItM0CyCZlgWOiMCG5PLr2mRsc8xqwbRL+zExIeTnJNGiB0KkVdm9t4j3TfBb5cVCB2p71NlpB3Q==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -13907,19 +13907,19 @@ react-native-worklets@0.5.1:
     convert-source-map "^2.0.0"
     semver "7.7.2"
 
-react-native@0.81.1:
-  version "0.81.1"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.81.1.tgz#0825cde0cc00d569cbec7d2fa1abd38a66885250"
-  integrity sha512-k2QJzWc/CUOwaakmD1SXa4uJaLcwB2g2V9BauNIjgtXYYAeyFjx9jlNz/+wAEcHLg9bH5mgMdeAwzvXqjjh9Hg==
+react-native@0.81.2:
+  version "0.81.2"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.81.2.tgz#1fb11df1407181ee16739ef9b433759874ef2c54"
+  integrity sha512-5ReSNXX4svm5mpqS5bZQCT7UzuyLgKdjEccvU8IZm3A5Hiv2Ay157jFBKRrZJrtmiqt7xMGQmqQqARD0cEFVUQ==
   dependencies:
     "@jest/create-cache-key-function" "^29.7.0"
-    "@react-native/assets-registry" "0.81.1"
-    "@react-native/codegen" "0.81.1"
-    "@react-native/community-cli-plugin" "0.81.1"
-    "@react-native/gradle-plugin" "0.81.1"
-    "@react-native/js-polyfills" "0.81.1"
-    "@react-native/normalize-colors" "0.81.1"
-    "@react-native/virtualized-lists" "0.81.1"
+    "@react-native/assets-registry" "0.81.2"
+    "@react-native/codegen" "0.81.2"
+    "@react-native/community-cli-plugin" "0.81.2"
+    "@react-native/gradle-plugin" "0.81.2"
+    "@react-native/js-polyfills" "0.81.2"
+    "@react-native/normalize-colors" "0.81.2"
+    "@react-native/virtualized-lists" "0.81.2"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/39192

Obs:  ~~autolinking is broken on iOS when building from source~~ Fixed by upgrading to 0.81.3

# How 

- update package versions
  - `react-native  0.81.1 -> 0.81.3`  
  - `@react-native/normalize-colors 0.81.1 ->  0.81.3` 
  - `@react-native/babel-preset 0.81.1 ->  0.81.3` 
  - `@react-native/dev-middleware 0.81.1 ->  0.81.3`    

# Test Plan
 
bare-expo ios / android
paper-tester ios / android
ci passed

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
