### PR TITLE
[sqlite] fix memory db path issue

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `:memory:` path issue when building on Xcode 26. ([#39511](https://github.com/expo/expo/pull/39511) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 16.0.7 — 2025-09-02

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -68,7 +68,7 @@ public final class SQLiteModule: Module {
     AsyncFunction("importAssetDatabaseAsync") { (databasePath: String, assetDatabasePath: String, forceOverwrite: Bool) in
       let path = try ensureDatabasePathExists(path: databasePath)
       let fileManager = FileManager.default
-      if fileManager.fileExists(atPath: path.standardizedFileURL.path) && !forceOverwrite {
+      if fileManager.fileExists(atPath: path.toFilePath()) && !forceOverwrite {
         return
       }
       guard let assetPath = Utilities.urlFrom(string: assetDatabasePath)?.path,
@@ -76,7 +76,7 @@ public final class SQLiteModule: Module {
         throw DatabaseNotFoundException(assetDatabasePath)
       }
       try? fileManager.removeItem(atPath: path.absoluteString)
-      try fileManager.copyItem(atPath: assetPath, toPath: path.standardizedFileURL.path)
+      try fileManager.copyItem(atPath: assetPath, toPath: path.toFilePath())
     }.runOnQueue(moduleQueue)
 
     AsyncFunction("ensureDatabasePathExistsAsync") { (databasePath: String) in
@@ -111,7 +111,7 @@ public final class SQLiteModule: Module {
           }
 
           let path = try ensureDatabasePathExists(path: databasePath)
-          if exsqlite3_open(path.standardizedFileURL.path, &db) != SQLITE_OK {
+          if exsqlite3_open(path.toFilePath(), &db) != SQLITE_OK {
             throw DatabaseException()
           }
         }
@@ -314,7 +314,7 @@ public final class SQLiteModule: Module {
     guard let pathUrl = URL(string: path) else {
       throw DatabaseInvalidPathException(path)
     }
-    fileSystem.ensureDirExists(withPath: pathUrl.deletingLastPathComponent().standardizedFileURL.path)
+    fileSystem.ensureDirExists(withPath: pathUrl.deletingLastPathComponent().toFilePath())
 
     return pathUrl
   }
@@ -515,7 +515,7 @@ public final class SQLiteModule: Module {
     if databasePath == MEMORY_DB_NAME {
       return
     }
-    let path = try ensureDatabasePathExists(path: databasePath).standardizedFileURL.path
+    let path = try ensureDatabasePathExists(path: databasePath).toFilePath()
 
     if !FileManager.default.fileExists(atPath: path) {
       throw DatabaseNotFoundException(path)

--- a/packages/expo-sqlite/ios/SQLiteModuleLibSQL.swift
+++ b/packages/expo-sqlite/ios/SQLiteModuleLibSQL.swift
@@ -58,7 +58,7 @@ public final class SQLiteModule: Module {
     AsyncFunction("importAssetDatabaseAsync") { (databasePath: String, assetDatabasePath: String, forceOverwrite: Bool) in
       let path = try ensureDatabasePathExists(path: databasePath)
       let fileManager = FileManager.default
-      if fileManager.fileExists(atPath: path.standardizedFileURL.path) && !forceOverwrite {
+      if fileManager.fileExists(atPath: path.toFilePath()) && !forceOverwrite {
         return
       }
       guard let assetPath = Utilities.urlFrom(string: assetDatabasePath)?.path,
@@ -66,7 +66,7 @@ public final class SQLiteModule: Module {
         throw DatabaseNotFoundException(assetDatabasePath)
       }
       try? fileManager.removeItem(atPath: path.absoluteString)
-      try fileManager.copyItem(atPath: assetPath, toPath: path.standardizedFileURL.path)
+      try fileManager.copyItem(atPath: assetPath, toPath: path.toFilePath())
     }.runOnQueue(moduleQueue)
 
     AsyncFunction("ensureDatabasePathExistsAsync") { (databasePath: String) in
@@ -114,7 +114,7 @@ public final class SQLiteModule: Module {
           } else {
             let path = try ensureDatabasePathExists(path: databasePath)
             var result: Int32 = 0
-            path.standardizedFileURL.path.withCString { dbPath in
+            path.toFilePath().withCString { dbPath in
               libSQLUrl.absoluteString.withCString { libSQLUrl in
                 libSQLAuthToken.withCString { libSQLAuthToken in
                   let libSQLConfig = libsql.libsql_config(
@@ -338,7 +338,7 @@ public final class SQLiteModule: Module {
     guard let pathUrl = URL(string: path) else {
       throw DatabaseInvalidPathException(path)
     }
-    fileSystem.ensureDirExists(withPath: pathUrl.deletingLastPathComponent().standardizedFileURL.path)
+    fileSystem.ensureDirExists(withPath: pathUrl.deletingLastPathComponent().toFilePath())
 
     return pathUrl
   }
@@ -539,7 +539,7 @@ public final class SQLiteModule: Module {
     if databasePath == MEMORY_DB_NAME {
       return
     }
-    let path = try ensureDatabasePathExists(path: databasePath).standardizedFileURL.path
+    let path = try ensureDatabasePathExists(path: databasePath).toFilePath()
 
     if !FileManager.default.fileExists(atPath: path) {
       throw DatabaseNotFoundException(path)

--- a/packages/expo-sqlite/ios/URL+FilePath.swift
+++ b/packages/expo-sqlite/ios/URL+FilePath.swift
@@ -1,0 +1,10 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+internal extension URL {
+  func toFilePath() -> String {
+    if !self.isFileURL {
+      return self.absoluteString
+    }
+    return self.standardizedFileURL.path
+  }
+}


### PR DESCRIPTION
# Why

fix expo-sqlite issue when building on ios 26

# How

for `:memory:` URL, on ios sdk 26 with `.standardizedFileURL.path`. it returns invalid path. this pr tries to support this memory db path.

# Test Plan

bare-expo + xcode 26 + test-suite sqlite

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
