### PR TITLE
[docs] Replace `fast-glob` links in docs with `glob`

### DIFF
--- a/docs/pages/build-reference/android-builds.mdx
+++ b/docs/pages/build-reference/android-builds.mdx
@@ -47,7 +47,7 @@ Next, this is what happens when EAS Build picks up your request:
 1. Store a cache of files and directories defined in the [build profile](/build/eas-json/). Subsequent builds will restore this cache.
 1. Upload the application archive to AWS S3.
 
-   - The artifact path can be configured in **eas.json** at `builds.android.PROFILE_NAME.applicationArchivePath`. It defaults to `android/app/build/outputs/**/*.{apk,aab}`. We're using the [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) package for pattern matching.
+   - The artifact path can be configured in **eas.json** at `builds.android.PROFILE_NAME.applicationArchivePath`. It defaults to `android/app/build/outputs/**/*.{apk,aab}`. We're using [glob patterns](https://github.com/isaacs/node-glob#glob-primer) for pattern matching.
 
 1. If the build was successful: run the `eas-build-on-success` script from **package.json** if defined.
 1. If the build failed: run the `eas-build-on-error` script from **package.json** if defined.

--- a/docs/pages/build-reference/ios-builds.mdx
+++ b/docs/pages/build-reference/ios-builds.mdx
@@ -53,7 +53,7 @@ In this next phase, this is what happens when EAS Build picks up your request:
 1. Store a cache of files and directories defined in the [build profile](/build/eas-json). **Podfile.lock** is cached by default. Subsequent builds will restore this cache.
 1. Upload the application archive to a private AWS S3 bucket.
 
-   - The artifact path can be configured in **eas.json** at `builds.ios.PROFILE_NAME.applicationArchivePath`. It defaults to **ios/build/App.ipa**. You can specify a glob-like pattern for `applicationArchivePath`. We're using the [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) package under the hood.
+   - The artifact path can be configured in **eas.json** at `builds.ios.PROFILE_NAME.applicationArchivePath`. It defaults to **ios/build/App.ipa**. You can specify a glob-like pattern for `applicationArchivePath`. We're using [glob patterns](https://github.com/isaacs/node-glob#glob-primer) for pattern matching.
 
 1. If the build was successful: run the `eas-build-on-success` script from **package.json** if defined.
 1. If the build failed: run the `eas-build-on-error` script from **package.json** if defined.

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -1639,10 +1639,10 @@ build:
             assets/*.png
 ```
 
-| Input  | Type     | Description                                                                                                                                                                                                                    |
-| ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `path` | `string` | Required. Path or newline-delimited list of paths to the artifacts to upload to EAS servers. You can use `*` wildcard and other [glob patterns that `fast-glob` supports](https://github.com/mrmlnc/fast-glob#pattern-syntax). |
-| `type` | `string` | The type of artifact that is uploaded to the EAS servers. Allowed values are `application-archive` and `build-artifact`. Defaults to `application-archive`.                                                                    |
+| Input  | Type     | Description                                                                                                                                                                                       |
+| ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `path` | `string` | Required. Path or newline-delimited list of paths to the artifacts to upload to EAS servers. You can use `*` wildcard and other [glob patterns](https://github.com/isaacs/node-glob#glob-primer). |
+| `type` | `string` | The type of artifact that is uploaded to the EAS servers. Allowed values are `application-archive` and `build-artifact`. Defaults to `application-archive`.                                       |
 
 <BoxLink
   title="eas/upload_artifact source code"

--- a/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
@@ -11,9 +11,7 @@ export default [
   {
     name: 'image',
     type: 'string',
-    description: [
-      '[Image with build environment](/build-reference/infrastructure/).',
-    ],
+    description: ['[Image with build environment](/build-reference/infrastructure/).'],
   },
   {
     name: 'resourceClass',
@@ -29,7 +27,7 @@ export default [
   {
     name: 'ndk',
     type: 'string',
-    description: [ 'Version of Android NDK.' ],
+    description: ['Version of Android NDK.'],
   },
   {
     name: 'autoIncrement',
@@ -40,7 +38,7 @@ export default [
       'Allowed values:',
       ' - `"version"` - bumps the patch of `expo.version` (for example, `1.2.3` to `1.2.4`).',
       ' - `"versionCode"` (or `true`) - bumps `expo.android.versionCode` (for example, `3` to `4`).',
-      ' - `false` - versions won\'t be bumped automatically (default).',
+      " - `false` - versions won't be bumped automatically (default).",
       '',
       'Based on the value of [`cli.appVersionSource` in **eas.json**](/build-reference/app-versions/), the values will be updated locally in your project or on EAS servers.',
     ],
@@ -66,7 +64,7 @@ export default [
     name: 'applicationArchivePath',
     type: 'string',
     description: [
-      'Path (or pattern) where EAS Build is going to look for the application archive. EAS Build uses the `fast-glob` npm library for [pattern matching](https://github.com/mrmlnc/fast-glob#pattern-syntax). The default value is `android/app/build/outputs/**/*.{apk,aab}`.'
+      'Path (or pattern) where EAS Build is going to look for the application archive. EAS Build uses [glob patterns](https://github.com/isaacs/node-glob#glob-primer) for pattern matching. The default value is `android/app/build/outputs/**/*.{apk,aab}`.',
     ],
   },
   {
@@ -75,7 +73,7 @@ export default [
     description: [
       'Custom workflow file name that will be used to run this Android build. You can also specify this property on profile level for platform-agnostic workflows. [Learn more](/custom-builds/get-started/).',
       '',
-      'Example: `"config": "production-android.yml"` will use workflow from `.eas/build/production-android.yml`.'
+      'Example: `"config": "production-android.yml"` will use workflow from `.eas/build/production-android.yml`.',
     ],
   },
-]
+];

--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -86,7 +86,7 @@ export default [
     name: 'buildArtifactPaths',
     type: 'string[]',
     description: [
-      'List of paths (or patterns) where EAS Build is going to look for the build artifacts. Use `applicationArchivePath` for specifying the path for uploading the application archive. Build artifacts are uploaded even if the build fails. EAS Build uses the `fast-glob` npm library for [pattern matching](https://github.com/mrmlnc/fast-glob#pattern-syntax).',
+      'List of paths (or patterns) where EAS Build is going to look for the build artifacts. Use `applicationArchivePath` for specifying the path for uploading the application archive. Build artifacts are uploaded even if the build fails. EAS Build uses [glob patterns](https://github.com/isaacs/node-glob#glob-primer) for pattern matching.',
     ],
   },
   {

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -11,13 +11,14 @@ export default [
   {
     name: 'simulator',
     type: 'boolean',
-    description: [ 'If set to true, creates build for iOS Simulator. Defaults to `false`.' ],
+    description: ['If set to true, creates build for iOS Simulator. Defaults to `false`.'],
   },
   {
     name: 'enterpriseProvisioning',
-    enum: [ 'universal', 'adhoc' ],
-    description: [ 'Provisioning method used for `"distribution": "internal"` when you have an Apple account with Apple Developer Enterprise Program membership. You can choose if you want to use `adhoc` or `universal` provisioning. The latter is recommended as it does not require you to register each individual device. If you don\'t provide this option and you still authenticate with an enterprise team, you\'ll be prompted which provisioning method to use.',
-    ]
+    enum: ['universal', 'adhoc'],
+    description: [
+      'Provisioning method used for `"distribution": "internal"` when you have an Apple account with Apple Developer Enterprise Program membership. You can choose if you want to use `adhoc` or `universal` provisioning. The latter is recommended as it does not require you to register each individual device. If you don\'t provide this option and you still authenticate with an enterprise team, you\'ll be prompted which provisioning method to use.',
+    ],
   },
   {
     name: 'autoIncrement',
@@ -28,7 +29,7 @@ export default [
       'Allowed values:',
       ' - `"version"` - bumps the patch of `expo.version` (for example, `1.2.3` to `1.2.4`).',
       ' - `"buildNumber"` (or `true`) - bumps the last component of `expo.ios.buildNumber` (for example, `1.2.3.39` to `1.2.3.40`).',
-      ' - `false` - versions won\'t be bumped automatically (default)',
+      " - `false` - versions won't be bumped automatically (default)",
       '',
       'Based on the value of [`cli.appVersionSource` in **eas.json**](/build-reference/app-versions/), the values will be updated locally in your project or on EAS servers.',
     ],
@@ -36,9 +37,7 @@ export default [
   {
     name: 'image',
     type: 'string',
-    description: [
-      '[Image with build environment](/build-reference/infrastructure).',
-    ],
+    description: ['[Image with build environment](/build-reference/infrastructure).'],
   },
   {
     name: 'resourceClass',
@@ -54,17 +53,17 @@ export default [
   {
     name: 'bundler',
     type: 'string',
-    description: [ 'Version of [bundler](https://bundler.io/).' ],
+    description: ['Version of [bundler](https://bundler.io/).'],
   },
   {
     name: 'fastlane',
     type: 'string',
-    description: [ 'Version of fastlane.' ],
+    description: ['Version of fastlane.'],
   },
   {
     name: 'cocoapods',
     type: 'string',
-    description: [ 'Version of CocoaPods.' ],
+    description: ['Version of CocoaPods.'],
   },
   {
     name: 'scheme',
@@ -74,14 +73,13 @@ export default [
       '   - Has multiple schemes, you should set this value.',
       '   - Has only one scheme, it will be detected automatically.',
       '   - Have multiple schemes schemes and if this value is **not** set, EAS CLI will prompt you to select one of them.',
-
-    ]
+    ],
   },
   {
     name: 'buildConfiguration',
     type: 'string',
     description: [
-      'Xcode project\'s Build Configuration.',
+      "Xcode project's Build Configuration.",
       ' - For an Expo project, the value is `"Release"` or `"Debug"`. Defaults to `"Release"`.',
       ' - For a [bare React Native](/bare/overview/) project, defaults to the value specified in the scheme.',
       '',
@@ -92,7 +90,7 @@ export default [
     name: 'applicationArchivePath',
     type: 'string',
     description: [
-      'Path (or pattern) where EAS Build is going to look for the application archive. EAS Build uses the `fast-glob` npm package for [pattern matching](https://github.com/mrmlnc/fast-glob#pattern-syntax). You should modify that path only if you are using a custom **Gymfile**. The default is `ios/build/Build/Products/*-iphonesimulator/*.app` when building for simulator and `ios/build/*.ipa` in other cases.'
+      'Path (or pattern) where EAS Build is going to look for the application archive. EAS Build uses [glob patterns](https://github.com/isaacs/node-glob#glob-primer) for pattern matching. You should modify that path only if you are using a custom **Gymfile**. The default is `ios/build/Build/Products/*-iphonesimulator/*.app` when building for simulator and `ios/build/*.ipa` in other cases.',
     ],
   },
   {
@@ -101,7 +99,7 @@ export default [
     description: [
       'Custom workflow file name that will be used to run this iOS build. You can also specify this property on profile level for platform-agnostic workflows. [Learn more](/custom-builds/get-started/).',
       '',
-      'Example: `"config": "production-ios.yml"` will use workflow from `.eas/build/production-ios.yml`.'
+      'Example: `"config": "production-ios.yml"` will use workflow from `.eas/build/production-ios.yml`.',
     ],
   },
-]
+];

--- a/docs/public/static/schemas/unversioned/eas-json-submit-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-submit-android-schema.js
@@ -2,27 +2,35 @@ export default [
   {
     name: 'serviceAccountKeyPath',
     type: 'string',
-    description: ['Path to the JSON file with [Google Service Account Key](https://expo.fyi/creating-google-service-account) used to authenticate with Google Play.'],
+    description: [
+      'Path to the JSON file with [Google Service Account Key](https://expo.fyi/creating-google-service-account) used to authenticate with Google Play.',
+    ],
   },
   {
     name: 'track',
     enum: ['production', 'beta', 'alpha', 'internal'],
-    description: ['The track of the application to use.']
+    description: ['The track of the application to use.'],
   },
   {
     name: 'releaseStatus',
     enum: ['completed', 'draft', 'halted', 'inProgress'],
-    description: ['The [status of a release](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#status).'],
+    description: [
+      'The [status of a release](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#status).',
+    ],
   },
   {
     name: 'rollout',
     type: 'number',
-    description: ['The initial fraction of users who are eligible to receive the release. Should be a value from 0 (no users) to 1 (all users). Works only with `inProgress` [release status](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#status).'],
+    description: [
+      'The initial fraction of users who are eligible to receive the release. Should be a value from 0 (no users) to 1 (all users). Works only with `inProgress` [release status](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks#status).',
+    ],
   },
   {
     name: 'changesNotSentForReview',
     type: 'boolean',
-    description: ['Indicates that the changes sent with this submission will not be reviewed until they are explicitly sent for review from the Google Play Console UI. Defaults to `false`.'],
+    description: [
+      'Indicates that the changes sent with this submission will not be reviewed until they are explicitly sent for review from the Google Play Console UI. Defaults to `false`.',
+    ],
   },
   {
     name: 'applicationId',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-15066

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Replace `fast-glob`links in multiple docs with `glob`'s primer
  - Updated references in Android and iOS build documentation to state that artifact path matching uses [glob patterns](https://github.com/isaacs/node-glob#glob-primer) instead of the `fast-glob` package.
  - Updated the custom builds schema documentation to reference standard glob patterns for artifact paths, removing mention of `fast-glob`.
  - Updated schema files (`eas-json-build-android-schema.js`, `eas-json-build-ios-schema.js`, `eas-json-build-common-schema.js`) to reference glob patterns. Also, automatically applied Prettier formatting from the docs config file for consistency.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
