### PR TITLE
[docs] Update the "Migrate to Expo CLI" guide to point to the Expo metro config

### DIFF
--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -24,6 +24,8 @@ In most cases, executing the following command in a project directory to install
 
 For a detailed installation guide, see [Install Expo modules](/bare/installing-expo-modules).
 
+> **info** After installing the `expo` package, you'll need to configure your project to use Expo CLI. This includes setting up Metro config, Babel preset, and native project configurations. See the [Configure Expo CLI for bundling on Android and iOS](/bare/installing-expo-modules/#configure-expo-cli-for-bundling-on-android-and-ios) section for the complete setup instructions.
+
 ## Why Expo CLI instead of React Native CLI
 
 Expo CLI commands provide several benefits over the similar commands in `@react-native-community/cli`, which includes:
@@ -105,6 +107,12 @@ Now, with the `expo` package installed and configured in your project, you can s
   title="Expo CLI Reference"
   description="Learn more about the commands and flags available in Expo CLI."
   href="/more/expo-cli"
+  Icon={BookOpen02Icon}
+/>
+<BoxLink
+  title="Customizing Metro"
+  description="Learn how to customize the Metro bundler configuration for your project."
+  href="/guides/customizing-metro"
   Icon={BookOpen02Icon}
 />
 <BoxLink


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-11244

# How

<!--
How did you build this feature or fix this bug and why?
-->

This pull request updates the documentation for using Expo CLI in bare React Native projects. It adds important guidance about configuring your project after installing the `expo` package and improves navigation by linking to related setup and customization guides.

Documentation improvements:

* Added a note clarifying that after installing the `expo` package, you must also configure Metro, Babel, and native project settings, with a link to the detailed configuration instructions.
* Added a new "Customizing Metro" BoxLink to help users find information on adjusting Metro bundler settings for their project.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally and visit: http://localhost:3002/bare/using-expo-cli/#install-the-expo-package.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
