### PR TITLE
[docs] Fix callout inconsistencies

### DIFF
--- a/docs/pages/build/orbit.mdx
+++ b/docs/pages/build/orbit.mdx
@@ -42,7 +42,7 @@ If you want Orbit to start when you log in automatically, click on the Orbit ico
 
 <Tab label="Windows">
 
-> **Note**: Orbit for Windows is in preview and is only compatible with x64 and x86 machines. Compatibility for other architectures will be added in the future.
+> **important** Orbit for Windows is in preview and is only compatible with x64 and x86 machines. Compatibility for other architectures will be added in the future.
 
 You can download Orbit for Windows directly from the [GitHub releases](https://github.com/expo/orbit/releases).
 

--- a/docs/pages/deploy/web.mdx
+++ b/docs/pages/deploy/web.mdx
@@ -6,7 +6,7 @@ description: Learn how to deploy your web app using EAS Hosting.
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> **warning** **EAS Hosting** is in preview and subject to changes.
+> **important** **EAS Hosting** is in preview and subject to changes.
 
 If you are building a universal app, you can quickly deploy your web app using [EAS Hosting](/eas/hosting/introduction/). It is a service for deploying web apps built with Expo Router and React.
 

--- a/docs/pages/develop/tools.mdx
+++ b/docs/pages/develop/tools.mdx
@@ -91,7 +91,7 @@ If you want Orbit to start when you log in automatically, click on the Orbit ico
 
 <Tab label="Windows">
 
-> **Note**: Orbit for Windows is in preview and is only compatible with x64 and x86 machines. Compatibility for other architectures will be added in the future.
+> **important** Orbit for Windows is in preview and is only compatible with x64 and x86 machines. Compatibility for other architectures will be added in the future.
 
 You can download Orbit for Windows directly from the [GitHub releases](https://github.com/expo/orbit/releases).
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
While working on #39521, found multiple docs that use `warning` callout type to display "in preview" notes. It seems, some of them missed the update in https://github.com/expo/expo/pull/36433.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Replace "Note" and "warning" callouts with "important" callouts for consistency and clarity across the documentation for "...in preview" callouts.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
