### PR TITLE
[core][Android] Fixes `JNI detected error in application: obj == null` in `ExpoModulesHostObject::get`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixes `JNI detected error in application: obj == null` in `ExpoModulesHostObject::get`.
+- [Android] Fixes `JNI detected error in application: obj == null` in `ExpoModulesHostObject::get`. ([#39523](https://github.com/expo/expo/pull/39523) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixes `JNI detected error in application: obj == null` in `ExpoModulesHostObject::get`.
+
 ### 💡 Others
 
 ## 3.0.14 — 2025-09-08

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -28,6 +28,10 @@ ExpoModulesHostObject::~ExpoModulesHostObject() {
 }
 
 jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {
+  if (installer->wasDeallocated()) {
+    return jsi::Value::undefined();
+  }
+
   auto cName = name.utf8(runtime);
 
   if (UniqueJSIObject &cachedObject = modulesCache[cName]) {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/39498
Fixes `JNI detected error in application: obj == null` in `ExpoModulesHostObject::get`

# How

We can't reproduce this issue. However, the current theory is that JavaScript tries to execute some pending code after deallocation. RN uses the async model for cleanup, so situations like this are very likely and have been addressed in many previous PRs. I've added a check to minimize the number of crashes.

# Test Plan

- none :/ 