### PR TITLE
fix(cli): Fix fast refresh with ESM live bindings by modifying getter skipping

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Apply upstream changes to optional require runtime fork ([#39473](https://github.com/expo/expo/pull/39473) by [@kitten](https://github.com/kitten))
+- Fix fast refresh with live bindings by applying getter exception and always using forked module system ([#39525](https://github.com/expo/expo/pull/39525) by [@kitten](https://github.com/kitten))
 
 ## 0.26.9 — 2025-09-08
 

--- a/packages/@expo/cli/e2e/__tests__/export/static-rendering.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-rendering.test.ts
@@ -57,9 +57,7 @@ describe('exports static', () => {
 
     ['other', 'welcome-to-the-universe'].forEach((post) => {
       it(`can serve up statically generated html for post: ${post}`, async () => {
-        const html = getHtml(
-          await server.fetchAsync(`/${post}`).then((res) => res.text())
-        );
+        const html = getHtml(await server.fetchAsync(`/${post}`).then((res) => res.text()));
         expect(html.querySelector('[data-testid="post-text"]')?.textContent).toEqual(
           `Post: ${post}`
         );
@@ -107,7 +105,15 @@ describe('exports static', () => {
         expect.arrayContaining([
           '__prelude__',
           // NOTE: No `/Users/evanbacon/`...
-          expect.pathMatching(/\/node_modules\/metro-runtime\/src\/polyfills\/require\.js/),
+          // NOTE(@kitten): We can slot in our own runtime here
+          expect.pathMatching(
+            new RegExp(
+              [
+                '/node_modules/metro-runtime/src/polyfills/require.js',
+                '/@expo/cli/build/metro-require/require.js',
+              ].join('|')
+            )
+          ),
 
           // NOTE: relative to the server root for optimal source map support
           expect.pathMatching(/\/apps\/router-e2e\/__e2e__\/static-rendering\/app\/\[post\]\.tsx/),

--- a/packages/@expo/cli/e2e/__tests__/start-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/start-test.ts
@@ -146,7 +146,15 @@ describe('server', () => {
       version: 3,
       sources: expect.arrayContaining([
         '__prelude__',
-        expect.pathMatching(/metro-runtime\/src\/polyfills\/require\.js$/),
+        // NOTE(@kitten): We can slot in our own runtime here
+        expect.pathMatching(
+          new RegExp(
+            [
+              '/metro-runtime/src/polyfills/require.js',
+              '/@expo/cli/build/metro-require/require.js',
+            ].join('|')
+          )
+        ),
         expect.pathMatching(/@react-native\/js-polyfills\/console\.js$/),
         expect.pathMatching(/@react-native\/js-polyfills\/error-guard\.js$/),
         '\0polyfill:external-require',

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -853,7 +853,6 @@ export async function withMetroMultiPlatformAsync(
     isFastResolverEnabled,
     isExporting,
     isReactCanaryEnabled,
-    isNamedRequiresEnabled,
     isReactServerComponentsEnabled,
     getMetroBundler,
   }: {
@@ -870,14 +869,12 @@ export async function withMetroMultiPlatformAsync(
     getMetroBundler: () => Bundler;
   }
 ) {
-  if (isNamedRequiresEnabled) {
-    debug('Using Expo metro require runtime.');
-    // Change the default metro-runtime to a custom one that supports bundle splitting.
-    const metroDefaults: Mutable<
-      typeof import('@expo/metro/metro-config/defaults/defaults')
-    > = require('@expo/metro/metro-config/defaults/defaults');
-    metroDefaults.moduleSystem = require.resolve('@expo/cli/build/metro-require/require');
-  }
+  // Change the default metro-runtime to a custom one that supports bundle splitting.
+  // NOTE(@kitten): This is now always active and EXPO_USE_METRO_REQUIRE / isNamedRequiresEnabled is disregarded
+  const metroDefaults: Mutable<
+    typeof import('@expo/metro/metro-config/defaults/defaults')
+  > = require('@expo/metro/metro-config/defaults/defaults');
+  metroDefaults.moduleSystem = require.resolve('@expo/cli/build/metro-require/require');
 
   if (!config.projectRoot) {
     // @ts-expect-error: read-only types


### PR DESCRIPTION
Resolves #39505

# Why

The default Metro runtime skips getters even if we're checking in ES Modules (`__esModule`). This is a bug and we can work around this for now by using our forked `moduleSystem`, which seems to have few changes apart from module ID hints and was updated here: https://github.com/expo/expo/pull/39473

# How

- Always enable `moduleSystem` override
- Ensure that we don't skip getters on `__esModule` marked exports

When we see a getter on `__esModule` marked `module.exports` objects, we should still access all properties on it, including the getters.

# Test Plan

- Test fast refresh against an app without `expo-router`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
