### PR TITLE
[android][updates] Propagate controller scope to state machine

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Propagate controller scope to state machine.
+
 ### 💡 Others
 
 ## 29.0.8 — 2025-09-02

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Propagate controller scope to state machine.
+- [Android] Propagate controller scope to state machine. ([#39526](https://github.com/expo/expo/pull/39526) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesStateMachineInstrumentationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesStateMachineInstrumentationTest.kt
@@ -64,14 +64,14 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_defaultState() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.entries.toSet())
     Assert.assertEquals(UpdatesStateValue.Idle, machine.getState())
   }
 
   @Test
   fun test_sequenceNumbers() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.entries.toSet())
     Assert.assertEquals(UpdatesStateValue.Idle, machine.getState())
 
     Assert.assertEquals(0, machine.context.sequenceNumber)
@@ -87,7 +87,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_restart() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.entries.toSet())
     Assert.assertEquals(UpdatesStateValue.Idle, machine.getState())
 
     Assert.assertEquals(false, machine.context.isRestarting)
@@ -104,7 +104,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_handleStartStartupAndEndStartup() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.entries.toSet())
 
     machine.processEventTest(UpdatesStateEvent.StartStartup())
 
@@ -120,7 +120,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_handleCheckAndCheckCompleteAvailable() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.entries.toSet())
 
     machine.processEventTest(UpdatesStateEvent.Check())
 
@@ -145,7 +145,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_handleCheckCompleteUnavailable() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.entries.toSet())
 
     machine.processEventTest(UpdatesStateEvent.Check())
 
@@ -169,7 +169,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_handleDownloadAndDownloadComplete() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.entries.toSet())
 
     machine.processEventTest(UpdatesStateEvent.Download())
 
@@ -201,7 +201,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_handleDownloadProgress() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.entries.toSet())
 
     machine.processEventTest(UpdatesStateEvent.Download())
     Assert.assertEquals(UpdatesStateValue.Downloading, machine.getState())
@@ -219,7 +219,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_handleRollback() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.entries.toSet())
     val commitTime = Date()
     machine.processEventTest(UpdatesStateEvent.Check())
 
@@ -245,7 +245,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_checkError() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.entries.toSet())
 
     machine.processEventTest(UpdatesStateEvent.Check())
 
@@ -273,7 +273,7 @@ class UpdatesStateMachineInstrumentationTest {
   @Test
   fun test_invalidTransitions() {
     val testStateChangeEventManager = TestStateChangeEventManager()
-    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.values().toSet())
+    val machine = UpdatesStateMachine(logger, testStateChangeEventManager, UpdatesStateValue.entries.toSet())
     machine.processEventTest(UpdatesStateEvent.Check())
     Assert.assertEquals(UpdatesStateValue.Checking, machine.getState())
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -32,6 +32,7 @@ import expo.modules.updates.statemachine.UpdatesStateValue
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -60,8 +61,8 @@ class EnabledUpdatesController(
 
   private val selectionPolicy: SelectionPolicy
     get() = SelectionPolicyFactory.createFilterAwarePolicy(updatesConfiguration.getRuntimeVersion(), updatesConfiguration)
-  private val stateMachine = UpdatesStateMachine(logger, eventManager, UpdatesStateValue.entries.toSet())
-  private val controllerScope = CoroutineScope(Dispatchers.IO)
+  private val controllerScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+  private val stateMachine = UpdatesStateMachine(logger, eventManager, UpdatesStateValue.entries.toSet(), controllerScope)
   private val fileDownloader: FileDownloader
     get() = FileDownloader(context.filesDir, EASClientID(context).uuid.toString(), updatesConfiguration, logger)
   private val databaseHolder = DatabaseHolder(UpdatesDatabase.getInstance(context, Dispatchers.IO))
@@ -111,7 +112,8 @@ class EnabledUpdatesController(
       override fun onRequestRelaunch(shouldRunReaper: Boolean, callback: LauncherCallback) {
         relaunchReactApplication(shouldRunReaper, callback)
       }
-    }
+    },
+    controllerScope
   )
 
   private val launchedUpdate
@@ -183,7 +185,8 @@ class EnabledUpdatesController(
       setCurrentLauncher = { currentLauncher -> startupProcedure.setLauncher(currentLauncher) },
       shouldRunReaper = shouldRunReaper,
       reloadScreenManager = reloadScreenManager,
-      callback
+      callback,
+      controllerScope
     )
     stateMachine.queueExecution(procedure)
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -33,6 +33,7 @@ import expo.modules.updatesinterface.UpdatesInterface
 import expo.modules.updatesinterface.UpdatesInterfaceCallbacks
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.json.JSONObject
@@ -67,7 +68,7 @@ class UpdatesDevLauncherController(
   private var updatesConfiguration: UpdatesConfiguration? = initialUpdatesConfiguration
 
   private val databaseHolder = DatabaseHolder(UpdatesDatabase.getInstance(context, Dispatchers.IO))
-  private val controllerScope = CoroutineScope(Dispatchers.IO)
+  private val controllerScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
   private var mSelectionPolicy: SelectionPolicy? = null
   private var defaultSelectionPolicy: SelectionPolicy = SelectionPolicy(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/NoDatabaseLauncher.kt
@@ -5,6 +5,7 @@ import expo.modules.updates.loader.EmbeddedLoader
 import expo.modules.updates.logging.UpdatesLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -20,7 +21,7 @@ class NoDatabaseLauncher @JvmOverloads constructor(
   private val context: Context,
   private val logger: UpdatesLogger,
   fatalException: Exception? = null,
-  launcherScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+  launcherScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 ) : Launcher {
   override val bundleAssetName = EmbeddedLoader.BARE_BUNDLE_FILENAME
   override val launchedUpdate = null

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -19,6 +19,7 @@ import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.manifest.Update
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import java.io.File
 import java.io.IOException
 import java.util.*
@@ -38,7 +39,7 @@ abstract class Loader protected constructor(
   private val database: UpdatesDatabase,
   private val updatesDirectory: File,
   private val loaderFiles: LoaderFiles,
-  private var scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+  private var scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 ) {
   private var updateResponse: UpdateResponse? = null
   private var updateEntity: UpdateEntity? = null

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/StartupProcedure.kt
@@ -80,7 +80,7 @@ class StartupProcedure(
     object : LoaderTask.LoaderTaskCallback {
       override fun onFailure(e: Exception) {
         logger.error("UpdatesController loaderTask onFailure", e, UpdatesErrorCode.None)
-        launcher = NoDatabaseLauncher(context, logger, e)
+        launcher = NoDatabaseLauncher(context, logger, e, procedureScope)
         emergencyLaunchException = e
         notifyController()
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -4,6 +4,8 @@ import expo.modules.updates.events.IUpdatesEventManager
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.procedures.StateMachineProcedure
 import expo.modules.updates.procedures.StateMachineSerialExecutorQueue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import java.util.Date
 
 /**
@@ -13,7 +15,8 @@ import java.util.Date
 class UpdatesStateMachine(
   private val logger: UpdatesLogger,
   private val eventManager: IUpdatesEventManager,
-  private val validUpdatesStateValues: Set<UpdatesStateValue>
+  private val validUpdatesStateValues: Set<UpdatesStateValue>,
+  scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 ) {
   private val serialExecutorQueue = StateMachineSerialExecutorQueue(
     logger,
@@ -30,7 +33,8 @@ class UpdatesStateMachine(
       override fun resetStateAfterRestart() {
         resetAndIncrementRestartCount()
       }
-    }
+    },
+    scope
   )
 
   /**


### PR DESCRIPTION
# Why
The lifecycle of the coroutines should be tied to the controller. That was the plan with the initial change but this is not the case currently with the state machine and its procedures. I added a scope argument to the procedures but also added a default if it wasn't provided, this was to reduce the number of errors during the refactor but I forgot to update the call sites and pass the controllers scope. Also, we were just using a standard `Job` meaning cancellation in any of the child coroutines causes the entire job to be cancelled. This is not what we want.

# How
- Replace the controllers job with a `SupervisorJob` so failures do not cascade up and cancel the parent. We are handling errors in the state machine and want it to continue even if a procedure encountered an error
- Provide the controllers scope to the state machine

# Test Plan
This fixes cancellation errors not being correctly propagated to the parent scope and stops the entire job from shutting down if an error is encountered. 

Local e2e ✅
CI

