### PR TITLE
Upgrade React Native to 0.81.4

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -632,10 +632,10 @@ PODS:
     - Yoga
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
-  - FBLazyVector (0.81.3)
-  - hermes-engine (0.81.3):
-    - hermes-engine/Pre-built (= 0.81.3)
-  - hermes-engine/Pre-built (0.81.3)
+  - FBLazyVector (0.81.4)
+  - hermes-engine (0.81.4):
+    - hermes-engine/Pre-built (= 0.81.4)
+  - hermes-engine/Pre-built (0.81.4)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -692,32 +692,32 @@ PODS:
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - Quick (7.3.1)
-  - RCTDeprecation (0.81.3)
-  - RCTRequired (0.81.3)
-  - RCTTypeSafety (0.81.3):
-    - FBLazyVector (= 0.81.3)
-    - RCTRequired (= 0.81.3)
-    - React-Core (= 0.81.3)
+  - RCTDeprecation (0.81.4)
+  - RCTRequired (0.81.4)
+  - RCTTypeSafety (0.81.4):
+    - FBLazyVector (= 0.81.4)
+    - RCTRequired (= 0.81.4)
+    - React-Core (= 0.81.4)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.3):
-    - React-Core (= 0.81.3)
-    - React-Core/DevSupport (= 0.81.3)
-    - React-Core/RCTWebSocket (= 0.81.3)
-    - React-RCTActionSheet (= 0.81.3)
-    - React-RCTAnimation (= 0.81.3)
-    - React-RCTBlob (= 0.81.3)
-    - React-RCTImage (= 0.81.3)
-    - React-RCTLinking (= 0.81.3)
-    - React-RCTNetwork (= 0.81.3)
-    - React-RCTSettings (= 0.81.3)
-    - React-RCTText (= 0.81.3)
-    - React-RCTVibration (= 0.81.3)
-  - React-callinvoker (0.81.3)
-  - React-Core (0.81.3):
+  - React (0.81.4):
+    - React-Core (= 0.81.4)
+    - React-Core/DevSupport (= 0.81.4)
+    - React-Core/RCTWebSocket (= 0.81.4)
+    - React-RCTActionSheet (= 0.81.4)
+    - React-RCTAnimation (= 0.81.4)
+    - React-RCTBlob (= 0.81.4)
+    - React-RCTImage (= 0.81.4)
+    - React-RCTLinking (= 0.81.4)
+    - React-RCTNetwork (= 0.81.4)
+    - React-RCTSettings (= 0.81.4)
+    - React-RCTText (= 0.81.4)
+    - React-RCTVibration (= 0.81.4)
+  - React-callinvoker (0.81.4)
+  - React-Core (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.81.3)
+    - React-Core/Default (= 0.81.4)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -732,66 +732,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.81.3):
+  - React-Core-prebuilt (0.81.4):
     - ReactNativeDependencies
-  - React-Core/CoreModulesHeaders (0.81.3):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/Default (0.81.3):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/DevSupport (0.81.3):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default (= 0.81.3)
-    - React-Core/RCTWebSocket (= 0.81.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.3):
+  - React-Core/CoreModulesHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -810,7 +753,45 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.3):
+  - React-Core/Default (0.81.4):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/DevSupport (0.81.4):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-Core/Default (= 0.81.4)
+    - React-Core/RCTWebSocket (= 0.81.4)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -829,7 +810,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.3):
+  - React-Core/RCTAnimationHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -848,7 +829,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.3):
+  - React-Core/RCTBlobHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -867,7 +848,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.3):
+  - React-Core/RCTImageHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -886,7 +867,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.3):
+  - React-Core/RCTLinkingHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -905,7 +886,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.3):
+  - React-Core/RCTNetworkHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -924,7 +905,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.3):
+  - React-Core/RCTSettingsHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -943,7 +924,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.3):
+  - React-Core/RCTTextHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -962,11 +943,11 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTWebSocket (0.81.3):
+  - React-Core/RCTVibrationHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.81.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -981,37 +962,56 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-CoreModules (0.81.3):
-    - RCTTypeSafety (= 0.81.3)
+  - React-Core/RCTWebSocket (0.81.4):
+    - hermes-engine
+    - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/CoreModulesHeaders (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - React-Core/Default (= 0.81.4)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-CoreModules (0.81.4):
+    - RCTTypeSafety (= 0.81.4)
+    - React-Core-prebuilt
+    - React-Core/CoreModulesHeaders (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.3)
+    - React-RCTImage (= 0.81.4)
     - React-runtimeexecutor
     - ReactCommon
     - ReactNativeDependencies
-  - React-cxxreact (0.81.3):
+  - React-cxxreact (0.81.4):
     - hermes-engine
-    - React-callinvoker (= 0.81.3)
+    - React-callinvoker (= 0.81.4)
     - React-Core-prebuilt
-    - React-debug (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - React-debug (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
+    - React-logger (= 0.81.4)
+    - React-perflogger (= 0.81.4)
     - React-runtimeexecutor
-    - React-timing (= 0.81.3)
+    - React-timing (= 0.81.4)
     - ReactNativeDependencies
-  - React-debug (0.81.3)
-  - React-defaultsnativemodule (0.81.3):
+  - React-debug (0.81.4)
+  - React-defaultsnativemodule (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-domnativemodule
@@ -1022,7 +1022,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - ReactNativeDependencies
-  - React-domnativemodule (0.81.3):
+  - React-domnativemodule (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-Fabric
@@ -1036,7 +1036,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric (0.81.3):
+  - React-Fabric (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1044,23 +1044,23 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.3)
-    - React-Fabric/attributedstring (= 0.81.3)
-    - React-Fabric/bridging (= 0.81.3)
-    - React-Fabric/componentregistry (= 0.81.3)
-    - React-Fabric/componentregistrynative (= 0.81.3)
-    - React-Fabric/components (= 0.81.3)
-    - React-Fabric/consistency (= 0.81.3)
-    - React-Fabric/core (= 0.81.3)
-    - React-Fabric/dom (= 0.81.3)
-    - React-Fabric/imagemanager (= 0.81.3)
-    - React-Fabric/leakchecker (= 0.81.3)
-    - React-Fabric/mounting (= 0.81.3)
-    - React-Fabric/observers (= 0.81.3)
-    - React-Fabric/scheduler (= 0.81.3)
-    - React-Fabric/telemetry (= 0.81.3)
-    - React-Fabric/templateprocessor (= 0.81.3)
-    - React-Fabric/uimanager (= 0.81.3)
+    - React-Fabric/animations (= 0.81.4)
+    - React-Fabric/attributedstring (= 0.81.4)
+    - React-Fabric/bridging (= 0.81.4)
+    - React-Fabric/componentregistry (= 0.81.4)
+    - React-Fabric/componentregistrynative (= 0.81.4)
+    - React-Fabric/components (= 0.81.4)
+    - React-Fabric/consistency (= 0.81.4)
+    - React-Fabric/core (= 0.81.4)
+    - React-Fabric/dom (= 0.81.4)
+    - React-Fabric/imagemanager (= 0.81.4)
+    - React-Fabric/leakchecker (= 0.81.4)
+    - React-Fabric/mounting (= 0.81.4)
+    - React-Fabric/observers (= 0.81.4)
+    - React-Fabric/scheduler (= 0.81.4)
+    - React-Fabric/telemetry (= 0.81.4)
+    - React-Fabric/templateprocessor (= 0.81.4)
+    - React-Fabric/uimanager (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1072,26 +1072,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animations (0.81.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/attributedstring (0.81.3):
+  - React-Fabric/animations (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1110,7 +1091,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/bridging (0.81.3):
+  - React-Fabric/attributedstring (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1129,7 +1110,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistry (0.81.3):
+  - React-Fabric/bridging (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1148,7 +1129,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistrynative (0.81.3):
+  - React-Fabric/componentregistry (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1167,30 +1148,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components (0.81.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.3)
-    - React-Fabric/components/root (= 0.81.3)
-    - React-Fabric/components/scrollview (= 0.81.3)
-    - React-Fabric/components/view (= 0.81.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.3):
+  - React-Fabric/componentregistrynative (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1209,7 +1167,30 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/root (0.81.3):
+  - React-Fabric/components (0.81.4):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.4)
+    - React-Fabric/components/root (= 0.81.4)
+    - React-Fabric/components/scrollview (= 0.81.4)
+    - React-Fabric/components/view (= 0.81.4)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1228,7 +1209,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/scrollview (0.81.3):
+  - React-Fabric/components/root (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1247,7 +1228,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/view (0.81.3):
+  - React-Fabric/components/scrollview (0.81.4):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/view (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1268,7 +1268,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric/consistency (0.81.3):
+  - React-Fabric/consistency (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1287,7 +1287,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/core (0.81.3):
+  - React-Fabric/core (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1306,7 +1306,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/dom (0.81.3):
+  - React-Fabric/dom (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1325,7 +1325,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/imagemanager (0.81.3):
+  - React-Fabric/imagemanager (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1344,7 +1344,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/leakchecker (0.81.3):
+  - React-Fabric/leakchecker (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1363,7 +1363,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/mounting (0.81.3):
+  - React-Fabric/mounting (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1382,7 +1382,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers (0.81.3):
+  - React-Fabric/observers (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1390,7 +1390,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.3)
+    - React-Fabric/observers/events (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1402,7 +1402,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers/events (0.81.3):
+  - React-Fabric/observers/events (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1421,7 +1421,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/scheduler (0.81.3):
+  - React-Fabric/scheduler (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1442,7 +1442,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/telemetry (0.81.3):
+  - React-Fabric/telemetry (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1461,7 +1461,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/templateprocessor (0.81.3):
+  - React-Fabric/templateprocessor (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1480,7 +1480,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager (0.81.3):
+  - React-Fabric/uimanager (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1488,7 +1488,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.3)
+    - React-Fabric/uimanager/consistency (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1501,7 +1501,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager/consistency (0.81.3):
+  - React-Fabric/uimanager/consistency (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1521,7 +1521,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-FabricComponents (0.81.3):
+  - React-FabricComponents (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1530,8 +1530,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.3)
-    - React-FabricComponents/textlayoutmanager (= 0.81.3)
+    - React-FabricComponents/components (= 0.81.4)
+    - React-FabricComponents/textlayoutmanager (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1544,7 +1544,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components (0.81.3):
+  - React-FabricComponents/components (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1553,17 +1553,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.3)
-    - React-FabricComponents/components/iostextinput (= 0.81.3)
-    - React-FabricComponents/components/modal (= 0.81.3)
-    - React-FabricComponents/components/rncore (= 0.81.3)
-    - React-FabricComponents/components/safeareaview (= 0.81.3)
-    - React-FabricComponents/components/scrollview (= 0.81.3)
-    - React-FabricComponents/components/switch (= 0.81.3)
-    - React-FabricComponents/components/text (= 0.81.3)
-    - React-FabricComponents/components/textinput (= 0.81.3)
-    - React-FabricComponents/components/unimplementedview (= 0.81.3)
-    - React-FabricComponents/components/virtualview (= 0.81.3)
+    - React-FabricComponents/components/inputaccessory (= 0.81.4)
+    - React-FabricComponents/components/iostextinput (= 0.81.4)
+    - React-FabricComponents/components/modal (= 0.81.4)
+    - React-FabricComponents/components/rncore (= 0.81.4)
+    - React-FabricComponents/components/safeareaview (= 0.81.4)
+    - React-FabricComponents/components/scrollview (= 0.81.4)
+    - React-FabricComponents/components/switch (= 0.81.4)
+    - React-FabricComponents/components/text (= 0.81.4)
+    - React-FabricComponents/components/textinput (= 0.81.4)
+    - React-FabricComponents/components/unimplementedview (= 0.81.4)
+    - React-FabricComponents/components/virtualview (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1576,28 +1576,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.3):
+  - React-FabricComponents/components/inputaccessory (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1618,7 +1597,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/modal (0.81.3):
+  - React-FabricComponents/components/iostextinput (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1639,7 +1618,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.3):
+  - React-FabricComponents/components/modal (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1660,7 +1639,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.3):
+  - React-FabricComponents/components/rncore (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1681,7 +1660,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.3):
+  - React-FabricComponents/components/safeareaview (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1702,7 +1681,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/switch (0.81.3):
+  - React-FabricComponents/components/scrollview (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1723,7 +1702,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/text (0.81.3):
+  - React-FabricComponents/components/switch (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1744,7 +1723,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.3):
+  - React-FabricComponents/components/text (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1765,7 +1744,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.3):
+  - React-FabricComponents/components/textinput (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1786,7 +1765,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.3):
+  - React-FabricComponents/components/unimplementedview (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1807,7 +1786,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.3):
+  - React-FabricComponents/components/virtualview (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1828,27 +1807,48 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricImage (0.81.3):
+  - React-FabricComponents/textlayoutmanager (0.81.4):
     - hermes-engine
-    - RCTRequired (= 0.81.3)
-    - RCTTypeSafety (= 0.81.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - React-FabricImage (0.81.4):
+    - hermes-engine
+    - RCTRequired (= 0.81.4)
+    - RCTTypeSafety (= 0.81.4)
     - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.3)
+    - React-jsiexecutor (= 0.81.4)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-featureflags (0.81.3):
+  - React-featureflags (0.81.4):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-featureflagsnativemodule (0.81.3):
+  - React-featureflagsnativemodule (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1857,26 +1857,26 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-graphics (0.81.3):
+  - React-graphics (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
     - React-jsiexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-hermes (0.81.3):
+  - React-hermes (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
     - React-jsi
-    - React-jsiexecutor (= 0.81.3)
+    - React-jsiexecutor (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.3)
+    - React-perflogger (= 0.81.4)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-idlecallbacksnativemodule (0.81.3):
+  - React-idlecallbacksnativemodule (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1886,7 +1886,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-ImageManager (0.81.3):
+  - React-ImageManager (0.81.4):
     - React-Core-prebuilt
     - React-Core/Default
     - React-debug
@@ -1895,7 +1895,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - ReactNativeDependencies
-  - React-jserrorhandler (0.81.3):
+  - React-jserrorhandler (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1904,22 +1904,22 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - ReactNativeDependencies
-  - React-jsi (0.81.3):
+  - React-jsi (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsiexecutor (0.81.3):
+  - React-jsiexecutor (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.3)
+    - React-perflogger (= 0.81.4)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspector (0.81.3):
+  - React-jsinspector (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1928,43 +1928,43 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.81.3)
+    - React-perflogger (= 0.81.4)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspectorcdp (0.81.3):
+  - React-jsinspectorcdp (0.81.4):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsinspectornetwork (0.81.3):
+  - React-jsinspectornetwork (0.81.4):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectorcdp
     - React-performancetimeline
     - React-timing
     - ReactNativeDependencies
-  - React-jsinspectortracing (0.81.3):
+  - React-jsinspectortracing (0.81.4):
     - React-Core-prebuilt
     - React-oscompat
     - React-timing
     - ReactNativeDependencies
-  - React-jsitooling (0.81.3):
+  - React-jsitooling (0.81.4):
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsitracing (0.81.3):
+  - React-jsitracing (0.81.4):
     - React-jsi
-  - React-logger (0.81.3):
+  - React-logger (0.81.4):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-Mapbuffer (0.81.3):
+  - React-Mapbuffer (0.81.4):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-microtasksnativemodule (0.81.3):
+  - React-microtasksnativemodule (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -2225,7 +2225,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-NativeModulesApple (0.81.3):
+  - React-NativeModulesApple (0.81.4):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -2239,20 +2239,20 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-oscompat (0.81.3)
-  - React-perflogger (0.81.3):
+  - React-oscompat (0.81.4)
+  - React-perflogger (0.81.4):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-performancetimeline (0.81.3):
+  - React-performancetimeline (0.81.4):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
     - ReactNativeDependencies
-  - React-RCTActionSheet (0.81.3):
-    - React-Core/RCTActionSheetHeaders (= 0.81.3)
-  - React-RCTAnimation (0.81.3):
+  - React-RCTActionSheet (0.81.4):
+    - React-Core/RCTActionSheetHeaders (= 0.81.4)
+  - React-RCTAnimation (0.81.4):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
@@ -2262,7 +2262,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTAppDelegate (0.81.3):
+  - React-RCTAppDelegate (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2290,7 +2290,7 @@ PODS:
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTBlob (0.81.3):
+  - React-RCTBlob (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
@@ -2303,7 +2303,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFabric (0.81.3):
+  - React-RCTFabric (0.81.4):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -2332,7 +2332,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.3):
+  - React-RCTFBReactNativeSpec (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2340,10 +2340,10 @@ PODS:
     - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.3)
+    - React-RCTFBReactNativeSpec/components (= 0.81.4)
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFBReactNativeSpec/components (0.81.3):
+  - React-RCTFBReactNativeSpec/components (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2360,7 +2360,7 @@ PODS:
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-RCTImage (0.81.3):
+  - React-RCTImage (0.81.4):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTImageHeaders
@@ -2370,14 +2370,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTLinking (0.81.3):
-    - React-Core/RCTLinkingHeaders (= 0.81.3)
-    - React-jsi (= 0.81.3)
+  - React-RCTLinking (0.81.4):
+    - React-Core/RCTLinkingHeaders (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.3)
-  - React-RCTNetwork (0.81.3):
+    - ReactCommon/turbomodule/core (= 0.81.4)
+  - React-RCTNetwork (0.81.4):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
@@ -2389,7 +2389,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTRuntime (0.81.3):
+  - React-RCTRuntime (0.81.4):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -2403,7 +2403,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - ReactNativeDependencies
-  - React-RCTSettings (0.81.3):
+  - React-RCTSettings (0.81.4):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
@@ -2412,10 +2412,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTText (0.81.3):
-    - React-Core/RCTTextHeaders (= 0.81.3)
+  - React-RCTText (0.81.4):
+    - React-Core/RCTTextHeaders (= 0.81.4)
     - Yoga
-  - React-RCTVibration (0.81.3):
+  - React-RCTVibration (0.81.4):
     - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
@@ -2423,15 +2423,15 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-rendererconsistency (0.81.3)
-  - React-renderercss (0.81.3):
+  - React-rendererconsistency (0.81.4)
+  - React-renderercss (0.81.4):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.3):
+  - React-rendererdebug (0.81.4):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-RuntimeApple (0.81.3):
+  - React-RuntimeApple (0.81.4):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2454,7 +2454,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeCore (0.81.3):
+  - React-RuntimeCore (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -2470,14 +2470,14 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-runtimeexecutor (0.81.3):
+  - React-runtimeexecutor (0.81.4):
     - React-Core-prebuilt
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.3)
+    - React-jsi (= 0.81.4)
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeHermes (0.81.3):
+  - React-RuntimeHermes (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -2492,7 +2492,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-runtimescheduler (0.81.3):
+  - React-runtimescheduler (0.81.4):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2508,17 +2508,17 @@ PODS:
     - React-timing
     - React-utils
     - ReactNativeDependencies
-  - React-timing (0.81.3):
+  - React-timing (0.81.4):
     - React-debug
-  - React-utils (0.81.3):
+  - React-utils (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-debug
-    - React-jsi (= 0.81.3)
+    - React-jsi (= 0.81.4)
     - ReactNativeDependencies
-  - ReactAppDependencyProvider (0.81.3):
+  - ReactAppDependencyProvider (0.81.4):
     - ReactCodegen
-  - ReactCodegen (0.81.3):
+  - ReactCodegen (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2538,43 +2538,43 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactCommon (0.81.3):
+  - ReactCommon (0.81.4):
     - React-Core-prebuilt
-    - ReactCommon/turbomodule (= 0.81.3)
+    - ReactCommon/turbomodule (= 0.81.4)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule (0.81.3):
+  - ReactCommon/turbomodule (0.81.4):
     - hermes-engine
-    - React-callinvoker (= 0.81.3)
+    - React-callinvoker (= 0.81.4)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
-    - ReactCommon/turbomodule/bridging (= 0.81.3)
-    - ReactCommon/turbomodule/core (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
+    - React-jsi (= 0.81.4)
+    - React-logger (= 0.81.4)
+    - React-perflogger (= 0.81.4)
+    - ReactCommon/turbomodule/bridging (= 0.81.4)
+    - ReactCommon/turbomodule/core (= 0.81.4)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/bridging (0.81.3):
+  - ReactCommon/turbomodule/bridging (0.81.4):
     - hermes-engine
-    - React-callinvoker (= 0.81.3)
+    - React-callinvoker (= 0.81.4)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
+    - React-jsi (= 0.81.4)
+    - React-logger (= 0.81.4)
+    - React-perflogger (= 0.81.4)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/core (0.81.3):
+  - ReactCommon/turbomodule/core (0.81.4):
     - hermes-engine
-    - React-callinvoker (= 0.81.3)
+    - React-callinvoker (= 0.81.4)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.3)
-    - React-debug (= 0.81.3)
-    - React-featureflags (= 0.81.3)
-    - React-jsi (= 0.81.3)
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
-    - React-utils (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
+    - React-debug (= 0.81.4)
+    - React-featureflags (= 0.81.4)
+    - React-jsi (= 0.81.4)
+    - React-logger (= 0.81.4)
+    - React-perflogger (= 0.81.4)
+    - React-utils (= 0.81.4)
     - ReactNativeDependencies
-  - ReactNativeDependencies (0.81.3)
+  - ReactNativeDependencies (0.81.4)
   - RNCAsyncStorage (2.2.0):
     - hermes-engine
     - RCTRequired
@@ -3625,10 +3625,10 @@ SPEC CHECKSUMS:
   ExpoWebBrowser: 84d4438464d9754a4c1f1eaa97cd747f3752187e
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
   EXTaskManager: eedcd03c1a574c47d3f48d83d4e4659b3c1fa29b
-  EXUpdates: dea432165f9769babf63e152969c42f0f881ec44
+  EXUpdates: 270a2043daef202851760c8824f9010635db51af
   EXUpdatesInterface: 5adf50cb41e079c861da6d9b4b954c3db9a50734
-  FBLazyVector: d06087501b6a425c222a186e94ce92aa4d3fb37c
-  hermes-engine: 5463d3c4a8a0d35701605934008f34c171ce71d5
+  FBLazyVector: 9e0cd874afd81d9a4d36679daca991b58b260d42
+  hermes-engine: 35c763d57c9832d0eef764316ca1c4d043581394
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3637,40 +3637,40 @@ SPEC CHECKSUMS:
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCTDeprecation: 0b7e84477d8780fc8dff04fc1ec89cb93f8f5c04
-  RCTRequired: 497c1356844e5e95975ff2259bedc2db446c4ed0
-  RCTTypeSafety: 6105baaba5a22b1ff4f2e420eda172aa423acd01
+  RCTDeprecation: 7487d6dda857ccd4cb3dd6ecfccdc3170e85dcbc
+  RCTRequired: 54128b7df8be566881d48c7234724a78cb9b6157
+  RCTTypeSafety: d2b07797a79e45d7b19e1cd2f53c79ab419fe217
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 639d04fed84b2ff824861d863891eaef7cb92f9c
-  React-callinvoker: 9eff267e8435b7ab377acf16a64d69e897f35c25
-  React-Core: fd1d3e15edf0b13c7b807a84cc1773c7076838ab
-  React-Core-prebuilt: 95b0c929b27d4265fcbf2fb034663608a8e4a1d4
-  React-CoreModules: 3615e6bb61c5480a6373ce99ff392029e6f0431e
-  React-cxxreact: 6cb49800945d16e767a4f5570f918fa2a81ab12c
-  React-debug: 9c09818ae432a10ab72c973b727b944b75ccadb9
-  React-defaultsnativemodule: 94edbde811796181e3a987e71d42d04c50376b6b
-  React-domnativemodule: 1befe7ea6b5483e7f7b65c9fcf6094002395a603
-  React-Fabric: 1178f05391e1d6ef41c9096a65390780c5c0b038
-  React-FabricComponents: 3e5812e4a317682d40411218dbac3d9d1212dae0
-  React-FabricImage: efd32d5944a7128c28e89b172f18bbbb9b882910
-  React-featureflags: 3cab9b4a0cc65390d6867cd8b2cf7074fa7cbeb8
-  React-featureflagsnativemodule: 56693505f4e43c30683079069ea6c4309e0187d7
-  React-graphics: 6c948e5ff22dcebd9019ad07fc91fa26fba02a04
-  React-hermes: deaa86612dcf7b3be232097d9233cb56fc42f04f
-  React-idlecallbacksnativemodule: 9bce141f4066fea6b199ca4d3afc5c7346b2069c
-  React-ImageManager: cd13a85fc05ba3d6a77138410be87122f93377aa
-  React-jserrorhandler: 5aa0e2f14fe9c2f60943c96bd1ab6731fba64cae
-  React-jsi: 298e8fe9d827e15092d984dbdb8aa027481763e2
-  React-jsiexecutor: 117228ba82691fe09c16f7faa3de7a4fd68fe2a1
-  React-jsinspector: 548d9899b7628194bb0ee750577fba2de2fe6340
-  React-jsinspectorcdp: f90bce5fae330fc9a4d0405b0b8e525d1cb212d5
-  React-jsinspectornetwork: 0010a409d514ebc8c485ca7da14b5f2da0c7a97d
-  React-jsinspectortracing: 210edc63b9623430f90b19382762ccd37afee39e
-  React-jsitooling: eaa12d6ce86706df1887bd3c77f20d31a6b8524d
-  React-jsitracing: 6f49a2f7106a6aa91b961375d513d9f5772aed28
-  React-logger: a70b52b3af34146e53117586cd255d9847fb62c8
-  React-Mapbuffer: 4cdf4d8d86e5ad005720e22ade9293ad9345ddaa
-  React-microtasksnativemodule: fddc8e254c18f4e3adc69bff7a81bc82a78b035f
+  React: 2073376f47c71b7e9a0af7535986a77522ce1049
+  React-callinvoker: 00fa0972a70df7408a4f088144b67207b157e386
+  React-Core: d375dd308561785c739a621a21802e5e7e047dee
+  React-Core-prebuilt: dde79b89f8863efebb1d532a3335f472927da669
+  React-CoreModules: 3eb9b1410a317987c557afc683cc50099562c91d
+  React-cxxreact: 724210b64158d97f150d8d254a7319e73ef77ee7
+  React-debug: c01d176522cf57cdc4a4a66d1974968fcf497f32
+  React-defaultsnativemodule: 3953ff49013fa997e72586628e1d218fdaf3abdb
+  React-domnativemodule: 540b9c7a8f31b6f4ed449aafd3a272e1f1107089
+  React-Fabric: 00b792be016edad758a63c4ebac15e01d35f6355
+  React-FabricComponents: 16ebdb9245d91ec27985a038d0a6460f499db54e
+  React-FabricImage: 2a967b5f0293c1c49ec883babfd4992d161e3583
+  React-featureflags: 4150b4ddac8210b1e3c538cfb455050b5ee05d8d
+  React-featureflagsnativemodule: ff977040205b96818ac1f884846493cb8a2aca28
+  React-graphics: ec689ac1c13a9ddb1af83baf195264676ecdbeb6
+  React-hermes: ff60a3407f27f3fc82f661774a7ab6559a24ab69
+  React-idlecallbacksnativemodule: 5f5ce3c424941f77da4ac3adba681149e68b1221
+  React-ImageManager: 8d87296a86f9ee290c1d32c68c7be1be63492467
+  React-jserrorhandler: 072756f12136284c86e96c33cdfece4d7286a99f
+  React-jsi: b507852b42a9125dffbf6ae7a33792fb521b29a2
+  React-jsiexecutor: f970eed6debb91fe5d5d6cb5734d39cf86c59896
+  React-jsinspector: 766e113e9482b22971b30236d10c04d8af38269e
+  React-jsinspectorcdp: 5b60350e29fe2566d9ed9799858c04b8e6095a3e
+  React-jsinspectornetwork: b3cc9a20c6b270f792eaaaa14313019a031b327d
+  React-jsinspectortracing: d99120fcf0864209c45cefbc9fc4605c8189c0ef
+  React-jsitooling: 9e41724cc47feadefbede31ca91d70f6ff079656
+  React-jsitracing: ca020d934502de8e02cccf451501434a5e584027
+  React-logger: 7b234de35acb469ce76d6bbb0457f664d6f32f62
+  React-Mapbuffer: fbe1da882a187e5898bdf125e1cc6e603d27ecae
+  React-microtasksnativemodule: 76905804171d8ccbe69329fc84c57eb7934add7f
   react-native-keyboard-controller: 1ad78688f744e0ebdf3b04007b91089a254b80f9
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-pager-view: c8817c1d9f4643417e68f0b846c51214b2252eea
@@ -3680,37 +3680,37 @@ SPEC CHECKSUMS:
   react-native-slider: 8c562583722c396a3682f451f0b6e68e351ec3b9
   react-native-view-shot: fb3c0774edb448f42705491802a455beac1502a2
   react-native-webview: b29007f4723bca10872028067b07abacfa1cb35a
-  React-NativeModulesApple: eb8f1f94794f630da092e88709d0e27330634f77
-  React-oscompat: 94245768a4c9e912776373255e9b9497d634b284
-  React-perflogger: 9bbafebe121d6b5cd865cc402c27f903cba99cdc
-  React-performancetimeline: 12b80590931f7106644db4d36c28e425295bfe4c
-  React-RCTActionSheet: dee4c5e267ec056f5ef912196a856df035e685ff
-  React-RCTAnimation: 856303d407392beb2de6be30d3354b676a261641
-  React-RCTAppDelegate: ce01fe7efd0596a3d8cd0418c497e1cd6288f097
-  React-RCTBlob: 4f3ddcd5e824f022436f5569ba26acb8dea58b8c
-  React-RCTFabric: dee2a54166c302966fb7c05e132b41a27f17b560
-  React-RCTFBReactNativeSpec: bb97525757f8f044043cb978edef2c4ba57a3983
-  React-RCTImage: f492208b20c4fd3b1d28f6cf5d8acaba3103384b
-  React-RCTLinking: 6f67b5c09b62c2eb439d6c9726d63a313597b8cc
-  React-RCTNetwork: 03e559d0d35b4340cde2c6fc5666a7b243b5ead5
-  React-RCTRuntime: ffa0ac667aa2f7a811a0a8d33018af2f97dd4e48
-  React-RCTSettings: a77ba39991af0ae93049a11db631e03348980e00
-  React-RCTText: 6b7b08c6f280bd92991120387b9a78d7052ba375
-  React-RCTVibration: 65dc32a35d66746bbefa857ab7d22c372cebdae6
-  React-rendererconsistency: 9cbc91c7a1890be02c2279ddf3f539dc24d0cdf7
-  React-renderercss: a1d9942547008341bcf7fc7f73e5475ae276011c
-  React-rendererdebug: 62d1d946637c6d10e25a2c9f866136d7f3ce8738
-  React-RuntimeApple: 0831e97d3ca0ffc33a3ec210dc1fd86a459be6c2
-  React-RuntimeCore: 25d5ef5413db0eee24af0edbd4f78afc0efa913a
-  React-runtimeexecutor: 3a5c3467974d8d0f924b6d9345e8e9971925eec8
-  React-RuntimeHermes: c18298f6edfa175b67f5bddc44ae018423bf5244
-  React-runtimescheduler: ceb7e36af88909f2385ce633c7c3d1edecd16603
-  React-timing: b41b04edaadcb6c08e03ba9a56deca54fcf53006
-  React-utils: c16fdf4edfdce8bcac24e56e7220ff312277da67
-  ReactAppDependencyProvider: ff33e383768c8bfb96cadd58174d7cb196c5c7f1
-  ReactCodegen: 4b906eeeb6595b7bd0a0ceab67aeb912a1524705
-  ReactCommon: fc2c2ad3413908690d40bad58a3874c6e5e7ba02
-  ReactNativeDependencies: 1d2c24fee8694aaf7cf5589288418cd78a24ec19
+  React-NativeModulesApple: a9464983ccc0f66f45e93558671f60fc7536e438
+  React-oscompat: 73db7dbc80edef36a9d6ed3c6c4e1724ead4236d
+  React-perflogger: 123272debf907cc423962adafcf4513320e43757
+  React-performancetimeline: 095146e4dc8fa4568e44d7a9debc134f27e103f9
+  React-RCTActionSheet: 9fc2a0901af63cefe09c8df95a08c2cf8bb7797b
+  React-RCTAnimation: 785e743e489bc7aec14415dbc15f4f275b2c0276
+  React-RCTAppDelegate: 0602c9e13130edcde4661ea66d11122a3a66f11a
+  React-RCTBlob: ae53b7508a5ced43378de2a88816f63423df1f24
+  React-RCTFabric: 687a0cfb5726adea7fac63560b04410c86d97134
+  React-RCTFBReactNativeSpec: 7c55cf4fb4d2baad32ce3850b8504a6ee22e11ce
+  React-RCTImage: f45474c75cdf1526114f75b27e86d004aa171b90
+  React-RCTLinking: 56622ff97570e15e01dd9b5a657010c756a9e2d8
+  React-RCTNetwork: 3fffa1ab5d6981f839e7679d56f8cb731ba92c07
+  React-RCTRuntime: f38c04f744596fc8e1b4c5f6a57fc05c26955257
+  React-RCTSettings: f4a8e1bd36f58ec8273c73d3deefdcf90143ac6a
+  React-RCTText: da852a51dd1d169b38136a4f4d1eaed35376556b
+  React-RCTVibration: ff92ef336e32e18efff0fa83c798a2dbbebe09bd
+  React-rendererconsistency: b83b300e607f4e30478a5c3365e260a760232b04
+  React-renderercss: aa6a3cdd4fa4e3726123c42b49ba4dd978f81688
+  React-rendererdebug: 6b12a782caf2e7e2f730434264357b7b6aed1781
+  React-RuntimeApple: 8934aab108dcab957a87208fef4b6f1b3a04973a
+  React-RuntimeCore: 1d4345561ecc402e9e88b38e1d9b059a7a13b113
+  React-runtimeexecutor: a9a059f222e4d78f45a4e92cada48a5fde989fb8
+  React-RuntimeHermes: 05b955709a75038d282a9420342d7bea5857768a
+  React-runtimescheduler: 4ce23c9157b51101092537d4171ea4de48a5b863
+  React-timing: 62441edf291b91ab5b96ab8f2f8fb648c063ce6f
+  React-utils: 485abe7eaefa04b20e0ef442593e022563a1419b
+  ReactAppDependencyProvider: 433ddfb4536948630aadd5bd925aff8a632d2fe3
+  ReactCodegen: 944ac2730c2a44350ee90be2a2930fafdaf90e77
+  ReactCommon: 149b6c05126f2e99f2ed0d3c63539369546f8cae
+  ReactNativeDependencies: ed6d1e64802b150399f04f1d5728ec16b437251e
   RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
   RNCMaskedView: d2578d41c59b936db122b2798ba37e4722d21035
   RNCPicker: a7170edbcbf8288de8edb2502e08e7fc757fa755
@@ -3725,7 +3725,7 @@ SPEC CHECKSUMS:
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   UMAppLoader: 2af2cc05fcaa9851233893c0e3dbc56a99f57e36
-  Yoga: f9025ab908f89228f6ab399c59bfcc334b53a734
+  Yoga: 051f086b5ccf465ff2ed38a2cf5a558ae01aaaa1
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 07ca240dc3c89dc461c221729e3f0a73e14e9ad8

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -66,7 +66,7 @@
     "native-component-list": "*",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.3",
+    "react-native": "0.81.4",
     "react-native-edge-to-edge": "~1.6.1",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.5",

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -22,7 +22,7 @@
       },
       "ios": {
         "cache": {
-          "key": "sdk54-0.81.3",
+          "key": "sdk54-0.81.4",
           "customPaths": ["../expo-go/ios/Pods"]
         },
         "image": "latest",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -363,7 +363,7 @@ PODS:
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.81.3)
+  - FBLazyVector (0.81.4)
   - FirebaseAnalytics (11.11.0):
     - FirebaseAnalytics/AdIdSupport (= 11.11.0)
     - FirebaseCore (~> 11.11.0)
@@ -486,17 +486,17 @@ PODS:
   - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - hermes-engine (0.81.3):
-    - hermes-engine/cdp (= 0.81.3)
-    - hermes-engine/Hermes (= 0.81.3)
-    - hermes-engine/inspector (= 0.81.3)
-    - hermes-engine/inspector_chrome (= 0.81.3)
-    - hermes-engine/Public (= 0.81.3)
-  - hermes-engine/cdp (0.81.3)
-  - hermes-engine/Hermes (0.81.3)
-  - hermes-engine/inspector (0.81.3)
-  - hermes-engine/inspector_chrome (0.81.3)
-  - hermes-engine/Public (0.81.3)
+  - hermes-engine (0.81.4):
+    - hermes-engine/cdp (= 0.81.4)
+    - hermes-engine/Hermes (= 0.81.4)
+    - hermes-engine/inspector (= 0.81.4)
+    - hermes-engine/inspector_chrome (= 0.81.4)
+    - hermes-engine/Public (= 0.81.4)
+  - hermes-engine/cdp (0.81.4)
+  - hermes-engine/Hermes (0.81.4)
+  - hermes-engine/inspector (0.81.4)
+  - hermes-engine/inspector_chrome (0.81.4)
+  - hermes-engine/Public (0.81.4)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -574,28 +574,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.81.3)
-  - RCTRequired (0.81.3)
-  - RCTTypeSafety (0.81.3):
-    - FBLazyVector (= 0.81.3)
-    - RCTRequired (= 0.81.3)
-    - React-Core (= 0.81.3)
+  - RCTDeprecation (0.81.4)
+  - RCTRequired (0.81.4)
+  - RCTTypeSafety (0.81.4):
+    - FBLazyVector (= 0.81.4)
+    - RCTRequired (= 0.81.4)
+    - React-Core (= 0.81.4)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.3):
-    - React-Core (= 0.81.3)
-    - React-Core/DevSupport (= 0.81.3)
-    - React-Core/RCTWebSocket (= 0.81.3)
-    - React-RCTActionSheet (= 0.81.3)
-    - React-RCTAnimation (= 0.81.3)
-    - React-RCTBlob (= 0.81.3)
-    - React-RCTImage (= 0.81.3)
-    - React-RCTLinking (= 0.81.3)
-    - React-RCTNetwork (= 0.81.3)
-    - React-RCTSettings (= 0.81.3)
-    - React-RCTText (= 0.81.3)
-    - React-RCTVibration (= 0.81.3)
-  - React-callinvoker (0.81.3)
-  - React-Core (0.81.3):
+  - React (0.81.4):
+    - React-Core (= 0.81.4)
+    - React-Core/DevSupport (= 0.81.4)
+    - React-Core/RCTWebSocket (= 0.81.4)
+    - React-RCTActionSheet (= 0.81.4)
+    - React-RCTAnimation (= 0.81.4)
+    - React-RCTBlob (= 0.81.4)
+    - React-RCTImage (= 0.81.4)
+    - React-RCTLinking (= 0.81.4)
+    - React-RCTNetwork (= 0.81.4)
+    - React-RCTSettings (= 0.81.4)
+    - React-RCTText (= 0.81.4)
+    - React-RCTVibration (= 0.81.4)
+  - React-callinvoker (0.81.4)
+  - React-Core (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -605,7 +605,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.3)
+    - React-Core/Default (= 0.81.4)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -620,82 +620,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.81.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.81.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.81.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.81.3)
-    - React-Core/RCTWebSocket (= 0.81.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.3):
+  - React-Core/CoreModulesHeaders (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -720,7 +645,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.3):
+  - React-Core/Default (0.81.4):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.81.4):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.4)
+    - React-Core/RCTWebSocket (= 0.81.4)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -745,7 +720,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.3):
+  - React-Core/RCTAnimationHeaders (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -770,7 +745,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.3):
+  - React-Core/RCTBlobHeaders (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -795,7 +770,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.3):
+  - React-Core/RCTImageHeaders (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -820,7 +795,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.3):
+  - React-Core/RCTLinkingHeaders (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -845,7 +820,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.3):
+  - React-Core/RCTNetworkHeaders (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -870,7 +845,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.3):
+  - React-Core/RCTSettingsHeaders (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -895,7 +870,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.3):
+  - React-Core/RCTTextHeaders (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -920,7 +895,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.81.3):
+  - React-Core/RCTVibrationHeaders (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -930,7 +905,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -945,7 +920,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.81.3):
+  - React-Core/RCTWebSocket (0.81.4):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.4)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -953,20 +953,20 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.81.3)
-    - React-Core/CoreModulesHeaders (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - RCTTypeSafety (= 0.81.4)
+    - React-Core/CoreModulesHeaders (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.3)
+    - React-RCTImage (= 0.81.4)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.81.3):
+  - React-cxxreact (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -975,19 +975,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.3)
-    - React-debug (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - React-callinvoker (= 0.81.4)
+    - React-debug (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
+    - React-logger (= 0.81.4)
+    - React-perflogger (= 0.81.4)
     - React-runtimeexecutor
-    - React-timing (= 0.81.3)
+    - React-timing (= 0.81.4)
     - SocketRocket
-  - React-debug (0.81.3)
-  - React-defaultsnativemodule (0.81.3):
+  - React-debug (0.81.4)
+  - React-defaultsnativemodule (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1004,7 +1004,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.81.3):
+  - React-domnativemodule (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1024,7 +1024,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.81.3):
+  - React-Fabric (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1038,23 +1038,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.3)
-    - React-Fabric/attributedstring (= 0.81.3)
-    - React-Fabric/bridging (= 0.81.3)
-    - React-Fabric/componentregistry (= 0.81.3)
-    - React-Fabric/componentregistrynative (= 0.81.3)
-    - React-Fabric/components (= 0.81.3)
-    - React-Fabric/consistency (= 0.81.3)
-    - React-Fabric/core (= 0.81.3)
-    - React-Fabric/dom (= 0.81.3)
-    - React-Fabric/imagemanager (= 0.81.3)
-    - React-Fabric/leakchecker (= 0.81.3)
-    - React-Fabric/mounting (= 0.81.3)
-    - React-Fabric/observers (= 0.81.3)
-    - React-Fabric/scheduler (= 0.81.3)
-    - React-Fabric/telemetry (= 0.81.3)
-    - React-Fabric/templateprocessor (= 0.81.3)
-    - React-Fabric/uimanager (= 0.81.3)
+    - React-Fabric/animations (= 0.81.4)
+    - React-Fabric/attributedstring (= 0.81.4)
+    - React-Fabric/bridging (= 0.81.4)
+    - React-Fabric/componentregistry (= 0.81.4)
+    - React-Fabric/componentregistrynative (= 0.81.4)
+    - React-Fabric/components (= 0.81.4)
+    - React-Fabric/consistency (= 0.81.4)
+    - React-Fabric/core (= 0.81.4)
+    - React-Fabric/dom (= 0.81.4)
+    - React-Fabric/imagemanager (= 0.81.4)
+    - React-Fabric/leakchecker (= 0.81.4)
+    - React-Fabric/mounting (= 0.81.4)
+    - React-Fabric/observers (= 0.81.4)
+    - React-Fabric/scheduler (= 0.81.4)
+    - React-Fabric/telemetry (= 0.81.4)
+    - React-Fabric/templateprocessor (= 0.81.4)
+    - React-Fabric/uimanager (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1066,32 +1066,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.81.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.81.3):
+  - React-Fabric/animations (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1116,7 +1091,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.81.3):
+  - React-Fabric/attributedstring (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1141,7 +1116,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.81.3):
+  - React-Fabric/bridging (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1166,7 +1141,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.81.3):
+  - React-Fabric/componentregistry (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1191,36 +1166,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.81.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.3)
-    - React-Fabric/components/root (= 0.81.3)
-    - React-Fabric/components/scrollview (= 0.81.3)
-    - React-Fabric/components/view (= 0.81.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.3):
+  - React-Fabric/componentregistrynative (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1245,7 +1191,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.81.3):
+  - React-Fabric/components (0.81.4):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.4)
+    - React-Fabric/components/root (= 0.81.4)
+    - React-Fabric/components/scrollview (= 0.81.4)
+    - React-Fabric/components/view (= 0.81.4)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1270,7 +1245,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.81.3):
+  - React-Fabric/components/root (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1295,7 +1270,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.81.3):
+  - React-Fabric/components/scrollview (0.81.4):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1322,7 +1322,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.81.3):
+  - React-Fabric/consistency (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1347,7 +1347,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.81.3):
+  - React-Fabric/core (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1372,7 +1372,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.81.3):
+  - React-Fabric/dom (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1397,7 +1397,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.81.3):
+  - React-Fabric/imagemanager (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1422,7 +1422,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.81.3):
+  - React-Fabric/leakchecker (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1447,7 +1447,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.81.3):
+  - React-Fabric/mounting (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1472,7 +1472,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.81.3):
+  - React-Fabric/observers (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1486,7 +1486,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.3)
+    - React-Fabric/observers/events (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1498,7 +1498,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.81.3):
+  - React-Fabric/observers/events (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1523,7 +1523,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.81.3):
+  - React-Fabric/scheduler (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1550,7 +1550,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.81.3):
+  - React-Fabric/telemetry (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1575,7 +1575,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.81.3):
+  - React-Fabric/templateprocessor (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1600,7 +1600,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.81.3):
+  - React-Fabric/uimanager (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1614,7 +1614,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.3)
+    - React-Fabric/uimanager/consistency (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1627,7 +1627,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.81.3):
+  - React-Fabric/uimanager/consistency (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1653,7 +1653,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.81.3):
+  - React-FabricComponents (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1668,8 +1668,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.3)
-    - React-FabricComponents/textlayoutmanager (= 0.81.3)
+    - React-FabricComponents/components (= 0.81.4)
+    - React-FabricComponents/textlayoutmanager (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1682,7 +1682,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.81.3):
+  - React-FabricComponents/components (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1697,17 +1697,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.3)
-    - React-FabricComponents/components/iostextinput (= 0.81.3)
-    - React-FabricComponents/components/modal (= 0.81.3)
-    - React-FabricComponents/components/rncore (= 0.81.3)
-    - React-FabricComponents/components/safeareaview (= 0.81.3)
-    - React-FabricComponents/components/scrollview (= 0.81.3)
-    - React-FabricComponents/components/switch (= 0.81.3)
-    - React-FabricComponents/components/text (= 0.81.3)
-    - React-FabricComponents/components/textinput (= 0.81.3)
-    - React-FabricComponents/components/unimplementedview (= 0.81.3)
-    - React-FabricComponents/components/virtualview (= 0.81.3)
+    - React-FabricComponents/components/inputaccessory (= 0.81.4)
+    - React-FabricComponents/components/iostextinput (= 0.81.4)
+    - React-FabricComponents/components/modal (= 0.81.4)
+    - React-FabricComponents/components/rncore (= 0.81.4)
+    - React-FabricComponents/components/safeareaview (= 0.81.4)
+    - React-FabricComponents/components/scrollview (= 0.81.4)
+    - React-FabricComponents/components/switch (= 0.81.4)
+    - React-FabricComponents/components/text (= 0.81.4)
+    - React-FabricComponents/components/textinput (= 0.81.4)
+    - React-FabricComponents/components/unimplementedview (= 0.81.4)
+    - React-FabricComponents/components/virtualview (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1720,34 +1720,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.3):
+  - React-FabricComponents/components/inputaccessory (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1774,7 +1747,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.81.3):
+  - React-FabricComponents/components/iostextinput (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1801,7 +1774,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.3):
+  - React-FabricComponents/components/modal (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1828,7 +1801,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.3):
+  - React-FabricComponents/components/rncore (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1855,7 +1828,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.3):
+  - React-FabricComponents/components/safeareaview (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1882,7 +1855,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.81.3):
+  - React-FabricComponents/components/scrollview (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1909,7 +1882,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.81.3):
+  - React-FabricComponents/components/switch (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1936,7 +1909,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.3):
+  - React-FabricComponents/components/text (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1963,7 +1936,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.3):
+  - React-FabricComponents/components/textinput (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -1990,7 +1963,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.3):
+  - React-FabricComponents/components/unimplementedview (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2017,7 +1990,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.3):
+  - React-FabricComponents/components/virtualview (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2044,7 +2017,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.81.3):
+  - React-FabricComponents/textlayoutmanager (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2053,21 +2026,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.81.3)
-    - RCTTypeSafety (= 0.81.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.81.4):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.81.4)
+    - RCTTypeSafety (= 0.81.4)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.3)
+    - React-jsiexecutor (= 0.81.4)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.81.3):
+  - React-featureflags (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2076,7 +2076,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.81.3):
+  - React-featureflagsnativemodule (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2091,7 +2091,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.81.3):
+  - React-graphics (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2104,7 +2104,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.81.3):
+  - React-hermes (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2113,16 +2113,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
     - React-jsi
-    - React-jsiexecutor (= 0.81.3)
+    - React-jsiexecutor (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.3)
+    - React-perflogger (= 0.81.4)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.81.3):
+  - React-idlecallbacksnativemodule (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2138,7 +2138,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.81.3):
+  - React-ImageManager (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2153,7 +2153,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.81.3):
+  - React-jserrorhandler (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2168,7 +2168,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.81.3):
+  - React-jsi (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2178,7 +2178,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.81.3):
+  - React-jsiexecutor (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2187,15 +2187,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.3)
+    - React-perflogger (= 0.81.4)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.81.3):
+  - React-jsinspector (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2210,10 +2210,10 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.81.3)
+    - React-perflogger (= 0.81.4)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.81.3):
+  - React-jsinspectorcdp (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2222,7 +2222,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.81.3):
+  - React-jsinspectornetwork (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2235,7 +2235,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.81.3):
+  - React-jsinspectortracing (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2246,7 +2246,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.81.3):
+  - React-jsitooling (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2254,16 +2254,16 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.81.3):
+  - React-jsitracing (0.81.4):
     - React-jsi
-  - React-logger (0.81.3):
+  - React-logger (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2272,7 +2272,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.81.3):
+  - React-Mapbuffer (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2282,7 +2282,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.81.3):
+  - React-microtasksnativemodule (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2621,7 +2621,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.81.3):
+  - React-NativeModulesApple (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2641,8 +2641,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.81.3)
-  - React-perflogger (0.81.3):
+  - React-oscompat (0.81.4)
+  - React-perflogger (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2651,7 +2651,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.81.3):
+  - React-performancetimeline (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2664,9 +2664,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.81.3):
-    - React-Core/RCTActionSheetHeaders (= 0.81.3)
-  - React-RCTAnimation (0.81.3):
+  - React-RCTActionSheet (0.81.4):
+    - React-Core/RCTActionSheetHeaders (= 0.81.4)
+  - React-RCTAnimation (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2682,7 +2682,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.81.3):
+  - React-RCTAppDelegate (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2716,7 +2716,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.81.3):
+  - React-RCTBlob (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2735,7 +2735,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.81.3):
+  - React-RCTFabric (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2770,7 +2770,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.3):
+  - React-RCTFBReactNativeSpec (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2784,10 +2784,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.3)
+    - React-RCTFBReactNativeSpec/components (= 0.81.4)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.81.3):
+  - React-RCTFBReactNativeSpec/components (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2810,7 +2810,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.81.3):
+  - React-RCTImage (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2826,14 +2826,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.81.3):
-    - React-Core/RCTLinkingHeaders (= 0.81.3)
-    - React-jsi (= 0.81.3)
+  - React-RCTLinking (0.81.4):
+    - React-Core/RCTLinkingHeaders (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.3)
-  - React-RCTNetwork (0.81.3):
+    - ReactCommon/turbomodule/core (= 0.81.4)
+  - React-RCTNetwork (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2851,7 +2851,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.81.3):
+  - React-RCTRuntime (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2871,7 +2871,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.81.3):
+  - React-RCTSettings (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2886,10 +2886,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.81.3):
-    - React-Core/RCTTextHeaders (= 0.81.3)
+  - React-RCTText (0.81.4):
+    - React-Core/RCTTextHeaders (= 0.81.4)
     - Yoga
-  - React-RCTVibration (0.81.3):
+  - React-RCTVibration (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2903,11 +2903,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.81.3)
-  - React-renderercss (0.81.3):
+  - React-rendererconsistency (0.81.4)
+  - React-renderercss (0.81.4):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.3):
+  - React-rendererdebug (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2917,7 +2917,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.81.3):
+  - React-RuntimeApple (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2946,7 +2946,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.81.3):
+  - React-RuntimeCore (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2968,7 +2968,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.81.3):
+  - React-runtimeexecutor (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2978,10 +2978,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.3)
+    - React-jsi (= 0.81.4)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.81.3):
+  - React-RuntimeHermes (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3002,7 +3002,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.81.3):
+  - React-runtimescheduler (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3024,9 +3024,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.81.3):
+  - React-timing (0.81.4):
     - React-debug
-  - React-utils (0.81.3):
+  - React-utils (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3036,11 +3036,11 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.81.3)
+    - React-jsi (= 0.81.4)
     - SocketRocket
-  - ReactAppDependencyProvider (0.81.3):
+  - ReactAppDependencyProvider (0.81.4):
     - ReactCodegen
-  - ReactCodegen (0.81.3):
+  - ReactCodegen (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3066,7 +3066,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.81.3):
+  - ReactCommon (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3074,9 +3074,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.81.3)
+    - ReactCommon/turbomodule (= 0.81.4)
     - SocketRocket
-  - ReactCommon/turbomodule (0.81.3):
+  - ReactCommon/turbomodule (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3085,15 +3085,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.3)
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
-    - ReactCommon/turbomodule/bridging (= 0.81.3)
-    - ReactCommon/turbomodule/core (= 0.81.3)
+    - React-callinvoker (= 0.81.4)
+    - React-cxxreact (= 0.81.4)
+    - React-jsi (= 0.81.4)
+    - React-logger (= 0.81.4)
+    - React-perflogger (= 0.81.4)
+    - ReactCommon/turbomodule/bridging (= 0.81.4)
+    - ReactCommon/turbomodule/core (= 0.81.4)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.81.3):
+  - ReactCommon/turbomodule/bridging (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3102,13 +3102,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.3)
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
+    - React-callinvoker (= 0.81.4)
+    - React-cxxreact (= 0.81.4)
+    - React-jsi (= 0.81.4)
+    - React-logger (= 0.81.4)
+    - React-perflogger (= 0.81.4)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.81.3):
+  - ReactCommon/turbomodule/core (0.81.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3117,14 +3117,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.3)
-    - React-cxxreact (= 0.81.3)
-    - React-debug (= 0.81.3)
-    - React-featureflags (= 0.81.3)
-    - React-jsi (= 0.81.3)
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
-    - React-utils (= 0.81.3)
+    - React-callinvoker (= 0.81.4)
+    - React-cxxreact (= 0.81.4)
+    - React-debug (= 0.81.4)
+    - React-featureflags (= 0.81.4)
+    - React-jsi (= 0.81.4)
+    - React-logger (= 0.81.4)
+    - React-perflogger (= 0.81.4)
+    - React-utils (= 0.81.4)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -4305,10 +4305,10 @@ SPEC CHECKSUMS:
   ExpoWebBrowser: 84d4438464d9754a4c1f1eaa97cd747f3752187e
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
   EXTaskManager: eedcd03c1a574c47d3f48d83d4e4659b3c1fa29b
-  EXUpdates: f307db2203f4568c7e2e986508b9cc9e93c94c5d
+  EXUpdates: 85e31f887f7917579807da455d2d91ef78f64c21
   EXUpdatesInterface: 5adf50cb41e079c861da6d9b4b954c3db9a50734
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: a80c331df9c6958a9cc391631578602b7973b0c7
+  FBLazyVector: 941bef1c8eeabd9fe1f501e30a5220beee913886
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
   FirebaseCore: 2321536f9c423b1f857e047a82b8a42abc6d9e2c
   FirebaseCoreExtension: 3a64994969dd05f4bcb7e6896c654eded238e75b
@@ -4324,7 +4324,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 94b8ac8b225c817c009396175e40a5aecc1e169c
+  hermes-engine: ddeef94dc8e0832e44f8e81f11c6425697311a98
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4337,39 +4337,39 @@ SPEC CHECKSUMS:
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
-  RCTDeprecation: 78aa7764dbddbc2c87060d26a3ab19fb65dad4ce
-  RCTRequired: df28d0769df9b6ace47200ac80095f9dffba555d
-  RCTTypeSafety: ffa3fa28228934f05db6d9d31dc746542fc447e0
+  RCTDeprecation: c0ed3249a97243002615517dff789bf4666cf585
+  RCTRequired: 58719f5124f9267b5f9649c08bf23d9aea845b23
+  RCTTypeSafety: 4aefa8328ab1f86da273f08517f1f6b343f6c2cc
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 639d04fed84b2ff824861d863891eaef7cb92f9c
-  React-callinvoker: adedd891222fbe90849c0bdc8873b9b94f061a03
-  React-Core: f98fdc6842c39b0f4d715c566fb6c330acd855ee
-  React-CoreModules: ca243a99705e9c5945a87500b525e8cb60384e0e
-  React-cxxreact: 3260344329710e38751a6426881dfa0972c62634
-  React-debug: e7fa634481419ac0b821224af2113001a997b5f3
-  React-defaultsnativemodule: 99df714e7ccdec2e47da11a8724250d52ff76496
-  React-domnativemodule: bb0893b370395ae13ae3a6b96b1e2579d3cdeee9
-  React-Fabric: c702556ed4692539b5419b6aa540d528e69cb19b
-  React-FabricComponents: b72f2dbe2b7ef60f6a157547e32aa07e7dab8627
-  React-FabricImage: e277341ec76a77ea43d3ad2308b8ba0010d7076c
-  React-featureflags: aea1abd1fcb0f836375458efe16774b0ff96bf35
-  React-featureflagsnativemodule: 72dd77359dcd9cb5959314f257443bfe1935c414
-  React-graphics: 4242e5ff49737ede2c920bc8d5c0d61b97a2b001
-  React-hermes: 9083f0ec5dd2fe38f00a70de2c69adec2b75eda6
-  React-idlecallbacksnativemodule: a392435d2940ba3a040dc8ba67c7f1dd69495e1b
-  React-ImageManager: 74bd5cbbed6b4aff9f0a9b587b5131db2364900f
-  React-jserrorhandler: 392521673af0cf20e81927948dcbb67293dbfc07
-  React-jsi: 9d2b263d419798560ec4b1a3fba8b4c76e0ef9a9
-  React-jsiexecutor: 19f8f7951f15d99547d429b575688169fbb82fd7
-  React-jsinspector: 97adc2efd843405992001f3a9608b210ae498d62
-  React-jsinspectorcdp: 78f82904331c3f250d01774c341be202e7bca5d3
-  React-jsinspectornetwork: 31673100437a0c910ca111c5128a613cf1e81bc4
-  React-jsinspectortracing: 729858bd46638450a222ac892f9b8fde269c30c0
-  React-jsitooling: dcd741b804bfd5a9e22ac1dc8fd5a085cc1ebad7
-  React-jsitracing: c0ef2a171e9bd57829436c7114dad19b389cbaa6
-  React-logger: 881f94d5ca5c50b64679fd5692330c192ae6e79c
-  React-Mapbuffer: d9fa53795351c53186f0c4d893afc9de629a7c45
-  React-microtasksnativemodule: 4fbac4bcda4a57be275a9fa48cf03cc83da3163b
+  React: 2073376f47c71b7e9a0af7535986a77522ce1049
+  React-callinvoker: 751b6f2c83347a0486391c3f266f291f0f53b27e
+  React-Core: dff5d29973349b11dd6631c9498456d75f846d5e
+  React-CoreModules: c0ae04452e4c5d30e06f8e94692a49107657f537
+  React-cxxreact: 376fd672c95dfb64ad5cc246e6a1e9edb78dec4c
+  React-debug: 7b56a0a7da432353287d2eedac727903e35278f5
+  React-defaultsnativemodule: 393b81aaa6211408f50a6ef00a277847256dd881
+  React-domnativemodule: 5fb5829baa7a7a0f217019cbad1eb226d94f7062
+  React-Fabric: a17c4ae35503673b57b91c2d1388429e7cbee452
+  React-FabricComponents: a76572ddeba78ebe4ec58615291e9db4a55cd46a
+  React-FabricImage: d806eb2695d7ef355ec28d1a21f5a14ac26b1cae
+  React-featureflags: 1690ec3c453920b6308e23a4e24eb9c3632f9c75
+  React-featureflagsnativemodule: 7b7e8483fc671c5a33aefd699b7c7a3c0bdfdfec
+  React-graphics: ea146ee799dc816524a3a0922fc7be0b5a52dcc1
+  React-hermes: fcbdc45ecf38259fe3b12642bd0757c52270a107
+  React-idlecallbacksnativemodule: a353f9162eaa7ad787e68aba9f52a1cfa8154098
+  React-ImageManager: ec5cf55ce9cc81719eb5f1f51d23d04db851c86c
+  React-jserrorhandler: 594c593f3d60f527be081e2cace7710c2bd9f524
+  React-jsi: 59ec3190dd364cca86a58869e7755477d2468948
+  React-jsiexecutor: b87d78a2e8dd7a6f56e9cdac038da45de98c944f
+  React-jsinspector: b9204adf1af622c98e78af96ec1bca615c2ce2bd
+  React-jsinspectorcdp: 4a356fa69e412d35d3a38c44d4a6cc555c5931e8
+  React-jsinspectornetwork: 7820056773178f321cbf18689e1ffcd38276a878
+  React-jsinspectortracing: b341c5ef6e031a33e0bd462d67fd397e8e9cd612
+  React-jsitooling: 401655e05cb966b0081225c5201d90734a567cb9
+  React-jsitracing: 67eff6dea0cb58a1e7bd8b49243012d88c0f511e
+  React-logger: a3cb5b29c32b8e447b5a96919340e89334062b48
+  React-Mapbuffer: 9d2434a42701d6144ca18f0ca1c4507808ca7696
+  React-microtasksnativemodule: 75b6604b667d297292345302cc5bfb6b6aeccc1b
   react-native-google-maps: c4f5c5b2dda17e7cb2cb2b37a81f140b039b3e7e
   react-native-keyboard-controller: 8bd5f5572b6d5d402a2f77987a17492f869e5d62
   react-native-maps: 9febd31278b35cd21e4fad2cf6fa708993be5dab
@@ -4381,36 +4381,36 @@ SPEC CHECKSUMS:
   react-native-slider: 663776e5683e257de8df8091abc2d93ff6ec67db
   react-native-view-shot: 6c008e58f4720de58370848201c5d4a082c6d4ca
   react-native-webview: 4cbb7f05f2c50671a7dcff4012d3e85faad271e4
-  React-NativeModulesApple: 2c8e9f3d5d34122f853984ebc413a7d80dfa972c
-  React-oscompat: 16640399a646baeac6baab4264891cc4892eeb56
-  React-perflogger: e450a9c345e833ec1c3fe5920c7bc303ecb4724b
-  React-performancetimeline: 73100eafb985145ea5b74a06968afa3a0cd53e23
-  React-RCTActionSheet: 4c4adabfd8bc747cf39ed7f3e8691eb060a59ba3
-  React-RCTAnimation: 4f3179965896dabe358a9aa7db142b10cb2db372
-  React-RCTAppDelegate: 4cc275baf148f63b9d3ce0dec7df850fcacbc10e
-  React-RCTBlob: 03bf79cf438ed6bdc77255937d0bf29421a92590
-  React-RCTFabric: 138e26a55aec0275aa26ab1fbc85260d8b443377
-  React-RCTFBReactNativeSpec: 06e80d5d338477d233d43a80ac1451d07e61e5ea
-  React-RCTImage: 50e0b7de4c4858fdb484a1da1f971f6770bc2b31
-  React-RCTLinking: ee7f37c879dd5cd29792b895fd9416f3cbb9b20b
-  React-RCTNetwork: 90292d96da937c93bdbf111a26ceb2099d99b926
-  React-RCTRuntime: ac909d01c6c8a6bdc04cafc05e98e287af63cfed
-  React-RCTSettings: 84f1bbb3c9aa08d8e4d8f8ed59bf95d1b5e59579
-  React-RCTText: 6c5ea9deff145e3065c10416b9e5dbc8ec614240
-  React-RCTVibration: 33c3fd6e232cf89b3f4db7ea21f36ccc483179be
-  React-rendererconsistency: 234fcdca03f9380acd8f85bb11c4bcbd6901b3cb
-  React-renderercss: 04e37f7f83d402fb82c3f4b9c05941e03b5858cb
-  React-rendererdebug: 742a14850632fb7a8d118dc7a0f55ca0b04d018b
-  React-RuntimeApple: 7d08d9e503a87de79819ddc938a12722cbedbe91
-  React-RuntimeCore: 721d435b57bec6a93d47d8de81cf460385b129b7
-  React-runtimeexecutor: 6656b16e8afd3d5e4bfa446e760dfdcc0c198065
-  React-RuntimeHermes: 05ccd43b8cac45fcc8be11c061855d38046a5485
-  React-runtimescheduler: e82731c391b044bcc970cbe14f92bdeda81f4b25
-  React-timing: f006091c1b28c2e27851c631e3e255f59639ca31
-  React-utils: bc9c836b6e6ed848fcf7413de41fa05504004be4
-  ReactAppDependencyProvider: ff33e383768c8bfb96cadd58174d7cb196c5c7f1
-  ReactCodegen: 77306c0ecd4c0357bae009b8fdca8ee89c05ccb0
-  ReactCommon: 5eb75122c48f80ca9a4582bd1bb4a27ad459b99d
+  React-NativeModulesApple: 879fbdc5dcff7136abceb7880fe8a2022a1bd7c3
+  React-oscompat: 93b5535ea7f7dff46aaee4f78309a70979bdde9d
+  React-perflogger: 5536d2df3d18fe0920263466f7b46a56351c0510
+  React-performancetimeline: 9041c53efa07f537164dcfe7670a36642352f4c2
+  React-RCTActionSheet: 42195ae666e6d79b4af2346770f765b7c29435b9
+  React-RCTAnimation: fa103ccc3503b1ed8dedca7e62e7823937748843
+  React-RCTAppDelegate: 665d4baf19424cef08276e9ac0d8771eec4519f9
+  React-RCTBlob: 0fa9530c255644db095f2c4fd8d89738d9d9ecc0
+  React-RCTFabric: 1fcd8af6e25f92532f56b4ba092e58662c14d156
+  React-RCTFBReactNativeSpec: db171247585774f9f0a30f75109cc51568686213
+  React-RCTImage: ba824e61ce2e920a239a65d130b83c3a1d426dff
+  React-RCTLinking: d2dc199c37e71e6f505d9eca3e5c33be930014d4
+  React-RCTNetwork: 87137d4b9bd77e5068f854dd5c1f30d4b072faf6
+  React-RCTRuntime: 137fafaa808a8b7e76a510e8be45f9f827899daa
+  React-RCTSettings: 71f5c7fd7b5f4e725a4e2114a4b4373d0e46048f
+  React-RCTText: b94d4699b49285bee22b8ebf768924d607eccee3
+  React-RCTVibration: 6e3993c4f6c36a3899059f9a9ead560ddaf5a7d7
+  React-rendererconsistency: b4785e5ed837dc7c242bbc5fdd464b33ef5bfae7
+  React-renderercss: e6fb0ba387b389c595ffa86b8b628716d31f58dc
+  React-rendererdebug: 60a03de5c7ea59bf2d39791eb43c4c0f5d8b24e3
+  React-RuntimeApple: 3df6788cd9b938bb8cb28298d80b5fbd98a4d852
+  React-RuntimeCore: fad8adb4172c414c00ff6980250caf35601a0f5d
+  React-runtimeexecutor: d2db7e72d97751855ea0bf5273d2ac84e5ea390c
+  React-RuntimeHermes: 04faa4cf9a285136a6d73738787fe36020170613
+  React-runtimescheduler: f6a1c9555e7131b4a8b64cce01489ad0405f6e8d
+  React-timing: 1e6a8acb66e2b7ac9d418956617fd1fdb19322fd
+  React-utils: 52bbb03f130319ef82e4c3bc7a85eaacdb1fec87
+  ReactAppDependencyProvider: 433ddfb4536948630aadd5bd925aff8a632d2fe3
+  ReactCodegen: 18769cc2a40be54ddd9268ca2a33c1beb713b1b6
+  ReactCommon: 394c6b92765cf6d211c2c3f7f6bc601dffb316a6
   RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
   RNCMaskedView: 5ef8c95cbab95334a32763b72896a7b7d07e6299
   RNCPicker: 66c392786945ecee5275242c148e6a4601221d3a
@@ -4435,7 +4435,7 @@ SPEC CHECKSUMS:
   StripePaymentsUI: 05d4be35b34f821d5ddc8617dee04219f3646253
   StripeUICore: d07bd63a4b53dee8cab4d6f81ce5a7ab3e28511e
   UMAppLoader: 2af2cc05fcaa9851233893c0e3dbc56a99f57e36
-  Yoga: 6b30b3f0beeeacf5a3fe68af23442196b196959a
+  Yoga: a3ed390a19db0459bd6839823a6ac6d9c6db198d
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: aaaa821356ecede13bd3ebe65b62ce223458b0fa

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -68,7 +68,7 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "19.1.0",
-    "react-native": "0.81.3",
+    "react-native": "0.81.4",
     "react-native-edge-to-edge": "1.6.0",
     "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~2.28.0",

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -9,6 +9,6 @@
     "expo": "~54.0.0-preview.16",
     "expo-clipboard": "~8.0.6",
     "react": "19.1.0",
-    "react-native": "0.81.3"
+    "react-native": "0.81.4"
   }
 }

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -140,7 +140,7 @@
     "processing-js": "^1.6.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.3",
+    "react-native": "0.81.4",
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-controller": "^1.18.5",

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -432,10 +432,10 @@ PODS:
     - Yoga
   - EXUpdatesInterface (2.0.0):
     - ExpoModulesCore
-  - FBLazyVector (0.81.3)
-  - hermes-engine (0.81.3):
-    - hermes-engine/Pre-built (= 0.81.3)
-  - hermes-engine/Pre-built (0.81.3)
+  - FBLazyVector (0.81.4)
+  - hermes-engine (0.81.4):
+    - hermes-engine/Pre-built (= 0.81.4)
+  - hermes-engine/Pre-built (0.81.4)
   - libavif/core (0.11.1)
   - libavif/libdav1d (0.11.1):
     - libavif/core
@@ -468,32 +468,32 @@ PODS:
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - Quick (7.3.0)
-  - RCTDeprecation (0.81.3)
-  - RCTRequired (0.81.3)
-  - RCTTypeSafety (0.81.3):
-    - FBLazyVector (= 0.81.3)
-    - RCTRequired (= 0.81.3)
-    - React-Core (= 0.81.3)
+  - RCTDeprecation (0.81.4)
+  - RCTRequired (0.81.4)
+  - RCTTypeSafety (0.81.4):
+    - FBLazyVector (= 0.81.4)
+    - RCTRequired (= 0.81.4)
+    - React-Core (= 0.81.4)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.3):
-    - React-Core (= 0.81.3)
-    - React-Core/DevSupport (= 0.81.3)
-    - React-Core/RCTWebSocket (= 0.81.3)
-    - React-RCTActionSheet (= 0.81.3)
-    - React-RCTAnimation (= 0.81.3)
-    - React-RCTBlob (= 0.81.3)
-    - React-RCTImage (= 0.81.3)
-    - React-RCTLinking (= 0.81.3)
-    - React-RCTNetwork (= 0.81.3)
-    - React-RCTSettings (= 0.81.3)
-    - React-RCTText (= 0.81.3)
-    - React-RCTVibration (= 0.81.3)
-  - React-callinvoker (0.81.3)
-  - React-Core (0.81.3):
+  - React (0.81.4):
+    - React-Core (= 0.81.4)
+    - React-Core/DevSupport (= 0.81.4)
+    - React-Core/RCTWebSocket (= 0.81.4)
+    - React-RCTActionSheet (= 0.81.4)
+    - React-RCTAnimation (= 0.81.4)
+    - React-RCTBlob (= 0.81.4)
+    - React-RCTImage (= 0.81.4)
+    - React-RCTLinking (= 0.81.4)
+    - React-RCTNetwork (= 0.81.4)
+    - React-RCTSettings (= 0.81.4)
+    - React-RCTText (= 0.81.4)
+    - React-RCTVibration (= 0.81.4)
+  - React-callinvoker (0.81.4)
+  - React-Core (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.81.3)
+    - React-Core/Default (= 0.81.4)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -508,66 +508,9 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core-prebuilt (0.81.3):
+  - React-Core-prebuilt (0.81.4):
     - ReactNativeDependencies
-  - React-Core/CoreModulesHeaders (0.81.3):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/Default (0.81.3):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/DevSupport (0.81.3):
-    - hermes-engine
-    - RCTDeprecation
-    - React-Core-prebuilt
-    - React-Core/Default (= 0.81.3)
-    - React-Core/RCTWebSocket (= 0.81.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactNativeDependencies
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.3):
+  - React-Core/CoreModulesHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -586,7 +529,45 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.3):
+  - React-Core/Default (0.81.4):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/DevSupport (0.81.4):
+    - hermes-engine
+    - RCTDeprecation
+    - React-Core-prebuilt
+    - React-Core/Default (= 0.81.4)
+    - React-Core/RCTWebSocket (= 0.81.4)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -605,7 +586,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.3):
+  - React-Core/RCTAnimationHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -624,7 +605,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.3):
+  - React-Core/RCTBlobHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -643,7 +624,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.3):
+  - React-Core/RCTImageHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -662,7 +643,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.3):
+  - React-Core/RCTLinkingHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -681,7 +662,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.3):
+  - React-Core/RCTNetworkHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -700,7 +681,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.3):
+  - React-Core/RCTSettingsHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -719,7 +700,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.3):
+  - React-Core/RCTTextHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
@@ -738,11 +719,11 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-Core/RCTWebSocket (0.81.3):
+  - React-Core/RCTVibrationHeaders (0.81.4):
     - hermes-engine
     - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/Default (= 0.81.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -757,37 +738,56 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-CoreModules (0.81.3):
-    - RCTTypeSafety (= 0.81.3)
+  - React-Core/RCTWebSocket (0.81.4):
+    - hermes-engine
+    - RCTDeprecation
     - React-Core-prebuilt
-    - React-Core/CoreModulesHeaders (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - React-Core/Default (= 0.81.4)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactNativeDependencies
+    - Yoga
+  - React-CoreModules (0.81.4):
+    - RCTTypeSafety (= 0.81.4)
+    - React-Core-prebuilt
+    - React-Core/CoreModulesHeaders (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.3)
+    - React-RCTImage (= 0.81.4)
     - React-runtimeexecutor
     - ReactCommon
     - ReactNativeDependencies
-  - React-cxxreact (0.81.3):
+  - React-cxxreact (0.81.4):
     - hermes-engine
-    - React-callinvoker (= 0.81.3)
+    - React-callinvoker (= 0.81.4)
     - React-Core-prebuilt
-    - React-debug (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - React-debug (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
+    - React-logger (= 0.81.4)
+    - React-perflogger (= 0.81.4)
     - React-runtimeexecutor
-    - React-timing (= 0.81.3)
+    - React-timing (= 0.81.4)
     - ReactNativeDependencies
-  - React-debug (0.81.3)
-  - React-defaultsnativemodule (0.81.3):
+  - React-debug (0.81.4)
+  - React-defaultsnativemodule (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-domnativemodule
@@ -798,7 +798,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - ReactNativeDependencies
-  - React-domnativemodule (0.81.3):
+  - React-domnativemodule (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-Fabric
@@ -812,7 +812,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric (0.81.3):
+  - React-Fabric (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -820,23 +820,23 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.3)
-    - React-Fabric/attributedstring (= 0.81.3)
-    - React-Fabric/bridging (= 0.81.3)
-    - React-Fabric/componentregistry (= 0.81.3)
-    - React-Fabric/componentregistrynative (= 0.81.3)
-    - React-Fabric/components (= 0.81.3)
-    - React-Fabric/consistency (= 0.81.3)
-    - React-Fabric/core (= 0.81.3)
-    - React-Fabric/dom (= 0.81.3)
-    - React-Fabric/imagemanager (= 0.81.3)
-    - React-Fabric/leakchecker (= 0.81.3)
-    - React-Fabric/mounting (= 0.81.3)
-    - React-Fabric/observers (= 0.81.3)
-    - React-Fabric/scheduler (= 0.81.3)
-    - React-Fabric/telemetry (= 0.81.3)
-    - React-Fabric/templateprocessor (= 0.81.3)
-    - React-Fabric/uimanager (= 0.81.3)
+    - React-Fabric/animations (= 0.81.4)
+    - React-Fabric/attributedstring (= 0.81.4)
+    - React-Fabric/bridging (= 0.81.4)
+    - React-Fabric/componentregistry (= 0.81.4)
+    - React-Fabric/componentregistrynative (= 0.81.4)
+    - React-Fabric/components (= 0.81.4)
+    - React-Fabric/consistency (= 0.81.4)
+    - React-Fabric/core (= 0.81.4)
+    - React-Fabric/dom (= 0.81.4)
+    - React-Fabric/imagemanager (= 0.81.4)
+    - React-Fabric/leakchecker (= 0.81.4)
+    - React-Fabric/mounting (= 0.81.4)
+    - React-Fabric/observers (= 0.81.4)
+    - React-Fabric/scheduler (= 0.81.4)
+    - React-Fabric/telemetry (= 0.81.4)
+    - React-Fabric/templateprocessor (= 0.81.4)
+    - React-Fabric/uimanager (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -848,26 +848,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/animations (0.81.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/attributedstring (0.81.3):
+  - React-Fabric/animations (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -886,7 +867,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/bridging (0.81.3):
+  - React-Fabric/attributedstring (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -905,7 +886,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistry (0.81.3):
+  - React-Fabric/bridging (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -924,7 +905,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/componentregistrynative (0.81.3):
+  - React-Fabric/componentregistry (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -943,30 +924,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components (0.81.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.3)
-    - React-Fabric/components/root (= 0.81.3)
-    - React-Fabric/components/scrollview (= 0.81.3)
-    - React-Fabric/components/view (= 0.81.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.3):
+  - React-Fabric/componentregistrynative (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -985,7 +943,30 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/root (0.81.3):
+  - React-Fabric/components (0.81.4):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.4)
+    - React-Fabric/components/root (= 0.81.4)
+    - React-Fabric/components/scrollview (= 0.81.4)
+    - React-Fabric/components/view (= 0.81.4)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1004,7 +985,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/scrollview (0.81.3):
+  - React-Fabric/components/root (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1023,7 +1004,26 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/components/view (0.81.3):
+  - React-Fabric/components/scrollview (0.81.4):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+  - React-Fabric/components/view (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1044,7 +1044,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-Fabric/consistency (0.81.3):
+  - React-Fabric/consistency (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1063,7 +1063,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/core (0.81.3):
+  - React-Fabric/core (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1082,7 +1082,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/dom (0.81.3):
+  - React-Fabric/dom (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1101,7 +1101,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/imagemanager (0.81.3):
+  - React-Fabric/imagemanager (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1120,7 +1120,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/leakchecker (0.81.3):
+  - React-Fabric/leakchecker (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1139,7 +1139,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/mounting (0.81.3):
+  - React-Fabric/mounting (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1158,7 +1158,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers (0.81.3):
+  - React-Fabric/observers (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1166,7 +1166,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.3)
+    - React-Fabric/observers/events (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1178,7 +1178,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/observers/events (0.81.3):
+  - React-Fabric/observers/events (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1197,7 +1197,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/scheduler (0.81.3):
+  - React-Fabric/scheduler (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1218,7 +1218,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/telemetry (0.81.3):
+  - React-Fabric/telemetry (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1237,7 +1237,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/templateprocessor (0.81.3):
+  - React-Fabric/templateprocessor (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1256,7 +1256,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager (0.81.3):
+  - React-Fabric/uimanager (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1264,7 +1264,7 @@ PODS:
     - React-Core-prebuilt
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.3)
+    - React-Fabric/uimanager/consistency (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1277,7 +1277,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-Fabric/uimanager/consistency (0.81.3):
+  - React-Fabric/uimanager/consistency (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1297,7 +1297,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-FabricComponents (0.81.3):
+  - React-FabricComponents (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1306,8 +1306,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.3)
-    - React-FabricComponents/textlayoutmanager (= 0.81.3)
+    - React-FabricComponents/components (= 0.81.4)
+    - React-FabricComponents/textlayoutmanager (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1320,7 +1320,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components (0.81.3):
+  - React-FabricComponents/components (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1329,17 +1329,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.3)
-    - React-FabricComponents/components/iostextinput (= 0.81.3)
-    - React-FabricComponents/components/modal (= 0.81.3)
-    - React-FabricComponents/components/rncore (= 0.81.3)
-    - React-FabricComponents/components/safeareaview (= 0.81.3)
-    - React-FabricComponents/components/scrollview (= 0.81.3)
-    - React-FabricComponents/components/switch (= 0.81.3)
-    - React-FabricComponents/components/text (= 0.81.3)
-    - React-FabricComponents/components/textinput (= 0.81.3)
-    - React-FabricComponents/components/unimplementedview (= 0.81.3)
-    - React-FabricComponents/components/virtualview (= 0.81.3)
+    - React-FabricComponents/components/inputaccessory (= 0.81.4)
+    - React-FabricComponents/components/iostextinput (= 0.81.4)
+    - React-FabricComponents/components/modal (= 0.81.4)
+    - React-FabricComponents/components/rncore (= 0.81.4)
+    - React-FabricComponents/components/safeareaview (= 0.81.4)
+    - React-FabricComponents/components/scrollview (= 0.81.4)
+    - React-FabricComponents/components/switch (= 0.81.4)
+    - React-FabricComponents/components/text (= 0.81.4)
+    - React-FabricComponents/components/textinput (= 0.81.4)
+    - React-FabricComponents/components/unimplementedview (= 0.81.4)
+    - React-FabricComponents/components/virtualview (= 0.81.4)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1352,28 +1352,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.3):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.3):
+  - React-FabricComponents/components/inputaccessory (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1394,7 +1373,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/modal (0.81.3):
+  - React-FabricComponents/components/iostextinput (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1415,7 +1394,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.3):
+  - React-FabricComponents/components/modal (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1436,7 +1415,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.3):
+  - React-FabricComponents/components/rncore (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1457,7 +1436,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.3):
+  - React-FabricComponents/components/safeareaview (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1478,7 +1457,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/switch (0.81.3):
+  - React-FabricComponents/components/scrollview (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1499,7 +1478,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/text (0.81.3):
+  - React-FabricComponents/components/switch (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1520,7 +1499,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.3):
+  - React-FabricComponents/components/text (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1541,7 +1520,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.3):
+  - React-FabricComponents/components/textinput (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1562,7 +1541,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.3):
+  - React-FabricComponents/components/unimplementedview (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1583,7 +1562,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.3):
+  - React-FabricComponents/components/virtualview (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1604,27 +1583,48 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - React-FabricImage (0.81.3):
+  - React-FabricComponents/textlayoutmanager (0.81.4):
     - hermes-engine
-    - RCTRequired (= 0.81.3)
-    - RCTTypeSafety (= 0.81.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
+  - React-FabricImage (0.81.4):
+    - hermes-engine
+    - RCTRequired (= 0.81.4)
+    - RCTTypeSafety (= 0.81.4)
     - React-Core-prebuilt
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.3)
+    - React-jsiexecutor (= 0.81.4)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-featureflags (0.81.3):
+  - React-featureflags (0.81.4):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-featureflagsnativemodule (0.81.3):
+  - React-featureflagsnativemodule (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1633,26 +1633,26 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-graphics (0.81.3):
+  - React-graphics (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
     - React-jsiexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-hermes (0.81.3):
+  - React-hermes (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
     - React-jsi
-    - React-jsiexecutor (= 0.81.3)
+    - React-jsiexecutor (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.3)
+    - React-perflogger (= 0.81.4)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-idlecallbacksnativemodule (0.81.3):
+  - React-idlecallbacksnativemodule (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1662,7 +1662,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-ImageManager (0.81.3):
+  - React-ImageManager (0.81.4):
     - React-Core-prebuilt
     - React-Core/Default
     - React-debug
@@ -1671,7 +1671,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - ReactNativeDependencies
-  - React-jserrorhandler (0.81.3):
+  - React-jserrorhandler (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1680,22 +1680,22 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - ReactNativeDependencies
-  - React-jsi (0.81.3):
+  - React-jsi (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsiexecutor (0.81.3):
+  - React-jsiexecutor (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.3)
+    - React-perflogger (= 0.81.4)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspector (0.81.3):
+  - React-jsinspector (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -1704,43 +1704,43 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.81.3)
+    - React-perflogger (= 0.81.4)
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsinspectorcdp (0.81.3):
+  - React-jsinspectorcdp (0.81.4):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-jsinspectornetwork (0.81.3):
+  - React-jsinspectornetwork (0.81.4):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectorcdp
     - React-performancetimeline
     - React-timing
     - ReactNativeDependencies
-  - React-jsinspectortracing (0.81.3):
+  - React-jsinspectortracing (0.81.4):
     - React-Core-prebuilt
     - React-oscompat
     - React-timing
     - ReactNativeDependencies
-  - React-jsitooling (0.81.3):
+  - React-jsitooling (0.81.4):
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - ReactNativeDependencies
-  - React-jsitracing (0.81.3):
+  - React-jsitracing (0.81.4):
     - React-jsi
-  - React-logger (0.81.3):
+  - React-logger (0.81.4):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-Mapbuffer (0.81.3):
+  - React-Mapbuffer (0.81.4):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-microtasksnativemodule (0.81.3):
+  - React-microtasksnativemodule (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-jsi
@@ -1748,7 +1748,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-NativeModulesApple (0.81.3):
+  - React-NativeModulesApple (0.81.4):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -1762,20 +1762,20 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - React-oscompat (0.81.3)
-  - React-perflogger (0.81.3):
+  - React-oscompat (0.81.4)
+  - React-perflogger (0.81.4):
     - React-Core-prebuilt
     - ReactNativeDependencies
-  - React-performancetimeline (0.81.3):
+  - React-performancetimeline (0.81.4):
     - React-Core-prebuilt
     - React-featureflags
     - React-jsinspectortracing
     - React-perflogger
     - React-timing
     - ReactNativeDependencies
-  - React-RCTActionSheet (0.81.3):
-    - React-Core/RCTActionSheetHeaders (= 0.81.3)
-  - React-RCTAnimation (0.81.3):
+  - React-RCTActionSheet (0.81.4):
+    - React-Core/RCTActionSheetHeaders (= 0.81.4)
+  - React-RCTAnimation (0.81.4):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTAnimationHeaders
@@ -1785,7 +1785,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTAppDelegate (0.81.3):
+  - React-RCTAppDelegate (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1813,7 +1813,7 @@ PODS:
     - React-utils
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTBlob (0.81.3):
+  - React-RCTBlob (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-Core/RCTBlobHeaders
@@ -1826,7 +1826,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFabric (0.81.3):
+  - React-RCTFabric (0.81.4):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -1855,7 +1855,7 @@ PODS:
     - React-utils
     - ReactNativeDependencies
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.3):
+  - React-RCTFBReactNativeSpec (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1863,10 +1863,10 @@ PODS:
     - React-Core-prebuilt
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.3)
+    - React-RCTFBReactNativeSpec/components (= 0.81.4)
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTFBReactNativeSpec/components (0.81.3):
+  - React-RCTFBReactNativeSpec/components (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -1883,7 +1883,7 @@ PODS:
     - ReactCommon
     - ReactNativeDependencies
     - Yoga
-  - React-RCTImage (0.81.3):
+  - React-RCTImage (0.81.4):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTImageHeaders
@@ -1893,14 +1893,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTLinking (0.81.3):
-    - React-Core/RCTLinkingHeaders (= 0.81.3)
-    - React-jsi (= 0.81.3)
+  - React-RCTLinking (0.81.4):
+    - React-Core/RCTLinkingHeaders (= 0.81.4)
+    - React-jsi (= 0.81.4)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.3)
-  - React-RCTNetwork (0.81.3):
+    - ReactCommon/turbomodule/core (= 0.81.4)
+  - React-RCTNetwork (0.81.4):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTNetworkHeaders
@@ -1912,7 +1912,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTRuntime (0.81.3):
+  - React-RCTRuntime (0.81.4):
     - hermes-engine
     - React-Core
     - React-Core-prebuilt
@@ -1926,7 +1926,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - ReactNativeDependencies
-  - React-RCTSettings (0.81.3):
+  - React-RCTSettings (0.81.4):
     - RCTTypeSafety
     - React-Core-prebuilt
     - React-Core/RCTSettingsHeaders
@@ -1935,10 +1935,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-RCTText (0.81.3):
-    - React-Core/RCTTextHeaders (= 0.81.3)
+  - React-RCTText (0.81.4):
+    - React-Core/RCTTextHeaders (= 0.81.4)
     - Yoga
-  - React-RCTVibration (0.81.3):
+  - React-RCTVibration (0.81.4):
     - React-Core-prebuilt
     - React-Core/RCTVibrationHeaders
     - React-jsi
@@ -1946,15 +1946,15 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactNativeDependencies
-  - React-rendererconsistency (0.81.3)
-  - React-renderercss (0.81.3):
+  - React-rendererconsistency (0.81.4)
+  - React-renderercss (0.81.4):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.3):
+  - React-rendererdebug (0.81.4):
     - React-Core-prebuilt
     - React-debug
     - ReactNativeDependencies
-  - React-RuntimeApple (0.81.3):
+  - React-RuntimeApple (0.81.4):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -1977,7 +1977,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeCore (0.81.3):
+  - React-RuntimeCore (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-cxxreact
@@ -1993,14 +1993,14 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactNativeDependencies
-  - React-runtimeexecutor (0.81.3):
+  - React-runtimeexecutor (0.81.4):
     - React-Core-prebuilt
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.3)
+    - React-jsi (= 0.81.4)
     - React-utils
     - ReactNativeDependencies
-  - React-RuntimeHermes (0.81.3):
+  - React-RuntimeHermes (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-featureflags
@@ -2015,7 +2015,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - ReactNativeDependencies
-  - React-runtimescheduler (0.81.3):
+  - React-runtimescheduler (0.81.4):
     - hermes-engine
     - React-callinvoker
     - React-Core-prebuilt
@@ -2031,17 +2031,17 @@ PODS:
     - React-timing
     - React-utils
     - ReactNativeDependencies
-  - React-timing (0.81.3):
+  - React-timing (0.81.4):
     - React-debug
-  - React-utils (0.81.3):
+  - React-utils (0.81.4):
     - hermes-engine
     - React-Core-prebuilt
     - React-debug
-    - React-jsi (= 0.81.3)
+    - React-jsi (= 0.81.4)
     - ReactNativeDependencies
-  - ReactAppDependencyProvider (0.81.3):
+  - ReactAppDependencyProvider (0.81.4):
     - ReactCodegen
-  - ReactCodegen (0.81.3):
+  - ReactCodegen (0.81.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2061,43 +2061,43 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - ReactCommon (0.81.3):
+  - ReactCommon (0.81.4):
     - React-Core-prebuilt
-    - ReactCommon/turbomodule (= 0.81.3)
+    - ReactCommon/turbomodule (= 0.81.4)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule (0.81.3):
+  - ReactCommon/turbomodule (0.81.4):
     - hermes-engine
-    - React-callinvoker (= 0.81.3)
+    - React-callinvoker (= 0.81.4)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
-    - ReactCommon/turbomodule/bridging (= 0.81.3)
-    - ReactCommon/turbomodule/core (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
+    - React-jsi (= 0.81.4)
+    - React-logger (= 0.81.4)
+    - React-perflogger (= 0.81.4)
+    - ReactCommon/turbomodule/bridging (= 0.81.4)
+    - ReactCommon/turbomodule/core (= 0.81.4)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/bridging (0.81.3):
+  - ReactCommon/turbomodule/bridging (0.81.4):
     - hermes-engine
-    - React-callinvoker (= 0.81.3)
+    - React-callinvoker (= 0.81.4)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
+    - React-jsi (= 0.81.4)
+    - React-logger (= 0.81.4)
+    - React-perflogger (= 0.81.4)
     - ReactNativeDependencies
-  - ReactCommon/turbomodule/core (0.81.3):
+  - ReactCommon/turbomodule/core (0.81.4):
     - hermes-engine
-    - React-callinvoker (= 0.81.3)
+    - React-callinvoker (= 0.81.4)
     - React-Core-prebuilt
-    - React-cxxreact (= 0.81.3)
-    - React-debug (= 0.81.3)
-    - React-featureflags (= 0.81.3)
-    - React-jsi (= 0.81.3)
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
-    - React-utils (= 0.81.3)
+    - React-cxxreact (= 0.81.4)
+    - React-debug (= 0.81.4)
+    - React-featureflags (= 0.81.4)
+    - React-jsi (= 0.81.4)
+    - React-logger (= 0.81.4)
+    - React-perflogger (= 0.81.4)
+    - React-utils (= 0.81.4)
     - ReactNativeDependencies
-  - ReactNativeDependencies (0.81.3)
+  - ReactNativeDependencies (0.81.4)
   - SDWebImage (5.21.0):
     - SDWebImage/Core (= 5.21.0)
   - SDWebImage/Core (5.21.0)
@@ -2406,100 +2406,100 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  EASClient: cfb28a340d86eeb03c2c67a2c34cd664c97dbc51
+  EASClient: 4e721c008528e7e2637be5913500744ea0d1d75c
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
-  EXManifests: 9b19413c322564f3c2dce83006f1d71a4df79ba9
-  EXNotifications: 41233e5c2c4a795139d08a9ff8bb3de2536b86f5
-  Expo: 05129f4ae3d73e0d362c88e767d73943663dd1c0
-  expo-dev-launcher: 30f8a8f913bd2bd51820af9cfe821d75d7e01609
-  expo-dev-menu: 7e3a1079f69e4cd1de6ce9c05ad484f68b4666d4
+  EXManifests: 8c3a1dc3d2cd353107616180b090b6cb8424e0ca
+  EXNotifications: bfcda0c49edd979747e1e50340de7bb0e9729ef5
+  Expo: 4baf76a592eb9aeef2d23da756126219c410cde6
+  expo-dev-launcher: 9bcafddbb217a4964e54571b0eacb0559bb6a375
+  expo-dev-menu: 32b27401b34be4752f4cb5c62d898a5bc5d134a2
   expo-dev-menu-interface: 600df12ea01efecdd822daaf13cc0ac091775533
-  ExpoClipboard: 9e1809dd6ffdc08ce990f9bf22dcab3791b694aa
-  ExpoImage: 2708a5a9e69b6432f43d368379cc7c9b5165048b
-  ExpoMediaLibrary: 3204a2cb76b8f9822d8631d801b60f9feb6792e4
-  ExpoModulesCore: e024de04e62251f18e893c9040389da95a0c1862
-  ExpoModulesTestCore: e65555b75a4ed7dd3bcf421ad01d7748bd372c88
+  ExpoClipboard: c87f8148d16283e65a164a619232350312333c96
+  ExpoImage: 18d9836939f8e271364a5a2a3566f099ea73b2e4
+  ExpoMediaLibrary: 7c555ad5d9234c0e9548e538bd892b695cd1355b
+  ExpoModulesCore: a8e30f3757db7bc381d77b02d1f743439ed954a9
+  ExpoModulesTestCore: be5073c51ffe7c2db9f14aedfce7d8cdc141f55a
   EXStructuredHeaders: c951e77f2d936f88637421e9588c976da5827368
-  EXUpdates: acd31e646f9ca7e4efb3747b590210f297ec6938
-  EXUpdatesInterface: 1436757deb0d574b84bba063bd024c315e0ec08b
-  FBLazyVector: d06087501b6a425c222a186e94ce92aa4d3fb37c
-  hermes-engine: 5463d3c4a8a0d35701605934008f34c171ce71d5
+  EXUpdates: 270a2043daef202851760c8824f9010635db51af
+  EXUpdatesInterface: 5adf50cb41e079c861da6d9b4b954c3db9a50734
+  FBLazyVector: 9e0cd874afd81d9a4d36679daca991b58b260d42
+  hermes-engine: 35c763d57c9832d0eef764316ca1c4d043581394
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: d32871931c05547cb4e0bc9009d66a18b50d8558
-  RCTDeprecation: 0b7e84477d8780fc8dff04fc1ec89cb93f8f5c04
-  RCTRequired: 497c1356844e5e95975ff2259bedc2db446c4ed0
-  RCTTypeSafety: 6105baaba5a22b1ff4f2e420eda172aa423acd01
+  RCTDeprecation: 7487d6dda857ccd4cb3dd6ecfccdc3170e85dcbc
+  RCTRequired: 54128b7df8be566881d48c7234724a78cb9b6157
+  RCTTypeSafety: d2b07797a79e45d7b19e1cd2f53c79ab419fe217
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 639d04fed84b2ff824861d863891eaef7cb92f9c
-  React-callinvoker: 9eff267e8435b7ab377acf16a64d69e897f35c25
-  React-Core: 114001953b5444cc62d652d0afdda9eefdba5362
-  React-Core-prebuilt: 39d0f778d6e21201895baec61c746843d1392984
-  React-CoreModules: 08308a974bbce620cb3abac6e2761a5245c96621
-  React-cxxreact: 302ece9f2b119a875a0d9d22dffb57557394e242
-  React-debug: 9c09818ae432a10ab72c973b727b944b75ccadb9
-  React-defaultsnativemodule: 4955e87b2b0ee8be90625b579658c57b04438cb4
-  React-domnativemodule: af79168a06f4da71b515ee63fa94072a395fd2a7
-  React-Fabric: 0f1cb599f71d2749a6aac92b07d243afaf8b5fb4
-  React-FabricComponents: 831e1af20196101467532a1e9947070a57b30f8f
-  React-FabricImage: 0cb0f9c8b0f58cc3ab21d9bcb02c5580de33ea19
-  React-featureflags: 50f6c269087123f68c5f3b7f1c5847a7328e4713
-  React-featureflagsnativemodule: 4fd687c47b7d68ee45ae39bc2d3bfc087292d8d4
-  React-graphics: 85d61c25ad0e2feb82703d830cb5f1447f26776c
-  React-hermes: 06fd40f5d8ca9cc60247f08feac9c2e4b5a11caa
-  React-idlecallbacksnativemodule: 7bc42c314257dfe112330afb3d63bffe0c712968
-  React-ImageManager: a93bb2a53c7f69b49feb13731c1dfe76cd123cd6
-  React-jserrorhandler: 7a10f7236723aec83dd81db9e22ab453a0ec4a01
-  React-jsi: 4867a7cc7638c5580f6bcc5af6009e5e53efc216
-  React-jsiexecutor: c22b20b5a1615878cfdaa7a1d0bfd363d3f34728
-  React-jsinspector: 233b55315afc9c5c46ba8a28b5ac70a1d844cb29
-  React-jsinspectorcdp: 085d8c4f96335f897cde933f06254cc9ed33040e
-  React-jsinspectornetwork: 7cb1c98c63979c9fe5d1e10660368ef86227bbd1
-  React-jsinspectortracing: 52d2b1534cdd7c01f8bf20921522b747d68d9ef8
-  React-jsitooling: 5e888c5c6f24e48e1978535a70e2296a57b21549
-  React-jsitracing: da1c7edd78c35dfdf7e26111888894ff9dec7880
-  React-logger: 793cf0a405596fc047e192f9e9b2f0565c8b97d9
-  React-Mapbuffer: 82cd04b7e0f4ee713fd848bd41f004659e82301e
-  React-microtasksnativemodule: 7604bc6677ca1c9c184ac217952394d6dc5534dc
-  React-NativeModulesApple: dc4d40310448a70b2a7b25f7280a501150b88fe2
-  React-oscompat: 94245768a4c9e912776373255e9b9497d634b284
-  React-perflogger: e58b0e28f1ee95e99e330dcde8b0beb710199e10
-  React-performancetimeline: a770d9c95f897c07e35f43247afc16c7b569737f
-  React-RCTActionSheet: dee4c5e267ec056f5ef912196a856df035e685ff
-  React-RCTAnimation: e3a5ce2e53f482e2daa2f8f43468abdbe0260c76
-  React-RCTAppDelegate: 4c9bcaaad7af57c5dd97561dba236d5a3baecd20
-  React-RCTBlob: 062da7c13848cc643589becc7b190900ad7e2499
-  React-RCTFabric: 37f875131330036c090d6b01f21b5285dee77757
-  React-RCTFBReactNativeSpec: 354e6cc4e681eb0f8cda9571d7a2fd00d6674b29
-  React-RCTImage: d32d7056068751e45b383561705bac719dedcbc7
-  React-RCTLinking: add103c480ae3f1d6fdbead7ecfa22eb6dbb1c4a
-  React-RCTNetwork: 0e3cc2664d73e11b3b97a8f7d318fa1034328394
-  React-RCTRuntime: 40092cdd126b1d3a2f240e13e94f36fdf8a4a05f
-  React-RCTSettings: ac3ea5b32e8542c7eac0701305214815594cb188
-  React-RCTText: 4d1c4ddab66b6170977a695348cdb0f989005192
-  React-RCTVibration: 20ec75d11d2cd2cecf82772a7d5101af20d2a322
-  React-rendererconsistency: 9cbc91c7a1890be02c2279ddf3f539dc24d0cdf7
-  React-renderercss: 6a9d220ffda31f005fbe2021633481c9343e603c
-  React-rendererdebug: 6531aa831f830e03b456469cfe3c1e4c8b98baf6
-  React-RuntimeApple: c0d858b8fe462ec9c435fd130348b7e89b6932fa
-  React-RuntimeCore: 3f868e7a500bcf5bc30fc0e6edb1e54e12b220ce
-  React-runtimeexecutor: 918598152c33b701821e0b9cb16472badbf23b3e
-  React-RuntimeHermes: ffb292bf8a08a3c674ee213c6bfe0ee3e2ae528d
-  React-runtimescheduler: d57929ce939bd518243e42614f9a95add27ba6f7
-  React-timing: cf0652d4c8a5bf1c48aef5b70eb3fa6f50c7f2ac
-  React-utils: 4687ee48d76381ceb583479fbc7026eae8adc744
-  ReactAppDependencyProvider: f9317094ed209f55ecbdd9ba792843cfb1c45c29
-  ReactCodegen: 973950553b2de05c8a261402b5034336207dee6b
-  ReactCommon: c7ad14babdb12b84989965987f87baebe062e6a5
-  ReactNativeDependencies: 1d2c24fee8694aaf7cf5589288418cd78a24ec19
+  React: 2073376f47c71b7e9a0af7535986a77522ce1049
+  React-callinvoker: 00fa0972a70df7408a4f088144b67207b157e386
+  React-Core: d375dd308561785c739a621a21802e5e7e047dee
+  React-Core-prebuilt: dde79b89f8863efebb1d532a3335f472927da669
+  React-CoreModules: 3eb9b1410a317987c557afc683cc50099562c91d
+  React-cxxreact: 724210b64158d97f150d8d254a7319e73ef77ee7
+  React-debug: c01d176522cf57cdc4a4a66d1974968fcf497f32
+  React-defaultsnativemodule: 3953ff49013fa997e72586628e1d218fdaf3abdb
+  React-domnativemodule: 540b9c7a8f31b6f4ed449aafd3a272e1f1107089
+  React-Fabric: 00b792be016edad758a63c4ebac15e01d35f6355
+  React-FabricComponents: 16ebdb9245d91ec27985a038d0a6460f499db54e
+  React-FabricImage: 2a967b5f0293c1c49ec883babfd4992d161e3583
+  React-featureflags: 4150b4ddac8210b1e3c538cfb455050b5ee05d8d
+  React-featureflagsnativemodule: ff977040205b96818ac1f884846493cb8a2aca28
+  React-graphics: ec689ac1c13a9ddb1af83baf195264676ecdbeb6
+  React-hermes: ff60a3407f27f3fc82f661774a7ab6559a24ab69
+  React-idlecallbacksnativemodule: 5f5ce3c424941f77da4ac3adba681149e68b1221
+  React-ImageManager: 8d87296a86f9ee290c1d32c68c7be1be63492467
+  React-jserrorhandler: 072756f12136284c86e96c33cdfece4d7286a99f
+  React-jsi: b507852b42a9125dffbf6ae7a33792fb521b29a2
+  React-jsiexecutor: f970eed6debb91fe5d5d6cb5734d39cf86c59896
+  React-jsinspector: 766e113e9482b22971b30236d10c04d8af38269e
+  React-jsinspectorcdp: 5b60350e29fe2566d9ed9799858c04b8e6095a3e
+  React-jsinspectornetwork: b3cc9a20c6b270f792eaaaa14313019a031b327d
+  React-jsinspectortracing: d99120fcf0864209c45cefbc9fc4605c8189c0ef
+  React-jsitooling: 9e41724cc47feadefbede31ca91d70f6ff079656
+  React-jsitracing: ca020d934502de8e02cccf451501434a5e584027
+  React-logger: 7b234de35acb469ce76d6bbb0457f664d6f32f62
+  React-Mapbuffer: fbe1da882a187e5898bdf125e1cc6e603d27ecae
+  React-microtasksnativemodule: 76905804171d8ccbe69329fc84c57eb7934add7f
+  React-NativeModulesApple: a9464983ccc0f66f45e93558671f60fc7536e438
+  React-oscompat: 73db7dbc80edef36a9d6ed3c6c4e1724ead4236d
+  React-perflogger: 123272debf907cc423962adafcf4513320e43757
+  React-performancetimeline: 095146e4dc8fa4568e44d7a9debc134f27e103f9
+  React-RCTActionSheet: 9fc2a0901af63cefe09c8df95a08c2cf8bb7797b
+  React-RCTAnimation: 785e743e489bc7aec14415dbc15f4f275b2c0276
+  React-RCTAppDelegate: 0602c9e13130edcde4661ea66d11122a3a66f11a
+  React-RCTBlob: ae53b7508a5ced43378de2a88816f63423df1f24
+  React-RCTFabric: 687a0cfb5726adea7fac63560b04410c86d97134
+  React-RCTFBReactNativeSpec: 7c55cf4fb4d2baad32ce3850b8504a6ee22e11ce
+  React-RCTImage: f45474c75cdf1526114f75b27e86d004aa171b90
+  React-RCTLinking: 56622ff97570e15e01dd9b5a657010c756a9e2d8
+  React-RCTNetwork: 3fffa1ab5d6981f839e7679d56f8cb731ba92c07
+  React-RCTRuntime: f38c04f744596fc8e1b4c5f6a57fc05c26955257
+  React-RCTSettings: f4a8e1bd36f58ec8273c73d3deefdcf90143ac6a
+  React-RCTText: da852a51dd1d169b38136a4f4d1eaed35376556b
+  React-RCTVibration: ff92ef336e32e18efff0fa83c798a2dbbebe09bd
+  React-rendererconsistency: b83b300e607f4e30478a5c3365e260a760232b04
+  React-renderercss: aa6a3cdd4fa4e3726123c42b49ba4dd978f81688
+  React-rendererdebug: 6b12a782caf2e7e2f730434264357b7b6aed1781
+  React-RuntimeApple: 8934aab108dcab957a87208fef4b6f1b3a04973a
+  React-RuntimeCore: 1d4345561ecc402e9e88b38e1d9b059a7a13b113
+  React-runtimeexecutor: a9a059f222e4d78f45a4e92cada48a5fde989fb8
+  React-RuntimeHermes: 05b955709a75038d282a9420342d7bea5857768a
+  React-runtimescheduler: 4ce23c9157b51101092537d4171ea4de48a5b863
+  React-timing: 62441edf291b91ab5b96ab8f2f8fb648c063ce6f
+  React-utils: 485abe7eaefa04b20e0ef442593e022563a1419b
+  ReactAppDependencyProvider: 433ddfb4536948630aadd5bd925aff8a632d2fe3
+  ReactCodegen: f009f6e241a83810e5a1a07466d4e1889d249ab1
+  ReactCommon: 149b6c05126f2e99f2ed0d3c63539369546f8cae
+  ReactNativeDependencies: ed6d1e64802b150399f04f1d5728ec16b437251e
   SDWebImage: f84b0feeb08d2d11e6a9b843cb06d75ebf5b8868
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  Yoga: f9025ab908f89228f6ab399c59bfcc334b53a734
+  Yoga: 051f086b5ccf465ff2ed38a2cf5a558ae01aaaa1
 
 PODFILE CHECKSUM: 7b324c13881703a862f70f400c68133d3b5568d5
 

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -19,7 +19,7 @@
     "expo-updates": "29.0.8",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.3"
+    "react-native": "0.81.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -31,7 +31,7 @@
     "expo-task-manager": "14.0.6",
     "react-native-gesture-handler": "~2.28.0",
     "react": "19.1.0",
-    "react-native": "0.81.3",
+    "react-native": "0.81.4",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0"
   },

--- a/apps/paper-tester/package.json
+++ b/apps/paper-tester/package.json
@@ -22,7 +22,7 @@
     "expo-video": "~3.0.10",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.3",
+    "react-native": "0.81.4",
     "react-native-web": "~0.21.0"
   },
   "devDependencies": {

--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -45,7 +45,7 @@
     "expo-sqlite": "~16.0.7",
     "jose": "^5",
     "react": "19.1.0",
-    "react-native": "0.81.3",
+    "react-native": "0.81.4",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0",
     "react-native-webview": "13.13.5"

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -15,7 +15,7 @@
     "expo-router": "^6.0.0-preview.16",
     "expo-splash-screen": "~31.0.8",
     "react": "19.1.0",
-    "react-native": "0.81.3",
+    "react-native": "0.81.4",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.11.1-nightly-20250611-8b82e081e"
   },

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -51,7 +51,7 @@
     "jasmine-core": "^2.4.1",
     "lodash": "^4.17.19",
     "react": "19.1.0",
-    "react-native": "0.81.3",
+    "react-native": "0.81.4",
     "react-native-gesture-handler": "~2.28.0",
     "sinon": "^7.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "resolutions": {
     "@expo/metro": "~0.1.1",
-    "react-native": "0.81.3",
+    "react-native": "0.81.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "@types/babel__core": "^7.20.5",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -59,7 +59,7 @@
     "@expo/spawn-async": "^1.7.2",
     "@expo/ws-tunnel": "^1.0.1",
     "@expo/xcpretty": "^4.3.0",
-    "@react-native/dev-middleware": "0.81.3",
+    "@react-native/dev-middleware": "0.81.4",
     "@urql/core": "^5.0.6",
     "@urql/exchange-retry": "^1.3.0",
     "accepts": "^1.3.8",

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -45,7 +45,7 @@
     "@expo/config-types": "^54.0.7",
     "@expo/image-utils": "^0.8.6",
     "@expo/json-file": "^10.0.6",
-    "@react-native/normalize-colors": "0.81.3",
+    "@react-native/normalize-colors": "0.81.4",
     "debug": "^4.3.1",
     "resolve-from": "^5.0.0",
     "semver": "^7.6.0",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -69,7 +69,7 @@
     "@babel/plugin-transform-parameters": "^7.24.7",
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.0",
-    "@react-native/babel-preset": "0.81.3",
+    "@react-native/babel-preset": "0.81.4",
     "babel-plugin-react-compiler": "^19.1.0-rc.2",
     "babel-plugin-react-native-web": "~0.21.0",
     "babel-plugin-transform-flow-enums": "^0.0.2",

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -45,7 +45,7 @@
     "expo-module-scripts": "^5.0.6",
     "fuse.js": "^6.4.6",
     "react": "19.1.0",
-    "react-native": "0.81.3",
+    "react-native": "0.81.4",
     "url": "^0.11.0",
     "use-subscription": "^1.8.0"
   },

--- a/packages/expo-module-template/$package.json
+++ b/packages/expo-module-template/$package.json
@@ -33,7 +33,7 @@
     "@types/react": "~19.1.0",
     "expo-module-scripts": "^5.0.6",
     "expo": "^54.0.0-preview.16",
-    "react-native": "0.81.3"
+    "react-native": "0.81.4"
   },
   "peerDependencies": {
     "expo": "*",

--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/navigation-bar",
   "dependencies": {
-    "@react-native/normalize-colors": "0.81.3",
+    "@react-native/normalize-colors": "0.81.4",
     "debug": "^4.3.2",
     "react-native-is-edge-to-edge": "^1.2.1"
   },

--- a/packages/expo-system-ui/package.json
+++ b/packages/expo-system-ui/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/system-ui",
   "dependencies": {
-    "@react-native/normalize-colors": "0.81.3",
+    "@react-native/normalize-colors": "0.81.4",
     "debug": "^4.3.2"
   },
   "jest": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -92,7 +92,7 @@
   "lottie-react-native": "~7.3.1",
   "react": "19.1.0",
   "react-dom": "19.1.0",
-  "react-native": "0.81.3",
+  "react-native": "0.81.4",
   "react-native-web": "~0.21.0",
   "react-native-gesture-handler": "~2.28.0",
   "react-native-get-random-values": "~1.11.0",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -103,7 +103,7 @@
     "expo-module-scripts": "^5.0.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.3",
+    "react-native": "0.81.4",
     "web-streams-polyfill": "^3.3.2"
   },
   "peerDependencies": {

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -14,6 +14,6 @@
     "expo": "~54.0.0-preview.16",
     "expo-status-bar": "~3.0.7",
     "react": "19.1.0",
-    "react-native": "0.81.3"
+    "react-native": "0.81.4"
   }
 }

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -14,7 +14,7 @@
     "expo": "~54.0.0-preview.16",
     "expo-status-bar": "~3.0.7",
     "react": "19.1.0",
-    "react-native": "0.81.3"
+    "react-native": "0.81.4"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -14,6 +14,6 @@
     "expo": "~54.0.0-preview.16",
     "expo-status-bar": "~3.0.7",
     "react": "19.1.0",
-    "react-native": "0.81.3"
+    "react-native": "0.81.4"
   }
 }

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -29,7 +29,7 @@
     "expo-web-browser": "~15.0.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.3",
+    "react-native": "0.81.4",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-worklets": "~0.5.1",
     "react-native-reanimated": "~4.1.0",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -23,7 +23,7 @@
     "expo-web-browser": "~15.0.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.3",
+    "react-native": "0.81.4",
     "react-native-worklets": "~0.5.1",
     "react-native-reanimated": "~4.1.0",
     "react-native-safe-area-context": "~5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3512,23 +3512,23 @@
   resolved "https://registry.yarnpkg.com/@react-native-segmented-control/segmented-control/-/segmented-control-2.5.7.tgz#7c91ef7dede8752796a234321fafa2c604fc82af"
   integrity sha512-l84YeVX8xAU3lvOJSvV4nK/NbGhIm2gBfveYolwaoCbRp+/SLXtc6mYrQmM9ScXNwU14mnzjQTpTHWl5YPnkzQ==
 
-"@react-native/assets-registry@0.81.3":
-  version "0.81.3"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.81.3.tgz#cabd36f8289c127ff4ddd353c228244d247943ca"
-  integrity sha512-vjLLbhhYA6JSW87flpf1TUciyCQOp7kwNZQaNqGPE6gRmqRDAf+3mwkSh96kaC4aa8Fqi5AFnMY8otfiKtiPGg==
+"@react-native/assets-registry@0.81.4":
+  version "0.81.4"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.81.4.tgz#bfa477c8e9d54d6ef4ab6e81b886d5be13c09fbd"
+  integrity sha512-AMcDadefBIjD10BRqkWw+W/VdvXEomR6aEZ0fhQRAv7igrBzb4PTn4vHKYg+sUK0e3wa74kcMy2DLc/HtnGcMA==
 
-"@react-native/babel-plugin-codegen@0.81.3":
-  version "0.81.3"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.3.tgz#64a9146cb9f3dd340dae2bfa551d762809b7c9cc"
-  integrity sha512-Fpo1hs0q5GGraPTlqKKl6JBKhPHTRX9vSLyObo0hr6NBYYAW1rML80ycaPAh65E6wYlylQzRHlM+3HVLnkHFcQ==
+"@react-native/babel-plugin-codegen@0.81.4":
+  version "0.81.4"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.81.4.tgz#0e513ac2108ff509eab1470982db472faab9ae46"
+  integrity sha512-6ztXf2Tl2iWznyI/Da/N2Eqymt0Mnn69GCLnEFxFbNdk0HxHPZBNWU9shTXhsLWOL7HATSqwg/bB1+3kY1q+mA==
   dependencies:
     "@babel/traverse" "^7.25.3"
-    "@react-native/codegen" "0.81.3"
+    "@react-native/codegen" "0.81.4"
 
-"@react-native/babel-preset@0.81.3":
-  version "0.81.3"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.81.3.tgz#48d03fe89e6babf26cb632f248bad497f6b24892"
-  integrity sha512-USi6dJH7FhJbu0cxrYGbcolfNUOMjpsytpP8vyi4nk7/OF6ZbH5lM2MmcJzBThd0Y2nauMosGgiTp6g6rbuhcg==
+"@react-native/babel-preset@0.81.4":
+  version "0.81.4"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.81.4.tgz#a9be20fb625014a65a51784b540992031bc12085"
+  integrity sha512-VYj0c/cTjQJn/RJ5G6P0L9wuYSbU9yGbPYDHCKstlQZQWkk+L9V8ZDbxdJBTIei9Xl3KPQ1odQ4QaeW+4v+AZg==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/plugin-proposal-export-default-from" "^7.24.7"
@@ -3571,15 +3571,15 @@
     "@babel/plugin-transform-typescript" "^7.25.2"
     "@babel/plugin-transform-unicode-regex" "^7.24.7"
     "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.81.3"
+    "@react-native/babel-plugin-codegen" "0.81.4"
     babel-plugin-syntax-hermes-parser "0.29.1"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
 
-"@react-native/codegen@0.81.3":
-  version "0.81.3"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.81.3.tgz#357449bc47ed375eeb153d2d26e726fafd3fe75f"
-  integrity sha512-nPphQP8EzeBsvsCGcsQV6juNeLyqyJWFAnKepXE6ERB1RKnv009cyjfbYs9f4dp4Bu8lgQpjlkW1q79KlKJu7Q==
+"@react-native/codegen@0.81.4":
+  version "0.81.4"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.81.4.tgz#eb884e2c3c6a46ccddbdfa6198705658e4a30c6c"
+  integrity sha512-LWTGUTzFu+qOQnvkzBP52B90Ym3stZT8IFCzzUrppz8Iwglg83FCtDZAR4yLHI29VY/x/+pkcWAMCl3739XHdw==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/parser" "^7.25.3"
@@ -3589,12 +3589,12 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/community-cli-plugin@0.81.3":
-  version "0.81.3"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.81.3.tgz#b02b4deb1c197de1d0bc3eb4723efbc202caaf96"
-  integrity sha512-6pDl9CfHsmuvYN/jdQlOfg1AJavYM+mIQr2LVDbw/0/JlsdvVUq0xCjXH+JlgzsyMihvNPZIwv16XAZ3yPnKYw==
+"@react-native/community-cli-plugin@0.81.4":
+  version "0.81.4"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.81.4.tgz#7bed570cec5277baa22a6eae0843abbd1345a290"
+  integrity sha512-8mpnvfcLcnVh+t1ok6V9eozWo8Ut+TZhz8ylJ6gF9d6q9EGDQX6s8jenan5Yv/pzN4vQEKI4ib2pTf/FELw+SA==
   dependencies:
-    "@react-native/dev-middleware" "0.81.3"
+    "@react-native/dev-middleware" "0.81.4"
     debug "^4.4.0"
     invariant "^2.2.4"
     metro "^0.83.1"
@@ -3602,18 +3602,18 @@
     metro-core "^0.83.1"
     semver "^7.1.3"
 
-"@react-native/debugger-frontend@0.81.3":
-  version "0.81.3"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.81.3.tgz#525e60216845f79f13ff9ffb91f57049a2eb0581"
-  integrity sha512-r85sd9lN/rVa8cQ1rEzUSFzBT3/Gt6HPPSLbqsvsNZFIRNoiSSLFsmkXTA6qxtAEtQfUm3Gr+6xfsNmO3Vvg3g==
+"@react-native/debugger-frontend@0.81.4":
+  version "0.81.4"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.81.4.tgz#da05018377a6d24ed694057c3445907ba81413ae"
+  integrity sha512-SU05w1wD0nKdQFcuNC9D6De0ITnINCi8MEnx9RsTD2e4wN83ukoC7FpXaPCYyP6+VjFt5tUKDPgP1O7iaNXCqg==
 
-"@react-native/dev-middleware@0.81.3":
-  version "0.81.3"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.81.3.tgz#342e4aa676abc95cd9ab1fcb031285b217a4d0aa"
-  integrity sha512-USq6rvCqHdyjZLNUdAgFeJ1YW8shzXBu5OD1TnQ5yZ19UDBxnWQ36jl2vKvpi6qEH5VHddxoVLVrn9dBRBN8rA==
+"@react-native/dev-middleware@0.81.4":
+  version "0.81.4"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.81.4.tgz#61271dbbd4ff92d7f53462f19f3273bc28bb8bf0"
+  integrity sha512-hu1Wu5R28FT7nHXs2wWXvQ++7W7zq5GPY83llajgPlYKznyPLAY/7bArc5rAzNB7b0kwnlaoPQKlvD/VP9LZug==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.81.3"
+    "@react-native/debugger-frontend" "0.81.4"
     chrome-launcher "^0.15.2"
     chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
@@ -3624,30 +3624,30 @@
     serve-static "^1.16.2"
     ws "^6.2.3"
 
-"@react-native/gradle-plugin@0.81.3":
-  version "0.81.3"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.81.3.tgz#02f3d0fbc5077e3360647e1ecbd466eadb0b0c00"
-  integrity sha512-zEDhVWxrbl7lxg1qiWvIIL7KEdxWhRQ8G9kYbVCvjZE42xE5CXBqvZUEgZL5d2pUR6z/2HAbwjgk4gFYh5g3zg==
+"@react-native/gradle-plugin@0.81.4":
+  version "0.81.4"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.81.4.tgz#249b7876df47a3ddefddffa71b1fd0193f7da376"
+  integrity sha512-T7fPcQvDDCSusZFVSg6H1oVDKb/NnVYLnsqkcHsAF2C2KGXyo3J7slH/tJAwNfj/7EOA2OgcWxfC1frgn9TQvw==
 
-"@react-native/js-polyfills@0.81.3":
-  version "0.81.3"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.81.3.tgz#446728e1cdcf3b63d95711cc061f93c6945cacd7"
-  integrity sha512-YWLrA4fsxFJ5lhIQk+ZaHRL0TSZ0GK8QyJwuAwIExnIugIRSCm8f4qafkTxtDToygbbjGQm61y8hxDIGd9sEtg==
+"@react-native/js-polyfills@0.81.4":
+  version "0.81.4"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.81.4.tgz#cbc3924cfb994ed00ef841a796f54be21520d3b0"
+  integrity sha512-sr42FaypKXJHMVHhgSbu2f/ZJfrLzgaoQ+HdpRvKEiEh2mhFf6XzZwecyLBvWqf2pMPZa+CpPfNPiejXjKEy8w==
 
-"@react-native/normalize-colors@0.81.3":
-  version "0.81.3"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.81.3.tgz#ecae9d5133511009180d712d7519666685ed46b3"
-  integrity sha512-RCyMSRpSgLPZcxIZVBirmsEJom7GHIP/4XlIepr85cM638t/YVr4S7pg7c79UXVgFJVGTDvBluORFXppJ0YHxQ==
+"@react-native/normalize-colors@0.81.4":
+  version "0.81.4"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.81.4.tgz#a0384d5aaac825aeefa5e391947189f6cee4a641"
+  integrity sha512-9nRRHO1H+tcFqjb9gAM105Urtgcanbta2tuqCVY0NATHeFPDEAB7gPyiLxCHKMi1NbhP6TH0kxgSWXKZl1cyRg==
 
 "@react-native/normalize-colors@^0.74.1":
   version "0.74.88"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.74.88.tgz#46f4c7270c8e6853281d7dd966e0eb362068e41a"
   integrity sha512-He5oTwPBxvXrxJ91dZzpxR7P+VYmc9IkJfhuH8zUiU50ckrt+xWNjtVugPdUv4LuVjmZ36Vk2EX8bl1gVn2dVA==
 
-"@react-native/virtualized-lists@0.81.3":
-  version "0.81.3"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.81.3.tgz#143cbab8c726e457e1ebea37a4707525d5b2d664"
-  integrity sha512-vYib5Ed4zTrJr+Hlv1mQ0JDNOUVoGoVsKIVn7UgxHwGv1M+a5Ehyze44chPQmq+7o7Y3ix3HwJZGV/tedthqGQ==
+"@react-native/virtualized-lists@0.81.4":
+  version "0.81.4"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.81.4.tgz#3c9c162fc96777c87ca07e8686f227343dbc8f13"
+  integrity sha512-hBM+rMyL6Wm1Q4f/WpqGsaCojKSNUBqAXLABNGoWm1vabZ7cSnARMxBvA/2vo3hLcoR4v7zDK8tkKm9+O0LjVA==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -13907,19 +13907,19 @@ react-native-worklets@0.5.1:
     convert-source-map "^2.0.0"
     semver "7.7.2"
 
-react-native@0.81.3:
-  version "0.81.3"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.81.3.tgz#e9739ba3b3d7d6acc6e460605bd7c28885d6e0d0"
-  integrity sha512-8Rk2pLJ4DerW09Vxi0URG9QoPQPC9Q7Q7/CMSisr9qVIBuDQqv5TI+ESoJZjjAJdN1t4QqHrMbzUXpkLCohUNQ==
+react-native@0.81.4:
+  version "0.81.4"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.81.4.tgz#d5e9d0a71ed2e80a550a6c358f2ce3ddb6f5b119"
+  integrity sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ==
   dependencies:
     "@jest/create-cache-key-function" "^29.7.0"
-    "@react-native/assets-registry" "0.81.3"
-    "@react-native/codegen" "0.81.3"
-    "@react-native/community-cli-plugin" "0.81.3"
-    "@react-native/gradle-plugin" "0.81.3"
-    "@react-native/js-polyfills" "0.81.3"
-    "@react-native/normalize-colors" "0.81.3"
-    "@react-native/virtualized-lists" "0.81.3"
+    "@react-native/assets-registry" "0.81.4"
+    "@react-native/codegen" "0.81.4"
+    "@react-native/community-cli-plugin" "0.81.4"
+    "@react-native/gradle-plugin" "0.81.4"
+    "@react-native/js-polyfills" "0.81.4"
+    "@react-native/normalize-colors" "0.81.4"
+    "@react-native/virtualized-lists" "0.81.4"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/39499

This will fix the remaining autoliking issues 

# How 

- update package versions
  - `react-native  0.81.3 -> 0.81.4`  
  - `@react-native/normalize-colors 0.81.3 ->  0.81.4` 
  - `@react-native/babel-preset 0.81.3 ->  0.81.4` 
  - `@react-native/dev-middleware 0.81.3 ->  0.81.4`    

# Test Plan
 
bare-expo ios / android
paper-tester ios / android
ci passed

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
