### PR TITLE
[docs] Add `macos-sequoia-15.6-xcode-26.0` to docs

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -307,7 +307,32 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 ### iOS server images
 
-#### <CopyTextButton>`macos-sequoia-15.5-xcode-26.0`</CopyTextButton>
+#### <CopyTextButton>`macos-sequoia-15.6-xcode-26.0`</CopyTextButton> (recommended for SDK 54 if you want to use Xcode 26.0)
+
+<Collapsible summary="Details">
+
+- macOS Sequoia 15.6
+- Xcode 26.0 RC 1 (17A321)
+- Node.js 20.19.4
+- Bun 1.2.21
+- Yarn 1.22.22
+- pnpm 10.15.1
+- npm 10.9.3
+- fastlane 2.228.0
+- CocoaPods 1.16.2
+- Ruby 3.2
+- node-gyp 11.3.0
+- jq 1.8.0
+- Azul Zulu JDK 17.58.21 (OpenJDK 17.0.15)
+- Git 2.49.0
+- Git LFS 3.6.1
+- applesimutils 0.9.12
+- idb-companion 1.1.8
+- Maestro 2.0.2
+
+</Collapsible>
+
+#### <CopyTextButton>`macos-sequoia-15.5-xcode-26.0`</CopyTextButton> (recommended for SDK 53 if you want to use Xcode 26.0)
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -307,7 +307,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 ### iOS server images
 
-#### <CopyTextButton>`macos-sequoia-15.6-xcode-26.0`</CopyTextButton> (recommended for SDK 54 if you want to use Xcode 26.0)
+#### <CopyTextButton>`macos-sequoia-15.6-xcode-26.0` (`sdk-54`)</CopyTextButton>
 
 <Collapsible summary="Details">
 
@@ -356,7 +356,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### <CopyTextButton>`macos-sequoia-15.6-xcode-16.4` (`sdk-54`)</CopyTextButton>
+#### <CopyTextButton>`macos-sequoia-15.6-xcode-16.4`</CopyTextButton> (recommended for SDK 54 if you don't want to use Xcode 26)
 
 <Collapsible summary="Details">
 


### PR DESCRIPTION
# Why

New SDK 54 Xcode 26 image.

# How

Copied previous Xcode 26 image this is built upon and updated values.

