### PR TITLE
[docs] Add `isNew` boolean for Expo Router native tabs reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/router-native-tabs.mdx
+++ b/docs/pages/versions/unversioned/sdk/router-native-tabs.mdx
@@ -4,6 +4,7 @@ description: An Expo Router submodule that provides native tabs layout.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'
 platforms: ['android', 'ios', 'tvos', 'web']
+isNew: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';

--- a/docs/pages/versions/v54.0.0/sdk/router-native-tabs.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/router-native-tabs.mdx
@@ -4,6 +4,7 @@ description: An Expo Router submodule that provides native tabs layout.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-54/packages/expo-router'
 packageName: 'expo-router'
 platforms: ['android', 'ios', 'tvos', 'web']
+isNew: true
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Add `isNew` boolean for Expo Router native tabs reference (unversioned and SDK 54).


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="548" height="808" alt="CleanShot 2025-09-10 at 22 28 18@2x" src="https://github.com/user-attachments/assets/b3f3ea10-c7e1-4f49-8c76-eac4550c1c82" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
