### PR TITLE
[sqlite][docs] Update example and link

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -405,11 +405,11 @@ Configure the App Group in app config:
 
 <Step label="2">
 
-Use [`Paths.appleSharedContainers`](filesystem-next/#applesharedcontainers) from the [`expo-file-system`](filesystem-next/) library to retrieve the path to the shared container:
+Use [`Paths.appleSharedContainers`](filesystem/#applesharedcontainers) from the [`expo-file-system`](filesystem/) library to retrieve the path to the shared container:
 
 ```tsx Using Shared Container for SQLite Database on iOS
 import { SQLiteProvider, defaultDatabaseDirectory } from 'expo-sqlite';
-import { Paths } from 'expo-file-system/next';
+import { Paths } from 'expo-file-system';
 import { useMemo } from 'react';
 import { Platform, View } from 'react-native';
 

--- a/docs/pages/versions/v54.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/sqlite.mdx
@@ -405,11 +405,11 @@ Configure the App Group in app config:
 
 <Step label="2">
 
-Use [`Paths.appleSharedContainers`](filesystem-next/#applesharedcontainers) from the [`expo-file-system`](filesystem-next/) library to retrieve the path to the shared container:
+Use [`Paths.appleSharedContainers`](filesystem/#applesharedcontainers) from the [`expo-file-system`](filesystem/) library to retrieve the path to the shared container:
 
 ```tsx Using Shared Container for SQLite Database on iOS
 import { SQLiteProvider, defaultDatabaseDirectory } from 'expo-sqlite';
-import { Paths } from 'expo-file-system/next';
+import { Paths } from 'expo-file-system';
 import { useMemo } from 'react';
 import { Platform, View } from 'react-native';
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

In the SQLite reference (unversioned and SDK 54), the links and example under "Sharing a database between apps/extensions (iOS)" were broken because they are redirecting to `expo-file-system/next`. This PR fixes both.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs app locally and visit: http://localhost:3002/versions/v54.0.0/sdk/sqlite/#sharing-a-database-between-appsextensions-ios > Step 2, and click both links.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
