### PR TITLE
[ios][expo-ui] Fix tvOS

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
@@ -108,4 +108,4 @@ jobs:
         id: build
         working_directory: ../../../updates-e2e
         run: |
-          yarn tvos:build | npx @expo/xcpretty
+          yarn tvos:build

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix tvOS compilation. ([#39542](https://github.com/expo/expo/pull/39542) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 ## 0.2.0-beta.0 — 2025-09-10

--- a/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
+++ b/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
@@ -180,7 +180,7 @@ internal struct ForegroundStyleModifier: ViewModifier, Record {
       case .quaternary:
         content.foregroundStyle(.quaternary)
       case .quinary:
-        if #available(iOS 16.0, *) {
+        if #available(iOS 16.0, tvOS 17.0, *) {
           content.foregroundStyle(.quinary)
         } else {
           content.foregroundStyle(.quaternary)

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Surface iOS compilation errors in updates E2E tests. ([#39542](https://github.com/expo/expo/pull/39542) by [@douglowder](https://github.com/douglowder))
+
 ## 29.0.9 — 2025-09-10
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -397,8 +397,8 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@0.81.0-0',
-        '@react-native-tvos/config-tv': '^0.1.3',
+        'react-native': 'npm:react-native-tvos@0.81.4-0',
+        '@react-native-tvos/config-tv': '^0.1.4',
       },
       expo: {
         install: {

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -328,11 +328,11 @@ async function preparePackageJson(
           'adb install android/app/build/outputs/apk/release/app-release.apk',
         'maestro:android:uninstall': 'adb uninstall dev.expo.updatese2e',
         'maestro:ios:debug:build':
-          'xcodebuild -workspace ios/updatese2e.xcworkspace -scheme updatese2e -configuration Debug -sdk iphonesimulator -arch arm64 -derivedDataPath ios/build | npx @expo/xcpretty',
+          'set -o pipefail && xcodebuild -workspace ios/updatese2e.xcworkspace -scheme updatese2e -configuration Debug -sdk iphonesimulator -arch arm64 -derivedDataPath ios/build | npx @expo/xcpretty',
         'maestro:ios:debug:install':
           'xcrun simctl install booted ios/build/Build/Products/Debug-iphonesimulator/updatese2e.app',
         'maestro:ios:release:build':
-          'xcodebuild -workspace ios/updatese2e.xcworkspace -scheme updatese2e -configuration Release -sdk iphonesimulator -arch arm64 -derivedDataPath ios/build | npx @expo/xcpretty',
+          'set -o pipefail && xcodebuild -workspace ios/updatese2e.xcworkspace -scheme updatese2e -configuration Release -sdk iphonesimulator -arch arm64 -derivedDataPath ios/build | npx @expo/xcpretty',
         'maestro:ios:release:install':
           'xcrun simctl install booted ios/build/Build/Products/Release-iphonesimulator/updatese2e.app',
         'maestro:ios:uninstall': 'xcrun simctl uninstall booted dev.expo.updatese2e',
@@ -340,7 +340,7 @@ async function preparePackageJson(
         'eas-build-on-success': './eas-hooks/eas-build-on-success.sh',
         'check-android-emulator': 'npx ts-node ./scripts/check-android-emulator.ts',
         'tvos:build':
-          'xcodebuild -workspace ios/updatese2e.xcworkspace -scheme updatese2e -configuration Debug -sdk appletvsimulator -arch arm64 -derivedDataPath ios/build | npx @expo/xcpretty',
+          'set -o pipefail && xcodebuild -workspace ios/updatese2e.xcworkspace -scheme updatese2e -configuration Debug -sdk appletvsimulator -arch arm64 -derivedDataPath ios/build | npx @expo/xcpretty',
         postinstall: 'patch-package',
         'start:dev-client':
           'npx expo start --private-key-path ./keys/private-key.pem > /dev/null 2>&1 &',


### PR DESCRIPTION
# Why

Fix compile error on tvOS when using @expo/ui , ensure compilation errors are surfaced.

# How

- Add missing platform availability in ViewModifierRegistry.swift.
- Update RNTV version used for testing.
- Add `set -o pipefail` to commands so that errors are surfaced even through piped output.

# Test Plan

TV compile CI should pass.

