### PR TITLE
[all][file-system] Fix package exports for Typescript projects

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [file-system] Fix package exports for Typescript projects ([#39543](https://github.com/expo/expo/pull/39543) by [@smoores-dev](https://github.com/smoores-dev))
+
 ### 💡 Others
 
 ## 19.0.11 — 2025-09-10

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -4,6 +4,16 @@
   "description": "Provides access to the local file system on the device.",
   "main": "src/index.ts",
   "types": "build/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./src/index.ts"
+    },
+    "./legacy": {
+      "types": "./build/legacy/index.d.ts",
+      "default": "./src/legacy/index.ts"
+    }
+  },
   "sideEffects": false,
   "scripts": {
     "build": "expo-module build",

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -5,6 +5,9 @@
   "main": "src/index.ts",
   "types": "build/index.d.ts",
   "exports": {
+     "./app.plugin": "./app.plugin.js",
+     "./app.plugin.js": "./app.plugin.js",
+     "./package.json": "./package.json",
     ".": {
       "types": "./build/index.d.ts",
       "default": "./src/index.ts"

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -5,9 +5,9 @@
   "main": "src/index.ts",
   "types": "build/index.d.ts",
   "exports": {
-     "./app.plugin": "./app.plugin.js",
-     "./app.plugin.js": "./app.plugin.js",
-     "./package.json": "./package.json",
+    "./app.plugin": "./app.plugin.js",
+    "./app.plugin.js": "./app.plugin.js",
+    "./package.json": "./package.json",
     ".": {
       "types": "./build/index.d.ts",
       "default": "./src/index.ts"


### PR DESCRIPTION
# Why

At the moment, importing `expo-file-system/legacy` from another project will force Typescript to typecheck the `expo-file-system/legacy` source files, even with `skipLibCheck` enabled in the consuming project. This is because `expo-file-system/legacy` actually resolves to `expo-file-system/legacy.ts`, which itself imports `expo-file-system/src/legacy/index.ts`.

This is a problem for two reasons:

1. It means that consumers have to spend time/resources type-checking `expo-file-system` source code
2. More importantly, it means that any consumer with stricter Typescript rules than expo will be unable to successfully build their project.

For example, with `exactOptionalPropertyTypes` enabled, the following error is emitted:

```
node_modules/expo-file-system/src/legacy/FileSystem.ts:560:5 - error TS2375: Type '{ url: string; fileUri: string; options: DownloadOptions; resumeData: string | undefined; }' is not assignable to type 'DownloadPauseState' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'resumeData' are incompatible.
    Type 'string | undefined' is not assignable to type 'string'.
      Type 'undefined' is not assignable to type 'string'.

560     return {
        ~~~~~~


Found 1 error.
```

It's not possible to convince Typescript to ignore this error. Its only way to obtain the types for this module is to actually compile the source code, since it's being given a path to the source Typescript files, and the only tsconfig it has to typecheck with is the consuming project's.

# How

I updated the `package.json` for `expo-file-system` to use conditional exports. By adding `"./legacy": { "types": "./build/legacy/index.d.ts" }`, we can instruct Typescript to look for the already-built type definitions in the `build` directory, instead of trying to obtain the types from the source code.

# Test Plan

To reproduce the error, create a new expo project that depends on `expo-file-system/legacy`. In the tsconfig.json for this project, set `compilerOptions.exactOptionalPropertyTypes` to `true`, and run `tsc`.

I have confirmed that this change resolves this error by applying it locally with `yarn patch`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
