### PR TITLE
refactor(@expo/cli): Use public Metro Terminal API to handle console logs

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Replace usage of metro internals in `instantiateMetro` with `Terminal.log` ([#39531](https://github.com/expo/expo/pull/39531) by [@robhogan](https://github.com/robhogan))
+
 ## 54.0.1 — 2025-09-10
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -12,7 +12,6 @@ import { Terminal } from '@expo/metro/metro-core';
 import { getDefaultConfig, type LoadOptions } from '@expo/metro-config';
 import chalk from 'chalk';
 import http from 'http';
-import util from 'node:util';
 import path from 'path';
 
 import { createDevToolsPluginWebsocketEndpoint } from './DevToolsPluginWebsocketEndpoint';
@@ -42,12 +41,7 @@ class LogRespectingTerminal extends Terminal {
     super(stream, { ttyPrint: true });
 
     const sendLog = (...args: any[]) => {
-      this._logLines.push(
-        // format args like console.log
-        util.format(...args)
-      );
-      this._scheduleUpdate();
-
+      this.log(...args);
       // Flush the logs to the terminal immediately so logs at the end of the process are not lost.
       this.flush();
     };

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -40,8 +40,8 @@ class LogRespectingTerminal extends Terminal {
   constructor(stream: import('node:net').Socket | import('node:stream').Writable) {
     super(stream, { ttyPrint: true });
 
-    const sendLog = (...args: any[]) => {
-      this.log(...args);
+    const sendLog = (format: string, ...args: any[]) => {
+      this.log(format, ...args);
       // Flush the logs to the terminal immediately so logs at the end of the process are not lost.
       this.flush();
     };


### PR DESCRIPTION
See: https://github.com/expo/expo/pull/39531

(I messed up the maintainer changelog push)