### PR TITLE
[structured-headers] remove iOS test files from the published package

### DIFF
--- a/packages/expo-structured-headers/.npmignore
+++ b/packages/expo-structured-headers/.npmignore
@@ -9,3 +9,4 @@ __tests__
 /babel.config.js
 /android/src/androidTest/
 /android/src/test/
+/ios/Tests

--- a/packages/expo-structured-headers/CHANGELOG.md
+++ b/packages/expo-structured-headers/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Remove iOS test files from the published package content.
+
 ## 5.0.0 — 2025-08-13
 
 ### 🎉 New features

--- a/packages/expo-structured-headers/CHANGELOG.md
+++ b/packages/expo-structured-headers/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Remove iOS test files from the published package content.
+- Remove iOS test files from the published package content. ([#39547](https://github.com/expo/expo/pull/39547) by [@Simek](https://github.com/Simek))
 
 ## 5.0.0 — 2025-08-13
 


### PR DESCRIPTION
# Why

After testing new metadata addition to the React Native Directory I have spotted that the `expo-structured-headers` published package size is quite large. After investigating, looks like 90% of the total size (1.43 MiB) comes from iOS test files included in the dist, see:
* https://www.npmjs.com/package/expo-structured-headers?activeTab=code

# How

Edit `.npmignore` content to include iOS test files path.

# Test Plan

Run the `npm pack --dry-run` command, and verified that iOS test files are gone, and the package size shrinked from 1.36MB to 103kB:

```
simek expo-structured-headers % npm pack --dry-run
npm notice
npm notice 📦  expo-structured-headers@5.0.0
npm notice Tarball Contents
npm notice 103B .eslintrc.js
npm notice 6.1kB CHANGELOG.md
npm notice 725B README.md
npm notice 588B android/build.gradle
npm notice 11.4kB android/LICENSE
npm notice 23B android/src/main/AndroidManifest.xml
npm notice 1.8kB android/src/main/java/expo/modules/structuredheaders/BooleanItem.java
npm notice 2.0kB android/src/main/java/expo/modules/structuredheaders/ByteSequenceItem.java
npm notice 3.7kB android/src/main/java/expo/modules/structuredheaders/DecimalItem.java
npm notice 2.1kB android/src/main/java/expo/modules/structuredheaders/Dictionary.java
npm notice 2.1kB android/src/main/java/expo/modules/structuredheaders/InnerList.java
npm notice 2.1kB android/src/main/java/expo/modules/structuredheaders/IntegerItem.java
npm notice 432B android/src/main/java/expo/modules/structuredheaders/Item.java
npm notice 409B android/src/main/java/expo/modules/structuredheaders/ListElement.java
npm notice 224B android/src/main/java/expo/modules/structuredheaders/LongSupplier.java
npm notice 963B android/src/main/java/expo/modules/structuredheaders/NumberItem.java
npm notice 1.5kB android/src/main/java/expo/modules/structuredheaders/OuterList.java
npm notice 7.7kB android/src/main/java/expo/modules/structuredheaders/Parameters.java
npm notice 899B android/src/main/java/expo/modules/structuredheaders/Parametrizable.java
npm notice 3.5kB android/src/main/java/expo/modules/structuredheaders/ParseException.java
npm notice 29.9kB android/src/main/java/expo/modules/structuredheaders/Parser.java
npm notice 2.4kB android/src/main/java/expo/modules/structuredheaders/StringItem.java
npm notice 2.3kB android/src/main/java/expo/modules/structuredheaders/TokenItem.java
npm notice 904B android/src/main/java/expo/modules/structuredheaders/Type.java
npm notice 1.4kB android/src/main/java/expo/modules/structuredheaders/Utils.java
npm notice 40B expo-module.config.json
npm notice 1.1kB ios/EXStructuredHeaders.podspec
npm notice 795B ios/EXStructuredHeaders/EXStructuredHeadersParser.h
npm notice 15.7kB ios/EXStructuredHeaders/EXStructuredHeadersParser.m
npm notice 625B package.json
npm notice Tarball Details
npm notice name: expo-structured-headers
npm notice version: 5.0.0
npm notice filename: expo-structured-headers-5.0.0.tgz
npm notice package size: 20.4 kB
npm notice unpacked size: 103.3 kB
npm notice shasum: 21825f3f154338148e600e78fdb96e2e16015e3d
npm notice integrity: sha512-U8NKR1FlXOdoN[...]cSRxnwuTVlLZw==
npm notice total files: 30
npm notice
expo-structured-headers-5.0.0.tgz
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
