### PR TITLE
[ios][dev-client] Fix UI on iPad

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix incorrect text color in the error dialog.
-- [iOS] Fix UI on iPad.
+- [Android] Fix incorrect text color in the error dialog. ([#39550](https://github.com/expo/expo/pull/39550) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix UI on iPad. ([#39549](https://github.com/expo/expo/pull/39549) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix incorrect text color in the error dialog.
+- [iOS] Fix UI on iPad.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViews.swift
@@ -42,6 +42,7 @@ public struct DevLauncherRootView: View {
       .environmentObject(viewModel)
       .environmentObject(DevLauncherNavigation(showingUserProfile: $showingUserProfile))
     }
+    .navigationViewStyle(.stack)
     .sheet(isPresented: $showingUserProfile) {
       AccountSheet()
         .environmentObject(viewModel)

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix desynchronization issue between UI and state. ([#39553](https://github.com/expo/expo/pull/39553) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix UI on iPad.
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix desynchronization issue between UI and state. ([#39553](https://github.com/expo/expo/pull/39553) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Fix UI on iPad.
+- [iOS] Fix UI on iPad. ([#39549](https://github.com/expo/expo/pull/39549) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuRootView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuRootView.swift
@@ -23,6 +23,7 @@ struct DevMenuRootView: View {
         }
       }
     }
+    .navigationViewStyle(.stack)
   }
 }
 


### PR DESCRIPTION
# Why
On iPad, navigation views default to split views when running on iPad.

# How
Force the stack navigation style.

# Test Plan
<img width="450" height="338" alt="Simulator Screenshot - iPad Pro 13-inch (M4) - 2025-09-11 at 10 28 06" src="https://github.com/user-attachments/assets/7a294d65-c132-4fbd-bfe6-19c0608b3929" />
<img width="450" height="338" alt="Simulator Screenshot - iPad Pro 13-inch (M4) - 2025-09-11 at 10 28 08" src="https://github.com/user-attachments/assets/69e478f7-303f-4f5b-9b02-3a85ac04ae2a" />
