### PR TITLE
[launcher][Android] Fix incorrect text color in the error dialog

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix incorrect text color in the error dialog.
+
 ### 💡 Others
 
 ## 6.0.10 — 2025-09-08

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/AppLoadingErrorDialog.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/AppLoadingErrorDialog.kt
@@ -23,7 +23,6 @@ import com.composables.core.DialogState
 import com.composables.core.Scrim
 import com.composables.core.rememberDialogState
 import com.composeunstyled.Button
-import com.composeunstyled.Text
 import expo.modules.devlauncher.compose.models.HomeAction
 import expo.modules.devlauncher.compose.models.HomeState
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
@@ -92,7 +91,7 @@ fun AppLoadingErrorDialog(
         Divider()
 
         Row(modifier = Modifier.padding(NewAppTheme.spacing.`3`)) {
-          Text(currentError ?: "No error message available.")
+          NewText(currentError ?: "No error message available.")
         }
       }
     }


### PR DESCRIPTION
# Why

Fixes incorrect text color in the error dialog


# Test Plan

<img width="573" height="367" alt="image" src="https://github.com/user-attachments/assets/04aeb2db-7350-4f4b-bf2d-f48b18b8245a" />