### PR TITLE
[modules-scripts] expand `.npmignore` template list, regenerate in packages

### DIFF
--- a/packages/expo-clipboard/.npmignore
+++ b/packages/expo-clipboard/.npmignore
@@ -10,6 +10,9 @@ __mocks__
 __tests__
 __rsc_tests__
 
+/e2e
+/e2e-cli
 /babel.config.js
 /android/src/androidTest/
 /android/src/test/
+/ios/Tests

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Remove tests related files from the published package content.
+
 ## 8.0.7 — 2025-09-11
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Remove tests related files from the published package content.
+- Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 
 ## 8.0.7 — 2025-09-11
 

--- a/packages/expo-dev-menu/.npmignore
+++ b/packages/expo-dev-menu/.npmignore
@@ -10,6 +10,9 @@ __mocks__
 __tests__
 __rsc_tests__
 
+/e2e
+/e2e-cli
 /babel.config.js
 /android/src/androidTest/
 /android/src/test/
+/ios/Tests

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Remove unused dev dependencies ([#39987](https://github.com/expo/expo/pull/39987) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [android] Make reactNativeHost optional in ReactHostWrapper ([#40085](https://github.com/expo/expo/pull/40085) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Remove `ReactHostWrapper` ([#40295](https://github.com/expo/expo/pull/40295) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Remove tests related files from the published package content.
 
 ### ⚠️ Notices
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Remove unused dev dependencies ([#39987](https://github.com/expo/expo/pull/39987) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [android] Make reactNativeHost optional in ReactHostWrapper ([#40085](https://github.com/expo/expo/pull/40085) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Remove `ReactHostWrapper` ([#40295](https://github.com/expo/expo/pull/40295) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Remove tests related files from the published package content.
+- Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 
 ### ⚠️ Notices
 

--- a/packages/expo-image/.npmignore
+++ b/packages/expo-image/.npmignore
@@ -10,6 +10,9 @@ __mocks__
 __tests__
 __rsc_tests__
 
+/e2e
+/e2e-cli
 /babel.config.js
 /android/src/androidTest/
 /android/src/test/
+/ios/Tests

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- Remove tests related files from the published package content.
+
 ## 3.0.10 - 2025-10-20
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 💡 Others
 
-- Remove tests related files from the published package content.
+- Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 
 ## 3.0.10 - 2025-10-20
 

--- a/packages/expo-manifests/.npmignore
+++ b/packages/expo-manifests/.npmignore
@@ -10,6 +10,9 @@ __mocks__
 __tests__
 __rsc_tests__
 
+/e2e
+/e2e-cli
 /babel.config.js
 /android/src/androidTest/
 /android/src/test/
+/ios/Tests

--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Remove tests related files from the published package content.
+- Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 
 ## 1.0.8 — 2025-09-11
 

--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Remove tests related files from the published package content.
+
 ## 1.0.8 — 2025-09-11
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-media-library/.npmignore
+++ b/packages/expo-media-library/.npmignore
@@ -10,6 +10,9 @@ __mocks__
 __tests__
 __rsc_tests__
 
+/e2e
+/e2e-cli
 /babel.config.js
 /android/src/androidTest/
 /android/src/test/
+/ios/Tests

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - [next] Add test screens ([#39951](https://github.com/expo/expo/pull/39951) by [@Wenszel](https://github.com/Wenszel))
 - [next] Add documentation ([#39754](https://github.com/expo/expo/pull/39754) by [@Wenszel](https://github.com/Wenszel))
+- Remove tests related files from the published package content.
 
 ## 18.2.0 — 2025-09-16
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - [next] Add test screens ([#39951](https://github.com/expo/expo/pull/39951) by [@Wenszel](https://github.com/Wenszel))
 - [next] Add documentation ([#39754](https://github.com/expo/expo/pull/39754) by [@Wenszel](https://github.com/Wenszel))
-- Remove tests related files from the published package content.
+- Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 
 ## 18.2.0 — 2025-09-16
 

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Add more tests related files to the `.npmignore` template.
+- Add more tests related files to the `.npmignore` template. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 
 ## 5.0.7 — 2025-09-10
 

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add more tests related files to the `.npmignore` template.
+
 ## 5.0.7 — 2025-09-10
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-module-scripts/templates/.npmignore
+++ b/packages/expo-module-scripts/templates/.npmignore
@@ -10,6 +10,9 @@ __mocks__
 __tests__
 __rsc_tests__
 
+/e2e
+/e2e-cli
 /babel.config.js
 /android/src/androidTest/
 /android/src/test/
+/ios/Tests

--- a/packages/expo-modules-core/.npmignore
+++ b/packages/expo-modules-core/.npmignore
@@ -10,6 +10,9 @@ __mocks__
 __tests__
 __rsc_tests__
 
+/e2e
+/e2e-cli
 /babel.config.js
 /android/src/androidTest/
 /android/src/test/
+/ios/Tests

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -38,7 +38,7 @@
 - [iOS] Use the `RuntimeScheduler` to schedule tasks on the JS thread. ([#40473](https://github.com/expo/expo/pull/40473) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Added base props support for SwiftUI integration. ([#40492](https://github.com/expo/expo/pull/40492) by [@kudo](https://github.com/kudo))
 - [iOS] Removed some runtime type checks for dynamic types. ([#40611](https://github.com/expo/expo/pull/40611) by [@tsapeta](https://github.com/tsapeta))
-- Remove tests related files from the published package content.
+- Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 
 
 ## 3.0.22 - 2025-10-20

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -38,6 +38,8 @@
 - [iOS] Use the `RuntimeScheduler` to schedule tasks on the JS thread. ([#40473](https://github.com/expo/expo/pull/40473) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Added base props support for SwiftUI integration. ([#40492](https://github.com/expo/expo/pull/40492) by [@kudo](https://github.com/kudo))
 - [iOS] Removed some runtime type checks for dynamic types. ([#40611](https://github.com/expo/expo/pull/40611) by [@tsapeta](https://github.com/tsapeta))
+- Remove tests related files from the published package content.
+
 
 ## 3.0.22 - 2025-10-20
 

--- a/packages/expo-notifications/.npmignore
+++ b/packages/expo-notifications/.npmignore
@@ -10,6 +10,9 @@ __mocks__
 __tests__
 __rsc_tests__
 
+/e2e
+/e2e-cli
 /babel.config.js
 /android/src/androidTest/
 /android/src/test/
+/ios/Tests

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Remove tests related files from the published package content.
+
 ## 0.32.12 - 2025-10-01
 
 ### 💡 Others

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Remove tests related files from the published package content.
+- Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 
 ## 0.32.12 - 2025-10-01
 

--- a/packages/expo-updates/.npmignore
+++ b/packages/expo-updates/.npmignore
@@ -10,6 +10,9 @@ __mocks__
 __tests__
 __rsc_tests__
 
+/e2e
+/e2e-cli
 /babel.config.js
 /android/src/androidTest/
 /android/src/test/
+/ios/Tests

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### 💡 Others
 
 - Surface iOS compilation errors in updates E2E tests. ([#39542](https://github.com/expo/expo/pull/39542) by [@douglowder](https://github.com/douglowder))
+- Remove tests related files from the published package content.
 
 ## 29.0.9 — 2025-09-10
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -30,7 +30,7 @@
 ### 💡 Others
 
 - Surface iOS compilation errors in updates E2E tests. ([#39542](https://github.com/expo/expo/pull/39542) by [@douglowder](https://github.com/douglowder))
-- Remove tests related files from the published package content.
+- Remove tests related files from the published package content. ([#39551](https://github.com/expo/expo/pull/39551) by [@Simek](https://github.com/Simek))
 
 ## 29.0.9 — 2025-09-10
 


### PR DESCRIPTION
# Why

After testing new metadata addition to the React Native Directory I have spotted that the some of the expo published packages size is quite large. After investigating, looks like part of the increased published package size comes from iOS or E2E test files included in the dist.

Follow up to:
* https://github.com/expo/expo/pull/39547

# How

All edited packages in this changeset uses autogenerted `.npmignore` file from `expo-module-scripts`, hence the changes to the `.npmignore` file template. 

After performing changes in the scripts package, I have run `npm pack --dry-run` in monorepo packages containing `/ios/Tests` or `/e2e` directories.

# Test Plan

Run the `npm pack --dry-run` command in altered packages, verify that iOS test files are gone, and the package size has been decreased.

Summary:
* clipboard: 269.35 kB -> 174.6 kB
* dev-menu: 2.67 MB -> 2.65 MB
* image: 779.82 kb -> 450.7 kB
* manifests: 60.3 kB -> 54.0 kB
* media-library: 548.89 kB -> 440.7 kB
* modules-core: 1.88 MB -> 1.7 MB
* notifications: 1.55 MB -> 1.0 MB
* updates: 2.47 MB -> 1.5 MB

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
