### PR TITLE
[app-integrity] fix decoding attest and assertion objects

### DIFF
--- a/apps/native-component-list/src/screens/AppIntegrity/AppIntegrityScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/AppIntegrity/AppIntegrityScreen.ios.tsx
@@ -41,22 +41,7 @@ export default function AppIntegrityIOSScreen() {
     }
   };
 
-  const testGenerateAssertion = async () => {
-    setIsLoading(true);
-    try {
-      const key = await AppIntegrity.generateKey();
-      addResult(`Generated key: ${key}`);
-      const challenge = 'test-challenge-' + Date.now();
-      const assertion = await AppIntegrity.generateAssertion(key, challenge);
-      addResult(`generateAssertion: Success (assertion length: ${assertion.length})`);
-    } catch (error) {
-      addResult(`generateAssertion error: ${error}`);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const testFullFlow = async () => {
+  const testAssertion = async () => {
     setIsLoading(true);
     try {
       const key = await AppIntegrity.generateKey();
@@ -90,12 +75,8 @@ export default function AppIntegrityIOSScreen() {
           <Text style={styles.buttonText}>Test attestKey</Text>
         </Pressable>
 
-        <Pressable style={styles.button} onPress={testGenerateAssertion} disabled={isLoading}>
-          <Text style={styles.buttonText}>Test generateAssertion</Text>
-        </Pressable>
-
-        <Pressable style={styles.button} onPress={testFullFlow} disabled={isLoading}>
-          <Text style={styles.buttonText}>Test Full Flow</Text>
+        <Pressable style={styles.button} onPress={testAssertion} disabled={isLoading}>
+          <Text style={styles.buttonText}>Test Assertion</Text>
         </Pressable>
 
         <Pressable style={[styles.button, styles.clearButton]} onPress={clearResults}>

--- a/packages/expo-app-integrity/CHANGELOG.md
+++ b/packages/expo-app-integrity/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unpublished
+
+### 🛠 Breaking changes
+
+### 🎉 New features
+
+### 🐛 Bug fixes
+
+- [iOS] Fixed `attestKey` and `generateAssertion` methods failing due to improper UTF-8 decoding of binary data. Now returns base64-encoded strings as expected. ([#39566](https://github.com/expo/expo/pull/39566) by [@nishan](https://github.com/intergalacticspacehighway))
+
+### 💡 Others

--- a/packages/expo-app-integrity/ios/IntegrityErrorCodes.swift
+++ b/packages/expo-app-integrity/ios/IntegrityErrorCodes.swift
@@ -6,6 +6,5 @@ struct IntegrityErrorCodes {
   static let invalidKey = "ERR_APP_INTEGRITY_INVALID_KEY"
   static let serverUnavailable = "ERR_APP_INTEGRITY_SERVER_UNAVAILABLE"
   static let systemFailure = "ERR_APP_INTEGRITY_SYSTEM_FAILURE"
-  static let decodeFailed = "ERR_APP_INTEGRITY_DECODE_FAILED"
   static let unknown = "ERR_APP_INTEGRITY_UNKNOWN"
 }

--- a/packages/expo-app-integrity/ios/IntegrityModule.swift
+++ b/packages/expo-app-integrity/ios/IntegrityModule.swift
@@ -26,10 +26,8 @@ public class IntegrityModule: Module {
 
       do {
         let result = try await service.attestKey(key, clientDataHash: clientDataHash)
-        guard let attestation = String(data: result, encoding: .utf8) else {
-          throw IntegrityException("Failed to decode attestation result from data", code: IntegrityErrorCodes.decodeFailed)
-        }
-        return attestation
+        let attestationString = result.base64EncodedString()
+        return attestationString
       } catch let error {
         throw handleIntegrityCheckError(error)
       }
@@ -40,10 +38,8 @@ public class IntegrityModule: Module {
       let clientDataHash = Data(SHA256.hash(data: data))
       do {
         let result = try await service.generateAssertion(key, clientDataHash: clientDataHash)
-        guard let assertion = String(data: result, encoding: .utf8) else {
-          throw IntegrityException("Failed to decode assertion result from data", code: IntegrityErrorCodes.decodeFailed)
-        }
-        return assertion
+        let assertionString = result.base64EncodedString()
+        return assertionString
       } catch let error {
         throw handleIntegrityCheckError(error)
       }

--- a/packages/expo-app-integrity/ios/IntegrityModule.swift
+++ b/packages/expo-app-integrity/ios/IntegrityModule.swift
@@ -26,8 +26,7 @@ public class IntegrityModule: Module {
 
       do {
         let result = try await service.attestKey(key, clientDataHash: clientDataHash)
-        let attestationString = result.base64EncodedString()
-        return attestationString
+        return result.base64EncodedString()
       } catch let error {
         throw handleIntegrityCheckError(error)
       }
@@ -38,8 +37,7 @@ public class IntegrityModule: Module {
       let clientDataHash = Data(SHA256.hash(data: data))
       do {
         let result = try await service.generateAssertion(key, clientDataHash: clientDataHash)
-        let assertionString = result.base64EncodedString()
-        return assertionString
+        return result.base64EncodedString()
       } catch let error {
         throw handleIntegrityCheckError(error)
       }


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/38109#issuecomment-3280371338

As per the docs, the data is not utf8 compatible, we need to serialise it to base64. I think while testing i mixed up android and iOS results. So iOS implementation was not tested 😅 

<img width="889" height="200" alt="Screenshot 2025-09-11 at 6 53 08 PM" src="https://github.com/user-attachments/assets/bf8d0ef5-68af-4d07-a2d7-ffbbd17a7178" />


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Encode attest and assertion objects in base64 instead of decoding to utf8

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Test AppIntegrityScreen in NCL app on real device.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
