### PR TITLE
[core][ios] Fix NSURL to JS conversion returnig nil

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix NSURL to JSIString conversion returning nil.
+- [iOS] Fix NSURL to JSIString conversion returning nil. ([#39567](https://github.com/expo/expo/pull/39567) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix NSURL to JSIString conversion returning nil.
+
 ### 💡 Others
 
 ## 3.0.15 — 2025-09-10

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.h
@@ -24,6 +24,8 @@ namespace expo
 
     jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *value);
 
+    jsi::String convertNSURLToJSIString(jsi::Runtime &runtime, NSURL *value);
+
     jsi::Object convertNSDictionaryToJSIObject(jsi::Runtime &runtime, NSDictionary *value);
 
     jsi::Array convertNSArrayToJSIArray(jsi::Runtime &runtime, NSArray *value);

--- a/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIConversions.mm
@@ -9,6 +9,7 @@
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>
 #import <ExpoModulesCore/EXJavaScriptSharedObjectBinding.h>
 #import <ExpoModulesCore/EXStringUtils.h>
+#import <Foundation/NSURL.h>
 
 namespace expo {
 
@@ -39,6 +40,12 @@ jsi::String convertNSStringToJSIString(jsi::Runtime &runtime, NSString *value)
   // TODO(@jakex7): Remove after update to react-native-macos@0.79.0
   return jsi::String::createFromUtf8(runtime, [value UTF8String]);
 #endif
+}
+
+jsi::String convertNSURLToJSIString(jsi::Runtime &runtime, NSURL *value)
+{
+  NSString *stringValue = [value absoluteString];
+  return convertNSStringToJSIString(runtime, stringValue);
 }
 
 jsi::Object convertNSDictionaryToJSIObject(jsi::Runtime &runtime, NSDictionary *value)
@@ -107,6 +114,8 @@ jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value)
     return convertNSArrayToJSIArray(runtime, (NSArray *)value);
   } else if ([value isKindOfClass:[NSData class]]) {
     return createUint8Array(runtime, (NSData *)value);
+  } else if ([value isKindOfClass:[NSURL class]]) {
+    return convertNSURLToJSIString(runtime, (NSURL *)value);
   } else if (value == (id)kCFNull) {
     return jsi::Value::null();
   }

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -245,6 +245,17 @@ class FunctionSpec: ExpoSpec {
         @Field var property: String = "expo"
       }
 
+      struct TestURLRecord: Record {
+        static let defaultURLString = "https://expo.dev"
+        static let defaultURL = URL(string: defaultURLString)!
+
+        @Field var url: URL = defaultURL
+      }
+
+      afterEach {
+        try runtime.eval("globalThis.result = undefined")
+      }
+
       beforeSuite {
         appContext.moduleRegistry.register(holder: mockModuleHolder(appContext) {
           Name("TestModule")
@@ -286,10 +297,18 @@ class FunctionSpec: ExpoSpec {
             return "\(f.property)"
           }
 
+          Function("withURL") {
+            return TestURLRecord.defaultURL
+          }
+
+          Function("withNestedURL") {
+            return TestURLRecord()
+          }
+
           Function("withOptionalRecord") { (f: TestRecord?) in
             return "\(f?.property ?? "no value")"
           }
-          
+
           Function("withSharedObject") {
             return SharedString("Test")
           }
@@ -305,7 +324,15 @@ class FunctionSpec: ExpoSpec {
           AsyncFunction("withSharedObjectPromise") { (p: Promise) in
             p.resolve(SharedString("Test with Promise"))
           }
-          
+
+          AsyncFunction("withURLAsync") {
+            return TestURLRecord.defaultURL
+          }
+
+          AsyncFunction("withNestedURLAsync") {
+            return TestURLRecord()
+          }
+
           Class("Shared", SharedString.self) {
             Property("value") { shared in
               return shared.ref
@@ -360,7 +387,43 @@ class FunctionSpec: ExpoSpec {
       it("accepts optional record") {
         expect(try runtime.eval("expo.modules.TestModule.withOptionalRecord({property: \"123\"})").asString()) == "123"
       }
-      
+
+      it("returns URL (sync)") {
+        let result = try runtime.eval("globalThis.result = expo.modules.TestModule.withURL()")
+        expect(result.kind) == .string
+        expect(result.getString()) == TestURLRecord.defaultURLString
+      }
+
+      it("returns URL (async)") {
+        try runtime.eval("expo.modules.TestModule.withURLAsync().then((result) => { globalThis.result = result; })")
+        expect(safeBoolEval("!!globalThis.result")).toEventually(beTrue(), timeout: .milliseconds(2000))
+
+        let urlValue = try runtime.eval("url = globalThis.result")
+        expect(urlValue.kind) == .string
+        expect(urlValue.getString()) == TestURLRecord.defaultURLString
+      }
+
+      it("returns a record wit url (sync)") {
+        let object = try runtime.eval("globalThis.result = expo.modules.TestModule.withNestedURL()")
+        expect(object.kind) == .object
+        expect(object.getObject().hasProperty("url")) == true
+        expect(object.getObject().getProperty("url").getString()) == TestURLRecord.defaultURLString
+      }
+
+      it("returns a record with url (async)") {
+        try runtime.eval("expo.modules.TestModule.withNestedURLAsync().then((result) => { globalThis.result = result; })")
+
+        expect(safeBoolEval("!!globalThis.result.url")).toEventually(beTrue(), timeout: .milliseconds(2000))
+
+        let object = try runtime.eval("object = globalThis.result")
+        expect(object.kind) == .object
+        expect(object.getObject().hasProperty("url")) == true
+
+        let urlValue = try runtime.eval("object.url")
+        expect(urlValue.kind) == .string
+        expect(urlValue.getString()) == TestURLRecord.defaultURLString
+      }
+
       it("returns a SharedObject (sync)") {
         let object = try runtime.eval("expo.modules.TestModule.withSharedObject()")
         
@@ -385,7 +448,7 @@ class FunctionSpec: ExpoSpec {
         expect(result.kind) == .string
         expect(result.getString()) == "Test"
       }
-      
+
       it("returns an Array of SharedObjects (async)") {
         try runtime
           .eval(


### PR DESCRIPTION
# Why

I have noticed that for expo-video events the `uri` field of the event payload is nil on the JS side, even though the value is passed into the `emit` method of the SharedObject.

It looks like `EXJSIConversions` for objects do not support URL/NSURL values.

# How

Added a conversion for URL and NSURL that returns the `absoluteString` value of the url.

# Test Plan

Tested in BareExpo on iOS

