### PR TITLE
[updates] Fix dev-client e2e tests on Android

### DIFF
--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
@@ -5,18 +5,33 @@ onFlowStart:
 ---
 # Use dev client to load a bundle from updates server
 - evalScript:
-    script:  ${output.api.serveManifest('test-update-basic', MAESTRO_PLATFORM)}
+    script: ${output.api.serveManifest('test-update-basic', MAESTRO_PLATFORM)}
     label: Setup updates server to serve a basic update
     env:
       MAESTRO_PLATFORM: ${MAESTRO_PLATFORM}
 - launchApp
-- tapOn:
-    label: Tap on "Enter URL manually"
-    text: Enter URL manually
-- tapOn:
-    label: Tap on "Updates URL" text field
-    text: '.*http:.*'
-    below: Enter URL manually
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          label: Tap on "Enter URL manually"
+          text: Enter URL manually
+      - tapOn:
+          label: Tap on "Updates URL" text field
+          text: '.*http:.*'
+          below: Enter URL manually
+- runFlow:
+    when:
+      platform: android
+    commands:
+      - tapOn:
+          label: Tap on "New development server"
+          text: New development server
+      - tapOn:
+          label: Tap on "Updates URL" text field
+          text: '.*http:.*'
+          below: New development server
 - inputText:
     label: Input local update server URL
     text: "http://localhost:4747/update\n"


### PR DESCRIPTION
# Why

Dev launcher text is slightly different in iOS and Android, we need to account for that in our e2e tests

# How

Update expo-updates dev-client e2e tests to use different texts depending on the platform

# Test Plan

CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
