### PR TITLE
[ios][sdk-55] added removal time (sdk-55) to deprecation

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- [iOS] appended removal info (SDK-55) to the deprecation message of the `EXAppDelegateWrapper` interface.
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- [iOS] appended removal info (SDK-55) to the deprecation message of the `EXAppDelegateWrapper` interface.
+- [iOS] appended removal info (SDK-55) to the deprecation message of the `EXAppDelegateWrapper` interface. ([#39574](https://github.com/expo/expo/pull/39574) by [@chrfalch](https://github.com/chrfalch))
 
 ### 🎉 New features
 

--- a/packages/expo/ios/AppDelegates/EXAppDelegateWrapper.h
+++ b/packages/expo/ios/AppDelegates/EXAppDelegateWrapper.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-__deprecated_msg("EXAppDelegateWrapper is deprecated. Migrate your AppDelegate to Swift and use ExpoAppDelegate instead.")
+__deprecated_msg("EXAppDelegateWrapper is deprecated. Migrate your AppDelegate to Swift and use ExpoAppDelegate instead. EXAppDelegateWrapper will be removed in SDK 55.")
 @interface EXAppDelegateWrapper : NSObject <UIApplicationDelegate, UISceneDelegate, RCTReactNativeFactoryDelegate>
 
 @property (nonatomic, strong, readonly) EXReactDelegateWrapper *reactDelegate;


### PR DESCRIPTION
# Why

`EXAppDelegateWrapper` has been deprecated since SDK-52 (?) - we need to inform people on when we should remove the interface.

# How

Added removal time (SDK-55)

# Test Plan

Nothing to test yet.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
