### PR TITLE
install-expo-modules sdk 54

### DIFF
--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- add support for react-native 0.81 & sdk 54 ([#39575](https://github.com/expo/expo/pull/39575) by [@vonovak](https://github.com/vonovak))
+- Added support for react-native 0.81 and Expo SDK 54 ([#39575](https://github.com/expo/expo/pull/39575) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- add support for react-native 0.81 & sdk 54 ([#39575](https://github.com/expo/expo/pull/39575) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 ## 0.13.8 — 2025-09-10

--- a/packages/install-expo-modules/package.json
+++ b/packages/install-expo-modules/package.json
@@ -39,6 +39,7 @@
     "@expo/config": "~12.0.8",
     "@expo/config-plugins": "~54.0.0",
     "@expo/package-manager": "^1.9.7",
+    "@expo/spawn-async": "^1.7.2",
     "@types/prompts": "^2.0.6",
     "@types/semver": "^7.0.0",
     "chalk": "^4.1.2",

--- a/packages/install-expo-modules/src/index.ts
+++ b/packages/install-expo-modules/src/index.ts
@@ -191,7 +191,7 @@ async function runAsync() {
   console.log('\u203A Installing expo packages...');
   await installExpoPackageAsync(projectRoot, expoPackageVersion);
   if (cliIntegration) {
-    await installBabelPresetExpoNonInteractiveAsync();
+    await installBabelPresetExpoNonInteractiveAsync(projectRoot);
   }
 
   console.log('\u203A Installing ios pods...');

--- a/packages/install-expo-modules/src/index.ts
+++ b/packages/install-expo-modules/src/index.ts
@@ -21,7 +21,11 @@ import { withSwiftVersion } from './plugins/ios/withSwiftVersion';
 import { withXCParseXcodeProjectBaseMod } from './plugins/ios/withXCParseXcodeProject';
 import { getDefaultSdkVersion, getVersionInfo, VersionInfo } from './utils/expoVersionMappings';
 import { learnMore } from './utils/link';
-import { installExpoPackageAsync, installPodsAsync } from './utils/packageInstaller';
+import {
+  installBabelPresetExpoNonInteractiveAsync,
+  installExpoPackageAsync,
+  installPodsAsync,
+} from './utils/packageInstaller';
 import { normalizeProjectRootAsync } from './utils/projectRoot';
 
 const packageJSON = require('../package.json');
@@ -186,6 +190,9 @@ async function runAsync() {
 
   console.log('\u203A Installing expo packages...');
   await installExpoPackageAsync(projectRoot, expoPackageVersion);
+  if (cliIntegration) {
+    await installBabelPresetExpoNonInteractiveAsync();
+  }
 
   console.log('\u203A Installing ios pods...');
   await installPodsAsync(projectRoot);

--- a/packages/install-expo-modules/src/plugins/cli/withCliIntegration.ts
+++ b/packages/install-expo-modules/src/plugins/cli/withCliIntegration.ts
@@ -11,6 +11,7 @@ import fs from 'fs';
 import path from 'path';
 import { ISA, PBXShellScriptBuildPhase } from 'xcparse';
 
+import { installBabelPresetExpoNonInteractiveAsync } from '../../utils/packageInstaller';
 import { withXCParseXcodeProject } from '../ios/withXCParseXcodeProject';
 
 export const withCliIntegration: ConfigPlugin = (config) => {
@@ -67,6 +68,7 @@ const withCliBabelConfig: ConfigPlugin = (config) => {
     async (config) => {
       try {
         const babelConfigPath = await findBabelConfigPathAsync(config.modRequest.projectRoot);
+        await installBabelPresetExpoNonInteractiveAsync(config.modRequest.projectRoot);
         let contents = await fs.promises.readFile(babelConfigPath, 'utf8');
         contents = updateBabelConfig(contents);
         await fs.promises.writeFile(babelConfigPath, contents);

--- a/packages/install-expo-modules/src/plugins/cli/withCliIntegration.ts
+++ b/packages/install-expo-modules/src/plugins/cli/withCliIntegration.ts
@@ -68,7 +68,6 @@ const withCliBabelConfig: ConfigPlugin = (config) => {
     async (config) => {
       try {
         const babelConfigPath = await findBabelConfigPathAsync(config.modRequest.projectRoot);
-        await installBabelPresetExpoNonInteractiveAsync(config.modRequest.projectRoot);
         let contents = await fs.promises.readFile(babelConfigPath, 'utf8');
         contents = updateBabelConfig(contents);
         await fs.promises.writeFile(babelConfigPath, contents);

--- a/packages/install-expo-modules/src/plugins/cli/withCliIntegration.ts
+++ b/packages/install-expo-modules/src/plugins/cli/withCliIntegration.ts
@@ -11,7 +11,6 @@ import fs from 'fs';
 import path from 'path';
 import { ISA, PBXShellScriptBuildPhase } from 'xcparse';
 
-import { installBabelPresetExpoNonInteractiveAsync } from '../../utils/packageInstaller';
 import { withXCParseXcodeProject } from '../ios/withXCParseXcodeProject';
 
 export const withCliIntegration: ConfigPlugin = (config) => {

--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -116,6 +116,10 @@ export function getDefaultSdkVersion(projectRoot: string): VersionInfo {
     throw new Error(
       `Unable to find compatible expo sdk version - reactNativeVersion[${reactNativeVersion}]`
     );
+  } else {
+    console.log(
+      `Defaulting to SDK ${versionInfo.sdkVersion} for react-native version ${reactNativeVersion}`
+    );
   }
   return versionInfo;
 }

--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -14,6 +14,13 @@ export interface VersionInfo {
 export const ExpoVersionMappings: VersionInfo[] = [
   // Please keep sdk versions in sorted order (latest sdk first)
   {
+    expoPackageVersion: '~54.0.0',
+    sdkVersion: '54.0.0',
+    iosDeploymentTarget: '15.1',
+    reactNativeVersionRange: '~0.81.0',
+    supportCliIntegration: true,
+  },
+  {
     expoPackageVersion: '~53.0.0',
     sdkVersion: '53.0.0',
     iosDeploymentTarget: '15.1',

--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -17,7 +17,7 @@ export const ExpoVersionMappings: VersionInfo[] = [
     expoPackageVersion: '~54.0.0',
     sdkVersion: '54.0.0',
     iosDeploymentTarget: '15.1',
-    reactNativeVersionRange: '~0.81.4',
+    reactNativeVersionRange: '~0.81.0',
     supportCliIntegration: true,
   },
   {

--- a/packages/install-expo-modules/src/utils/expoVersionMappings.ts
+++ b/packages/install-expo-modules/src/utils/expoVersionMappings.ts
@@ -17,7 +17,7 @@ export const ExpoVersionMappings: VersionInfo[] = [
     expoPackageVersion: '~54.0.0',
     sdkVersion: '54.0.0',
     iosDeploymentTarget: '15.1',
-    reactNativeVersionRange: '~0.81.0',
+    reactNativeVersionRange: '~0.81.4',
     supportCliIntegration: true,
   },
   {

--- a/packages/install-expo-modules/src/utils/packageInstaller.ts
+++ b/packages/install-expo-modules/src/utils/packageInstaller.ts
@@ -22,8 +22,10 @@ async function installPackageNonInteractiveAsync(projectRoot: string, pkg: strin
   return manager.addAsync([pkg]);
 }
 
-export async function installBabelPresetExpoNonInteractiveAsync() {
-  await spawnAsync('npx', ['expo', 'install', '--dev', 'babel-preset-expo']);
+export async function installBabelPresetExpoNonInteractiveAsync(projectRoot: string) {
+  await spawnAsync('npx', ['expo', 'install', '--dev', 'babel-preset-expo'], {
+    cwd: projectRoot,
+  });
 }
 
 /**

--- a/packages/install-expo-modules/src/utils/packageInstaller.ts
+++ b/packages/install-expo-modules/src/utils/packageInstaller.ts
@@ -22,17 +22,7 @@ async function installPackageNonInteractiveAsync(projectRoot: string, pkg: strin
 }
 
 export async function installBabelPresetExpoNonInteractiveAsync(projectRoot: string) {
-  const manager = PackageManager.createForProject(projectRoot, { silent: false });
-  const pkg = 'babel-preset-expo';
-
-  if (manager.name === 'yarn') {
-    const version = await manager.versionAsync();
-    if (semver.major(version) === 1) {
-      return manager.addDevAsync([pkg, '--non-interactive']);
-    }
-  }
-
-  return manager.addDevAsync([pkg]);
+  await spawnAsync('npx', ['expo', 'install', 'babel-preset-expo']);
 }
 
 /**

--- a/packages/install-expo-modules/src/utils/packageInstaller.ts
+++ b/packages/install-expo-modules/src/utils/packageInstaller.ts
@@ -21,6 +21,20 @@ async function installPackageNonInteractiveAsync(projectRoot: string, pkg: strin
   return manager.addAsync([pkg]);
 }
 
+export async function installBabelPresetExpoNonInteractiveAsync(projectRoot: string) {
+  const manager = PackageManager.createForProject(projectRoot, { silent: false });
+  const pkg = 'babel-preset-expo';
+
+  if (manager.name === 'yarn') {
+    const version = await manager.versionAsync();
+    if (semver.major(version) === 1) {
+      return manager.addDevAsync([pkg, '--non-interactive']);
+    }
+  }
+
+  return manager.addDevAsync([pkg]);
+}
+
 /**
  * Install the `expo` package
  *

--- a/packages/install-expo-modules/src/utils/packageInstaller.ts
+++ b/packages/install-expo-modules/src/utils/packageInstaller.ts
@@ -1,4 +1,5 @@
 import * as PackageManager from '@expo/package-manager';
+import spawnAsync from '@expo/spawn-async';
 import path from 'path';
 import semver from 'semver';
 
@@ -21,8 +22,8 @@ async function installPackageNonInteractiveAsync(projectRoot: string, pkg: strin
   return manager.addAsync([pkg]);
 }
 
-export async function installBabelPresetExpoNonInteractiveAsync(projectRoot: string) {
-  await spawnAsync('npx', ['expo', 'install', 'babel-preset-expo']);
+export async function installBabelPresetExpoNonInteractiveAsync() {
+  await spawnAsync('npx', ['expo', 'install', '--dev', 'babel-preset-expo']);
 }
 
 /**


### PR DESCRIPTION
# Why

closes https://github.com/expo/expo/issues/39571

# How

adds version mapping for RN 0.81 -> expo sdk 54

# Test Plan

- tested locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
