### PR TITLE
Remove ref prop from TabButtonProps type

### DIFF
--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -226,7 +226,6 @@ type Icon = ComponentProps<typeof FontAwesome>['name'];
 
 export type TabButtonProps = TabTriggerSlotProps & {
   icon?: Icon;
-  ref: Ref<View>;
 };
 
 export function TabButton({ icon, children, isFocused, ...props }: TabButtonProps) {


### PR DESCRIPTION
The ref is not needed since TabTriggerSlotProps already includes React.RefAttributes<View>

# Why

The ref was explicitly declared in the props, but it’s already included in TabTriggerSlotProps through React.RefAttributes<View>. This duplication was unnecessary and could cause confusion.

# How

I removed the redundant ref declaration from the props. Since TabTriggerSlotProps already handles the forwarding of refs, no additional changes were needed.

# Test Plan

Confirmed that refs still work as expected when passed to the component.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
