### PR TITLE
fix(cli): Fix fallback resolver for unhoisted dependencies of `expo` and `expo-router`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix fallback resolution for modules that failed to hoist (inside `expo` or `expo-router`'s child `node_modules` folder) ([#39581](https://github.com/expo/expo/pull/39581) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 - Replace usage of metro internals in `instantiateMetro` with `Terminal.log` ([#39531](https://github.com/expo/expo/pull/39531) by [@robhogan](https://github.com/robhogan))

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -1027,7 +1027,7 @@ describe(withExtendedResolver, () => {
       expect(getResolveFunc()).toHaveBeenNthCalledWith(
         3,
         expect.objectContaining({
-          originModulePath: '/node_modules/expo',
+          originModulePath: '/node_modules/expo/index.js',
           nodeModulesPaths: ['/node_modules/expo'],
         }),
         '@babel/runtime/helpers/interopRequireDefault',
@@ -1105,7 +1105,7 @@ describe(withExtendedResolver, () => {
       expect(getResolveFunc()).toHaveBeenNthCalledWith(
         4,
         expect.objectContaining({
-          originModulePath: '/node_modules/expo-router',
+          originModulePath: '/node_modules/expo-router/index.js',
           nodeModulesPaths: ['/node_modules/expo-router'],
         }),
         'example',

--- a/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
@@ -179,7 +179,10 @@ export function createFallbackModuleResolver({
         const context: ResolutionContext = {
           ...immutableContext,
           nodeModulesPaths: [moduleDescription.originModulePath],
-          originModulePath: moduleDescription.originModulePath,
+          // NOTE(@kitten): We need to add a fake filename here. Metro performs a `path.dirname` on this path
+          // and then searches `${path.dirname(originModulePath)}/node_modules`. If we don't add it, we miss
+          // fallback resolution for packages that failed to hoist
+          originModulePath: path.join(moduleDescription.originModulePath, 'index.js'),
         };
         const res = getStrictResolver(context, platform)(moduleName);
         debug(


### PR DESCRIPTION
# Why

In npm v11, we've seen that hoisting sometimes fails. The fallback resolver is supposed to protect us from these cases too. However, `originModulePath` needs to be a file path rather than a directory path for this to work.

# How

- Append fake `index.js` to `originModulePath` in fallback resolver

# Test Plan

- Unit tests updated

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
