### PR TITLE
update compilationMode in babel-preset-expo

### DIFF
--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -170,7 +170,7 @@ module.exports = function (api) {
         {
           'react-compiler': {
             // Passed directly to the React Compiler Babel plugin.
-            compilationMode: 'strict',
+            compilationMode: 'all',
             panicThreshold: 'all_errors',
           },
           web: {

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+Fix accepted react-compiler compilationMode values and update documentation.
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -61,7 +61,7 @@ type BabelPresetExpoPlatformOptions = {
     | {
         // TODO: Add full types and doc blocks.
         enableUseMemoCachePolyfill?: boolean;
-        compilationMode?: 'infer' | 'strict';
+        compilationMode?: 'infer' | 'syntax' | 'annotation' | 'all';
         panicThreshold?: 'none' | 'all_errors' | 'critical_errors';
         logger?: any;
         environment?: {


### PR DESCRIPTION
# Why

Based on the finding in https://github.com/expo/expo/issues/39579. It appears that `babel-preset-expo` and Expo documentation accepts incorrect values that result in crash when using React Compiler.

This PR updates docs and fixes type definition to accept correct values.

# How

Updated `babel-preset-expo` to accept the same values as specified in official React Compiler docs:
https://react.dev/reference/react-compiler/compilationMode#compilationmode

`'infer' | 'syntax' | 'annotation' | 'all'`

# Test Plan

Run Expo app with custom React Compiler config and validate that app does not crash.

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
