### PR TITLE
[docs] updated Navigation bar configuration guide to include Platform import

### DIFF
--- a/docs/pages/develop/user-interface/system-bars.mdx
+++ b/docs/pages/develop/user-interface/system-bars.mdx
@@ -69,7 +69,7 @@ To control the `StatusBar` visibility, you can set the [`hidden`](/versions/late
 On Android devices, the Navigation Bar appears at the bottom of the screen. You can customize it using the [`expo-navigation-bar`](/versions/latest/sdk/navigation-bar) library. It provides a `NavigationBar` component that you can use to set the style of the navigation bar using the [`setStyle`](/versions/latest/sdk/navigation-bar/#navigationbarsetstylestyle) method:
 
 ```tsx app/_layout.tsx
-import { Platform } from "react-native";
+import { Platform } from 'react-native';
 import * as NavigationBar from 'expo-navigation-bar';
 import { useEffect } from 'react';
 

--- a/docs/pages/develop/user-interface/system-bars.mdx
+++ b/docs/pages/develop/user-interface/system-bars.mdx
@@ -69,6 +69,7 @@ To control the `StatusBar` visibility, you can set the [`hidden`](/versions/late
 On Android devices, the Navigation Bar appears at the bottom of the screen. You can customize it using the [`expo-navigation-bar`](/versions/latest/sdk/navigation-bar) library. It provides a `NavigationBar` component that you can use to set the style of the navigation bar using the [`setStyle`](/versions/latest/sdk/navigation-bar/#navigationbarsetstylestyle) method:
 
 ```tsx app/_layout.tsx
+import { Platform } from "react-native";
 import * as NavigationBar from 'expo-navigation-bar';
 import { useEffect } from 'react';
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
While going through the tuorial, I noticed that the tutorial for the Navigation bar guide did not include the Platform import, and this might be confusing to some, hence why I updated the doc content.

<img width="1424" height="494" alt="Screenshot 2025-09-11 at 17 03 59" src="https://github.com/user-attachments/assets/22436aac-e234-4bb5-9829-75e894cef82c" />

# How
Added the import statement to the doc.

<!--
How did you build this feature or fix this bug and why?
-->
<img width="1414" height="596" alt="Screenshot 2025-09-11 at 17 06 58" src="https://github.com/user-attachments/assets/9856e0a2-d52d-4d4b-aa85-3dba7ab695ce" />


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
