### PR TITLE
fix: expo-dev-launcher version mismatch

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -56,7 +56,7 @@
     "expo": "~54.0.1",
     "expo-build-properties": "~1.0.7",
     "expo-camera": "~17.0.7",
-    "expo-dev-client": "~6.0.11",
+    "expo-dev-client": "~6.0.12",
     "expo-image": "~3.0.7",
     "expo-insights": "~0.10.6",
     "expo-network-addons": "~0.10.6",

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "expo": "~54.0.1",
     "expo-clipboard": "8.0.6",
-    "expo-dev-client": "~6.0.11",
+    "expo-dev-client": "~6.0.12",
     "expo-image": "~3.0.7",
     "expo-media-library": "18.1.1",
     "expo-notifications": "~0.32.10",

--- a/apps/paper-tester/package.json
+++ b/apps/paper-tester/package.json
@@ -13,7 +13,7 @@
     "expo-apple-authentication": "~8.0.6",
     "expo-blur": "~15.0.6",
     "expo-camera": "~17.0.7",
-    "expo-dev-client": "~6.0.11",
+    "expo-dev-client": "~6.0.12",
     "expo-image": "~3.0.7",
     "expo-linear-gradient": "~15.0.6",
     "expo-splash-screen": "~31.0.8",

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Bumps the version of `expo-dev-launcher` to fix a duplicated dependency. ([#39580](https://github.com/expo/expo/issues/39580) by [@carloschida](https://github.com/expo/expo/issues/39580))
+
 ### 💡 Others
 
 ## 6.0.11 — 2025-09-10

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-dev-client",
-  "version": "6.0.11",
+  "version": "6.0.12",
   "description": "Expo Development Client",
   "main": "build/DevClient.js",
   "types": "build/DevClient.d.ts",
@@ -32,7 +32,7 @@
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/latest/sdk/dev-client/",
   "dependencies": {
-    "expo-dev-launcher": "6.0.10",
+    "expo-dev-launcher": "6.0.11",
     "expo-dev-menu": "7.0.10",
     "expo-dev-menu-interface": "2.0.0",
     "expo-manifests": "~1.0.7",

--- a/packages/expo-dev-client/package.json
+++ b/packages/expo-dev-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-dev-client",
-  "version": "6.0.12",
+  "version": "6.0.11",
   "description": "Expo Development Client",
   "main": "build/DevClient.js",
   "types": "build/DevClient.d.ts",

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- Version 6.0.10 of this package lists in the repo `expo-dev-menu@7.0.10` as a dependency but the published version in npm lists `expo-dev-menu@7.0.9`. ([#39580](https://github.com/expo/expo/issues/39580) by [@carloschida](https://github.com/expo/expo/issues/39580))
+
 ## 6.0.10 — 2025-09-08
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-dev-launcher",
   "title": "Expo Development Launcher",
-  "version": "6.0.11",
+  "version": "6.0.10",
   "description": "Pre-release version of the Expo development launcher package for testing.",
   "repository": {
     "type": "git",

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-dev-launcher",
   "title": "Expo Development Launcher",
-  "version": "6.0.10",
+  "version": "6.0.11",
   "description": "Pre-release version of the Expo development launcher package for testing.",
   "repository": {
     "type": "git",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -36,7 +36,7 @@
   "expo-constants": "~18.0.8",
   "expo-contacts": "~15.0.8",
   "expo-crypto": "~15.0.6",
-  "expo-dev-client": "~6.0.11",
+  "expo-dev-client": "~6.0.12",
   "expo-device": "~8.0.6",
   "expo-document-picker": "~14.0.6",
   "expo-file-system": "~19.0.11",


### PR DESCRIPTION
Solves #39580.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

`expo-dev-launcher@6.0.10` lists `expo-dev-menu@7.0.10` currently in the repo but the published code in npm lists `expo-dev-menu@7.0.9`.

This creates an `expo-doctor` warning on duplicated dependencies.

# How

<!--
How did you build this feature or fix this bug and why?
-->

1. I added a simple CHANGELOG.md entry to `expo-dev-launcher` stating this fact. Nothing else should be done as I believe that the publish script will bump the version.

2. I changed the dependency of `expo-dev-client` from `expo-dev-launcher@6.0.10` (current) to `expo-dev-launcher@6.0.11` (pending publication).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I don't really know how or whether this should be tested. 

From my shallow understanding, this PR should be followed by publishing new patch versions of:

- `expo-dev-launcher`
- `expo-dev-client`

I wouldn't know either whether these changes will be caught by `expo-doctor`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
