### PR TITLE
[ios][glass-effect] Handle child views for liquid glass view

### DIFF
--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 ### 🎉 New features
+Child views of `<GlassView/>` gains all animations from parent view.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🛠 Breaking changes
 
 ### 🎉 New features
-Child views of `<GlassView/>` gains all animations from parent view.
+Add child view support to <GlassView />, allowing child views to inherit animations from the parent view. ([#39595](https://github.com/expo/expo/pull/39595) by [@patrikduksin](https://github.com/patrikduksin))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-glass-effect/ios/GlassView.swift
+++ b/packages/expo-glass-effect/ios/GlassView.swift
@@ -70,4 +70,11 @@ public final class GlassView: ExpoView {
       #endif
     }
   }
+  public override func mountChildComponentView(_ childComponentView: UIView, index: Int) {
+    glassEffectView.contentView.insertSubview(childComponentView, at: index)
+  }
+
+  public override func unmountChildComponentView(_ childComponentView: UIView, index: Int) {
+    childComponentView.removeFromSuperview()
+  }
 }


### PR DESCRIPTION
# Why
Right now there is no way to add child view that will gain all glass effect animations from `<GlassView/>`. To ship apps that feels truly native I believe that child views should inherit animation from parent. 
# How
I've overridden mountChildComponentView to add child views inside content view in visualEffectView, for removing child views i used unmountChildComponentView
# Test Plan
I tested changed <GlassView/> with chile <View/>,<Text/>, <TextInput/> and it gains all animation from parent `<GlassView/>. Also it works fine with `<GlassContainer/>`

how it was before: pay attention to how text behaves when you click

https://github.com/user-attachments/assets/da05be53-2c1f-4039-9247-7aee2b889ef9

now

https://github.com/user-attachments/assets/59fe22b5-f1be-4ae3-955d-d0d39bb17b93
# Checklist
- [*] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [*] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [*] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
