### PR TITLE
[docs] Update Maestro version in latest Android image

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -1,5 +1,5 @@
 ---
-modificationDate: August 22nd, 2025
+modificationDate: September 11th, 2025
 title: Build server infrastructure
 sidebar_title: Server infrastructure
 maxHeadingDepth: 4
@@ -82,7 +82,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 - npm 10.9.3
 - Java 17
 - node-gyp 11.3.0
-- Maestro 1.41.0
+- Maestro 2.0.2
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Found that Maestro version is not ald with the what shows in EAS Workflows in the latest Android image.

<img width="2434" height="674" alt="CleanShot 2025-09-12 at 15 06 09@2x" src="https://github.com/user-attachments/assets/d3b4dc89-50d1-47cb-b89f-b03b84aa74c4" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update Maestro version in latest Android image
- Update document date based on the last change by @sjchmiela 


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
