### PR TITLE
fix(jest-expo): add trailing `/` to format `transformIgnorePattern` correctly

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing trailing `/` to `transformIgnorePatterns` resolving pnpm isolated modules paths. ([#39605](https://github.com/expo/expo/pull/39605) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 54.0.10 — 2025-09-10

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -100,7 +100,7 @@ if (!Array.isArray(jestPreset.transformIgnorePatterns)) {
 
 // Also please keep `unit-testing.mdx` file up to date
 jestPreset.transformIgnorePatterns = [
-  '/node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg)',
+  '/node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg)/',
   '/node_modules/react-native-reanimated/plugin/',
 ];
 


### PR DESCRIPTION
# Why

I just ran into this when moving https://github.com/byCedric/expo-monorepo-example over to use isolated modules. It's weird that this is only an issue on pnpm store paths, like `node_modules/.pnpm/<grouped-libs>/node_modules/react-native/index.js`.

> Edit, this is not related to pnpm store paths. Just like React Native, Jest consists of lots of internal packages. These internal packages are referenced as `"jest-core": "^29.7.0"`. That also applies to older Jest versions, like `jest@29.4.0 -> jest-cli@^29.4.0` and resolves to `29.7.0`. Meaning that once the lockfile changes, you can't get back to an older version.
>
> That's the cause. Something has changed when interpreting the regex instance from `transformIgnorePatterns` breaking paths notation like `/node_modules/(?!(react-native))`. While this used to work, it only works when providing the full regex path `/node_modules/(?!(react-native))/`, which isn't even the same. We need to change this to `/\/node_modules\/(?!(react-native))\//` to ensure we are only matching on exact directory names.
>
> BUT, even that (`/\/node_modules\/(?!(react-native))\//`) get's interpreted wrong. Instead of `/\/node_modules\/..\//` it's interpreted as `/\/\/node_modules\/..\/\//` which doesn't make any sense as we don't have double `//`... 
> <img width="412" height="36" alt="image" src="https://github.com/user-attachments/assets/050d78e2-3474-49e9-9c05-45def2e4def2" />


 which doesn't make any sense as `/node_modules/(?!(react-native))/` is interpreted as 

But, it is a thing... See PR https://github.com/byCedric/expo-monorepo-example/pull/152

- Before: https://github.com/byCedric/expo-monorepo-example/pull/152/commits/7b12bc55da8cec026a114f1891b4dc93709bf648 (failing CI)
- After: https://github.com/byCedric/expo-monorepo-example/pull/152/commits/d384cf9e81e3078e57cce4456b745d3fbf148662 (passing CI)

# How

- Added missing trailing `/` to the `transformIgnorePatterns` in `jest-expo`

# Test Plan

See monorepo PR https://github.com/byCedric/expo-monorepo-example/pull/152, and commit https://github.com/byCedric/expo-monorepo-example/pull/152/commits/d384cf9e81e3078e57cce4456b745d3fbf148662

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
