### PR TITLE
[camera][android] Fix barcode scanner on devices without Play Services

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix barcode scanner on devices without access to Google Play Services. ([#39612](https://github.com/expo/expo/pull/39612) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 17.0.7 — 2025-09-10

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -492,7 +492,7 @@ class ExpoCameraView(
       .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
       .build()
       .also { analyzer ->
-        if (shouldScanBarcodes && CameraUtils.isMLKitAvailable(context)) {
+        if (shouldScanBarcodes && CameraUtils.isMLKitBarcodeScannerAvailable()) {
           try {
             analyzer.setAnalyzer(
               ContextCompat.getMainExecutor(context),

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/utils/CameraUtils.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/utils/CameraUtils.kt
@@ -19,16 +19,20 @@ object CameraUtils {
     }
   }
 
-  fun isMLKitAvailable(context: Context?): Boolean {
-    if (!hasGooglePlayServices(context)) {
-      return false
-    }
-
+  fun isMLKitBarcodeScannerAvailable(): Boolean {
     return try {
       Class.forName("com.google.mlkit.vision.barcode.BarcodeScanning")
       true
     } catch (_: ClassNotFoundException) {
       false
     }
+  }
+
+  fun isMLKitAvailable(context: Context?): Boolean {
+    if (!hasGooglePlayServices(context)) {
+      return false
+    }
+
+    return isMLKitBarcodeScannerAvailable()
   }
 }


### PR DESCRIPTION
# Why

Recent changes introduced a check that blocks barcode scanner on devices without google play services. Which broke barcode scanning in Expo Go for Quest.

We actually don't need Google Play Services for access to the barcode scanner, since we are using a bundled version of 
`com.google.mlkit.vision.barcode.BarcodeScanning` see:
https://developers.google.com/ml-kit/vision/barcode-scanning/android

# How

Introduced `isMLKitBarcodeScannerAvailable` that checks only for presence of `com.google.mlkit.vision.barcode.BarcodeScanning`

# Test Plan

Tested in Expo Go Barcode Scanner on Quest
