### PR TITLE
[docs] Use the TestFlight job in iOS submission guide

### DIFF
--- a/docs/pages/submit/ios.mdx
+++ b/docs/pages/submit/ios.mdx
@@ -194,14 +194,13 @@ You can use [EAS Workflows](/eas-workflows/get-started/) to build and submit you
      submit_ios:
        name: Submit to Apple App Store
        needs: [build_ios]
-       type: submit
+       type: testflight
        params:
-         platform: ios
          build_id: ${{ needs.build_ios.outputs.build_id }}
      # @end #
    ```
 
-   The workflow above will build the iOS app and then submit it to the Apple App Store.
+   The workflow above will build the iOS app and then submit it Apple App Store's TestFlight. You can share with internal and external testing groups using the `testflight` job. See the [pre-packaged `testflight` job](/eas/workflows/pre-packaged-jobs/#testflight) for more information.
 
 ### Use other CI/CD services
 

--- a/docs/pages/submit/ios.mdx
+++ b/docs/pages/submit/ios.mdx
@@ -192,7 +192,7 @@ You can use [EAS Workflows](/eas-workflows/get-started/) to build and submit you
 
      # @info #
      submit_ios:
-       name: Submit to Apple App Store
+       name: Submit to TestFlight
        needs: [build_ios]
        type: testflight
        params:


### PR DESCRIPTION
# Why

We have a pre-packaged job to submit to TestFlight that has better options than `type: submit`. This PR updates the iOS submission guide's CI/CD section to suggest `type: testflight`.

# Test Plan

Make sure the changes read well.

<img width="693" height="827" alt="Screenshot 2025-09-12 at 11 49 46 AM" src="https://github.com/user-attachments/assets/c3a568d4-4f82-459c-a89f-660c51806f83" />
