### PR TITLE
[cli] Prevent iOS device builds from being remotely cached

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent iOS device builds from being remotely cached ([#39621](https://github.com/expo/expo/pull/39621) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 - Replace usage of metro internals in `instantiateMetro` with `Terminal.log` ([#39531](https://github.com/expo/expo/pull/39531) by [@robhogan](https://github.com/robhogan))

--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -42,6 +42,7 @@ export async function runIosAsync(projectRoot: string, options: Options) {
   const props = await profile(resolveOptionsAsync)(projectRoot, options);
 
   const projectConfig = getConfig(projectRoot);
+  // We only support build cache for simulator builds for now.
   if (!options.binary && props.buildCacheProvider && props.isSimulator) {
     const localPath = await resolveBuildCache({
       projectRoot,
@@ -132,7 +133,8 @@ export async function runIosAsync(projectRoot: string, options: Options) {
     // Find the path to the built app binary, this will be used to install the binary
     // on a device.
     binaryPath = await profile(XcodeBuild.getAppBinaryPath)(buildOutput);
-    shouldUpdateBuildCache = true;
+    // We only support build cache for simulator builds for now.
+    shouldUpdateBuildCache = props.isSimulator;
   }
   debug('Binary path:', binaryPath);
 


### PR DESCRIPTION
# Why

Currently, we don't support remotely caching iOS device builds because even though the fingerprint might be the same, the build may not be provided for the physical device the user is trying to run. Given that we can use those artifacts, we shouldn't upload them either.

Closes https://github.com/expo/expo/issues/39614

# How

Only set shouldUpdateBuildCache to true if building for the simulator

# Test Plan

`npx expo run:ios --device`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
