### PR TITLE
[docs][tutorial] align tutorial with template changes from PR #39358

### DIFF
--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -133,14 +133,13 @@ Styles applied to these components use JavaScript objects rather than CSS, which
 
 Let's modify **app/index.tsx** screen:
 
-1. Import `StyleSheet` from `react-native` and create a `styles` object to define our custom styles.
-2. Add a `styles.container.backgroundColor` property to `<View>` with the value of `#25292e`. This changes the background color.
-3. Replace the default value of `<Text>` with "Home screen".
-4. Add a `styles.text.color` property to `<Text>` with the value of `#fff` (white) to change the text color.
+1. Add a `styles.container.backgroundColor` property to `<View>` with the value of `#25292e`. This changes the background color.
+2. Replace the default value of `<Text>` with "Home screen".
+3. Add a `styles.text.color` property to `<Text>` with the value of `#fff` (white) to change the text color.
 
 {/* prettier-ignore */}
 ```tsx app/index.tsx|collapseHeight=340
-import { Text, View, /* @tutinfo Import <CODE>StyleSheet</CODE> to define styles. */ StyleSheet/* @end */ } from 'react-native';
+import { Text, View, StyleSheet } from 'react-native';
 
 export default function Index() {
   return (
@@ -161,9 +160,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  /* @tutinfo Create a <CODE>text</CODE> style with a <CODE>color</CODE> property of <CODE>'#fff'</CODE>. */
   text: {
     color: '#fff',
   },
+  /* @end */
 });
 ```
 


### PR DESCRIPTION
# Why
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
This PR follows up on [PR #39358](https://github.com/expo/expo/pull/39358), which updated the project templates (e.g. `reset-project`) to use **StyleSheet.create** instead of inline styles.  
Now that those template changes have been published, the tutorial documentation should be updated so that users see examples consistent with the generated code.

# How
<!--
How did you build this feature or fix this bug and why?
-->
- Updated the tutorial code snippets to use **StyleSheet.create**, matching the template changes from PR #39358.  
- Removed the redundant “import StyleSheet” step and its associated highlighting.  
- Fixed syntax highlighting for the `text: { color: '#fff' }` style block in the tutorial code sample.

# Test Plan
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
- Built the docs locally and navigated to the “Create your first app → Edit the index screen” section.  
- Confirmed that the code examples now match the output from the updated templates (per PR #39358).  
- Verified that the redundant step was removed and syntax highlighting appears correctly in both light and dark themes.

# Checklist
<!--
Please check the appropriate items below if they apply to your diff.
-->
- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
