### PR TITLE
[iOS][screen-capture] Prevent multiple blur views from being added during rapid app state changes

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent multiple blur views from being added during rapid app state changes. ([#39633](https://github.com/expo/expo/pull/39633) by [@hryhoriiK97](https://github.com/hryhoriiK97))
+
 ### 💡 Others
 
 ## 8.0.7 — 2025-09-11

--- a/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
+++ b/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
@@ -194,27 +194,31 @@ public final class ScreenCaptureModule: Module {
   }
 
   private func showPrivacyOverlay() {
-    if let keyWindow = keyWindow,
-      let rootView = keyWindow.subviews.first {
-      let blurEffectView = AnimatedBlurEffectView(style: .light, intensity: self.blurIntensity)
-      blurEffectView.frame = rootView.bounds
-      blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-      blurEffectView.alpha = 0
-
-      rootView.addSubview(blurEffectView)
-      self.blurEffectView = blurEffectView
-
-      blurEffectView.setupBlur()
-
-      UIView.animate(
-        withDuration: 0.3,
-        delay: 0,
-        options: [.curveEaseOut],
-        animations: {
-          blurEffectView.alpha = 1.0
-        }
-      )
+    // Don't add a new blur view if one already exists
+    guard self.blurEffectView == nil,
+      let keyWindow = keyWindow,
+      let rootView = keyWindow.subviews.first else {
+      return
     }
+
+    let blurEffectView = AnimatedBlurEffectView(style: .light, intensity: self.blurIntensity)
+    blurEffectView.frame = rootView.bounds
+    blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    blurEffectView.alpha = 0
+
+    rootView.addSubview(blurEffectView)
+    self.blurEffectView = blurEffectView
+
+    blurEffectView.setupBlur()
+
+    UIView.animate(
+      withDuration: 0.3,
+      delay: 0,
+      options: [.curveEaseOut],
+      animations: {
+        blurEffectView.alpha = 1.0
+      }
+    )
   }
 
   private func removePrivacyOverlay() {


### PR DESCRIPTION
# Why
Based on [issue](https://github.com/expo/expo/issues/39589) - when app states switch too quickly, multiple blur overlays could be added, causing the app to remain constantly blurred.

closes #39589

# How
Added a guard statement in showPrivacyOverlay() to prevent creating additional blur views when one already exists.

https://github.com/user-attachments/assets/3a657f4b-5a98-4ae6-8fb7-6a93a56e3705

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
