### PR TITLE
fix(cli): Prevent forwarding empty log lines to Metro terminal

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Prevent iOS device builds from being remotely cached ([#39621](https://github.com/expo/expo/pull/39621) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Prevent empty/non-string logs
+- Prevent empty/non-string logs ([#39635](https://github.com/expo/expo/pull/39635) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Prevent iOS device builds from being remotely cached ([#39621](https://github.com/expo/expo/pull/39621) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Prevent empty/non-string logs
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -41,11 +41,9 @@ class LogRespectingTerminal extends Terminal {
     super(stream, { ttyPrint: true });
 
     const sendLog = (format: unknown, ...args: any[]) => {
-      if (format != null) {
-        this.log(format as string, ...args);
-        // Flush the logs to the terminal immediately so logs at the end of the process are not lost.
-        this.flush();
-      }
+      this.log(format != null ? (format as string) : '', ...args);
+      // Flush the logs to the terminal immediately so logs at the end of the process are not lost.
+      this.flush();
     };
 
     console.log = sendLog;

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -40,10 +40,12 @@ class LogRespectingTerminal extends Terminal {
   constructor(stream: import('node:net').Socket | import('node:stream').Writable) {
     super(stream, { ttyPrint: true });
 
-    const sendLog = (format: string, ...args: any[]) => {
-      this.log(format, ...args);
-      // Flush the logs to the terminal immediately so logs at the end of the process are not lost.
-      this.flush();
+    const sendLog = (format: unknown, ...args: any[]) => {
+      if (format != null) {
+        this.log(format as string, ...args);
+        // Flush the logs to the terminal immediately so logs at the end of the process are not lost.
+        this.flush();
+      }
     };
 
     console.log = sendLog;


### PR DESCRIPTION
# Why

Regression in #39546

Seeing some `undefined` log lines in the Metro output.

# How

Filter out null or undefined logs. This is probably a tiny difference in how this is formatted. Either way, we can trace down the `undefined` log later, but should just restore to what we did before.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
