### PR TITLE
[ios][ui][glass-effect] Fix tvOS 26 compilation, add tvOS card button style

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] tvOS 26 compile fix and card button. ([#39639](https://github.com/expo/expo/pull/39639) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 ## 0.2.0-beta.2 — 2025-09-12

--- a/packages/expo-ui/ios/Button/Button.swift
+++ b/packages/expo-ui/ios/Button/Button.swift
@@ -39,7 +39,12 @@ struct Button: ExpoSwiftUI.View {
     .if(props.variant == .borderedProminent, {
       $0.buttonStyle(.borderedProminent)
     })
-    #if !os(tvOS)
+
+    #if os(tvOS)
+    .if(props.variant == .card, {
+      $0.buttonStyle(.card)
+    })
+    #else
     .if(props.variant == .borderless, {
       $0.buttonStyle(.borderless)
     })
@@ -60,7 +65,7 @@ struct Button: ExpoSwiftUI.View {
     })
     #endif
 
-    if #available(iOS 26.0, *) {
+    if #available(iOS 26.0, tvOS 26.0, *) {
       #if compiler(>=6.2) // Xcode 26
       switch props.variant {
       case .glass:


### PR DESCRIPTION
# Why

We want Expo UI to work as expected on tvOS 26 and support its glass effect and card button style APIs.

# How

Update Expo UI's `Button.swift`:

- Fix tvOS 26 compilation error for glass and glassProminent styles
- Add missing card style for tvOS (available since tvOS 14.0)

# Test Plan

Tested with the Xcode and iOS/tvOS 26 release candidates.

