### PR TITLE
[core][Android] Start using PCH

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [Android] Starts using precompiled headers to improve build times.
+- [Android] Starts using precompiled headers to improve build times. ([#39641](https://github.com/expo/expo/pull/39641) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [Android] Starts using precompiled headers to improve build times.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.16)
 
 project(expo-modules-core)
 
@@ -42,6 +42,8 @@ add_library(
         ${sources_android_types}
         ${sources_android_javaclasses}
 )
+
+target_precompile_headers(${PACKAGE_NAME} PRIVATE ${SRC_DIR}/main/cpp/ExpoHeader.pch)
 
 if(IS_NEW_ARCHITECTURE_ENABLED)
   add_subdirectory("${SRC_DIR}/fabric")

--- a/packages/expo-modules-core/android/src/fabric/CMakeLists.txt
+++ b/packages/expo-modules-core/android/src/fabric/CMakeLists.txt
@@ -9,6 +9,8 @@ add_library(fabric STATIC
   ${SOURCES}
 )
 
+target_precompile_headers(fabric PRIVATE ${SRC_DIR}/main/cpp/ExpoHeader.pch)
+
 include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
 
 target_compile_options(fabric PRIVATE

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoHeader.pch
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoHeader.pch
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <unistd.h>
+#include <unordered_map>
+#include <vector>
+
+#include <fbjni/fbjni.h>
+
+#include <folly/dynamic.h>
+
+#include <jsi/jsi.h>
+#include <jsi/JSIDynamic.h>
+
+#include <react/jni/ReadableNativeArray.h>
+#include <react/jni/ReadableNativeMap.h>
+#include <react/jni/WritableNativeArray.h>
+#include <react/jni/WritableNativeMap.h>


### PR DESCRIPTION
# Why

Starts using PCH

# How

In CMake version 3.16, support for precompiled headers was added. It's an elegant feature that allows us to reduce the CPU time of the CMake build by simply adding a couple of lines of configuration. On my machine (M3), the total time was reduced by approximately 1 second (from 7 seconds to 6 seconds). However, the total CPU time spent compiling e-m-c was reduced by ~40%. It's not that noticeable because now more threads are waiting for the result. I think we can still improve it; this is just a proof of concept. 

Note: I tried to share the same PCH between the main target and the fabric one, but it doesn't seem to work.

# Test Plan

Before: 
<img width="1476" height="988" alt="image" src="https://github.com/user-attachments/assets/7f78a080-e563-4b80-acd1-ea2fe2cf2a52" />

After:
<img width="1476" height="988" alt="image" src="https://github.com/user-attachments/assets/027f8260-2e73-494c-a062-3ef5c93446ee" />
