### PR TITLE
[core][Android] Clean up cmake

### DIFF
--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -16,6 +16,7 @@ endif ()
 
 set(SRC_DIR ${CMAKE_SOURCE_DIR}/src)
 set(COMMON_DIR ${CMAKE_SOURCE_DIR}/../common/cpp)
+
 file(GLOB sources_android "${SRC_DIR}/main/cpp/*.cpp")
 file(GLOB sources_android_types "${SRC_DIR}/main/cpp/types/*.cpp")
 file(GLOB sources_android_javaclasses "${SRC_DIR}/main/cpp/javaclasses/*.cpp")
@@ -89,15 +90,11 @@ find_package(fbjni REQUIRED CONFIG)
 
 # includes
 
-if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
-  get_target_property(INCLUDE_reactnativejni
-       ReactAndroid::reactnative
-       INTERFACE_INCLUDE_DIRECTORIES)
-else()
-  get_target_property(INCLUDE_reactnativejni
-        ReactAndroid::reactnativejni
-        INTERFACE_INCLUDE_DIRECTORIES)
-endif()
+
+get_target_property(INCLUDE_reactnativejni
+  ReactAndroid::reactnative
+  INTERFACE_INCLUDE_DIRECTORIES
+)
 
 target_include_directories(
        ${PACKAGE_NAME}
@@ -131,16 +128,8 @@ target_link_libraries(
   ${NEW_ARCHITECTURE_DEPENDENCIES}
 )
 
-if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
-   target_link_libraries(
-    ${PACKAGE_NAME}
-    ReactAndroid::reactnative
-   )
-else()
-  target_link_libraries(
-    ${PACKAGE_NAME}
-    ReactAndroid::reactnativejni
-    ReactAndroid::folly_runtime
-    ReactAndroid::react_nativemodule_core
-  )
-endif()
+
+target_link_libraries(
+  ${PACKAGE_NAME}
+  ReactAndroid::reactnative
+)

--- a/packages/expo-modules-core/android/src/fabric/CMakeLists.txt
+++ b/packages/expo-modules-core/android/src/fabric/CMakeLists.txt
@@ -20,15 +20,10 @@ find_package(ReactAndroid REQUIRED CONFIG)
 
 find_package(fbjni REQUIRED CONFIG)
 
-if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
-  get_target_property(INCLUDE_fabricjni
-        ReactAndroid::reactnative
-        INTERFACE_INCLUDE_DIRECTORIES)
-else()
-  get_target_property(INCLUDE_fabricjni
-        ReactAndroid::fabricjni
-        INTERFACE_INCLUDE_DIRECTORIES)
-endif()
+get_target_property(INCLUDE_fabricjni
+  ReactAndroid::reactnative
+  INTERFACE_INCLUDE_DIRECTORIES
+)
 
 target_include_directories(fabric PRIVATE
   "${REACT_NATIVE_DIR}/ReactCommon"
@@ -42,22 +37,4 @@ target_link_libraries(fabric
   ReactAndroid::jsi
 )
 
-if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
-   target_link_libraries(fabric ReactAndroid::reactnative)
-else()
-  target_link_libraries(fabric
-    ReactAndroid::fabricjni
-    ReactAndroid::folly_runtime
-    ReactAndroid::glog
-    ReactAndroid::react_debug
-    ReactAndroid::react_render_componentregistry
-    ReactAndroid::react_render_core
-    ReactAndroid::react_render_debug
-    ReactAndroid::react_render_graphics
-    ReactAndroid::react_render_mapbuffer
-    ReactAndroid::react_utils
-    ReactAndroid::rrc_view
-    ReactAndroid::runtimeexecutor
-    ReactAndroid::yoga
-  )
-endif()
+target_link_libraries(fabric ReactAndroid::reactnative)


### PR DESCRIPTION
# Why

Cleans up CMake by removing configuration needed for old RN versions that are no longer supported. 
