### PR TITLE
[docs] Update instructions for drawer

### DIFF
--- a/docs/pages/router/advanced/drawer.mdx
+++ b/docs/pages/router/advanced/drawer.mdx
@@ -4,64 +4,110 @@ description: Learn how to use the Drawer layout in Expo Router.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
-To use [drawer navigator](https://reactnavigation.org/docs/drawer-based-navigation) you'll need to install some extra dependencies.
+A navigation drawer is a common pattern in mobile apps, it allows users to swipe open a menu from a side of their screen to expose navigation options. This menu is also typically toggleable through a button in the app's header.
+
+<Tabs>
+<Tab label="SDK 54 and above">
+
+To use [drawer navigator](https://reactnavigation.org/docs/drawer-based-navigation) you'll need to install some additional dependencies if you do not have them already. On Android and iOS, the drawer navigator requires `react-native-reanimated` and `react-native-worklets` to drive its animations. On web, this is handled by CSS animations.
 
 ## Installation
 
 <Terminal
   cmd={[
-    '$ npx expo install @react-navigation/drawer react-native-gesture-handler react-native-reanimated',
+    '$ npx expo install @react-navigation/drawer react-native-reanimated react-native-worklets',
   ]}
 />
 
-No additional configuration is required. [Reanimated Babel plugin](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#reanimated-babel-plugin) is automatically configured in `babel-preset-expo` when you install the library.
-
 ## Usage
 
-Now you can use the `Drawer` layout to create a drawer navigator. You'll need to wrap the `<Drawer />` in a `<GestureHandlerRootView>` to enable gestures. You only need one `<GestureHandlerRootView>` in your component tree. Any nested routes are not required to be wrapped individually.
+Now you can use the `Drawer` layout to create a drawer navigator
 
 ```tsx app/_layout.tsx
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Drawer } from 'expo-router/drawer';
 
 export default function Layout() {
-  return (
-    <GestureHandlerRootView style={{ flex: 1 }}>
-      <Drawer />
-    </GestureHandlerRootView>
-  );
+  return <Drawer />;
 }
 ```
 
 To edit the drawer navigation menu labels, titles and screen options specific screens are required as follows:
 
 ```tsx app/_layout.tsx
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Drawer } from 'expo-router/drawer';
 
 export default function Layout() {
   return (
-    <GestureHandlerRootView style={{ flex: 1 }}>
-      <Drawer>
-        <Drawer.Screen
-          name="index" // This is the name of the page and must match the url from root
-          options={{
-            drawerLabel: 'Home',
-            title: 'overview',
-          }}
-        />
-        <Drawer.Screen
-          name="user/[id]" // This is the name of the page and must match the url from root
-          options={{
-            drawerLabel: 'User',
-            title: 'overview',
-          }}
-        />
-      </Drawer>
-    </GestureHandlerRootView>
+    <Drawer>
+      <Drawer.Screen
+        name="index" // This is the name of the page and must match the url from root
+        options={{
+          drawerLabel: 'Home',
+          title: 'overview',
+        }}
+      />
+      <Drawer.Screen
+        name="user/[id]" // This is the name of the page and must match the url from root
+        options={{
+          drawerLabel: 'User',
+          title: 'overview',
+        }}
+      />
+    </Drawer>
   );
 }
 ```
 
-> **Note:** Be careful when using `react-native-gesture-handler` on the web. It can increase the JavaScript bundle size significantly. Learn more about using [platform-specific modules](/router/advanced/platform-specific-modules/).
+</Tab>
+<Tab label="SDK 53 and below">
+## Installation
+
+<Terminal
+  cmd={[
+    '$ npx expo install @react-navigation/drawer react-native-reanimated react-native-gesture-handler',
+  ]}
+/>
+
+## Usage
+
+Now you can use the `Drawer` layout to create a drawer navigator.
+
+```tsx app/_layout.tsx
+import { Drawer } from 'expo-router/drawer';
+
+export default function Layout() {
+  return <Drawer />;
+}
+```
+
+To edit the drawer navigation menu labels, titles and screen options specific screens are required as follows:
+
+```tsx app/_layout.tsx
+import { Drawer } from 'expo-router/drawer';
+
+export default function Layout() {
+  return (
+    <Drawer>
+      <Drawer.Screen
+        name="index" // This is the name of the page and must match the url from root
+        options={{
+          drawerLabel: 'Home',
+          title: 'overview',
+        }}
+      />
+      <Drawer.Screen
+        name="user/[id]" // This is the name of the page and must match the url from root
+        options={{
+          drawerLabel: 'User',
+          title: 'overview',
+        }}
+      />
+    </Drawer>
+  );
+}
+```
+
+</Tab>
+</Tabs>


### PR DESCRIPTION
# Why

- Requires installing worklets in SDK 54+
- RNGH root view isn't required and wasn't for SDK 53 either

# How

Chat with my old pal @satya164 

# Test Plan

Walk through instructions and verify they work