### PR TITLE
fix(expo-router): Fix installs for yarn v1 not pulling in `@expo/metro-runtime` (regressed in #39603)

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add `@expo/metro-runtime` to dependencies & peer dependencies to fix Yarn v1 having no auto-installs ([#39644](https://github.com/expo/expo/pull/39644) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 6.0.3 — 2025-09-12

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -128,6 +128,7 @@
     "tsd": "^0.28.1"
   },
   "dependencies": {
+    "@expo/metro-runtime": "^6.1.2",
     "@expo/schema-utils": "^0.1.7",
     "@expo/server": "^0.7.4",
     "@radix-ui/react-slot": "1.2.0",


### PR DESCRIPTION
# Why

Resolves regression from #39603
Resolves #39636 

The original intention was that users will never have to install `@expo/metro-runtime` explicitly with `expo-router`, which we tried to achieve with auto-installing peer dependencies. However, I forgot that Yarn v1 doesn't have auto-installing peer dependencies.

# How

`@expo/metro-runtime` has a few special requirements. We want it to be a required peer for `expo-router`, but an optional peer for `@expo/metro-config`, when a user adds it to non-router apps.

As such, the only solution here is to actually add it to both `dependencies` and `peerDependencies`. We shouldn't do this often and aim to only do this for this one package, aiming to replace `@expo/metro-runtime` being installed as signal in general, and moving some of its functionality to flags instead (which would be auto-flipped when `expo-router` is installed)

However, for now, this approach is actually doing what `urql` + `@urql/core` (for example) have been using for quite a while without problems. Auto-installing dependency managers (Bun, npm, pnpm) are well-behaved with this approach. Yarn v1 auto-installs forcefully but deduplicates in this case, and warns for conflicts, as expected.

# Test Plan

- `yarn pack` expo-router and add a resolution to a new template
  - test installing with Yarn v1 (auto-installs)
  - test installing with pnpm (works as before)
  - test installing with bun (works as before)
  - test installing with npm (works as before)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
