### PR TITLE
fix(cli): fix undefined logs being printed

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- fix undefined logs being printed.
 - Prevent iOS device builds from being remotely cached ([#39621](https://github.com/expo/expo/pull/39621) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- fix undefined logs being printed.
+- fix undefined logs being printed. ([#39645](https://github.com/expo/expo/pull/39645) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent iOS device builds from being remotely cached ([#39621](https://github.com/expo/expo/pull/39621) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others

--- a/packages/@expo/cli/src/log.ts
+++ b/packages/@expo/cli/src/log.ts
@@ -23,6 +23,10 @@ export function warn(...message: string[]): void {
 }
 
 export function log(...message: string[]): void {
+  if (!message.length) {
+    console.log('');
+    return;
+  }
   console.log(...message);
 }
 

--- a/packages/@expo/cli/src/log.ts
+++ b/packages/@expo/cli/src/log.ts
@@ -23,10 +23,6 @@ export function warn(...message: string[]): void {
 }
 
 export function log(...message: string[]): void {
-  if (!message.length) {
-    console.log('');
-    return;
-  }
   console.log(...message);
 }
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -40,8 +40,13 @@ class LogRespectingTerminal extends Terminal {
   constructor(stream: import('node:net').Socket | import('node:stream').Writable) {
     super(stream, { ttyPrint: true });
 
-    const sendLog = (format: string, ...args: any[]) => {
-      this.log(format, ...args);
+    const sendLog = (...msg: any[]) => {
+      if (!msg.length) {
+        this.log('');
+      } else {
+        const [format, ...args] = msg;
+        this.log(format, ...args);
+      }
       // Flush the logs to the terminal immediately so logs at the end of the process are not lost.
       this.flush();
     };


### PR DESCRIPTION
# Why

- For some reason `console.log()` is printing "undefined" instead of `\n`. This clears it in the helper function.
- Traced it to this PR https://github.com/expo/expo/pull/39546
