### PR TITLE
[docs] Fix document link on keyboard controller reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/keyboard-controller.mdx
+++ b/docs/pages/versions/unversioned/sdk/keyboard-controller.mdx
@@ -20,7 +20,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection
   packageName="react-native-keyboard-controller"
-  href="https://github.com/lottie-react-native/lottie-react-native#installing"
+  href="https://kirillzyusko.github.io/react-native-keyboard-controller/docs/installation"
 />
 
 ## Usage


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
