### PR TITLE
[contacts] Added contacts image remote uri validation

### DIFF
--- a/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
@@ -1,6 +1,7 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import * as Contacts from 'expo-contacts';
+import { Directory, File, Paths } from 'expo-file-system';
 import { Platform } from 'expo-modules-core';
 import React from 'react';
 import { RefreshControl, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
@@ -46,9 +47,32 @@ export default function ContactsScreen({ navigation }: Props) {
           <HeaderIconButton
             disabled={Platform.select({ web: true, default: false })}
             name="add"
-            onPress={() => {
+            onPress={async () => {
               const randomContact = { note: 'Likes expo...' } as Contacts.Contact;
-              ContactUtils.presentNewContactFormAsync({ contact: randomContact });
+              try {
+                // Download a placeholder avatar image
+                const destination = new Directory(Paths.cache, 'avatars');
+                destination.create();
+                const output = await File.downloadFileAsync(
+                  'https://raw.githubusercontent.com/expo/expo/main/.github/resources/banner.png',
+                  destination
+                );
+                output.rename('expo-avatar.png');
+                const localUri = output.uri;
+
+                const randomContact = {
+                  note: 'Likes expo...',
+                  image: { uri: localUri },
+                } as Contacts.Contact;
+
+                ContactUtils.presentNewContactFormAsync({
+                  contact: { ...randomContact, image: { uri: localUri } },
+                });
+              } catch (error) {
+                console.error('Failed to download avatar:', error);
+                // Fallback to contact without image
+                ContactUtils.presentNewContactFormAsync({ contact: randomContact });
+              }
             }}
           />
         </HeaderContainerRight>

--- a/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
@@ -1,6 +1,7 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import * as Contacts from 'expo-contacts';
+import { Directory, File, Paths } from 'expo-file-system';
 import { Platform } from 'expo-modules-core';
 import React from 'react';
 import { RefreshControl, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
@@ -37,6 +38,33 @@ type Props = {
 
 const CONTACT_PAGE_SIZE = 500;
 
+const handleAddContact = async () => {
+  try {
+    const destination = new Directory(Paths.document, 'avatars');
+    if (!destination.exists) {
+      destination.create();
+    }
+
+    const randomSeed = Math.floor(Math.random() * 1000);
+    const customFileName = new File(destination, `avatar-${randomSeed}.png`);
+    const output = await File.downloadFileAsync(
+      `https://robohash.org/TestUser${randomSeed}.png?size=200x200&set=set1`,
+      customFileName
+    );
+
+    const randomContact = {
+      note: 'Likes expo...',
+      image: {
+        uri: output.uri,
+      },
+    } as Contacts.Contact;
+
+    await ContactUtils.presentNewContactFormAsync({ contact: randomContact });
+  } catch (error) {
+    console.error(error);
+  }
+};
+
 export default function ContactsScreen({ navigation }: Props) {
   React.useLayoutEffect(() => {
     navigation.setOptions({
@@ -46,10 +74,7 @@ export default function ContactsScreen({ navigation }: Props) {
           <HeaderIconButton
             disabled={Platform.select({ web: true, default: false })}
             name="add"
-            onPress={() => {
-              const randomContact = { note: 'Likes expo...' } as Contacts.Contact;
-              ContactUtils.presentNewContactFormAsync({ contact: randomContact });
-            }}
+            onPress={handleAddContact}
           />
         </HeaderContainerRight>
       ),

--- a/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
@@ -1,7 +1,6 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import * as Contacts from 'expo-contacts';
-import { Directory, File, Paths } from 'expo-file-system';
 import { Platform } from 'expo-modules-core';
 import React from 'react';
 import { RefreshControl, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
@@ -47,32 +46,9 @@ export default function ContactsScreen({ navigation }: Props) {
           <HeaderIconButton
             disabled={Platform.select({ web: true, default: false })}
             name="add"
-            onPress={async () => {
+            onPress={() => {
               const randomContact = { note: 'Likes expo...' } as Contacts.Contact;
-              try {
-                // Download a placeholder avatar image
-                const destination = new Directory(Paths.cache, 'avatars');
-                destination.create();
-                const output = await File.downloadFileAsync(
-                  'https://raw.githubusercontent.com/expo/expo/main/.github/resources/banner.png',
-                  destination
-                );
-                output.rename('expo-avatar.png');
-                const localUri = output.uri;
-
-                const randomContact = {
-                  note: 'Likes expo...',
-                  image: { uri: localUri },
-                } as Contacts.Contact;
-
-                ContactUtils.presentNewContactFormAsync({
-                  contact: { ...randomContact, image: { uri: localUri } },
-                });
-              } catch (error) {
-                console.error('Failed to download avatar:', error);
-                // Fallback to contact without image
-                ContactUtils.presentNewContactFormAsync({ contact: randomContact });
-              }
+              ContactUtils.presentNewContactFormAsync({ contact: randomContact });
             }}
           />
         </HeaderContainerRight>

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Added example of using a remote image URI for a contact in bare-expo. ([#39658](https://github.com/expo/expo/pull/39658) by [@hryhoriiK97](https://github.com/hryhoriiK97))
+
 ## 15.0.8 — 2025-09-10
 
 ### 🎉 New features

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Added example of using a remote image URI for a contact in bare-expo. ([#39658](https://github.com/expo/expo/pull/39658) by [@hryhoriiK97](https://github.com/hryhoriiK97))
+- Added contacts image remote uri validation. ([#39658](https://github.com/expo/expo/pull/39658) by [@hryhoriiK97](https://github.com/hryhoriiK97))
 
 ## 15.0.8 — 2025-09-10
 

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Added contacts image remote uri validation. ([#39658](https://github.com/expo/expo/pull/39658) by [@hryhoriiK97](https://github.com/hryhoriiK97))
+- Added contact image uri validation. ([#39658](https://github.com/expo/expo/pull/39658) by [@hryhoriiK97](https://github.com/hryhoriiK97))
 
 ## 15.0.8 — 2025-09-10
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
@@ -228,18 +228,16 @@ class Contact(var contactId: String, var appContext: AppContext) {
       .withValue(CommonDataKinds.Note.NOTE, note)
     ops.add(op.build())
     op.withYieldAllowed(true)
-    if (!TextUtils.isEmpty(photoUri) || !TextUtils.isEmpty(rawPhotoUri)) {
-      val maybePhoto = rawPhotoUri ?: photoUri
-      if (!maybePhoto.isNullOrBlank()) {
-        val photo = getThumbnailBitmap(maybePhoto)
-        ops.add(
-          ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
-            .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
-            .withValue(Columns.MIMETYPE, CommonDataKinds.Photo.CONTENT_ITEM_TYPE)
-            .withValue(CommonDataKinds.Photo.PHOTO, toByteArray(photo))
-            .build()
-        )
-      }
+    val maybePhoto = rawPhotoUri ?: photoUri
+    if (!maybePhoto.isNullOrBlank()) {
+      val photo = getThumbnailBitmap(maybePhoto)
+      ops.add(
+        ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+          .withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, 0)
+          .withValue(Columns.MIMETYPE, CommonDataKinds.Photo.CONTENT_ITEM_TYPE)
+          .withValue(CommonDataKinds.Photo.PHOTO, toByteArray(photo))
+          .build()
+      )
     }
     for (map in baseModels) {
       for (item in map) {
@@ -275,23 +273,21 @@ class Contact(var contactId: String, var appContext: AppContext) {
       .withValue(CommonDataKinds.Note.NOTE, note)
     ops.add(op.build())
     op.withYieldAllowed(true)
-    if (!TextUtils.isEmpty(photoUri) || !TextUtils.isEmpty(rawPhotoUri)) {
-      val maybePhoto = rawPhotoUri ?: photoUri
-      if (!maybePhoto.isNullOrBlank()) {
-        val photo = getThumbnailBitmap(maybePhoto)
-        ops.add(
-          ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
-            .withSelection(selection, arrayOf(rawContactId, CommonDataKinds.Photo.CONTENT_ITEM_TYPE))
-            .build()
-        )
-        ops.add(
-          ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
-            .withValue(ContactsContract.Data.RAW_CONTACT_ID, rawContactId)
-            .withValue(Columns.MIMETYPE, CommonDataKinds.Photo.CONTENT_ITEM_TYPE)
-            .withValue(CommonDataKinds.Photo.PHOTO, toByteArray(photo))
-            .build()
-        )
-      }
+    val maybePhoto = rawPhotoUri ?: photoUri
+    if (!maybePhoto.isNullOrBlank()) {
+      val photo = getThumbnailBitmap(maybePhoto)
+      ops.add(
+        ContentProviderOperation.newDelete(ContactsContract.Data.CONTENT_URI)
+          .withSelection(selection, arrayOf(rawContactId, CommonDataKinds.Photo.CONTENT_ITEM_TYPE))
+          .build()
+      )
+      ops.add(
+        ContentProviderOperation.newInsert(ContactsContract.Data.CONTENT_URI)
+          .withValue(ContactsContract.Data.RAW_CONTACT_ID, rawContactId)
+          .withValue(Columns.MIMETYPE, CommonDataKinds.Photo.CONTENT_ITEM_TYPE)
+          .withValue(CommonDataKinds.Photo.PHOTO, toByteArray(photo))
+          .build()
+      )
     }
     op = ContentProviderOperation.newUpdate(ContactsContract.Contacts.CONTENT_URI)
       .withSelection("${ContactsContract.Contacts._ID}=?", arrayOf(contactId))

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
@@ -5,7 +5,6 @@ import android.content.ContentValues
 import android.database.Cursor
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.net.Uri
 import android.os.Bundle
 import android.provider.ContactsContract
 import android.provider.ContactsContract.CommonDataKinds
@@ -13,6 +12,7 @@ import android.provider.ContactsContract.CommonDataKinds.StructuredName
 import android.provider.ContactsContract.RawContacts
 import android.text.TextUtils
 import android.util.Log
+import androidx.core.net.toUri
 import expo.modules.contacts.models.BaseModel
 import expo.modules.contacts.models.DateModel
 import expo.modules.contacts.models.EmailModel
@@ -29,7 +29,6 @@ import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
-import java.io.File
 
 // TODO: MaidenName Nickname
 class Contact(var contactId: String, var appContext: AppContext) {
@@ -561,7 +560,7 @@ class Contact(var contactId: String, var appContext: AppContext) {
 
   private fun getThumbnailBitmap(photoUri: String): Bitmap {
     val context = appContext.reactContext ?: throw Exceptions.ReactContextLost()
-    val uri = Uri.parse(photoUri)
+    val uri = photoUri.toUri()
     context.contentResolver.openInputStream(uri).use { inputStream ->
       return BitmapFactory.decodeStream(inputStream)
     }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
@@ -29,6 +29,7 @@ import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
+import java.io.File
 
 // TODO: MaidenName Nickname
 class Contact(var contactId: String, var appContext: AppContext) {
@@ -553,7 +554,7 @@ class Contact(var contactId: String, var appContext: AppContext) {
 
   private fun getThumbnailBitmap(photoUri: String?): Bitmap {
     val context = appContext.reactContext ?: throw Exceptions.ReactContextLost()
-    val uri = Uri.parse(photoUri)
+    val uri = Uri.fromFile(File(photoUri))
     context.contentResolver.openInputStream(uri).use { inputStream ->
       return BitmapFactory.decodeStream(inputStream)
     }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/Contact.kt
@@ -525,7 +525,7 @@ class Contact(var contactId: String, var appContext: AppContext) {
       contactData.add(notes)
 
       if (!photoUri.isNullOrBlank()) {
-        val photo = getThumbnailBitmap(Uri.parse(photoUri).path)
+        val photo = getThumbnailBitmap(photoUri)
         val image = ContentValues().apply {
           put(Columns.MIMETYPE, CommonDataKinds.Photo.CONTENT_ITEM_TYPE)
           put(CommonDataKinds.Photo.PHOTO, toByteArray(photo))
@@ -554,7 +554,7 @@ class Contact(var contactId: String, var appContext: AppContext) {
 
   private fun getThumbnailBitmap(photoUri: String?): Bitmap {
     val context = appContext.reactContext ?: throw Exceptions.ReactContextLost()
-    val uri = Uri.fromFile(File(photoUri))
+    val uri = Uri.parse(photoUri)
     context.contentResolver.openInputStream(uri).use { inputStream ->
       return BitmapFactory.decodeStream(inputStream)
     }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsExceptions.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsExceptions.kt
@@ -20,4 +20,4 @@ class ContactUpdateException : CodedException("Given contact couldn't be updated
 
 class LookupKeyNotFoundException : CodedException("Couldn't find lookup key for contact")
 
-class RemoteImageUriException : CodedException("Remote image URIs are not supported. Please download the image first using File.downloadFileAsync from expo-file-system and provide a local URI.")
+class RemoteImageUriException(uri: String) : CodedException("Only file:// URIs are supported for contact images. Provided URI: '$uri'. Please download the image first using File.downloadFileAsync from expo-file-system and provide a local file URI.")

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsExceptions.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsExceptions.kt
@@ -20,4 +20,4 @@ class ContactUpdateException : CodedException("Given contact couldn't be updated
 
 class LookupKeyNotFoundException : CodedException("Couldn't find lookup key for contact")
 
-class RemoteImageUriException(uri: String) : CodedException("Only file:// URIs are supported for contact images. Provided URI: '$uri'. Please download the image first using File.downloadFileAsync from expo-file-system and provide a local file URI.")
+class RemoteImageUriException(uri: String) : CodedException("Only file:// URIs are supported for contact images. Provided URI: '$uri'. Download the image first using File.downloadFileAsync from expo-file-system and provide a local file URI.")

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsExceptions.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsExceptions.kt
@@ -19,3 +19,5 @@ class ContactNotFoundException : CodedException("Couldn't find contact")
 class ContactUpdateException : CodedException("Given contact couldn't be updated")
 
 class LookupKeyNotFoundException : CodedException("Couldn't find lookup key for contact")
+
+class RemoteImageUriException : CodedException("Remote image URIs are not supported. Please download the image first using File.downloadFileAsync from expo-file-system and provide a local URI.")

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
@@ -368,7 +368,6 @@ class ContactsModule : Module() {
       val image = data["image"]
       if (image is Map<*, *> && image.containsKey("uri")) {
         val uri = image["uri"] as String?
-        // Check if this is a file URI (required for local images)
         if (uri != null && !uri.startsWith("file://")) {
           throw RemoteImageUriException(uri)
         }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
@@ -367,7 +367,12 @@ class ContactsModule : Module() {
     if (data.containsKey("image")) {
       val image = data["image"]
       if (image is Map<*, *> && image.containsKey("uri")) {
-        contact.photoUri = image["uri"] as String?
+        val uri = image["uri"] as String?
+        // Check if this is a remote URI (http/https)
+        if (uri != null && (uri.startsWith("http://") || uri.startsWith("https://"))) {
+          throw RemoteImageUriException()
+        }
+        contact.photoUri = uri
         contact.hasPhoto = true
       }
     }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
@@ -368,9 +368,9 @@ class ContactsModule : Module() {
       val image = data["image"]
       if (image is Map<*, *> && image.containsKey("uri")) {
         val uri = image["uri"] as String?
-        // Check if this is a remote URI (http/https)
-        if (uri != null && (uri.startsWith("http://") || uri.startsWith("https://"))) {
-          throw RemoteImageUriException()
+        // Check if this is a file URI (required for local images)
+        if (uri != null && !uri.startsWith("file://")) {
+          throw RemoteImageUriException(uri)
         }
         contact.photoUri = uri
         contact.hasPhoto = true

--- a/packages/expo-contacts/ios/ContactsExceptions.swift
+++ b/packages/expo-contacts/ios/ContactsExceptions.swift
@@ -116,12 +116,12 @@ internal final class AccessPickerAlreadyPresentedException: Exception {
 
 internal final class RemoteImageUriException: Exception {
   private let providedUri: String
-  
+
   init(_ uri: String) {
     self.providedUri = uri
     super.init()
   }
-  
+
   override var reason: String {
     "Only file:// URIs are supported for contact images. Provided URI: '\(providedUri)'. Please download the image first using File.downloadFileAsync from expo-file-system and provide a local file URI."
   }

--- a/packages/expo-contacts/ios/ContactsExceptions.swift
+++ b/packages/expo-contacts/ios/ContactsExceptions.swift
@@ -113,3 +113,9 @@ internal final class AccessPickerAlreadyPresentedException: Exception {
     "Contact access picker is already presented"
   }
 }
+
+internal final class RemoteImageUriException: Exception {
+  override var reason: String {
+    "Remote image URIs are not supported. Please download the image first using File.downloadFileAsync from expo-file-system and provide a local URI."
+  }
+}

--- a/packages/expo-contacts/ios/ContactsExceptions.swift
+++ b/packages/expo-contacts/ios/ContactsExceptions.swift
@@ -123,6 +123,6 @@ internal final class RemoteImageUriException: Exception {
   }
 
   override var reason: String {
-    "Only file:// URIs are supported for contact images. Provided URI: '\(providedUri)'. Please download the image first using File.downloadFileAsync from expo-file-system and provide a local file URI."
+    "Only file:// URIs are supported for contact images. Provided URI: '\(providedUri)'. Download the image first using File.downloadFileAsync from expo-file-system and provide a local file URI."
   }
 }

--- a/packages/expo-contacts/ios/ContactsExceptions.swift
+++ b/packages/expo-contacts/ios/ContactsExceptions.swift
@@ -115,7 +115,14 @@ internal final class AccessPickerAlreadyPresentedException: Exception {
 }
 
 internal final class RemoteImageUriException: Exception {
+  private let providedUri: String
+  
+  init(_ uri: String) {
+    self.providedUri = uri
+    super.init()
+  }
+  
   override var reason: String {
-    "Remote image URIs are not supported. Please download the image first using File.downloadFileAsync from expo-file-system and provide a local URI."
+    "Only file:// URIs are supported for contact images. Provided URI: '\(providedUri)'. Please download the image first using File.downloadFileAsync from expo-file-system and provide a local file URI."
   }
 }

--- a/packages/expo-contacts/ios/ContactsModule.swift
+++ b/packages/expo-contacts/ios/ContactsModule.swift
@@ -553,7 +553,6 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
       throw FilePermissionException(uri)
     }
 
-    // Check if this is a file URI (required for local images)
     guard url.isFileURL else {
       throw RemoteImageUriException(uri)
     }

--- a/packages/expo-contacts/ios/ContactsModule.swift
+++ b/packages/expo-contacts/ios/ContactsModule.swift
@@ -553,6 +553,11 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
       throw FilePermissionException(uri)
     }
 
+    // Check if this is a remote URI (http/https)
+    guard url.scheme != "http" && url.scheme != "https" else {
+      throw RemoteImageUriException()
+    }
+
     let path = url.path
     let standardizedPath = NSString(string: path).standardizingPath
 

--- a/packages/expo-contacts/ios/ContactsModule.swift
+++ b/packages/expo-contacts/ios/ContactsModule.swift
@@ -553,9 +553,9 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
       throw FilePermissionException(uri)
     }
 
-    // Check if this is a remote URI (http/https)
-    guard url.scheme != "http" && url.scheme != "https" else {
-      throw RemoteImageUriException()
+    // Check if this is a file URI (required for local images)
+    guard url.isFileURL else {
+      throw RemoteImageUriException(uri)
     }
 
     let path = url.path


### PR DESCRIPTION
# Why
Based on this [issue](https://github.com/expo/expo/issues/38855), I think it would be helpful to have a validation of the remote image URI for contacts when using presentFormAsync.

<img width="300" height="700" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-14 at 21 34 27" src="https://github.com/user-attachments/assets/9f2ee3f4-e679-4de8-ae7d-b4611e9a143c" />

Fixes: #38855

# How
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
