### PR TITLE
[expo-modules-core] Add `CMAKE_OBJECT_PATH_MAX=1024` default

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -91,6 +91,7 @@ android {
           "-DUSE_HERMES=${USE_HERMES}",
           "-DIS_NEW_ARCHITECTURE_ENABLED=${isNewArchitectureEnabled}",
           "-DUNIT_TEST=${isExpoModulesCoreTests}"
+          "-DCMAKE_OBJECT_PATH_MAX=1024"
       }
     }
   }


### PR DESCRIPTION
# Why

The default on Windows is `256`, which can cause many warnings to be issued for CMake with an eventual build failure on common path lengths in a home folder, typically due to `reanimated` and `worklets` which create deeper path structures.

The default on Darwin/Linux (other platforms) is `1000`. The safe maximum on Linux and macOS is at least 1,024, sometimes higher. The default definition can be found on these lines: https://github.com/Kitware/CMake/blob/c204231bd20114e7674b1e267a393c5291364087/Source/cmLocalGenerator.cxx#L246-L250

# How

Choosing `1,024` since it's the safe maximum on macOS.

- Windows without long paths has a very low 256 limit
- Linux typically has 4,096 or higher
- macOS typically has a 1,024 limit

Hence, ignoring Windows without long paths support, we should pick `1,024` to avoid Windows being force-truncated to `256` characters in older versions of CMake on Windows. Setting this explicitly also makes errors related to this limitation explicit across platform, and hence avoids surprises.

This should be safe as long as long paths support is enabled, which is now often the default. This isn't easily observable and having the `256` limit in place actually makes it harder to identify any problems, and also enforces the limit even with long paths support.

# Test Plan

- Manually run a `./gradlew assembleDebug` build on Windows in a nested folder, such as `$HOME/Development/expo-monorepo-example/apps/example` (a pnpm structure can actually be beneficial in spotting long paths issues)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
