### PR TITLE
docs(react-native-maps): fix incorrect usage example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -108,17 +108,14 @@ const styles = StyleSheet.create({
 
 Since you are using Google as the map provider, you need to add the API key to the `react-native-maps` [config plugin](/config-plugins/introduction/). Copy your **API Key** into your project to either a **.env** file or copy it directly and then add it to your app config under the `plugins.react-native-maps.androidGoogleMapsApiKey` field like:
 
-```json app.json
+```json app.config.js
 {
   "expo": {
-    "plugins": [
-      [
-        "react-native-maps",
-        {
-          "androidGoogleMapsApiKey": "process.env.YOUR_GOOGLE_MAPS_API_KEY"
-        }
-      ]
-    ]
+    "ios": {
+      "config": {
+        "googleMapsApiKey": process.env.YOUR_GOOGLE_MAPS_API_KEY
+      }
+    },
   }
 }
 ```
@@ -157,17 +154,16 @@ Since you are using Google as the map provider, you need to add the API key to t
 
 Since you are using Google as the map provider, you need to add the API key to the `react-native-maps` [config plugin](/config-plugins/introduction/). Copy your **API Key** into your project to either a **.env** file or copy it directly and then add it to your app config under the `plugins.react-native-maps.iosGoogleMapsApiKey` field like:
 
-```json app.json
+```json app.config.js
 {
   "expo": {
-    "plugins": [
-      [
-        "react-native-maps",
-        {
-          "iosGoogleMapsApiKey": "process.env.YOUR_GOOGLE_MAPS_API_KEY"
+    "android": {
+      "config": {
+        "googleMaps": {
+          "apiKey": process.env.YOUR_GOOGLE_MAPS_API_KEY
         }
-      ]
-    ]
+      },
+    },
   }
 }
 ```


### PR DESCRIPTION
# Why

The current documentation examples are misleading:

They show using process.env inside app.json, which is not supported (should use app.config.js instead).

They place the API key in the wrong location, which triggers runtime errors.

These mistakes can easily confuse beginners and lead to errors like:

```bash
PluginError: Package "react-native-maps" does not contain a valid config plugin.
Learn more: https://docs.expo.dev/guides/config-plugins/#creating-a-plugin

Unexpected token '<'
/Users/victor/Desktop/wuf/node_modules/react-native-maps/lib/MapView.js:347
        return (<decorateMapComponent_1.ProviderContext.Provider value={this.props.provider}>
                ^

# What this PR does

Fixes the examples to use app.config.js instead of app.json.

Updates the API key placement to the correct location.