### PR TITLE
[expo] Fix spotless configuration checks 3rd party libraries

### DIFF
--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -23,7 +23,10 @@ allprojects {
   }
 }
 
-subprojects {
+subprojects { project ->
+  if (project.name.startsWith("react-native")) { return; }
+  if (project.projectDir.toString().contains("/node_modules/")) { return; }
+
   plugins.apply("com.diffplug.spotless")
   spotless {
     // note that spotless config is currently duplicated in expo-go too

--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -98,6 +98,7 @@ def ktlintTarget = '**/*.kt'
 subprojects { project ->
   if (project.name == "ReactAndroid") { return; }
   if (project.name.startsWith("vendored_")) { return; }
+  if (project.name.startsWith("react-native")) { return; }
   if (project.projectDir.toString().contains("/node_modules/")) { return; }
   if (project.projectDir.toString().contains("/modules/")) { return; }
 


### PR DESCRIPTION
# Why

Fixes spotless configuration runs 3rd-party libraries.

# How

Excludes projects that start with `react-native` and are in the `node_modules` folder.

# Test Plan

- run `./gradlew spotlessCheck`
	- expo go ✅ 
	- bare-expo ✅