### PR TITLE
[docs] mention react-native-enriched in richtext-editing

### DIFF
--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -105,6 +105,7 @@ You can use a native Android or iOS rich text editor wrapped into a React Native
 - [`react-native-aztec`](https://github.com/WordPress/gutenberg/tree/trunk/packages/react-native-aztec)
 - [`gutenberg-mobile`](https://github.com/wordpress-mobile/gutenberg-mobile)
 - [`react-native-live-markdown`](https://github.com/Expensify/react-native-live-markdown)
+- [`react-native-enriched`](https://github.com/software-mansion-labs/react-native-enriched)
 
 You can also wrap any native rich text editor using [Expo Modules](/modules/overview/), but if you use different ones on each platform, you need to unify their APIs and input formats.
 


### PR DESCRIPTION
# Why

The library just got its first release and is worth mentioning in the docs because it is a new maintained solution to the rich text editing.

# How

Added a point with the library repo link.

# Test Plan

Run the docs and open `Edit rich text` page. The new mention should be under `Native editors` section.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
