### PR TITLE
[docs] Fix inconsistencies in Authentication in Expo Router guide

### DIFF
--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -50,6 +50,7 @@ This provider uses a mock implementation. You can replace it with your own [auth
 
 ```tsx ctx.tsx
 import { use, createContext, type PropsWithChildren } from 'react';
+
 import { useStorageState } from './useStorageState';
 
 const AuthContext = createContext<{
@@ -64,7 +65,7 @@ const AuthContext = createContext<{
   isLoading: false,
 });
 
-// This hook can be used to access the user info.
+// Use this hook to access the user info.
 export function useSession() {
   const value = use(AuthContext);
   if (!value) {
@@ -175,7 +176,7 @@ export function useStorageState(key: string): UseStateHook<string> {
 
 <Step label="2">
 
-Create a **SplashScreenController** to manage the splash screen. Because loading the authentication is asynchronous we can keep the splash screen visible until the authentication has loaded.
+Create a **SplashScreenController** to manage the splash screen. Authentication loading is asynchronous, so keep the splash screen visible until authentication loads.
 
 ```tsx splash.tsx
 import { SplashScreen } from 'expo-router';
@@ -196,15 +197,16 @@ export function SplashScreenController() {
 
 <Step label="3">
 
-Use the **SessionProvider** in the root layout to provide the authentication context to the entire app. Ensure the **SplashScreenController** is inside the **SessionProvider**
+Add the `SessionProvider` to your root layout. This gives your entire app access to the authentication context. Ensure the `SplashScreenController` is inside the `SessionProvider`.
 
 ```tsx app/_layout.tsx
 import { Stack } from 'expo-router';
+
 import { SessionProvider } from '../ctx';
 import { SplashScreenController } from '../splash';
 
 export default function Root() {
-  // Set up the auth context and render our layout inside of it.
+  // Set up the auth context and render your layout inside of it.
   return (
     <SessionProvider>
       <SplashScreenController />
@@ -213,7 +215,7 @@ export default function Root() {
   );
 }
 
-// Separate this into a new component so it can access the SessionProvider context later
+// Create a new component that can access the SessionProvider context later.
 function RootNavigator() {
   return <Stack />;
 }
@@ -223,7 +225,7 @@ function RootNavigator() {
 
 <Step label="4">
 
-Create the `/sign-in` screen. It can toggle the authentication using `signIn()`. Since this screen is outside the `(app)` group, the group's layout and authentication check do not run when rendering this screen. This lets logged-out users see this screen.
+Create the `/sign-in` screen. This screen toggles authentication using `signIn()`. Since this screen is outside the `(app)` group, the group's layout and authentication check do not run when rendering this screen. This lets logged-out users access this screen.
 
 ```tsx app/sign-in.tsx|collapseHeight=480
 import { router } from 'expo-router';
@@ -238,8 +240,7 @@ export default function SignIn() {
       <Text
         onPress={() => {
           signIn();
-          // Navigate after signing in. You may want to tweak this to ensure sign-in is
-          // successful before navigating.
+          // Navigate after signing in. You may want to tweak this to ensure sign-in is successful before navigating.
           router.replace('/');
         }}>
         Sign In
@@ -253,10 +254,13 @@ export default function SignIn() {
 
 <Step label="5">
 
-Now we can modify the `<RootNavigator />` to protect routes based on our SessionProvider.
+Now modify the `RootNavigator` to protect routes based on your `SessionProvider`.
 
 ```tsx app/_layout.tsx|collapseHeight=400
-/* Keep the code the same above, just edit the RootNavigator */
+// All import statements remain the same except you need to import `useSession` from your `ctx.tsx` file.
+import { SessionProvider } from '../ctx';
+
+// All of the above code remains unchanged. Update the `RootNavigator` to protect routes based on your `SessionProvider` below.
 
 function RootNavigator() {
   const { session } = useSession();
@@ -292,7 +296,7 @@ export default function Index() {
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
       <Text
         onPress={() => {
-          // The `app/(app)/_layout.tsx` will redirect to the sign-in screen.
+          // The `app/(app)/_layout.tsx` redirects to the sign-in screen.
           signOut();
         }}>
         Sign Out
@@ -312,7 +316,7 @@ Create the **app/(app)/\_layout.tsx**:
 import { Stack } from 'expo-router';
 
 export default function AppLayout() {
-  // Renders the navigation stack for all authenticated app routes
+  // This renders the navigation stack for all authenticated app routes.
   return <Stack />;
 }
 ```
@@ -364,13 +368,12 @@ export default function AppLayout() {
 
 ## More information
 
-For more information, read the [Protected routes documentation](/router/advanced/protected/) to learn more patterns
+For more information, read the [Protected routes documentation](/router/advanced/protected/) to learn more about patterns.
 
 <VideoBoxLink
   videoId="XCTaMu0qnFY"
-  title="How to use Protected Routes in Expo Router V5 for smooth auth"
-  description="Learn how to use Protected Routes in Expo Router V5 to create an authentication flow"
-  className="mb-6"
+  title="How to use Protected Routes in Expo Router V5 and higher for smooth authentication"
+  description="Learn how to use Protected Routes in Expo Router V5 and higher to create an authentication flow."
 />
 
 ## Middleware


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix inconsistencies in the Authentication section of the Expo Router guide. It wasn't following our writing style guide, had grammatical mistakes, and examples are missing import statements.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR focuses on improving the clarity and readability of the authentication guide. The changes update instructional language, rephrase comments for better understanding, and clarify component usage and code structure.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally and visit: http://localhost:3002/router/advanced/authentication.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
