### PR TITLE
[home][iOS] Fix laggy bottom tabs

### DIFF
--- a/apps/expo-go/src/navigation/NativeBottomTabsNavigator.tsx
+++ b/apps/expo-go/src/navigation/NativeBottomTabsNavigator.tsx
@@ -38,6 +38,7 @@ function NativeBottomTabsNavigator({
     <BottomTabs
       tabBarBackgroundColor={rest.tabBarStyle?.backgroundColor}
       tabBarTintColor={rest.tabBarActiveTintColor}
+      experimentalControlNavigationStateInJS={false}
       onNativeFocusChange={({ nativeEvent: { tabKey } }) => {
         const descriptor = descriptors[tabKey];
         const route = descriptor.route;


### PR DESCRIPTION
# Why

* On native event animation starts
* Tab change gets cancelled while waiting for JS state (animation goes back to original tab)
* JS state changes (animation resumes)

# How

Add `experimentalControlNavigationStateInJS={false}`. 

## Before

https://github.com/user-attachments/assets/6cfbcd56-2904-4d4c-a68b-8aa9dce5f1ba

## After

https://github.com/user-attachments/assets/53d16747-af62-4b50-9fe5-6ec51b0bf189
