### PR TITLE
[doc] Fixed syntax for SDK upgrade

### DIFF
--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -24,20 +24,20 @@ Install the new version of the Expo package:
 
 <Tabs>
   <Tab label="npm">
-    <Terminal cmd={['$ npm install expo@^54.0.0']} />
+    <Terminal cmd={['$ npm install expo@54.0.0']} />
   </Tab>
   <Tab label="Yarn">
-    <Terminal cmd={['$ yarn add expo@^54.0.0']} />
+    <Terminal cmd={['$ yarn add expo@54.0.0']} />
   </Tab>
   <Tab label="pnpm">
-    <Terminal cmd={['$ pnpm add expo@^54.0.0']} />
+    <Terminal cmd={['$ pnpm add expo@54.0.0']} />
   </Tab>
   <Tab label="Bun">
-    <Terminal cmd={['$ bun install expo@^54.0.0']} />
+    <Terminal cmd={['$ bun install expo@54.0.0']} />
   </Tab>
 </Tabs>
 
-Depending on which SDK you're upgrading to, substitute the `expo@^54.0.0` with the version range of the Expo SDK version you're targeting. For example, `expo@^54.0.0` stands for SDK 54.
+Depending on which SDK you're upgrading to, substitute the `expo@54.0.0` with the version range of the Expo SDK version you're targeting. For example, `expo@54.0.0` stands for SDK 54.
 
 </Step>
 

--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -24,20 +24,20 @@ Install the new version of the Expo package:
 
 <Tabs>
   <Tab label="npm">
-    <Terminal cmd={['$ npm install expo@54.0.0']} />
+    <Terminal cmd={['$ npm install expo@^54.0.0']} />
   </Tab>
   <Tab label="Yarn">
-    <Terminal cmd={['$ yarn add expo@54.0.0']} />
+    <Terminal cmd={['$ yarn add expo@^54.0.0']} />
   </Tab>
   <Tab label="pnpm">
-    <Terminal cmd={['$ pnpm add expo@54.0.0']} />
+    <Terminal cmd={['$ pnpm add expo@^54.0.0']} />
   </Tab>
   <Tab label="Bun">
-    <Terminal cmd={['$ bun install expo@54.0.0']} />
+    <Terminal cmd={['$ bun install expo@^54.0.0']} />
   </Tab>
 </Tabs>
 
-Depending on which SDK you're upgrading to, substitute the `expo@54.0.0` with the version range of the Expo SDK version you're targeting. For example, `expo@54.0.0` stands for SDK 54.
+Depending on which SDK you're upgrading to, substitute the `expo@^54.0.0` with the version range of the Expo SDK version you're targeting. For example, `expo@^54.0.0` stands for SDK 54.
 
 </Step>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
The current code `npm install expo@^54.0.0` throws an error because of the inclusion of `^` in the syntax.


<img width="726" height="71" alt="Screenshot 2025-09-15 at 13 08 58" src="https://github.com/user-attachments/assets/904a2c1f-a460-4734-89c7-7808805d6005" />

<img width="1127" height="760" alt="Screenshot 2025-09-15 at 13 45 00" src="https://github.com/user-attachments/assets/051b55fa-96a1-4471-9521-73efabb7957b" />



# How

<!--
How did you build this feature or fix this bug and why?
-->
Fixed the bug by omitting `^` from the upgrade sysntax
<img width="844" height="379" alt="Screenshot 2025-09-15 at 13 43 45" src="https://github.com/user-attachments/assets/829f33cb-ad01-40e3-a0eb-c4b0b11bd924" />


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
