### PR TITLE
[docs] add info about reserved parameters

### DIFF
--- a/docs/pages/router/basics/navigation.mdx
+++ b/docs/pages/router/basics/navigation.mdx
@@ -173,6 +173,8 @@ export default function Page() {
 }
 ```
 
+> **info** Some parameters are reserved for internal use by Expo Router and React Navigation. You can find them in the [Using URL parameters guide](/router/reference/url-parameters/#reserved-parameters).
+
 ### Passing query parameters
 
 You can specify query parameters in the link URL itself, or as additional parameters in the `params` object. Any parameters that don't match the name of the dynamic route variable are equivalent to query parameters.

--- a/docs/pages/router/reference/url-parameters.mdx
+++ b/docs/pages/router/reference/url-parameters.mdx
@@ -358,3 +358,12 @@ export default function User() {
   );
 }
 ```
+
+## Reserved parameters
+
+Certain URL parameters are reserved for internal use by Expo Router and React Navigation. Avoid using these names for your own parameters to prevent conflicts:
+
+- `screen`
+- `params`
+- `initial`
+- `state`

--- a/docs/pages/router/reference/url-parameters.mdx
+++ b/docs/pages/router/reference/url-parameters.mdx
@@ -361,7 +361,7 @@ export default function User() {
 
 ## Reserved parameters
 
-Certain URL parameters are reserved for internal use by Expo Router and React Navigation. Avoid using these names for your own parameters to prevent conflicts:
+Certain URL parameters are reserved for internal use by Expo Router and React Navigation. Avoid using the following names for your own parameters to prevent conflicts:
 
 - `screen`
 - `params`


### PR DESCRIPTION
# Why

There are issues where people use reserved names for their parameters. We don't have this information anywhere in our docs.

There are also other parameters that people cannot use:
- `__internal__expo_router_is_preview_navigation`
- `__internal_expo_router_no_animation`
but since they start with `__internal__expo_router`, we can safely omit these from docs.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
