### PR TITLE
[web-browser][plugin] Fix multiple runs of prebuild without clean

### DIFF
--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix multiple runs of prebuild repeateadly adding generated code.
+
 ### 💡 Others
 
 ## 15.0.7 — 2025-09-11

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix multiple runs of prebuild repeateadly adding generated code.
+- [Android] Fix multiple runs of prebuild repeateadly adding generated code. ([#39702](https://github.com/expo/expo/pull/39702) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-web-browser/plugin/build/withWebBrowserAndroid.js
+++ b/packages/expo-web-browser/plugin/build/withWebBrowserAndroid.js
@@ -5,8 +5,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.withWebBrowserAndroid = void 0;
 const config_plugins_1 = require("expo/config-plugins");
-const promises_1 = __importDefault(require("fs/promises"));
 const fs_1 = require("fs");
+const promises_1 = __importDefault(require("fs/promises"));
 const path_1 = __importDefault(require("path"));
 const utils_1 = require("./utils");
 const withWebBrowserAndroid = (config) => {

--- a/packages/expo-web-browser/plugin/build/withWebBrowserAndroid.js
+++ b/packages/expo-web-browser/plugin/build/withWebBrowserAndroid.js
@@ -5,7 +5,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.withWebBrowserAndroid = void 0;
 const config_plugins_1 = require("expo/config-plugins");
-const fs_1 = require("fs");
+const fs_1 = __importDefault(require("fs"));
 const promises_1 = __importDefault(require("fs/promises"));
 const path_1 = __importDefault(require("path"));
 const utils_1 = require("./utils");
@@ -51,7 +51,7 @@ function addLauncherClassToProject(config) {
             const fileName = 'BrowserLauncherActivity.kt';
             const dir = path_1.default.dirname(config_plugins_1.AndroidConfig.Paths.getProjectFilePath(config.modRequest.projectRoot, 'MainApplication'));
             const fullPath = path_1.default.join(dir, fileName);
-            if ((0, fs_1.existsSync)(fullPath)) {
+            if (fs_1.default.existsSync(fullPath)) {
                 return config;
             }
             const classTemplate = `package ${config.android?.package || ''};
@@ -81,11 +81,11 @@ function modifyMainApplication(config) {
     return (0, config_plugins_1.withMainApplication)(config, (config) => {
         const mainApplication = config.modResults;
         const importsMod = (0, utils_1.addImports)(mainApplication.contents, ['android.app.Activity', 'android.os.Bundle'], false);
-        let onCreateMod = importsMod;
+        let contents = importsMod;
         if (!importsMod.includes('registerActivityLifecycleCallbacks(lifecycleCallbacks)')) {
-            onCreateMod = (0, utils_1.appendContentsInsideDeclarationBlock)(importsMod, 'onCreate', '  registerActivityLifecycleCallbacks(lifecycleCallbacks)');
+            contents = (0, utils_1.appendContentsInsideDeclarationBlock)(importsMod, 'onCreate', '  registerActivityLifecycleCallbacks(lifecycleCallbacks)');
         }
-        const result = addMainApplicationMod(onCreateMod);
+        const result = addMainApplicationMod(contents);
         return {
             ...config,
             modResults: {

--- a/packages/expo-web-browser/plugin/build/withWebBrowserAndroid.js
+++ b/packages/expo-web-browser/plugin/build/withWebBrowserAndroid.js
@@ -6,7 +6,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.withWebBrowserAndroid = void 0;
 const config_plugins_1 = require("expo/config-plugins");
 const fs_1 = __importDefault(require("fs"));
-const promises_1 = __importDefault(require("fs/promises"));
 const path_1 = __importDefault(require("path"));
 const utils_1 = require("./utils");
 const withWebBrowserAndroid = (config) => {
@@ -72,7 +71,7 @@ class BrowserLauncherActivity : Activity() {
   }
 }
 `;
-            await promises_1.default.writeFile(fullPath, classTemplate);
+            await fs_1.default.promises.writeFile(fullPath, classTemplate);
             return config;
         },
     ]);
@@ -82,8 +81,8 @@ function modifyMainApplication(config) {
         const mainApplication = config.modResults;
         const importsMod = (0, utils_1.addImports)(mainApplication.contents, ['android.app.Activity', 'android.os.Bundle'], false);
         let contents = importsMod;
-        if (!importsMod.includes('registerActivityLifecycleCallbacks(lifecycleCallbacks)')) {
-            contents = (0, utils_1.appendContentsInsideDeclarationBlock)(importsMod, 'onCreate', '  registerActivityLifecycleCallbacks(lifecycleCallbacks)');
+        if (!mainApplication.contents.includes('registerActivityLifecycleCallbacks(lifecycleCallbacks)')) {
+            contents = (0, utils_1.appendContentsInsideDeclarationBlock)(importsMod, 'onCreate', 'registerActivityLifecycleCallbacks(lifecycleCallbacks)');
         }
         const result = addMainApplicationMod(contents);
         return {

--- a/packages/expo-web-browser/plugin/src/withWebBrowserAndroid.ts
+++ b/packages/expo-web-browser/plugin/src/withWebBrowserAndroid.ts
@@ -7,8 +7,7 @@ import {
   withDangerousMod,
   withMainApplication,
 } from 'expo/config-plugins';
-import filesystem from 'fs';
-import fs from 'fs/promises';
+import fs from 'fs';
 import path from 'path';
 
 import { appendContentsInsideDeclarationBlock, addImports } from './utils';
@@ -69,7 +68,7 @@ function addLauncherClassToProject(config: ExpoConfig) {
 
       const fullPath = path.join(dir, fileName);
 
-      if (filesystem.existsSync(fullPath)) {
+      if (fs.existsSync(fullPath)) {
         return config;
       }
 
@@ -92,7 +91,7 @@ class BrowserLauncherActivity : Activity() {
 }
 `;
 
-      await fs.writeFile(fullPath, classTemplate);
+      await fs.promises.writeFile(fullPath, classTemplate);
       return config;
     },
   ]);
@@ -109,11 +108,13 @@ function modifyMainApplication(config: ExpoConfig) {
     );
 
     let contents = importsMod;
-    if (!importsMod.includes('registerActivityLifecycleCallbacks(lifecycleCallbacks)')) {
+    if (
+      !mainApplication.contents.includes('registerActivityLifecycleCallbacks(lifecycleCallbacks)')
+    ) {
       contents = appendContentsInsideDeclarationBlock(
         importsMod,
         'onCreate',
-        '  registerActivityLifecycleCallbacks(lifecycleCallbacks)'
+        'registerActivityLifecycleCallbacks(lifecycleCallbacks)'
       );
     }
 

--- a/packages/expo-web-browser/plugin/src/withWebBrowserAndroid.ts
+++ b/packages/expo-web-browser/plugin/src/withWebBrowserAndroid.ts
@@ -7,7 +7,7 @@ import {
   withDangerousMod,
   withMainApplication,
 } from 'expo/config-plugins';
-import { existsSync } from 'fs';
+import filesystem from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -69,7 +69,7 @@ function addLauncherClassToProject(config: ExpoConfig) {
 
       const fullPath = path.join(dir, fileName);
 
-      if (existsSync(fullPath)) {
+      if (filesystem.existsSync(fullPath)) {
         return config;
       }
 
@@ -108,16 +108,16 @@ function modifyMainApplication(config: ExpoConfig) {
       false
     );
 
-    let onCreateMod = importsMod;
+    let contents = importsMod;
     if (!importsMod.includes('registerActivityLifecycleCallbacks(lifecycleCallbacks)')) {
-      onCreateMod = appendContentsInsideDeclarationBlock(
+      contents = appendContentsInsideDeclarationBlock(
         importsMod,
         'onCreate',
         '  registerActivityLifecycleCallbacks(lifecycleCallbacks)'
       );
     }
 
-    const result = addMainApplicationMod(onCreateMod);
+    const result = addMainApplicationMod(contents);
 
     return {
       ...config,


### PR DESCRIPTION
# Why
Closes #39698

# How
With the `expo-web-browser` plugin, multiple runs of prebuild will make the code modifications multiple times resulting in error. Added some checks so it is safe to run multiple times without `--clean`

# Test Plan
Sandbox ✅
