### PR TITLE
[ios][audio] Fix setting audioQuality in recordings

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix setting audio quality for recordings.
+
 ### 💡 Others
 
 ## 1.0.11 — 2025-09-11

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix setting audio quality for recordings.
+- [iOS] Fix setting audio quality for recordings. ([#39705](https://github.com/expo/expo/pull/39705) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioUtils.swift
+++ b/packages/expo-audio/ios/AudioUtils.swift
@@ -125,15 +125,17 @@ struct AudioUtils {
   }
 
   static func createRecordingOptions(_ options: RecordingOptions) -> [String: Any] {
-    let strategy = options.bitRateStrategy?.toAVBitRateStrategy() ?? AVAudioBitRateStrategy_Variable
+    let strategy = options.bitRateStrategy?.toAVBitRateStrategy()
 
     var settings = [String: Any]()
 
-    if strategy == AVAudioBitRateStrategy_Variable {
-      settings[AVEncoderAudioQualityForVBRKey] = strategy
-    } else {
-      settings[AVEncoderAudioQualityKey] = strategy
+    if let strategy {
+      settings[AVEncoderBitRateStrategyKey] = strategy
     }
+
+    let usesVBRQualityKey = strategy == AVAudioBitRateStrategy_Variable || strategy == AVAudioBitRateStrategy_VariableConstrained
+    let qualityKey = usesVBRQualityKey ? AVEncoderAudioQualityForVBRKey : AVEncoderAudioQualityKey
+    settings[qualityKey] = options.audioQuality
     settings[AVSampleRateKey] = options.sampleRate
     settings[AVNumberOfChannelsKey] = options.numberOfChannels
     settings[AVEncoderBitRateKey] = options.bitRate


### PR DESCRIPTION
# Why
Noticed that audio quality is not correctly set in recordings. 

# How
We are applying the strategy to the quality keys which is incorrect and ignoring the users selected `audioQuality`. Because of this the audio quality was always set to the default. 

# Test Plan
Bare-expo. Noticeable difference in recording quality when setting low quality options. 

