### PR TITLE
[video/jest] Fix mocks for expo-video

### DIFF
--- a/apps/jest-expo-mock-generator/App.tsx
+++ b/apps/jest-expo-mock-generator/App.tsx
@@ -11,6 +11,7 @@ const blacklist = [
   'ExpoLinking',
   'ExpoFont',
   'ExpoFileSystem',
+  'ExpoVideo',
 ];
 
 type ModuleRegistrySchema = [

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [Android] Fix media controls (e.g. bluetooth) not working when `ExpoVideoPlaybackService` is not registered. ([#40728](https://github.com/expo/expo/pull/40728) by [@behenate](https://github.com/behenate))
 - [Web] Fix crash on older versions of Safari. ([#41101](https://github.com/expo/expo/pull/41101) by [@CamWass](https://github.com/CamWass))
 - [Web] Fix video pausing when entering fullscreen in electron apps. ([#40989](https://github.com/expo/expo/pull/40989) by [@behenate](https://github.com/behenate))
+- Fix mocks for the `jest-expo` preset. ([#39707](https://github.com/expo/expo/pull/39707) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/mocks/ExpoVideo.ts
+++ b/packages/expo-video/mocks/ExpoVideo.ts
@@ -1,0 +1,125 @@
+import type { VideoPlayerStatus, BufferOptions, AudioMixingMode, VideoThumbnail } from '../src';
+
+export type VideoContentFit = any;
+
+export type CGVector = any;
+
+export type FullscreenOptions = any;
+
+export type VideoSource = any;
+
+export type CMTime = any;
+
+export type VideoThumbnailOptions = any;
+
+export type VideoTrack = any;
+
+export type SubtitleTrack = any;
+
+export type AudioTrack = any;
+
+export function isPictureInPictureSupported(): boolean {
+  return false;
+}
+
+export function getCurrentVideoCacheSize(): any {}
+
+export async function setVideoCacheSizeAsync(size: void): Promise<any> {}
+
+export async function clearVideoCacheAsync(): Promise<any> {}
+
+export type VideoViewProps = {
+  player: typeof VideoPlayer | undefined;
+  nativeControls: boolean | undefined;
+  contentFit: VideoContentFit | undefined;
+  contentPosition: CGVector | undefined;
+  allowsFullscreen: boolean | undefined;
+  fullscreenOptions: FullscreenOptions | undefined;
+  showsTimecodes: boolean | undefined;
+  requiresLinearPlayback: boolean | undefined;
+  allowsPictureInPicture: boolean | undefined;
+  startsPictureInPictureAutomatically: boolean | undefined;
+  allowsVideoFrameAnalysis: boolean | undefined;
+  onPictureInPictureStart: (event: any) => void;
+  onPictureInPictureStop: (event: any) => void;
+  onFullscreenEnter: (event: any) => void;
+  onFullscreenExit: (event: any) => void;
+  onFirstFrameRender: (event: any) => void;
+};
+
+export function VideoView(props: VideoViewProps) {}
+
+export type VideoAirPlayButtonViewProps = {
+  tint: any | undefined;
+  activeTint: any | undefined;
+  prioritizeVideoDevices: boolean | undefined;
+  onBeginPresentingRoutes: (event: any) => void;
+  onEndPresentingRoutes: (event: any) => void;
+};
+
+export function VideoAirPlayButtonView(props: VideoAirPlayButtonViewProps) {}
+
+export const VideoPlayer = (source: VideoSource, useSynchronousReplace?: boolean) => ({
+  // ----------------------------------------------------------------
+  // Readonly Properties (with default mock values)
+  // ----------------------------------------------------------------
+  playing: false,
+  currentLiveTimestamp: null,
+  currentOffsetFromLive: null,
+  duration: 0,
+  isLive: false,
+  status: 'idle' as VideoPlayerStatus,
+  bufferedPosition: 0,
+  availableAudioTracks: [] as AudioTrack[],
+  availableSubtitleTracks: [] as SubtitleTrack[],
+  videoTrack: null as VideoTrack | null,
+  availableVideoTracks: [] as VideoTrack[],
+  isExternalPlaybackActive: false,
+
+  // ----------------------------------------------------------------
+  // Writable Properties (with default mock values)
+  // ----------------------------------------------------------------
+  loop: false,
+  allowsExternalPlayback: true,
+  audioMixingMode: 'auto' as AudioMixingMode,
+  muted: false,
+  currentTime: 0,
+  targetOffsetFromLive: 0,
+  volume: 1.0,
+  preservesPitch: true,
+  timeUpdateEventInterval: 0,
+  playbackRate: 1.0,
+  keepScreenOnWhilePlaying: true,
+  showNowPlayingNotification: false,
+  staysActiveInBackground: false,
+  bufferOptions: {
+    preferForwardBuffer: false,
+    maxBitrate: 0,
+    minTime: 0,
+    maxTime: 0,
+  } as BufferOptions,
+  subtitleTrack: null as SubtitleTrack | null,
+  audioTrack: null as AudioTrack | null,
+
+  // ----------------------------------------------------------------
+  // Methods (mocked with jest.fn() or simple functions)
+  // ----------------------------------------------------------------
+  play: jest.fn(),
+  pause: jest.fn(),
+  replace: jest.fn(),
+  seekBy: jest.fn(),
+  replay: jest.fn(),
+  release: jest.fn(), // From SharedObject parent class
+
+  // Async Methods
+  replaceAsync: jest.fn().mockResolvedValue(undefined),
+  generateThumbnailsAsync: jest.fn().mockResolvedValue([] as VideoThumbnail[]),
+
+  // --- Methods from SharedObject ---
+  // You can add mock implementations for event listeners if needed
+  addListener: jest.fn(() => ({ remove: jest.fn() })),
+  removeListener: jest.fn(),
+  removeAllListeners: jest.fn(),
+  emit: jest.fn(),
+  listenerCount: jest.fn().mockReturnValue(0),
+});

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Improve local mock lookup. ([#39743](https://github.com/expo/expo/pull/39743) by [@aleqsio](https://github.com/aleqsio))
 - Remove `experiments.reactCanary` support in favor of built-in React +19.1 support. ([#40386](https://github.com/expo/expo/pull/40386) by [@EvanBacon](https://github.com/EvanBacon))
 - Fixed check-packages error on Windows. ([#41194](https://github.com/expo/expo/pull/41194) by [@kudo](https://github.com/kudo))
+- Remove `expo-video` mocks, update other mocks. ([#39707](https://github.com/expo/expo/pull/39707) by [@behenate](https://github.com/behenate))
 
 ### ⚠️ Notices
 

--- a/packages/jest-expo/src/preset/moduleMocks/expoModules.js
+++ b/packages/jest-expo/src/preset/moduleMocks/expoModules.js
@@ -100,6 +100,7 @@ module.exports = {
             argumentsCount: 0,
             key: 'setSystemBrightnessModeAsync',
           },
+          { name: 'useSystemBrightnessAsync', argumentsCount: 0, key: 'useSystemBrightnessAsync' },
         ],
         ExpoCalendar: [
           {
@@ -265,6 +266,7 @@ module.exports = {
         ExpoFontUtils: [
           { name: 'renderToImageAsync', argumentsCount: 2, key: 'renderToImageAsync' },
         ],
+        ExpoGlassEffect: [],
         ExpoGo: [{ name: 'getModulesSchema', argumentsCount: 0, key: 'getModulesSchema' }],
         ExpoHaptics: [
           { name: 'impactAsync', argumentsCount: 1, key: 'impactAsync' },
@@ -391,7 +393,17 @@ module.exports = {
           { name: 'requestPermissionsAsync', argumentsCount: 1, key: 'requestPermissionsAsync' },
           { name: 'saveToLibraryAsync', argumentsCount: 1, key: 'saveToLibraryAsync' },
         ],
+        ExpoMediaLibraryNext: [
+          { name: 'createAlbum', argumentsCount: 2, key: 'createAlbum' },
+          { name: 'createAsset', argumentsCount: 2, key: 'createAsset' },
+          { name: 'deleteManyAlbums', argumentsCount: 2, key: 'deleteManyAlbums' },
+          { name: 'deleteManyAssets', argumentsCount: 1, key: 'deleteManyAssets' },
+          { name: 'getAllAlbums', argumentsCount: 0, key: 'getAllAlbums' },
+          { name: 'getPermissionsAsync', argumentsCount: 1, key: 'getPermissionsAsync' },
+          { name: 'requestPermissionsAsync', argumentsCount: 1, key: 'requestPermissionsAsync' },
+        ],
         ExpoMeshGradient: [],
+        ExpoModulesCoreJSLogger: [],
         ExponentAccelerometer: [
           { name: 'isAvailableAsync', argumentsCount: 0, key: 'isAvailableAsync' },
           { name: 'setUpdateInterval', argumentsCount: 1, key: 'setUpdateInterval' },
@@ -435,7 +447,7 @@ module.exports = {
           { name: 'uploadTaskStartAsync', argumentsCount: 4, key: 'uploadTaskStartAsync' },
           { name: 'writeAsStringAsync', argumentsCount: 3, key: 'writeAsStringAsync' },
         ],
-        ExpoGL: [],
+        ExponentGLView: [],
         ExponentGyroscope: [
           { name: 'isAvailableAsync', argumentsCount: 0, key: 'isAvailableAsync' },
           { name: 'setUpdateInterval', argumentsCount: 1, key: 'setUpdateInterval' },
@@ -568,7 +580,6 @@ module.exports = {
           },
         ],
         ExpoRouterNativeLinkPreview: [],
-        ExpoRouter: [],
         ExpoScreenCapture: [
           { name: 'allowScreenCapture', argumentsCount: 0, key: 'allowScreenCapture' },
           {
@@ -663,16 +674,6 @@ module.exports = {
           { name: 'reload', argumentsCount: 0, key: 'reload' },
           { name: 'setExtraParamAsync', argumentsCount: 2, key: 'setExtraParamAsync' },
         ],
-        ExpoVideo: [
-          { name: 'clearVideoCacheAsync', argumentsCount: 0, key: 'clearVideoCacheAsync' },
-          { name: 'getCurrentVideoCacheSize', argumentsCount: 0, key: 'getCurrentVideoCacheSize' },
-          {
-            name: 'isPictureInPictureSupported',
-            argumentsCount: 0,
-            key: 'isPictureInPictureSupported',
-          },
-          { name: 'setVideoCacheSizeAsync', argumentsCount: 1, key: 'setVideoCacheSizeAsync' },
-        ],
         ExpoVideoThumbnails: [{ name: 'getThumbnail', argumentsCount: 2, key: 'getThumbnail' }],
         ExpoVideoView: [{ name: 'setFullscreen', argumentsCount: 2, key: 'setFullscreen' }],
         ExpoWebBrowser: [
@@ -692,6 +693,8 @@ module.exports = {
         FileSystem: [
           { name: 'downloadFileAsync', argumentsCount: 3, key: 'downloadFileAsync' },
           { name: 'info', argumentsCount: 1, key: 'info' },
+          { name: 'pickDirectoryAsync', argumentsCount: 1, key: 'pickDirectoryAsync' },
+          { name: 'pickFileAsync', argumentsCount: 2, key: 'pickFileAsync' },
         ],
         NotificationsServerRegistrationModule: [
           { name: 'getInstallationIdAsync', argumentsCount: 0, key: 'getInstallationIdAsync' },
@@ -705,11 +708,7 @@ module.exports = {
     modulesConstants: {
       type: 'mock',
       mockDefinition: {
-        EASClient: {
-          addListener: { type: 'function' },
-          clientID: { type: 'string' },
-          removeListeners: { type: 'function' },
-        },
+        EASClient: { addListener: { type: 'function' }, removeListeners: { type: 'function' } },
         ExpoAppleAuthentication: {
           addListener: { type: 'function' },
           formatFullName: { type: 'function' },
@@ -720,14 +719,10 @@ module.exports = {
         },
         ExpoApplication: {
           addListener: { type: 'function' },
-          applicationId: { type: 'string' },
-          applicationName: { type: 'string' },
           getApplicationReleaseTypeAsync: { type: 'function' },
           getInstallationTimeAsync: { type: 'function' },
           getIosIdForVendorAsync: { type: 'function' },
           getPushNotificationServiceEnvironmentAsync: { type: 'function' },
-          nativeApplicationVersion: { type: 'string' },
-          nativeBuildVersion: { type: 'string' },
           removeListeners: { type: 'function' },
         },
         ExpoAsset: {
@@ -782,7 +777,6 @@ module.exports = {
           getBatteryLevelAsync: { type: 'function' },
           getBatteryStateAsync: { type: 'function' },
           isLowPowerModeEnabledAsync: { type: 'function' },
-          isSupported: { type: 'boolean', mock: false },
           removeListeners: { type: 'function' },
         },
         ExpoBlurView: { addListener: { type: 'function' }, removeListeners: { type: 'function' } },
@@ -842,18 +836,12 @@ module.exports = {
         },
         ExpoCellular: {
           addListener: { type: 'function' },
-          allowsVoip: { type: 'null' },
           allowsVoipAsync: { type: 'function' },
-          carrier: { type: 'null' },
-          generation: { type: 'number', mock: 0 },
           getCarrierNameAsync: { type: 'function' },
           getCellularGenerationAsync: { type: 'function' },
           getIsoCountryCodeAsync: { type: 'function' },
           getMobileCountryCodeAsync: { type: 'function' },
           getMobileNetworkCodeAsync: { type: 'function' },
-          isoCountryCode: { type: 'null' },
-          mobileCountryCode: { type: 'null' },
-          mobileNetworkCode: { type: 'null' },
           removeListeners: { type: 'function' },
         },
         ExpoContactAccessButton: {
@@ -887,24 +875,10 @@ module.exports = {
         },
         ExpoDevice: {
           addListener: { type: 'function' },
-          brand: { type: 'string' },
-          deviceName: { type: 'string' },
-          deviceType: { type: 'number', mock: 1 },
-          deviceYearClass: { type: 'number', mock: 2025 },
           getDeviceTypeAsync: { type: 'function' },
           getUptimeAsync: { type: 'function' },
-          isDevice: { type: 'boolean', mock: false },
           isRootedExperimentalAsync: { type: 'function' },
-          manufacturer: { type: 'string' },
-          modelId: { type: 'string' },
-          modelName: { type: 'string' },
-          osBuildId: { type: 'string' },
-          osInternalBuildId: { type: 'string' },
-          osName: { type: 'string' },
-          osVersion: { type: 'string' },
           removeListeners: { type: 'function' },
-          supportedCpuArchitectures: { type: 'array' },
-          totalMemory: { type: 'unknown' },
         },
         ExpoDocumentPicker: {
           addListener: { type: 'function' },
@@ -931,6 +905,10 @@ module.exports = {
           removeListeners: { type: 'function' },
           renderToImageAsync: { type: 'function' },
         },
+        ExpoGlassEffect: {
+          addListener: { type: 'function' },
+          removeListeners: { type: 'function' },
+        },
         ExpoGo: {
           addListener: { type: 'function' },
           expoVersion: { type: 'string' },
@@ -946,7 +924,6 @@ module.exports = {
           selectionAsync: { type: 'function' },
         },
         ExpoHead: {
-          activities: { type: 'object' },
           addListener: { type: 'function' },
           clearActivitiesAsync: { type: 'function' },
           createActivity: { type: 'function' },
@@ -981,9 +958,6 @@ module.exports = {
         ExpoLinearGradient: {
           addListener: { type: 'function' },
           removeListeners: { type: 'function' },
-        },
-        ExpoGlassEffect: {
-          isLiquidGlassAvailable: { type: 'string' },
         },
         ExpoLivePhoto: { addListener: { type: 'function' }, removeListeners: { type: 'function' } },
         ExpoLocalAuthentication: {
@@ -1030,7 +1004,6 @@ module.exports = {
         ExpoMediaLibrary: {
           addAssetsToAlbumAsync: { type: 'function' },
           addListener: { type: 'function' },
-          CHANGE_LISTENER_NAME: { type: 'string' },
           createAlbumAsync: { type: 'function' },
           createAssetAsync: { type: 'function' },
           deleteAlbumsAsync: { type: 'function' },
@@ -1041,15 +1014,28 @@ module.exports = {
           getAssetsAsync: { type: 'function' },
           getMomentsAsync: { type: 'function' },
           getPermissionsAsync: { type: 'function' },
-          MediaType: { type: 'object' },
           presentPermissionsPickerAsync: { type: 'function' },
           removeAssetsFromAlbumAsync: { type: 'function' },
           removeListeners: { type: 'function' },
           requestPermissionsAsync: { type: 'function' },
           saveToLibraryAsync: { type: 'function' },
-          SortBy: { type: 'object' },
+        },
+        ExpoMediaLibraryNext: {
+          addListener: { type: 'function' },
+          createAlbum: { type: 'function' },
+          createAsset: { type: 'function' },
+          deleteManyAlbums: { type: 'function' },
+          deleteManyAssets: { type: 'function' },
+          getAllAlbums: { type: 'function' },
+          getPermissionsAsync: { type: 'function' },
+          removeListeners: { type: 'function' },
+          requestPermissionsAsync: { type: 'function' },
         },
         ExpoMeshGradient: {
+          addListener: { type: 'function' },
+          removeListeners: { type: 'function' },
+        },
+        ExpoModulesCoreJSLogger: {
           addListener: { type: 'function' },
           removeListeners: { type: 'function' },
         },
@@ -1062,7 +1048,7 @@ module.exports = {
         ExponentConstants: {
           addListener: { type: 'function' },
           appOwnership: { type: 'string' },
-          debugMode: { type: 'boolean', mock: true },
+          debugMode: { type: 'boolean', mock: false },
           deviceName: { type: 'string' },
           executionEnvironment: { type: 'string' },
           experienceUrl: { type: 'string' },
@@ -1083,7 +1069,6 @@ module.exports = {
         ExponentDeviceMotion: {
           addListener: { type: 'function' },
           getPermissionsAsync: { type: 'function' },
-          Gravity: { type: 'number', mock: 9.80665 },
           isAvailableAsync: { type: 'function' },
           removeListeners: { type: 'function' },
           requestPermissionsAsync: { type: 'function' },
@@ -1091,11 +1076,8 @@ module.exports = {
         },
         ExponentFileSystem: {
           addListener: { type: 'function' },
-          bundleDirectory: { type: 'string' },
-          cacheDirectory: { type: 'string' },
           copyAsync: { type: 'function' },
           deleteAsync: { type: 'function' },
-          documentDirectory: { type: 'string' },
           downloadAsync: { type: 'function' },
           downloadResumablePauseAsync: { type: 'function' },
           downloadResumableStartAsync: { type: 'function' },
@@ -1112,7 +1094,7 @@ module.exports = {
           uploadTaskStartAsync: { type: 'function' },
           writeAsStringAsync: { type: 'function' },
         },
-        ExpoGL: {
+        ExponentGLView: {
           addListener: { type: 'function' },
           removeListeners: { type: 'function' },
         },
@@ -1200,7 +1182,6 @@ module.exports = {
         },
         ExpoPrint: {
           addListener: { type: 'function' },
-          Orientation: { type: 'object' },
           print: { type: 'function' },
           printToFileAsync: { type: 'function' },
           removeListeners: { type: 'function' },
@@ -1211,10 +1192,6 @@ module.exports = {
           getDevicePushTokenAsync: { type: 'function' },
           removeListeners: { type: 'function' },
           unregisterForNotificationsAsync: { type: 'function' },
-        },
-        ExpoRouter: {
-          Material3Color: { type: 'function' },
-          Material3DynamicColor: { type: 'function' },
         },
         ExpoRouterNativeLinkPreview: {
           addListener: { type: 'function' },
@@ -1240,10 +1217,6 @@ module.exports = {
         },
         ExpoSecureStore: {
           addListener: { type: 'function' },
-          AFTER_FIRST_UNLOCK: { type: 'number', mock: 0 },
-          AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: { type: 'number', mock: 1 },
-          ALWAYS: { type: 'number', mock: 2 },
-          ALWAYS_THIS_DEVICE_ONLY: { type: 'number', mock: 4 },
           canUseBiometricAuthentication: { type: 'function' },
           deleteValueWithKeyAsync: { type: 'function' },
           getValueWithKeyAsync: { type: 'function' },
@@ -1251,9 +1224,6 @@ module.exports = {
           removeListeners: { type: 'function' },
           setValueWithKeyAsync: { type: 'function' },
           setValueWithKeySync: { type: 'function' },
-          WHEN_PASSCODE_SET_THIS_DEVICE_ONLY: { type: 'number', mock: 3 },
-          WHEN_UNLOCKED: { type: 'number', mock: 5 },
-          WHEN_UNLOCKED_THIS_DEVICE_ONLY: { type: 'number', mock: 6 },
         },
         ExpoSharing: {
           addListener: { type: 'function' },
@@ -1280,7 +1250,6 @@ module.exports = {
           addListener: { type: 'function' },
           backupDatabaseAsync: { type: 'function' },
           backupDatabaseSync: { type: 'function' },
-          defaultDatabaseDirectory: { type: 'string' },
           deleteDatabaseAsync: { type: 'function' },
           deleteDatabaseSync: { type: 'function' },
           ensureDatabasePathExistsAsync: { type: 'function' },
@@ -1321,21 +1290,13 @@ module.exports = {
           isEmergencyLaunch: { type: 'boolean', mock: false },
           isEnabled: { type: 'boolean', mock: true },
           isUsingEmbeddedAssets: { type: 'boolean', mock: false },
-          launchDuration: { type: 'number', mock: 455.30903339385986 },
+          launchDuration: { type: 'number', mock: 3780.5049419403076 },
           readLogEntriesAsync: { type: 'function' },
           reload: { type: 'function' },
           removeListeners: { type: 'function' },
           runtimeVersion: { type: 'string' },
           setExtraParamAsync: { type: 'function' },
           shouldDeferToNativeForAPIMethodAvailabilityInDevelopment: { type: 'boolean', mock: true },
-        },
-        ExpoVideo: {
-          addListener: { type: 'function' },
-          clearVideoCacheAsync: { type: 'function' },
-          getCurrentVideoCacheSize: { type: 'function' },
-          isPictureInPictureSupported: { type: 'function' },
-          removeListeners: { type: 'function' },
-          setVideoCacheSizeAsync: { type: 'function' },
         },
         ExpoVideoThumbnails: {
           addListener: { type: 'function' },
@@ -1345,10 +1306,6 @@ module.exports = {
         ExpoVideoView: {
           addListener: { type: 'function' },
           removeListeners: { type: 'function' },
-          ScaleAspectFill: { type: 'unknown' },
-          ScaleAspectFit: { type: 'unknown' },
-          ScaleNone: { type: 'unknown' },
-          ScaleToFill: { type: 'unknown' },
           setFullscreen: { type: 'function' },
         },
         ExpoWebBrowser: {
@@ -1365,13 +1322,11 @@ module.exports = {
         },
         FileSystem: {
           addListener: { type: 'function' },
-          appleSharedContainers: { type: 'object' },
           availableDiskSpace: { type: 'property' },
-          bundleDirectory: { type: 'string' },
-          cacheDirectory: { type: 'string' },
-          documentDirectory: { type: 'string' },
           downloadFileAsync: { type: 'function' },
           info: { type: 'function' },
+          pickDirectoryAsync: { type: 'function' },
+          pickFileAsync: { type: 'function' },
           removeListeners: { type: 'function' },
           totalDiskSpace: { type: 'property' },
         },
@@ -1428,6 +1383,16 @@ module.exports = {
             'webviewDebuggingEnabled',
           ],
         },
+        ExpoGlassEffect: {
+          propNames: [
+            'borderCurve',
+            'borderRadius',
+            'glassEffectStyle',
+            'isInteractive',
+            'spacing',
+            'tintColor',
+          ],
+        },
         ExpoImage: {
           propNames: [
             'accessibilityLabel',
@@ -1454,11 +1419,12 @@ module.exports = {
         ExpoLivePhoto: {
           propNames: ['contentFit', 'isMuted', 'source', 'useDefaultGestureRecognizer'],
         },
-        ExpoGL: { propNames: ['enableExperimentalWorkletSupport', 'msaaSamples'] },
+        ExponentGLView: { propNames: ['enableExperimentalWorkletSupport', 'msaaSamples'] },
         ExpoRouterNativeLinkPreview: {
           propNames: [
             'destructive',
             'disabled',
+            'disableForceFlatten',
             'displayAsPalette',
             'displayInline',
             'icon',
@@ -1469,24 +1435,6 @@ module.exports = {
             'singleSelection',
             'tabPath',
             'title',
-          ],
-        },
-        ExpoVideo: {
-          propNames: [
-            'activeTint',
-            'allowsFullscreen',
-            'allowsPictureInPicture',
-            'allowsVideoFrameAnalysis',
-            'contentFit',
-            'contentPosition',
-            'fullscreenOptions',
-            'nativeControls',
-            'player',
-            'prioritizeVideoDevices',
-            'requiresLinearPlayback',
-            'showsTimecodes',
-            'startsPictureInPictureAutomatically',
-            'tint',
           ],
         },
         ExpoVideoView: { propNames: ['resizeMode', 'source', 'status', 'useNativeControls'] },


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/37842

Jest doesn't currently work with expo-video

# How

I tried to use the new mock generator (running ` npx expo-modules-test-core generate-ts-mocks`) but it didn't generate a valid mock. 

For now pasted the typescript definition into ChatGPT and asked it to generate a mock 🤷. Seems to be working.

# Test Plan

Tested in the repro app provided by the user