### PR TITLE
feat(cli): Add `--api-only` as an alias for `--no-ssg` to `expo export -p web`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 - Added MCP tunnel integration. ([#39392](https://github.com/expo/expo/pull/39392) by [@kudo](https://github.com/kudo))
 - Allow `experiments.autolinkingModuleResolution` to apply to web bundling ([#39701](https://github.com/expo/expo/pull/39701) by [@kitten](https://github.com/kitten))
+- Add `--api-only` as an alias for `--ssg-only` to `expo export -p web` ([#39709](https://github.com/expo/expo/pull/39709) by [@kitten](https://github.com/kitten))
 
 ## 54.0.5 — 2025-09-13
 

--- a/packages/@expo/cli/e2e/__tests__/export.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export.test.ts
@@ -62,7 +62,7 @@ it('runs `npx expo export --help`', async () => {
         --no-bytecode              Prevent generating Hermes bytecode
         --max-workers <number>     Maximum number of tasks to allow the bundler to spawn
         --dump-assetmap            Emit an asset map for further processing
-        --no-ssg                   Skip exporting static HTML files for web routes
+        --no-ssg, --api-only       Skip exporting static HTML files and only export API routes for web
         -p, --platform <platform>  Options: android, ios, web, all. Default: all
         -s, --source-maps          Emit JavaScript source maps
         -c, --clear                Clear the bundler cache

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -20,6 +20,7 @@ export const expoExport: Command = async (argv) => {
       '--no-minify': Boolean,
       '--no-bytecode': Boolean,
       '--no-ssg': Boolean,
+      '--api-only': Boolean,
       '--unstable-hosted-native': Boolean,
 
       // Hack: This is added because EAS CLI always includes the flag.
@@ -54,7 +55,7 @@ export const expoExport: Command = async (argv) => {
         `--no-bytecode              Prevent generating Hermes bytecode`,
         `--max-workers <number>     Maximum number of tasks to allow the bundler to spawn`,
         `--dump-assetmap            Emit an asset map for further processing`,
-        `--no-ssg                   Skip exporting static HTML files for web routes`,
+        `--no-ssg, --api-only       Skip exporting static HTML files and only export API routes for web`,
         chalk`-p, --platform <platform>  Options: android, ios, web, all. {dim Default: all}`,
         `-s, --source-maps          Emit JavaScript source maps`,
         `-c, --clear                Clear the bundler cache`,

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -92,6 +92,6 @@ export async function resolveOptionsAsync(projectRoot: string, args: any): Promi
     maxWorkers: args['--max-workers'],
     dumpAssetmap: !!args['--dump-assetmap'],
     sourceMaps: !!args['--source-maps'],
-    skipSSG: !!args['--no-ssg'],
+    skipSSG: !!args['--no-ssg'] || !!args['--api-only'],
   };
 }


### PR DESCRIPTION
# Why

The `--no-ssg` name is a little misleading. It doesn't clarify what happens to assets and isn't very precise. Neither is `--api-only`. However, having both present temporarily may clarify this better and convey the intention better.

Basically, both arguments are temporary until we have per-route settings for how they're rendered (e.g. when we have SSR, we can allow a per-route config of SPA/SSG/SSR), but right now, we should make sure the arugment matches its current use-cases better (dual-deployment implies `--no-ssg` always, but `--api-only` is a better match for that as well; and RSC is an API route bur related to pages)

# How

- Add alias of `--api-only` that's equivalent to `--no-ssg` to `export -p web`

# Test Plan

- Manually tested

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
