### PR TITLE
fix(expo): Remove properties added upstream from `react-native-web.d.ts` overlay

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Remove overlapping properties that were defined upstream from `react-native-web.d.ts` ([#39710](https://github.com/expo/expo/pull/39710) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 54.0.7 — 2025-09-13

--- a/packages/expo/types/react-native-web.d.ts
+++ b/packages/expo/types/react-native-web.d.ts
@@ -45,15 +45,9 @@ declare module 'react-native' {
     /** @platform web */
     backgroundSize?: string;
     /** @platform web */
-    boxShadow?: string;
-    /** @platform web */
     boxSizing?: string;
     /** @platform web */
     clip?: string;
-    /** @platform web */
-    cursor?: string;
-    /** @platform web */
-    filter?: string;
     /** @platform web */
     gridAutoColumns?: string;
     /** @platform web */
@@ -80,8 +74,6 @@ declare module 'react-native' {
     gridTemplateAreas?: string;
     /** @platform web */
     outline?: string;
-    /** @platform web */
-    outlineColor?: string;
     /** @platform web */
     overflowX?: string;
     /** @platform web */
@@ -225,8 +217,6 @@ declare module 'react-native' {
     transitionProperty?: string | string[];
     /** @platform web */
     transitionTimingFunction?: string | Function | (string | Function)[];
-    /** @platform web */
-    userSelect?: string;
     /** @platform web */
     visibility?: string;
     /** @platform web */


### PR DESCRIPTION
# Why

Resolves #34389

Some properties we're overlaying in `react-native-web.d.ts` have now been defined upstream as native built-ins.

# How

- Remove properties that were added in `react-native` from `react-native-web.d.ts`' overrides

# Test Plan

- Open file to check type errors

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
