### PR TITLE
[image][Android] Bumps Glide to `5.0.5`

### DIFF
--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     dbFlowVersion = '4.2.4'
     buildToolsVersion = '36.0.0'
     kotlinVersion = "2.1.20"
+    kspVersion = "2.1.20-2.0.1"
     gradleDownloadTaskVersion = '5.0.1'
     repositoryUrl = "file:${System.env.HOME}/.m2/repository/"
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [Android] Upgrades Glide to `5.0.5`.
+- [Android] Upgrades Glide to `5.0.5`. ([#39713](https://github.com/expo/expo/pull/39713) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [Android] Upgrades Glide to `5.0.5`.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -1,8 +1,16 @@
+buildscript {
+  dependencies {
+    classpath "com.google.devtools.ksp:symbol-processing-gradle-plugin:${rootProject["kspVersion"]}"
+  }
+}
+
 plugins {
   id 'com.android.library'
   id 'kotlin-kapt'
   id 'expo-module-gradle-plugin'
 }
+
+apply plugin: 'com.google.devtools.ksp'
 
 android {
   namespace "expo.modules.image"
@@ -26,18 +34,18 @@ android {
 }
 
 dependencies {
-  def GLIDE_VERSION = "4.16.0"
+  def GLIDE_VERSION = "5.0.5"
 
   implementation 'com.facebook.react:react-android'
 
   api "com.github.bumptech.glide:glide:${GLIDE_VERSION}"
-  kapt "com.github.bumptech.glide:compiler:${GLIDE_VERSION}"
+  ksp "com.github.bumptech.glide:ksp:${GLIDE_VERSION}"
   api 'com.caverock:androidsvg-aar:1.4'
 
   implementation "com.github.penfeizhou.android.animation:glide-plugin:3.0.5"
   implementation "com.github.bumptech.glide:avif-integration:${GLIDE_VERSION}"
 
-  api 'com.github.bumptech.glide:okhttp3-integration:4.11.0'
+  api "com.github.bumptech.glide:okhttp3-integration:${GLIDE_VERSION}"
   api "com.squareup.okhttp3:okhttp:${expoModule.safeExtGet("okHttpVersion", '4.9.2')}"
 
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1'


### PR DESCRIPTION
# Why

Bumps Glide to `5.0.5`

# How

Upgrade Glide to `5.0.5` and migrate from using kapt to KSP

# Test Plan

- bare-expo ✅ 