### PR TITLE
[media-library][next] Fix modificationTime to return ms 

### DIFF
--- a/apps/test-suite/tests/MediaLibraryNext.ts
+++ b/apps/test-suite/tests/MediaLibraryNext.ts
@@ -128,19 +128,6 @@ export async function test(t) {
         }
       });
     }
-
-    t.it('fails when mixing audio and images', async () => {
-      try {
-        const albumName = createAlbumName('mixed audio & image');
-        const assets = await Promise.all(filesWithAudio.map((f) => Asset.create(f.localUri)));
-        assetsContainer.push(assets);
-        const album = await Album.create(albumName, assets);
-        albumsContainer.push(album);
-        t.fail();
-      } catch (e) {
-        t.expect(e).toBeDefined();
-      }
-    });
   });
 
   t.describe('Asset creation', () => {
@@ -270,8 +257,9 @@ export async function test(t) {
       t.expect(mediaType).toBeDefined();
     });
 
-    t.it('returns positive modification time', async () => {
+    t.it('returns correct modification time', async () => {
       const modificationTime = await asset.getModificationTime();
+      t.expect(new Date(modificationTime).getFullYear()).toBeGreaterThan(1970);
       t.expect(modificationTime).toBeGreaterThan(0);
     });
 
@@ -319,8 +307,9 @@ export async function test(t) {
       t.expect(mediaType).toBeDefined();
     });
 
-    t.it('returns positive modification time', async () => {
+    t.it('returns correct modification time', async () => {
       const modificationTime = await videoAsset.getModificationTime();
+      t.expect(new Date(modificationTime).getFullYear()).toBeGreaterThan(1970);
       t.expect(modificationTime).toBeGreaterThan(0);
     });
 
@@ -440,8 +429,8 @@ export async function test(t) {
       const [queriedAsset] = await new Query()
         .limit(1)
         .album(album)
-        .gte(AssetField.MODIFICATION_TIME, (await asset.getModificationTime()) - 1)
-        .lte(AssetField.MODIFICATION_TIME, (await asset.getModificationTime()) + 1)
+        .gte(AssetField.MODIFICATION_TIME, (await asset.getModificationTime()) - 1000)
+        .lte(AssetField.MODIFICATION_TIME, (await asset.getModificationTime()) + 1000)
         .exe();
       // then
       t.expect(queriedAsset.id).toBe(asset.id);
@@ -477,8 +466,8 @@ export async function test(t) {
       const [queriedAsset] = await new Query()
         .limit(1)
         .album(album)
-        .gte(AssetField.MODIFICATION_TIME, (await asset.getModificationTime()) + 1)
-        .lte(AssetField.MODIFICATION_TIME, (await asset.getModificationTime()) - 1)
+        .gte(AssetField.MODIFICATION_TIME, (await asset.getModificationTime()) + 1000)
+        .lte(AssetField.MODIFICATION_TIME, (await asset.getModificationTime()) - 1000)
         .exe();
       // then
       t.expect(queriedAsset).toBeUndefined();

--- a/apps/test-suite/tests/MediaLibraryNext.ts
+++ b/apps/test-suite/tests/MediaLibraryNext.ts
@@ -18,7 +18,7 @@ const jpgPath = require('../assets/qrcode_expo.jpg');
 
 export async function test(t) {
   let permissions;
-  let files, filesWithAudio;
+  let files;
   let jpgFile, pngFile, mp4File, mp3File;
 
   const checkIfAllPermissionsWereGranted = () => {
@@ -34,7 +34,6 @@ export async function test(t) {
     [jpgFile] = await ExpoAsset.loadAsync(jpgPath);
     [mp4File] = await ExpoAsset.loadAsync(mp4Path);
     files = [pngFile, jpgFile, mp4File];
-    filesWithAudio = [pngFile, jpgFile, mp4File, mp3File];
     permissions = await requestPermissionsAsync();
     if (!checkIfAllPermissionsWereGranted()) {
       console.warn('Tests will fail - not enough permissions to run them.');

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [next] Fix `asset.getModificationTime` to return milliseconds
+- [next] Fix `asset.getModificationTime` to return milliseconds ([#39715](https://github.com/expo/expo/pull/39715) by [@Wenszel](https://github.com/Wenszel))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [next] Fix `asset.getModificationTime` to return milliseconds
+
 ### 💡 Others
 
 ## 18.1.1 — 2025-09-10

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/MediaLibraryNextModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/MediaLibraryNextModule.kt
@@ -164,29 +164,29 @@ class MediaLibraryNextModule : Module() {
         self.album(album)
       }
 
-      Function("eq") { self: Query, field: AssetField, value: Either<MediaType, Int> ->
-        self.eq(field, MediaStoreQueryFormatter.parse(value))
+      Function("eq") { self: Query, field: AssetField, value: Either<MediaType, Long> ->
+        self.eq(field, MediaStoreQueryFormatter.parse(field, value))
       }
 
-      Function("within") { self: Query, field: AssetField, values: List<Either<MediaType, Int>> ->
-        val stringValues = values.map { value -> MediaStoreQueryFormatter.parse(value) }
+      Function("within") { self: Query, field: AssetField, values: List<Either<MediaType, Long>> ->
+        val stringValues = values.map { value -> MediaStoreQueryFormatter.parse(field, value) }
         self.within(field, stringValues)
       }
 
-      Function("gt") { self: Query, field: AssetField, value: Int ->
-        self.gt(field, MediaStoreQueryFormatter.parse(value))
+      Function("gt") { self: Query, field: AssetField, value: Long ->
+        self.gt(field, MediaStoreQueryFormatter.parse(field, value))
       }
 
-      Function("gte") { self: Query, field: AssetField, value: Int ->
-        self.gte(field, MediaStoreQueryFormatter.parse(value))
+      Function("gte") { self: Query, field: AssetField, value: Long ->
+        self.gte(field, MediaStoreQueryFormatter.parse(field, value))
       }
 
-      Function("lt") { self: Query, field: AssetField, value: Int ->
-        self.lt(field, MediaStoreQueryFormatter.parse(value))
+      Function("lt") { self: Query, field: AssetField, value: Long ->
+        self.lt(field, MediaStoreQueryFormatter.parse(field, value))
       }
 
-      Function("lte") { self: Query, field: AssetField, value: Int ->
-        self.lte(field, MediaStoreQueryFormatter.parse(value))
+      Function("lte") { self: Query, field: AssetField, value: Long ->
+        self.lte(field, MediaStoreQueryFormatter.parse(field, value))
       }
 
       Function("orderBy") { self: Query, sortDescriptorRef: Either<AssetField, SortDescriptor> ->

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/AssetExtensions.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/AssetExtensions.kt
@@ -17,8 +17,8 @@ import kotlinx.coroutines.withContext
 suspend fun ContentResolver.queryAssetDisplayName(contentUri: Uri): String? =
   queryOne(contentUri, MediaStore.MediaColumns.DISPLAY_NAME, Cursor::getString)
 
-suspend fun ContentResolver.queryGetCreationTime(contentUri: Uri): Long? =
-  queryOne(contentUri, MediaStore.MediaColumns.DATE_TAKEN, Cursor::getLong)
+suspend fun ContentResolver.queryAssetCreationTime(contentUri: Uri): Long? =
+  queryOne(contentUri, MediaStore.Images.Media.DATE_TAKEN, Cursor::getLong)
 
 suspend fun ContentResolver.queryAssetModificationTime(contentUri: Uri): Long? =
   queryOne(contentUri, MediaStore.MediaColumns.DATE_MODIFIED, Cursor::getLong)

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/delegates/AssetLegacyDelegate.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/delegates/AssetLegacyDelegate.kt
@@ -19,7 +19,7 @@ import expo.modules.medialibrary.next.extensions.resolver.queryAssetHeight
 import expo.modules.medialibrary.next.extensions.resolver.queryAssetModificationTime
 import expo.modules.medialibrary.next.extensions.resolver.queryAssetPath
 import expo.modules.medialibrary.next.extensions.resolver.queryAssetWidth
-import expo.modules.medialibrary.next.extensions.resolver.queryGetCreationTime
+import expo.modules.medialibrary.next.extensions.resolver.queryAssetCreationTime
 import expo.modules.medialibrary.next.extensions.safeCopy
 import expo.modules.medialibrary.next.extensions.safeMove
 import expo.modules.medialibrary.next.objects.wrappers.RelativePath
@@ -30,6 +30,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.lang.ref.WeakReference
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 @DeprecatedSinceApi(Build.VERSION_CODES.Q)
 class AssetLegacyDelegate(contentUri: Uri, context: Context) : AssetDelegate {
@@ -50,7 +52,7 @@ class AssetLegacyDelegate(contentUri: Uri, context: Context) : AssetDelegate {
 
   override suspend fun getCreationTime(): Long? {
     return contentResolver
-      .queryGetCreationTime(contentUri)
+      .queryAssetCreationTime(contentUri)
       .takeIf { it != 0L }
   }
 
@@ -98,7 +100,10 @@ class AssetLegacyDelegate(contentUri: Uri, context: Context) : AssetDelegate {
     MediaType.fromContentUri(contentUri)
 
   override suspend fun getModificationTime(): Long? =
-    contentResolver.queryAssetModificationTime(contentUri).takeIf { it != 0L }
+    contentResolver.queryAssetModificationTime(contentUri)
+      ?.takeIf { it != 0L }
+      ?.toDuration(DurationUnit.SECONDS)
+      ?.inWholeMilliseconds
 
   override suspend fun getMimeType(): MimeType {
     return contentResolver.getType(contentUri)?.let { MimeType(it) }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/delegates/AssetModernDelegate.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/delegates/AssetModernDelegate.kt
@@ -18,7 +18,7 @@ import expo.modules.medialibrary.next.extensions.resolver.queryAssetHeight
 import expo.modules.medialibrary.next.extensions.resolver.queryAssetModificationTime
 import expo.modules.medialibrary.next.extensions.resolver.queryAssetPath
 import expo.modules.medialibrary.next.extensions.resolver.queryAssetWidth
-import expo.modules.medialibrary.next.extensions.resolver.queryGetCreationTime
+import expo.modules.medialibrary.next.extensions.resolver.queryAssetCreationTime
 import expo.modules.medialibrary.next.extensions.resolver.updateRelativePath
 import expo.modules.medialibrary.next.objects.wrappers.RelativePath
 import expo.modules.medialibrary.next.objects.asset.Asset
@@ -28,6 +28,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.lang.ref.WeakReference
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 @RequiresApi(Build.VERSION_CODES.Q)
 class AssetModernDelegate(override val contentUri: Uri, context: Context) : AssetDelegate {
@@ -40,7 +42,7 @@ class AssetModernDelegate(override val contentUri: Uri, context: Context) : Asse
 
   override suspend fun getCreationTime(): Long? {
     return contentResolver
-      .queryGetCreationTime(contentUri)
+      .queryAssetCreationTime(contentUri)
       .takeIf { it != 0L }
   }
 
@@ -88,7 +90,10 @@ class AssetModernDelegate(override val contentUri: Uri, context: Context) : Asse
     MediaType.fromContentUri(contentUri)
 
   override suspend fun getModificationTime(): Long? =
-    contentResolver.queryAssetModificationTime(contentUri).takeIf { it != 0L }
+    contentResolver.queryAssetModificationTime(contentUri)
+      ?.takeIf { it != 0L }
+      ?.toDuration(DurationUnit.SECONDS)
+      ?.inWholeMilliseconds
 
   override suspend fun getUri(): Uri {
     // e.g. storage/emulated/0/Android/data/expo/files/[ROOT_ALBUM]/[ALBUM_NAME]

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/query/MediaStoreQueryFormatter.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/query/MediaStoreQueryFormatter.kt
@@ -3,18 +3,24 @@ package expo.modules.medialibrary.next.objects.query
 import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.types.Either
 import expo.modules.medialibrary.next.objects.wrappers.MediaType
+import expo.modules.medialibrary.next.records.AssetField
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 @OptIn(EitherType::class)
 class MediaStoreQueryFormatter {
   companion object {
-    fun parse(value: Either<MediaType, Int>): String {
+    fun parse(field: AssetField, value: Either<MediaType, Long>): String {
       if (value.`is`(MediaType::class)) {
         return parse(value.get(MediaType::class))
       }
-      return parse(value.get(Int::class))
+      return parse(field, value.get(Long::class))
     }
 
-    fun parse(value: Int): String {
+    fun parse(field: AssetField, value: Long): String {
+      if (field == AssetField.MODIFICATION_TIME) {
+        return value.toDuration(DurationUnit.MILLISECONDS).inWholeSeconds.toString()
+      }
       return value.toString()
     }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/query/Query.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/query/Query.kt
@@ -32,7 +32,6 @@ class Query(context: Context) : SharedObject() {
   private val args = mutableListOf<String>()
   private val orderBy = mutableListOf<SortDescriptor>()
 
-  private var album: Album? = null
   private var limit: Int? = null
   private var offset: Int? = null
 

--- a/packages/expo-media-library/ios/next/MediaLibraryNextModule.swift
+++ b/packages/expo-media-library/ios/next/MediaLibraryNextModule.swift
@@ -134,13 +134,13 @@ public final class MediaLibraryNextModule: Module {
       }
     }
 
-    AsyncFunction("deleteManyAlbums") { (albums: [Album], deleteAssets: Bool) async throws in
+    AsyncFunction("deleteAlbums") { (albums: [Album], deleteAssets: Bool) async throws in
       try await checkIfPermissionGranted()
       let albumsIds = albums.map { $0.id }
       try await AssetCollectionRepository.shared.delete(by: albumsIds, deleteAssets: deleteAssets)
     }
 
-    AsyncFunction("deleteManyAssets") { (assets: [Asset]) async throws in
+    AsyncFunction("deleteAssets") { (assets: [Asset]) async throws in
       try await checkIfPermissionGranted()
       let assetIds = assets.map { $0.id }
       try await AssetRepository.shared.delete(by: assetIds)

--- a/packages/expo-media-library/ios/next/extensions/DateExtensions.swift
+++ b/packages/expo-media-library/ios/next/extensions/DateExtensions.swift
@@ -1,0 +1,8 @@
+extension Date {
+  var millisecondsSince1970: Int {
+    return Int((self.timeIntervalSince1970 * 1000.0).rounded())
+  }
+  init(milliseconds: Int) {
+    self = Date(timeIntervalSince1970: TimeInterval(milliseconds) / 1000.0)
+  }
+}

--- a/packages/expo-media-library/ios/next/objects/Query/PredicateBuilder.swift
+++ b/packages/expo-media-library/ios/next/objects/Query/PredicateBuilder.swift
@@ -4,7 +4,7 @@ import ExpoModulesCore
 class AssetFieldPredicateBuilder {
   static func buildPredicate(assetField: AssetField, value: Int, symbol: String) -> NSPredicate {
     if assetField == .CREATION_TIME || assetField == .MODIFICATION_TIME {
-      let date = Date(timeIntervalSince1970: TimeInterval(value))
+      let date = Date(milliseconds: value)
       return NSPredicate(format: "\(assetField.photosKey()) \(symbol) %@", argumentArray: [date])
     }
     return NSPredicate(format: "\(assetField.photosKey()) \(symbol) %@", argumentArray: [value])

--- a/packages/expo-media-library/ios/next/objects/asset/Asset.swift
+++ b/packages/expo-media-library/ios/next/objects/asset/Asset.swift
@@ -39,7 +39,7 @@ class Asset: SharedObject {
     guard let date = phAsset.creationDate else {
       return nil
     }
-    return Int(date.timeIntervalSince1970)
+    return date.millisecondsSince1970
   }
 
   func getModificationTime() async throws -> Int? {
@@ -47,7 +47,7 @@ class Asset: SharedObject {
     guard let date = phAsset.modificationDate else {
       return nil
     }
-    return Int(date.timeIntervalSince1970)
+    return date.millisecondsSince1970
   }
 
   func getMediaType() async throws -> MediaTypeNext {


### PR DESCRIPTION
# Why
On Android, MediaStore stores modificationTime in ms, whereas creationTime is stored in seconds.  
On iOS, both modificationTime and creationTime are stored in seconds.

# How
On Android:
- parsed MediaStore database modification time query result using `toDuration(DurationUnit.SECONDS).inWholeMilliseconds`
- changed function argument types to `Long` to support milliseconds

On iOS:
- added a Date extension to parse milliseconds

Additionally, fixed issues with deleting assets after tests on iOS:
- removed `mixed audio and image` tests — the module does not handle this use case properly yet
- fixed `deleteAssets`/`albums` DSL function declaration names

# Test Plan
Added new assertions to tests in bare-expo