### PR TITLE
[media-library][next] Fix root directory

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [next][android] Change default root directory to Pictures
 - [next] Fix `asset.getModificationTime` to return milliseconds ([#39715](https://github.com/expo/expo/pull/39715) by [@Wenszel](https://github.com/Wenszel))
 
 ### 💡 Others

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [next][android] Change default root directory to Pictures
+- [next][android] Change default root directory to Pictures ([#39716](https://github.com/expo/expo/pull/39716) by [@Wenszel](https://github.com/Wenszel))
 - [next] Fix `asset.getModificationTime` to return milliseconds ([#39715](https://github.com/expo/expo/pull/39715) by [@Wenszel](https://github.com/Wenszel))
 
 ### 💡 Others

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/AssetExtensions.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/AssetExtensions.kt
@@ -38,9 +38,6 @@ suspend fun ContentResolver.queryAssetPath(contentUri: Uri): String? =
 suspend fun ContentResolver.queryAssetBucketId(contentUri: Uri): Int? =
   queryOne(contentUri, MediaStore.MediaColumns.BUCKET_ID, Cursor::getInt)
 
-suspend fun ContentResolver.queryAssetMediaType(contentUri: Uri): Int? =
-  queryOne(contentUri, MediaStore.Files.FileColumns.MEDIA_TYPE, Cursor::getInt)
-
 suspend fun ContentResolver.insertPendingAsset(
   displayName: String,
   mimeType: MimeType,

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/factories/AssetLegacyFactory.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/factories/AssetLegacyFactory.kt
@@ -35,7 +35,7 @@ class AssetLegacyFactory(context: Context) : AssetFactory {
     val baseDir = if (relativePath != null) {
       File(relativePath.toFilePath())
     } else {
-      mimeType.externalStoragePublicDirectory()
+      mimeType.externalStorageAssetDirectory()
     }
     baseDir.mkdirs()
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/wrappers/MimeType.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/wrappers/MimeType.kt
@@ -24,15 +24,22 @@ value class MimeType(val value: String?) {
   fun isVideo(): Boolean = type == "video"
   fun isAudio(): Boolean = type == "audio"
 
-  fun rootDirectory(): String = when {
+  fun assetRootDirectory(): String = when {
     value == null -> Environment.DIRECTORY_DCIM
     isImage() || isVideo() -> Environment.DIRECTORY_DCIM
     isAudio() -> Environment.DIRECTORY_MUSIC
     else -> Environment.DIRECTORY_DCIM
   }
 
-  fun externalStoragePublicDirectory(): File =
-    Environment.getExternalStoragePublicDirectory(rootDirectory())
+  fun albumRootDirectory(): String = when {
+    value == null -> Environment.DIRECTORY_PICTURES
+    isImage() || isVideo() -> Environment.DIRECTORY_PICTURES
+    isAudio() -> Environment.DIRECTORY_MUSIC
+    else -> Environment.DIRECTORY_PICTURES
+  }
+
+  fun externalStorageAssetDirectory(): File =
+    Environment.getExternalStoragePublicDirectory(assetRootDirectory())
 
   fun mediaCollectionUri(): Uri = when {
     value == null -> EXTERNAL_CONTENT_URI

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/wrappers/RelativePath.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/wrappers/RelativePath.kt
@@ -21,10 +21,11 @@ value class RelativePath(val value: String) {
 
   companion object {
     fun create(mimeType: MimeType, albumName: String? = null): RelativePath {
-      val rootDirectory = mimeType.rootDirectory()
       if (albumName != null) {
+        val rootDirectory = mimeType.albumRootDirectory()
         return RelativePath("$rootDirectory/$albumName/")
       }
+      val rootDirectory = mimeType.assetRootDirectory()
       return RelativePath("$rootDirectory/")
     }
   }


### PR DESCRIPTION
# Why
On Android:
Changed the default root directory for assets with albums from DCIM to Pictures.  
Pictures is meant to be the root directory for app assets, while DCIM is intended for camera photos.

# How
Added a new function to the MimeType class.

also removed queryAssetMediaType - unused 
# Test Plan
Tested on bare-expo.