### PR TITLE
Update android-development-build.mdx

### DIFF
--- a/docs/pages/tutorial/eas/android-development-build.mdx
+++ b/docs/pages/tutorial/eas/android-development-build.mdx
@@ -34,7 +34,9 @@ To create a **.apk**:
 
   <Terminal cmd={['$ eas build --platform android --profile development']} />
 
-  > **info** **Tip**: Next time you run `eas build` command, you can also use `-p` to specify the platform. It is short for `--platform`.
+  > **info** The build takes 15-20 mins.
+  >
+  > **Tip**: Next time you run `eas build` command, you can also use `-p` to specify the platform. It is short for `--platform`.
 
 This command prompts us with the following questions:
 


### PR DESCRIPTION
### Description

This PR adds a note to the Android development build documentation specifying that the build process takes approximately 15-20 minutes.

### Why this is needed

This information provides users with a clear time estimate, helping to manage expectations and improve the overall documentation experience.

### How to test

No testing is required, as this is a documentation-only change. The update can be viewed directly in the rendered markdown file.