### PR TITLE
[expo-modules-core] avoid TurboModuleRegistry import on web

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix runtime error due to passing undefined into function that doesnt receive any argument ([#39594](https://github.com/expo/expo/pull/39594) by [@mrevanzak](https://github.com/mrevanzak))
+- Fix build error on Vite due to non-existent import for `TurboModuleRegistry` on web ([#39726](https://github.com/expo/expo/pull/39726) by [@satya164](https://github.com/satya164))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/build/ensureNativeModulesAreInstalled.d.ts.map
+++ b/packages/expo-modules-core/build/ensureNativeModulesAreInstalled.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ensureNativeModulesAreInstalled.d.ts","sourceRoot":"","sources":["../src/ensureNativeModulesAreInstalled.ts"],"names":[],"mappings":"AAGA,OAAO,YAAY,CAAC;AAEpB;;;GAGG;AACH,wBAAgB,+BAA+B,IAAI,IAAI,CAgBtD"}
+{"version":3,"file":"ensureNativeModulesAreInstalled.d.ts","sourceRoot":"","sources":["../src/ensureNativeModulesAreInstalled.ts"],"names":[],"mappings":"AACA,OAAO,YAAY,CAAC;AAEpB;;;GAGG;AACH,wBAAgB,+BAA+B,IAAI,IAAI,CAEtD"}

--- a/packages/expo-modules-core/build/ensureNativeModulesAreInstalled.native.d.ts
+++ b/packages/expo-modules-core/build/ensureNativeModulesAreInstalled.native.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Ensures that the native modules are installed in the current runtime.
+ * Otherwise, it synchronously calls a native function that installs them.
+ */
+export declare function ensureNativeModulesAreInstalled(): void;
+//# sourceMappingURL=ensureNativeModulesAreInstalled.native.d.ts.map

--- a/packages/expo-modules-core/build/ensureNativeModulesAreInstalled.native.d.ts.map
+++ b/packages/expo-modules-core/build/ensureNativeModulesAreInstalled.native.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"ensureNativeModulesAreInstalled.native.d.ts","sourceRoot":"","sources":["../src/ensureNativeModulesAreInstalled.native.ts"],"names":[],"mappings":"AAEA;;;GAGG;AACH,wBAAgB,+BAA+B,IAAI,IAAI,CAetD"}

--- a/packages/expo-modules-core/src/ensureNativeModulesAreInstalled.native.ts
+++ b/packages/expo-modules-core/src/ensureNativeModulesAreInstalled.native.ts
@@ -1,0 +1,22 @@
+import { TurboModuleRegistry } from 'react-native';
+
+/**
+ * Ensures that the native modules are installed in the current runtime.
+ * Otherwise, it synchronously calls a native function that installs them.
+ */
+export function ensureNativeModulesAreInstalled(): void {
+  if (globalThis.expo) {
+    return;
+  }
+
+  try {
+    // TODO: ExpoModulesCore shouldn't be optional here,
+    // but to keep backwards compatibility let's just ignore it in SDK 50.
+    // In most cases the modules were already installed from the native side.
+    (
+      TurboModuleRegistry.get('ExpoModulesCore') as { installModules: () => void } | null
+    )?.installModules();
+  } catch (error) {
+    console.error(`Unable to install Expo modules: ${error}`);
+  }
+}

--- a/packages/expo-modules-core/src/ensureNativeModulesAreInstalled.ts
+++ b/packages/expo-modules-core/src/ensureNativeModulesAreInstalled.ts
@@ -1,5 +1,3 @@
-import { TurboModuleRegistry } from 'react-native';
-
 // Installs the expo global on web
 import './polyfill';
 
@@ -8,19 +6,5 @@ import './polyfill';
  * Otherwise, it synchronously calls a native function that installs them.
  */
 export function ensureNativeModulesAreInstalled(): void {
-  if (globalThis.expo) {
-    return;
-  }
-  try {
-    if (process.env.EXPO_OS !== 'web') {
-      // TODO: ExpoModulesCore shouldn't be optional here,
-      // but to keep backwards compatibility let's just ignore it in SDK 50.
-      // In most cases the modules were already installed from the native side.
-      (
-        TurboModuleRegistry.get('ExpoModulesCore') as { installModules: () => void } | null
-      )?.installModules();
-    }
-  } catch (error) {
-    console.error(`Unable to install Expo modules: ${error}`);
-  }
+  // No-op on web
 }


### PR DESCRIPTION
# Why

react-native-web doesn't export TurboModuleRegistry. so importing it fails the build on bundler such as vite which validate whether the export exists.

this splits web and native code to separate files to avoid the issue.

# How

# Test Plan

tested with vite in react-navigation monorepo.

vite config: https://github.com/react-navigation/react-navigation/blob/main/example/vite.config.mjs
wip pr: https://github.com/react-navigation/react-navigation/pull/12753

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
