### PR TITLE
[docs] Add info on using Node.js global variables for Flat config in ESLint guide

### DIFF
--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -69,7 +69,6 @@ const expoConfig = require('eslint-config-expo/flat');
 module.exports = defineConfig([
   expoConfig,
   {
-    ignores: ['dist/*'],
     files: ['babel.config.js'],
     languageOptions: {
       globals: globals.node,

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -54,7 +54,47 @@ Running the above command will run the `lint` script from **package.json**.
 
 ESLint is generally configured for a single environment. However, the source code is written in JavaScript in an Expo app that runs in multiple different environments. For example, the **app.config.js**, **metro.config.js**, **babel.config.js**, and **app/+html.tsx** files are run in a Node.js environment. It means they have access to the global `__dirname` variable and can use Node.js modules such as `path`. Standard Expo project files like **app/index.js** can be run in Hermes, Node.js, or the web browser.
 
-You can add the `eslint-env` comment directive to the top of a file to tell ESLint which environment the file is running in. For example, to tell ESLint that a file is run in Node.js, add the following comment to the top of the file:
+The approach to configure environment-specific globals differs between flat config and legacy config:
+
+<Tabs>
+
+<Tab label="Flat config">
+
+For flat config, use `languageOptions.globals` in your **eslint.config.js** to include Node.js global variables for specific configuration files:
+
+```js eslint.config.js
+const { defineConfig } = require('eslint/config');
+const expoConfig = require('eslint-config-expo/flat');
+
+module.exports = defineConfig([
+  expoConfig,
+  {
+    files: ['metro.config.js', 'babel.config.js'],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
+]);
+```
+
+This configuration allows Node.js globals like `__dirname` to be used without ESLint errors:
+
+```js metro.config.js
+const { getDefaultConfig } = require('expo/metro-config');
+
+/** @type {import('expo/metro-config').MetroConfig} */
+const config = getDefaultConfig(
+  /* @info This will no longer assert linting errors. */ __dirname /* @end */
+);
+
+module.exports = config;
+```
+
+</Tab>
+
+<Tab label="Legacy config">
+
+For legacy config, you can add the `eslint-env` comment to the top of a file to tell ESLint which environment the file is running in:
 
 ```js metro.config.js
 /* eslint-env node */
@@ -67,6 +107,10 @@ const config = getDefaultConfig(
 
 module.exports = config;
 ```
+
+</Tab>
+
+</Tabs>
 
 ## Prettier
 

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -63,10 +63,11 @@ The approach to configure environment-specific globals differs between Flat conf
 For Flat config, **metro.config.js** files already work with Node.js globals because of the built-in support in `eslint-config-expo`. For other configuration files that might need Node.js globals, use [`languageOptions.globals`](https://eslint.org/docs/latest/use/configure/language-options#predefined-global-variables) in your **eslint.config.js**:
 
 ```js eslint.config.js
-const { defineConfig } = require('eslint/config');
+const { defineConfig, globalIgnores } = require('eslint/config');
 const expoConfig = require('eslint-config-expo/flat');
 
 module.exports = defineConfig([
+  globalIgnores(['dist/*']),
   expoConfig,
   {
     files: ['babel.config.js'],

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -54,7 +54,7 @@ Running the above command will run the `lint` script from **package.json**.
 
 ESLint is generally configured for a single environment. However, the source code is written in JavaScript in an Expo app that runs in multiple different environments. For example, the **app.config.js**, **metro.config.js**, **babel.config.js**, and **app/+html.tsx** files are run in a Node.js environment. It means they have access to the global `__dirname` variable and can use Node.js modules such as `path`. Standard Expo project files like **app/index.js** can be run in Hermes, Node.js, or the web browser.
 
-The approach to configure environment-specific globals differs between flat config and legacy config:
+The approach to configure environment-specific globals differs between Flat config and legacy config:
 
 <Tabs>
 

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -60,7 +60,7 @@ The approach to configure environment-specific globals differs between Flat conf
 
 <Tab label="Flat config">
 
-For flat config, use `languageOptions.globals` in your **eslint.config.js** to include Node.js global variables for specific configuration files:
+For Flat config, **metro.config.js** files already work with Node.js globals because of the built-in support in `eslint-config-expo`. For other configuration files that might need Node.js globals, use [`languageOptions.globals`](https://eslint.org/docs/latest/use/configure/language-options#predefined-global-variables) in your **eslint.config.js**:
 
 ```js eslint.config.js
 const { defineConfig } = require('eslint/config');
@@ -69,7 +69,8 @@ const expoConfig = require('eslint-config-expo/flat');
 module.exports = defineConfig([
   expoConfig,
   {
-    files: ['metro.config.js', 'babel.config.js'],
+    ignores: ['dist/*'],
+    files: ['babel.config.js'],
     languageOptions: {
       globals: globals.node,
     },
@@ -77,17 +78,18 @@ module.exports = defineConfig([
 ]);
 ```
 
-This configuration allows Node.js globals like `__dirname` to be used without ESLint errors:
+For example, with this setup, you can now use Node.js globals in **babel.config.js**:
 
-```js metro.config.js
-const { getDefaultConfig } = require('expo/metro-config');
+```js babel.config.js
+import path from 'path';
+const __dirname = path.dirname(__filename);
 
-/** @type {import('expo/metro-config').MetroConfig} */
-const config = getDefaultConfig(
-  /* @info This will no longer assert linting errors. */ __dirname /* @end */
-);
-
-module.exports = config;
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};
 ```
 
 </Tab>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-17409

# How

<!--
How did you build this feature or fix this bug and why?
-->

* Added a section explaining how to use `languageOptions.globals` with flat config (`eslint.config.js`) to specify Node.js globals for specific files, including a code example.
* Retained and clarified instructions for using the `eslint-env` comment in legacy config, now presented as an alternative in a tabbed interface.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally and visit: http://localhost:3002/guides/using-eslint/#environment-configuration.

## Preview

<img width="1054" height="1035" alt="CleanShot 2025-09-17 at 00 39 39" src="https://github.com/user-attachments/assets/3447d608-208f-40d2-baf6-3159b2f59432" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
