### PR TITLE
[CI][ios] Add logging to e2e ios

### DIFF
--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -136,10 +136,13 @@ export function setupLogger(predicate: string, signal: AbortSignal): () => Promi
   // Kill process when aborted
   signal.addEventListener(
     'abort',
-    () => {
+    async () => {
       if (loggerProcess.child) {
         loggerProcess.child.kill('SIGTERM');
       }
+      try {
+        await loggerProcess;
+      } catch {}
     },
     { once: true }
   );


### PR DESCRIPTION
# Why

Current CI setup doesn't really surface any more info than the test suite that failed. It also doesn't correctly surface native crash logs if a runner is killed.

After this change, we print the exact test suite results:

<img width="554" height="386" alt="image" src="https://github.com/user-attachments/assets/290695a3-b9d7-470a-afff-c7f73564c8c2" />

If the runner app crashed, we also print recent native crash logs to make it a bit easier to recognize:

<img width="830" height="375" alt="image" src="https://github.com/user-attachments/assets/df5008d8-bcbd-4393-91dd-92e002f5a0cb" />


# How

Used simctrl directly since maestro doesn't really have much in terms of plugins/message passing APIs (this is iOS only for now)

# Test Plan

Tested locally by running the CI and breaking tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
