### PR TITLE
[expo-glass-effect] Set default glass style to regular

### DIFF
--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Set defualt glass style to regular
+- Set default glass style to regular ([#39732](https://github.com/expo/expo/pull/39732) by [@brentvatne](https://github.com/brentvatne))
 
 ### 💡 Others
 

--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Set defualt glass style to regular
+
 ### 💡 Others
 
 ## 0.1.3 — 2025-09-12

--- a/packages/expo-glass-effect/ios/GlassEffectModule.swift
+++ b/packages/expo-glass-effect/ios/GlassEffectModule.swift
@@ -21,7 +21,7 @@ public final class GlassEffectModule: Module {
     }
 
     View(GlassView.self) {
-      Prop("glassEffectStyle") { (view, style: GlassStyle) in
+      Prop("glassEffectStyle", .regular) { (view, style: GlassStyle) in
         view.setGlassStyle(style)
       }
 


### PR DESCRIPTION
# Why

We say it's default in the type definition, and without this set our examples on https://docs.expo.dev/versions/latest/sdk/glass-effect/ look wrong

# How

Set one line diff haha

# Test Plan

Applied patch in test project