### PR TITLE
fix(web): replace TurboModuleRegistry import with require in ensureNa…

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 - Fix runtime error due to passing undefined into function that doesnt receive any argument ([#39594](https://github.com/expo/expo/pull/39594) by [@mrevanzak](https://github.com/mrevanzak))
 
+- [Web] Only import `TurboModuleRegistry` when not on web. ([#39737](https://github.com/expo/expo/pull/39737) by [@Bram-dc](https://github.com/Bram-dc))
+
 ## 3.0.15 — 2025-09-10
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/build/ensureNativeModulesAreInstalled.d.ts.map
+++ b/packages/expo-modules-core/build/ensureNativeModulesAreInstalled.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ensureNativeModulesAreInstalled.d.ts","sourceRoot":"","sources":["../src/ensureNativeModulesAreInstalled.ts"],"names":[],"mappings":"AAGA,OAAO,YAAY,CAAC;AAEpB;;;GAGG;AACH,wBAAgB,+BAA+B,IAAI,IAAI,CAgBtD"}
+{"version":3,"file":"ensureNativeModulesAreInstalled.d.ts","sourceRoot":"","sources":["../src/ensureNativeModulesAreInstalled.ts"],"names":[],"mappings":"AACA,OAAO,YAAY,CAAC;AAEpB;;;GAGG;AACH,wBAAgB,+BAA+B,IAAI,IAAI,CAgBtD"}

--- a/packages/expo-modules-core/build/ensureNativeModulesAreInstalled.d.ts.map
+++ b/packages/expo-modules-core/build/ensureNativeModulesAreInstalled.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ensureNativeModulesAreInstalled.d.ts","sourceRoot":"","sources":["../src/ensureNativeModulesAreInstalled.ts"],"names":[],"mappings":"AACA,OAAO,YAAY,CAAC;AAEpB;;;GAGG;AACH,wBAAgB,+BAA+B,IAAI,IAAI,CAgBtD"}
+{"version":3,"file":"ensureNativeModulesAreInstalled.d.ts","sourceRoot":"","sources":["../src/ensureNativeModulesAreInstalled.ts"],"names":[],"mappings":"AACA,OAAO,YAAY,CAAC;AAEpB;;;GAGG;AACH,wBAAgB,+BAA+B,IAAI,IAAI,CAkBtD"}

--- a/packages/expo-modules-core/src/ensureNativeModulesAreInstalled.ts
+++ b/packages/expo-modules-core/src/ensureNativeModulesAreInstalled.ts
@@ -1,5 +1,3 @@
-import { TurboModuleRegistry } from 'react-native';
-
 // Installs the expo global on web
 import './polyfill';
 
@@ -17,7 +15,7 @@ export function ensureNativeModulesAreInstalled(): void {
       // but to keep backwards compatibility let's just ignore it in SDK 50.
       // In most cases the modules were already installed from the native side.
       (
-        TurboModuleRegistry.get('ExpoModulesCore') as { installModules: () => void } | null
+        require('react-native').TurboModuleRegistry.get('ExpoModulesCore') as { installModules: () => void } | null
       )?.installModules();
     }
   } catch (error) {

--- a/packages/expo-modules-core/src/ensureNativeModulesAreInstalled.ts
+++ b/packages/expo-modules-core/src/ensureNativeModulesAreInstalled.ts
@@ -15,7 +15,9 @@ export function ensureNativeModulesAreInstalled(): void {
       // but to keep backwards compatibility let's just ignore it in SDK 50.
       // In most cases the modules were already installed from the native side.
       (
-        require('react-native').TurboModuleRegistry.get('ExpoModulesCore') as { installModules: () => void } | null
+        require('react-native').TurboModuleRegistry.get('ExpoModulesCore') as {
+          installModules: () => void;
+        } | null
       )?.installModules();
     }
   } catch (error) {


### PR DESCRIPTION
…tiveModulesAreInstalled

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix for the following issues:
- https://github.com/expo/expo/issues/39689
- https://github.com/Bram-dc/vite-plugin-react-native-web/issues/7

# How

<!--
How did you build this feature or fix this bug and why?
-->

Only import the registry if not on web.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

-

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
