### PR TITLE
[bare-minimum][Android] Expose `debugOptimized`

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/debugOptimized/AndroidManifest.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/debugOptimized/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+    <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" tools:replace="android:usesCleartextTraffic" />
+</manifest>


### PR DESCRIPTION
# Why

Exposes `debugOptimized` variant.
Part of ENG-17258

# How

From my testing, the new variant mostly worked out of the box. The only issue I encountered was that `usesCleartextTraffic` wasn't enabled. In React Native, the default templates were migrated to use a manifest placeholder. We couldn't use the same mechanism because we also added the additional permission: `android.permission.SYSTEM_ALERT_WINDOW`. I've decided to create a copy of the debug manifest in the debugOptimized folder.

# Test Plan

- try to build `debugOptimized` variant ✅ 