### PR TITLE
[expo][Android] Bump native dependencies

### DIFF
--- a/packages/expo-application/android/build.gradle
+++ b/packages/expo-application/android/build.gradle
@@ -20,6 +20,6 @@ dependencies {
   if (project.findProject(':expo-modules-test-core')) {
     testImplementation project(':expo-modules-test-core')
   }
-  testImplementation "org.robolectric:robolectric:4.10"
+  testImplementation "org.robolectric:robolectric:4.16"
   testImplementation 'junit:junit:4.13.2'
 }

--- a/packages/expo-asset/android/build.gradle
+++ b/packages/expo-asset/android/build.gradle
@@ -15,8 +15,8 @@ android {
 }
 
 dependencies {
-  testImplementation 'androidx.test:core:1.6.1'
   testImplementation 'io.mockk:mockk:1.13.11'
+  testImplementation 'androidx.test:core:1.7.0'
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'org.robolectric:robolectric:4.14.1'
+  testImplementation 'org.robolectric:robolectric:4.16'
 }

--- a/packages/expo-audio/android/build.gradle
+++ b/packages/expo-audio/android/build.gradle
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'androidx.appcompat:appcompat:1.7.0'
+  implementation 'androidx.appcompat:appcompat:1.7.1'
 
   def androidxMedia3Version = "1.8.0"
   implementation "androidx.media3:media3-session:$androidxMedia3Version"

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -85,11 +85,11 @@ dependencies {
   api 'com.google.android.exoplayer:exoplayer:2.18.1'
   api 'com.google.android.exoplayer:extension-okhttp:2.18.1'
 
-  api "com.squareup.okhttp3:okhttp:3.14.9"
-  api "com.squareup.okhttp3:okhttp-urlconnection:3.14.9"
+  api "com.squareup.okhttp3:okhttp:4.9.2"
+  api "com.squareup.okhttp3:okhttp-urlconnection:4.9.2"
 
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.1'
-  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.5.1"
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.13.4'
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.13.4"
   // Gradle 9+ requires explicit dependency on the launcher
   testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.3'
 

--- a/packages/expo-background-task/android/build.gradle
+++ b/packages/expo-background-task/android/build.gradle
@@ -6,11 +6,6 @@ plugins {
 group = 'host.exp.exponent'
 version = '1.0.7'
 
-dependencies {
-  implementation 'androidx.work:work-runtime-ktx:2.9.1'
-  implementation 'com.facebook.react:react-android'
-}
-
 android {
   namespace "expo.modules.backgroundtask"
   defaultConfig {
@@ -18,4 +13,9 @@ android {
     versionName "1.0.7"
     consumerProguardFiles("proguard-rules.pro")
   }
+}
+
+dependencies {
+  implementation 'androidx.work:work-runtime-ktx:2.9.1'
+  implementation 'com.facebook.react:react-android'
 }

--- a/packages/expo-battery/android/build.gradle
+++ b/packages/expo-battery/android/build.gradle
@@ -20,5 +20,5 @@ dependencies {
   if (project.findProject(':expo-modules-test-core')) {
     testImplementation project(':expo-modules-test-core')
   }
-  testImplementation "org.robolectric:robolectric:4.10"
+  testImplementation "org.robolectric:robolectric:4.16"
 }

--- a/packages/expo-calendar/android/build.gradle
+++ b/packages/expo-calendar/android/build.gradle
@@ -15,8 +15,8 @@ android {
 }
 
 dependencies {
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'io.mockk:mockk:1.13.5'

--- a/packages/expo-clipboard/android/build.gradle
+++ b/packages/expo-clipboard/android/build.gradle
@@ -15,9 +15,9 @@ android {
 }
 
 dependencies {
-  implementation "androidx.core:core-ktx:1.6.0"
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2")
+  implementation "androidx.core:core-ktx:1.17.0"
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
 
   if (project.findProject(':expo-modules-test-core')) {
     testImplementation project(':expo-modules-test-core')

--- a/packages/expo-crypto/android/build.gradle
+++ b/packages/expo-crypto/android/build.gradle
@@ -19,5 +19,5 @@ dependencies {
     testImplementation project(':expo-modules-test-core')
   }
   testImplementation 'junit:junit:4.13.2'
-  testImplementation "org.robolectric:robolectric:4.10"
+  testImplementation "org.robolectric:robolectric:4.16"
 }

--- a/packages/expo-dev-client/android/build.gradle
+++ b/packages/expo-dev-client/android/build.gradle
@@ -46,28 +46,28 @@ dependencies {
   androidTestImplementation 'com.facebook.react:react-android'
   androidTestImplementation 'com.facebook.react:hermes-android'
 
-  androidTestImplementation('androidx.test.espresso:espresso-core:3.6.1')
-  androidTestImplementation('androidx.test:core:1.6.1')
-  androidTestImplementation('androidx.test:core-ktx:1.6.1')
-  androidTestImplementation('androidx.test.ext:junit:1.2.1')
-  androidTestImplementation('androidx.test.ext:junit-ktx:1.2.1')
-  androidTestImplementation('androidx.test:runner:1.6.2')
-  androidTestImplementation('androidx.test:rules:1.6.1')
+  androidTestImplementation('androidx.test.espresso:espresso-core:3.7.0')
+  androidTestImplementation('androidx.test:core:1.7.0')
+  androidTestImplementation('androidx.test:core-ktx:1.7.0')
+  androidTestImplementation('androidx.test.ext:junit:1.3.0')
+  androidTestImplementation('androidx.test.ext:junit-ktx:1.3.0')
+  androidTestImplementation('androidx.test:runner:1.7.0')
+  androidTestImplementation('androidx.test:rules:1.7.0')
 
   androidTestImplementation 'org.webkit:android-jsc:+'
 
   androidTestImplementation "io.insert-koin:koin-test:3.1.2"
   androidTestImplementation "io.insert-koin:koin-test-junit4:3.1.2"
 
-  androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3"
-  androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1"
+  androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2"
+  androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
 
-  androidTestImplementation "androidx.appcompat:appcompat:1.7.0"
+  androidTestImplementation "androidx.appcompat:appcompat:1.7.1"
 
-  androidTestImplementation "com.google.truth:truth:1.1.2"
   androidTestImplementation 'io.mockk:mockk-android:1.13.11'
+  androidTestImplementation "com.google.truth:truth:1.4.5"
 
   // Fixes "e: java.lang.AssertionError: No such enum entry LIBRARY_GROUP_PREFIX in org.jetbrains.kotlin.ir.types.impl.IrSimpleTypeImpl@b254b575"
   // According to the https://stackoverflow.com/a/67736351
-  implementation 'androidx.annotation:annotation:1.2.0'
+  implementation 'androidx.annotation:annotation:1.9.1'
 }

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -75,17 +75,17 @@ dependencies {
 
   implementation 'commons-io:commons-io:2.6'
 
-  implementation 'com.squareup.okhttp3:okhttp:3.14.9'
-  implementation 'com.google.code.gson:gson:2.8.6'
+  implementation 'com.squareup.okhttp3:okhttp:4.9.2'
+  implementation 'com.google.code.gson:gson:2.13.2'
 
   // Fixes
   // Cannot access 'androidx....' which is a supertype of 'expo.modules.devmenu.DevMenuActivity'.
   // Check your module classpath for missing or conflicting dependencies
-  api "androidx.appcompat:appcompat:1.1.0"
+  api "androidx.appcompat:appcompat:1.7.1"
   api "androidx.lifecycle:lifecycle-extensions:2.2.0"
 
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
   implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}"
 
   api project.dependencies.platform("io.insert-koin:koin-bom:3.5.6")
@@ -96,7 +96,7 @@ dependencies {
   implementation "androidx.compose.foundation:foundation-android:$composeVersion"
   implementation "androidx.compose.ui:ui:$composeVersion"
   implementation "androidx.compose.ui:ui-tooling:$composeVersion"
-  implementation "androidx.navigation:navigation-compose:2.9.0"
+  implementation "androidx.navigation:navigation-compose:2.9.4"
   implementation "com.google.android.gms:play-services-code-scanner:16.1.0"
   implementation "com.google.mlkit:barcode-scanning:17.3.0"
 
@@ -104,14 +104,14 @@ dependencies {
 
   implementation("com.apollographql.apollo:apollo-runtime:4.3.1")
 
-  implementation("com.composables:core:1.37.0")
+  implementation("com.composables:core:1.43.1")
 
-  testImplementation 'androidx.test:core:1.4.0'
-  testImplementation 'androidx.test:core-ktx:1.4.0'
-  testImplementation "com.google.truth:truth:1.1.2"
-  testImplementation 'com.squareup.okhttp3:mockwebserver:4.3.1'
+  testImplementation 'androidx.test:core:1.7.0'
+  testImplementation 'androidx.test:core-ktx:1.7.0'
+  testImplementation "com.google.truth:truth:1.4.5"
+  testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.2'
   testImplementation "io.insert-koin:koin-test"
   testImplementation "io.insert-koin:koin-test-junit4"
   testImplementation 'io.mockk:mockk:1.12.3'
-  testImplementation "org.robolectric:robolectric:4.10"
+  testImplementation "org.robolectric:robolectric:4.16"
 }

--- a/packages/expo-dev-menu-interface/android/build.gradle
+++ b/packages/expo-dev-menu-interface/android/build.gradle
@@ -20,6 +20,6 @@ android {
 
 dependencies {
   implementation 'com.facebook.react:react-android'
-  implementation 'com.squareup.okhttp3:okhttp:3.14.9'
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3"
+  implementation 'com.squareup.okhttp3:okhttp:4.9.2'
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2"
 }

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -48,26 +48,24 @@ repositories {
 dependencies {
   implementation project(":expo-manifests")
 
-  implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
-  implementation 'com.google.android.material:material:1.2.1'
+  implementation 'androidx.coordinatorlayout:coordinatorlayout:1.3.0'
 
   implementation project(":expo-dev-menu-interface")
 
-  implementation 'com.squareup.okhttp3:okhttp:3.14.9'
-  implementation 'com.google.code.gson:gson:2.8.6'
+  implementation 'com.squareup.okhttp3:okhttp:4.9.2'
+  implementation 'com.google.code.gson:gson:2.13.2'
 
   implementation 'com.facebook.react:react-android'
   implementation 'com.facebook.soloader:soloader:0.11.0'
-  implementation "androidx.transition:transition:1.1.0" // use by react-native-reanimated
 
   // Fixes
   // Cannot access 'androidx....' which is a supertype of 'expo.modules.devmenu.DevMenuActivity'.
   // Check your module classpath for missing or conflicting dependencies
-  api "androidx.appcompat:appcompat:1.1.0"
+  api "androidx.appcompat:appcompat:1.7.1"
   api "androidx.lifecycle:lifecycle-extensions:2.2.0"
 
-  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7'
-  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.5'
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2'
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2'
 
   def composeVersion = "1.9.0"
 
@@ -75,17 +73,17 @@ dependencies {
   implementation "androidx.compose.ui:ui:$composeVersion"
   implementation "androidx.compose.ui:ui-tooling:$composeVersion"
 
-  implementation("com.composables:core:1.37.0")
+  implementation("com.composables:core:1.43.1")
 
   api 'io.github.lukmccall:radix-ui-colors:1.0.1'
 
   // Needed by gesture handler
-  implementation "androidx.core:core-ktx:1.6.0"
+  implementation "androidx.core:core-ktx:1.17.0"
 
-  api "androidx.browser:browser:1.6.0"
+  api "androidx.browser:browser:1.9.0"
 
-  testImplementation "com.google.truth:truth:1.1.2"
-  testImplementation "org.robolectric:robolectric:4.10"
-  testImplementation 'com.squareup.okhttp3:mockwebserver:4.3.1'
-  testImplementation 'androidx.test:core:1.4.0'
+  testImplementation "com.google.truth:truth:1.4.5"
+  testImplementation "org.robolectric:robolectric:4.16"
+  testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.2'
+  testImplementation 'androidx.test:core:1.7.0'
 }

--- a/packages/expo-eas-client/android/build.gradle
+++ b/packages/expo-eas-client/android/build.gradle
@@ -24,8 +24,8 @@ android {
 
 dependencies {
   androidTestImplementation 'org.amshove.kluent:kluent-android:1.68'
-  androidTestImplementation 'androidx.test:runner:1.4.0'
-  androidTestImplementation 'androidx.test:core:1.4.0'
-  androidTestImplementation 'androidx.test:rules:1.4.0'
   androidTestImplementation 'io.mockk:mockk-android:1.12.3'
+  androidTestImplementation 'androidx.test:runner:1.7.0'
+  androidTestImplementation 'androidx.test:core:1.7.0'
+  androidTestImplementation 'androidx.test:rules:1.7.0'
 }

--- a/packages/expo-image-loader/android/build.gradle
+++ b/packages/expo-image-loader/android/build.gradle
@@ -14,8 +14,6 @@ android {
   }
 }
 
-def glideVersion = expoModule.safeExtGet('glideVersion', '4.16.0')
-
 dependencies {
-  api "com.github.bumptech.glide:glide:${glideVersion}"
+  api "com.github.bumptech.glide:glide:5.0.5"
 }

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -19,12 +19,12 @@ android {
 }
 
 dependencies {
-  implementation "androidx.activity:activity-ktx:1.10.0"
-  implementation "androidx.appcompat:appcompat:1.7.0"
-  implementation "androidx.exifinterface:exifinterface:1.3.7"
+  implementation "androidx.activity:activity-ktx:1.11.0"
+  implementation "androidx.appcompat:appcompat:1.7.1"
+  implementation "androidx.exifinterface:exifinterface:1.4.1"
   implementation "com.vanniktech:android-image-cropper:4.6.0"
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.3"
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.3"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2"
 
   if (project.findProject(':expo-modules-test-core')) {
     androidTestImplementation project(':expo-modules-test-core')

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -48,6 +48,6 @@ dependencies {
   api "com.github.bumptech.glide:okhttp3-integration:${GLIDE_VERSION}"
   api "com.squareup.okhttp3:okhttp:${expoModule.safeExtGet("okHttpVersion", '4.9.2')}"
 
-  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1'
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2'
   implementation "jp.wasabeef:glide-transformations:4.3.0"
 }

--- a/packages/expo-json-utils/android/build.gradle
+++ b/packages/expo-json-utils/android/build.gradle
@@ -24,16 +24,16 @@ android {
 
 dependencies {
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test:core:1.4.0'
-  testImplementation 'org.mockito:mockito-core:1.10.19'
   testImplementation 'io.mockk:mockk:1.12.3'
+  testImplementation 'androidx.test:core:1.7.0'
+  testImplementation 'org.mockito:mockito-core:5.19.0'
 
   androidTestImplementation('org.amshove.kluent:kluent-android:1.72') {
     exclude group: 'org.jetbrains.kotlin'
   }
-  androidTestImplementation 'androidx.test:runner:1.4.0'
-  androidTestImplementation 'androidx.test:core:1.4.0'
-  androidTestImplementation 'androidx.test:rules:1.4.0'
-  androidTestImplementation 'org.mockito:mockito-android:3.7.7'
   androidTestImplementation 'io.mockk:mockk-android:1.12.3'
+  androidTestImplementation 'androidx.test:runner:1.7.0'
+  androidTestImplementation 'androidx.test:core:1.7.0'
+  androidTestImplementation 'androidx.test:rules:1.7.0'
+  androidTestImplementation 'org.mockito:mockito-android:5.19.0'
 }

--- a/packages/expo-localization/android/build.gradle
+++ b/packages/expo-localization/android/build.gradle
@@ -15,5 +15,5 @@ android {
 }
 
 dependencies {
-  implementation "androidx.core:core-ktx:1.6.0"
+  implementation "androidx.core:core-ktx:1.17.0"
 }

--- a/packages/expo-mail-composer/android/build.gradle
+++ b/packages/expo-mail-composer/android/build.gradle
@@ -15,5 +15,5 @@ android {
 }
 
 dependencies {
-  api "androidx.appcompat:appcompat:1.2.0"
+  implementation "androidx.appcompat:appcompat:1.7.1"
 }

--- a/packages/expo-manifests/android/build.gradle
+++ b/packages/expo-manifests/android/build.gradle
@@ -29,9 +29,9 @@ dependencies {
   implementation project(':expo-json-utils')
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test:core:1.5.0'
-  testImplementation 'org.mockito:mockito-core:4.0.0'
   testImplementation 'io.mockk:mockk:1.13.5'
-  testImplementation 'org.json:json:20230227'
-  testImplementation "com.google.truth:truth:1.1.2"
+  testImplementation 'androidx.test:core:1.7.0'
+  testImplementation 'org.mockito:mockito-core:5.19.0'
+  testImplementation 'org.json:json:20250517'
+  testImplementation "com.google.truth:truth:1.4.5"
 }

--- a/packages/expo-maps/android/build.gradle
+++ b/packages/expo-maps/android/build.gradle
@@ -31,12 +31,12 @@ android {
 }
 
 dependencies {
-  implementation 'androidx.compose.foundation:foundation-android:1.7.6'
-  implementation 'androidx.compose.ui:ui-android:1.7.6'
-  implementation "androidx.compose.material3:material3:1.3.1"
-  implementation 'androidx.lifecycle:lifecycle-runtime:2.8.7'
-  implementation 'androidx.fragment:fragment-ktx:1.8.5'
-  implementation 'androidx.compose.material3:material3-android:1.3.1'
+  implementation 'androidx.compose.foundation:foundation-android:1.9.1'
+  implementation 'androidx.compose.ui:ui-android:1.9.1'
+  implementation "androidx.compose.material3:material3:1.3.2"
+  implementation 'androidx.lifecycle:lifecycle-runtime:2.9.3'
+  implementation 'androidx.fragment:fragment-ktx:1.8.9'
+  implementation 'androidx.compose.material3:material3-android:1.3.2'
 
-  implementation 'com.google.maps.android:maps-compose:6.6.0'
+  implementation 'com.google.maps.android:maps-compose:6.10.0'
 }

--- a/packages/expo-media-library/android/build.gradle
+++ b/packages/expo-media-library/android/build.gradle
@@ -15,12 +15,12 @@ android {
 }
 
 dependencies {
-  implementation "androidx.annotation:annotation:1.2.0"
-  api "androidx.exifinterface:exifinterface:1.3.3"
-  implementation 'androidx.activity:activity-ktx:1.10.1'
+  implementation "androidx.annotation:annotation:1.9.1"
+  api "androidx.exifinterface:exifinterface:1.4.1"
+  implementation 'androidx.activity:activity-ktx:1.11.0'
 
   if (project.findProject(':expo-modules-test-core')) {
     testImplementation project(':expo-modules-test-core')
   }
-  testImplementation "org.robolectric:robolectric:4.10"
+  testImplementation "org.robolectric:robolectric:4.16"
 }

--- a/packages/expo-mesh-gradient/android/build.gradle
+++ b/packages/expo-mesh-gradient/android/build.gradle
@@ -31,6 +31,6 @@ android {
 }
 
 dependencies {
-  implementation 'androidx.compose.foundation:foundation-android:1.7.6'
-  implementation 'androidx.compose.ui:ui-android:1.7.6'
+  implementation 'androidx.compose.foundation:foundation-android:1.9.1'
+  implementation 'androidx.compose.ui:ui-android:1.9.1'
 }

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -186,11 +186,11 @@ android {
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlinVersion}"
   implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}"
-  implementation 'androidx.annotation:annotation:1.7.1'
+  implementation 'androidx.annotation:annotation:1.9.1'
 
-  api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3"
-  api "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
-  api "androidx.core:core-ktx:1.13.1"
+  api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2"
+  api "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
+  api "androidx.core:core-ktx:1.17.0"
 
   if (shouldIncludeCompose) {
     implementation 'androidx.compose.foundation:foundation-android:1.7.6'
@@ -202,20 +202,20 @@ dependencies {
 
   compileOnly 'com.facebook.fbjni:fbjni:0.5.1'
 
-  testImplementation 'androidx.test:core:1.5.0'
+  testImplementation 'androidx.test:core:1.7.0'
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'io.mockk:mockk:1.13.10'
-  testImplementation "com.google.truth:truth:1.1.2"
-  testImplementation "org.robolectric:robolectric:4.11.1"
-  testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
-  testImplementation "org.json:json:20230227"
+  testImplementation "com.google.truth:truth:1.4.5"
+  testImplementation "org.robolectric:robolectric:4.16"
+  testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2"
+  testImplementation "org.json:json:20250517"
 
-  androidTestImplementation 'androidx.test:runner:1.5.2'
-  androidTestImplementation 'androidx.test:core:1.5.0'
-  androidTestImplementation 'androidx.test:rules:1.5.0'
+  androidTestImplementation 'androidx.test:runner:1.7.0'
+  androidTestImplementation 'androidx.test:core:1.7.0'
+  androidTestImplementation 'androidx.test:rules:1.7.0'
   androidTestImplementation "io.mockk:mockk-android:1.13.10"
-  androidTestImplementation "com.google.truth:truth:1.1.2"
-  androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
+  androidTestImplementation "com.google.truth:truth:1.4.5"
+  androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2"
 
   if (isExpoModulesCoreTests) {
     if (USE_HERMES) {

--- a/packages/expo-modules-test-core/android/build.gradle
+++ b/packages/expo-modules-test-core/android/build.gradle
@@ -27,29 +27,29 @@ android {
 }
 
 dependencies {
-  api 'androidx.test:core:1.6.1'
+  api 'androidx.test:core:1.7.0'
   api 'junit:junit:4.13.2'
   api('io.mockk:mockk:1.13.5') {
     // jupiter is junit 5 which we don't use
     exclude group: 'org.junit.jupiter'
   }
-  api ("org.robolectric:robolectric:4.11.1") {
+  api ("org.robolectric:robolectric:4.16") {
     // Duplicate class bcprov-jdk15to18-1.78.1.jar and bcprov-jdk18on-1.78.1.jar
     // Exclude the conflicting jdk18on version, so that jdk15to18 is used
     exclude group: 'org.bouncycastle', module: 'bcprov-jdk18on'
   }
   // specify a version of Bouncy Castle - used in robolectric and androidx.room (expo-updates)
-  implementation 'org.bouncycastle:bcprov-jdk15to18:1.78.1'
-  testImplementation 'org.bouncycastle:bcprov-jdk15to18:1.78.1'
+  implementation 'org.bouncycastle:bcprov-jdk15to18:1.81'
+  testImplementation 'org.bouncycastle:bcprov-jdk15to18:1.81'
 
   implementation 'com.facebook.react:react-android'
 
   implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}"
 
   // instrumented testing dependencies
-  api 'androidx.test.ext:junit:1.2.1'
-  api 'androidx.test:runner:1.6.2'
-  api 'androidx.test:rules:1.6.1'
-  api "com.google.truth:truth:1.1.2"
-  api "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0"
+  api 'androidx.test.ext:junit:1.3.0'
+  api 'androidx.test:runner:1.7.0'
+  api 'androidx.test:rules:1.7.0'
+  api "com.google.truth:truth:1.4.5"
+  api "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2"
 }

--- a/packages/expo-navigation-bar/android/build.gradle
+++ b/packages/expo-navigation-bar/android/build.gradle
@@ -15,6 +15,6 @@ android {
 }
 
 dependencies {
-  implementation 'androidx.core:core:1.6.0'
-  implementation 'androidx.appcompat:appcompat:1.2.0'
+  implementation 'androidx.core:core:1.17.0'
+  implementation 'androidx.appcompat:appcompat:1.7.1'
 }

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -32,11 +32,11 @@ android {
 }
 
 dependencies {
-  implementation 'androidx.core:core:1.6.0'
-  implementation 'androidx.lifecycle:lifecycle-runtime:2.2.0'
-  implementation 'androidx.lifecycle:lifecycle-process:2.2.0'
-  implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
-  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+  implementation 'androidx.core:core:1.17.0'
+  implementation 'androidx.lifecycle:lifecycle-runtime:2.9.3'
+  implementation 'androidx.lifecycle:lifecycle-process:2.9.3'
+  implementation 'androidx.lifecycle:lifecycle-common-java8:2.9.3'
+  implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2'
 
   // release notes in https://firebase.google.com/support/release-notes/android - cmd + f "Cloud Messaging version"
   implementation 'com.google.firebase:firebase-messaging:24.0.1'

--- a/packages/expo-screen-capture/android/build.gradle
+++ b/packages/expo-screen-capture/android/build.gradle
@@ -15,5 +15,5 @@ android {
 }
 
 dependencies {
-  implementation 'androidx.appcompat:appcompat:1.2.0'
+  implementation 'androidx.appcompat:appcompat:1.7.1'
 }

--- a/packages/expo-secure-store/android/build.gradle
+++ b/packages/expo-secure-store/android/build.gradle
@@ -15,5 +15,5 @@ android {
 }
 
 dependencies {
-  api "androidx.biometric:biometric:1.1.0"
+  implementation "androidx.biometric:biometric:1.1.0"
 }

--- a/packages/expo-sms/android/build.gradle
+++ b/packages/expo-sms/android/build.gradle
@@ -18,6 +18,6 @@ dependencies {
   if (project.findProject(':expo-modules-test-core')) {
     testImplementation project(':expo-modules-test-core')
   }
-  testImplementation "org.robolectric:robolectric:4.10"
+  testImplementation "org.robolectric:robolectric:4.16"
   testImplementation 'junit:junit:4.13.2'
 }

--- a/packages/expo-splash-screen/android/build.gradle
+++ b/packages/expo-splash-screen/android/build.gradle
@@ -15,7 +15,7 @@ android {
 }
 
 dependencies {
-  implementation 'androidx.appcompat:appcompat:1.7.0'
+  implementation 'androidx.appcompat:appcompat:1.7.1'
   implementation "androidx.core:core-splashscreen:1.2.0-alpha02"
   implementation "com.facebook.react:react-android"
 }

--- a/packages/expo-structured-headers/android/build.gradle
+++ b/packages/expo-structured-headers/android/build.gradle
@@ -19,7 +19,7 @@ android {
 }
 
 dependencies {
-  implementation "androidx.appcompat:appcompat:1.2.0"
+  implementation "androidx.appcompat:appcompat:1.7.1"
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'commons-codec:commons-codec:1.14'

--- a/packages/expo-system-ui/android/build.gradle
+++ b/packages/expo-system-ui/android/build.gradle
@@ -16,6 +16,6 @@ android {
 
 dependencies {
   implementation 'com.facebook.react:react-android'
-  implementation 'androidx.core:core:1.6.0'
-  implementation 'androidx.appcompat:appcompat:1.2.0'
+  implementation 'androidx.core:core:1.17.0'
+  implementation 'androidx.appcompat:appcompat:1.7.1'
 }

--- a/packages/expo-task-manager/android/build.gradle
+++ b/packages/expo-task-manager/android/build.gradle
@@ -16,5 +16,5 @@ android {
 
 dependencies {
   implementation project(':unimodules-app-loader')
-  api "androidx.core:core:1.0.0"
+  api "androidx.core:core:1.17.0"
 }

--- a/packages/expo-ui/android/build.gradle
+++ b/packages/expo-ui/android/build.gradle
@@ -29,11 +29,11 @@ android {
 }
 
 dependencies {
-  implementation 'androidx.compose.foundation:foundation-android:1.7.6'
-  implementation 'androidx.compose.ui:ui-android:1.7.6'
-  implementation "androidx.compose.material3:material3:1.3.1"
-  implementation 'androidx.lifecycle:lifecycle-runtime:2.8.7'
-  implementation 'androidx.fragment:fragment-ktx:1.8.5'
-  implementation 'androidx.compose.material3:material3-android:1.3.1'
+  implementation 'androidx.compose.foundation:foundation-android:1.9.1'
+  implementation 'androidx.compose.ui:ui-android:1.9.1'
+  implementation "androidx.compose.material3:material3:1.3.2"
+  implementation 'androidx.lifecycle:lifecycle-runtime:2.9.3'
+  implementation 'androidx.fragment:fragment-ktx:1.8.9'
+  implementation 'androidx.compose.material3:material3-android:1.3.2'
   implementation "androidx.graphics:graphics-shapes:1.0.1"
 }

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -140,23 +140,23 @@ dependencies {
   implementation("com.squareup.okhttp3:okhttp:4.9.2")
   implementation("com.squareup.okhttp3:okhttp-urlconnection:4.9.2")
   implementation("com.squareup.okhttp3:okhttp-brotli:4.9.2")
-  implementation("org.bouncycastle:bcutil-jdk15to18:1.78.1")
+  implementation("org.bouncycastle:bcutil-jdk15to18:1.81")
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test:core:1.6.1'
-  testImplementation 'com.google.truth:truth:1.1.2'
+  testImplementation 'androidx.test:core:1.7.0'
+  testImplementation 'com.google.truth:truth:1.4.5'
   testImplementation "io.mockk:mockk:$mockk_version"
   testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${kotlinVersion}"
-  testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
-  testImplementation 'org.robolectric:robolectric:4.14.1'
+  testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2'
+  testImplementation 'org.robolectric:robolectric:4.16'
 
   androidTestImplementation 'com.squareup.okio:okio:2.9.0'
-  androidTestImplementation 'androidx.test:runner:1.6.2'
-  androidTestImplementation 'androidx.test:core:1.6.1'
-  androidTestImplementation 'androidx.test:rules:1.6.1'
+  androidTestImplementation 'androidx.test:runner:1.7.0'
+  androidTestImplementation 'androidx.test:core:1.7.0'
+  androidTestImplementation 'androidx.test:rules:1.7.0'
   androidTestImplementation "io.mockk:mockk-android:$mockk_version"
   androidTestImplementation "androidx.room:room-testing:$room_version"
-  androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
+  androidTestImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2'
   androidTestImplementation "org.jetbrains.kotlin:kotlin-test-junit:${kotlinVersion}"
 
   implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}"

--- a/packages/expo-video/android/build.gradle
+++ b/packages/expo-video/android/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   implementation "androidx.media3:media3-ui:${androidxMedia3Version}"
   implementation "androidx.media3:media3-datasource-okhttp:${androidxMedia3Version}"
 
-  def fragment_version = "1.6.2"
+  def fragment_version = "1.8.9"
   implementation "androidx.fragment:fragment:$fragment_version"
   implementation "androidx.fragment:fragment-ktx:$fragment_version"
 }

--- a/packages/expo-web-browser/android/build.gradle
+++ b/packages/expo-web-browser/android/build.gradle
@@ -15,12 +15,12 @@ android {
 }
 
 dependencies {
-  api "androidx.browser:browser:1.6.0"
+  implementation "androidx.browser:browser:1.6.0"
 
-  implementation "androidx.core:core-ktx:1.13.1"
+  implementation "androidx.core:core-ktx:1.17.0"
 
   if (project.findProject(':expo-modules-test-core')) {
     testImplementation project(':expo-modules-test-core')
   }
-  testImplementation "org.robolectric:robolectric:4.11.1"
+  testImplementation "org.robolectric:robolectric:4.16"
 }

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -65,11 +65,11 @@ dependencies { dependencyHandler ->
   implementation 'com.facebook.react:react-android'
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test:core:1.5.0'
-  testImplementation "com.google.truth:truth:1.1.2"
   testImplementation 'io.mockk:mockk:1.13.5'
+  testImplementation 'androidx.test:core:1.7.0'
+  testImplementation "com.google.truth:truth:1.4.5"
   testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2'
-  testImplementation 'org.robolectric:robolectric:4.15.1'
+  testImplementation 'org.robolectric:robolectric:4.16'
 
   if (useLegacyAutolinking) {
     // Link expo modules as dependencies of the adapter. It uses `api` configuration so they all will be visible for the app as well.


### PR DESCRIPTION
# Why

Bumps native dependencies

# How

In this PR, I've attempted to bump some native dependencies. I've only bumped dependencies that were safe to update because they were either already resolved to a newer version or had changelogs that didn't include any breaking changes. Additionally, I've focused on upgrading dependencies from Google, JetBrains, and our test suite kit. I avoided bumping dependencies that are a crucial part of our API, such as camera or blur view.

# Test Plan

- bare-expo with NCL ✅ 