### PR TITLE
[ios][background-task] fixed timing issue on startup

### DIFF
--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed timing issue where background task iOS handler was not registered when we try to schedule a task.
+- [iOS] Fixed timing issue where background task iOS handler was not registered when we try to schedule a task. ([#39769](https://github.com/expo/expo/pull/39769) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed timing issue where background task iOS handler was not registered when we try to schedule a task.
+
 ### 💡 Others
 
 ## 1.0.7 — 2025-09-11

--- a/packages/expo-background-task/ios/BackgroundTaskAppDelegate.swift
+++ b/packages/expo-background-task/ios/BackgroundTaskAppDelegate.swift
@@ -37,6 +37,9 @@ public class BackgroundTaskAppDelegateSubscriber: ExpoAppDelegateSubscriber {
           log.error("Expo Background Tasks: Could not find TaskService module")
         }
       }
+      
+      // Signal to the scheduler that we're done.
+      BackgroundTaskScheduler.bgTaskSchedulerDidFinishRegister()
     }
 
     return true

--- a/packages/expo-background-task/ios/BackgroundTaskAppDelegate.swift
+++ b/packages/expo-background-task/ios/BackgroundTaskAppDelegate.swift
@@ -37,7 +37,7 @@ public class BackgroundTaskAppDelegateSubscriber: ExpoAppDelegateSubscriber {
           log.error("Expo Background Tasks: Could not find TaskService module")
         }
       }
-      
+
       // Signal to the scheduler that we're done.
       BackgroundTaskScheduler.bgTaskSchedulerDidFinishRegister()
     }

--- a/packages/expo-background-task/ios/BackgroundTaskScheduler.swift
+++ b/packages/expo-background-task/ios/BackgroundTaskScheduler.swift
@@ -123,7 +123,7 @@ public class BackgroundTaskScheduler {
       case .notPermitted:
         throw CouldNotRegisterWorkerTask("Task request not permitted.")
       case .immediateRunIneligible:
-        throw CouldNotRegisterWorkerTask("Task request not illegible.")
+        throw CouldNotRegisterWorkerTask("Task request not ineligible.")
       @unknown default:
         print("An unknown BGTaskScheduler error occurred.")
         // Handle any future cases added by Apple

--- a/packages/expo-background-task/ios/BackgroundTaskScheduler.swift
+++ b/packages/expo-background-task/ios/BackgroundTaskScheduler.swift
@@ -14,6 +14,52 @@ public class BackgroundTaskScheduler {
   private static var intervalSeconds: TimeInterval = 12 * 60 * 60
 
   /**
+   A one-time async gate that becomes ready after BGTaskScheduler registration finishes.
+   Multiple awaiters will be resumed when ready; subsequent awaiters return immediately.
+   */
+  private actor RegistrationGate {
+    private var ready: Bool = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func awaitReady() async {
+      if ready { return }
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        if ready {
+          continuation.resume()
+        } else {
+          waiters.append(continuation)
+        }
+      }
+    }
+
+    func signalReady() {
+      guard !ready else { return }
+      ready = true
+      let continuations = waiters
+      waiters.removeAll()
+      for c in continuations {
+        c.resume()
+      }
+    }
+  }
+
+  /**
+   Registration gate that will only be signaled when the bgTaskSchedulerDidFinishRegister is called.
+   */
+  private static let registrationGate = RegistrationGate()
+
+  /**
+   Call from the BackgroundTaskAppDelegate after the call to BGTaskScheduler.shared.register has finished
+   so that we can hold back any tryScheduleWorker calls, especially the call to BGTaskScheduler.shared.submit
+   that will fail if called before the BGTaskScheduler has successfully registered its handler.
+   */
+  public static func bgTaskSchedulerDidFinishRegister() {
+    Task {
+      await registrationGate.signalReady()
+    }
+  }
+
+  /**
    * Call when a task is registered to keep track of how many background task consumers we have
    */
   public static func didRegisterTask(minutes: Int?) {
@@ -50,6 +96,9 @@ public class BackgroundTaskScheduler {
       return
     }
 
+    // Wait until BGTaskScheduler registration has completed.
+    await registrationGate.awaitReady()
+
     // Stop existing tasks
     await stopWorker()
 
@@ -73,6 +122,8 @@ public class BackgroundTaskScheduler {
         throw CouldNotRegisterWorkerTask("Too many pending task requests.")
       case .notPermitted:
         throw CouldNotRegisterWorkerTask("Task request not permitted.")
+      case .immediateRunIneligible:
+        throw CouldNotRegisterWorkerTask("Task request not illegible.")
       @unknown default:
         print("An unknown BGTaskScheduler error occurred.")
         // Handle any future cases added by Apple


### PR DESCRIPTION
# Why

We've gotten a few reports from users of the background-task library getting errors like this:

```
Last Exception Backtrace:
0   CoreFoundation                  0x189cce8c8 __exceptionPreprocess + 164 (NSException.m:249)
1   libobjc.A.dylib                 0x186c457c4 objc_exception_throw + 88 (objc-exception.mm:356)
2   Foundation                      0x187bcce80 -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 288 (NSException.m:252)
3   BackgroundTasks                 0x1b2aded80 -[BGTaskScheduler _handleSubmissionWithoutRegistrationForTaskRequest:error:] + 204 (BGTaskScheduler.m:289)
4   BackgroundTasks                 0x1b2adf130 -[BGTaskScheduler _unsafe_submitTaskRequest:error:] + 664 (BGTaskScheduler.m:301)
5   BackgroundTasks                 0x1b2adec70 -[BGTaskScheduler submitTaskRequest:error:] + 168 (BGTaskScheduler.m:267)
6   StubHub                         0x102deba44 specialized static BackgroundTaskScheduler.tryScheduleWorker() + 472 (BackgroundTaskScheduler.swift:67)
```

This is caused by a timing issue where `expo-task-manager` calls `taskDidRegister` in `BackgroundTaskConsumer` which in turn ends up trying to register a BGTask - and in some circumstances (different threads) the BGTaskScheduler isn't done registering the handler yet.

# How

This fixes this by adding a registration gate class that lets us wait until the BGTaskScheduler is done registering its handler.

This should fix the timing issue:

Closing #39406

# Test Plan

BareExpo - it is a bit hard to test, but we should stop getting reports about this!

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
