### PR TITLE
[docs] Fix import statements in native tabs guide

### DIFF
--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -348,7 +348,7 @@ export default function TabLayout() {
 ```
 
 ```tsx app/search/_layout.tsx
-import { Stack } from 'expo-router/unstable-native-tabs';
+import { Stack } from 'expo-router';
 
 export default function SearchLayout() {
   return <Stack />;
@@ -356,7 +356,7 @@ export default function SearchLayout() {
 ```
 
 ```tsx app/search/index.tsx
-import { Stack } from 'expo-router/unstable-native-tabs';
+import { Stack } from 'expo-router';
 
 export default function SearchIndex() {
   return (


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While going through native tabs guide, I found that the `Stack` is wrongly imported in the following examples:

<img width="2084" height="1364" alt="CleanShot 2025-09-17 at 23 04 39@2x" src="https://github.com/user-attachments/assets/6e50976f-9352-474e-a8a1-a64243885553" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

 Fix import statements in native tabs guide so that `Stack` is imported from the `expo-router` library.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
