### PR TITLE
[ios][ci] Updated scripts to use iPhone 17 instead of 16

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E bricking measures disabled project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"
@@ -57,7 +57,7 @@ jobs:
           yarn maestro:ios:release:build
       - uses: eas/start_ios_simulator
         with:
-          device_identifier: iPhone 16
+          device_identifier: iPhone 17
       - name: Run Maestro tests (release)
         id: testrelease
         working_directory: ../../../updates-e2e
@@ -73,7 +73,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E bricking measures disabled project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E custom init project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"
@@ -62,7 +62,7 @@ jobs:
           yarn maestro:ios:release:build
       - uses: eas/start_ios_simulator
         with:
-          device_identifier: iPhone 16
+          device_identifier: iPhone 17
       - name: Run Maestro tests (debug)
         id: testdebug
         working_directory: ../../../updates-e2e
@@ -85,7 +85,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E enabled project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E disabled project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"
@@ -71,7 +71,7 @@ jobs:
           yarn maestro:ios:debug:build
       - uses: eas/start_ios_simulator
         with:
-          device_identifier: iPhone 16
+          device_identifier: iPhone 17
       - name: Run Maestro tests (debug)
         id: testdebug
         working_directory: ../../../updates-e2e
@@ -89,7 +89,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E disabled project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E disabled project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"
@@ -70,7 +70,7 @@ jobs:
           yarn maestro:ios:release:build
       - uses: eas/start_ios_simulator
         with:
-          device_identifier: iPhone 16
+          device_identifier: iPhone 17
       - name: Run Maestro tests (debug)
         id: testdebug
         working_directory: ../../../updates-e2e
@@ -91,7 +91,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E disabled project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E enabled project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"
@@ -86,7 +86,7 @@ jobs:
           yarn maestro:ios:release:build
       - uses: eas/start_ios_simulator
         with:
-          device_identifier: iPhone 16
+          device_identifier: iPhone 17
       - name: Run Maestro tests (debug)
         id: testdebug
         working_directory: ../../../updates-e2e
@@ -107,7 +107,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E enabled project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E error recovery project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"
@@ -57,7 +57,7 @@ jobs:
           yarn maestro:ios:release:build
       - uses: eas/start_ios_simulator
         with:
-          device_identifier: iPhone 16
+          device_identifier: iPhone 17
       - name: Run Maestro tests (release)
         id: testrelease
         working_directory: ../../../updates-e2e
@@ -73,7 +73,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E error recovery project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E fingerprint project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"
@@ -57,7 +57,7 @@ jobs:
           yarn maestro:ios:release:build
       - uses: eas/start_ios_simulator
         with:
-          device_identifier: iPhone 16
+          device_identifier: iPhone 17
       - name: Run Maestro tests (release)
         id: testrelease
         working_directory: ../../../updates-e2e
@@ -73,7 +73,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E fingerprint project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E startup project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"
@@ -62,7 +62,7 @@ jobs:
           yarn maestro:ios:release:build
       - uses: eas/start_ios_simulator
         with:
-          device_identifier: iPhone 16
+          device_identifier: iPhone 17
       - name: Run Maestro tests (debug)
         id: testdebug
         working_directory: ../../../updates-e2e
@@ -83,7 +83,7 @@ jobs:
       - uses: eas/install_node_modules
       - name: Set up Updates E2E startup project
         id: setup
-        working_directory: ../..        
+        working_directory: ../..
         env:
           UPDATES_HOST: localhost
           UPDATES_PORT: "4747"


### PR DESCRIPTION
# Why

We're seeing some e2e tests failing due to passing the wrong ios simulator name to the `eas/start_ios_simulator` task in maestro.

# How

Updated from `iPhone 16` -> `iPhone 17`

# Test Plan

Run CI
