### PR TITLE
[ci][ios]. Updated start-ios-e2e-tests to use iPhone 17 + iOS 26

### DIFF
--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -15,8 +15,8 @@ import {
   getMaestroFlowFilePath,
 } from './lib/e2e-common';
 
-const TARGET_DEVICE = 'iPhone 16 Pro';
-const TARGET_DEVICE_IOS_VERSION = 18;
+const TARGET_DEVICE = 'iPhone 17 Pro';
+const TARGET_DEVICE_IOS_VERSION = 26;
 const APP_ID = 'dev.expo.Payments';
 const OUTPUT_APP_PATH = 'ios/build/BareExpo.app';
 const MAESTRO_DRIVER_STARTUP_TIMEOUT = '120000'; // Wait 2 minutes for Maestro driver to start


### PR DESCRIPTION
# Why

iOS e2e tests are failing due to missing simulator/iOS version

# How

Fixed by:
- Updated from iPhone 16 -> iPhone 17
- Updated iOS from iOS 18 -> iOS 26

# Test Plan

Run CI
