### PR TITLE
[go] Decouple loading fonts and fetching initial data

### DIFF
--- a/apps/expo-go/src/HomeApp.tsx
+++ b/apps/expo-go/src/HomeApp.tsx
@@ -8,7 +8,7 @@ import { ThemePreference, ThemeProvider } from 'expo-dev-client-components';
 import * as Font from 'expo-font';
 import * as SplashScreen from 'expo-splash-screen';
 import * as React from 'react';
-import { Linking, Platform, StyleSheet, View, useColorScheme, Alert } from 'react-native';
+import { Linking, Platform, StyleSheet, View, useColorScheme } from 'react-native';
 import url from 'url';
 
 import ApolloClient from './api/ApolloClient';

--- a/apps/expo-go/src/HomeApp.tsx
+++ b/apps/expo-go/src/HomeApp.tsx
@@ -8,7 +8,7 @@ import { ThemePreference, ThemeProvider } from 'expo-dev-client-components';
 import * as Font from 'expo-font';
 import * as SplashScreen from 'expo-splash-screen';
 import * as React from 'react';
-import { Linking, Platform, StyleSheet, View, useColorScheme } from 'react-native';
+import { Linking, Platform, StyleSheet, View, useColorScheme, Alert } from 'react-native';
 import url from 'url';
 
 import ApolloClient from './api/ApolloClient';
@@ -92,23 +92,9 @@ export default function HomeApp() {
     });
   };
 
-  const initStateAsync = async () => {
+  const loadFontsAsync = async () => {
     try {
-      dispatch(SettingsActions.loadSettings());
-      dispatch(HistoryActions.loadHistory());
-
-      const storedSession = await LocalStorage.getSessionAsync();
-
-      if (storedSession) {
-        dispatch(SessionActions.setSession(storedSession));
-      }
-
-      const [currentUserQueryResult, persistedCurrentAccount] = await Promise.all([
-        ApolloClient.query<Home_CurrentUserActorQuery, Home_CurrentUserActorQueryVariables>({
-          query: Home_CurrentUserActorDocument,
-          context: { headers: { 'expo-session': storedSession?.sessionSecret } },
-        }),
-        AsyncStorage.getItem('currentAccount'),
+      await Promise.all([
         Font.loadAsync(Ionicons.font),
         Platform.OS === 'android'
           ? Font.loadAsync(MaterialIcons.font)
@@ -133,6 +119,30 @@ export default function HomeApp() {
           'Inter-Thin': require('./assets/Inter/Inter-Thin.otf'),
           'Inter-ThinItalic': require('./assets/Inter/Inter-ThinItalic.otf'),
         }),
+      ]);
+    } finally {
+      return;
+    }
+  };
+
+  const initStateAsync = async () => {
+    try {
+      dispatch(SettingsActions.loadSettings());
+      dispatch(HistoryActions.loadHistory());
+
+      const storedSession = await LocalStorage.getSessionAsync();
+
+      if (storedSession) {
+        dispatch(SessionActions.setSession(storedSession));
+      }
+
+      const [currentUserQueryResult, persistedCurrentAccount] = await Promise.all([
+        ApolloClient.query<Home_CurrentUserActorQuery, Home_CurrentUserActorQueryVariables>({
+          query: Home_CurrentUserActorDocument,
+          context: { headers: { 'expo-session': storedSession?.sessionSecret } },
+        }),
+        AsyncStorage.getItem('currentAccount'),
+        loadFontsAsync(),
       ]);
 
       if (currentUserQueryResult.data && currentUserQueryResult.data.meUserActor) {

--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exps://u.expo.dev/e3ec11de-308d-48c3-9f4c-c07d90733495/group/50533595-700e-46a1-b51b-8202b8c8b9e9"
+  "url": "exps://u.expo.dev/e3ec11de-308d-48c3-9f4c-c07d90733495/group/7b522187-3b23-4b61-b849-05a6d5aedbd5"
 }


### PR DESCRIPTION
# Why

Closes ENG-17407 

# How

Decouple loading fonts and fetching initial data, this way, if loading fonts fail, we will still fetch the user data

# Test Plan

Update dev-home and run from the published kernel 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
