### PR TITLE
[docs] Update page title for brownfield > get started guide

### DIFF
--- a/docs/pages/brownfield/get-started.mdx
+++ b/docs/pages/brownfield/get-started.mdx
@@ -1,5 +1,5 @@
 ---
-title: Get started
+title: How to add Expo to an existing native (brownfield) app
 sidebar_title: Get started
 description: A guide for adding Expo and React Native to existing native apps and adding a first view component.
 hideTOC: true

--- a/docs/pages/brownfield/get-started.mdx
+++ b/docs/pages/brownfield/get-started.mdx
@@ -2,7 +2,6 @@
 title: How to add Expo to an existing native (brownfield) app
 sidebar_title: Get started
 description: A guide for adding Expo and React Native to existing native apps and adding a first view component.
-hideTOC: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/brownfield/overview.mdx
+++ b/docs/pages/brownfield/overview.mdx
@@ -35,8 +35,8 @@ Expo is primarily built with greenfield apps in mind, but we are increasingly in
 ## Next steps
 
 <BoxLink
-  title="Integrating your first React Native view"
-  description="Learn how to add a React Native root view to your existing native app."
+  title="How to add Expo to an existing native (brownfield) app"
+  description="Learn how to add Expo and React Native root view into existing native apps."
   href="/brownfield/get-started/"
   Icon={BookOpen02Icon}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Feedback from @dankelly2040 

Fix ENG-17425

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update page title for brownfield > get started guide
- Update BoxLink title and description on the overview page
- Remove `hideTOC` to show the right sidebar

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="1656" height="1048" alt="CleanShot 2025-09-18 at 00 33 19" src="https://github.com/user-attachments/assets/2e7a31bf-4e97-4d5b-a140-a96542743738" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
