### PR TITLE
[audio][android]  Fix zero-byte audio recordings

### DIFF
--- a/apps/native-component-list/src/screens/Audio/expo-audio/RecordingScreen.tsx
+++ b/apps/native-component-list/src/screens/Audio/expo-audio/RecordingScreen.tsx
@@ -15,7 +15,7 @@ export default function RecordingScreen() {
     return uri ? (
       <>
         <HeadingText>Last recording</HeadingText>
-        <AudioPlayer source={{ uri }} />
+        <AudioPlayer key={uri} source={{ uri }} />
       </>
     ) : null;
   };

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix zero-byte audio recordings after calling `audioRecorder.stop()` ([#39788](https://github.com/expo/expo/pull/39788) by [@hirbod](https://github.com/hirbod))
+
 ### 💡 Others
 
 ## 1.0.12 — 2025-09-16

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
@@ -125,16 +125,11 @@ class AudioRecorder(
   }
 
   fun stopRecording(): Bundle {
-    val currentFilePath = filePath // Capture file path before reset
-
     try {
       recorder?.stop()
     } finally {
       reset()
     }
-
-    // Auto-prepare for next recording to match iOS/Web behavior
-    prepareRecording(null)
 
     // Emit completion event on the main thread
     appContext?.mainQueue?.launch {
@@ -145,7 +140,7 @@ class AudioRecorder(
           "isFinished" to true,
           "hasError" to false,
           "error" to null,
-          "url" to currentFilePath?.toUri().toString()
+          "url" to filePath?.toUri().toString()
         )
       )
     }
@@ -164,7 +159,6 @@ class AudioRecorder(
     durationAlreadyRecorded = 0
     startTime = 0L
     isPrepared = false
-    filePath = null // Reset file path for next recording
   }
 
   private fun createRecorder(options: RecordingOptions) =


### PR DESCRIPTION
# Why

The audio recorder returns a URI pointing to a zero-byte file instead of the actual recording on Android. This was caused by auto-preparation in stopRecording() which immediately created a new empty file after each recording, causing the uri property to point to the wrong file.

This was a regression introduced in #38612 because I tried to auto-prepare the next recording to align more with iOS and Web. Since our docs also state that you need to call `prepareToRecordAsync()` before each recording, we can safely revert this.

Fixes #39646

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Removed auto-preparation call from stopRecording() method
- Preserved filePath after recording stops so uri property continues to work as documented

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
