### PR TITLE
fix(kotlin): migrate to compilerOptions DSL

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- fix(kotlin): migrate to compilerOptions DSL ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
+
 ## 6.0.11 — 2025-09-11
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- fix(kotlin): migrate to compilerOptions DSL ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
+- [Android] Migrated from `kotlinOptions` to `compilerOptions` DSL. ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
 
 ## 6.0.11 — 2025-09-11
 

--- a/packages/expo-dev-launcher/expo-dev-launcher-gradle-plugin/build.gradle.kts
+++ b/packages/expo-dev-launcher/expo-dev-launcher-gradle-plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {

--- a/packages/expo-dev-launcher/expo-dev-launcher-gradle-plugin/build.gradle.kts
+++ b/packages/expo-dev-launcher/expo-dev-launcher-gradle-plugin/build.gradle.kts
@@ -22,8 +22,8 @@ java {
 }
 
 tasks.withType<KotlinCompile> {
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_11)
   }
 }
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- fix(kotlin): migrate to compilerOptions DSL ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
+- [Android] Migrated from `kotlinOptions` to `compilerOptions` DSL. ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
 
 ## 3.0.11 — 2025-09-16
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- fix(kotlin): migrate to compilerOptions DSL ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
+
 ## 3.0.11 — 2025-09-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/build.gradle.kts
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/build.gradle.kts
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin/build.gradle.kts
@@ -22,8 +22,8 @@ java {
 }
 
 tasks.withType<KotlinCompile> {
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_11)
   }
 }
 

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/build.gradle.kts
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/build.gradle.kts
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/build.gradle.kts
@@ -27,8 +27,8 @@ java {
 }
 
 tasks.withType<KotlinCompile> {
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_11)
   }
 }
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- fix(kotlin): migrate to compilerOptions DSL ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
+- [Android] Migrated from `kotlinOptions` to `compilerOptions` DSL. ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
 
 ## 3.0.16 — 2025-09-16
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- fix(kotlin): migrate to compilerOptions DSL ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
+
 ## 3.0.16 — 2025-09-16
 
 ### 🎉 New features

--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {

--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -55,8 +55,8 @@ java {
 }
 
 tasks.withType<KotlinCompile> {
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_11)
   }
 }
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- fix(kotlin): migrate to compilerOptions DSL ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
+
 ## 29.0.10 — 2025-09-11
 
 ### 💡 Others

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- fix(kotlin): migrate to compilerOptions DSL ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
+- [Android] Migrated from `kotlinOptions` to `compilerOptions` DSL. ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
 
 ## 29.0.10 — 2025-09-11
 

--- a/packages/expo-updates/expo-updates-gradle-plugin/build.gradle.kts
+++ b/packages/expo-updates/expo-updates-gradle-plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {

--- a/packages/expo-updates/expo-updates-gradle-plugin/build.gradle.kts
+++ b/packages/expo-updates/expo-updates-gradle-plugin/build.gradle.kts
@@ -22,8 +22,8 @@ java {
 }
 
 tasks.withType<KotlinCompile> {
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.toString()
+  compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_11)
   }
 }
 


### PR DESCRIPTION
# Why

The Kotlin Gradle plugin has deprecated the kotlinOptions DSL in favor of the newer compilerOptions DSL. This change eliminates deprecation warnings that appear during builds and ensures compatibility with future versions of the Kotlin Gradle plugin.
The deprecation warning was:
`'kotlinOptions(KotlinJvmOptionsDeprecated /* = KotlinJvmOptions */.() -> Unit): Unit' is deprecated. Please migrate to the compilerOptions DSL.`

# How

Migrated the deprecated kotlinOptions configuration to the modern compilerOptions DSL in the expo-autolinking-settings-plugin build file:

Before:
```kotlin
tasks.withType<KotlinCompile> {
  kotlinOptions {
    jvmTarget = JavaVersion.VERSION_11.toString()
  }
}
```

After:
```kotlin
tasks.withType<KotlinCompile> {
  compilerOptions {
    jvmTarget.set(JvmTarget.JVM_11)
  }
}
```

Key changes:

- Replaced kotlinOptions with compilerOptions
- Updated JVM target from string-based JavaVersion.VERSION_11.toString() to enum-based JvmTarget.JVM_11
- Used .set() method instead of direct assignment for proper configuration

# Test Plan

1. Build the expo-autolinking-settings-plugin to verify no deprecation warnings appear
2. Verify the plugin still compiles correctly with JVM target 11
3. Test that the plugin functionality remains unchanged in existing projects

Terminal output before fix:
`w: file:///tmp/runner/eas-build-local-nodejs/.../build.gradle.kts:30:3: 'kotlinOptions(...)' is deprecated. Please migrate to the compilerOptions DSL.`

Terminal output after fix:
`[No deprecation warnings]`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
