### PR TITLE
[ios][expo-device] update UIDevice with iPhone 17

### DIFF
--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Added support for iOS 17.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [iOS] Added support for iOS 17.
+- [iOS] Added support for iOS 17. ([#39797](https://github.com/expo/expo/pull/39797) by [@chrfalch](https://github.com/chrfalch))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-device/ios/UIDevice.swift
+++ b/packages/expo-device/ios/UIDevice.swift
@@ -7,6 +7,8 @@ struct ExpoDeviceType {
 
 public extension UIDevice {
   // Credit: https://stackoverflow.com/a/26962452
+  // Added support for iPhone 17 from https://deviceatlas.com/resources/clientside/ios-hardware-identification
+  // and https://gist.github.com/adamawolf/3048717
   static let modelIdentifier: String = {
     var systemInfo = utsname()
     uname(&systemInfo)
@@ -94,6 +96,14 @@ public extension UIDevice {
         return ExpoDeviceType(modelName: "iPhone 16 Pro", deviceYearClass: 2024)
       case "iPhone17,2":
         return ExpoDeviceType(modelName: "iPhone 16 Pro Max", deviceYearClass: 2024)
+      case "iPhone18,1":
+        return ExpoDeviceType(modelName: "iPhone 17 Pro", deviceYearClass: 2025)
+      case "iPhone18,2":
+        return ExpoDeviceType(modelName: "iPhone 17 Pro Max", deviceYearClass: 2025)
+      case "iPhone18,3":
+        return ExpoDeviceType(modelName: "iPhone 17", deviceYearClass: 2025)
+      case "iPhone18,4":
+        return ExpoDeviceType(modelName: "iPhone Air", deviceYearClass: 2025)
       case "iPhone8,4":
         return ExpoDeviceType(modelName: "iPhone SE", deviceYearClass: 2016)
       case "iPhone12,8":


### PR DESCRIPTION
# Why

Added support for iPhone 17 models in UIDevice class

# How

Updated lookup table in UIDevice.swift

**Sources:**
https://deviceatlas.com/resources/clientside/ios-hardware-identification
https://gist.github.com/adamawolf/3048717

# Test Plan

Test in BareExpo on iPhone 17

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
