### PR TITLE
chore: Update issue templates with larger note

### DIFF
--- a/.github/ISSUE_TEMPLATE/0-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/0-bug_report.yml
@@ -14,6 +14,7 @@ body:
         > [!IMPORTANT]  
         > Reproductions are necessary for **most** bug reports.
         > Without one, maintainers will be forced to first reproduce the issue and craft missing context, rather than being able to address the report immediately.
+        > Issues without a reproduction link may be closed without further notice.
   - type: input
     attributes:
       label: Minimal reproducible example

--- a/.github/ISSUE_TEMPLATE/0-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/0-bug_report.yml
@@ -18,7 +18,9 @@ body:
     attributes:
       label: Minimal reproducible example
       description: |
-        To create a minimal reproducible example, run `npx create-expo-app@latest --template blank` (or use an equivalent for your package manager of choice) and then add in only the necessary code and configuration necessary to reproduce the issue. Next, put the project on GitHub and share the link here.
+        Create a minimal repository that is used to demonstrate the bug you're trying to report.
+        Either, reduce your app's repository to the bare minimum to reproduce the bug, or create a new app with `npx create-expo-app@latest --template blank` (or an equivalent).
+        Upload this repository (for example to GitHub) and paste the link to it here.
 
         - If the issue depends on a third party library that Expo does not maintain, you should make your best effort to reproduce it without that library in order to ensure that the issue belongs on this repository, rather than the other library's repository.
         - A maintainer may close your issue if they feel it is not minimal enough. The purpose of this is to make it as safe and fast as possible for maintainers to reproduce and fix the issue.

--- a/.github/ISSUE_TEMPLATE/0-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/0-bug_report.yml
@@ -8,6 +8,12 @@ body:
   - type: markdown
     attributes:
       value: If you are unsure if this is a bug in Expo tools, or have a question, or you think your issue might be caused by your application code, you can get help from the community on [Discord](https://chat.expo.dev).
+  - type: markdown
+    attributes:
+      value: |
+        > [!IMPORTANT]  
+        > Reproductions are necessary for **most** bug reports.
+        > Without one, maintainers will be forced to first reproduce the issue and craft missing context, rather than being able to address the report immediately.
   - type: input
     attributes:
       label: Minimal reproducible example

--- a/.github/ISSUE_TEMPLATE/0-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/0-bug_report.yml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Minimal reproducible example
       description: |
-        Create a minimal repository that is used to demonstrate the bug you're trying to report.
+        Create a minimal repository that clearly demonstrates the bug you're trying to report.
         Either, reduce your app's repository to the bare minimum to reproduce the bug, or create a new app with `npx create-expo-app@latest --template blank` (or an equivalent).
         Upload this repository (for example to GitHub) and paste the link to it here.
 

--- a/.github/ISSUE_TEMPLATE/1-bug_report_cli.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report_cli.yml
@@ -14,6 +14,7 @@ body:
         > [!IMPORTANT]  
         > Reproductions are necessary for **most** bug reports.
         > Without one, maintainers will be forced to first reproduce the issue and craft missing context, rather than being able to address the report immediately.
+        > Issues without a reproduction link may be closed without further notice.
   - type: input
     attributes:
       label: Minimal reproducible example

--- a/.github/ISSUE_TEMPLATE/1-bug_report_cli.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report_cli.yml
@@ -14,7 +14,7 @@ body:
         > [!IMPORTANT]  
         > Reproductions are necessary for **most** bug reports.
         > Without one, maintainers will be forced to first reproduce the issue and craft missing context, rather than being able to address the report immediately.
-  - type: textarea
+  - type: input
     attributes:
       label: Minimal reproducible example
       description: |

--- a/.github/ISSUE_TEMPLATE/1-bug_report_cli.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report_cli.yml
@@ -8,6 +8,12 @@ body:
   - type: markdown
     attributes:
       value: If you are unsure if this is a bug in Expo CLI, or have a question, or you think your issue might be caused by your application code, you can get help from the community on [Discord](https://chat.expo.dev).
+  - type: markdown
+    attributes:
+      value: |
+        > [!IMPORTANT]  
+        > Reproductions are necessary for **most** bug reports.
+        > Without one, maintainers will be forced to first reproduce the issue and craft missing context, rather than being able to address the report immediately.
   - type: textarea
     attributes:
       label: Minimal reproducible example

--- a/.github/ISSUE_TEMPLATE/1-bug_report_cli.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report_cli.yml
@@ -18,7 +18,9 @@ body:
     attributes:
       label: Minimal reproducible example
       description: |
-        To create a minimal reproducible example, run `npx create-expo-app@latest --template blank` (or use an equivalent for your package manager of choice) and then add in only the necessary code and configuration necessary to reproduce the issue. Next, put the project on GitHub and share the link here.
+        Create a minimal repository that is used to demonstrate the bug you're trying to report.
+        Either, reduce your app's repository to the bare minimum to reproduce the bug, or create a new app with `npx create-expo-app@latest --template blank` (or an equivalent).
+        Upload this repository (for example to GitHub) and paste the link to it here.
 
         - If the issue depends on a third party library that Expo does not maintain, you should make your best effort to reproduce it without that library in order to ensure that the issue belongs on this repository, rather than the other library's repository.
         - A maintainer may close your issue if they feel it is not minimal enough. The purpose of this is to make it as safe and fast as possible for maintainers to reproduce and fix the issue.

--- a/.github/ISSUE_TEMPLATE/1-bug_report_cli.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report_cli.yml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Minimal reproducible example
       description: |
-        Create a minimal repository that is used to demonstrate the bug you're trying to report.
+        Create a minimal repository that clearly demonstrates the bug you're trying to report.
         Either, reduce your app's repository to the bare minimum to reproduce the bug, or create a new app with `npx create-expo-app@latest --template blank` (or an equivalent).
         Upload this repository (for example to GitHub) and paste the link to it here.
 

--- a/.github/ISSUE_TEMPLATE/2-bug_report_router.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug_report_router.yml
@@ -14,6 +14,7 @@ body:
         > [!IMPORTANT]  
         > Reproductions are necessary for **most** bug reports.
         > Without one, maintainers will be forced to first reproduce the issue and craft missing context, rather than being able to address the report immediately.
+        > Issues without a reproduction link may be closed without further notice.
   - type: input
     attributes:
       label: Minimal reproducible example

--- a/.github/ISSUE_TEMPLATE/2-bug_report_router.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug_report_router.yml
@@ -8,6 +8,12 @@ body:
   - type: markdown
     attributes:
       value: If you are unsure if this is a bug in Expo Router, or have a question, or you think your issue might be caused by your application code, you can get help from the community on [Discord](https://chat.expo.dev).
+  - type: markdown
+    attributes:
+      value: |
+        > [!IMPORTANT]  
+        > Reproductions are necessary for **most** bug reports.
+        > Without one, maintainers will be forced to first reproduce the issue and craft missing context, rather than being able to address the report immediately.
   - type: input
     attributes:
       label: Minimal reproducible example

--- a/.github/ISSUE_TEMPLATE/2-bug_report_router.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug_report_router.yml
@@ -18,7 +18,9 @@ body:
     attributes:
       label: Minimal reproducible example
       description: |
-        To create a minimal reproducible example, run `npx create-expo-app@latest` (or use an equivalent for your package manager of choice) and then run `npm run reset-project` in the project directory and press `n` to delete the files, then run `git commit -m "Initial commit"`. Now, add in only the necessary pieces of code to reproduce the issue. Next, put the project on GitHub and share the link here.
+        Create a minimal repository that is used to demonstrate the bug you're trying to report.
+        Either, reduce your app's repository to the bare minimum to reproduce the bug, or create a new app with `npx create-expo-app@latest --template blank` (or an equivalent).
+        Upload this repository (for example to GitHub) and paste the link to it here.
         
         - If the issue depends on a third party library that Expo does not maintain, you should make your best effort to reproduce it without that library in order to ensure that the issue belongs on this repository, rather than the other library's repository.
         - A maintainer may close your issue if they feel it is not minimal enough. The purpose of this is to make it as safe and fast as possible for maintainers to reproduce and fix the issue.

--- a/.github/ISSUE_TEMPLATE/2-bug_report_router.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug_report_router.yml
@@ -19,7 +19,7 @@ body:
     attributes:
       label: Minimal reproducible example
       description: |
-        Create a minimal repository that is used to demonstrate the bug you're trying to report.
+        Create a minimal repository that clearly demonstrates the bug you're trying to report.
         Either, reduce your app's repository to the bare minimum to reproduce the bug, or create a new app with `npx create-expo-app@latest --template blank` (or an equivalent).
         Upload this repository (for example to GitHub) and paste the link to it here.
         


### PR DESCRIPTION
This is just a proposal, which I believe I've mentioned to @alanjhughes in DMs. I've seen similar issues on the [`gql.tada`](https://github.com/0no-co/gql.tada) and `urql` repos. To experiment, a few months back we added a markdown "important" callout to the issue template, which is _very_ visible when opening the issue creation modal.

Adding this notice and getting people's attention in this way improved the issue quality there dramatically. This is anecdata, but if we think this is safe to try out, it's relatively low risk to revert or tweak as needed.

Copy here isn't final. I've made a tweak to clarify that _reducing_ an app to a minimal reproduction is a valid way to provide a reproduction. I've also updated the CLI issue template to have an input field rather than text are for the repro, since that seems to have been a typo