### PR TITLE
chore: Bump to `@expo/metro@~54.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "resolutions": {
-    "@expo/metro": "~0.1.1",
+    "@expo/metro": "~54.0.0",
     "react-native": "0.81.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/metro@~54.0.0` ([#39800](https://github.com/expo/expo/pull/39800) by [@kitten](https://github.com/kitten))
+
 ## 54.0.6 — 2025-09-16
 
 ### 💡 Others

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -50,7 +50,7 @@
     "@expo/image-utils": "^0.8.7",
     "@expo/json-file": "^10.0.7",
     "@expo/mcp-tunnel": "~0.0.7",
-    "@expo/metro": "~0.1.1",
+    "@expo/metro": "~54.0.0",
     "@expo/metro-config": "~54.0.3",
     "@expo/osascript": "^2.3.7",
     "@expo/package-manager": "^1.9.8",

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/metro@~54.0.0` ([#39800](https://github.com/expo/expo/pull/39800) by [@kitten](https://github.com/kitten))
+
 ## 54.0.3 — 2025-09-12
 
 ### 💡 Others

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "^7.20.0",
     "@babel/generator": "^7.20.5",
     "@expo/config": "~12.0.9",
-    "@expo/metro": "~0.1.1",
+    "@expo/metro": "~54.0.0",
     "@expo/env": "~2.0.7",
     "@expo/json-file": "~10.0.7",
     "@expo/spawn-async": "^1.7.2",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -80,7 +80,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.0",
     "@types/babel__core": "^7.20.5",
-    "@expo/metro": "~0.1.1",
+    "@expo/metro": "~54.0.0",
     "expo-module-scripts": "^5.0.7",
     "jest": "^29.2.1",
     "react-refresh": "^0.14.2"

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -36,7 +36,7 @@
     "@expo/config": "~12.0.9",
     "@expo/env": "~2.0.7",
     "@expo/json-file": "~10.0.7",
-    "@expo/metro": "~0.1.1",
+    "@expo/metro": "~54.0.0",
     "@expo/schemer": "2.1.0",
     "@expo/spawn-async": "^1.7.2",
     "@types/debug": "^4.1.8",

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Bump to `@expo/metro@~54.0.0` fixing `metro-runtime` resolution error when `unstable_enablePackageExports` is forcefully disabled ([#39800](https://github.com/expo/expo/pull/39800) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 54.0.8 — 2025-09-16

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -80,7 +80,7 @@
     "@expo/config-plugins": "~54.0.1",
     "@expo/devtools": "0.1.7",
     "@expo/fingerprint": "0.15.1",
-    "@expo/metro": "~0.1.1",
+    "@expo/metro": "~54.0.0",
     "@expo/metro-config": "54.0.3",
     "@expo/vector-icons": "^15.0.2",
     "@ungap/structured-clone": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,10 +1579,10 @@
     zod "^3.25.76"
     zod-to-json-schema "^3.24.6"
 
-"@expo/metro@~0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@expo/metro/-/metro-0.1.1.tgz#234099226509f88d3a431f386e83c21a64a01630"
-  integrity sha512-zvA9BE6myFoCxeiw/q3uE/kVkIwLTy27a+fDoEl7WQ7EvKfFeiXnRVhUplDMLGZIHH8VC38Gay6RBtVhnmOm5w==
+"@expo/metro@~54.0.0":
+  version "54.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/metro/-/metro-54.0.0.tgz#ebb3846ee2fee688147fc08f7fed5b75fabde17f"
+  integrity sha512-x2HlliepLJVLSe0Fl/LuPT83Mn2EXpPlb1ngVtcawlz4IfbkYJo16/Zfsfrn1t9d8LpN5dD44Dc55Q1/fO05Nw==
   dependencies:
     metro "0.83.1"
     metro-babel-transformer "0.83.1"


### PR DESCRIPTION
- Maintenance update
- Align versioning to SDK version
- Also alters `metro-runtime` resolution to succeed in `expo` for `HmrClient` when `unstable_enablePackageExports` is forcefully disabled

Resolves https://github.com/facebook/metro/issues/1583