### PR TITLE
fix(jest-expo): avoid unnecessary transformations when running Jest tests

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Simplify `transformIgnorePatterns` to avoid unnecessary transforms and remove legacy packages. ([#39807](https://github.com/expo/expo/pull/39807) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 54.0.11 — 2025-09-12

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -100,7 +100,8 @@ if (!Array.isArray(jestPreset.transformIgnorePatterns)) {
 
 // Also please keep `unit-testing.mdx` file up to date
 jestPreset.transformIgnorePatterns = [
-  '/node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg)/',
+  '/node_modules/(?!(.pnpm|react-native|@react-native|@react-native-community|expo|@expo|@expo-google-fonts|react-navigation|@react-navigation|@sentry/react-native|native-base))',
+  // Disable transforming the reanimated plugin in multi-platform tests, causing "Reentrant plugin detected trying to load react-native-reanimated/plugin.."
   '/node_modules/react-native-reanimated/plugin/',
 ];
 

--- a/packages/jest-expo/tests/__tests__/jest-transform-ignore.test.node.js
+++ b/packages/jest-expo/tests/__tests__/jest-transform-ignore.test.node.js
@@ -1,0 +1,66 @@
+const path = require('node:path');
+
+const jestPreset = require('../../jest-preset');
+
+it('transforms project code', () => {
+  expect(shouldTransform('/path/to/project', 'App.tsx')).toBe(true);
+  expect(shouldTransform('/path/to/project', 'app/index.js')).toBe(true);
+});
+
+describe.each([
+  ['normal package paths', '/path/to/project'],
+  ['pnpm isolated package paths', '/path/to/project/node_modules/.pnpm/package+group@0.0.0'],
+])('%s', (_name, rootDir) => {
+  it('transforms expo* packages', () => {
+    expect(shouldTransform(rootDir, 'node_modules/expo/src/Expo.ts')).toBe(true);
+    expect(shouldTransform(rootDir, 'node_modules/expo-audio/build/index.js')).toBe(true);
+    expect(shouldTransform(rootDir, 'node_modules/expo-router/entry.js')).toBe(true);
+  });
+
+  it('transforms @expo/* packages', () => {
+    expect(shouldTransform(rootDir, 'node_modules/@expo/devtools/build/index.js')).toBe(true);
+    expect(shouldTransform(rootDir, 'node_modules/@expo/dom-webview/src/index.ts')).toBe(true);
+    expect(shouldTransform(rootDir, 'node_modules/@expo/metro-runtime/src/index.ts')).toBe(true);
+  });
+
+  it('transforms react-native* packages', () => {
+    expect(shouldTransform(rootDir, 'node_modules/react-native/index.js')).toBe(true);
+    expect(shouldTransform(rootDir, 'node_modules/react-native-svg/index.js')).toBe(true);
+    expect(shouldTransform(rootDir, 'node_modules/react-native-reanimated/index.js')).toBe(true);
+    expect(shouldTransform(rootDir, 'node_modules/react-native-worklets/index.js')).toBe(true);
+  });
+
+  it('transforms @react-native* packages', () => {
+    /* eslint-disable prettier/prettier */
+    expect(shouldTransform(rootDir, 'node_modules/@react-native/normalize-colors/index.flow.js')).toBe(true);
+    expect(shouldTransform(rootDir, 'node_modules/@react-native/js-polyfills/index.js')).toBe(true);
+    expect(shouldTransform(rootDir, 'node_modules/@react-native/virtualized-lists/Lists/VirtualizedList.js')).toBe(true);
+  });
+
+  it('does not transform reanimated/plugin', () => {
+    expect(shouldTransform(rootDir, 'node_modules/react-native-reanimated/plugin/index.js')).toBe(false);
+  });
+
+  it('does not transform other packages', () => {
+    expect(shouldTransform(rootDir, 'node_modules/@tsd/typescript/typescript/lib/typescript.js')).toBe(false);
+    expect(shouldTransform(rootDir, 'node_modules/lodash/index.js')).toBe(false);
+    expect(shouldTransform(rootDir, 'node_modules/react/index.js')).toBe(false);
+    expect(shouldTransform(rootDir, 'node_modules/typescript/index.js')).toBe(false);
+  });
+});
+
+// See: https://github.com/jestjs/jest/blob/4e56991693da7cd4c3730dc3579a1dd1403ee630/packages/jest-transform/src/ScriptTransformer.ts#L1018
+const transformIgnoreRegex = new RegExp(jestPreset.transformIgnorePatterns.join('|'));
+
+/**
+ * Check if the file paths should be transformed by Jest.
+ * This follows a similar `shouldTransform` check within Jest itself.
+ *
+ * @see https://github.com/jestjs/jest/blob/4e56991693da7cd4c3730dc3579a1dd1403ee630/packages/jest-transform/src/ScriptTransformer.ts#L839-L844
+ * @param {string} rootDir
+ * @param {string} filename
+ * @return {boolean}
+ */
+function shouldTransform(rootDir, filename) {
+  return !transformIgnoreRegex.test(path.join(rootDir, filename));
+}

--- a/packages/jest-expo/tests/__tests__/jest-transform-ignore.test.node.js
+++ b/packages/jest-expo/tests/__tests__/jest-transform-ignore.test.node.js
@@ -23,6 +23,12 @@ describe.each([
     expect(shouldTransform(rootDir, 'node_modules/@expo/metro-runtime/src/index.ts')).toBe(true);
   });
 
+  it('transforms @expo-google-fonts/* packages', () => {
+    expect(shouldTransform(rootDir, 'node_modules/@expo-google-fonts/inter/index.js')).toBe(true);
+    expect(shouldTransform(rootDir, 'node_modules/@expo-google-fonts/poppins/index.js')).toBe(true);
+    expect(shouldTransform(rootDir, 'node_modules/@expo-google-fonts/roboto/index.js')).toBe(true);
+  });
+
   it('transforms react-native* packages', () => {
     expect(shouldTransform(rootDir, 'node_modules/react-native/index.js')).toBe(true);
     expect(shouldTransform(rootDir, 'node_modules/react-native-svg/index.js')).toBe(true);
@@ -35,6 +41,16 @@ describe.each([
     expect(shouldTransform(rootDir, 'node_modules/@react-native/normalize-colors/index.flow.js')).toBe(true);
     expect(shouldTransform(rootDir, 'node_modules/@react-native/js-polyfills/index.js')).toBe(true);
     expect(shouldTransform(rootDir, 'node_modules/@react-native/virtualized-lists/Lists/VirtualizedList.js')).toBe(true);
+  });
+
+  it('transforms @react-navigation/* packages', () => {
+    expect(shouldTransform(rootDir, 'node_modules/@react-navigation/native/lib/module/index.js')).toBe(true);
+    expect(shouldTransform(rootDir, 'node_modules/@react-navigation/elements/lib/module/index.js')).toBe(true);
+    expect(shouldTransform(rootDir, 'node_modules/@react-navigation/devtools/lib/module/index.js')).toBe(true);
+  });
+
+  it('transforms @sentry/react-native package', () => {
+    expect(shouldTransform(rootDir, 'node_modules/@sentry/react-native/dist/js/index.js')).toBe(true);
   });
 
   it('does not transform reanimated/plugin', () => {


### PR DESCRIPTION
# Why

Fixes #39789
Follow-up from #39605

This resolves an issue with the Expo Router tests transforming way more than expected, causing `yarn test hooks` to stall as it's trying to transform `@tsd/typescript`. 

# How

- Added a few unit tests to avoid regressing on broken Jest `transformIgnorePatterns`
- Fixed pnpm support "the proper way"(tm)
- Dropped legacy packages that are not in use anymore

# Test Plan

See added test, or:

- `cd packages/expo-router`
- `yarn test hooks`
  - Should not stall for longer than ±10s

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
