### PR TITLE
Fix `expo/tsconfig.base.json` by adding `${configDir}` prefix and ios / android directories to `excludes`

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### 💡 Others
 
+- Updated `expo/tsconfig.base` to resolve `exclude` paths relative to the extending tsconfig ([#39816](https://github.com/expo/expo/pull/39816) by [@kraenhansen](https://github.com/kraenhansen))
+
 ## 54.0.8 — 2025-09-16
 
 ### 🐛 Bug fixes

--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -17,5 +17,5 @@
     "target": "ESNext"
   },
 
-  "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]
+  "exclude": ["${configDir}/node_modules", "${configDir}/babel.config.js", "${configDir}/metro.config.js", "${configDir}/jest.config.js", "${configDir}/android", "${configDir}/ios"]
 }


### PR DESCRIPTION
# Why

The `tsconfig.base.json` is extended in `tsconfig.json` files from templates such as the `expo-template-blank-typescript` https://github.com/expo/expo/blob/5c9a975736f857b6ddaf577d9e242773892d12b9/templates/expo-template-blank-typescript/tsconfig.json#L2

In its current form, the `excludes` declared in the `tsconfig.base.json` has no effect on the template app's project:

https://github.com/expo/expo/blob/5c9a975736f857b6ddaf577d9e242773892d12b9/packages/expo/tsconfig.base.json#L20

This is because `excludes` are resolved relative to the `tsconfig.base.json`, not the extending config.

In practice, this is not a huge deal for most developers, because the template most often doesn't have a lot of TS / JS files. It does however result in a crash of the TypeScript language server in VS Code, if you for example build Hermes from source, in which case the app project will start including JS files from the Hermes project (nested under `./ios/Pods/hermes-engine/`) - which is how I discovered this issue initially.

I also suggest adding the `ios` and `android` directories to the `excludes` to further help limit the amount files considered by the compiler.

# How

My suggestion is to use [the `${configDir}` "template variable" introduced in TypeScript 5.5](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#the-configdir-template-variable-for-configuration-files) to ensure the `excludes` declared are resolved relative to the extending tsconfig (from the template app, or [any other tsconfig extending this in the expo repo](https://github.com/expo/expo/blob/main/packages/expo/tsconfig.json))

# Test Plan

I initialized an Expo app from the blank TypeScript template:

```
npx create-expo-app@latest test-app --template blank-typescript
```

I updated `app.json` to include `ios.buildReactNativeFromSource: true` to get a lot of Hermes source-code into the app directory.

## Running `tsc --showConfig` before this diff

```json5
{
    "compilerOptions": {
        "allowJs": true,
        "esModuleInterop": true,
        "jsx": "react-native",
        "lib": [
            "dom",
            "esnext"
        ],
        "module": "preserve",
        "moduleDetection": "force",
        "moduleResolution": "bundler",
        "customConditions": [
            "react-native"
        ],
        "noEmit": true,
        "resolveJsonModule": true,
        "skipLibCheck": true,
        "target": "esnext",
        "strict": true,
        "allowSyntheticDefaultImports": true,
        "resolvePackageJsonExports": true,
        "resolvePackageJsonImports": true,
        "useDefineForClassFields": true,
        "noImplicitAny": true,
        "noImplicitThis": true,
        "strictNullChecks": true,
        "strictFunctionTypes": true,
        "strictBindCallApply": true,
        "strictPropertyInitialization": true,
        "strictBuiltinIteratorReturn": true,
        "alwaysStrict": true,
        "useUnknownInCatchVariables": true
    },
    "files": [
        "./App.tsx",
        "./index.ts",
        "./ios/Pods/hermes-engine/API/hermes/cdp/tools/hermes-inspector-msggen/src/Command.js",
        "./ios/Pods/hermes-engine/API/hermes/cdp/tools/hermes-inspector-msggen/src/Converters.js",
        // I removed 1594 lines of files from ./ios/Pods/hermes-engine
        "./ios/Pods/hermes-engine/utils/promise/rollup.config.js"
    ],
    "exclude": [
        "../../node_modules/expo/node_modules",
        "../../node_modules/expo/babel.config.js",
        "../../node_modules/expo/metro.config.js",
        "../../node_modules/expo/jest.config.js"
    ]
}
```

Note how the `exclude` is relative to `../../node_modules/expo/` and how a bunch of JS files from `./ios/Pods/hermes-engine/` are included in the TS project.

## Running `tsc --showConfig` after this diff

```json5
{
    "compilerOptions": {
        "allowJs": true,
        "esModuleInterop": true,
        "jsx": "react-native",
        "lib": [
            "dom",
            "esnext"
        ],
        "module": "preserve",
        "moduleDetection": "force",
        "moduleResolution": "bundler",
        "customConditions": [
            "react-native"
        ],
        "noEmit": true,
        "resolveJsonModule": true,
        "skipLibCheck": true,
        "target": "esnext",
        "strict": true,
        "allowSyntheticDefaultImports": true,
        "resolvePackageJsonExports": true,
        "resolvePackageJsonImports": true,
        "useDefineForClassFields": true,
        "noImplicitAny": true,
        "noImplicitThis": true,
        "strictNullChecks": true,
        "strictFunctionTypes": true,
        "strictBindCallApply": true,
        "strictPropertyInitialization": true,
        "strictBuiltinIteratorReturn": true,
        "alwaysStrict": true,
        "useUnknownInCatchVariables": true
    },
    "files": [
        "./App.tsx",
        "./index.ts"
    ],
    "exclude": [
        "/Users/kraen.hansen/Repositories/test-app/node_modules",
        "/Users/kraen.hansen/Repositories/test-app/babel.config.js",
        "/Users/kraen.hansen/Repositories/test-app/metro.config.js",
        "/Users/kraen.hansen/Repositories/test-app/jest.config.js",
        "/Users/kraen.hansen/Repositories/test-app/ios"
    ]
}
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
