### PR TITLE
[docs] Fix copy command not present in step 2 of Upgrade Expo SDK guide

### DIFF
--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -47,7 +47,10 @@ Depending on which SDK you're upgrading to, substitute the `expo@^54.0.0` with t
 
 Upgrade all dependencies to match the installed SDK version. Then run [`expo-doctor`](/develop/tools/#expo-doctor) command to check for common problems.
 
-<Terminal cmd={['$ npx expo install --fix', '', '$ npx expo-doctor']} />
+<Terminal
+  cmd={['$ npx expo install --fix', '', '$ npx expo-doctor']}
+  cmdCopy="npx expo install --fix && npx expo-doctor"
+/>
 
 </Step>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #39730 

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add `cmdCopy` in Step 2 to allow copy-pasting the commands.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="927" height="274" alt="CleanShot 2025-09-19 at 01 44 02" src="https://github.com/user-attachments/assets/9b124b0c-1d64-41b8-934a-fe11c0861e97" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
