### PR TITLE
[modules-core][iOS] Add explicit CallInvoker and CallbackWrapper imports to EXJSIUtils

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - [Android] Migrated from `kotlinOptions` to `compilerOptions` DSL. ([#39794](https://github.com/expo/expo/pull/39794) by [@huextrat](https://github.com/huextrat))
+- [iOS] Add explicit CallInvoker and CallbackWrapper imports to EXJSIUtils ([#39818](https://github.com/expo/expo/pull/39818) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 3.0.16 — 2025-09-16
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
@@ -7,6 +7,8 @@
 #import <jsi/jsi.h>
 #import <React/RCTBridgeModule.h>
 #import <ReactCommon/TurboModuleUtils.h>
+#import <ReactCommon/CallInvoker.h>
+#import <react/bridging/CallbackWrapper.h>
 #import <ExpoModulesCore/ObjectDeallocator.h>
 
 namespace jsi = facebook::jsi;


### PR DESCRIPTION
# Why

In react-native 0.82, some headers were moved around, requiring us to now explicitly import CallInvoker and CallbackWrapper 

# How

Add explicit CallInvoker and CallbackWrapper imports to EXJSIUtils

# Test Plan

Run BareExpo locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
