### PR TITLE
[docs] Fix for missing Icon import in iOS native tabs

### DIFF
--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -414,7 +414,7 @@ To use icons from `@expo/vector-icons`, you can use `VectorIcon` component.
 
 ```tsx app/_layout.tsx|collapseHeight=480
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-import { NativeTabs, VectorIcon } from 'expo-router/unstable-native-tabs';
+import { NativeTabs, Icon, VectorIcon } from 'expo-router/unstable-native-tabs';
 import { Platform } from 'react-native';
 
 export default function TabLayout() {


### PR DESCRIPTION
Icon was missing as an import in the code example.

# Why

Improve documentation

# How

Updated documentation

# Test Plan

No testing needed for this doc fix

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
