### PR TITLE
[ios][audio] Fixed category so that lock screen is visible when recording is off

### DIFF
--- a/apps/native-component-list/src/screens/Audio/expo-audio/AudioControlsScreen.tsx
+++ b/apps/native-component-list/src/screens/Audio/expo-audio/AudioControlsScreen.tsx
@@ -20,6 +20,7 @@ export default function AudioControlsScreen(props: any) {
       shouldPlayInBackground: true,
       interruptionMode: 'doNotMix',
       playsInSilentMode: true,
+      allowsRecording: false,
     });
     AudioModule.setIsAudioActiveAsync(true);
     props.navigation.setOptions({

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -528,7 +528,7 @@ public class AudioModule: Module {
       }
 
 #if !os(tvOS)
-      if category == .playAndRecord {
+      if category == .playAndRecord || category == .playback {
         categoryOptions.insert(.allowBluetooth)
       }
 #endif

--- a/packages/expo-audio/ios/MediaController.swift
+++ b/packages/expo-audio/ios/MediaController.swift
@@ -117,7 +117,7 @@ class MediaController {
         return .commandFailed
       }
 
-      player.play(at: Float(player.currentRate > 0 ? player.currentTime : 1.0))
+      player.play(at: Float(player.currentRate > 0 ? player.currentRate : 1.0))
       return .success
     }
 
@@ -138,7 +138,7 @@ class MediaController {
       if player.isPlaying {
         player.ref.pause()
       } else {
-        player.play(at: Float(player.currentRate > 0 ? player.currentTime : 1.0))
+        player.play(at: Float(player.currentRate > 0 ? player.currentRate : 1.0))
       }
       return .success
     }


### PR DESCRIPTION
# Why

When the option `allowsRecording` is sent to the module, the lock screen controls wouldn't be visible since bluetooth has to be enabled.

# How

To fix this, i added an extra category check for this.

Also added `allowsRecording: false` to the test screen.

# Test Plan

Bare Expo

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
