### PR TITLE
chore(tests): Bump react-native-webview to 13.15.0

### DIFF
--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -48,7 +48,7 @@
     "react-native": "0.81.4",
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "4.16.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.15.0"
   },
   "devDependencies": {
     "compression": "^1.8.0",

--- a/packages/@expo/cli/e2e/fixtures/with-dom/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-dom/package.json
@@ -8,7 +8,7 @@
     "react-dom": "18.3.1",
     "react-native": "0.76.3",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.0"
+    "react-native-webview": "13.15.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13844,14 +13844,6 @@ react-native-web@~0.21.0:
     postcss-value-parser "^4.2.0"
     styleq "^0.1.3"
 
-react-native-webview@13.13.5:
-  version "13.13.5"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.13.5.tgz#4ef5f9310ddff5747f884a6655228ec9c7d52c73"
-  integrity sha512-MfC2B+woL4Hlj2WCzcb1USySKk+SteXnUKmKktOk/H/AQy5+LuVdkPKm8SknJ0/RxaxhZ48WBoTRGaqgR137hw==
-  dependencies:
-    escape-string-regexp "^4.0.0"
-    invariant "2.2.4"
-
 react-native-webview@13.15.0:
   version "13.15.0"
   resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.15.0.tgz#b6d2f8d8dd65897db76659ddd8198d2c74ec5a79"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

13.15.0 is the recommended version, the test app were not updated.

The previous version doesn't work in the test apps. The `source` prop is lost and not passed to native (on iOS it's always nil).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Build and run the app, dom components load.
