### PR TITLE
[templates][ios] Add support for `USE_CCACHE`

### DIFF
--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -41,12 +41,25 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
+  ccache_enabled = false
+  if podfile_properties['apple.ccacheEnabled'] == 'true'
+    ccache_enabled = true
+  elsif podfile_properties['apple.ccacheEnabled'] == 'false'
+    ccache_enabled = false
+  end
+
+  if ENV['USE_CCACHE'] == '1'
+    ccache_enabled = true
+  elsif ENV['USE_CCACHE'] == '0'
+    ccache_enabled = false
+  end
+
   post_install do |installer|
     react_native_post_install(
       installer,
       config[:reactNativePath],
       :mac_catalyst_enabled => false,
-      :ccache_enabled => podfile_properties['apple.ccacheEnabled'] == 'true',
+      :ccache_enabled => ccache_enabled,
     )
   end
 end

--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -4,6 +4,14 @@ require File.join(File.dirname(`node --print "require.resolve('react-native/pack
 require 'json'
 podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}
 
+def ccache_enabled?(podfile_properties)
+  # Environment variable takes precedence
+  return ENV['USE_CCACHE'] == '1' if ENV['USE_CCACHE']
+  
+  # Fall back to Podfile properties
+  podfile_properties['apple.ccacheEnabled'] == 'true'
+end
+
 ENV['RCT_NEW_ARCH_ENABLED'] ||= '0' if podfile_properties['newArchEnabled'] == 'false'
 ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] ||= podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
 ENV['RCT_USE_RN_DEP'] ||= '1' if podfile_properties['ios.buildReactNativeFromSource'] != 'true' && podfile_properties['newArchEnabled'] != 'false'
@@ -41,25 +49,12 @@ target 'HelloWorld' do
     :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
   )
 
-  ccache_enabled = false
-  if podfile_properties['apple.ccacheEnabled'] == 'true'
-    ccache_enabled = true
-  elsif podfile_properties['apple.ccacheEnabled'] == 'false'
-    ccache_enabled = false
-  end
-
-  if ENV['USE_CCACHE'] == '1'
-    ccache_enabled = true
-  elsif ENV['USE_CCACHE'] == '0'
-    ccache_enabled = false
-  end
-
   post_install do |installer|
     react_native_post_install(
       installer,
       config[:reactNativePath],
       :mac_catalyst_enabled => false,
-      :ccache_enabled => ccache_enabled,
+      :ccache_enabled => ccache_enabled?(podfile_properties),
     )
   end
 end


### PR DESCRIPTION
# Why

We need this in EAS to manage whether cache is or isn't enabled without having to require user to configure it in `expo-build-properties`.

Also it brings back the convention that upstream uses: https://github.com/facebook/react-native/blob/2590cd739aae5c73b5261a8927e19191b2730ff7/packages/react-native/scripts/react_native_pods.rb#L502

# How

Added a `ccache_enabled?(podfile_properties)` function that, given Podfile properties, returns whether ccache should or should not be considered enabled. It gives precedence to `USE_CCACHE` environment variable (`1` enables, `0` disables). Lack of `USE_CCACHE` means "use value from build properties".

# Test Plan

I ran `irb` and played with the code. And asked Claude if it's good.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
