### PR TITLE
[CRITICAL] Fix expo-router set multiple headers

### DIFF
--- a/packages/@expo/cli/src/api/rest/cache/ResponseCache.ts
+++ b/packages/@expo/cli/src/api/rest/cache/ResponseCache.ts
@@ -23,7 +23,7 @@ export function getResponseInfo(response: Response) {
     url: response.url,
     status: response.status,
     statusText: response.statusText,
-    headers: Object.fromEntries(response.headers.entries()),
+    headers: new Headers(response.headers),
   };
 }
 
@@ -52,7 +52,7 @@ export function getRequestInfoCacheData(info: RequestInfo) {
       // cache: req.cache,
       credentials: info.credentials.toString(),
       destination: info.destination.toString(),
-      headers: Object.fromEntries(info.headers.entries()),
+      headers: new Headers(info.headers),
       integrity: info.integrity,
       method: info.method,
       redirect: info.redirect,

--- a/packages/@expo/server/src/index.ts
+++ b/packages/@expo/server/src/index.ts
@@ -232,7 +232,7 @@ export function createRequestHandler({
     response: Response
   ): Response {
     const modifiedResponseInit: ResponseInitLike = {
-      headers: Object.fromEntries(response.headers.entries()),
+      headers: new Headers(response.headers),
       status: response.status,
       statusText: response.statusText,
       cf: response.cf,


### PR DESCRIPTION
# Why

Hey! This PR fixes a critical issue introduced in #38743 with multiple set-cookie. 

Bug #1: https://github.com/expo/expo/blob/5bae98b8aeca98a9c9e324f29c865c2633b14262/packages/%40expo/server/src/index.ts#L235

Bug #2: https://github.com/expo/expo/blob/5bae98b8aeca98a9c9e324f29c865c2633b14262/packages/%40expo/cli/src/api/rest/cache/ResponseCache.ts#L26

The issue is that this PR creates a copy of headers using this method:
`headers: Object.fromEntries(response.headers.entries()),`

But headers are allowed to have multiple entries of the same key, for example set-cookie. Right now all SSR auths that use multiple cookies (e.g. supabase) are broken.

# How

I replaced `Object.fromEntries(response.headers.entries()),` with `new Headers(response.headers)`. It works, but i'm not why this approach was not used initially, so i could miss some context. Please close this PR if the issue should be fixed with a different approach.

# Test Plan

I've made a patch on Rork's repo and were able to fix Supabase SSR auth.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
