### PR TITLE
[expo-dev-launcher] Fix manual URL entry in Dev Client: decode URLs, hook up return key, support dark mode

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### 🐛 Bug fixes
 
+- [expo-dev-launcher] Fix manual URL entry: decode percent-encoded URLs, enable return key submit, and support dark mode text. ([#<PR-number>](https://github.com/expo/expo/pull/39840))
+
+
 ### 💡 Others
 
 ## 6.0.11 — 2025-09-11

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 - [expo-dev-launcher] Fix manual URL entry: decode percent-encoded URLs, enable return key submit, and support dark mode text. ([#<PR-number>](https://github.com/expo/expo/pull/39840))
 
-
 ### 💡 Others
 
 ## 6.0.11 — 2025-09-11

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [expo-dev-launcher] Fix manual URL entry: decode percent-encoded URLs, enable return key submit, and support dark mode text. ([#<PR-number>](https://github.com/expo/expo/pull/39840))
+- [expo-dev-launcher] Fix manual URL entry: decode percent-encoded URLs, enable return key submit, and support dark mode text. ([#39840](https://github.com/expo/expo/pull/39840) by [@blazejkustra](https://github.com/blazejkustra))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ServerUrlInput.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ServerUrlInput.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -26,7 +27,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.composeunstyled.TextField
 import com.composeunstyled.TextInput
-import expo.modules.devlauncher.compose.utils.validateUrl
+import expo.modules.devlauncher.compose.utils.sanitizeUrlString
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
 import expo.modules.devmenu.compose.primitives.NewText
 
@@ -36,6 +37,18 @@ fun ServerUrlInput(
 ) {
   var url by remember { mutableStateOf("") }
   val context = LocalContext.current
+
+  fun connectToURL() {
+    val sanitizedURL = sanitizeUrlString(url)
+    if (sanitizedURL != null) {
+      openApp(sanitizedURL)
+      url = ""
+    } else {
+      Toast
+        .makeText(context, "Invalid URL", Toast.LENGTH_SHORT)
+        .show()
+    }
+  }
 
   Column(
     verticalArrangement = Arrangement.spacedBy(NewAppTheme.spacing.`2`)
@@ -63,6 +76,9 @@ fun ServerUrlInput(
         autoCorrectEnabled = false,
         keyboardType = KeyboardType.Uri
       ),
+      keyboardActions = KeyboardActions(
+        onDone = { connectToURL() }
+      ),
       cursorBrush = SolidColor(NewAppTheme.colors.text.default.copy(alpha = 0.9f))
     ) {
       TextInput(
@@ -85,15 +101,7 @@ fun ServerUrlInput(
       textStyle = NewAppTheme.font.md.merge(
         fontWeight = FontWeight.SemiBold
       ),
-      onClick = {
-        if (validateUrl(url)) {
-          openApp(url)
-        } else {
-          Toast
-            .makeText(context, "Invalid URL", Toast.LENGTH_SHORT)
-            .show()
-        }
-      }
+      onClick = { connectToURL() }
     )
   }
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/utils/UrlUtils.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/utils/UrlUtils.kt
@@ -1,12 +1,31 @@
 package expo.modules.devlauncher.compose.utils
 
 import androidx.core.net.toUri
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 
-fun validateUrl(url: String): Boolean {
+fun sanitizeUrlString(urlString: String): String? {
+  var sanitizedUrl = urlString.trim()
+
+  val decodedUrl = try {
+    URLDecoder.decode(sanitizedUrl, StandardCharsets.UTF_8.toString())
+  } catch (_: Exception) {
+    sanitizedUrl
+  }
+  sanitizedUrl = decodedUrl
+
+  if (!sanitizedUrl.contains("://")) {
+    sanitizedUrl = "http://$sanitizedUrl"
+  }
+
   return try {
-    val uri = url.toUri()
-    uri.scheme != null && uri.host != null
+    val uri = sanitizedUrl.toUri()
+    if (uri.scheme != null && uri.host != null) {
+      sanitizedUrl
+    } else {
+      null
+    }
   } catch (_: Throwable) {
-    false
+    null
   }
 }

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -7,7 +7,7 @@ import Combine
 
 private func sanitizeUrlString(_ urlString: String) -> String? {
   var sanitizedUrl = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
-  
+
   if let decodedUrl = sanitizedUrl.removingPercentEncoding {
     sanitizedUrl = decodedUrl
   }

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -7,6 +7,10 @@ import Combine
 
 private func sanitizeUrlString(_ urlString: String) -> String? {
   var sanitizedUrl = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+  
+  if let decodedUrl = sanitizedUrl.removingPercentEncoding {
+    sanitizedUrl = decodedUrl
+  }
 
   if !sanitizedUrl.contains("://") {
     sanitizedUrl = "http://" + sanitizedUrl
@@ -25,6 +29,19 @@ struct DevServersView: View {
   @State private var showingURLInput = false
   @State private var urlText = ""
   @State private var cancellables = Set<AnyCancellable>()
+
+  private func connectToURL() {
+    if !urlText.isEmpty {
+      let sanitizedURL = sanitizeUrlString(urlText)
+      if let validURL = sanitizedURL {
+        viewModel.openApp(url: validURL)
+        withAnimation(.easeInOut(duration: 0.3)) {
+          showingURLInput = false
+        }
+        urlText = ""
+      }
+    }
+  }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
@@ -81,7 +98,8 @@ struct DevServersView: View {
           .disableAutocorrection(true)
           .padding(.horizontal, 16)
           .padding(.vertical, 12)
-          .foregroundColor(.black)
+          .foregroundColor(.primary)
+          .onSubmit(connectToURL)
         #if !os(tvOS)
           .overlay(
             RoundedRectangle(cornerRadius: 5)
@@ -124,18 +142,7 @@ struct DevServersView: View {
   }
 
   private var connectButton: some View {
-    Button {
-      if !urlText.isEmpty {
-        let sanitizedURL = sanitizeUrlString(urlText)
-        if let validURL = sanitizedURL {
-          viewModel.openApp(url: validURL)
-          withAnimation(.easeInOut(duration: 0.3)) {
-            showingURLInput = false
-          }
-          urlText = ""
-        }
-      }
-    } label: {
+    Button(action: connectToURL) {
       Text("Connect")
         .font(.headline)
         .foregroundColor(.white)


### PR DESCRIPTION
# Why

When entering a URL manually in the Expo Dev Client:

* Percent-encoded URLs (like `exp%3A%2F%2F127.0.0.1%3A8081`) fail to connect.
* Pressing **return** on the keyboard doesn’t trigger connection.
* Input text is invisible in dark mode because `.foregroundColor(.black)` was hard-coded (only on iOS)

This made it cumbersome to connect to local dev servers via manual input.

Fixes: #39839

# How

* Updated `sanitizeUrlString` to decode percent-encoded URLs via `removingPercentEncoding`.
* Extracted the connection logic into a reusable `connectToURL()` function.
* Added `.onSubmit(connectToURL)` to the text field so pressing return works.

# Test Plan

1. Open Dev Client and select “Enter URL manually”.
2. Paste a percent-encoded URL (e.g. copied from a QR code).
3. Type a valid URL and press **return**.
4. Switch the system appearance between light and dark.

Verified locally on iOS simulator and android emulator.

# Checklist

* [x]  I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
* [x]  This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
* [x]  Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)


