### PR TITLE
[go][android] Disable predictive back gesture

### DIFF
--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -56,7 +56,8 @@
         android:label="${appLabel}"
         android:requestLegacyExternalStorage="true"
         android:supportsRtl="true"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="true"
+        android:enableOnBackInvokedCallback="false">
         <service android:name="expo.modules.video.playbackService.ExpoVideoPlaybackService" android:exported="false" android:foregroundServiceType="mediaPlayback">
             <intent-filter>
                 <action android:name="androidx.media3.session.MediaSessionService"/>


### PR DESCRIPTION
# Why

Fixes the error reported in https://www.reddit.com/r/expo/comments/1nkysak/android_back_gesture_or_device_button_not_working/?share_id=iDF5FyS4yNuVSU9pugEvi&utm_content=1&utm_medium=ios_app&utm_name=ioscss&utm_source=share&utm_term=1

# How
 
Disable predictive back gesture on Expo Go 

# Test Plan

Run Expo Go locally on android 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
