### PR TITLE
[sdk-54] Remove ExpoAppDelegate requirement in ExpoReactNativeFactory, DevClient and Updates

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [Android] Adds loading state when connecting to a development server. ([#39873](https://github.com/expo/expo/pull/39873) by [@lukmccall](https://github.com/lukmccall))
+- Remove `ExpoAppDelegate` inheritance requirement ([#39844](https://github.com/expo/expo/pull/39844) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -81,16 +81,17 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
           initialProps: initialProps,
           launchOptions: launchOptions
         )
-      } else if let factory = reactDelegate?.reactNativeFactory {
+      }
+      if let factory = reactDelegate?.reactNativeFactory {
         return factory.recreateRootView(
           withBundleURL: withBundleURL,
           moduleName: moduleName,
           initialProps: initialProps,
           launchOptions: launchOptions
         )
-      } else {
-        fatalError("`UIApplication.shared.delegate` must be an `ExpoAppDelegate` or `EXAppDelegateWrapper`")
       }
+
+      fatalError("`UIApplication.shared.delegate` must be an `ExpoAppDelegate` or `EXAppDelegateWrapper`")
     }
 
     let rootView = recreateRootView(

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -21,6 +21,7 @@ _This version does not introduce any user-facing changes._
 ### 🎉 New features
 
 - [Android] Starts using precompiled headers to improve build times. ([#39641](https://github.com/expo/expo/pull/39641) by [@lukmccall](https://github.com/lukmccall))
+- Remove `ExpoAppDelegate` inheritance requirement in ExpoReactNativeFactory ([#39844](https://github.com/expo/expo/pull/39844) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoReactNativeFactoryProtocol.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoReactNativeFactoryProtocol.swift
@@ -1,0 +1,12 @@
+public protocol ExpoReactNativeFactoryProtocol: AnyObject {
+  /**
+   To decouple RCTAppDelegate dependency from expo-modules-core,
+   expo-modules-core doesn't include the concrete `RCTReactNativeFactory` type and let the callsite to include the type
+   */
+  func recreateRootView(
+    withBundleURL: URL?,
+    moduleName: String?,
+    initialProps: [AnyHashable: Any]?,
+    launchOptions: [AnyHashable: Any]?
+  ) -> UIView
+}

--- a/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegate.swift
+++ b/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegate.swift
@@ -6,9 +6,11 @@
 @objc(EXReactDelegate)
 public class ExpoReactDelegate: NSObject {
   private let handlers: [ExpoReactDelegateHandler]
+  public let reactNativeFactory: ExpoReactNativeFactoryProtocol
 
-  public init(handlers: [ExpoReactDelegateHandler]) {
+  public init(handlers: [ExpoReactDelegateHandler], reactNativeFactory: ExpoReactNativeFactoryProtocol) {
     self.handlers = handlers
+    self.reactNativeFactory = reactNativeFactory
   }
 
   @objc
@@ -23,7 +25,7 @@ public class ExpoReactDelegate: NSObject {
       ?? {
         guard let appDelegate = (UIApplication.shared.delegate as? (any ReactNativeFactoryProvider)) ??
           ((UIApplication.shared.delegate as? NSObject)?.value(forKey: "_expoAppDelegate") as? (any ReactNativeFactoryProvider)) else {
-          fatalError("`UIApplication.shared.delegate` must be an `ExpoAppDelegate` or `EXAppDelegateWrapper`")
+          return reactNativeFactory.recreateRootView(withBundleURL: nil, moduleName: moduleName, initialProps: initialProperties, launchOptions: launchOptions)
         }
 
         return appDelegate.recreateRootView(

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Remove `ExpoAppDelegate` inheritance requirement ([#39844](https://github.com/expo/expo/pull/39844) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -76,12 +76,31 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
       fatalError("`reactDelegate` should not be nil")
     }
 
-    guard let appDelegate = (UIApplication.shared.delegate as? (any ReactNativeFactoryProvider)) ??
-      ((UIApplication.shared.delegate as? NSObject)?.value(forKey: "_expoAppDelegate") as? (any ReactNativeFactoryProvider)) else {
-      fatalError("`UIApplication.shared.delegate` must be an `ExpoAppDelegate` or `EXAppDelegateWrapper`")
+    func recreateRootView(
+        withBundleURL: URL?,
+        moduleName: String?,
+        initialProps: [AnyHashable: Any]?,
+        launchOptions: [AnyHashable: Any]?
+    ) -> UIView {
+        if let appDelegate = (UIApplication.shared.delegate as? (any ReactNativeFactoryProvider)) ??
+            ((UIApplication.shared.delegate as? NSObject)?.value(forKey: "_expoAppDelegate") as? (any ReactNativeFactoryProvider)) {
+            return appDelegate.recreateRootView(
+                withBundleURL: withBundleURL,
+                moduleName: moduleName,
+                initialProps: initialProps,
+                launchOptions: launchOptions
+            )
+        }
+      
+        return reactDelegate.reactNativeFactory.recreateRootView(
+            withBundleURL: withBundleURL,
+            moduleName: moduleName,
+            initialProps: initialProps,
+            launchOptions: launchOptions
+        )
     }
 
-    let rootView = appDelegate.recreateRootView(
+    let rootView = recreateRootView(
       withBundleURL: AppController.sharedInstance.launchAssetUrl(),
       moduleName: self.rootViewModuleName,
       initialProps: self.rootViewInitialProperties,

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -77,26 +77,26 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     }
 
     func recreateRootView(
-        withBundleURL: URL?,
-        moduleName: String?,
-        initialProps: [AnyHashable: Any]?,
-        launchOptions: [AnyHashable: Any]?
+      withBundleURL: URL?,
+      moduleName: String?,
+      initialProps: [AnyHashable: Any]?,
+      launchOptions: [AnyHashable: Any]?
     ) -> UIView {
-        if let appDelegate = (UIApplication.shared.delegate as? (any ReactNativeFactoryProvider)) ??
-            ((UIApplication.shared.delegate as? NSObject)?.value(forKey: "_expoAppDelegate") as? (any ReactNativeFactoryProvider)) {
-            return appDelegate.recreateRootView(
-                withBundleURL: withBundleURL,
-                moduleName: moduleName,
-                initialProps: initialProps,
-                launchOptions: launchOptions
-            )
-        }
-      
-        return reactDelegate.reactNativeFactory.recreateRootView(
+      if let appDelegate = (UIApplication.shared.delegate as? (any ReactNativeFactoryProvider)) ??
+        ((UIApplication.shared.delegate as? NSObject)?.value(forKey: "_expoAppDelegate") as? (any ReactNativeFactoryProvider)) {
+          return appDelegate.recreateRootView(
             withBundleURL: withBundleURL,
             moduleName: moduleName,
             initialProps: initialProps,
             launchOptions: launchOptions
+          )
+        }
+
+        return reactDelegate.reactNativeFactory.recreateRootView(
+          withBundleURL: withBundleURL,
+          moduleName: moduleName,
+          initialProps: initialProps,
+          launchOptions: launchOptions
         )
     }
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Remove `ExpoAppDelegate` inheritance requirement in ExpoReactNativeFactory ([#39844](https://github.com/expo/expo/pull/39844) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -2,8 +2,14 @@
 
 import React
 
-@MainActor public class ExpoReactNativeFactory: RCTReactNativeFactory {
-  private let reactDelegate = ExpoReactDelegate(handlers: ExpoAppDelegateSubscriberRepository.reactDelegateHandlers)
+public class ExpoReactNativeFactory: RCTReactNativeFactory, ExpoReactNativeFactoryProtocol {
+  private let defaultModuleName = "main"
+  private lazy var reactDelegate: ExpoReactDelegate = {
+    ExpoReactDelegate(
+      handlers: ExpoAppDelegateSubscriberRepository.reactDelegateHandlers,
+      reactNativeFactory: self
+    )
+  }()
 
   // TODO: Remove check when react-native-macos 0.81 is released
   #if !os(macOS)
@@ -21,6 +27,7 @@ import React
   }
   #endif
 
+  @MainActor
   @objc func createRCTRootViewFactory() -> RCTRootViewFactory {
     // Alan: This is temporary. We need to cast to ExpoReactNativeFactoryDelegate here because currently, if you extend RCTReactNativeFactory
     // from Swift, customizeRootView will not work on the new arch because the cast to RCTRootView will never
@@ -82,5 +89,50 @@ import React
       configuration: configuration,
       turboModuleManagerDelegate: self
     )
+  }
+
+  public func recreateRootView(
+    withBundleURL: URL?,
+    moduleName: String?,
+    initialProps: [AnyHashable: Any]?,
+    launchOptions: [AnyHashable: Any]?
+  ) -> UIView {
+    guard let delegate = self.delegate else {
+      fatalError("recreateRootView: Missing RCTReactNativeFactoryDelegate")
+    }
+
+    if RCTIsNewArchEnabled() {
+      // chrfalch: rootViewFactory.reactHost is not available here in swift due to the underlying RCTHost type of the property. (todo: check)
+      assert(self.rootViewFactory.value(forKey: "reactHost") == nil, "recreateRootViewWithBundleURL: does not support when react instance is created")
+    } else {
+      assert(self.rootViewFactory.bridge == nil, "recreateRootViewWithBundleURL: does not support when react instance is created")
+    }
+
+    let configuration = self.rootViewFactory.value(forKey: "_configuration") as? RCTRootViewFactoryConfiguration
+
+    if let bundleURL = withBundleURL {
+      configuration?.bundleURLBlock = {
+        return bundleURL
+      }
+    }
+
+    let rootView: UIView
+    if let factory = self.rootViewFactory as? ExpoReactRootViewFactory {
+      // When calling `recreateRootViewWithBundleURL:` from `EXReactRootViewFactory`,
+      // we don't want to loop the ReactDelegate again. Otherwise, it will be an infinite loop.
+      rootView = factory.superView(
+        withModuleName: moduleName ?? defaultModuleName,
+        initialProperties: initialProps,
+        launchOptions: launchOptions ?? [:]
+      )
+    } else {
+      rootView = rootViewFactory.view(
+        withModuleName: moduleName ?? defaultModuleName,
+        initialProperties: initialProps,
+        launchOptions: launchOptions
+      )
+    }
+
+    return rootView
   }
 }


### PR DESCRIPTION
# Why

Safer alternative of https://github.com/expo/expo/pull/39417 for SDK 54

When integrating Expo with a brownfield app, users get a fatal error when using `ExpoReactNativeFactory` without changing their main UIApplication delegate to inherit from ExpoAppDelegate. The same happens if you try to use DevClient or Updates without inheriting from ExpoAppDelegate.

# How

The main difference between this change and what is merged on main (https://github.com/expo/expo/pull/39417) is that this maintains the exact same behavior if the user is using `ExpoAppDelegate`, but no longer makes it required, further improving the brownfield experience 

# Test Plan

Removed `ExpoAppDelegate` from PaperTester AppDelegate and run the app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
