### PR TITLE
fix(expo-router): fix icons in context menu not being removed with `undefined`

### DIFF
--- a/apps/router-e2e/__e2e__/link-preview/app/menu.tsx
+++ b/apps/router-e2e/__e2e__/link-preview/app/menu.tsx
@@ -10,6 +10,7 @@ const Menus = () => {
 
   const [palette, setPalette] = useState<string>('1');
   const [submenu, setSubmenu] = useState<string>('1');
+  const [isIconVisible, setIsIconVisible] = useState(false);
 
   const timeOptions = useMemo(
     () =>
@@ -28,6 +29,10 @@ const Menus = () => {
   useEffect(() => {
     console.log('Submenu:', submenu);
   }, [submenu]);
+
+  const toggleIconVisibility = () => {
+    setIsIconVisible(!isIconVisible);
+  }
 
   return (
     <ScrollView
@@ -225,6 +230,16 @@ const Menus = () => {
               console.log('Delete Pressed');
             }}
           />
+        </Link.Menu>
+      </Link>
+
+      <Link href="/one">
+        <Link.Trigger>Link.Menu with togglable icon</Link.Trigger>
+        <Link.Menu>
+          <Link.MenuAction title="Menu action" icon={isIconVisible ? "0.square" : undefined} onPress={() => console.log("ACME")}/>
+          <Link.Menu title="Submenu" icon={isIconVisible ? "checkmark" : undefined}>
+            <Link.MenuAction title={`${isIconVisible ? 'Hide' : 'Show'} icons`} onPress={toggleIconVisibility}/>
+          </Link.Menu>
         </Link.Menu>
       </Link>
     </ScrollView>

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - fix VectorIcon types ([#39747](https://github.com/expo/expo/pull/39747) by [@Ubax](https://github.com/Ubax))
+- [iOS] fix icons in context menu not being removed with `undefined` ([#39845](https://github.com/expo/expo/pull/39845) by [@hassankhan](https://github.com/hassankhan))
 
 ### 💡 Others
 

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeModule.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeModule.swift
@@ -48,7 +48,7 @@ public class LinkPreviewNativeModule: Module {
       Prop("title") { (view: LinkPreviewNativeActionView, title: String) in
         view.title = title
       }
-      Prop("icon") { (view: LinkPreviewNativeActionView, icon: String) in
+      Prop("icon") { (view: LinkPreviewNativeActionView, icon: String?) in
         view.icon = icon
       }
       Prop("disabled") { (view: LinkPreviewNativeActionView, disabled: Bool) in


### PR DESCRIPTION
# Why

If you set an icon in a context menu, and later change the icon to undefined, the previously set icon remains and cannot be unset.

# How

When JavaScript passes `undefined`, the setter isn't invoked because `undefined` can't be converted to a non-optional `String`, so the old value remains. 

The Swift native module declaration has now been updated to use `String?`, which allows the prop setter to be called with `nil` when JavaScript passes `undefined` (which in turn properly clears the icon).

# Test Plan

```
cd apps/router-e2e
yarn expo prebuild --clean && yarn ios
yarn start:link-preview -d
npx uri-scheme open com.expo.routere2e:///menu --ios
```

Then test by opening the "Link.Menu with togglable icon" menu and showing/hiding the icon.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
