### PR TITLE
[ios][expo-maps] - onTapGesture do not work on iOS 26

### DIFF
--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Add workaround for iOS 26 onTapGesture known issue ([#39849](https://github.com/expo/expo/pull/39849) by [@nishan](https://github.com/intergalacticspacehighway))
+
 ### 💡 Others
 
 ## 0.12.7 — 2025-09-11

--- a/packages/expo-maps/ios/AppleMapsViewiOS18.swift
+++ b/packages/expo-maps/ios/AppleMapsViewiOS18.swift
@@ -113,6 +113,9 @@ struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
           UserAnnotation()
         }
       }
+      // We use simultaneousGesture to work around the iOS 26 onTapGesture known issue
+      // https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-26-release-notes#Maps
+      // TODO: Replace with onTapGesture once apple fixes the issue
       .simultaneousGesture(
         DragGesture(minimumDistance: 0)
           // swiftlint:disable:next closure_body_length

--- a/packages/expo-maps/ios/AppleMapsViewiOS18.swift
+++ b/packages/expo-maps/ios/AppleMapsViewiOS18.swift
@@ -62,6 +62,7 @@ struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
 
     // swiftlint:disable:next closure_body_length
     MapReader { reader in
+      // swiftlint:disable:next closure_body_length
       Map(position: $state.mapCameraPosition, selection: $state.selection) {
         ForEach(props.markers) { marker in
           Marker(
@@ -114,6 +115,7 @@ struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
       }
       .simultaneousGesture(
         DragGesture(minimumDistance: 0)
+          // swiftlint:disable:next closure_body_length
           .onEnded { value in
             if let coordinate = reader.convert(value.location, from: .local) {
               // check if we hit a polygon and send an event
@@ -133,8 +135,7 @@ struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
                   "lineWidth": hit.lineWidth,
                   "coordinates": coords
                 ])
-              }
-              else if let hit = props.circles.first(where: { circle in
+              } else if let hit = props.circles.first(where: { circle in
                 isTapInsideCircle(
                   tapCoordinate: coordinate,
                   circleCenter: circle.clLocationCoordinate2D,

--- a/packages/expo-maps/ios/AppleMapsViewiOS18.swift
+++ b/packages/expo-maps/ios/AppleMapsViewiOS18.swift
@@ -112,70 +112,73 @@ struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
           UserAnnotation()
         }
       }
-      .onTapGesture(coordinateSpace: .local) { position in
-        if let coordinate = reader.convert(position, from: .local) {
-          // check if we hit a polygon and send an event
-          if let hit = props.polygons.first(where: { polygon in
-            isTapInsidePolygon(tapCoordinate: coordinate, polygonCoordinates: polygon.clLocationCoordinates2D)
-          }) {
-            let coords = hit.coordinates.map {
-              [
-                "latitude": $0.latitude,
-                "longitude": $0.longitude
-              ]
-            }
-            props.onPolygonClick([
-              "id": hit.id,
-              "color": hit.color,
-              "lineColor": hit.lineColor,
-              "lineWidth": hit.lineWidth,
-              "coordinates": coords
-            ])
-          }
-          else if let hit = props.circles.first(where: { circle in
-            isTapInsideCircle(
-              tapCoordinate: coordinate,
-              circleCenter: circle.clLocationCoordinate2D,
-              radius: circle.radius
-            )}) {
-              props.onCircleClick([
-                "id": hit.id,
-                "color": hit.color,
-                "lineColor": hit.lineColor,
-                "lineWidth": hit.lineWidth,
-                "radius": hit.radius,
+      .simultaneousGesture(
+        DragGesture(minimumDistance: 0)
+          .onEnded { value in
+            if let coordinate = reader.convert(value.location, from: .local) {
+              // check if we hit a polygon and send an event
+              if let hit = props.polygons.first(where: { polygon in
+                isTapInsidePolygon(tapCoordinate: coordinate, polygonCoordinates: polygon.clLocationCoordinates2D)
+              }) {
+                let coords = hit.coordinates.map {
+                  [
+                    "latitude": $0.latitude,
+                    "longitude": $0.longitude
+                  ]
+                }
+                props.onPolygonClick([
+                  "id": hit.id,
+                  "color": hit.color,
+                  "lineColor": hit.lineColor,
+                  "lineWidth": hit.lineWidth,
+                  "coordinates": coords
+                ])
+              }
+              else if let hit = props.circles.first(where: { circle in
+                isTapInsideCircle(
+                  tapCoordinate: coordinate,
+                  circleCenter: circle.clLocationCoordinate2D,
+                  radius: circle.radius
+                )}) {
+                  props.onCircleClick([
+                    "id": hit.id,
+                    "color": hit.color,
+                    "lineColor": hit.lineColor,
+                    "lineWidth": hit.lineWidth,
+                    "radius": hit.radius,
+                    "coordinates": [
+                      "latitude": hit.center.latitude,
+                      "longitude": hit.center.longitude
+                    ]
+                  ])
+                }
+              // Then check if we hit a polyline and send an event
+              else if let hit = polyline(at: coordinate) {
+                let coords = hit.coordinates.map {
+                  [
+                    "latitude": $0.latitude,
+                    "longitude": $0.longitude
+                  ]
+                }
+                props.onPolylineClick([
+                  "id": hit.id,
+                  "color": hit.color,
+                  "width": hit.width,
+                  "contourStyle": hit.contourStyle,
+                  "coordinates": coords
+                ])
+              }
+
+              // Send an event of map click regardless
+              props.onMapClick([
                 "coordinates": [
-                  "latitude": hit.center.latitude,
-                  "longitude": hit.center.longitude
+                  "latitude": coordinate.latitude,
+                  "longitude": coordinate.longitude
                 ]
               ])
             }
-          // Then check if we hit a polyline and send an event
-          else if let hit = polyline(at: coordinate) {
-            let coords = hit.coordinates.map {
-              [
-                "latitude": $0.latitude,
-                "longitude": $0.longitude
-              ]
-            }
-            props.onPolylineClick([
-              "id": hit.id,
-              "color": hit.color,
-              "width": hit.width,
-              "contourStyle": hit.contourStyle,
-              "coordinates": coords
-            ])
           }
-
-          // Send an event of map click regardless
-          props.onMapClick([
-            "coordinates": [
-              "latitude": coordinate.latitude,
-              "longitude": coordinate.longitude
-            ]
-          ])
-        }
-      }
+      )
       .mapControls {
         if uiSettings.compassEnabled {
           MapCompass()


### PR DESCRIPTION
# Why

Fixes - https://github.com/expo/expo/issues/39848

iOS 26 has a known issue where `onTapGesture` do not work
https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-26-release-notes#Maps

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
<img width="auto" height="200" alt="Screenshot 2025-09-20 at 10 18 15 AM" src="https://github.com/user-attachments/assets/1d0e990d-bf81-47c1-94a3-383b78127ff8" />

# How

Used `simultaneousGesture` as recommended in the workaround. We use [DragGesture](https://developer.apple.com/documentation/swiftui/draggesture) with minimumDistance 0 (behaves like a tap) instead of [TapGesture](https://developer.apple.com/documentation/swiftui/tapgesture). `TapGesture` does not have a location or [Value struct](https://developer.apple.com/documentation/swiftui/draggesture/value) similar to DragGesture, which we need to calculate the tapped coordinate.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested the repro on iOS 18 and iOS 26. 

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
