### PR TITLE
fix(expo-router): fix optional context menu props not being unset with `undefined`

### DIFF
--- a/apps/router-e2e/__e2e__/link-preview/app/menu.tsx
+++ b/apps/router-e2e/__e2e__/link-preview/app/menu.tsx
@@ -11,6 +11,10 @@ const Menus = () => {
   const [palette, setPalette] = useState<string>('1');
   const [submenu, setSubmenu] = useState<string>('1');
   const [isIconVisible, setIsIconVisible] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(false);
+  const [isDestructive, setIsDestructive] = useState(false);
+  const [keepPresented, setKeepPresented] = useState(false);
+  const [isOnState, setIsOnState] = useState(false);
 
   const timeOptions = useMemo(
     () =>
@@ -234,11 +238,38 @@ const Menus = () => {
       </Link>
 
       <Link href="/one">
-        <Link.Trigger>Link.Menu with togglable icon</Link.Trigger>
+        <Link.Trigger>Link.Menu with togglable props</Link.Trigger>
         <Link.Menu>
-          <Link.MenuAction title="Menu action" icon={isIconVisible ? "0.square" : undefined} onPress={() => console.log("ACME")}/>
-          <Link.Menu title="Submenu" icon={isIconVisible ? "checkmark" : undefined}>
-            <Link.MenuAction title={`${isIconVisible ? 'Hide' : 'Show'} icons`} onPress={toggleIconVisibility}/>
+          <Link.MenuAction
+            title="Menu action"
+            icon={isIconVisible ? "0.square" : undefined}
+            disabled={isDisabled ? true : undefined}
+            destructive={isDestructive ? true : undefined}
+            unstable_keepPresented={keepPresented ? true : undefined}
+            isOn={isOnState ? true : undefined}
+            onPress={() => {}}
+          />
+          <Link.Menu title="Submenu">
+            <Link.MenuAction
+              title={`${isIconVisible ? 'Hide' : 'Show'} icon`}
+              onPress={toggleIconVisibility}
+            />
+            <Link.MenuAction
+              title={`${isDisabled ? 'Enable' : 'Disable'} action`}
+              onPress={() => setIsDisabled(!isDisabled)}
+            />
+            <Link.MenuAction
+              title={`${isDestructive ? 'Remove' : 'Make'} destructive`}
+              onPress={() => setIsDestructive(!isDestructive)}
+            />
+            <Link.MenuAction
+              title={`${keepPresented ? 'Disable' : 'Enable'} keepPresented`}
+              onPress={() => setKeepPresented(!keepPresented)}
+            />
+            <Link.MenuAction
+              title={`${isOnState ? 'Turn off' : 'Turn on'} isOn`}
+              onPress={() => setIsOnState(!isOnState)}
+            />
           </Link.Menu>
         </Link.Menu>
       </Link>

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - fix VectorIcon types ([#39747](https://github.com/expo/expo/pull/39747) by [@Ubax](https://github.com/Ubax))
 - [iOS] fix icons in context menu not being removed with `undefined` ([#39845](https://github.com/expo/expo/pull/39845) by [@hassankhan](https://github.com/hassankhan))
+- [iOS] fix optional context menu props not being unset with `undefined` ([#39853](https://github.com/expo/expo/pull/39853) by [@hassankhan](https://github.com/hassankhan))
+
 
 ### 💡 Others
 

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeActionView.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeActionView.swift
@@ -19,7 +19,7 @@ class LinkPreviewNativeActionView: ExpoView, LinkPreviewMenuUpdatable {
       }
     }
   }
-  var destructive: Bool = false {
+  var destructive: Bool? {
     didSet {
       updateUiAction()
       if isMenuAction {
@@ -29,17 +29,17 @@ class LinkPreviewNativeActionView: ExpoView, LinkPreviewMenuUpdatable {
   }
 
   // MARK: - Action only props
-  var disabled: Bool = false {
+  var disabled: Bool? {
     didSet {
       updateUiAction()
     }
   }
-  var isOn: Bool = false {
+  var isOn: Bool? {
     didSet {
       updateUiAction()
     }
   }
-  var keepPresented: Bool = false {
+  var keepPresented: Bool? {
     didSet {
       updateUiAction()
     }
@@ -114,7 +114,7 @@ class LinkPreviewNativeActionView: ExpoView, LinkPreviewMenuUpdatable {
     if displayInline {
       options.insert(.displayInline)
     }
-    if destructive {
+    if destructive == true {
       options.insert(.destructive)
     }
 
@@ -130,17 +130,17 @@ class LinkPreviewNativeActionView: ExpoView, LinkPreviewMenuUpdatable {
 
   private func updateUiAction() {
     var attributes: UIMenuElement.Attributes = []
-    if destructive { attributes.insert(.destructive) }
-    if disabled { attributes.insert(.disabled) }
+    if destructive == true { attributes.insert(.destructive) }
+    if disabled == true { attributes.insert(.disabled) }
 
     if #available(iOS 16.0, *) {
-      if keepPresented { attributes.insert(.keepsMenuPresented) }
+      if keepPresented == true { attributes.insert(.keepsMenuPresented) }
     }
 
     baseUiAction.title = title
     baseUiAction.image = icon.flatMap { UIImage(systemName: $0) }
     baseUiAction.attributes = attributes
-    baseUiAction.state = isOn ? .on : .off
+    baseUiAction.state = isOn == true ? .on : .off
 
     parentMenuUpdatable?.updateMenu()
   }

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeModule.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeModule.swift
@@ -51,10 +51,10 @@ public class LinkPreviewNativeModule: Module {
       Prop("icon") { (view: LinkPreviewNativeActionView, icon: String?) in
         view.icon = icon
       }
-      Prop("disabled") { (view: LinkPreviewNativeActionView, disabled: Bool) in
+      Prop("disabled") { (view: LinkPreviewNativeActionView, disabled: Bool?) in
         view.disabled = disabled
       }
-      Prop("destructive") { (view: LinkPreviewNativeActionView, destructive: Bool) in
+      Prop("destructive") { (view: LinkPreviewNativeActionView, destructive: Bool?) in
         view.destructive = destructive
       }
       Prop("singleSelection") { (view: LinkPreviewNativeActionView, singleSelection: Bool) in
@@ -63,10 +63,10 @@ public class LinkPreviewNativeModule: Module {
       Prop("displayAsPalette") { (view: LinkPreviewNativeActionView, displayAsPalette: Bool) in
         view.displayAsPalette = displayAsPalette
       }
-      Prop("isOn") { (view: LinkPreviewNativeActionView, isOn: Bool) in
+      Prop("isOn") { (view: LinkPreviewNativeActionView, isOn: Bool?) in
         view.isOn = isOn
       }
-      Prop("keepPresented") { (view: LinkPreviewNativeActionView, keepPresented: Bool) in
+      Prop("keepPresented") { (view: LinkPreviewNativeActionView, keepPresented: Bool?) in
         view.keepPresented = keepPresented
       }
       Prop("displayInline") { (view: LinkPreviewNativeActionView, displayInline: Bool) in


### PR DESCRIPTION
# Why

Followup to #39845.

When changing the value of a prop for [`<Link.MenuAction />`](https://docs.expo.dev/versions/latest/sdk/router/#linkmenuaction) from a non-optional value to `undefined`, the prop would not update. This was true for the following props:

- `disabled`
- `destructive`
- `isOn`
- `unstable_keepPresented`

# How

Optional props are now initialized as `nil` in Swift, and these props are explicitly checked for truthiness. `nil` and `false` are treated as the same.

# Test Plan

```
cd apps/router-e2e
yarn expo prebuild --clean && yarn ios
yarn start:link-preview -d
npx uri-scheme open com.expo.routere2e:///menu --ios
```

Then test by opening the "Link.Menu with togglable props" menu and using the submenu to toggle states.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
