### PR TITLE
fix(docs): update "Picking files using system pickers" example to fix TypeScript errors

### DIFF
--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -65,8 +65,11 @@ import * as DocumentPicker from 'expo-document-picker';
 
 try {
   const result = await DocumentPicker.getDocumentAsync({ copyToCacheDirectory: true });
-  const file = new File(result.assets[0]);
-  console.log(file.textSync());
+  if (!result.canceled) {
+    const { uri } = result.assets[0];
+    const file = new File(uri);
+    console.log(file.textSync());
+  }
 } catch (error) {
   console.error(error);
 }


### PR DESCRIPTION
The old example was causing TypeScript errors:

- 'result.assets' could be null.
- Argument of type 'DocumentPickerAsset' is not assignable to type 'string | File | Directory'.

So i updated the example to handle the possible null result and pass a valid URI to File, so it no longer triggers these ts errors.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="753" height="124" alt="image" src="https://github.com/user-attachments/assets/d10371f1-9474-4b61-b0f7-25fe31ebb7da" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
