### PR TITLE
[core][iOS] Return EXJavaScriptValue from null/undefined in arrays

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix NSURL to JSIString conversion returning nil. ([#39567](https://github.com/expo/expo/pull/39567) by [@behenate](https://github.com/behenate))
+- [iOS] Return EXJavaScriptValue from null/undefined in arrays. ([#39872](https://github.com/expo/expo/pull/39872) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
@@ -123,12 +123,7 @@
 
   for (size_t i = 0; i < arraySize; i++) {
     jsi::Value item = jsiArray.getValueAtIndex(*runtime, i);
-
-    if (item.isUndefined() || item.isNull()) {
-      [result addObject:(id)kCFNull];
-    } else {
-      [result addObject:[[EXJavaScriptValue alloc] initWithRuntime:_runtime value:std::move(item)]];
-    }
+    [result addObject:[[EXJavaScriptValue alloc] initWithRuntime:_runtime value:std::move(item)]];
   }
   return result;
 }


### PR DESCRIPTION
# Why

Fixes ENG-17209

```tsx
Image.prefetch([undefined]).then(console.log).catch(console.log);
```

Would crash the app, as passing the undefined value to array that don't accept it would end up inserting null to an array where array on `JavaScriptValue` is expected.

# How

Make the API same as on Android: https://github.com/expo/expo/blob/d711d59ee260239487bfc30a4ef4408e000b27b7/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt#L32  

# Test Plan

CI should be green ✅
And this V should not crash
```tsx
Image.prefetch([undefined]).then(console.log).catch(console.log);
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
