### PR TITLE
[asset] use isAndroidAssetNameValid from expo/config-plugins

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- validate asset names with `isAndroidAssetNameValid` from `expo/config-plugins` ([#39883](https://github.com/expo/expo/pull/39883) by [@vonovak](https://github.com/vonovak))
+
 ## 12.0.8 — 2025-09-10
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-asset/plugin/build/utils.js
+++ b/packages/expo-asset/plugin/build/utils.js
@@ -25,15 +25,11 @@ async function resolveAssetPaths(assets, projectRoot) {
     });
     return (await Promise.all(promises)).flat();
 }
-const validPattern = /^[a-z0-9_]+$/;
-function isAndroidAssetNameValid(assetName) {
-    return validPattern.test(assetName);
-}
 function validateAssets(assets, platform) {
     return assets.filter((asset) => {
         const ext = path_1.default.extname(asset);
         const name = path_1.default.basename(asset, ext);
-        const isNameValid = platform === 'android' ? isAndroidAssetNameValid(name) : true;
+        const isNameValid = platform === 'android' ? (0, config_plugins_1.isValidAndroidAssetName)(name) : true;
         const accepted = exports.ACCEPTED_TYPES.includes(ext);
         const isFont = exports.FONT_TYPES.includes(ext);
         if (!isNameValid) {

--- a/packages/expo-asset/plugin/src/utils.ts
+++ b/packages/expo-asset/plugin/src/utils.ts
@@ -1,4 +1,4 @@
-import { WarningAggregator } from 'expo/config-plugins';
+import { isValidAndroidAssetName, WarningAggregator } from 'expo/config-plugins';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -20,16 +20,11 @@ export async function resolveAssetPaths(assets: string[], projectRoot: string) {
   return (await Promise.all(promises)).flat();
 }
 
-const validPattern = /^[a-z0-9_]+$/;
-function isAndroidAssetNameValid(assetName: string) {
-  return validPattern.test(assetName);
-}
-
 export function validateAssets(assets: string[], platform: 'android' | 'ios') {
   return assets.filter((asset) => {
     const ext = path.extname(asset);
     const name = path.basename(asset, ext);
-    const isNameValid = platform === 'android' ? isAndroidAssetNameValid(name) : true;
+    const isNameValid = platform === 'android' ? isValidAndroidAssetName(name) : true;
     const accepted = ACCEPTED_TYPES.includes(ext);
     const isFont = FONT_TYPES.includes(ext);
 


### PR DESCRIPTION
# Why

This PR replaces the local implementation of `isAndroidAssetNameValid` with the one from `expo/config-plugins`

# How

- Removed the local implementation of the function
- Updated the validation logic to use the imported function

# Test Plan

- tested locally

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).