### PR TITLE
[notifications] use assertValidAndroidAssetName from expo/config-plugins

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- validate sound resource names with `assertValidAndroidAssetName` from `expo/config-plugins` ([#39883](https://github.com/expo/expo/pull/39883) by [@vonovak](https://github.com/vonovak))
+
 ## 0.32.11 — 2025-09-11
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-notifications/package.json
+++ b/packages/expo-notifications/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "build": "expo-module build",
+    "build:plugin": "expo-module build plugin",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",

--- a/packages/expo-notifications/plugin/build/withNotificationsAndroid.js
+++ b/packages/expo-notifications/plugin/build/withNotificationsAndroid.js
@@ -174,9 +174,11 @@ function setNotificationSounds(projectRoot, sounds) {
  * there isn't already an existing file under that name.
  */
 function writeNotificationSoundFile(soundFileRelativePath, projectRoot) {
-    const rawResourcesPath = (0, path_1.resolve)(projectRoot, exports.ANDROID_RES_PATH, 'raw');
     const inputFilename = (0, path_1.basename)(soundFileRelativePath);
     if (inputFilename) {
+        const nameWithoutExt = (0, path_1.parse)(inputFilename).name;
+        (0, config_plugins_1.assertValidAndroidAssetName)(nameWithoutExt, 'expo-notifications');
+        const rawResourcesPath = (0, path_1.resolve)(projectRoot, exports.ANDROID_RES_PATH, 'raw');
         try {
             const sourceFilepath = (0, path_1.resolve)(projectRoot, soundFileRelativePath);
             const destinationFilepath = (0, path_1.resolve)(rawResourcesPath, inputFilename);

--- a/packages/expo-notifications/plugin/src/__tests__/withNotificationsAndroid-test.ts
+++ b/packages/expo-notifications/plugin/src/__tests__/withNotificationsAndroid-test.ts
@@ -42,8 +42,8 @@ const LIST_OF_GENERATED_NOTIFICATION_FILES = [
   'android/app/src/main/res/drawable-xxxhdpi/notification_icon.png',
   'android/app/src/main/res/values/colors.xml',
   'assets/notificationIcon.png',
-  'assets/notificationSound.wav',
-  'android/app/src/main/res/raw/notificationSound.wav',
+  'assets/notification_sound.wav',
+  'android/app/src/main/res/raw/notification_sound.wav',
 ];
 
 const iconPath = path.resolve(__dirname, './fixtures/icon.png');
@@ -62,7 +62,7 @@ describe('Android notifications configuration', () => {
     setUpDrawableDirectories();
     vol.mkdirpSync('/app/assets');
     vol.writeFileSync('/app/assets/notificationIcon.png', icon);
-    vol.writeFileSync('/app/assets/notificationSound.wav', sound);
+    vol.writeFileSync('/app/assets/notification_sound.wav', sound);
   });
 
   afterEach(() => {
@@ -90,7 +90,7 @@ describe('Android notifications configuration', () => {
 
   it('writes all the asset files (sounds and images) as expected', async () => {
     await setNotificationIconAsync(projectRoot, '/app/assets/notificationIcon.png');
-    setNotificationSounds(projectRoot, ['/app/assets/notificationSound.wav']);
+    setNotificationSounds(projectRoot, ['/app/assets/notification_sound.wav']);
 
     const after = getDirFromFS(vol.toJSON(), projectRoot);
     expect(Object.keys(after).sort()).toEqual(LIST_OF_GENERATED_NOTIFICATION_FILES.sort());

--- a/packages/expo-notifications/plugin/src/withNotificationsAndroid.ts
+++ b/packages/expo-notifications/plugin/src/withNotificationsAndroid.ts
@@ -6,9 +6,10 @@ import {
   withDangerousMod,
   withAndroidColors,
   withAndroidManifest,
+  assertValidAndroidAssetName,
 } from 'expo/config-plugins';
 import { writeFileSync, unlinkSync, copyFileSync, existsSync, mkdirSync } from 'fs';
-import { basename, resolve } from 'path';
+import { basename, resolve, parse } from 'path';
 
 import { NotificationsPluginProps } from './withNotifications';
 
@@ -230,7 +231,6 @@ function removeNotificationIconImageFiles(projectRoot: string) {
     }
   });
 }
-
 /**
  * Save sound files to `<project-root>/android/app/src/main/res/raw`
  */
@@ -241,6 +241,7 @@ export function setNotificationSounds(projectRoot: string, sounds: string[]) {
         `Must provide an array of sound files in your app config, found ${typeof sounds}.`
     );
   }
+
   for (const soundFileRelativePath of sounds) {
     writeNotificationSoundFile(soundFileRelativePath, projectRoot);
   }
@@ -251,10 +252,13 @@ export function setNotificationSounds(projectRoot: string, sounds: string[]) {
  * there isn't already an existing file under that name.
  */
 function writeNotificationSoundFile(soundFileRelativePath: string, projectRoot: string) {
-  const rawResourcesPath = resolve(projectRoot, ANDROID_RES_PATH, 'raw');
   const inputFilename = basename(soundFileRelativePath);
 
   if (inputFilename) {
+    const nameWithoutExt = parse(inputFilename).name;
+    assertValidAndroidAssetName(nameWithoutExt, 'expo-notifications');
+    const rawResourcesPath = resolve(projectRoot, ANDROID_RES_PATH, 'raw');
+
     try {
       const sourceFilepath = resolve(projectRoot, soundFileRelativePath);
       const destinationFilepath = resolve(rawResourcesPath, inputFilename);


### PR DESCRIPTION
# Why

Added validation for Android notification sound resource names to ensure they follow Android's asset naming conventions.

# How

- added validation for sound resource names in the `expo-notifications` plugin using `assertValidAndroidAssetName` from `expo/config-plugins`

# Test Plan

- tested locally

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).