### PR TITLE
[sharing][ios] Support sharing http(s) urls

### DIFF
--- a/packages/expo-sharing/ios/SharingModule.swift
+++ b/packages/expo-sharing/ios/SharingModule.swift
@@ -6,10 +6,13 @@ public final class SharingModule: Module {
     Name("ExpoSharing")
 
     AsyncFunction("shareAsync") { (url: URL, options: SharingOptions, promise: Promise) in
-      let grantedPermissions = FileSystemUtilities.permissions(appContext, for: url)
+      // Skip file permission checks for remote URLs (http/https)
+      if url.scheme != "http" && url.scheme != "https" {
+        let grantedPermissions = FileSystemUtilities.permissions(appContext, for: url)
 
-      guard grantedPermissions.contains(.read) && FileManager.default.isReadableFile(atPath: url.path) else {
-        throw FilePermissionException()
+        guard grantedPermissions.contains(.read) && FileManager.default.isReadableFile(atPath: url.path) else {
+          throw FilePermissionException()
+        }
       }
 
       let activityController = UIActivityViewController(activityItems: [url], applicationActivities: nil)


### PR DESCRIPTION
I am not 100% sure what exactly is happening here, but this PR fixes https://github.com/expo/expo/issues/39861

# Why

Sharing of http(s) URLs is broken (see https://github.com/expo/expo/issues/39861 for more)

# How

I added a check if the shared url is a http or https url

# Test Plan

Checkout the reproducible example from the issue mentioned above, apply the following patch:

```diff
diff --git a/node_modules/expo-sharing/ios/SharingModule.swift b/node_modules/expo-sharing/ios/SharingModule.swift
index a918fa7..402e328 100644
--- a/node_modules/expo-sharing/ios/SharingModule.swift
+++ b/node_modules/expo-sharing/ios/SharingModule.swift
@@ -6,10 +6,13 @@ public final class SharingModule: Module {
     Name("ExpoSharing")
 
     AsyncFunction("shareAsync") { (url: URL, options: SharingOptions, promise: Promise) in
-      let grantedPermissions = FileSystemUtilities.permissions(appContext, for: url)
+      // Skip file permission checks for remote URLs (http/https)
+      if url.scheme != "http" && url.scheme != "https" {
+        let grantedPermissions = FileSystemUtilities.permissions(appContext, for: url)
 
-      guard grantedPermissions.contains(.read) && FileManager.default.isReadableFile(atPath: url.path) else {
-        throw FilePermissionException()
+        guard grantedPermissions.contains(.read) && FileManager.default.isReadableFile(atPath: url.path) else {
+          throw FilePermissionException()
+        }
       }
 
       let activityController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
```

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
