### PR TITLE
[ci] use xcode 26

### DIFF
--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -20,8 +20,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 16.4
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - name: 🔨 Switch to Xcode 26.0
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 💎 Setup Ruby

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -56,6 +56,13 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: 3.2.2
+      - name: 🧹 Cleanup unused simulator runtimes
+        run: |
+          xcrun simctl list devices -j | jq -r '.devices | to_entries[] | select(.key | contains("iOS") | not) | .value[].udid' | xargs -r -n1 xcrun simctl delete
+          xcrun simctl list devices --json
+          xcrun simctl erase all
+          xcrun simctl shutdown all
+          sudo xcodebuild -runFirstLaunch
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -43,8 +43,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 16.0
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - name: 🔨 Switch to Xcode 26.0
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       - name: 🔓 Decrypt secrets if possible
         uses: ./.github/actions/expo-git-decrypt
         with:

--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -26,8 +26,8 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v4
-      - name: 🔨 Switch to Xcode 16.0
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - name: 🔨 Switch to Xcode 26.0
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true

--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -38,8 +38,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 16.0
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - name: 🔨 Switch to Xcode 26.0
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -32,8 +32,8 @@ jobs:
           # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
           # TODO(cedric): swap `latest` back once the issue is resolved
           bun-version: latest
-      - name: 🔨 Switch to Xcode 16.0
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - name: 🔨 Switch to Xcode 26.0
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true
@@ -97,6 +97,8 @@ jobs:
           # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
           # TODO(cedric): swap `latest` back once the issue is resolved
           bun-version: latest
+      - name: 🔨 Switch to Xcode 26.0
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -106,6 +106,13 @@ jobs:
         with:
           name: bare-expo-ios-builds
           path: apps/bare-expo/ios/build/BareExpo.app
+      - name: 🧹 Cleanup unused simulator runtimes
+        run: |
+          xcrun simctl list devices -j | jq -r '.devices | to_entries[] | select(.key | contains("iOS") | not) | .value[].udid' | xargs -r -n1 xcrun simctl delete
+          xcrun simctl list devices --json
+          xcrun simctl erase all
+          xcrun simctl shutdown all
+          sudo xcodebuild -runFirstLaunch
       - name: 🍺 Install Maestro
         run: |
           curl -Ls "https://get.maestro.mobile.dev" | bash

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -109,8 +109,6 @@ jobs:
       - name: 🍺 Install Maestro
         run: |
           curl -Ls "https://get.maestro.mobile.dev" | bash
-          brew tap facebook/fb
-          brew install facebook/fb/idb-companion
           echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -124,11 +124,15 @@ jobs:
         with:
           name: bare-expo-ios-builds
           path: apps/bare-expo/ios/build/BareExpo.app
+      - name: 🧹 Cleanup unused simulator runtimes
+        run: |
+          xcrun simctl list devices -j | jq -r '.devices | to_entries[] | select(.key | contains("iOS") | not) | .value[].udid' | xargs -r -n1 xcrun simctl delete
+          xcrun simctl list devices --json
+          xcrun simctl erase all
+          xcrun simctl shutdown all
       - name: 🍺 Install Maestro
         run: |
           curl -Ls "https://get.maestro.mobile.dev" | bash
-          brew tap facebook/fb
-          brew install facebook/fb/idb-companion
           echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -130,6 +130,7 @@ jobs:
           xcrun simctl list devices --json
           xcrun simctl erase all
           xcrun simctl shutdown all
+          sudo xcodebuild -runFirstLaunch
       - name: 🍺 Install Maestro
         run: |
           curl -Ls "https://get.maestro.mobile.dev" | bash

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -38,8 +38,8 @@ jobs:
           # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
           # TODO(cedric): swap `latest` back once the issue is resolved
           bun-version: latest
-      - name: 🔨 Switch to Xcode 16.4
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - name: 🔨 Switch to Xcode 26.0
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true
@@ -115,6 +115,8 @@ jobs:
           # Version `1.x` fails due to https://github.com/oven-sh/setup-bun/issues/37
           # TODO(cedric): swap `latest` back once the issue is resolved
           bun-version: latest
+      - name: 🔨 Switch to Xcode 26.0
+        run: sudo xcode-select --switch /Applications/Xcode_26.0.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds

--- a/apps/bare-expo/scripts/lib/e2e-common.ts
+++ b/apps/bare-expo/scripts/lib/e2e-common.ts
@@ -22,7 +22,11 @@ export interface MaestroFlowParams {
   confirmFirstRunPrompt?: boolean;
 }
 
-export async function createMaestroFlowAsync({ appId, workflowFile, confirmFirstRunPrompt }: MaestroFlowParams): Promise<void> {
+export async function createMaestroFlowAsync({
+  appId,
+  workflowFile,
+  confirmFirstRunPrompt,
+}: MaestroFlowParams): Promise<void> {
   const inputFile = await import('../../e2e/TestSuite-test.native.js');
   const testCases = inputFile.TESTS as string[];
   const contents = [

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -138,8 +138,10 @@ export function setupLogger(predicate: string, signal: AbortSignal): () => Promi
 async function startSimulatorAsync(deviceId: string, timeout: number = 1000 * 60 * 3) {
   await retryAsync(async (retryNumber) => {
     if (process.env.CI) {
-      await spawnAsync('xcrun', ['simctl', 'shutdown', deviceId]);
-      await spawnAsync('xcrun', ['simctl', 'erase', deviceId]);
+      try {
+        await spawnAsync('xcrun', ['simctl', 'shutdown', deviceId]);
+        await spawnAsync('xcrun', ['simctl', 'erase', deviceId]);
+      } catch {}
     }
 
     console.time(

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -137,6 +137,11 @@ export function setupLogger(predicate: string, signal: AbortSignal): () => Promi
 
 async function startSimulatorAsync(deviceId: string, timeout: number = 1000 * 60 * 3) {
   await retryAsync(async (retryNumber) => {
+    if (process.env.CI) {
+      await spawnAsync('xcrun', ['simctl', 'shutdown', deviceId]);
+      await spawnAsync('xcrun', ['simctl', 'erase', deviceId]);
+    }
+
     console.time(
       `\n📱 Starting Device - name[${TARGET_DEVICE}] udid[${deviceId}] retry[${retryNumber}]`
     );

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -177,7 +177,7 @@ platform :ios do
     run_tests(
       workspace: workspace,
       scheme: generated_scheme,
-      devices: ["iPhone 16 Pro (18.5)"],
+      devices: ["iPhone 17 Pro (26.0)"],
       configuration: 'Debug',
       clean: false,
       skip_build: true,


### PR DESCRIPTION
# Why

try to fix test-suite ios-e2e-test failures

# How

- use xcode 26.0 and iphone 17 simulators
- remove unused simulator runtimes (tvos, watchos) to would hopefully to reduce simulator boot time
- remove unused idb (maestro doesn't need idb now) and it looks like idb would slow down simulator boot time on github actions

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
