### PR TITLE
[media-library][next] Fix `delete()` throws security exception

### DIFF
--- a/apps/test-suite/tests/MediaLibraryNext.ts
+++ b/apps/test-suite/tests/MediaLibraryNext.ts
@@ -44,10 +44,14 @@ export async function test(t) {
   let assetsContainer = [];
 
   t.afterAll(async () => {
-    await Album.delete(albumsContainer.flat(), true);
-    await Asset.delete(assetsContainer.flat());
-    albumsContainer = [];
-    assetsContainer = [];
+    try {
+      await Asset.delete(assetsContainer.flat());
+      await Album.delete(albumsContainer.flat(), true);
+      albumsContainer = [];
+      assetsContainer = [];
+    } catch (error) {
+      console.error('Error cleaning up test assets:', error);
+    }
   });
 
   t.describe('Album creation', () => {
@@ -63,7 +67,6 @@ export async function test(t) {
       t.expect(assets.length).toBe(files.length);
       t.expect(await album.getTitle()).toBe(albumName);
     });
-
     t.it('creates an album from a list of assets', async () => {
       // given
       const assets = await Promise.all(files.map((f) => Asset.create(f.localUri)));
@@ -78,7 +81,7 @@ export async function test(t) {
       t.expect(assets.length).toBe(files.length);
       t.expect(await album.getTitle()).toBe(albumName);
       const fetchedAssets = await album.getAssets();
-      if (Platform.OS === 'android' && Platform.Version >= 29) {
+      if (Platform.OS === 'android' && Platform.Version >= 30) {
         for (const asset of assets) {
           t.expect(
             fetchedAssets.findIndex((fetchedAsset) => fetchedAsset.id === asset.id)
@@ -118,7 +121,7 @@ export async function test(t) {
         // then
         const newAssetUris = await Promise.all(assets.map((asset) => asset.getUri()));
         albumsContainer.push(album);
-        if (Platform.OS === 'android' && Platform.Version >= 29) {
+        if (Platform.OS === 'android' && Platform.Version >= 30) {
           for (const oldAssetUri of oldAssetUris) {
             t.expect(newAssetUris.findIndex((uri) => uri === oldAssetUri)).not.toBe(-1);
           }
@@ -181,6 +184,19 @@ export async function test(t) {
       const assetIds = assets.map((a) => a.id);
       t.expect(assetIds).toContain(newAsset.id);
     });
+
+    if (Platform.OS === 'android') {
+      t.it('creates two different assets with different uri from the same source', async () => {
+        const firstAsset = await Asset.create(jpgFile.localUri);
+        const secondAsset = await Asset.create(jpgFile.localUri);
+        assetsContainer.push([firstAsset, secondAsset]);
+        const firstUri = await firstAsset.getUri();
+        const secondUri = await secondAsset.getUri();
+
+        t.expect(firstUri).not.toBe(secondUri);
+        t.expect(firstAsset.id).not.toBe(secondAsset.id);
+      });
+    }
   });
 
   t.describe('Album get', () => {

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [next][android] Fix `delete()` throwing security exception
 - [next][android] Change default root directory to Pictures ([#39716](https://github.com/expo/expo/pull/39716) by [@Wenszel](https://github.com/Wenszel))
 - [next] Fix `asset.getModificationTime` to return milliseconds ([#39715](https://github.com/expo/expo/pull/39715) by [@Wenszel](https://github.com/Wenszel))
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [next][android] Fix `delete()` throwing security exception
+- [next][android] Fix `delete()` throwing security exception ([#39914](https://github.com/expo/expo/pull/39914) by [@Wenszel](https://github.com/Wenszel))
 - [next][android] Change default root directory to Pictures ([#39716](https://github.com/expo/expo/pull/39716) by [@Wenszel](https://github.com/Wenszel))
 - [next] Fix `asset.getModificationTime` to return milliseconds ([#39715](https://github.com/expo/expo/pull/39715) by [@Wenszel](https://github.com/Wenszel))
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/MediaLibraryNextModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/MediaLibraryNextModule.kt
@@ -15,6 +15,8 @@ import expo.modules.medialibrary.next.objects.album.AlbumQuery
 import expo.modules.medialibrary.next.objects.asset.Asset
 import expo.modules.medialibrary.next.objects.album.factories.AlbumModernFactory
 import expo.modules.medialibrary.next.objects.album.factories.AlbumLegacyFactory
+import expo.modules.medialibrary.next.objects.asset.deleters.AssetLegacyDeleter
+import expo.modules.medialibrary.next.objects.asset.deleters.AssetModernDeleter
 import expo.modules.medialibrary.next.objects.asset.factories.AssetModernFactory
 import expo.modules.medialibrary.next.objects.asset.factories.AssetLegacyFactory
 import expo.modules.medialibrary.next.objects.query.MediaStoreQueryFormatter
@@ -40,22 +42,30 @@ class MediaLibraryNextModule : Module() {
   }
 
   private val albumQuery by lazy {
-    AlbumQuery(context)
+    AlbumQuery(albumFactory, context)
   }
 
   private val albumFactory by lazy {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      AlbumModernFactory(assetFactory, context)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      AlbumModernFactory(assetFactory, assetDeleter, context)
     } else {
-      AlbumLegacyFactory(assetFactory, context)
+      AlbumLegacyFactory(assetFactory, assetDeleter, context)
     }
   }
 
   private val assetFactory by lazy {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      AssetModernFactory(context)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      AssetModernFactory(assetDeleter, context)
     } else {
-      AssetLegacyFactory(context)
+      AssetLegacyFactory(assetDeleter, context)
+    }
+  }
+
+  private val assetDeleter by lazy {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      AssetModernDeleter(mediaStorePermissionsDelegate)
+    } else {
+      AssetLegacyDeleter(context)
     }
   }
 
@@ -64,7 +74,7 @@ class MediaLibraryNextModule : Module() {
 
     Class(Asset::class) {
       Constructor { contentUri: Uri ->
-        Asset(contentUri, context)
+        assetFactory.create(contentUri)
       }
 
       Property("id") { self: Asset ->
@@ -114,14 +124,13 @@ class MediaLibraryNextModule : Module() {
 
       AsyncFunction("delete") Coroutine { self: Asset ->
         systemPermissionsDelegate.requireSystemPermissions(true)
-        mediaStorePermissionsDelegate.requestMediaLibraryActionPermission(listOf(self.contentUri), needsDeletePermission = true)
         self.delete()
       }
     }
 
     Class(Album::class) {
       Constructor { id: String ->
-        Album(id, context)
+        Album(id, assetDeleter, assetFactory, context)
       }
 
       Property("id") { self: Album ->
@@ -140,21 +149,19 @@ class MediaLibraryNextModule : Module() {
 
       AsyncFunction("add") Coroutine { self: Album, asset: Asset ->
         systemPermissionsDelegate.requireSystemPermissions(true)
-        mediaStorePermissionsDelegate.requestMediaLibraryActionPermission(listOf(asset.contentUri))
+        mediaStorePermissionsDelegate.requestMediaLibraryWritePermission(listOf(asset.contentUri))
         self.add(asset)
       }
 
       AsyncFunction("delete") Coroutine { self: Album ->
         systemPermissionsDelegate.requireSystemPermissions(true)
-        val assetIdsToDelete = self.getAssets().map { it.contentUri }
-        mediaStorePermissionsDelegate.requestMediaLibraryActionPermission(assetIdsToDelete, needsDeletePermission = true)
         self.delete()
       }
     }
 
     Class(Query::class) {
       Constructor {
-        Query(context)
+        Query(assetFactory, context)
       }
 
       Function("limit") { self: Query, limit: Int ->
@@ -233,14 +240,16 @@ class MediaLibraryNextModule : Module() {
 
     AsyncFunction("deleteAlbums") Coroutine { albums: List<Album> ->
       systemPermissionsDelegate.requireSystemPermissions(true)
-      albums.forEach { album -> album.delete() }
+      val contentUris = albums
+        .map { it.getAssets() }
+        .flatten()
+        .map { it.contentUri }
+      assetDeleter.delete(contentUris)
     }
 
     AsyncFunction("deleteAssets") Coroutine { assets: List<Asset> ->
       systemPermissionsDelegate.requireSystemPermissions(true)
-      val assetIdsToDelete = assets.map { it.contentUri }
-      mediaStorePermissionsDelegate.requestMediaLibraryActionPermission(assetIdsToDelete, needsDeletePermission = true)
-      assets.forEach { asset -> asset.delete() }
+      assetDeleter.delete(assets.map { it.contentUri })
     }
 
     AsyncFunction("requestPermissionsAsync") { writeOnly: Boolean, permissions: List<GranularPermission>?, promise: Promise ->

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/CursorExtensions.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/extensions/resolver/CursorExtensions.kt
@@ -3,16 +3,26 @@ package expo.modules.medialibrary.next.extensions.resolver
 import android.content.ContentUris
 import android.database.Cursor
 import android.net.Uri
+import android.os.Build
 import android.provider.MediaStore
 
 fun Cursor.extractAssetContentUri(idColumn: Int, typeColumn: Int): Uri {
   val id = getLong(idColumn)
   val mediaType = getInt(typeColumn)
-  val baseUri = when (mediaType) {
-    MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE -> MediaStore.Images.Media.EXTERNAL_CONTENT_URI
-    MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO -> MediaStore.Video.Media.EXTERNAL_CONTENT_URI
-    MediaStore.Files.FileColumns.MEDIA_TYPE_AUDIO -> MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
-    else -> EXTERNAL_CONTENT_URI
+  val baseUri = if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
+    when (mediaType) {
+      MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE -> MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+      MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO -> MediaStore.Video.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+      MediaStore.Files.FileColumns.MEDIA_TYPE_AUDIO -> MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+      else -> MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+    }
+  } else {
+    when (mediaType) {
+      MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE -> MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+      MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO -> MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+      MediaStore.Files.FileColumns.MEDIA_TYPE_AUDIO -> MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
+      else -> EXTERNAL_CONTENT_URI
+    }
   }
   return ContentUris.withAppendedId(baseUri, id)
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/album/AlbumQuery.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/album/AlbumQuery.kt
@@ -4,9 +4,10 @@ import android.content.Context
 import expo.modules.medialibrary.next.exceptions.ContentResolverNotObtainedException
 import expo.modules.medialibrary.next.extensions.getOrThrow
 import expo.modules.medialibrary.next.extensions.resolver.queryAlbumId
+import expo.modules.medialibrary.next.objects.album.factories.AlbumFactory
 import java.lang.ref.WeakReference
 
-class AlbumQuery(context: Context) {
+class AlbumQuery(val albumFactory: AlbumFactory, context: Context) {
   private val contextRef = WeakReference(context)
 
   private val contentResolver
@@ -17,6 +18,6 @@ class AlbumQuery(context: Context) {
   suspend fun getAlbum(title: String): Album? {
     val id = contentResolver.queryAlbumId(title)
       ?: return null
-    return Album(id, contextRef.getOrThrow())
+    return albumFactory.create(id)
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/album/factories/AlbumFactory.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/album/factories/AlbumFactory.kt
@@ -5,6 +5,7 @@ import expo.modules.medialibrary.next.objects.album.Album
 import expo.modules.medialibrary.next.objects.asset.Asset
 
 interface AlbumFactory {
+  fun create(id: String): Album
   suspend fun createFromAssets(albumName: String, assets: List<Asset>, deleteOriginalAssets: Boolean): Album
   suspend fun createFromFilePaths(albumName: String, filePaths: List<Uri>): Album
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/album/factories/AlbumLegacyFactory.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/album/factories/AlbumLegacyFactory.kt
@@ -12,20 +12,29 @@ import expo.modules.medialibrary.next.extensions.resolver.queryAssetBucketId
 import expo.modules.medialibrary.next.objects.album.Album
 import expo.modules.medialibrary.next.objects.wrappers.RelativePath
 import expo.modules.medialibrary.next.objects.asset.Asset
+import expo.modules.medialibrary.next.objects.asset.deleters.AssetDeleter
 import expo.modules.medialibrary.next.objects.wrappers.MimeType
 import expo.modules.medialibrary.next.objects.asset.factories.AssetFactory
 import java.io.File
 import java.io.IOException
 import java.lang.ref.WeakReference
 
-@DeprecatedSinceApi(Build.VERSION_CODES.Q)
-class AlbumLegacyFactory(private val assetFactory: AssetFactory, context: Context) : AlbumFactory {
+@DeprecatedSinceApi(Build.VERSION_CODES.R)
+class AlbumLegacyFactory(
+  private val assetFactory: AssetFactory,
+  private val assetDeleter: AssetDeleter,
+  context: Context
+) : AlbumFactory {
   private val contextRef = WeakReference(context)
 
   private val contentResolver
     get() = contextRef
       .getOrThrow()
       .contentResolver ?: throw AlbumCouldNotBeCreated("Failed to create album: ContentResolver is unavailable.")
+
+  override fun create(id: String): Album {
+    return Album(id, assetDeleter, assetFactory, contextRef.getOrThrow())
+  }
 
   override suspend fun createFromAssets(albumName: String, assets: List<Asset>, deleteOriginalAssets: Boolean): Album {
     try {
@@ -37,7 +46,7 @@ class AlbumLegacyFactory(private val assetFactory: AssetFactory, context: Contex
       processAssetsLocation(assets, relativePath, true)
       val albumId = contentResolver.queryAssetBucketId(assets[0].contentUri)
         ?: throw AlbumNotFoundException("Could not find album with filePath: ${relativePath.toFilePath()}")
-      return Album(albumId.toString(), contextRef.getOrThrow())
+      return Album(albumId.toString(), assetDeleter, assetFactory, contextRef.getOrThrow())
     } catch (e: SecurityException) {
       throw AlbumCouldNotBeCreated("Missing WRITE_EXTERNAL_STORAGE permission: ${e.message}", e)
     } catch (e: IOException) {
@@ -55,7 +64,7 @@ class AlbumLegacyFactory(private val assetFactory: AssetFactory, context: Contex
     }
     val albumId = contentResolver.queryAssetBucketId(assets[0].contentUri)
       ?: throw AlbumCouldNotBeCreated("Could not find album with relativePath: $relativePath")
-    return Album(albumId.toString(), contextRef.getOrThrow())
+    return Album(albumId.toString(), assetDeleter, assetFactory, contextRef.getOrThrow())
   }
 
   private suspend fun processAssetsLocation(assets: List<Asset>, relativePath: RelativePath, deleteOriginalAssets: Boolean) {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/album/factories/AlbumModernFactory.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/album/factories/AlbumModernFactory.kt
@@ -11,19 +11,28 @@ import expo.modules.medialibrary.next.extensions.resolver.queryAlbumId
 import expo.modules.medialibrary.next.objects.album.Album
 import expo.modules.medialibrary.next.objects.wrappers.RelativePath
 import expo.modules.medialibrary.next.objects.asset.Asset
+import expo.modules.medialibrary.next.objects.asset.deleters.AssetDeleter
 import expo.modules.medialibrary.next.objects.wrappers.MimeType
 import expo.modules.medialibrary.next.objects.asset.factories.AssetFactory
 import java.io.IOException
 import java.lang.ref.WeakReference
 
-@RequiresApi(Build.VERSION_CODES.Q)
-class AlbumModernFactory(private val assetFactory: AssetFactory, context: Context) : AlbumFactory {
+@RequiresApi(Build.VERSION_CODES.R)
+class AlbumModernFactory(
+  private val assetFactory: AssetFactory,
+  private val assetDeleter: AssetDeleter,
+  context: Context
+) : AlbumFactory {
   private val contextRef = WeakReference(context)
 
   private val contentResolver
     get() = contextRef
       .getOrThrow()
       .contentResolver ?: throw AlbumCouldNotBeCreated("Failed to create album: ContentResolver is unavailable.")
+
+  override fun create(id: String): Album {
+    return Album(id, assetDeleter, assetFactory, contextRef.getOrThrow())
+  }
 
   override suspend fun createFromAssets(albumName: String, assets: List<Asset>, deleteOriginalAssets: Boolean): Album =
     try {
@@ -32,7 +41,7 @@ class AlbumModernFactory(private val assetFactory: AssetFactory, context: Contex
       processAssetsLocation(assets, albumRelativePath, deleteOriginalAssets)
       val albumId = contentResolver.queryAlbumId(albumRelativePath)
         ?: throw AlbumNotFoundException("Could not find album with relativePath: $albumRelativePath")
-      Album(albumId, contextRef.getOrThrow())
+      Album(albumId, assetDeleter, assetFactory, contextRef.getOrThrow())
     } catch (e: SecurityException) {
       throw AlbumCouldNotBeCreated("Security Exception: ${e.message}", e)
     } catch (e: IOException) {
@@ -47,7 +56,7 @@ class AlbumModernFactory(private val assetFactory: AssetFactory, context: Contex
     }
     val albumId = contentResolver.queryAlbumId(relativePath)
       ?: throw AlbumCouldNotBeCreated("Failed to create album: newly created album was not found in the MediaStore.")
-    return Album(albumId, contextRef.getOrThrow())
+    return Album(albumId, assetDeleter, assetFactory, contextRef.getOrThrow())
   }
 
   private suspend fun processAssetsLocation(assets: List<Asset>, relativePath: RelativePath, deleteOriginalAssets: Boolean) {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/Asset.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/Asset.kt
@@ -1,31 +1,15 @@
 package expo.modules.medialibrary.next.objects.asset
 
-import android.content.Context
 import android.net.Uri
-import android.os.Build
 import expo.modules.kotlin.sharedobjects.SharedObject
-import expo.modules.medialibrary.next.extensions.getOrThrow
+import expo.modules.medialibrary.next.objects.asset.delegates.AssetDelegate
 import expo.modules.medialibrary.next.objects.wrappers.RelativePath
-import expo.modules.medialibrary.next.objects.asset.delegates.AssetLegacyDelegate
-import expo.modules.medialibrary.next.objects.asset.delegates.AssetModernDelegate
 import expo.modules.medialibrary.next.objects.wrappers.MediaType
 import expo.modules.medialibrary.next.objects.wrappers.MimeType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.lang.ref.WeakReference
-import kotlin.getValue
 
-class Asset(contentUri: Uri, context: Context) : SharedObject() {
-  private val contextRef = WeakReference(context)
-
-  val assetDelegate by lazy {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      AssetModernDelegate(contentUri, contextRef.getOrThrow())
-    } else {
-      AssetLegacyDelegate(contentUri, contextRef.getOrThrow())
-    }
-  }
-
+class Asset(val assetDelegate: AssetDelegate) : SharedObject() {
   val contentUri: Uri get() = assetDelegate.contentUri
 
   suspend fun getCreationTime(): Long? =

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/deleters/AssetDeleter.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/deleters/AssetDeleter.kt
@@ -1,0 +1,8 @@
+package expo.modules.medialibrary.next.objects.asset.deleters
+
+import android.net.Uri
+
+interface AssetDeleter {
+  suspend fun delete(contentUri: Uri)
+  suspend fun delete(contentUris: List<Uri>)
+}

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/deleters/AssetLegacyDeleter.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/deleters/AssetLegacyDeleter.kt
@@ -1,0 +1,46 @@
+package expo.modules.medialibrary.next.objects.asset.deleters
+
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import androidx.annotation.DeprecatedSinceApi
+import expo.modules.medialibrary.AssetFileException
+import expo.modules.medialibrary.next.exceptions.AssetPropertyNotFoundException
+import expo.modules.medialibrary.next.exceptions.ContentResolverNotObtainedException
+import expo.modules.medialibrary.next.extensions.getOrThrow
+import expo.modules.medialibrary.next.extensions.resolver.queryAssetPath
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.lang.ref.WeakReference
+
+@DeprecatedSinceApi(Build.VERSION_CODES.Q)
+class AssetLegacyDeleter(context: Context) : AssetDeleter {
+  private val contextRef = WeakReference(context)
+
+  private val contentResolver
+    get() = contextRef
+      .getOrThrow()
+      .contentResolver ?: throw ContentResolverNotObtainedException()
+
+  override suspend fun delete(contentUri: Uri): Unit = withContext(Dispatchers.IO) {
+    val path = contentResolver.queryAssetPath(contentUri)
+      ?: throw AssetPropertyNotFoundException("Uri")
+    if (!File(path).delete()) {
+      throw AssetFileException("Could not delete a file.")
+    }
+    contentResolver.delete(contentUri, null, null)
+  }
+
+  override suspend fun delete(contentUris: List<Uri>): Unit = withContext(Dispatchers.IO) {
+    contentUris.map { uri ->
+      async {
+        runCatching {
+          delete(uri)
+        }
+      }
+    }.awaitAll()
+  }
+}

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/deleters/AssetModernDeleter.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/deleters/AssetModernDeleter.kt
@@ -1,0 +1,21 @@
+package expo.modules.medialibrary.next.objects.asset.deleters
+
+import android.net.Uri
+import android.os.Build
+import androidx.annotation.RequiresApi
+import expo.modules.medialibrary.next.permissions.MediaStorePermissionsDelegate
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@RequiresApi(Build.VERSION_CODES.R)
+class AssetModernDeleter(
+  val mediaStorePermissionsDelegate: MediaStorePermissionsDelegate
+) : AssetDeleter {
+  override suspend fun delete(contentUri: Uri) = withContext(Dispatchers.IO) {
+    mediaStorePermissionsDelegate.launchMediaStoreDeleteRequest(listOf(contentUri))
+  }
+
+  override suspend fun delete(contentUris: List<Uri>) = withContext(Dispatchers.IO) {
+    mediaStorePermissionsDelegate.launchMediaStoreDeleteRequest(contentUris)
+  }
+}

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/factories/AssetFactory.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/factories/AssetFactory.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import expo.modules.medialibrary.next.objects.wrappers.RelativePath
 import expo.modules.medialibrary.next.objects.asset.Asset
 
-fun interface AssetFactory {
+interface AssetFactory {
+  fun create(contentUri: Uri): Asset
   suspend fun create(filePath: Uri, relativePath: RelativePath?): Asset
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/factories/AssetLegacyFactory.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/asset/factories/AssetLegacyFactory.kt
@@ -4,14 +4,17 @@ import android.content.Context
 import android.net.Uri
 import android.os.Build
 import androidx.annotation.DeprecatedSinceApi
-import androidx.core.net.toUri
+import androidx.core.net.toFile
 import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.next.exceptions.AssetCouldNotBeCreated
 import expo.modules.medialibrary.next.exceptions.ContentResolverNotObtainedException
 import expo.modules.medialibrary.next.extensions.getOrThrow
-import expo.modules.medialibrary.next.extensions.resolver.copyUriContent
+import expo.modules.medialibrary.next.extensions.safeCopy
 import expo.modules.medialibrary.next.objects.wrappers.RelativePath
 import expo.modules.medialibrary.next.objects.asset.Asset
+import expo.modules.medialibrary.next.objects.asset.delegates.AssetDelegate
+import expo.modules.medialibrary.next.objects.asset.delegates.AssetLegacyDelegate
+import expo.modules.medialibrary.next.objects.asset.deleters.AssetDeleter
 import expo.modules.medialibrary.next.objects.wrappers.MimeType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
@@ -19,8 +22,11 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.lang.ref.WeakReference
 
-@DeprecatedSinceApi(Build.VERSION_CODES.Q)
-class AssetLegacyFactory(context: Context) : AssetFactory {
+@DeprecatedSinceApi(Build.VERSION_CODES.R)
+class AssetLegacyFactory(
+  val assetDeleter: AssetDeleter,
+  context: Context
+) : AssetFactory {
   private val contextRef = WeakReference(context)
 
   private val contentResolver
@@ -28,25 +34,34 @@ class AssetLegacyFactory(context: Context) : AssetFactory {
       .getOrThrow()
       .contentResolver ?: throw ContentResolverNotObtainedException()
 
+  private fun createAssetDelegate(contentUri: Uri): AssetDelegate {
+    return AssetLegacyDelegate(contentUri, assetDeleter, contextRef.getOrThrow())
+  }
+
+  override fun create(contentUri: Uri): Asset {
+    val assetDelegate = createAssetDelegate(contentUri)
+    return Asset(assetDelegate)
+  }
+
   override suspend fun create(filePath: Uri, relativePath: RelativePath?): Asset = withContext(Dispatchers.IO) {
     val mimeType = contentResolver.getType(filePath)?.let { MimeType(it) }
       ?: MimeType.from(filePath)
-    val displayName = filePath.lastPathSegment ?: ""
-    val baseDir = if (relativePath != null) {
+    val destinationDirectory = if (relativePath != null) {
       File(relativePath.toFilePath())
     } else {
       mimeType.externalStorageAssetDirectory()
     }
-    baseDir.mkdirs()
+    destinationDirectory.mkdirs()
 
-    val destFile = File(baseDir, displayName)
-    contentResolver.copyUriContent(filePath, destFile.toUri())
+    val destFile = filePath
+      .toFile()
+      .safeCopy(destinationDirectory)
     val (_, uri) = MediaLibraryUtils.scanFile(contextRef.getOrThrow(), arrayOf(destFile.toString()), null)
     coroutineContext.ensureActive()
 
     if (uri == null) {
       throw AssetCouldNotBeCreated("Failed to create asset: could not add asset to MediaStore")
     }
-    return@withContext Asset(uri, contextRef.getOrThrow())
+    return@withContext create(uri)
   }
 }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/query/Query.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/objects/query/Query.kt
@@ -10,6 +10,7 @@ import expo.modules.medialibrary.next.extensions.getOrThrow
 import expo.modules.medialibrary.next.extensions.resolver.extractAssetContentUri
 import expo.modules.medialibrary.next.objects.album.Album
 import expo.modules.medialibrary.next.objects.asset.Asset
+import expo.modules.medialibrary.next.objects.asset.factories.AssetFactory
 import expo.modules.medialibrary.next.objects.query.builder.QueryLegacyExecutor
 import expo.modules.medialibrary.next.objects.query.builder.QueryModernExecutor
 import expo.modules.medialibrary.next.records.AssetField
@@ -20,7 +21,10 @@ import kotlinx.coroutines.withContext
 import java.lang.ref.WeakReference
 import kotlin.collections.joinToString
 
-class Query(context: Context) : SharedObject() {
+class Query(
+  val assetFactory: AssetFactory,
+  context: Context
+) : SharedObject() {
   private val contextRef = WeakReference(context)
 
   private val contentResolver
@@ -101,7 +105,7 @@ class Query(context: Context) : SharedObject() {
       val typeColumn = it.getColumnIndexOrThrow(MediaStore.Files.FileColumns.MEDIA_TYPE)
       it.asIterable()
         .map { row -> row.extractAssetContentUri(idColumn, typeColumn) }
-        .map { uri -> Asset(uri, contextRef.getOrThrow()) }
+        .map { uri -> assetFactory.create(uri) }
         .toList()
     }
   }


### PR DESCRIPTION
# Why
Under the hood, `MediaStore.createDeleteRequest` calls `contentResolver.delete()`, and unlike `MediaStore.createWriteRequest`, it does not obtain permissions for deleting assets.
- This change has another advantage: in the old media library on API ≥ 30, `contentResolver` was called for each asset separately, whereas now it is called only once.

# How
- Refactored `mediaStorePermissionsDelegate` — added two separate functions: one for write permissions and one for launchDeleteRequest.  
- Isolated asset delete logic behind a `Deleter` interface.  
- Changed maximum legacy API level to 29 — API 29 can still use the File API to modify assets with the `android:requestLegacyExternalStorage="true"` flag.  
  - On Android 29, putting a video asset into the Pictures directory using `contentResolver` results in an exception, whereas using the File API does not. This workaround had to be introduced.

# Test plan 
Tested on bare-expo 