### PR TITLE
fix(doctor): Prevent `PeerDependencyChecks` from flagging peer/regular hybrid deps

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent peer dependency check from warning on peer/regular hybrid dependency ([#39916](https://github.com/expo/expo/pull/39916) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 1.17.7 — 2025-09-11

--- a/packages/expo-doctor/src/checks/__tests__/PeerDependencyChecks.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/PeerDependencyChecks.test.ts
@@ -245,6 +245,41 @@ describe('PeerDependencyChecks', () => {
     expect(result.issues).toHaveLength(0);
   });
 
+  it('ignores hybrid peer/regular dependencies', async () => {
+    vol.fromJSON({
+      [`${projectRoot}/node_modules/some-ui-lib/package.json`]: JSON.stringify({
+        name: 'some-ui-lib',
+        version: '1.0.0',
+        peerDependencies: {
+          'styled-components': '^5.0.0',
+        },
+        dependencies: {
+          'styled-components': '>=5.0.0',
+        },
+      }),
+    });
+
+    const check = new PeerDependencyChecks();
+    const result = await check.runAsync(
+      {
+        pkg: {
+          name: 'test-project',
+          version: '1.0.0',
+          dependencies: {
+            'some-ui-lib': '^1.0.0',
+          },
+        },
+        ...additionalProjectProps,
+      },
+      {
+        nativeModuleNames: Promise.resolve([]),
+      }
+    );
+
+    expect(result.isSuccessful).toBeTruthy();
+    expect(result.issues).toHaveLength(0);
+  });
+
   it('handles missing package.json gracefully', async () => {
     const check = new PeerDependencyChecks();
     const result = await check.runAsync(


### PR DESCRIPTION
# Why

`@expo/metro-runtime` is a hybrid peer/regular dependency in `expo-router`. It is always auto-installed and shouldn't lead to a doctor warning.

# How

- Exclude peers that are also dependencies

# Test Plan

- Added unit test

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
