### PR TITLE
[docs] Fix Tabbar search input example in native tabs guide

### DIFF
--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -370,7 +370,7 @@ export default function SearchLayout() {
 ```
 
 ```tsx app/search/index.tsx
-import { Stack } from 'expo-router';
+import { ScrollView } from 'react-native';
 
 export default function SearchIndex() {
   return <ScrollView>{/* Screen content */}</ScrollView>;

--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -351,16 +351,8 @@ export default function TabLayout() {
 import { Stack } from 'expo-router';
 
 export default function SearchLayout() {
-  return <Stack />;
-}
-```
-
-```tsx app/search/index.tsx
-import { Stack } from 'expo-router';
-
-export default function SearchIndex() {
   return (
-    <>
+    <Stack>
       <Stack.Screen
         name="index"
         options={{
@@ -372,9 +364,16 @@ export default function SearchIndex() {
           },
         }}
       />
-      <ScrollView>{/* Screen content */}</ScrollView>
-    </>
+    </Stack>
   );
+}
+```
+
+```tsx app/search/index.tsx
+import { Stack } from 'expo-router';
+
+export default function SearchIndex() {
+  return <ScrollView>{/* Screen content */}</ScrollView>;
 }
 ```
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #39859

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Fix Tabbar search input example in native tabs guide by moving `Stack.Screen` in `app/search/_layout.tsx` file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
