### PR TITLE
[video][Android] Remove @UnstableReactNativeAPI annotations

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [Android] Remove @UnstableReactNativeAPI annotations.
+- [Android] Remove @UnstableReactNativeAPI annotations. ([#39921](https://github.com/expo/expo/pull/39921) by [@jakex7](https://github.com/jakex7))
 
 ## 3.0.11 — 2025-09-10
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [Android] Remove @UnstableReactNativeAPI annotations.
+
 ## 3.0.11 — 2025-09-10
 
 ### 🎉 New features

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoModule.kt
@@ -7,7 +7,6 @@ import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player.REPEAT_MODE_OFF
 import androidx.media3.common.Player.REPEAT_MODE_ONE
 import androidx.media3.common.util.UnstableApi
-import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.functions.Coroutine
@@ -33,7 +32,6 @@ import kotlinx.coroutines.runBlocking
 import kotlin.time.Duration
 
 // https://developer.android.com/guide/topics/media/media3/getting-started/migration-guide#improvements_in_media3
-@UnstableReactNativeAPI
 @androidx.annotation.OptIn(UnstableApi::class)
 class VideoModule : Module() {
   override fun definition() = ModuleDefinition {


### PR DESCRIPTION
# Why

There is no reason to mark video module with unstable annotation. 

# How

Remove @UnstableReactNativeAPI annotation. 