### PR TITLE
[dev-launcher][iOS] Clean up EXDevLauncherController startWithWindow

### DIFF
--- a/packages/expo-dev-client/e2e/ios/AppDelegate.m
+++ b/packages/expo-dev-client/e2e/ios/AppDelegate.m
@@ -44,7 +44,8 @@
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
 
   EXDevLauncherController *controller = [EXDevLauncherController sharedInstance];
-  [controller startWithWindow:self.window delegate:(id<EXDevLauncherControllerDelegate>)self launchOptions:launchOptions];
+  [controller autoSetupPrepare:(id<EXDevLauncherControllerDelegate>)self launchOptions:launchOptions];
+  [controller startWithWindow:self.window];
 
   [super application:application didFinishLaunchingWithOptions:launchOptions];
 
@@ -90,11 +91,11 @@
 @end
 
 @implementation AppDelegate (EXDevLauncherControllerDelegate)
- 
+
 - (void)devLauncherController:(EXDevLauncherController *)developmentClientController
           didStartWithSuccess:(BOOL)success
 {
   developmentClientController.appBridge = [self initializeReactNativeApp];
 }
- 
+
 @end

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedInstance;
 
-- (void)startWithWindow:(UIWindow *)window delegate:(id<EXDevLauncherControllerDelegate>)delegate launchOptions:(NSDictionary * _Nullable)launchOptions;
+- (void)startWithWindow:(UIWindow *)window;
 
 - (void)autoSetupPrepare:(id<EXDevLauncherControllerDelegate>)delegate launchOptions:(NSDictionary * _Nullable)launchOptions;
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -252,15 +252,13 @@
   return _errorManager;
 }
 
-- (void)startWithWindow:(UIWindow *)window delegate:(id<EXDevLauncherControllerDelegate>)delegate launchOptions:(NSDictionary *)launchOptions
+- (void)startWithWindow:(UIWindow *)window
 {
   _isStarted = YES;
-  _delegate = delegate;
-  _launchOptions = launchOptions;
   _window = window;
   EXDevLauncherUncaughtExceptionHandler.isInstalled = true;
 
-  if (launchOptions[UIApplicationLaunchOptionsURLKey]) {
+  if (_launchOptions[UIApplicationLaunchOptionsURLKey]) {
     // For deeplink launch, we need the keyWindow for expo-splash-screen to setup correctly.
     [_window makeKeyWindow];
     return;
@@ -310,7 +308,7 @@
 - (void)autoSetupStart:(UIWindow *)window
 {
   if (_delegate != nil) {
-    [self startWithWindow:window delegate:_delegate launchOptions:_launchOptions];
+    [self startWithWindow:window];
   } else {
     @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"[EXDevLauncherController autoSetupStart:] was called before autoSetupPrepare:. Make sure you've set up expo-modules correctly in AppDelegate and are using ReactDelegate to create a bridge before calling [super application:didFinishLaunchingWithOptions:]." userInfo:nil];
   }


### PR DESCRIPTION
# Why

EXDevLauncherController `startWithWindow` function is only called inside `autoSetupStart` and `autoSetupStart` does not receive `delegate` nor `launchOptions` in its parameters, so it no longer makes sense to set these values inside the `startWithWindow` function

# How

Clean up EXDevLauncherController startWithWindow, this will be useful later on when we eventually decouple dev-launcher from didFinishLaunchingWithOptions for brownfield 

# Test Plan

Run BareExpo locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
