### PR TITLE
[docs] Remove `sideOffset` from MarkdownActionsDropdown

### DIFF
--- a/docs/ui/components/MarkdownActions/MarkdownActionsDropdown.tsx
+++ b/docs/ui/components/MarkdownActions/MarkdownActionsDropdown.tsx
@@ -143,8 +143,6 @@ export function MarkdownActionsDropdown() {
   );
 
   return (
-    <Dropdown.Dropdown trigger={<div>{dropdownTrigger}</div>} sideOffset={8}>
-      {dropdownItems}
-    </Dropdown.Dropdown>
+    <Dropdown.Dropdown trigger={<div>{dropdownTrigger}</div>}>{dropdownItems}</Dropdown.Dropdown>
   );
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Feedback received on MarkdownActionsDropdown component. The offset is currently too much:

<img width="600" height="384" alt="CleanShot 2025-09-24 at 00 42 04@2x" src="https://github.com/user-attachments/assets/70a6f63a-d545-4139-88ef-8e6cfa1e8c8d" />

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove `sideOffset` from MarkdownActionsDropdown.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

<img width="2850" height="824" alt="CleanShot 2025-09-24 at 00 42 30@2x" src="https://github.com/user-attachments/assets/1d518519-29fe-4d79-b39f-e199867226e4" />


<img width="570" height="368" alt="CleanShot 2025-09-24 at 00 42 20@2x" src="https://github.com/user-attachments/assets/032c5681-28e5-4009-a4a3-2e75d2ee47f2" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
