### PR TITLE
[core][Android] Add support for `ArrayBuffer`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [Android] Adds support for `ArrayBuffer`.
+- [Android] Adds support for `ArrayBuffer`. ([#39943](https://github.com/expo/expo/pull/39943) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [Android] Adds support for `ArrayBuffer`.
+
 ### 🐛 Bug fixes
 
 - [iOS] Fix NSURL to JSIString conversion returning nil. ([#39567](https://github.com/expo/expo/pull/39567) by [@behenate](https://github.com/behenate))

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/JavaScriptArrayBufferConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/JavaScriptArrayBufferConversionTest.kt
@@ -1,0 +1,23 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package expo.modules.kotlin.jni.types
+
+import com.google.common.truth.Truth
+import expo.modules.kotlin.jni.JavaScriptArrayBuffer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+
+class JavaScriptArrayBufferConversionTest {
+  @Test
+  fun array_buffer_should_be_convertible() = conversionTest<JavaScriptArrayBuffer, _>(
+    jsValue = "new Uint8Array([0x00, 0xff]).buffer",
+    nativeAssertion = { arrayBuffer ->
+      Truth.assertThat(arrayBuffer.size()).isEqualTo(2)
+      Truth.assertThat(arrayBuffer.readByte(0)).isEqualTo(0x00.toByte())
+      Truth.assertThat(arrayBuffer.readByte(1)).isEqualTo(0xff.toByte())
+      Truth.assertThat(arrayBuffer.read2Byte(0)).isEqualTo(-256)
+    },
+    map = {},
+    jsAssertion = {}
+  )
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
@@ -7,6 +7,7 @@
 #include "JavaScriptObject.h"
 #include "JavaScriptWeakObject.h"
 #include "JavaScriptFunction.h"
+#include "JavaScriptArrayBuffer.h"
 #include "JavaScriptTypedArray.h"
 #include "JavaReferencesCache.h"
 #include "JavaCallback.h"
@@ -38,6 +39,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {
     expo::JavaScriptObject::registerNatives();
     expo::JavaScriptWeakObject::registerNatives();
     expo::JavaScriptFunction::registerNatives();
+    expo::JavaScriptArrayBuffer::registerNatives();
     expo::JavaScriptTypedArray::registerNatives();
     expo::JavaCallback::registerNatives();
     expo::JNIUtils::registerNatives();

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -77,14 +77,14 @@ public:
    * @param moduleName
    * @return An instance of `JavaScriptModuleObject`
    */
-  jni::local_ref<JavaScriptModuleObject::javaobject> getModule(const std::string &moduleName) const;
+  [[nodiscard]] jni::local_ref<JavaScriptModuleObject::javaobject> getModule(const std::string &moduleName) const;
 
-  bool hasModule(const std::string &moduleName) const;
+  [[nodiscard]] bool hasModule(const std::string &moduleName) const;
 
   /**
    * Gets names of all available modules.
    */
-  jni::local_ref<jni::JArrayClass<jni::JString>> getModulesName() const;
+  [[nodiscard]] jni::local_ref<jni::JArrayClass<jni::JString>> getModulesName() const;
 
   /**
    * Exposes a `JavaScriptRuntime::evaluateScript` function to Kotlin
@@ -106,7 +106,7 @@ public:
   /**
   * Gets a core module.
   */
-  jni::local_ref<JavaScriptModuleObject::javaobject> getCoreModule() const;
+  [[nodiscard]] jni::local_ref<JavaScriptModuleObject::javaobject> getCoreModule() const;
 
   /**
    * Adds a shared object to the internal registry
@@ -148,7 +148,7 @@ public:
 
   void prepareForDeallocation() noexcept;
 
-  bool wasDeallocated() const noexcept;
+  [[nodiscard]] bool wasDeallocated() const noexcept;
 
 private:
   friend HybridBase;
@@ -168,14 +168,14 @@ private:
 
   explicit JSIContext(jni::alias_ref<jhybridobject> jThis);
 
-  inline jni::local_ref<JavaScriptModuleObject::javaobject>
+  [[nodiscard]] inline jni::local_ref<JavaScriptModuleObject::javaobject>
   callGetJavaScriptModuleObjectMethod(const std::string &moduleName) const;
 
-  inline jni::local_ref<jni::JArrayClass<jni::JString>> callGetJavaScriptModulesNames() const;
+  [[nodiscard]] inline jni::local_ref<jni::JArrayClass<jni::JString>> callGetJavaScriptModulesNames() const;
 
-  inline jni::local_ref<JavaScriptModuleObject::javaobject> callGetCoreModuleObject() const;
+  [[nodiscard]] inline jni::local_ref<JavaScriptModuleObject::javaobject> callGetCoreModuleObject() const;
 
-  inline bool callHasModule(const std::string &moduleName) const;
+  [[nodiscard]] inline bool callHasModule(const std::string &moduleName) const;
 
   void prepareJSIContext(
     jlong jsRuntimePointer,

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptArrayBuffer.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptArrayBuffer.cpp
@@ -1,0 +1,52 @@
+#include "JavaScriptArrayBuffer.h"
+
+#include "JavaScriptRuntime.h"
+#include "JSIContext.h"
+
+namespace expo {
+
+void JavaScriptArrayBuffer::registerNatives() {
+  registerHybrid({
+                   makeNativeMethod("size", JavaScriptArrayBuffer::size),
+                   makeNativeMethod("readByte", JavaScriptArrayBuffer::read<int8_t>),
+                   makeNativeMethod("read2Byte", JavaScriptArrayBuffer::read<int16_t>),
+                   makeNativeMethod("read4Byte", JavaScriptArrayBuffer::read<int32_t>),
+                   makeNativeMethod("read8Byte", JavaScriptArrayBuffer::read<int64_t>),
+                   makeNativeMethod("readFloat", JavaScriptArrayBuffer::read<float>),
+                   makeNativeMethod("readDouble", JavaScriptArrayBuffer::read<double>),
+                 });
+}
+
+JavaScriptArrayBuffer::JavaScriptArrayBuffer(
+  std::weak_ptr<JavaScriptRuntime> runtime,
+  std::shared_ptr<jsi::ArrayBuffer> jsObject
+) : runtimeHolder(std::move(runtime)), arrayBuffer(std::move(jsObject)) {
+  runtimeHolder.ensureRuntimeIsValid();
+}
+
+JavaScriptArrayBuffer::JavaScriptArrayBuffer(
+  WeakRuntimeHolder runtime,
+  std::shared_ptr<jsi::ArrayBuffer> jsObject
+) : runtimeHolder(std::move(runtime)), arrayBuffer(std::move(jsObject)) {
+  runtimeHolder.ensureRuntimeIsValid();
+}
+
+jni::local_ref<JavaScriptArrayBuffer::javaobject> JavaScriptArrayBuffer::newInstance(
+  JSIContext *jsiContext,
+  std::weak_ptr<JavaScriptRuntime> runtime,
+  std::shared_ptr<jsi::ArrayBuffer> jsValue
+) {
+  auto value = JavaScriptArrayBuffer::newObjectCxxArgs(
+    std::move(runtime),
+    std::move(jsValue)
+  );
+  jsiContext->jniDeallocator->addReference(value);
+  return value;
+}
+
+int JavaScriptArrayBuffer::size() {
+  jsi::Runtime &jsRuntime = runtimeHolder.getJSRuntime();
+  return (int) arrayBuffer->size(jsRuntime);
+}
+
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptArrayBuffer.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptArrayBuffer.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "WeakRuntimeHolder.h"
+#include "JNIDeallocator.h"
+
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+
+#include <memory>
+
+namespace expo {
+
+class JavaScriptRuntime;
+
+namespace jni = facebook::jni;
+namespace jsi = facebook::jsi;
+
+class JavaScriptArrayBuffer : public jni::HybridClass<JavaScriptArrayBuffer, Destructible> {
+public:
+  static auto constexpr
+    kJavaDescriptor = "Lexpo/modules/kotlin/jni/JavaScriptArrayBuffer;";
+  static auto constexpr TAG = "JavaScriptArrayBuffer";
+
+  static void registerNatives();
+
+  static jni::local_ref<JavaScriptArrayBuffer::javaobject> newInstance(
+    JSIContext *jSIContext,
+    std::weak_ptr<JavaScriptRuntime> runtime,
+    std::shared_ptr<jsi::ArrayBuffer> arrayBuffer
+  );
+
+  JavaScriptArrayBuffer(
+    std::weak_ptr<JavaScriptRuntime> runtime,
+    std::shared_ptr<jsi::ArrayBuffer> arrayBuffer
+  );
+
+  JavaScriptArrayBuffer(
+    WeakRuntimeHolder runtime,
+    std::shared_ptr<jsi::ArrayBuffer> arrayBuffer
+  );
+
+  int size();
+
+  template<class T>
+  T read(int position) {
+    jsi::Runtime &jsRuntime = runtimeHolder.getJSRuntime();
+    return *reinterpret_cast<T *>(arrayBuffer->data(jsRuntime) + position);
+  }
+
+private:
+  WeakRuntimeHolder runtimeHolder;
+  std::shared_ptr<jsi::ArrayBuffer> arrayBuffer;
+};
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -23,7 +23,7 @@ namespace expo {
 class JavaScriptFunction;
 class JavaScriptValue;
 class JavaScriptWeakObject;
-
+class JavaScriptArrayBuffer;
 
 /**
  * Represents any JavaScript object. Its purpose is to exposes `jsi::Object` API back to Kotlin.
@@ -84,6 +84,12 @@ public:
    * Sets the memory pressure to inform the GC about how much external memory is associated with that specific JS object.
   */
   void setExternalMemoryPressure(int size);
+
+  [[nodiscard]] bool isArray();
+  [[nodiscard]] jni::local_ref<jni::JArrayClass<jni::HybridClass<JavaScriptValue, Destructible>::javaobject>> getArray();
+
+  [[nodiscard]] bool isArrayBuffer();
+  [[nodiscard]] jni::local_ref<jni::HybridClass<JavaScriptArrayBuffer, Destructible>::javaobject> getArrayBuffer();
 
 protected:
   WeakRuntimeHolder runtimeHolder;

--- a/packages/expo-modules-core/android/src/main/cpp/WeakRuntimeHolder.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/WeakRuntimeHolder.cpp
@@ -6,7 +6,7 @@ namespace expo {
 WeakRuntimeHolder::WeakRuntimeHolder(std::weak_ptr<JavaScriptRuntime> runtime)
   : std::weak_ptr<JavaScriptRuntime>(std::move(runtime)) {}
 
-jsi::Runtime &WeakRuntimeHolder::getJSRuntime() {
+jsi::Runtime &WeakRuntimeHolder::getJSRuntime() const {
   auto runtime = lock();
   assert((runtime != nullptr) && "JS Runtime was used after deallocation");
   return runtime->get();

--- a/packages/expo-modules-core/android/src/main/cpp/WeakRuntimeHolder.h
+++ b/packages/expo-modules-core/android/src/main/cpp/WeakRuntimeHolder.h
@@ -31,7 +31,7 @@ public:
   /**
    * @return an reference to the jsi::Runtime.
    */
-  jsi::Runtime &getJSRuntime();
+  jsi::Runtime &getJSRuntime() const;
 
   JSIContext *getJSIContext();
 

--- a/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
@@ -31,5 +31,6 @@ enum CppType {
   ANY = 1 << 19,
   NULLABLE = 1 << 20,
   VALUE_OR_UNDEFINED = 1 << 21,
+  JS_ARRAY_BUFFER = 1 << 22,
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -8,6 +8,7 @@
 #include "../JavaScriptTypedArray.h"
 #include "../JSIContext.h"
 #include "../JavaScriptObject.h"
+#include "../JavaScriptArrayBuffer.h"
 #include "../JavaScriptValue.h"
 #include "../JavaScriptFunction.h"
 #include "../javaclasses/Collections.h"
@@ -217,6 +218,26 @@ bool JavaScriptObjectFrontendConverter::canConvert(
   const jsi::Value &value
 ) const {
   return value.isObject();
+}
+
+jobject JavaScriptArrayBufferFrontendConverter::convert(
+  jsi::Runtime &rt,
+  JNIEnv *env,
+  const jsi::Value &value
+) const {
+  JSIContext *jsiContext = getJSIContext(rt);
+  return JavaScriptArrayBuffer::newInstance(
+    jsiContext,
+    jsiContext->runtimeHolder->weak_from_this(),
+    std::make_shared<jsi::ArrayBuffer>(value.asObject(rt).getArrayBuffer(rt))
+  ).release();
+}
+
+bool JavaScriptArrayBufferFrontendConverter::canConvert(
+  jsi::Runtime &rt,
+  const jsi::Value &value
+) const {
+  return value.isObject() && value.getObject(rt).isArrayBuffer(rt);
 }
 
 jobject JavaScriptFunctionFrontendConverter::convert(

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
@@ -222,6 +222,20 @@ public:
 };
 
 /**
+ * Converter from js function to [expo.modules.kotlin.jni.JavaScriptArrayBuffer].
+ */
+class JavaScriptArrayBufferFrontendConverter : public FrontendConverter {
+public:
+  jobject convert(
+    jsi::Runtime &rt,
+    JNIEnv *env,
+    const jsi::Value &value
+  ) const override;
+
+  bool canConvert(jsi::Runtime &rt, const jsi::Value &value) const override;
+};
+
+/**
  * Converter from js view object to int.
  */
 class ViewTagFrontendConverter : public FrontendConverter {

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.cpp
@@ -20,6 +20,7 @@ void FrontendConverterProvider::createConverters() {
   RegisterConverter(CppType::TYPED_ARRAY, TypedArrayFrontendConverter);
   RegisterConverter(CppType::JS_OBJECT, JavaScriptObjectFrontendConverter);
   RegisterConverter(CppType::JS_VALUE, JavaScriptValueFrontendConverter);
+  RegisterConverter(CppType::JS_ARRAY_BUFFER, JavaScriptArrayBufferFrontendConverter);
   RegisterConverter(CppType::JS_FUNCTION, JavaScriptFunctionFrontendConverter);
   RegisterConverter(CppType::STRING, StringFrontendConverter);
   RegisterConverter(CppType::READABLE_MAP, ReadableNativeMapArrayFrontendConverter);

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
@@ -36,5 +36,6 @@ enum class CppType(val clazz: KClass<*>, val value: Int = nextValue()) {
   JS_FUNCTION(JavaScriptFunction::class),
   ANY(Any::class),
   NULLABLE(Any::class),
-  VALUE_OR_UNDEFINED(ValueOrUndefined::class)
+  VALUE_OR_UNDEFINED(ValueOrUndefined::class),
+  JS_ARRAY_BUFFER(JavaScriptArrayBuffer::class)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptArrayBuffer.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptArrayBuffer.kt
@@ -1,0 +1,32 @@
+package expo.modules.kotlin.jni
+
+import com.facebook.jni.HybridData
+import expo.modules.core.interfaces.DoNotStrip
+
+/**
+ * A Kotlin representation of jsi::Value.
+ * Should be used only on the runtime thread.
+ */
+@Suppress("KotlinJniMissingFunction")
+@DoNotStrip
+class JavaScriptArrayBuffer @DoNotStrip private constructor(@DoNotStrip private val mHybridData: HybridData) : Destructible {
+  fun isValid() = mHybridData.isValid
+
+  external fun size(): Int
+
+  external fun readByte(position: Int): Byte
+  external fun read2Byte(position: Int): Short
+  external fun read4Byte(position: Int): Int
+  external fun read8Byte(position: Int): Long
+  external fun readFloat(position: Int): Float
+  external fun readDouble(position: Int): Double
+
+  @Throws(Throwable::class)
+  protected fun finalize() {
+    deallocate()
+  }
+
+  override fun deallocate() {
+    mHybridData.resetNative()
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
@@ -44,6 +44,12 @@ open class JavaScriptObject @DoNotStrip internal constructor(@DoNotStrip private
 
   external fun getPropertyNames(): Array<String>
 
+  external fun isArray(): Boolean
+  external fun getArray(): Array<JavaScriptValue>
+
+  external fun isArrayBuffer(): Boolean
+  external fun getArrayBuffer(): JavaScriptArrayBuffer
+
   external fun createWeak(): JavaScriptWeakObject
 
   private external fun setBoolProperty(name: String, value: Boolean)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -12,6 +12,7 @@ import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.MissingTypeConverter
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
+import expo.modules.kotlin.jni.JavaScriptArrayBuffer
 import expo.modules.kotlin.jni.JavaScriptFunction
 import expo.modules.kotlin.jni.JavaScriptObject
 import expo.modules.kotlin.jni.JavaScriptValue
@@ -233,6 +234,9 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       ),
       JavaScriptObject::class to createTrivialTypeConverter(
         ExpectedType(CppType.JS_OBJECT)
+      ),
+      JavaScriptArrayBuffer::class to createTrivialTypeConverter(
+        ExpectedType(CppType.JS_ARRAY_BUFFER)
       ),
 
       Int8Array::class to Int8ArrayTypeConverter(),


### PR DESCRIPTION
# Why

Adds support for `ArrayBuffer`

# How

Added support for the new type `ArrayBuffer` that can be obtained from `JavaScriptObject` or as a function parameter. 

# Test Plan

- unit test ✅ 