### PR TITLE
[CI] Add better logging to Android e2e CI

### DIFF
--- a/apps/bare-expo/scripts/start-android-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-android-e2e-test.ts
@@ -12,6 +12,8 @@ import {
   getStartMode,
   retryAsync,
   getMaestroFlowFilePath,
+  prettyPrintTestSuiteLogs,
+  setupLogger,
 } from './lib/e2e-common';
 
 const APP_ID = 'dev.expo.payments';
@@ -76,19 +78,55 @@ async function testAsync(
   appBinaryPath: string,
   adbPath: string
 ): Promise<void> {
+  const stopLogCollectionController = new AbortController();
+
   console.log(`\n🔌 Installing App - appBinaryPath[${appBinaryPath}]`);
   await spawnAsync(adbPath, ['-s', deviceId, 'install', '-r', appBinaryPath]);
 
   console.log(
     `\n📷 Starting Maestro tests - deviceId[${deviceId}] maestroFlowFilePath[${maestroFlowFilePath}]`
   );
-  await spawnAsync('maestro', ['--platform', 'android', 'test', maestroFlowFilePath], {
-    stdio: 'inherit',
-    env: {
-      ...process.env,
-      MAESTRO_DRIVER_STARTUP_TIMEOUT,
-    },
-  });
+  const getLogs = setupLogger(`adb logcat -e ${APP_ID}`, stopLogCollectionController.signal);
+  try {
+    await spawnAsync('maestro', ['--platform', 'android', 'test', maestroFlowFilePath], {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        MAESTRO_DRIVER_STARTUP_TIMEOUT,
+      },
+    });
+  } catch {
+    stopLogCollectionController.abort();
+    console.warn(`\n⚠️ Maestro flow failed, because:\n\n`);
+    const logs = await getLogs();
+    console.log(prettyPrintTestSuiteLogs(logs));
+    if (!(await isAppRunning())) {
+      if (logs.length > 0) {
+        console.warn(
+          '\n\n  ❌ The runner app has probably crashed, here are the recent native error logs:\n\n'
+        );
+        console.log(logs.slice(-30).join('\n'));
+      } else {
+        console.warn(
+          '\n\n  ❌ The runner app has probably crashed, but no native logs were captured.\n\n'
+        );
+      }
+    }
+    console.log('\n\n');
+    throw new Error('e2e tests have failed.');
+  } finally {
+    stopLogCollectionController.abort();
+  }
+}
+
+async function isAppRunning() {
+  const adbPath = await findAdbAsync();
+  try {
+    await spawnAsync(adbPath, ['shell', 'pidof', APP_ID]);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function findAdbAsync(): Promise<string | null> {


### PR DESCRIPTION
# Why

Mirrors https://github.com/expo/expo/pull/39729 for Android.

# How

Used adb logcat.

# Test Plan

Tested manually that failed tests show up in logs, also if app has crashed we surface 30 latest adb logs for the test binary.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
